### PR TITLE
Adding chainability to p5 DOM Element methods.

### DIFF
--- a/lib/addons/p5.dom.js
+++ b/lib/addons/p5.dom.js
@@ -398,6 +398,7 @@ var p5DOM = (function(){
     } else {
       this.elt.className = c;
     }
+    return this;
   }
 
   /**
@@ -411,6 +412,7 @@ var p5DOM = (function(){
     var regex = new RegExp('(?:^|\\s)'+c+'(?!\\S)');
     this.elt.className = this.elt.className.replace(regex, '');
     this.elt.className = this.elt.className.replace(/^\s+|\s+$/g, ""); //prettify (optional)
+    return this;
   }
 
   /**
@@ -427,6 +429,7 @@ var p5DOM = (function(){
       c = document.getElementById(c);
     }
     this.elt.appendChild(c);
+    return this;
   };
 
 
@@ -440,6 +443,7 @@ var p5DOM = (function(){
    */
   p5.Element.prototype.html = function(html) {
     this.elt.innerHTML = html;
+    return this;
   };
 
   /**
@@ -456,6 +460,7 @@ var p5DOM = (function(){
     this.elt.style.position = 'absolute';
     this.elt.style.left = x+'px';
     this.elt.style.top = y+'px';
+    return this;
   };
 
   /**
@@ -474,6 +479,7 @@ var p5DOM = (function(){
       return this.elt.style[prop];
     } else {
       this.elt.style[prop] = val;
+      return this;
     }
   };
 
@@ -494,6 +500,7 @@ var p5DOM = (function(){
       return this.elt.getAttribute(attr);
     } else {
       this.elt.setAttribute(attr, value);
+      return this;
     }
   };
 
@@ -509,6 +516,7 @@ var p5DOM = (function(){
   p5.Element.prototype.value = function() {
     if (arguments.length > 0) {
       this.elt.value = arguments[0];
+      return this;
     } else {
       if (this.elt.type === 'range') {
         return parseFloat(this.elt.value);
@@ -525,6 +533,7 @@ var p5DOM = (function(){
    */
   p5.Element.prototype.show = function() {
     this.elt.style.display = 'block';
+    return this;
   };
 
   /**
@@ -534,6 +543,7 @@ var p5DOM = (function(){
    */
   p5.Element.prototype.hide = function() {
     this.elt.style.display = 'none';
+    return this;
   };
 
   /**
@@ -574,6 +584,7 @@ var p5DOM = (function(){
         }
       }
     }
+    return this;
   };
 
   /**


### PR DESCRIPTION
As explained in https://github.com/processing/p5.js/issues/227#issuecomment-51721245

Adding this **chain** ability makes **p5js** more _jQueryesque_. It should make learner to think more in mode `<javascript>` than in mode `<processing>`.

Lastly, I didn't find DOM library in the `src` folder so I worked directly in `lib/addons/p5.dom.js`. Make me know if should have done otherwise.
