### PR TITLE
Setting font defaults for new canvases/graphics per #356

### DIFF
--- a/src/objects/p5.Graphics.js
+++ b/src/objects/p5.Graphics.js
@@ -57,6 +57,7 @@ define(function(require) {
     this.drawingContext.fillStyle = '#FFFFFF';
     this.drawingContext.strokeStyle = '#000000';
     this.drawingContext.lineCap = constants.ROUND;
+    this.drawingContext.font = 'normal 12px sans-serif';
   };
 
   p5.Graphics.prototype = Object.create(p5.Element.prototype);


### PR DESCRIPTION
This isn't ideal because there's a disconnect between the defaults here and the defaults in typography/attributes.js. It's minor, but it would be nice for them to connect. I'm thinking this could emerge from work on p5.Font?
