### PR TITLE
Lerping Color Correctly

### DIFF
--- a/lib/p5.js
+++ b/lib/p5.js
@@ -2103,17 +2103,17 @@ amdclean['colorcreating_reading'] = function (require, core, p5Color) {
     if (c1 instanceof Array) {
       var c = [];
       for (var i = 0; i < c1.length; i++) {
-        c.push(p5.prototype.lerp(c1[i], c2[i], amt));
+        c.push(Math.sqrt(p5.prototype.lerp(c1[i]*c1[i], c2[i]*c2[i], amt)));
       }
       return c;
     } else if (c1 instanceof p5.Color) {
       var pc = [];
       for (var j = 0; j < 4; j++) {
-        pc.push(p5.prototype.lerp(c1.rgba[j], c2.rgba[j], amt));
+        pc.push(Math.sqrt(p5.prototype.lerp(c1.rgba[j]*c1.rgba[j], c2.rgba[j]*c2.rgba[j], amt)));
       }
       return new p5.Color(this, pc);
     } else {
-      return p5.prototype.lerp(c1, c2, amt);
+      return Math.sqrt(p5.prototype.lerp(c1*c1, c2*c2, amt));
     }
   };
   p5.prototype.red = function (c) {

--- a/lib/p5.js
+++ b/lib/p5.js
@@ -2100,6 +2100,7 @@ amdclean['colorcreating_reading'] = function (require, core, p5Color) {
     return c.getHue();
   };
   p5.prototype.lerpColor = function (c1, c2, amt) {
+    amt = Math.max(Math.min(amt, 1), 0);
     if (c1 instanceof Array) {
       var c = [];
       for (var i = 0; i < c1.length; i++) {


### PR DESCRIPTION
RGB color values actually represent the square root of the displayed color, not the color itself. Your monitor squares all the color values before displaying it.

This means that when interpolating between two colors, one must first square the individual values before mixing, and then take the square root, as explained here: https://www.youtube.com/watch?v=LKnqECcg6Gw
I think this looks significantly better! This patch fixes lerpColor to the correct approach. Here is an example:

OLD lerpColor from rgb(0,255,0) to rgb(255,0,0)
![screenshot 2015-05-08 20 55 45](https://cloud.githubusercontent.com/assets/181043/7548596/a3f6e1ba-f5c4-11e4-9acd-5b142e82c56f.png)

NEW lerpColor  from rgb(0,255,0) to rgb(255,0,0)
![screenshot 2015-05-08 20 55 31](https://cloud.githubusercontent.com/assets/181043/7548597/ac86aac2-f5c4-11e4-89fc-511450d59371.png)

