### PR TITLE
Add separate test suite for color(r,g,b) and color(r,g,b,a)

### DIFF
--- a/test/unit/objects/p5.Color.js
+++ b/test/unit/objects/p5.Color.js
@@ -5,9 +5,9 @@ suite('p5.Color', function() {
   });
   var c;
 
-  suite('p5.prototype.color(a,b,c)', function() {
+  suite('p5.prototype.color(r,g,b)', function() {
     setup(function() {
-      c = myp5.color(10, 20, 30, 255);
+      c = myp5.color(10, 20, 30);
     });
     test('should create instance of p5.Color', function() {
       assert.instanceOf(c, p5.Color);
@@ -36,6 +36,41 @@ suite('p5.Color', function() {
 
     test('should correctly render color string', function() {
       assert.equal(c.toString(), 'rgba(10,20,30,1)');
+    });
+  });
+
+  suite('p5.prototype.color(r,g,b,a)', function() {
+    setup(function() {
+      c = myp5.color(10, 20, 30, 51);
+    });
+    test('should create instance of p5.Color', function() {
+      assert.instanceOf(c, p5.Color);
+    });
+
+    test('should correctly set RGBA property', function() {
+      assert.deepEqual(c.rgba, [10, 20, 30, 51]);
+    });
+
+    test('should correctly set HSBA property', function() {
+      assert.deepEqual(c.hsba, [149, 170, 30, 51] );
+    });
+
+    test('should correctly set RGBA values', function() {
+      assert.equal(c.getRed(), 10);
+      assert.equal(c.getGreen(), 20);
+      assert.equal(c.getBlue(), 30);
+      assert.equal(c.getAlpha(), 51);
+    });
+
+    test('should correctly set HSB values', function() {
+      assert.equal(c.getHue(), 149);
+      assert.equal(c.getSaturation(), 170);
+      assert.equal(c.getBrightness(), 30);
+      assert.equal(c.getAlpha(), 51);
+    });
+
+    test('should correctly render color string', function() {
+      assert.equal(c.toString(), 'rgba(10,20,30,0.2)');
     });
   });
 
@@ -71,7 +106,7 @@ suite('p5.Color', function() {
   });
 
   suite('new p5.Color with Base 1 colors', function() {
-    var base_1_rgba = [0.2, 0.4, 0.6, 0.5]; 
+    var base_1_rgba = [0.2, 0.4, 0.6, 0.5];
     var base_255_rgba = [51, 102, 153, 127.5];
 
     setup(function() {


### PR DESCRIPTION
I'm trying to catch up on what's happened with the color module in the months since I looked at it, and I noticed that the tests for `color(a,b,c)` were implicitly testing `color(r,g,b)` and checking the rgba results. This set of tests clarifies and validates that both `color(r,g,b)` and `color(r,g,b,a)` work and are properly parsed.