### PR TITLE
Better documentation of the pixels array.

### DIFF
--- a/src/image/pixels.js
+++ b/src/image/pixels.js
@@ -13,15 +13,18 @@ define(function (require) {
   require('p5.Color');
 
   /**
-   * Array containing the values for all the pixels in the display window.
-   * These values are numbers. This array is the size of the display window x4,
-   * representing the R, G, B, A values in order for each pixel, moving from 
-   * left to right across each row, then down each column. For example, 
-   * if the image is 100x100 pixels, there will be 40000. The first four values
-   * (indices 0-3) in the array will be the R, G, B, A values of the pixel at 
-   * (0, 0). The second four values (indices 4-7) will contain the R, G, B, A
-   * values of the pixel at (1, 0). More generally, to set values for a pixel
-   * at (x, y): 
+   * <a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference
+   * /Global_Objects/Uint8ClampedArray' target='_blank'>Uint8ClampedArray</a>
+   * containing the values for all the pixels in the display
+   * window. These values are numbers. This array is the size of the display 
+   * window x4, representing the R, G, B, A values in order for each pixel, 
+   * moving from left to right across each row, then down each column. For 
+   * example, if the image is 100x100 pixels, there will be 40000. The 
+   * first four values (indices 0-3) in the array will be the R, G, B, A  
+   * values of the pixel at (0, 0). The second four values (indices 4-7) will 
+   * contain the R, G, B, A values of the pixel at (1, 0). More generally, to 
+   * set values for a pixel at (x, y): 
+   * <br>
    * <code>pixels[y*width+x] = r; 
    * pixels[y*width+x+1] = g;
    * pixels[y*width+x+2] = b;
@@ -30,6 +33,11 @@ define(function (require) {
    * Before accessing this array, the data must loaded with the loadPixels()
    * function. After the array data has been modified, the updatePixels()
    * function must be run to update the changes.
+   * <br><br>
+   * Note that this is not a standard javascript array.  This means that 
+   * standard javascript functions such as <code>slice()</code> or 
+   * <code>arrayCopy()</code> do not
+   * work.
    *
    * @property pixels[]   
    * @example


### PR DESCRIPTION
Modified the documentation to explicitly state that `pixels[]` is not a standard JS array.  See #478 for context.