### PR TITLE
cleanup examples + removing unnecessary callbacks

### DIFF
--- a/lib/addons/p5.sound.js
+++ b/lib/addons/p5.sound.js
@@ -118,100 +118,6 @@ var p5SOUND = (function(){
 
 
   /**
-   * Private callbacks to be used for soundfile playback & loading.
-   * These may not be necessary since loadSound works in
-   * preload and with callbacks.
-   */
-
-  // If a SoundFile is played before the buffer has loaded,
-  // it will load the file and pass this function as the callback.
-  var play_now = function(sfile) {
-    if (sfile.buffer) {
-      sfile.source = sfile.p5s.audiocontext.createBufferSource();
-      sfile.source.buffer = sfile.buffer;
-      sfile.source.loop = sfile.looping;
-
-      // firefox
-      if (!sfile.source.gain) {
-        sfile.source.gain = sfile.p5s.audiocontext.createGain();
-        sfile.source.connect(sfile.source.gain);
-        // connect to output
-        sfile.source.gain.connect(sfile.output); 
-      }
-      else {
-        //connect to output
-        sfile.source.connect(sfile.output); 
-      }
-
-      // set variables like playback rate, gain and panning
-      sfile.source.playbackRate.value = sfile.playbackRate;
-
-      sfile.source.onended = function() {
-        if (sfile.playing) {
-          sfile.playing = !sfile.playing;
-          sfile.stop();
-         }
-       };
-
-      // play the sound
-      sfile.source.start(0, sfile.startTime);
-      sfile.startSeconds = sfile.p5s.audiocontext.currentTime;
-      sfile.playing = true;
-      sfile.paused = false;
-
-      sfile.sources.push(sfile.source);
-    }
-
-    else {
-      console.log(sfile.url + ' not loaded yet');
-    }
-  };
-
-  // If getPeaks() is called on a SoundFile before the buffer loads
-  // it will load the file and pass this function as the callback.
-  var getPeaksNow = function(sfile) {
-    if (sfile.buffer) {
-      // set length to p5's width if no length is provided
-      var length = window.width;
-      if (this.buffer) {
-        var buffer = this.buffer;
-        var sampleSize = buffer.length / length;
-        var sampleStep = ~~(sampleSize / 10) || 1;
-        var channels = buffer.numberOfChannels;
-        var peaks = new Float32Array(length);
-
-        for (var c = 0; c < channels; c++) {
-          var chan = buffer.getChannelData(c);
-          for (var i = 0; i < length; i++) {
-            var start = ~~(i*sampleSize); 
-            var end = ~~(start + sampleSize);
-            var max = 0;
-            for (var j = start; j < end; j+= sampleStep) {
-              var value = chan[j];
-              if (value > max) {
-                max = value;
-              // faster than Math.abs
-              } else if (-value > max) {
-                max = value;
-              }
-            }
-            if (c === 0 || max > peaks[i]) {
-              peaks[i] = max;
-            }
-          }
-        }
-
-        return peaks;
-      }
-
-    }
-
-    else {
-      console.log(sfile.url + ' not loaded yet');
-    }
-  };
-
-  /**
    * Master contains AudioContext and the master sound output.
    */
   var Master = function() {
@@ -248,26 +154,26 @@ var p5SOUND = (function(){
 
 
   /**
-   * <p>Set the master amplitude (volume) for sound in this sketch.</p>
+   *  <p>Set the master amplitude (volume) for sound in this sketch.</p>
    *
-   * <p>Note that values greater than 1.0 may lead to digital distortion.</p>
+   *  <p>Note that values greater than 1.0 may lead to digital distortion.</p>
    * 
-   * <p><b>How This Works</b>: When you load the p5Sound module, it
-   * creates a single instance of p5sound. All sound objects in this
-   * module output to p5sound before reaching your computer's output.
-   * So if you change the amplitude of p5sound, it impacts all of the
-   * sound in this module.</p>
+   *  <p><b>How This Works</b>: When you load the p5Sound module, it
+   *  creates a single instance of p5sound. All sound objects in this
+   *  module output to p5sound before reaching your computer's output.
+   *  So if you change the amplitude of p5sound, it impacts all of the
+   *  sound in this module.</p>
    *
-   * @for    p5.sound
-   * @method masterVolume
-   * @param {Number} volume   Master amplitude (volume) for sound in
-   *                          this sketch. Should be between 0.0
-   *                          (silence) and 1.0. Values greater than
-   *                          1.0 may lead to digital distortion.
-   * @example
-   *   <div><code>
-   *   masterVolume(.5);
-   *   </code></div>
+   *  @for    p5.sound
+   *  @method masterVolume
+   *  @param {Number} volume   Master amplitude (volume) for sound in
+   *                           this sketch. Should be between 0.0
+   *                           (silence) and 1.0. Values greater than
+   *                           1.0 may lead to digital distortion.
+   *  @example
+   *  <div><code>
+   *  masterVolume(.5);
+   *  </code></div>
    *   
    */
   p5.prototype.masterVolume = function(vol){
@@ -336,15 +242,15 @@ var p5SOUND = (function(){
    * @param {Function} [callback]   Name of a function to call once file loads
    * @return {Object}    SoundFile Object
    * @example 
-   *   <div><code>
-   *     function setup() {
-   *       mySound = new SoundFile(['mySound.mp3', 'mySound.ogg'], onload);
-   *     }
+   * <div><code>
+   * function setup() {
+   *   mySound = new SoundFile(['mySound.mp3', 'mySound.ogg'], onload);
+   * }
    *
-   *     function onload() {
-   *       mySound.play();
-   *     }
-   *   </code></div>
+   * function onload() {
+   *   mySound.play();
+   * }
+   * </code></div>
    */
   p5.prototype.SoundFile = function(paths, onload) {
     var path;
@@ -423,14 +329,6 @@ var p5SOUND = (function(){
     // by default, the panner is connected to the p5s destination
     this.panner.connect(this.p5s.input);
 
-    // load the AudioBuffer asyncronously with onload as the callback
-    if (onload == 'play') {
-      onload = play_now;
-    }
-    if (onload == 'loop') {
-      this.looping = true;
-      onload = play_now;
-    }
     this.load(onload);
   };
 
@@ -577,7 +475,6 @@ var p5SOUND = (function(){
     // If soundFile hasn't loaded the buffer yet, load it then play it in the callback
     else {
       console.log('not ready to play');
-      // this.load(play_now);
     }
   };
 
@@ -911,7 +808,7 @@ var p5SOUND = (function(){
    * 
    * @for p5.sound:SoundFile 
    * @method  getPeaks
-   * @params {Number} [length] length is the size of the returned array.
+   * @params {[Number]} length length is the size of the returned array.
    *                          Larger length results in more precision.
    *                          Defaults to 5*width of the browser window.
    * @returns {Float32Array} Array of peaks.
@@ -954,8 +851,7 @@ var p5SOUND = (function(){
       }
     }
     else {
-      // this is called before file loads, load it with a callback
-      this.load(getPeaksNow);
+      throw 'Cannot load peaks yet, buffer is not loaded';
     }
   };
 
@@ -964,6 +860,7 @@ var p5SOUND = (function(){
    * Playback must be handled separately (see example).
    *
    * @for  p5.sound:SoundFile
+   * @method  reverseBuffer
    * @example
    * <div><code>
    * s = new SoundFile('beat.mp3');
@@ -1089,29 +986,29 @@ var p5SOUND = (function(){
 // =============================================================================
 
   /**
-   * Create an Amplitude object, which measures amplitude (volume)
-   * between 0.0 and 1.0. Accepts an optional smoothing value,
-   * which defaults to 0. Reads global p5sound output by default,
-   * or use setInput() to listen to a specific sound source.
+   *  Create an Amplitude object, which measures amplitude (volume)
+   *  between 0.0 and 1.0. Accepts an optional smoothing value,
+   *  which defaults to 0. Reads global p5sound output by default,
+   *  or use setInput() to listen to a specific sound source.
    *
-   * @for p5.sound:Amplitude
-   * @method new Amplitude
-   * @param {Number} [smoothing] between 0.0 and .999 to smooth
+   *  @for p5.sound:Amplitude
+   *  @method new Amplitude
+   *  @param {Number} [smoothing] between 0.0 and .999 to smooth
    *                             amplitude readings (defaults to 0)
-   * @return {Object}    Amplitude Object
-   * @example
-   *    <div><code>
-   *      function setup() { 
-   *         mic = new AudioIn();
-   *         mic.on();
-   *         amplitude = new Amplitude();
-   *         amplitude.setInput(mic);
-   *      }
-   *      function draw() {
-   *         micLevel = amplitude.analyze();
-   *         ellipse(width/2, height - micLevel*height, 10, 10);
-   *      }
-   *   </code></div>
+   *  @return {Object}    Amplitude Object
+   *  @example
+   *  <div><code>
+   *  function setup() { 
+   *    mic = new AudioIn();
+   *    mic.on();
+   *    amplitude = new Amplitude();
+   *    amplitude.setInput(mic);
+   *  }
+   *  function draw() {
+   *    micLevel = amplitude.analyze();
+   *    ellipse(width/2, height - micLevel*height, 10, 10);
+   *  }
+   *  </code></div>
    */
   p5.prototype.Amplitude = function(smoothing) {
 
@@ -1148,26 +1045,23 @@ var p5SOUND = (function(){
   };
 
   /**
-   * Connects to the p5sound instance (master output) by default.
-   * Optionally, you can pass in a specific source (i.e. a soundfile).
+   *  Connects to the p5sound instance (master output) by default.
+   *  Optionally, you can pass in a specific source (i.e. a soundfile).
    *
-   * @for p5.sound:Amplitude
-   * @method setInput
-   * @param {soundObject|undefined} [snd]       set the sound source (optional, defaults to master output)
-   * @param {Number|undefined} [smoothing]      a range between 0.0 and .999 to smooth amplitude readings
-   * @example
+   *  @for p5.sound:Amplitude
+   *  @method setInput
+   *  @param {soundObject|undefined} [snd]       set the sound source (optional, defaults to master output)
+   *  @param {Number|undefined} [smoothing]      a range between 0.0 and .999 to smooth amplitude readings
+   *  @example
    *  <div><code>
-   *   function setup() {
-   *     mic = new AudioIn().on();
-   *     amplitude = new Amplitude();
-   *
-   *     // don't send mic to master output
-   *     mic.disconnect();
-   *
-   *     // only send to the Amplitude reader, so we can see it but not hear it.
-   *     amplitude.setInput(mic);
-   *   }
-   *   </code></div>
+   *  function preload(){
+   *    soundFile = loadSound('mySound.mp3');
+   *  }
+   *  function setup(){
+   *    amplitude = new Amplitude();
+   *    amplitude.setInput(soundFile);
+   *  }
+   *  </code></div>
    */
   p5.prototype.Amplitude.prototype.setInput = function(snd, smoothing) {
 
@@ -1189,16 +1083,6 @@ var p5SOUND = (function(){
       // Not working: snd.load(this.input); // TO DO: figure out how to make it work!
       this.p5s.output.connect(this.processor);
     }
-
-    // TO DO figure out how to connect to a buffer before it is loaded,
-    // i.e. .load() with 'connect' as callback
-    // 
-    // This was not working:
-    // else if (typeof(snd.load) == 'function' && snd.source == null) {
-    //   console.log('source is not ready to connect. Connecting to master output instead');
-    //   // Not working: snd.load(this.input); 
-    //   this.p5s.output.connect(this.processor);
-    // }
 
     // connect to the sound if it is available
     else if (typeof(snd.load) === 'function' && typeof(snd.connect)) {
@@ -1263,21 +1147,21 @@ var p5SOUND = (function(){
   };
 
   /**
-   * Returns a single Amplitude reading at the moment it is called.
-   * For continuous readings, run in the draw loop.
+   *  Returns a single Amplitude reading at the moment it is called.
+   *  For continuous readings, run in the draw loop.
    *
-   * @for p5.sound:Amplitude
-   * @method getLevel
-   * @return {Number}       Amplitude as a number between 0.0 and 1.0
-   * @example
-   *   <div><code>
-   *      function setup() { 
-   *         amplitude = new Amplitude();
-   *      }
-   *      function draw() {
-   *         volume = amplitude.getLevel();
-   *      }
-   *   </code></div>
+   *  @for p5.sound:Amplitude
+   *  @method getLevel
+   *  @return {Number}       Amplitude as a number between 0.0 and 1.0
+   *  @example
+   *  <div><code>
+   *  function setup() { 
+   *    amplitude = new Amplitude();
+   *  }
+   *  function draw() {
+   *    volume = amplitude.getLevel();
+   *  }
+   *  </code></div>
    */
   p5.prototype.Amplitude.prototype.getLevel = function() {
     if (this.normalize) {
@@ -1797,19 +1681,17 @@ var p5SOUND = (function(){
 // =============================================================================
 
   /**
-   * Similar to p5.dom createCapture() but for audio, without
-   * creating a DOM element.
+   *  Similar to p5.dom createCapture() but for audio, without
+   *  creating a DOM element.
    *
-   * @for    p5.sound:AudioIn
-   * @method new AudioIn
-   * @return {Object} capture
-   * @example
-   *  <div>
-   *    <code>
-   *      mic = new AudioIn()
-   *      mic.on();
-   *    </code>
-   *   </div>
+   *  @for    p5.sound:AudioIn
+   *  @method new AudioIn
+   *  @return {Object} capture
+   *  @example
+   *  <div><code>
+   *  mic = new AudioIn()
+   *  mic.on();
+   *  </code></div>
    */
   p5.prototype.AudioIn = function() {
     // set up audio input


### PR DESCRIPTION
I had a couple private callbacks that made it possible for users to do things like this:

```
function setup(){
  sound = loadSound('sound.mp3');
  sound.play();
}
```

If play() was called before a sound loads, the play() method would load the sound buffer with the private play_now() function as the callback. I thought this could be a useful alternative to preload(), and it was a fun experiment. But I think this hides what's going on behind the scenes, rather than teach users about the way JavaScript works. Preload() is much more effective, and another option could just be confusing, so I'm removing this little experiment.
