### PR TITLE
Rework arc implementation, fixes #740

### DIFF
--- a/src/core/2d_primitives.js
+++ b/src/core/2d_primitives.js
@@ -90,15 +90,19 @@ define(function (require) {
     stop %= constants.TWO_PI;
 
     // Adjust angles to counter linear scaling.
-    if (start >= constants.HALF_PI && start < 3 * constants.HALF_PI) {
-      start = Math.atan(w / h * Math.tan(start)) + 2 * constants.HALF_PI;
-    } else {
+    if (start <= constants.HALF_PI) {
       start = Math.atan(w / h * Math.tan(start));
-    }
-    if (stop >= constants.HALF_PI && stop < 3 * constants.HALF_PI) {
-      stop = Math.atan(w / h * Math.tan(stop)) + 2 * constants.HALF_PI;
+    } else  if (start > constants.HALF_PI && start <= 3 * constants.HALF_PI) {
+      start = Math.atan(w / h * Math.tan(start)) + constants.PI;
     } else {
+      start = Math.atan(w / h * Math.tan(start)) + constants.TWO_PI;
+    }
+    if (stop <= constants.HALF_PI) {
       stop = Math.atan(w / h * Math.tan(stop));
+    } else  if (stop > constants.HALF_PI && stop <= 3 * constants.HALF_PI) {
+      stop = Math.atan(w / h * Math.tan(stop)) + constants.PI;
+    } else {
+      stop = Math.atan(w / h * Math.tan(stop)) + constants.TWO_PI;
     }
 
     // Exceed the interval if necessary in order to preserve the size and

--- a/src/core/2d_primitives.js
+++ b/src/core/2d_primitives.js
@@ -78,6 +78,17 @@ define(function (require) {
       stop = this.radians(stop);
     }
 
+    // Make all angles positive...
+    while (start < 0) {
+      start += constants.TWO_PI;
+    }
+    while (stop < 0) {
+      stop += constants.TWO_PI;
+    }
+    // ...and confine them to the interval [0,TWO_PI).
+    start %= constants.TWO_PI;
+    stop %= constants.TWO_PI;
+
     // Adjust angles to counter linear scaling.
     if (start >= constants.HALF_PI && start < 3 * constants.HALF_PI) {
       start = Math.atan(w / h * Math.tan(start)) + 2 * constants.HALF_PI;
@@ -89,17 +100,6 @@ define(function (require) {
     } else {
       stop = Math.atan(w / h * Math.tan(stop));
     }
-
-    // Make all angles positive...
-    while (start < 0) {
-      start += constants.TWO_PI;
-    }
-    while (stop < 0) {
-      stop += constants.TWO_PI;
-    }
-    // ...and confine them to the interval [0,TWO_PI).
-    start %= constants.TWO_PI;
-    stop %= constants.TWO_PI;
 
     // Exceed the interval if necessary in order to preserve the size and
     // orientation of the arc.

--- a/src/core/2d_primitives.js
+++ b/src/core/2d_primitives.js
@@ -79,34 +79,32 @@ define(function (require) {
     }
 
     // Adjust angles to counter linear scaling.
-    var half_pi = Math.PI / 2.0;
-    if (start >= half_pi && start < 3 * half_pi) {
-      start = Math.atan(w / h * Math.tan(start)) + 2 * half_pi;
+    if (start >= constants.HALF_PI && start < 3 * constants.HALF_PI) {
+      start = Math.atan(w / h * Math.tan(start)) + 2 * constants.HALF_PI;
     } else {
       start = Math.atan(w / h * Math.tan(start));
     }
-    if (stop >= half_pi && stop < 3 * half_pi) {
-      stop = Math.atan(w / h * Math.tan(stop)) + 2 * half_pi;
+    if (stop >= constants.HALF_PI && stop < 3 * constants.HALF_PI) {
+      stop = Math.atan(w / h * Math.tan(stop)) + 2 * constants.HALF_PI;
     } else {
       stop = Math.atan(w / h * Math.tan(stop));
     }
 
     // Make all angles positive...
-    var two_pi = Math.PI * 2.0;
     while (start < 0) {
-      start += two_pi;
+      start += constants.TWO_PI;
     }
     while (stop < 0) {
-      stop += two_pi;
+      stop += constants.TWO_PI;
     }
     // ...and confine them to the interval [0,TWO_PI).
-    start %= two_pi;
-    stop %= two_pi;
+    start %= constants.TWO_PI;
+    stop %= constants.TWO_PI;
 
     // Exceed the interval if necessary in order to preserve the size and
     // orientation of the arc.
     if (start > stop) {
-      stop += two_pi;
+      stop += constants.TWO_PI;
     }
     // p5 supports negative width and heights for ellipses
     w = Math.abs(w);

--- a/src/core/2d_primitives.js
+++ b/src/core/2d_primitives.js
@@ -14,97 +14,11 @@ define(function (require) {
 
   require('core/error_helpers');
 
-  // source: https://sites.google.com/site/hansmuller/flex-blog/CircularArc.mxml
-  // blog post: http://hansmuller-flex.blogspot.ca/
-  //            2011/04/approximating-circular-arc-with-cubic.html
-
-  var EPSILON = 0.00001;  // Roughly 1/1000th of a degree, see below
-
   /**
-   *  Return a array of objects that represent bezier curves which approximate
-   *  the circular arc centered at the origin, from startAngle to endAngle
-   *  (radians) with the specified radius.
-   *
-   *  Each bezier curve is an object with four points, where x1,y1 and
-   *  x4,y4 are the arc's end points and x2,y2 and x3,y3 are the cubic bezier's
-   *  control points.
-   */
-  p5.prototype._createArc = function(radius, startAngle, endAngle) {
-    var twoPI = Math.PI * 2;
-
-    var curves = [];
-    var piOverTwo = Math.PI / 2.0;
-    var sgn = (startAngle < endAngle) ? 1 : -1;
-
-    var a1 = startAngle;
-    var totalAngle = Math.min(twoPI, Math.abs(endAngle - startAngle));
-    while (totalAngle > EPSILON) {
-      var a2 = a1 + sgn * Math.min(totalAngle, piOverTwo);
-      curves.push(this._createSmallArc(radius, a1, a2));
-      totalAngle -= Math.abs(a2 - a1);
-      a1 = a2;
-    }
-
-    return curves;
-  };
-
-  /**
-   *  Cubic bezier approximation of a circular arc centered at the origin,
-   *  from (radians) a1 to a2, where a2-a1 < pi/2.  The arc's radius is r.
-   *
-   *  Returns an object with four points, where x1,y1 and x4,y4 are the arc's
-   *  end points and x2,y2 and x3,y3 are the cubic bezier's control points.
-   *
-   *  This algorithm is based on the approach described in:
-   *  A. Riškus, "Approximation of a Cubic Bezier Curve by Circular Arcs and
-   *  Vice Versa," Information Technology and Control, 35(4), 2006 pp. 371-378.
-   */
-  p5.prototype._createSmallArc = function(r, a1, a2) {
-    // Compute all four points for an arc that subtends the same total angle
-    // but is centered on the X-axis
-
-    var a = (a2 - a1) / 2.0; //
-
-    var x4 = r * Math.cos(a);
-    var y4 = r * Math.sin(a);
-    var x1 = x4;
-    var y1 = -y4;
-
-    var k = 0.5522847498;
-    var f = k * Math.tan(a);
-
-    var x2 = x1 + f * y4;
-    var y2 = y1 + f * x4;
-    var x3 = x2;
-    var y3 = -y2;
-
-    // Find the arc points actual locations by computing x1,y1 and x4,y4
-    // and rotating the control points by a + a1
-
-    var ar = a + a1;
-    var cos_ar = Math.cos(ar);
-    var sin_ar = Math.sin(ar);
-
-    return {
-      x1: r * Math.cos(a1),
-      y1: r * Math.sin(a1),
-      x2: x2 * cos_ar - y2 * sin_ar,
-      y2: x2 * sin_ar + y2 * cos_ar,
-      x3: x3 * cos_ar - y3 * sin_ar,
-      y3: x3 * sin_ar + y3 * cos_ar,
-      x4: r * Math.cos(a2),
-      y4: r * Math.sin(a2)
-    };
-  };
-
-  /**
-   * Draw an arc.
-   *
-   * If a,b,c,d,start and stop are the only params provided, draws an
-   * open pie.
-   *
-   * If mode is provided draws the arc either open, chord or pie, dependent
-   * on the variable provided.
+   * Draw an arc to the screen. If called with only a, b, c, d, start, and
+   * stop, the arc will pe drawn as an open pie. If mode is provided, the arc
+   * will be drawn either open, as a chord, or as a pie as specified. The
+   * origin may be changed with the ellipseMode() function.
    *
    * @method arc
    * @param  {Number} a      x-coordinate of the arc's ellipse
@@ -145,7 +59,17 @@ define(function (require) {
    * </code>
    * </div>
    */
-  p5.prototype.arc = function(x, y, width, height, start, stop, mode) {
+  p5.prototype.arc = function(x, y, w, h, start, stop, mode) {
+    this._validateParameters(
+      'arc',
+      arguments,
+      [
+        ['Number', 'Number', 'Number', 'Number', 'Number', 'Number'],
+        [ 'Number', 'Number', 'Number', 'Number',
+          'Number', 'Number', 'String' ]
+      ]
+    );
+
     if (!this._doStroke && !this._doFill) {
       return this;
     }
@@ -153,8 +77,41 @@ define(function (require) {
       start = this.radians(start);
       stop = this.radians(stop);
     }
-    var curves = this._createArc(1.0, start, stop);
-    this._graphics.arc(x, y, width, height, start, stop, mode, curves);
+
+    // Adjust angles to counter linear scaling.
+    var half_pi = Math.PI / 2.0;
+    if (start >= half_pi && start < 3 * half_pi) {
+      start = Math.atan(w / h * Math.tan(start)) + 2 * half_pi;
+    } else {
+      start = Math.atan(w / h * Math.tan(start));
+    }
+    if (stop >= half_pi && stop < 3 * half_pi) {
+      stop = Math.atan(w / h * Math.tan(stop)) + 2 * half_pi;
+    } else {
+      stop = Math.atan(w / h * Math.tan(stop));
+    }
+
+    // Make all angles positive...
+    var two_pi = Math.PI * 2.0;
+    while (start < 0) {
+      start += two_pi;
+    }
+    while (stop < 0) {
+      stop += two_pi;
+    }
+    // ...and confine them to the interval [0,TWO_PI).
+    start %= two_pi;
+    stop %= two_pi;
+
+    // Exceed the interval if necessary in order to preserve the size and
+    // orientation of the arc.
+    if (start > stop) {
+      stop += two_pi;
+    }
+    // p5 supports negative width and heights for ellipses
+    w = Math.abs(w);
+    h = Math.abs(h);
+    this._graphics.arc(x, y, w, h, start, stop, mode);
     return this;
   };
 

--- a/src/core/p5.Renderer2D.js
+++ b/src/core/p5.Renderer2D.js
@@ -393,11 +393,12 @@ define(function(require) {
     var vals = canvas.arcModeAdjust(x, y, w, h, this._pInst._ellipseMode);
     var rx = vals.w / 2.0;
     var ry = vals.h / 2.0;
+    var epsilon = 0.00001;  // Smallest visible angle on displays up to 4K.
     var arcToDraw = 0;
     var curves = [];
 
     // Create curves
-    while(stop - start > 0.00001) {
+    while(stop - start > epsilon) {
       arcToDraw = Math.min(stop - start, constants.HALF_PI);
       curves.push(this._acuteArcToBezier(start, arcToDraw));
       start += arcToDraw;

--- a/src/core/p5.Renderer2D.js
+++ b/src/core/p5.Renderer2D.js
@@ -393,13 +393,12 @@ define(function(require) {
     var vals = canvas.arcModeAdjust(x, y, w, h, this._pInst._ellipseMode);
     var rx = vals.w / 2.0;
     var ry = vals.h / 2.0;
-    var half_pi = Math.PI / 2.0;
     var arcToDraw = 0;
     var curves = [];
 
     // Create curves
     while(stop - start > 0.00001) {
-      arcToDraw = Math.min(stop - start, half_pi);
+      arcToDraw = Math.min(stop - start, constants.HALF_PI);
       curves.push(this._acuteArcToBezier(start, arcToDraw));
       start += arcToDraw;
     }


### PR DESCRIPTION
Arcs should now be drawn accurate to the nearest pixel on canvas sizes up to 4K. I used a slightly different approach which I've documented [here](http://cridge.co/1TNnsMI). (Sorry it's a bit long-winded! 😝)

Other changes:
- Adds friendly error messaging to `arc()`.
- Adds support for negative widths and heights, similar to `ellipse()`.
- Fixes a bug where `mode` was ignored if you had set `noFill()`.
- Adds an angle correction so that the angles drawn always match the angles specified, even when width does not equal height.
- Removes odd behaviour for arcs that cross the zero degrees line: arcs are now always drawn anticlockwise from `start` to `stop`.
- Removes dependence on angular convention: arcs will now be drawn correctly regardless of whether you use -PI to PI, 0 to TWO_PI, an unbounded range, or even with a different convention each for `start` and `stop`.