### PR TITLE
loadStrings fix

### DIFF
--- a/src/input/files.js
+++ b/src/input/files.js
@@ -46,12 +46,11 @@ define(function (require) {
           ret[k] = arr[k];
         }
         if (typeof callback !== 'undefined') {
-          callback();
+          callback(ret);
         }
       }
     };
     req.send(null);
-    return ret;
   };
 
   Processing.prototype.loadTable = function () {


### PR DESCRIPTION
loadStrings was returning an empty array ('ret'), before the array gets
populated with strings. So I deleted 'return ret' and put the array
'ret' into the callback function once it's populated. Now it's working
for me, hopefully for others too!
