### PR TITLE
bump version number in bower.json

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "p5.js",
-  "version": "0.3.7",
+  "version": "0.4.4",
   "main": "lib/p5.min.js",
   "homepage": "http://p5js.org/",
   "authors": [


### PR DESCRIPTION
p5's bower.json says it's at version 0.3.7, while the current release is actually 0.4.4.

After adding p5 as a dependency for my project and running `bower install`, I get a warning about the version mismatch.

Seems like a minor thing, but I figured it was an easy fix to submit.

```
$ bower install
bower p5.js#0.4.4           not-cached git://github.com/processing/p5.js.git#0.4.4
bower p5.js#0.4.4              resolve git://github.com/processing/p5.js.git#0.4.4
bower p5.js#0.4.4             download https://github.com/processing/p5.js/archive/0.4.4.tar.gz
bower p5.js#0.4.4              extract archive.tar.gz
bower p5.js#0.4.4             mismatch Version declared in the json (0.3.7) is different than the resolved one (0.4.4)
bower p5.js#0.4.4             resolved git://github.com/processing/p5.js.git#0.4.4
bower p5.js#0.4.4              install p5.js#0.4.4
```

My project's `bower.json` looks like this:
```json
{
  "name": "heartbeat",
  "version": "0.0.0",
  "authors": [
    "Alex Dean <alex@crackpot.org>"
  ],
  "moduleType": [
    "globals"
  ],
  "license": "MIT",
  "ignore": [
    "**/.*",
    "node_modules",
    "bower_components",
    "test",
    "tests"
  ],
  "dependencies": {
    "p5.js": "git://github.com/processing/p5.js#0.4.4"
  }
}
```