### PR TITLE
Change _downKeys from Array to Object

### DIFF
--- a/lib/p5.js
+++ b/lib/p5.js
@@ -3000,11 +3000,7 @@ var inputfiles = function (require, core, reqwest) {
 var inputkeyboard = function (require, core) {
     'use strict';
     var p5 = core;
-
-    //p5.prototype._downKeys = [];
     p5.prototype._downKeys = {};
-    //p5.prototype._downKeys = new Set();
-
     p5.prototype.isKeyPressed = false;
     p5.prototype.keyIsPressed = false;
     p5.prototype.key = '';
@@ -3013,16 +3009,7 @@ var inputkeyboard = function (require, core) {
       this._setProperty('isKeyPressed', true);
       this._setProperty('keyIsPressed', true);
       this._setProperty('keyCode', e.which);
-
-      /* Array add */
-      //~this._downKeys.indexOf(e.which) || this._downKeys.push(e.which);
-
-      /* Object add */
       this._downKeys[e.which] = true;
-
-      /* Set add */
-      //this._downKeys.add(e.which);
-
       var key = String.fromCharCode(e.which);
       if (!key) {
         key = e.which;
@@ -3040,18 +3027,8 @@ var inputkeyboard = function (require, core) {
       var keyReleased = this.keyReleased || window.keyReleased;
       this._setProperty('isKeyPressed', false);
       this._setProperty('keyIsPressed', false);
-
-      /* Array remove */
-      //const idx = this._downKeys.indexOf(e.which);
-      //~idx && this._downKeys.splice(idx, 1);
-
-      /* Object remove */
-      //delete this._downKeys[e.which];
       this._downKeys[e.which] = false;
-
-      /* Set remove */
-      //this._downKeys.delete(e.which);
-
+      //delete this._downKeys[e.which];
       var key = String.fromCharCode(e.which);
       if (!key) {
         key = e.which;
@@ -3077,14 +3054,7 @@ var inputkeyboard = function (require, core) {
       }
     };
     p5.prototype.keyIsDown = function (code) {
-      /* Array check */
-      //return this._downKeys.indexOf(code) != -1;
-
-      /* Object check */
       return this._downKeys[code];
-
-      /* Set check */
-      //return this._downKeys.has(code);
     };
     return p5;
   }({}, core);


### PR DESCRIPTION
Submited these to https://github.com/limikael/p5.js/pull/1 but @limikael had no time to analyze and commit them!
Changed `Array` to `Object` as @hamoid advised @ https://github.com/lmccart/p5.js/pull/411#issuecomment-64721647.
Kept `Array` & `Set` commented out so it's easier to toggle among any of them in the future!  ^_^
