### PR TITLE
Context font is now updated whenever text properties are set.

### DIFF
--- a/src/typography/attributes.js
+++ b/src/typography/attributes.js
@@ -116,6 +116,7 @@ define(function (require) {
    */
   p5.prototype.textSize = function(s) {
     this._setProperty('_textSize', s);
+    this._applyTextProperties();
   };
 
   /**
@@ -147,6 +148,7 @@ define(function (require) {
       s === constants.ITALIC ||
       s === constants.BOLD) {
       this._setProperty('_textStyle', s);
+      this._applyTextProperties();
     }
   };
 
@@ -169,6 +171,15 @@ define(function (require) {
    */
   p5.prototype.textWidth = function(s) {
     return this.drawingContext.measureText(s).width;
+  };
+
+  /**
+   * Helper fxn to apply text properties. 
+   *
+   */
+  p5.prototype._applyTextProperties = function () {
+    var str = this._textStyle + ' ' + this._textSize + 'px ' + this._textFont;
+    this.drawingContext.font = str;
   };
 
   return p5;

--- a/src/typography/loading_displaying.js
+++ b/src/typography/loading_displaying.js
@@ -54,8 +54,6 @@ define(function (require) {
    * </div>
    */
   p5.prototype.text = function () {
-    var str = this._textStyle + ' ' + this._textSize + 'px ' + this._textFont;
-    this.drawingContext.font = str;
     if (arguments.length === 3) {
       if (this._doFill) {
         this.drawingContext.fillText(arguments[0], arguments[1], arguments[2]);
@@ -119,6 +117,7 @@ define(function (require) {
    */
   p5.prototype.textFont = function(str) {
     this._setProperty('_textFont', str); //pend temp?
+    this._applyTextProperties();
   };
 
   return p5;


### PR DESCRIPTION
Fix for #356, but doesn't address the issues that emerged about textHeight, etc.
