### PR TITLE
document that loadImage callback is optional

### DIFF
--- a/src/image/loading_displaying.js
+++ b/src/image/loading_displaying.js
@@ -22,10 +22,10 @@ define(function (require) {
    * callback, or place the loadImage() call in preload().
    *
    * @method loadImage
-   * @param  {String}   path
-   * @param  {Function} callback Function to be called once the image is
-   *                             loaded. Will be passed the p5.Image.
-   * @return {p5.Image}            the p5.Image object
+   * @param  {String} path Path of the image to be loaded
+   * @param  {Function(p5.Image)} [callback]   Function to be called once the image is
+   *                                 loaded. Will be passed the p5.Image.
+   * @return {p5.Image}              the p5.Image object
    */
   p5.prototype.loadImage = function(path, callback) {
     var img = new Image();


### PR DESCRIPTION
Fixes lmccart/p5js.org#71 .
I am not sure if it is a good idea to document the type as `{Function(p5.Image)}` to kinda show that the callback will return an image. If you like this idea, I can extend it to other functions, so they might look like `{Function(Error,p5.SomeOtherType)}` or `{Function(Number,String)}`. Otherwise I'll just re-send a pull request with just the optional part changed.

Once this one is accepted/rejected, I can send a larger pull request checking which callbacks are optional for the rest of the documentation. 
