### PR TITLE
Adjust JSHint options and standardize quote marks

### DIFF
--- a/.jshintrc
+++ b/.jshintrc
@@ -1,14 +1,16 @@
 {
+  "boss": true,
   "curly": true,
   "eqeqeq": true,
+  "eqnull": true,
   "immed": true,
   "latedef": "nofunc",
   "newcap": true,
   "noarg": true,
-  "sub": true,
+  "quotmark": "single",
+  "trailing": true,
   "undef": true,
   "unused": "vars",
-  "boss": true,
-  "eqnull": true,
+
   "node": true
 }

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -16,7 +16,7 @@ module.exports = function(grunt) {
       },
       test: {
         options: {jshintrc: 'test/.jshintrc'},
-        src: ['src/math/*.js']
+        src: ['test/unit/**/*.js']
       }
     },
     watch: {

--- a/src/.jshintrc
+++ b/src/.jshintrc
@@ -1,17 +1,18 @@
 {
+  "boss": true,
   "curly": true,
+  "devel": true,
   "eqeqeq": true,
+  "eqnull": true,
   "immed": true,
   "latedef": "nofunc",
   "newcap": true,
   "noarg": true,
-  "sub": true,
+  "quotmark": "single",
   "undef": true,
   "unused": "vars",
-  "boss": true,
-  "eqnull": true,
+
   "browser": true,
-  "devel": true,
   "globals": {
     "define": false,
     "require": false

--- a/src/core/core.js
+++ b/src/core/core.js
@@ -138,10 +138,10 @@ define(function (require) {
 
     if (preload) {
 
-      context.loadJSON = function(path) { return this.preloadFunc("loadJSON", path); };
-      context.loadStrings = function(path) { return this.preloadFunc("loadStrings", path); };
-      context.loadXML = function(path) { return this.preloadFunc("loadXML", path); };
-      context.loadImage = function(path) { return this.preloadFunc("loadImage", path); };
+      context.loadJSON = function(path) { return this.preloadFunc('loadJSON', path); };
+      context.loadStrings = function(path) { return this.preloadFunc('loadStrings', path); };
+      context.loadXML = function(path) { return this.preloadFunc('loadXML', path); };
+      context.loadImage = function(path) { return this.preloadFunc('loadImage', path); };
 
       preload();
 

--- a/src/data/string_functions.js
+++ b/src/data/string_functions.js
@@ -15,7 +15,7 @@ define(function (require) {
   };
 
   Processing.prototype.matchAll = function(str, reg) {
-    var re = new RegExp(reg, "g");
+    var re = new RegExp(reg, 'g');
     var match = re.exec(str);
     var matches = [];
     while (match !== null) {

--- a/src/image/image.js
+++ b/src/image/image.js
@@ -18,7 +18,7 @@ define(function (require) {
 
       // draw to canvas to get image data
       var canvas = document.createElement('canvas');
-      var ctx=canvas.getContext("2d");
+      var ctx=canvas.getContext('2d');
       canvas.width=pimg.width;
       canvas.height=pimg.height;
       ctx.drawImage(pimg.sourceImage, 0, 0);

--- a/src/structure/structure.js
+++ b/src/structure/structure.js
@@ -5,7 +5,7 @@ define(function (require) {
   var Processing = require('core');
 
   Processing.prototype.exit = function() {
-    throw "Not implemented";
+    throw 'Not implemented';
   };
 
   Processing.prototype.noLoop = function() {
@@ -62,11 +62,11 @@ define(function (require) {
   };
 
   Processing.prototype.redraw = function() {
-    throw "Not implemented";
+    throw 'Not implemented';
   };
 
   Processing.prototype.size = function() {
-    throw "Not implemented";
+    throw 'Not implemented';
   };
 
   return Processing;

--- a/src/var/constants.js
+++ b/src/var/constants.js
@@ -17,8 +17,8 @@ define(function(require) {
     QUARTER_PI: PI / 4,
     TAU: PI * 2,
     TWO_PI: PI * 2,
-    DEGREES: "degrees",
-    RADIANS: "radians",
+    DEGREES: 'degrees',
+    RADIANS: 'radians',
 
     // SHAPE
     CORNER: 'corner',

--- a/test/.jshintrc
+++ b/test/.jshintrc
@@ -1,21 +1,27 @@
 {
+  "boss": true,
   "curly": true,
   "eqeqeq": true,
+  "eqnull": true,
   "immed": true,
   "latedef": "nofunc",
   "newcap": true,
   "noarg": true,
-  "sub": true,
+  "quotmark": "single",
   "undef": true,
   "unused": "vars",
-  "boss": true,
-  "eqnull": true,
+
   "browser": true,
   "globals": {
-    "define": true,
-    "describe": true,
-    "expect": true,
-    "it": true,
-    "sinon": true
+    "afterEach": false,
+    "beforeEach": false,
+    "define": false,
+    "describe": false,
+    "expect": false,
+    "it": false,
+    "sinon": false,
+    "PElement": false,
+    "Processing": false,
+    "PVector": false
   }
 }

--- a/test/unit/math/pvector.js
+++ b/test/unit/math/pvector.js
@@ -11,38 +11,38 @@ describe('PVector', function() {
     expect(this.sut).to.be.an.instanceof(PVector);
   });
 
-  it("should have x, y, z be initialized to 0", function() {
+  it('should have x, y, z be initialized to 0', function() {
     expect(this.sut.x).to.eql(0);
     expect(this.sut.y).to.eql(0);
     expect(this.sut.z).to.eql(0);
   });
 
-  describe("new PVector(1,2,3)", function() {
+  describe('new PVector(1,2,3)', function() {
     beforeEach(function() {
       this.sut = new PVector(1,2,3);
     });
 
-    it("should have x, y, z be initialized to 1,2,3", function() {
+    it('should have x, y, z be initialized to 1,2,3', function() {
       expect(this.sut.x).to.eql(1);
       expect(this.sut.y).to.eql(2);
       expect(this.sut.z).to.eql(3);
     });
   });
 
-  describe("new PVector(1,2,undefined)", function() {
+  describe('new PVector(1,2,undefined)', function() {
     beforeEach(function() {
       this.sut = new PVector(1,2,undefined);
     });
 
-    it("should have x, y, z be initialized to 1,2,0", function() {
+    it('should have x, y, z be initialized to 1,2,0', function() {
       expect(this.sut.x).to.eql(1);
       expect(this.sut.y).to.eql(2);
       expect(this.sut.z).to.eql(0);
     });
   });
- describe("set()", function() {
-    describe("with PVector", function() {
-      it("should have x, y, z be initialized to the vector's x, y, z", function() {
+ describe('set()', function() {
+    describe('with PVector', function() {
+      it('should have x, y, z be initialized to the vector\'s x, y, z', function() {
         this.sut.set(new PVector(2,5,6));
         expect(this.sut.x).to.eql(2);
         expect(this.sut.y).to.eql(5);
@@ -50,14 +50,14 @@ describe('PVector', function() {
       });
     });
 
-    describe("with Array", function() {
-      it("[2,4] should set x == 2, y == 4, z == 0", function() {
+    describe('with Array', function() {
+      it('[2,4] should set x == 2, y == 4, z == 0', function() {
         this.sut.set([2,4]);
         expect(this.sut.x).to.eql(2);
         expect(this.sut.y).to.eql(4);
         expect(this.sut.z).to.eql(0);
       });
-      it("should have x, y, z be initialized to the array's 0,1,2 index", function() {
+      it('should have x, y, z be initialized to the array\'s 0,1,2 index', function() {
         this.sut.set([2,5,6]);
         expect(this.sut.x).to.eql(2);
         expect(this.sut.y).to.eql(5);
@@ -65,8 +65,8 @@ describe('PVector', function() {
       });
     });
 
-    describe("set(1,2,3)", function() {
-      it("should have x, y, z be initialized to the 1, 2, 3", function() {
+    describe('set(1,2,3)', function() {
+      it('should have x, y, z be initialized to the 1, 2, 3', function() {
         this.sut.set(1, 2, 3);
         expect(this.sut.x).to.eql(1);
         expect(this.sut.y).to.eql(2);
@@ -76,13 +76,13 @@ describe('PVector', function() {
   });
 
 
-  describe("get()", function() {
-    it("should not return the same instance", function() {
+  describe('get()', function() {
+    it('should not return the same instance', function() {
       var newObject = this.sut.get();
       expect(newObject).to.not.equal(this.sut);
     });
 
-    it("should return the calling object's x, y, z", function() {
+    it('should return the calling object\'s x, y, z', function() {
       this.sut.x = 2;
       this.sut.y = 3;
       this.sut.z = 4;
@@ -93,14 +93,14 @@ describe('PVector', function() {
     });
   });
 
-  describe("add()", function() {
+  describe('add()', function() {
     beforeEach(function() {
       this.sut.x = 0;
       this.sut.y = 0;
       this.sut.z = 0;
     });
-    describe("with PVector", function() {
-      it("should add x, y, z  from the vector argument", function() {
+    describe('with PVector', function() {
+      it('should add x, y, z  from the vector argument', function() {
         this.sut.add(new PVector(2,5,6));
         expect(this.sut.x).to.eql(2);
         expect(this.sut.y).to.eql(5);
@@ -108,9 +108,9 @@ describe('PVector', function() {
       });
     });
 
-    describe("with Array", function() {
-      describe("add([2, 4])", function() {
-        it("should add the x and y components", function() {
+    describe('with Array', function() {
+      describe('add([2, 4])', function() {
+        it('should add the x and y components', function() {
         this.sut.add([2,4]);
         expect(this.sut.x).to.eql(2);
         expect(this.sut.y).to.eql(4);
@@ -118,7 +118,7 @@ describe('PVector', function() {
         });
       });
 
-      it("should add the array's 0,1,2 index", function() {
+      it('should add the array\'s 0,1,2 index', function() {
         this.sut.add([2,5,6]);
         expect(this.sut.x).to.eql(2);
         expect(this.sut.y).to.eql(5);
@@ -126,8 +126,8 @@ describe('PVector', function() {
       });
     });
 
-    describe("add(3,5)", function() {
-      it("should add the x and y components", function() {
+    describe('add(3,5)', function() {
+      it('should add the x and y components', function() {
         this.sut.add(3,5);
         expect(this.sut.x).to.eql(3);
         expect(this.sut.y).to.eql(5);
@@ -135,8 +135,8 @@ describe('PVector', function() {
       });
     });
 
-    describe("add(2,3,4)", function() {
-      it("should add the x, y, z components", function() {
+    describe('add(2,3,4)', function() {
+      it('should add the x, y, z components', function() {
         this.sut.add(5,5,5);
         expect(this.sut.x).to.eql(5);
         expect(this.sut.y).to.eql(5);
@@ -144,7 +144,7 @@ describe('PVector', function() {
       });
     });
 
-    describe("PVector.add(v1, v2)", function() {
+    describe('PVector.add(v1, v2)', function() {
       var v1, v2, res;
       beforeEach(function() {
         v1 = new PVector(2,0,3);
@@ -152,12 +152,12 @@ describe('PVector', function() {
         res = PVector.add(v1, v2);
       });
 
-      it("should return neither v1 nor v2", function() {
+      it('should return neither v1 nor v2', function() {
         expect(res).to.not.eql(v1);
         expect(res).to.not.eql(v2);
       });
 
-      it("should be sum of the two PVectors", function() {
+      it('should be sum of the two PVectors', function() {
         expect(res.x).to.eql(v1.x + v2.x);
         expect(res.y).to.eql(v1.y + v2.y);
         expect(res.z).to.eql(v1.z + v2.z);
@@ -167,14 +167,14 @@ describe('PVector', function() {
   });
 
 
-  describe("sub()", function() {
+  describe('sub()', function() {
     beforeEach(function() {
       this.sut.x = 0;
       this.sut.y = 0;
       this.sut.z = 0;
     });
-    describe("with PVector", function() {
-      it("should sub x, y, z  from the vector argument", function() {
+    describe('with PVector', function() {
+      it('should sub x, y, z  from the vector argument', function() {
         this.sut.sub(new PVector(2,5,6));
         expect(this.sut.x).to.eql(-2);
         expect(this.sut.y).to.eql(-5);
@@ -182,9 +182,9 @@ describe('PVector', function() {
       });
     });
 
-    describe("with Array", function() {
-      describe("sub([2, 4])", function() {
-        it("should sub the x and y components", function() {
+    describe('with Array', function() {
+      describe('sub([2, 4])', function() {
+        it('should sub the x and y components', function() {
         this.sut.sub([2,4]);
         expect(this.sut.x).to.eql(-2);
         expect(this.sut.y).to.eql(-4);
@@ -192,7 +192,7 @@ describe('PVector', function() {
         });
       });
 
-      it("should substract from the array's 0,1,2 index", function() {
+      it('should substract from the array\'s 0,1,2 index', function() {
         this.sut.sub([2,5,6]);
         expect(this.sut.x).to.eql(-2);
         expect(this.sut.y).to.eql(-5);
@@ -200,8 +200,8 @@ describe('PVector', function() {
       });
     });
 
-    describe("sub(3,5)", function() {
-      it("should substract the x and y components", function() {
+    describe('sub(3,5)', function() {
+      it('should substract the x and y components', function() {
         this.sut.sub(3,5);
         expect(this.sut.x).to.eql(-3);
         expect(this.sut.y).to.eql(-5);
@@ -209,8 +209,8 @@ describe('PVector', function() {
       });
     });
 
-    describe("sub(2,3,4)", function() {
-      it("should substract the x, y, z components", function() {
+    describe('sub(2,3,4)', function() {
+      it('should substract the x, y, z components', function() {
         this.sut.sub(5,5,5);
         expect(this.sut.x).to.eql(-5);
         expect(this.sut.y).to.eql(-5);
@@ -218,7 +218,7 @@ describe('PVector', function() {
       });
     });
 
-    describe("PVector.sub(v1, v2)", function() {
+    describe('PVector.sub(v1, v2)', function() {
       var v1, v2, res;
       beforeEach(function() {
         v1 = new PVector(2,0,3);
@@ -226,12 +226,12 @@ describe('PVector', function() {
         res = PVector.sub(v1, v2);
       });
 
-      it("should return neither v1 nor v2", function() {
+      it('should return neither v1 nor v2', function() {
         expect(res).to.not.eql(v1);
         expect(res).to.not.eql(v2);
       });
 
-      it("should be v1 - v2", function() {
+      it('should be v1 - v2', function() {
         expect(res.x).to.eql(v1.x - v2.x);
         expect(res.y).to.eql(v1.y - v2.y);
         expect(res.z).to.eql(v1.z - v2.z);
@@ -239,7 +239,7 @@ describe('PVector', function() {
     });
   });
 
-  describe("mult()", function() {
+  describe('mult()', function() {
     beforeEach(function() {
       this.sut = new PVector();
       this.sut.x = 1;
@@ -247,12 +247,12 @@ describe('PVector', function() {
       this.sut.z = 1;
     });
 
-    it("should return the same object", function() {
+    it('should return the same object', function() {
       expect(this.sut.mult(1)).to.eql(this.sut);
     });
 
-    describe("with scalar", function() {
-      it("multiply the x, y, z with the scalar", function() {
+    describe('with scalar', function() {
+      it('multiply the x, y, z with the scalar', function() {
         this.sut.mult(2);
         expect(this.sut.x).to.eql(2);
         expect(this.sut.y).to.eql(2);
@@ -260,18 +260,18 @@ describe('PVector', function() {
       });
     });
 
-    describe("PVector.mult(v, n)", function() {
-      var v;
+    describe('PVector.mult(v, n)', function() {
+      var v, res;
       beforeEach(function() {
         v = new PVector(1,2,3);
         res = PVector.mult(v, 4);
       });
 
-      it("should return a new PVector", function() {
+      it('should return a new PVector', function() {
         expect(res).to.not.eql(v);
       });
 
-      it("should multiply the scalar", function() {
+      it('should multiply the scalar', function() {
         expect(res.x).to.eql(4);
         expect(res.y).to.eql(8);
         expect(res.z).to.eql(12);
@@ -281,19 +281,19 @@ describe('PVector', function() {
 
   });
 
-  describe("div()", function() {
+  describe('div()', function() {
     beforeEach(function() {
       this.sut.x = 1;
       this.sut.y = 1;
       this.sut.z = 1;
     });
 
-    it("should return the same object", function() {
+    it('should return the same object', function() {
       expect(this.sut.div(0)).to.eql(this.sut);
     });
 
-    describe("with scalar", function() {
-      it("divide the x, y, z with the scalar", function() {
+    describe('with scalar', function() {
+      it('divide the x, y, z with the scalar', function() {
         this.sut.div(2);
         expect(this.sut.x).to.be.closeTo(0.5, 0.01);
         expect(this.sut.y).to.be.closeTo(0.5, 0.01);
@@ -301,22 +301,22 @@ describe('PVector', function() {
       });
     });
 
-    describe("PVector.div(v, n)", function() {
+    describe('PVector.div(v, n)', function() {
       var v, res;
       beforeEach(function() {
         v = new PVector(1,1,1);
         res = PVector.div(v, 4);
       });
 
-      it("should not be undefined", function() {
+      it('should not be undefined', function() {
         expect(res).to.not.eql(undefined);
       });
 
-      it("should return a new PVector", function() {
+      it('should return a new PVector', function() {
         expect(res).to.not.eql(v);
       });
 
-      it("should divide the scalar", function() {
+      it('should divide the scalar', function() {
         expect(res.x).to.eql(0.25);
         expect(res.y).to.eql(0.25);
         expect(res.z).to.eql(0.25);
@@ -325,35 +325,35 @@ describe('PVector', function() {
   });
 
 
-  describe("dot", function() {
+  describe('dot', function() {
     beforeEach(function() {
       this.sut.x = 1;
       this.sut.y = 1;
       this.sut.z = 1;
     });
  
-    it("should return a number", function() {
-       expect(typeof(this.sut.dot(new PVector())) ===  "number").to.eql(true);
+    it('should return a number', function() {
+       expect(typeof(this.sut.dot(new PVector())) ===  'number').to.eql(true);
     });
 
 
-    describe("with PVector", function() {
-      it("should be the dot product of the vector", function() {
+    describe('with PVector', function() {
+      it('should be the dot product of the vector', function() {
         expect(this.sut.dot(new PVector(2,2))).to.eql(4);
       });
     });
 
-    describe("with x, y, z", function() {
-      it("should be the dot product with x, y", function() {
+    describe('with x, y, z', function() {
+      it('should be the dot product with x, y', function() {
         expect(this.sut.dot(2,2)).to.eql(4);
       });
 
-      it("should be the dot product with x, y, z", function() {
+      it('should be the dot product with x, y, z', function() {
         expect(this.sut.dot(2,2,2)).to.eql(6);
       });
     });
 
-    describe("PVector.dot(v, n)", function() {
+    describe('PVector.dot(v, n)', function() {
       var v1, v2, res;
       beforeEach(function() {
         v1 = new PVector(1,1,1);
@@ -361,29 +361,29 @@ describe('PVector', function() {
         res = PVector.dot(v1, v2);
       });
 
-      it("should return a number", function() {
-        expect(typeof(res) ===  "number").to.eql(true);
+      it('should return a number', function() {
+        expect(typeof(res) ===  'number').to.eql(true);
       });
 
-      it("should be the dot product of the two vectors", function() {
+      it('should be the dot product of the two vectors', function() {
         expect(res).to.eql(9);
       });
     });
   });
 
-  describe("cross", function() {
+  describe('cross', function() {
     var res;
     beforeEach(function() {
       this.sut.x = 1;
       this.sut.y = 1;
       this.sut.z = 1;
     });
-      it("should return a new product", function() {
+      it('should return a new product', function() {
         expect(this.sut.cross(new PVector())).to.not.eql(this.sut);
       });
 
-    describe("with PVector", function() {
-      it("should cross x, y, z  from the vector argument", function() {
+    describe('with PVector', function() {
+      it('should cross x, y, z  from the vector argument', function() {
         res = this.sut.cross(new PVector(2,5,6));
         expect(res.x).to.eql(1);   //this.y * v.z - this.z * v.y
         expect(res.y).to.eql(-4);  //this.z * v.x - this.x * v.z
@@ -391,7 +391,7 @@ describe('PVector', function() {
       });
     });
 
-    describe("PVector.cross(v1, v2)", function() {
+    describe('PVector.cross(v1, v2)', function() {
       var v1, v2, res;
       beforeEach(function() {
         v1 = new PVector(3,6,9);
@@ -399,17 +399,17 @@ describe('PVector', function() {
         res = PVector.cross(v1, v2);
       });
 
-      it("should not be undefined", function() {
+      it('should not be undefined', function() {
         expect(res).to.not.eql(undefined);
       });
 
  
-      it("should return neither v1 nor v2", function() {
+      it('should return neither v1 nor v2', function() {
         expect(res).to.not.eql(v1);
         expect(res).to.not.eql(v2);
       });
 
-      it("should the cross product of v1 and v2", function() {
+      it('should the cross product of v1 and v2', function() {
         expect(res.x).to.eql(-3);
         expect(res.y).to.eql(6);
         expect(res.z).to.eql(-3);
@@ -417,7 +417,7 @@ describe('PVector', function() {
     });
   });
 
-  describe("dist", function() {
+  describe('dist', function() {
     var b, c;
     beforeEach(function() {
       this.sut.x = 0;
@@ -427,53 +427,53 @@ describe('PVector', function() {
       c = new PVector(3,4,1);
     });
 
-    it("should return a number", function() {
-      expect(typeof(this.sut.dist(b)) ===  "number").to.eql(true);
+    it('should return a number', function() {
+      expect(typeof(this.sut.dist(b)) ===  'number').to.eql(true);
     });
 
-    it("should return distance between two vectors", function() {
+    it('should return distance between two vectors', function() {
       expect(this.sut.dist(b)).to.eql(4);
     });
 
-    it("should return distance between two vectors", function() {
+    it('should return distance between two vectors', function() {
       expect(this.sut.dist(c)).to.eql(5);
     });
 
-    it("should be commutative", function() {
+    it('should be commutative', function() {
       expect(b.dist(c)).to.eql(c.dist(b));
     });
 
   });
 
-  describe("PVector.dist(v1, v2)", function() {
-    var v1, v2, res;
+  describe('PVector.dist(v1, v2)', function() {
+    var v1, v2;
     beforeEach(function() {
       v1 = new PVector(0,0,0);
       v2 = new PVector(0,3,4);
     });
 
-    it("should return a number", function() {
-      expect(typeof(PVector.dist(v1, v2)) ===  "number").to.eql(true);
+    it('should return a number', function() {
+      expect(typeof(PVector.dist(v1, v2)) ===  'number').to.eql(true);
     });
 
-    it("should be commutative", function() {
+    it('should be commutative', function() {
       expect(PVector.dist(v1, v2)).to.eql(PVector.dist(v2, v1));
     });
   });
 
-  describe("normalize", function() {
+  describe('normalize', function() {
     beforeEach(function() {
       this.sut.x = 1;
       this.sut.y = 1;
       this.sut.z = 1;
     });
 
-    it("should return the same object", function() {
+    it('should return the same object', function() {
       expect(this.sut.normalize()).to.eql(this.sut);
     });
 
-    describe("with unit vector", function() {
-      it("should not change the vector", function() {
+    describe('with unit vector', function() {
+      it('should not change the vector', function() {
         this.sut.x = 1;
       this.sut.y = 0;
       this.sut.z = 0;
@@ -484,8 +484,8 @@ describe('PVector', function() {
       });
     });
 
-    describe("with 2,2,1", function() {
-      it("should normalize to 0.66,0.66,0.33", function() {
+    describe('with 2,2,1', function() {
+      it('should normalize to 0.66,0.66,0.33', function() {
         this.sut.x = 2;
       this.sut.y = 2;
       this.sut.z = 1;
@@ -497,19 +497,19 @@ describe('PVector', function() {
     });
   });
 
-  describe("limit", function() {
+  describe('limit', function() {
     beforeEach(function() {
       this.sut.x = 1;
       this.sut.y = 1;
       this.sut.z = 1;
     });
 
-    it("should return the same object", function() {
+    it('should return the same object', function() {
       expect(this.sut.limit()).to.eql(this.sut);
     });
 
-    describe("with a vector larger than the limit", function() {
-      it("should limit the vector", function() {
+    describe('with a vector larger than the limit', function() {
+      it('should limit the vector', function() {
         this.sut.x = 5;
       this.sut.y = 5;
       this.sut.z = 5;
@@ -520,8 +520,8 @@ describe('PVector', function() {
       });
     });
 
-    describe("with a vector smaller than the limit", function() {
-      it("should not limit the vector", function() {
+    describe('with a vector smaller than the limit', function() {
+      it('should not limit the vector', function() {
         this.sut.x = 5;
       this.sut.y = 5;
       this.sut.z = 5;
@@ -533,23 +533,23 @@ describe('PVector', function() {
     });
   });
 
-  describe("setMag", function() {
+  describe('setMag', function() {
     beforeEach(function() {
       this.sut.x = 1;
       this.sut.y = 0;
       this.sut.z = 0;
     });
 
-    it("should return the same object", function() {
+    it('should return the same object', function() {
       expect(this.sut.setMag(2)).to.eql(this.sut);
     });
 
-    it("should set the magnitude of the vector", function() {
+    it('should set the magnitude of the vector', function() {
       this.sut.setMag(4);
       expect(this.sut.mag()).to.eql(4);
     });
 
-    it("should set the magnitude of the vector", function() {
+    it('should set the magnitude of the vector', function() {
       this.sut.x = 2;
       this.sut.y = 3;
       this.sut.z = 0;
@@ -560,26 +560,26 @@ describe('PVector', function() {
     });
   });
 
-  describe("heading", function() {
-    it("should return a number", function() {
-      expect(typeof(this.sut.heading()) ===  "number").to.eql(true);
+  describe('heading', function() {
+    it('should return a number', function() {
+      expect(typeof(this.sut.heading()) ===  'number').to.eql(true);
     });
 
-    it("heading for vector pointing right is 0", function() {
+    it('heading for vector pointing right is 0', function() {
       this.sut.x = 1;
       this.sut.y = 0;
       this.sut.z = 0;
       expect(this.sut.heading()).to.be.closeTo(0, 0.01);
     });
 
-    it("heading for vector pointing down is PI/2", function() {
+    it('heading for vector pointing down is PI/2', function() {
       this.sut.x = 0;
       this.sut.y = 1;
       this.sut.z = 0;
       expect(this.sut.heading()).to.be.closeTo(Math.PI/2, 0.01);
     });
 
-    it("heading for vector pointing left is PI", function() {
+    it('heading for vector pointing left is PI', function() {
       this.sut.x = -1;
       this.sut.y = 0;
       this.sut.z = 0;
@@ -587,12 +587,12 @@ describe('PVector', function() {
     });
   });
 
-  describe("rotate2D", function() {
-    it("should return the same object", function() {
+  describe('rotate2D', function() {
+    it('should return the same object', function() {
       expect(this.sut.rotate2D()).to.eql(this.sut);
     });
 
-    it("should rotate the vector", function() {
+    it('should rotate the vector', function() {
       this.sut.x = 1;
       this.sut.y = 0;
       this.sut.z = 0;
@@ -601,7 +601,7 @@ describe('PVector', function() {
       expect(this.sut.y).to.be.closeTo(0, 0.01);
     });
 
-    it("should rotate the vector", function() {
+    it('should rotate the vector', function() {
       this.sut.x = 1;
       this.sut.y = 0;
       this.sut.z = 0;
@@ -611,42 +611,42 @@ describe('PVector', function() {
     });
   });
 
-  describe("lerp", function() {
-    // it("should return the same object", function() {
+  describe('lerp', function() {
+    // it('should return the same object', function() {
     //   expect(this.sut.lerp()).to.eql(this.sut);
     // });
 
     // PEND: ADD BACK IN
-    // describe("with PVector", function() {
-    //   it("should call lerp with 4 arguments", function() {
-    //     spyOn(this.sut, "lerp").andCallThrough();
+    // describe('with PVector', function() {
+    //   it('should call lerp with 4 arguments', function() {
+    //     spyOn(this.sut, 'lerp').andCallThrough();
     //     this.sut.lerp(new PVector(1,2,3), 1);
     //     expect(this.sut.lerp).toHaveBeenCalledWith(1, 2, 3, 1);
     //   });
     // });
 
-    describe("with x, y, z, amt", function() {
+    describe('with x, y, z, amt', function() {
       beforeEach(function() {
         this.sut.x = 0;
       this.sut.y = 0;
       this.sut.z = 0;
         this.sut.lerp(2,2,2,0.5);
       });
-      it("should lerp x by amt", function() {
+      it('should lerp x by amt', function() {
         expect(this.sut.x).to.eql(1);
       });
 
-      it("should lerp y by amt", function() {
+      it('should lerp y by amt', function() {
         expect(this.sut.y).to.eql(1);
       });
 
-      it("should lerp z by amt", function() {
+      it('should lerp z by amt', function() {
         expect(this.sut.z).to.eql(1);
       });
     });
 
-    describe("with no amt", function() {
-      it("should assume 0 amt", function() {
+    describe('with no amt', function() {
+      it('should assume 0 amt', function() {
         this.sut.x = 0;
       this.sut.y = 0;
       this.sut.z = 0;
@@ -657,34 +657,34 @@ describe('PVector', function() {
       });
     });
   });
-  describe("PVector.lerp(v1, v2, amt)", function() {
+  describe('PVector.lerp(v1, v2, amt)', function() {
     var res, v1, v2;
     beforeEach(function() {
       v1 = new PVector(0, 0, 0);
       v2 = new PVector(2, 2, 2);
       res = PVector.lerp(v1, v2, 0.5);
     });
-    it("should not be undefined", function() {
+    it('should not be undefined', function() {
       expect(res).to.not.eql(undefined);
     });
 
-    it("should be a PVector", function() {
+    it('should be a PVector', function() {
       expect(res).to.be.an.instanceof(PVector);
     });
 
-    it("should return neither v1 nor v2", function() {
+    it('should return neither v1 nor v2', function() {
       expect(res).to.not.eql(v1);
       expect(res).to.not.eql(v2);
     });
 
-    it("should res to be [1, 1, 1]", function() {
+    it('should res to be [1, 1, 1]', function() {
       expect(res.x).to.eql(1);
       expect(res.y).to.eql(1);
       expect(res.z).to.eql(1);
     });
   });
 
-  describe("PVector.angleBetween(v1, v2)", function() {
+  describe('PVector.angleBetween(v1, v2)', function() {
     var res, v1, v2;
     beforeEach(function() {
       v1 = new PVector(1, 0, 0);
@@ -692,11 +692,11 @@ describe('PVector', function() {
       res = PVector.angleBetween(v1, v2);
 
     });
-    it("should be a Number", function() {
+    it('should be a Number', function() {
       expect(typeof(res)).to.eql('number');
     });
-    describe("with [1,0,0] and [2,2,0]", function() {
-      it("should be 45 deg differnce", function() {
+    describe('with [1,0,0] and [2,2,0]', function() {
+      it('should be 45 deg differnce', function() {
         v1 = new PVector(1, 0, 0);
         v2 = new PVector(2, 2, 0);
         res = PVector.angleBetween(v1, v2);
@@ -704,8 +704,8 @@ describe('PVector', function() {
       });
     });
 
-    describe("with [2,0,0] and [-2,0,0]", function() {
-      it("should be 180 deg differnce", function() {
+    describe('with [2,0,0] and [-2,0,0]', function() {
+      it('should be 180 deg differnce', function() {
         v1 = new PVector(2, 0, 0);
         v2 = new PVector(-2, 0, 0);
         res = PVector.angleBetween(v1, v2);
@@ -713,15 +713,15 @@ describe('PVector', function() {
       });
     });
 
-    describe("with [2,0,0] and [-2,-2,0]", function() {
-      it("should be 135 deg differnce", function() {
+    describe('with [2,0,0] and [-2,-2,0]', function() {
+      it('should be 135 deg differnce', function() {
         v1 = new PVector(2, 0, 0);
         v2 = new PVector(-2, -2, 0);
         res = PVector.angleBetween(v1, v2);
         expect(res).to.be.closeTo(Math.PI/2 + Math.PI/4, 0.01);
       });
 
-      it("should be commutative", function() {
+      it('should be commutative', function() {
         v1 = new PVector(2, 0, 0);
         v2 = new PVector(-2, -2, 0);
         res = PVector.angleBetween(v1, v2);
@@ -730,12 +730,12 @@ describe('PVector', function() {
     });
   });
 
-  describe("array", function() {
-    it("should return an array", function() {
+  describe('array', function() {
+    it('should return an array', function() {
       expect(this.sut.array()).to.be.instanceof(Array);
     });
 
-    it("should return an with the x y and z components", function() {
+    it('should return an with the x y and z components', function() {
       this.sut.x = 1;
       this.sut.y = 23;
       this.sut.z = 4;

--- a/test/unit/math/random.js
+++ b/test/unit/math/random.js
@@ -7,54 +7,54 @@ describe('Random', function() {
     delete this.sut;
   });
 
-  describe("random()", function() {
+  describe('random()', function() {
     beforeEach(function() {
       this.sut = Processing.prototype.random();
     });
 
-    it("should return a number", function() {
-       expect(typeof(this.sut) ===  "number").to.eql(true);
+    it('should return a number', function() {
+       expect(typeof(this.sut) ===  'number').to.eql(true);
     });
   });
 
-  describe("random(10)", function() {
+  describe('random(10)', function() {
     beforeEach(function() {
       this.sut = Processing.prototype.random(10);
     });
 
-    it("should return a number < 10", function() {
+    it('should return a number < 10', function() {
        expect(this.sut).to.be.below(10);
     });
 
-    it("should return a number >= 0", function() {
+    it('should return a number >= 0', function() {
        expect(this.sut).to.be.at.least(0);
     });
   });
 
-  describe("random(1, 10)", function() {
+  describe('random(1, 10)', function() {
     beforeEach(function() {
       this.sut = Processing.prototype.random(1, 10);
     });
 
-    it("should return a number < 10", function() {
+    it('should return a number < 10', function() {
        expect(this.sut).to.be.below(10);
     });
 
-    it("should return a number >= 1", function() {
+    it('should return a number >= 1', function() {
        expect(this.sut).to.be.at.least(1);
     });
   });
 
-  describe("noise()", function() {
+  describe('noise()', function() {
     // beforeEach(function() {
     //   this.sut = Processing.prototype.random(1, 10);
     // });
 
-    // it("should return a number < 10", function() {
+    // it('should return a number < 10', function() {
     //    expect(this.sut).to.be.below(10);
     // });
 
-    // it("should return a number >= 1", function() {
+    // it('should return a number >= 1', function() {
     //    expect(this.sut).to.be.at.least(1);
     // });
   });


### PR DESCRIPTION
- Alphabetized non-environmental options within each .jshintrc file
- Removed "sub" option from all .jshintrc files
- Pointed Grunt at the correct test spec directory
- Added "quotmark": "single" to enforce consistent use of single-quotes
- Converted all remaining double-quotes to single-quotes
- Fix variable declarations in pvector test spec

Reference: #105
