### PR TITLE
removing console.log from style() method

### DIFF
--- a/lib/addons/p5.dom.js
+++ b/lib/addons/p5.dom.js
@@ -557,7 +557,7 @@ var p5DOM = (function(){
           this.elt.style[parts[0].trim()] = parts[1].trim();
         }
       }
-      console.log(this.elt.style)
+      // console.log(this.elt.style)
     } else {
       this.elt.style[prop] = val;
     }


### PR DESCRIPTION
This is a minor thing but when running examples in class the automatic console logging in `style()` is getting in the way.
