### PR TITLE
adding bower manifest

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,12 +1,12 @@
 {
   "name": "p5.js",
   "version": "0.3.6",
+  "main": "lib/p5.min.js",
   "homepage": "http://p5js.org/",
   "authors": [
     "Lauren lmccart McCarthy"
   ],
   "description": "A JS client-side library for creating graphic and interactive experiences, based on the core principles of Processing.",
-  "main": "lib/p5.min.js",
   "keywords": [
     "javascript",
     "p5",


### PR DESCRIPTION
I think this could be a starter for adding p5.js to bower. Like requested in issue #371 
I'm not sure if this is enough but worth a try.  
To push it to the registry it only needs:  

```
# if bower is not installed  
npm install -g bower
# then
bower register p5js https://github.com/lmccart/p5.js.git  
```
