### PR TITLE
Minor fix for touchX, touchY, ptouchX, ptouchY docs

### DIFF
--- a/src/input/touch.js
+++ b/src/input/touch.js
@@ -10,7 +10,7 @@ define(function (require) {
 
   var p5 = require('core');
 
-  /**
+/**
    * The system variable touchX always contains the horizontal position of
    * one finger, relative to (0, 0) of the canvas. This is best used for
    * single touch interactions. For multi-touch interactions, use the
@@ -21,9 +21,8 @@ define(function (require) {
   p5.prototype.touchX = 0;
 
   /**
-   * The system variable touchY always contains the horizontal position of
-   * one finger, relative to (0, 0) of the canvas in the frame previous to the
-   * current frame. This is best used for
+   * The system variable touchY always contains the vertical position of
+   * one finger, relative to (0, 0) of the canvas. This is best used for
    * single touch interactions. For multi-touch interactions, use the
    * touches[] array.
    *
@@ -32,20 +31,20 @@ define(function (require) {
   p5.prototype.touchY = 0;
 
   /**
-   * The system variable touchY always contains the horizontal position of
-   * one finger, relative to (0, 0) of the canvas in the frame previous to the
-   * current frame. This is best used for
-   * single touch interactions. For multi-touch interactions, use the
-   * touches[] array.
+   * The system variable ptouchX always contains the horizontal position of
+   * one finger, relative to (0, 0) of the canvas, in the frame previous to the
+   * current frame. This is best used for single touch interactions.
+   * For multi-touch interactions, use the touches[] array.
    *
    * @property ptouchX
    */
   p5.prototype.ptouchX = 0;
 
   /**
-   * The system variable pmouseY always contains the vertical position of the
-   * mouse in the frame previous to the current frame, relative to (0, 0) of
-   * the canvas.
+   * The system variable pmouseY always contains the vertical position of
+   * one finger, relative to (0, 0) of the canvas, in the frame previous to the
+   * current frame. This is best used for single touch interactions.
+   * For multi-touch interactions, use the touches[] array.
    *
    * @property ptouchY
    */

--- a/src/input/touch.js
+++ b/src/input/touch.js
@@ -41,7 +41,7 @@ define(function (require) {
   p5.prototype.ptouchX = 0;
 
   /**
-   * The system variable pmouseY always contains the vertical position of
+   * The system variable ptouchY always contains the vertical position of
    * one finger, relative to (0, 0) of the canvas, in the frame previous to the
    * current frame. This is best used for single touch interactions.
    * For multi-touch interactions, use the touches[] array.

--- a/src/input/touch.js
+++ b/src/input/touch.js
@@ -33,8 +33,7 @@ define(function (require) {
   /**
    * The system variable ptouchX always contains the horizontal position of
    * one finger, relative to (0, 0) of the canvas, in the frame previous to the
-   * current frame. This is best used for single touch interactions.
-   * For multi-touch interactions, use the touches[] array.
+   * current frame.
    *
    * @property ptouchX
    */
@@ -43,8 +42,7 @@ define(function (require) {
   /**
    * The system variable ptouchY always contains the vertical position of
    * one finger, relative to (0, 0) of the canvas, in the frame previous to the
-   * current frame. This is best used for single touch interactions.
-   * For multi-touch interactions, use the touches[] array.
+   * current frame.
    *
    * @property ptouchY
    */


### PR DESCRIPTION
The documentation for the various touchX & touchY was copy-pasted and at times duplicated.  I've just gone in and made sure that horizontal/vertical and the names were correct across all four functions.