### PR TITLE
grunt watch patch

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -20,8 +20,10 @@ module.exports = function(grunt) {
       }
     },
     watch: {
-      files: ['<%= jshint.files %>'],
-      tasks: ['jshint', 'qunit']
+//      files: ['<%= jshint.files %>'],
+//      tasks: ['jshint', 'qunit'],
+        files: ['src/**/*.js'],
+        tasks: ['jshint', 'requirejs']
     },
     mocha: {
       test: {


### PR DESCRIPTION
Related to: https://github.com/lmccart/p5.js/issues/93

Builds P5 automatically (uncompressed and compressed versions) when saving any .js file in the src directory. Use: `grunt watch`
Note that P5 will not build if Jshint finds any error in the code (it will print error messages in the console).
