### PR TITLE
fix background to take into account alpha as well

### DIFF
--- a/lib/pjs.js
+++ b/lib/pjs.js
@@ -769,7 +769,8 @@
     // save out the fill
     var curFill = pCurCanvas.context.fillStyle;
     // create background rect
-    pCurCanvas.context.fillStyle = rgbToHex(c[0], c[1], c[2]); 
+    pCurCanvas.context.fillStyle = getCSSRGBColor(c);
+ 
     pCurCanvas.context.fillRect(0, 0, width, height);
     // reset fill
     pCurCanvas.context.fillStyle = curFill;


### PR DESCRIPTION
Previous implementation of fillStyle was using rgbToHex(). This output a hex string '#FFFFFF'

This means that alpha portion was being ignored. fixed to getCSSRGBColor, which output 'rgba(...)'
