### PR TITLE
Better documentation for loadTable.

### DIFF
--- a/src/input/files.js
+++ b/src/input/files.js
@@ -203,7 +203,12 @@ define(function (require) {
    * </p>
    *
    * <p>When passing in multiple options, pass them in as separate parameters,
-   * seperated by commas. For example: "csv, header".</p>
+   * seperated by commas. For example:
+   * <br><br>
+   * <code>
+   *   loadTable("my_csv_file.csv", "csv", "header")
+   * </code>
+   * </p>
    *
    * <p> All files loaded and saved use UTF-8 encoding.</p>
    *


### PR DESCRIPTION
There was a typo in the loadTable docs parameter string example. 