### PR TITLE
Ellipse now allows negative width and height.

### DIFF
--- a/src/shape/2d_primitives.js
+++ b/src/shape/2d_primitives.js
@@ -130,6 +130,11 @@ define(function (require) {
     if (!this._doStroke && !this._doFill) {
       return;
     }
+
+    // processing supports negative width and heights for ellipses
+    w = Math.abs(w);
+    h = Math.abs(h);
+
     var ctx = this.drawingContext;
     var vals = canvas.modeAdjust(
       x,


### PR DESCRIPTION
Made ellipse primitive take absolute of specified width and height such that it now no longer throws an error when negative sizes are specified. #413
