### PR TITLE
Text metrics

### DIFF
--- a/examples/async/loadFont/global/sketch.js
+++ b/examples/async/loadFont/global/sketch.js
@@ -1,15 +1,12 @@
-// In this example, we want to load a font
-// image and use it in setup().
+// In this example, we want to load a font image and use it in setup().
 //
 // Since setup() happens quickly at the beginning, the font doesn't
 // have time to properly load before setup() is done.
 //
-// We are introducing preload() where you can run load
-// operations that are guaranteed to complete by setup().
-// This is called asynchronous loading, because it happens whenever
-// the computer is done and ready, not necessarily when you call it.
-
-var font1, font2, x=30, y=80, words = 'cean eans';
+// So we use preload() for this type of load operations, which guarantees
+// such functions will complete before setup() is called.
+//
+var font1, font2, x=30, y=80, words = 'Green Ideas';
 
 function preload() {
   font1 = loadFont('SourceSansPro-Regular.otf');
@@ -20,6 +17,7 @@ function setup() {
 
   createCanvas(400, 200);
 
+  fill(0,100,0);
   textFont(font1, 58);
   text(words, x, y);
 
@@ -34,15 +32,14 @@ function setup() {
   line(0,y+descent,width,y+descent);
   line(x,0,x,200);
 
-  var tb = font1.textBounds(words, x, y); // tight
+  var tb = font1.textBounds(words, x, y); // tight bounds
   noFill();
   stroke(200,0,0);
   rect(tb.x,tb.y,tb.w,tb.h);
 
-  //fill(0);
   fill(100);
   stroke(100,0,0);
   textSize(40);
   textFont(font2);
-  text('sleep furiously', x+20, y+80);
+  text('sleep furiously', x+20, y+60);
 };

--- a/examples/async/loadFont/global/sketch.js
+++ b/examples/async/loadFont/global/sketch.js
@@ -6,7 +6,7 @@
 // So we use preload() for this type of load operations, which guarantees
 // such functions will complete before setup() is called.
 //
-var font1, font2, x=30, y=80, words = 'Green Ideas';
+var font1, font2, x=30, y=80, words = 'green ideas';
 
 function preload() {
   font1 = loadFont('SourceSansPro-Regular.otf');

--- a/examples/p5.Font/opentype/index.html
+++ b/examples/p5.Font/opentype/index.html
@@ -1,6 +1,6 @@
 <html>
 <head>
-  <script language="javascript" type="text/javascript" src="../../../lib/p5.min.js"></script>
+  <script language="javascript" type="text/javascript" src="../../../lib/p5.js"></script>
   <script language="javascript" type="text/javascript" src="sketch.js"></script>
   <style> body {padding: 0; margin: 0;}</style>
 </head>

--- a/examples/p5.Font/opentype/sketch.js
+++ b/examples/p5.Font/opentype/sketch.js
@@ -11,13 +11,14 @@ function setup() {
   createCanvas(720, 480);
   frameRate(24);
   fill(255);
+  textSize(150);
 }
 
 function draw() {
 
   background(237,34,93);
 
-  var path = font._getPath('p5*js', 170, 275, 150);
+  var path = font._getPath('p5*js', 170, 275);
   doSnap(path, snapDistance);
   font._renderPath(path);
 

--- a/examples/p5.Font/opentype/sketch.js
+++ b/examples/p5.Font/opentype/sketch.js
@@ -1,54 +1,54 @@
 var font;
-var snapDistance = 72;
-var textToRender = "p5*js";
-var opFont;
+var snapDistance = 71;
 
-function preload(){
+function preload() {
+
   font = loadFont('AvenirNextLTPro-Demi.otf');
 }
 
-function setup(){
+function setup() {
+
   createCanvas(720, 480);
-  opFont = font.font;
   frameRate(24);
+  fill(255);
 }
 
 function draw() {
+
   background(237,34,93);
 
-  if( snapDistance == -25) {
-    snapDistance = 68;
+  var path = font._getPath('p5*js', 170, 275, 150);
+  doSnap(path, snapDistance);
+  font._renderPath(path);
+
+  if (--snapDistance == -26) {
+    snapDistance = 67;
   }
-
-  var path = opFont.getPath(textToRender, 170, 275, 150, {kerning: true});
-  path.fill = "#ffffff";
-  var value = (snapDistance <= 0) ? 1: snapDistance;
-  doSnap(path, value);
-  path.draw(this.drawingContext);
-
-  snapDistance--;
 }
 
-function doSnap(path, value) {
-    var i;
+function doSnap(path, dist) {
+
+    var i, value = (dist <= 0) ? 1: dist;
+
     for (i = 0; i < path.commands.length; i++) {
         var cmd = path.commands[i];
         if (cmd.type !== 'Z') {
-            cmd.x = snap(cmd.x, value, 1);
-            cmd.y = snap(cmd.y, value, 1);
+            cmd.x = snap(cmd.x, value);
+            cmd.y = snap(cmd.y, value);
         }
         if (cmd.type === 'Q' || cmd.type === 'C') {
-            cmd.x1 = snap(cmd.x1, value, 1);
-            cmd.y1 = snap(cmd.y1, value, 1);
+            cmd.x1 = snap(cmd.x1, value);
+            cmd.y1 = snap(cmd.y1, value);
         }
         if (cmd.type === 'C') {
-            cmd.x2 = snap(cmd.x2, value, 1);
-            cmd.y2 = snap(cmd.y2, value, 1);
+            cmd.x2 = snap(cmd.x2, value);
+            cmd.y2 = snap(cmd.y2, value);
         }
     }
 }
 
 // Round a value to the nearest "step".
-function snap(v, distance, strength) {
-    return (v * (1.0 - strength)) + (strength * Math.round(v / distance) * distance);
+function snap(v, distance) {
+
+    return Math.round(v / distance) * distance;
 }

--- a/src/core/p5.Graphics2D.js
+++ b/src/core/p5.Graphics2D.js
@@ -1117,7 +1117,8 @@ define(function(require) {
 
     if (p._isOpenType()) {
 
-      return p._textFont.textBounds(s, 0, 0).w;
+      var tb = p._textFont.textBounds(s, 0, 0);
+      return tb.w + tb.advance;
     }
 
     return this.drawingContext.measureText(s).width;

--- a/src/typography/loading_displaying.js
+++ b/src/typography/loading_displaying.js
@@ -116,17 +116,6 @@ define(function(require) {
    */
   p5.prototype.textFont = function(theFont, theSize) {
 
-    this._validateParameters(
-      'textFont',
-      arguments,
-      [
-        ['String' ],
-        ['Object' ],
-        ['String', 'Number' ],
-        ['Object', 'Number' ]
-      ]
-    );
-
     if (arguments.length) {
 
       if (!theFont) {

--- a/src/typography/p5.Font.js
+++ b/src/typography/p5.Font.js
@@ -27,7 +27,6 @@ define(function(require) {
   var p5 = require('core/core');
   var constants = require('core/constants');
 
-
   /**
    * Base class for font handling
    * @class p5.Font
@@ -38,6 +37,8 @@ define(function(require) {
 
     this.parent = p;
 
+    this.cache = {};
+
     /**
      * Underlying opentype font implementation
      * @property font
@@ -45,12 +46,26 @@ define(function(require) {
     this.font = undefined;
   };
 
+
   /**
+   * Returns the set of opentype glyphs for the supplied string.
+   * Note that there is not a strict one-to-one mapping between characters
+   * and glyphs, so the list of returned glyphs can be larger or smaller
+   *  than the length of the given string.
+   *
+   * @param  {string} str the string to be converted
+   * @return {array}     the opentype glyphs
+   */
+  p5.Font.prototype._getGlyphs = function(str) {
+    return this.font.stringToGlyphs(str);
+  };
+
+  /*
    * Renders a set of glyph paths to the current graphics context
    */
   p5.Font.prototype._renderPath = function(line, x, y, fontSize, options) {
 
-    var pathdata, p = this.parent, pg = p._graphics, ctx = pg.drawingContext,
+    var pdata, p = this.parent, pg = p._graphics, ctx = pg.drawingContext,
       textWidth, textHeight, textAscent, textDescent;
 
     fontSize = fontSize || p._textSize;
@@ -75,11 +90,11 @@ define(function(require) {
       y -= textDescent;
     }
 
-    pathdata = this.font.getPath(line, x, y, fontSize, options).commands;
+    pdata = this.font.getPath(line, x, y, fontSize, options).commands;
 
     ctx.beginPath();
-    for (var i = 0; i < pathdata.length; i += 1) {
-      var cmd = pathdata[i];
+    for (var i = 0; i < pdata.length; i += 1) {
+      var cmd = pdata[i];
       if (cmd.type === 'M') {
         ctx.moveTo(cmd.x, cmd.y);
       } else if (cmd.type === 'L') {
@@ -142,9 +157,7 @@ define(function(require) {
    * </code>
    * </div>
    */
-  p5.Font.prototype.textBounds = function(str, x, y, fontSize) {
-
-    //console.log('textBounds::',str, x, y, fontSize);
+  p5.Font.prototype.textBounds = function(str, x, y, fontSize, options) {
 
     if (!this.parent._isOpenType()) {
 
@@ -155,37 +168,97 @@ define(function(require) {
     y = y !== undefined ? y : 0;
     fontSize = fontSize || this.parent._textSize;
 
-    var xCoords = [],
-      yCoords = [], minX, minY, maxX, maxY,
-      scale = 1 / this.font.unitsPerEm * fontSize;
+    //console.log('textBounds(',str, x, y, fontSize,")");
 
-    this.font.forEachGlyph(str, x, y, fontSize, {},
-      function(glyph, gX, gY) {
+    var result = this.cache[cacheKey('textBounds', str, x, y, fontSize)];
+    if (!result) {
 
-        if (glyph.name !== 'space') {
+      // console.log('computing');
 
-          gX = gX !== undefined ? gX : 0;
-          gY = gY !== undefined ? gY : 0;
+      var xCoords = [],
+        yCoords = [], minX, minY, maxX, maxY,
+        scale = 1 / this.font.unitsPerEm * fontSize;
 
-          var gm = glyph.getMetrics();
-          xCoords.push(gX + (gm.xMin * scale));
-          yCoords.push(gY + (-gm.yMin * scale));
-          xCoords.push(gX + (gm.xMax * scale));
-          yCoords.push(gY + (-gm.yMax * scale));
+      this.font.forEachGlyph(str, x, y, fontSize, options,
+        function(glyph, gX, gY, gFontSize) {
+
+          if (glyph.name !== 'space') {
+
+            gX = gX !== undefined ? gX : 0;
+            gY = gY !== undefined ? gY : 0;
+
+            var gm = glyph.getMetrics();
+            xCoords.push(gX + (gm.xMin * scale));
+            yCoords.push(gY + (-gm.yMin * scale));
+            xCoords.push(gX + (gm.xMax * scale));
+            yCoords.push(gY + (-gm.yMax * scale));
+          }
+        });
+
+      minX = Math.min.apply(null, xCoords);
+      minY = Math.min.apply(null, yCoords);
+      maxX = Math.max.apply(null, xCoords);
+      maxY = Math.max.apply(null, yCoords);
+
+      result = {
+        x: minX,
+        y: minY,
+        h: maxY - minY,
+        w: (maxX - minX),
+        advance: minX - x
+      };
+
+      this.cache[cacheKey('textBounds', str, x, y, fontSize)] = result;
+    }
+    //else { console.log('cache-hit'); }
+
+    return result;
+  };
+
+  p5.Font.prototype._drawPoints = function(str, tx, ty, fsize, options) {
+
+    var pdata, onCurvePts, offCurvePts, p = this.parent,
+      scale = (1 / this.font.unitsPerEm) * fsize;
+
+    tx = tx !== undefined ? tx : 0;
+    ty = ty !== undefined ? ty : 0;
+    fsize = fsize || p._textSize;
+
+    this.font.forEachGlyph(str, tx, ty, fsize, options,
+      function(glyph, x, y, fontSize) {
+
+        onCurvePts = [];
+        offCurvePts = [];
+        pdata = glyph.path.commands;
+
+        for (var i = 0; i < pdata.length; i += 1) {
+
+          var cmd = pdata[i];
+          if (cmd.x !== undefined) {
+            onCurvePts.push({ x: cmd.x, y: -cmd.y });
+          }
+
+          if (cmd.x1 !== undefined) {
+            offCurvePts.push({ x: cmd.x1, y: -cmd.y1 });
+          }
+
+          if (cmd.x2 !== undefined) {
+            offCurvePts.push({ x: cmd.x2, y: -cmd.y2 });
+          }
         }
+
+        p.noStroke();
+        p.fill(0,0,255);
+        drawCircles(onCurvePts, x, y, scale);
+        p.fill(255,0,0);
+        drawCircles(offCurvePts, x, y, scale);
       });
 
-    minX = Math.min.apply(null, xCoords);
-    minY = Math.min.apply(null, yCoords);
-    maxX = Math.max.apply(null, xCoords);
-    maxY = Math.max.apply(null, yCoords);
-
-    return {
-      x: minX,
-      y: minY,
-      w: maxX - minX,
-      h: maxY - minY
-    };
+    function drawCircles(l, x, y, scale) {
+      for (var j = 0; j < l.length; j++) {
+        p.ellipse(x + (l[j].x * scale), y + (l[j].y * scale), 3, 3);
+      }
+    }
   };
 
   p5.Font.prototype.list = function() {
@@ -193,6 +266,20 @@ define(function(require) {
     // TODO
     throw 'not yet implemented';
   };
+
+  // helpers
+
+  function cacheKey() {
+    var args = Array.prototype.slice.call(arguments),
+      i = args.length,
+      hash = '';
+
+    while (i--) {
+      hash += (args[i] === Object(args[i])) ?
+        JSON.stringify(args[i]) : args[i];
+    }
+    return hash;
+  }
 
   return p5.Font;
 });


### PR DESCRIPTION
Added p5.Font._getPath(), refactored XY's opentype example to use it, removed erroneous error message for textFont parameters, memoization of textBounds(), and a minor fix to calculation of font-metrics (textWidth() did not account for advanceWidth of first glyph, see below):

![fix](https://cloud.githubusercontent.com/assets/737638/7999528/cabc752e-0b1a-11e5-8057-d51bf9811a2e.jpg)
