### PR TITLE
remove func fix for p5js.org

### DIFF
--- a/src/core/core.js
+++ b/src/core/core.js
@@ -329,8 +329,11 @@ define(function (require) {
         }
 
         // call any registered remove functions
-        this._registeredMethods.remove.forEach(function(f) {
-          f.call(this);
+        var self = this;
+        this._registeredMethods.remove.forEach(function (f) {
+          if (typeof(f) !== 'undefined') {
+            f.call(self);
+          }
         });
 
         // remove window bound properties and methods
@@ -353,7 +356,7 @@ define(function (require) {
           }
         }
       }
-      window.p5 = undefined;
+      // window.p5 = undefined;
     }.bind(this);
 
 


### PR DESCRIPTION
This fixes an issue with restarting the example sketches on p5js.org. I'm not sure if it's the best fix in the long run, but hey, it works!
