### PR TITLE
Convert p5 to be built with Browserify

### DIFF
--- a/.jshintrc
+++ b/.jshintrc
@@ -13,8 +13,7 @@
   "unused": "vars",
 
   "node": true,
-  
+
   "trailing": true,
-  "curly": true,
-  "indent": 2
+  "curly": true
 }

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -191,7 +191,7 @@ module.exports = function(grunt) {
         'p5.prototype._friendlyFileLoadError = function() {};'
       },
       build: {
-        src: '<%= requirejs.p5_unminified.options.out %>',
+        src: 'lib/p5.js',
         dest: 'lib/p5.min.js'
       }
     },

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -134,142 +134,34 @@ module.exports = function(grunt) {
       }
     },
 
+    // Build p5 into a single, UMD-wrapped file
+    browserify: {
+      p5: {
+        options: {
+          browserifyOptions: {
+            standalone: 'p5'
+          }
+        },
+        src: 'src/app.js',
+        dest: 'lib/p5.js'
+      }
+    },
+
+    // Concatenate p5 together with OpenType
+    // TODO: There may be an opportunity to move this into the main p5 build
+    concat: {
+      p5: {
+        src: [
+          'lib/p5.js',
+          'src/external/opentype.min.js'
+        ],
+        dest: 'lib/p5.js',
+      },
+    },
+
     // The actual compile step:  This should collect all the dependencies
     // and compile them into a single file.
     requirejs: {
-      p5_unminified: {
-        options: {
-          baseUrl: 'src', // from whence do the files come?
-          optimize: 'none', // skip running uglify on the concatenated code
-          out: 'lib/p5.js', // name of the output file
-          useStrict: true, // Allow "use strict"; be included in the RequireJS files.
-          //findNestedDependencies: true,   // automatically find nested deps.  Doesn't appear to effect the code?
-          include: ['app'], // this is the file which we are actually building
-
-          // This will add a prefix and a suffix to the generated code.
-          // we're using this to both add a time/version stamp
-          // and also to wrap this in a commonjs/AMD header.
-          // there's also the **amdclean** stuff—not sure what that is yet.
-          wrap: {
-            start: ['/*! p5.js v<%= pkg.version %> <%= grunt.template.today("mmmm dd, yyyy") %> */',
-              '(function (root, factory) {',
-              '  if (typeof define === \'function\' && define.amd)',
-              '    define(\'p5\', [], function () { return (root.returnExportsGlobal = factory());});',
-              '  else if (typeof exports === \'object\')',
-              '    module.exports = factory();',
-              '  else',
-              '    root[\'p5\'] = factory();',
-              '}(this, function () {\n'
-            ].join('\n'),
-            end: 'return amdclean[\'app\'];\n}));'
-          },
-          // This will transform the compiled file, reversing out the AMD loader and creating a
-          // static JS file.  This code is potentially problematic.
-          onBuildWrite: function(name, path, contents) {
-            if (name === 'reqwest') {
-              contents = contents.replace('}(\'reqwest\', this, function () {', '}(\'reqwest\', amdclean, function () {');
-            }
-            return require('amdclean').clean({
-              code: contents,
-              'globalObject': true,
-              escodegen: {
-                'comment': true,
-                'format': {
-                  'indent': {
-                    'style': '  ',
-                    'adjustMultilineComment': true
-                  }
-                }
-              }
-            });
-          },
-
-          // This is a list of all dependencies, mapped to their AMD identifier.
-          paths: {
-            //'app': 'app',
-
-            // core
-            // 'canvas': 'core/canvas',
-            // 'constants': 'core/constants',
-            // 'core': 'core/core',
-            // 'environment': 'core/environment',
-            // 'helpers': 'core/error_helpers',
-            // 'p5.Element': 'core/p5.Element',
-            // 'p5.Graphics': 'core/p5.Graphics',
-            // 'p5.Graphics2D': 'core/p5.Graphics2D',
-            // 'rendering.rendering': 'core/rendering',
-            // 'shape.2d_primitives': 'core/2d_primitives',
-            // 'shape.attributes': 'core/attributes',
-            // 'shape.curves': 'core/curves',
-            // 'shape.vertex': 'core/vertex',
-            // 'shim': 'core/shim',
-            // 'structure': 'core/structure',
-            // 'transform': 'core/transform',
-
-            // 3d
-            // 'p5.Graphics3D': '3d/p5.Graphics3D',
-            // 'p5.Matrix': '3d/p5.Matrix',
-            // 'shaders': '3d/shaders',
-            // 'shape.3d_primitives': '3d/3d_primitives',
-
-            // image
-            // 'filters': 'image/filters',
-            // 'image.image': 'image/image',
-            // 'image.loading_displaying': 'image/loading_displaying',
-            // 'image.pixels': 'image/pixels',
-            // 'p5.Image': 'image/p5.Image',
-
-            // typography
-            // 'p5.Font': 'typography/p5.Font',
-            // 'typography.attributes': 'typography/attributes',
-            // 'typography.loading_displaying': 'typography/loading_displaying',
-
-            // math
-            // 'p5.Vector': 'math/p5.Vector',
-            // 'polargeometry': 'math/polargeometry',
-            // 'math.calculation': 'math/calculation',
-            // 'math.math': 'math/math',
-            // 'math.noise': 'math/noise',
-            // 'math.random': 'math/random',
-            // 'math.trigonometry': 'math/trigonometry',
-
-            // events
-            // 'input.acceleration': 'events/acceleration',
-            // 'input.keyboard': 'events/keyboard',
-            // 'input.mouse': 'events/mouse',
-            // 'input.touch': 'events/touch',
-
-
-            // io
-            // 'input.files': 'io/files',
-            // 'p5.TableRow': 'io/p5.TableRow',
-            // 'p5.Table': 'io/p5.Table',
-
-            // utilities
-            // 'input.time_date': 'utilities/time_date',
-            // 'data.conversion': 'utilities/conversion',
-            // 'data.array_functions': 'utilities/array_functions',
-            // 'data.string_functions': 'utilities/string_functions',
-
-            // color
-            // 'p5.Color': 'color/p5.Color',
-            // 'color.creating_reading': 'color/creating_reading',
-            // 'color.setting': 'color/setting',
-            // 'utils.color_utils': 'color/color_utils',
-
-            // external library
-            'reqwest': '../node_modules/reqwest/reqwest'
-          },
-          done: function(done, output) {
-            require('concat-files')([
-              'lib/p5.js',
-              'src/external/opentype.min.js',
-            ], 'lib/p5.js', function() {
-              done();
-            });
-          }
-        }
-      },
 
       // This generates the theme for the documentation from the theme source
       // files.
@@ -350,6 +242,8 @@ module.exports = function(grunt) {
   });
 
   // Load the external libraries used.
+  grunt.loadNpmTasks('grunt-browserify');
+  grunt.loadNpmTasks('grunt-contrib-concat');
   grunt.loadNpmTasks('grunt-contrib-jshint');
   grunt.loadNpmTasks('grunt-contrib-watch');
   grunt.loadNpmTasks('grunt-contrib-requirejs');
@@ -361,7 +255,8 @@ module.exports = function(grunt) {
   grunt.loadNpmTasks('grunt-newer');
 
   // Create the multitasks.
-  grunt.registerTask('test', ['connect', 'newer:jshint', 'requirejs', 'mocha']);
+  grunt.registerTask('build', ['browserify', 'concat']);
+  grunt.registerTask('test', ['connect', 'build', 'requirejs', 'mocha']);
   grunt.registerTask('yui', ['yuidoc']);
-  grunt.registerTask('default', ['connect', 'newer:jshint', 'requirejs', 'mocha', 'uglify']);
+  grunt.registerTask('default', ['test', 'uglify']);
 };

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -255,8 +255,9 @@ module.exports = function(grunt) {
   grunt.loadNpmTasks('grunt-newer');
 
   // Create the multitasks.
-  grunt.registerTask('build', ['browserify', 'concat']);
-  grunt.registerTask('test', ['connect', 'build', 'requirejs', 'mocha']);
+  // TODO: "requirejs" is in here to run the "yuidoc_themes" subtask. Is this needed?
+  grunt.registerTask('build', ['browserify', 'concat', 'uglify', 'requirejs']);
+  grunt.registerTask('test', ['connect', 'jshint', 'build', 'mocha']);
   grunt.registerTask('yui', ['yuidoc']);
-  grunt.registerTask('default', ['test', 'uglify']);
+  grunt.registerTask('default', ['test']);
 };

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "grunt-browserify": "^3.8.0",
     "grunt-contrib-concat": "^0.5.1",
     "grunt-contrib-connect": "^0.9.0",
-    "grunt-contrib-jshint": "~0.6.3",
+    "grunt-contrib-jshint": "^0.11.2",
     "grunt-contrib-requirejs": "~0.4.1",
     "grunt-contrib-uglify": "^0.7.0",
     "grunt-contrib-watch": "~0.5.3",

--- a/package.json
+++ b/package.json
@@ -9,6 +9,8 @@
     "amdclean": "~0.3.3",
     "concat-files": "^0.1.0",
     "grunt": "^0.4.5",
+    "grunt-browserify": "^3.8.0",
+    "grunt-contrib-concat": "^0.5.1",
     "grunt-contrib-connect": "^0.9.0",
     "grunt-contrib-jshint": "~0.6.3",
     "grunt-contrib-requirejs": "~0.4.1",
@@ -28,7 +30,7 @@
     }
   ],
   "dependencies": {
-    "reqwest": "1.1.5"
+    "reqwest": "^1.1.5"
   },
   "main": "./lib/p5.js",
   "files": [

--- a/src/.jshintrc
+++ b/src/.jshintrc
@@ -14,9 +14,11 @@
   "unused": "vars",
   "maxlen": 80,
 
+  "browserify": true,
   "browser": true,
-  "node": true,
   "globals": {
+    "require": false,
+    "module": false,
     "PImage": false
   }
 }

--- a/src/.jshintrc
+++ b/src/.jshintrc
@@ -2,7 +2,6 @@
   "boss": true,
   "curly": true,
   "trailing": true,
-  "indent": 2,
   "devel": true,
   "eqeqeq": true,
   "eqnull": true,
@@ -16,9 +15,8 @@
   "maxlen": 80,
 
   "browser": true,
+  "node": true,
   "globals": {
-    "define": false,
-    "require": false,
     "PImage": false
   }
 }

--- a/src/3d/3d_primitives.js
+++ b/src/3d/3d_primitives.js
@@ -6,12 +6,11 @@
  * @requires canvas
  * @requires constants
  */
-define(function (require) {
 
   'use strict';
 
-  var p5 = require('core/core');
-  require('3d/p5.Geometry3D');
+  var p5 = require('../core/core');
+  require('./p5.Geometry3D');
 
   /**
    * generate plane geomery
@@ -19,7 +18,7 @@ define(function (require) {
    * @param  {Number} height  the height of the plane
    * @param  {Number} detailX how many segments in the x axis
    * @param  {Number} detailY how many segments in the y axis
-   * @return {[type]}         [description]        
+   * @return {[type]}         [description]
    */
   p5.prototype.plane = function(width, height, detailX, detailY){
 
@@ -30,7 +29,7 @@ define(function (require) {
     detailY = detailY || 1;
 
     var uuid = 'plane|'+width+'|'+height+'|'+detailX+'|'+detailY;
- 
+
     if(this._graphics.notInHash(uuid)){
 
       var geometry3d = new p5.Geometry3D();
@@ -41,13 +40,13 @@ define(function (require) {
         var z = 0;
         return new p5.Vector(x, y, z);
       };
-      
+
       geometry3d.parametricGeometry(createPlane, detailX, detailY);
-      
+
       var obj = geometry3d.generateObj();
- 
+
       this._graphics.initBuffer(uuid, obj);
-    
+
     }
 
     this._graphics.drawBuffer(uuid);
@@ -71,7 +70,7 @@ define(function (require) {
     var uuid = 'sphere|'+radius+'|'+detailX+'|'+detailY;
 
     if(this._graphics.notInHash(uuid)){
-    
+
       var geometry3d = new p5.Geometry3D();
 
       var createSphere = function(u, v){
@@ -123,11 +122,11 @@ define(function (require) {
         var z = radius * Math.cos(theta);
         return new p5.Vector(x, y, z);
       };
-      
+
       geometry3d.parametricGeometry(createCylinder, detailX, detailY);
 
       //TODO: top and bottom faces
-      //this.vertices.push(new p5.Vector(0, height/2, 0));  
+      //this.vertices.push(new p5.Vector(0, height/2, 0));
       //this.vertices.push(new p5.Vector(0, -height/2, 0));
 
       var obj = geometry3d.generateObj();
@@ -149,7 +148,7 @@ define(function (require) {
    * @return {[type]}         [description]
    */
   p5.prototype.cone = function(radius, height, detailX, detailY){
-    
+
     radius = radius || 50;
     height = height || 50;
 
@@ -193,7 +192,7 @@ define(function (require) {
    * @return {[type]}         [description]
    */
   p5.prototype.torus = function(radius, tube, detailX, detailY){
-    
+
     radius = radius || 50;
     tube = tube || 20;
 
@@ -288,7 +287,7 @@ define(function (require) {
         var z = 2 * depth * v - depth;
         return new p5.Vector(x, y, z);
       };
-      
+
       geometry3d.parametricGeometry(
         createPlane1, detailX, detailY, geometry3d.vertices.length);
       geometry3d.parametricGeometry(
@@ -301,7 +300,7 @@ define(function (require) {
         createPlane5, detailX, detailY, geometry3d.vertices.length);
       geometry3d.parametricGeometry(
         createPlane6, detailX, detailY, geometry3d.vertices.length);
-      
+
       var obj = geometry3d.generateObj(true);
 
       this._graphics.initBuffer(uuid, obj);
@@ -313,6 +312,4 @@ define(function (require) {
 
   };
 
-  return p5;
-
-});
+  module.exports = p5;

--- a/src/3d/mat4.js
+++ b/src/3d/mat4.js
@@ -1,4 +1,3 @@
-define(function (require) {
 /* Copyright (c) 2015, Brandon Jones, Colin MacKenzie IV.
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal
@@ -783,5 +782,4 @@ THE SOFTWARE. */
     return out;
   };
 
-  return mat4;
-});
+  module.exports = mat4;

--- a/src/3d/p5.Geometry3D.js
+++ b/src/3d/p5.Geometry3D.js
@@ -5,11 +5,10 @@
  * @requires canvas
  * @requires constants
  */
-define(function (require){
 
   'use strict';
 
-  var p5 = require('core/core');
+  var p5 = require('../core/core');
   /**
    * p5 Geometry3D class
    */
@@ -41,7 +40,7 @@ define(function (require){
    */
   p5.Geometry3D.prototype.parametricGeometry =
     function(func, detailX, detailY, offset){
-    
+
     var i, j, p;
     var u, v;
     offset = offset || 0;
@@ -153,7 +152,7 @@ define(function (require){
     return diff;
 
   };
-  
+
   /**
    * [computeFaceNormals description]
    * @return {[type]} [description]
@@ -215,7 +214,7 @@ define(function (require){
       vertexNormals[f][1]= vertices[face[1]].copy();
       vertexNormals[f][2]= vertices[face[2]].copy();
     }
-    
+
     for (f = 0; f < this.faces.length; f++){
       face = this.faces[f];
       faceNormal = this.faceNormals[f];
@@ -223,7 +222,7 @@ define(function (require){
       this.vertexNormals[face[1]] = vertexNormals[f][1];
       this.vertexNormals[face[2]] = vertexNormals[f][2];
     }
-    
+
   };
 
   /**
@@ -271,6 +270,4 @@ define(function (require){
     }));
   }
 
-  return p5.Geometry3D;
-
-});
+  module.exports = p5.Geometry3D;

--- a/src/3d/p5.Matrix.js
+++ b/src/3d/p5.Matrix.js
@@ -2,13 +2,12 @@
  * @requires constants
  * @todo see methods below needing further implementation.
  */
-define(function (require) {
 
   'use strict';
 
-  var p5 = require('core/core');
-  var polarGeometry = require('math/polargeometry');
-  var constants = require('core/constants');
+  var p5 = require('../core/core');
+  var polarGeometry = require('../math/polargeometry');
+  var constants = require('../core/constants');
   var GLMAT_ARRAY_TYPE = (
       typeof Float32Array !== 'undefined') ?
     Float32Array : Array;
@@ -490,5 +489,4 @@ define(function (require) {
     this.rotate(a, [0,0,1]);
   };
 
-  return p5.Matrix;
-});
+  module.exports = p5.Matrix;

--- a/src/3d/p5.Renderer3D.js
+++ b/src/3d/p5.Renderer3D.js
@@ -1,9 +1,8 @@
-define(function(require) {
 
-  var p5 = require('core/core');
-  var shaders = require('3d/shaders');
-  require('core/p5.Renderer');
-  require('3d/p5.Matrix');
+  var p5 = require('../core/core');
+  var shaders = require('./shaders');
+  require('../core/p5.Renderer');
+  require('./p5.Matrix');
   var gl, shaderProgram;
   var uMVMatrixStack = [];
 
@@ -243,7 +242,7 @@ define(function(require) {
   };
 
   p5.Renderer3D.prototype.drawBuffer = function(uuid) {
-    
+
     gl.bindBuffer(gl.ARRAY_BUFFER, this.hash[uuid].vertexBuffer);
     gl.vertexAttribPointer(
       shaderProgram.vertexPositionAttribute, 3, gl.FLOAT, false, 0, 0);
@@ -253,7 +252,7 @@ define(function(require) {
       shaderProgram.vertexNormalAttribute, 3, gl.FLOAT, false, 0, 0);
 
     gl.bindBuffer(gl.ELEMENT_ARRAY_BUFFER, this.hash[uuid].indexBuffer);
-    
+
     this.setMatrixUniforms();
     gl.drawElements(
       gl.TRIANGLES, this.hash[uuid].len,
@@ -446,5 +445,4 @@ define(function(require) {
   //var _pMatrix = _makePerspective(45,
   //  gl.drawingBufferWidth/gl.drawingBufferHeight,
   //  0.1, 1000.0);
-  return p5.Renderer3D;
-});
+  module.exports = p5.Renderer3D;

--- a/src/3d/shaders.js
+++ b/src/3d/shaders.js
@@ -20,8 +20,7 @@
 /**
  * @description Default full shaders for our WebGL context
  */
-define(function (require){
-  return {
+  module.exports = {
     texLightVert : [
       'uniform mat4 modelviewMatrix;',
       'uniform mat4 transformMatrix;',
@@ -84,35 +83,35 @@ define(function (require){
       'void main() {',
         // Vertex in clip coordinates
       'gl_Position = transformMatrix * position;',
-          
+
         // Vertex in eye coordinates
       'vec3 ecVertex = vec3(modelviewMatrix * position);',
-        
+
         // Normal vector in eye coordinates
       'vec3 ecNormal = normalize(normalMatrix * normal);',
       'vec3 ecNormalInv = ecNormal * -one_float;',
-      
+
       // Light calculations
       'vec3 totalAmbient = vec3(0, 0, 0);',
-      
+
       'vec3 totalFrontDiffuse = vec3(0, 0, 0);',
       'vec3 totalFrontSpecular = vec3(0, 0, 0);',
-      
+
       'vec3 totalBackDiffuse = vec3(0, 0, 0);',
       'vec3 totalBackSpecular = vec3(0, 0, 0);',
-      
+
       'for (int i = 0; i < 8; i++) {',
       'if (lightCount == i) break;',
-      
+
       'vec3 lightPos = lightPosition[i].xyz;',
       'bool isDir = zero_float < lightPosition[i].w;',
       'float spotCos = lightSpot[i].x;',
       'float spotExp = lightSpot[i].y;',
-      
+
       'vec3 lightDir;',
       'float falloff;',
       'float spotf;',
-        
+
       'if (isDir) {',
       'falloff = one_float;',
       'lightDir = -one_float * lightNormal[i];',
@@ -120,24 +119,24 @@ define(function (require){
       'falloff = falloffFactor(lightPos, ecVertex, lightFalloff[i]);',
       'lightDir = normalize(lightPos - ecVertex);',
       '}',
-    
+
       'spotf=spotExp > zero_float ? spotFactor(lightPos,',
       'ecVertex,',
       'lightNormal[i],',
       'spotCos,',
       'spotExp):one_float;',
-      
+
       'if (any(greaterThan(lightAmbient[i], zero_vec3))) {',
       'totalAmbient+= lightAmbient[i] * falloff;',
       '}',
-      
+
       'if (any(greaterThan(lightDiffuse[i], zero_vec3))) {',
       'totalFrontDiffuse  += lightDiffuse[i] * falloff * spotf *',
       'lambertFactor(lightDir, ecNormal);',
       'totalBackDiffuse   += lightDiffuse[i] * falloff * spotf *',
       'lambertFactor(lightDir, ecNormalInv);',
       '}',
-      
+
       'if (any(greaterThan(lightSpecular[i], zero_vec3))) {',
       'totalFrontSpecular += lightSpecular[i] * falloff * spotf * ',
       'blinnPhongFactor(lightDir, ecVertex, ecNormal, shininess);',
@@ -145,19 +144,19 @@ define(function (require){
       'blinnPhongFactor(lightDir, ecVertex, ecNormalInv, shininess);',
       '}',
       '}',
-        
+
       // Calculating final color as result of all lights (plus emissive term).
       // Transparency is determined exclusively by the diffuse component.
       'vertColor =vec4(totalAmbient, 0) * ambient + ',
       'vec4(totalFrontDiffuse, 1) * color +' ,
       'vec4(totalFrontSpecular, 0) * specular +',
       'vec4(emissive.rgb, 0);',
-                  
+
       'backVertColor = vec4(totalAmbient, 0) * ambient + ',
       'vec4(totalBackDiffuse, 1) * color +',
       'vec4(totalBackSpecular, 0) * specular +',
       'vec4(emissive.rgb, 0);',
-                        
+
         // Calculating texture coordinates, with r and q set both to one
       'vertTexCoord = texMatrix * vec4(texCoord, 1.0, 1.0);',
       '}'
@@ -203,4 +202,3 @@ define(function (require){
       '}'
     ].join('\n')
   };
-});

--- a/src/app.js
+++ b/src/app.js
@@ -1,56 +1,55 @@
-define(function (require) {
 
   'use strict';
 
-  var p5 = require('core/core');
-  require('color/p5.Color');
-  require('core/p5.Element');
-  require('typography/p5.Font');
-  require('core/p5.Graphics');
-  require('core/p5.Renderer2D');
+  var p5 = require('./core/core');
+  require('./color/p5.Color');
+  require('./core/p5.Element');
+  require('./typography/p5.Font');
+  require('./core/p5.Graphics');
+  require('./core/p5.Renderer2D');
 
-  require('image/p5.Image');
-  require('math/p5.Vector');
-  require('io/p5.TableRow');
-  require('io/p5.Table');
+  require('./image/p5.Image');
+  require('./math/p5.Vector');
+  require('./io/p5.TableRow');
+  require('./io/p5.Table');
 
-  require('color/creating_reading');
-  require('color/setting');
-  require('core/constants');
-  require('utilities/conversion');
-  require('utilities/array_functions');
-  require('utilities/string_functions');
-  require('core/environment');
-  require('image/image');
-  require('image/loading_displaying');
-  require('image/pixels');
-  require('io/files');
-  require('events/keyboard');
-  require('events/acceleration'); //john
-  require('events/mouse');
-  require('utilities/time_date');
-  require('events/touch');
-  require('math/math');
-  require('math/calculation');
-  require('math/random');
-  require('math/noise');
-  require('math/trigonometry');
-  require('core/rendering');
-  require('core/2d_primitives');
-  
-  require('core/attributes');
-  require('core/curves');
-  require('core/vertex');
-  require('core/structure');
-  require('core/transform');
-  require('typography/attributes');
-  require('typography/loading_displaying');
-  
-  require('3d/p5.Renderer3D');
-  require('3d/p5.Geometry3D');
-  require('3d/3d_primitives');
-  require('3d/shaders');
-  require('3d/p5.Matrix');
+  require('./color/creating_reading');
+  require('./color/setting');
+  require('./core/constants');
+  require('./utilities/conversion');
+  require('./utilities/array_functions');
+  require('./utilities/string_functions');
+  require('./core/environment');
+  require('./image/image');
+  require('./image/loading_displaying');
+  require('./image/pixels');
+  require('./io/files');
+  require('./events/keyboard');
+  require('./events/acceleration'); //john
+  require('./events/mouse');
+  require('./utilities/time_date');
+  require('./events/touch');
+  require('./math/math');
+  require('./math/calculation');
+  require('./math/random');
+  require('./math/noise');
+  require('./math/trigonometry');
+  require('./core/rendering');
+  require('./core/2d_primitives');
+
+  require('./core/attributes');
+  require('./core/curves');
+  require('./core/vertex');
+  require('./core/structure');
+  require('./core/transform');
+  require('./typography/attributes');
+  require('./typography/loading_displaying');
+
+  require('./3d/p5.Renderer3D');
+  require('./3d/p5.Geometry3D');
+  require('./3d/3d_primitives');
+  require('./3d/shaders');
+  require('./3d/p5.Matrix');
 
   /**
    * _globalInit
@@ -81,6 +80,4 @@ define(function (require) {
     window.addEventListener('load', _globalInit , false);
   }
 
-  return p5;
-
-});
+  module.exports = p5;

--- a/src/color/color_utils.js
+++ b/src/color/color_utils.js
@@ -3,8 +3,8 @@
  * submodule Color Utils
  * @for p5
  */
-define(function(require) {
-  var p5 = require('core/core');
+
+  var p5 = require('../core/core');
 
   p5.ColorUtils = {};
 
@@ -79,7 +79,7 @@ define(function(require) {
 
   /**
    * For a color expressed as an RGBA array, return the corresponding HSBA value
-   * 
+   *
    * @param {Array} rgba An 'array' object that represents a list of RGB colors
    * @param {Array} maxes An 'array' object that represents the RGB range maxes
    * @return {Array} an array of HSB values, scaled by the HSB-space maxes
@@ -134,10 +134,10 @@ define(function(require) {
 
   /**
    * For a color expressed as an HSLA array, return the corresponding RGBA value
-   * 
+   *
    * @param  {Array} hsla An 'array' object that represents a list of HSL colors
    * @param  {Array} maxes An 'array' object that represents the HSL range maxes
-   * 
+   *
    * @return {Array} an array of RGBA values, on a scale of 0-255
    */
   p5.ColorUtils.hslaToRGBA = function(hsla, maxes){
@@ -197,7 +197,7 @@ define(function(require) {
 
   /**
    * For a color expressed as an RGBA array, return the corresponding HSBA value
-   * 
+   *
    * @param {Array} rgba An 'array' object that represents a list of RGB colors
    * @param {Array} maxes An 'array' object that represents the RGB range maxes
    * @return {Array} an array of HSL values, scaled by the HSL-space maxes
@@ -210,7 +210,7 @@ define(function(require) {
 
     var min = Math.min(r, g, b); //Min. value of RGB
     var max = Math.max(r, g, b); //Max. value of RGB
-    var delta_max = max - min;             //Delta RGB value 
+    var delta_max = max - min;             //Delta RGB value
 
     var h;
     var s;
@@ -224,7 +224,7 @@ define(function(require) {
       h = 0;             // HSL results from 0 to 1
       s = 0;
     } else {              // Chromatic data...
-       
+
       delta_r = ( ( ( max - r ) / 6 ) + ( delta_max / 2 ) ) / delta_max;
       delta_g = ( ( ( max - g ) / 6 ) + ( delta_max / 2 ) ) / delta_max;
       delta_b = ( ( ( max - b ) / 6 ) + ( delta_max / 2 ) ) / delta_max;
@@ -240,7 +240,7 @@ define(function(require) {
       if ( h < 0 ) {
         h += 1;
       }
-         
+
       if ( h > 1 ) {
         h -= 1;
       }
@@ -260,5 +260,4 @@ define(function(require) {
       ];
   };
 
-  return p5.ColorUtils;
-});
+  module.exports = p5.ColorUtils;

--- a/src/color/creating_reading.js
+++ b/src/color/creating_reading.js
@@ -270,7 +270,7 @@
    * </div>
    */
   p5.prototype.hue = function(c) {
-    if (!c instanceof p5.Color) {
+    if (!(c instanceof p5.Color)) {
       throw new Error('Needs p5.Color as argument.');
     }
     return c.getHue();
@@ -414,7 +414,7 @@
    * </div>
    */
   p5.prototype.saturation = function(c) {
-    if (!c instanceof p5.Color) {
+    if (!(c instanceof p5.Color)) {
       throw new Error('Needs p5.Color as argument.');
     }
     return c.getSaturation();

--- a/src/color/creating_reading.js
+++ b/src/color/creating_reading.js
@@ -4,12 +4,11 @@
  * @for p5
  * @requires core
  */
-define(function (require) {
 
   'use strict';
 
-  var p5 = require('core/core');
-  require('color/p5.Color');
+  var p5 = require('../core/core');
+  require('./p5.Color');
 
   /**
    * Extracts the alpha value from a color or pixel array.
@@ -199,7 +198,7 @@ define(function (require) {
    * rect(20, 20, 60, 60);  // Draw rectangle
    * </code>
    * </div>
-   * 
+   *
    *
    * // if switching from RGB to HSB or HSL both modes must be declared
    * colorMode(RGB, 255);  // Use RGB with scale of 0-255
@@ -423,6 +422,4 @@ define(function (require) {
 
 
 
-  return p5;
-
-});
+  module.exports = p5;

--- a/src/color/p5.Color.js
+++ b/src/color/p5.Color.js
@@ -3,11 +3,10 @@
  * @submodule Creating & Reading
  * @for p5
  */
-define(function(require) {
 
-  var p5 = require('core/core');
-  var color_utils = require('color/color_utils');
-  var constants = require('core/constants');
+  var p5 = require('../core/core');
+  var color_utils = require('./color_utils');
+  var constants = require('../core/constants');
 
   /**
    *
@@ -48,7 +47,7 @@ define(function(require) {
 
   p5.Color.prototype.getSaturation = function() {
     // Saturation exists in both HSB and HSL, but returns different values
-    // We are preferring HSL here (because it is a web color space) 
+    // We are preferring HSL here (because it is a web color space)
     // until the global flag issue can be resolved
     if (this.hsla) {
       return this.hsla[1];
@@ -307,7 +306,7 @@ define(function(require) {
       INTEGER.source,
       '\\)$'
     ].join(WHITESPACE.source), 'i'),
-    
+
 
     /**
      * Regular expression for matching colors in format rgb(R%, G%, B%),
@@ -426,7 +425,7 @@ define(function(require) {
       third   = arguments[2];
       alpha   = typeof arguments[3] === 'number' ?
                 arguments[3] : this._colorMaxes[mode][3];
-    
+
     // Handle strings: named colors, hex values, css strings
     } else if (numArgs === 1 && typeof arguments[0] === 'string') {
       str = arguments[0].trim().toLowerCase();
@@ -491,8 +490,8 @@ define(function(require) {
 
     // Handle greyscale color mode
     } else if (numArgs === 1 && typeof arguments[0] === 'number') {
-      // When users pass only one argument, they are presumed to be 
-      // working in grayscale mode. 
+      // When users pass only one argument, they are presumed to be
+      // working in grayscale mode.
       if (mode === constants.RGB) {
         first = second = third = arguments[0];
       } else if (mode === constants.HSB || mode === constants.HSL) {
@@ -503,13 +502,13 @@ define(function(require) {
       }
       alpha = typeof arguments[1] === 'number' ?
                      arguments[1] : this._colorMaxes[mode][3];
-    
+
     // Handle brightness and alpha (grayscale)
     } else if (numArgs === 2 &&
                typeof arguments[0] === 'number' &&
                typeof arguments[1] === 'number') {
-      // When users pass only one argument, they are presumed to be 
-      // working in grayscale mode. 
+      // When users pass only one argument, they are presumed to be
+      // working in grayscale mode.
       if (mode === constants.RGB) {
         first = second = third = arguments[0];
       } else if (mode === constants.HSB || mode === constants.HSL) {
@@ -530,5 +529,4 @@ define(function(require) {
     ];
   };
 
-  return p5.Color;
-});
+  module.exports = p5.Color;

--- a/src/color/setting.js
+++ b/src/color/setting.js
@@ -5,13 +5,12 @@
  * @requires core
  * @requires constants
  */
-define(function(require) {
 
   'use strict';
 
-  var p5 = require('core/core');
-  var constants = require('core/constants');
-  require('color/p5.Color');
+  var p5 = require('../core/core');
+  var constants = require('../core/constants');
+  require('./p5.Color');
 
   p5.prototype._doStroke = true;
   p5.prototype._doFill = true;
@@ -509,6 +508,4 @@ define(function(require) {
 
 
 
-  return p5;
-
-});
+  module.exports = p5;

--- a/src/core/2d_primitives.js
+++ b/src/core/2d_primitives.js
@@ -5,14 +5,13 @@
  * @requires core
  * @requires constants
  */
-define(function (require) {
 
   'use strict';
 
-  var p5 = require('core/core');
-  var constants = require('core/constants');
+  var p5 = require('./core');
+  var constants = require('./constants');
 
-  require('core/error_helpers');
+  require('./error_helpers');
 
   /**
    * Draw an arc to the screen. If called with only a, b, c, d, start, and
@@ -394,6 +393,4 @@ define(function (require) {
     return this;
   };
 
-  return p5;
-
-});
+  module.exports = p5;

--- a/src/core/attributes.js
+++ b/src/core/attributes.js
@@ -5,12 +5,11 @@
  * @requires core
  * @requires constants
  */
-define(function (require) {
 
   'use strict';
 
-  var p5 = require('core/core');
-  var constants = require('core/constants');
+  var p5 = require('./core');
+  var constants = require('./constants');
 
   p5.prototype._rectMode = constants.CORNER;
   p5.prototype._ellipseMode = constants.CENTER;
@@ -298,6 +297,4 @@ define(function (require) {
     return this;
   };
 
-  return p5;
-
-});
+  module.exports = p5;

--- a/src/core/canvas.js
+++ b/src/core/canvas.js
@@ -1,11 +1,10 @@
 /**
  * @requires constants
  */
-define(function(require) {
 
-  var constants = require('core/constants');
+  var constants = require('./constants');
 
-  return {
+  module.exports = {
 
     modeAdjust: function(a, b, c, d, mode) {
       if (mode === constants.CORNER) {
@@ -33,4 +32,3 @@ define(function(require) {
 
   };
 
-});

--- a/src/core/constants.js
+++ b/src/core/constants.js
@@ -3,11 +3,10 @@
  * @submodule Constants
  * @for p5
  */
-define(function(require) {
 
   var PI = Math.PI;
 
-  return {
+  module.exports = {
 
     // GRAPHICS RENDERER
     P2D: 'p2d',
@@ -200,5 +199,3 @@ define(function(require) {
     _DEFAULT_FILL: '#FFFFFF'
 
   };
-
-});

--- a/src/core/core.js
+++ b/src/core/core.js
@@ -4,14 +4,13 @@
  * @for p5
  * @requires constants
  */
-define(function (require) {
 
   'use strict';
 
-  require('core/shim');
+  require('./shim');
 
   // Core needs the PVariables object
-  var constants = require('core/constants');
+  var constants = require('./constants');
 
   /**
    * This is the p5 instance constructor.
@@ -507,6 +506,4 @@ define(function (require) {
     p5.prototype._registeredMethods[name].push(m);
   }.bind(this);
 
-  return p5;
-
-});
+  module.exports = p5;

--- a/src/core/core.js
+++ b/src/core/core.js
@@ -497,13 +497,13 @@
 
   p5.prototype.registerPreloadMethod = function(m) {
     p5.prototype._preloadMethods.push(m);
-  }.bind(this);
+  };
 
   p5.prototype.registerMethod = function(name, m) {
     if (!p5.prototype._registeredMethods.hasOwnProperty(name)) {
       p5.prototype._registeredMethods[name] = [];
     }
     p5.prototype._registeredMethods[name].push(m);
-  }.bind(this);
+  };
 
   module.exports = p5;

--- a/src/core/curves.js
+++ b/src/core/curves.js
@@ -4,13 +4,12 @@
  * @for p5
  * @requires core
  */
-define(function (require) {
 
   'use strict';
 
-  var p5 = require('core/core');
+  var p5 = require('./core');
 
-  require('core/error_helpers');
+  require('./error_helpers');
 
   var bezierDetail = 20;
   var curveDetail = 20;
@@ -394,6 +393,4 @@ define(function (require) {
     return a*f1 + b*f2 + c*f3 + d*f4;
   };
 
-  return p5;
-
-});
+  module.exports = p5;

--- a/src/core/environment.js
+++ b/src/core/environment.js
@@ -5,12 +5,11 @@
  * @requires core
  * @requires constants
  */
-define(function(require) {
 
   'use strict';
 
-  var p5 = require('core/core');
-  var C = require('core/constants');
+  var p5 = require('./core');
+  var C = require('./constants');
 
   var standardCursors = [C.ARROW, C.CROSS, C.HAND, C.MOVE, C.TEXT, C.WAIT];
 
@@ -556,6 +555,4 @@ define(function(require) {
     return v;
   };
 
-  return p5;
-
-});
+  module.exports = p5;

--- a/src/core/error_helpers.js
+++ b/src/core/error_helpers.js
@@ -2,14 +2,12 @@
  * @for p5
  * @requires core
  */
-define(function (require) {
 
   'use strict';
 
-  var p5 = require('core/core');
+  var p5 = require('./core');
   var doFriendlyWelcome = true;
 
-  
   // -- Borrowed from jQuery 1.11.3 --
   var class2type = {};
   var toString = class2type.toString;
@@ -262,6 +260,4 @@ define(function (require) {
     report(str, 'println', '#4DB200'); // auto dark green
   } */
 
-  return p5;
-
-});
+  module.exports = p5;

--- a/src/core/p5.Element.js
+++ b/src/core/p5.Element.js
@@ -3,9 +3,8 @@
  * @submodule DOM
  * @for p5.Element
  */
-define(function(require) {
 
-  var p5 = require('core/core');
+  var p5 = require('./core');
 
   /**
    * Base class for all elements added to a sketch, including canvas,
@@ -500,5 +499,4 @@ define(function(require) {
   };
 
 
-  return p5.Element;
-});
+  module.exports = p5.Element;

--- a/src/core/p5.Graphics.js
+++ b/src/core/p5.Graphics.js
@@ -3,16 +3,15 @@
  * @submodule Rendering
  * @for p5
  */
-define(function(require) {
 
-  var p5 = require('core/core');
-  var constants = require('core/constants');
+  var p5 = require('./core');
+  var constants = require('./constants');
 
   /**
    * Thin wrapper around a renderer, to be used for creating a
    * graphics buffer object. Use this class if you need
    * to draw into an off-screen graphics buffer. The two parameters define the
-   * width and height in pixels. The fields and methods for this class are 
+   * width and height in pixels. The fields and methods for this class are
    * extensive, but mirror the normal drawing API for p5.
    *
    * @class p5.Graphics
@@ -62,6 +61,5 @@ define(function(require) {
   };
 
   p5.Graphics.prototype = Object.create(p5.Element.prototype);
-  
-  return p5.Graphics;
-});
+
+  module.exports = p5.Graphics;

--- a/src/core/p5.Renderer.js
+++ b/src/core/p5.Renderer.js
@@ -3,9 +3,8 @@
  * @submodule Rendering
  * @for p5
  */
-define(function(require) {
 
-  var p5 = require('core/core');
+  var p5 = require('./core');
 
   /**
    * Main graphics and rendering context, as well as the base API
@@ -37,7 +36,7 @@ define(function(require) {
   };
 
   p5.Renderer.prototype = Object.create(p5.Element.prototype);
-  
+
   /**
    * Resize our canvas element.
    */
@@ -54,5 +53,4 @@ define(function(require) {
     }
   };
 
-  return p5.Renderer;
-});
+  module.exports = p5.Renderer;

--- a/src/core/p5.Renderer2D.js
+++ b/src/core/p5.Renderer2D.js
@@ -1,14 +1,13 @@
-define(function(require) {
 
-  var p5 = require('core/core');
-  var canvas = require('core/canvas');
-  var constants = require('core/constants');
-  var filters = require('image/filters');
+  var p5 = require('./core');
+  var canvas = require('./canvas');
+  var constants = require('./constants');
+  var filters = require('../image/filters');
 
-  require('core/p5.Renderer');
+  require('./p5.Renderer');
 
   /**
-   * 2D graphics renderer class.  Can also be used as an off-screen 
+   * 2D graphics renderer class.  Can also be used as an off-screen
    * graphics buffer. A p5.Renderer2D object can be constructed
    * with the <code>createRenderer2D()</code> function. The fields and methods
    * for this class are extensive, but mirror the normal drawing API for p5.
@@ -1085,7 +1084,7 @@ define(function(require) {
       }
 
       if (this._pInst._rectMode === constants.CENTER ){
-        
+
         x -= maxWidth / 2;
         y -= maxHeight / 2;
       }
@@ -1261,5 +1260,4 @@ define(function(require) {
     this.drawingContext.restore();
   };
 
-  return p5.Renderer2D;
-});
+  module.exports = p5.Renderer2D;

--- a/src/core/rendering.js
+++ b/src/core/rendering.js
@@ -3,13 +3,12 @@
  * @submodule Rendering
  * @for p5
  */
-define(function(require) {
 
-  var p5 = require('core/core');
-  var constants = require('core/constants');
-  require('core/p5.Graphics');
-  require('core/p5.Renderer2D');
-  require('3d/p5.Renderer3D');
+  var p5 = require('./core');
+  var constants = require('./constants');
+  require('./p5.Graphics');
+  require('./p5.Renderer2D');
+  require('../3d/p5.Renderer3D');
 
   /**
    * Creates a canvas element in the document, and sets the dimensions of it
@@ -78,7 +77,7 @@ define(function(require) {
     } else {
       document.body.appendChild(c);
     }
-    
+
 
 
     // Init our graphics renderer
@@ -257,6 +256,4 @@ define(function(require) {
     }
   };
 
-  return p5;
-
-});
+module.exports = p5;

--- a/src/core/shim.js
+++ b/src/core/shim.js
@@ -1,4 +1,3 @@
-define(function(require) {
 
   // requestAnim shim layer by Paul Irish
   window.requestAnimationFrame = (function(){
@@ -43,7 +42,7 @@ define(function(require) {
         window[vendors[x]+'CancelAnimationFrame'] ||
         window[vendors[x]+'CancelRequestAnimationFrame'];
     }
- 
+
     if (!window.requestAnimationFrame) {
       window.requestAnimationFrame = function(callback, element) {
         var currTime = new Date().getTime();
@@ -54,7 +53,7 @@ define(function(require) {
         return id;
       };
     }
- 
+
     if (!window.cancelAnimationFrame) {
       window.cancelAnimationFrame = function(id) {
         clearTimeout(id);
@@ -76,4 +75,4 @@ define(function(require) {
       Uint8ClampedArray.prototype.slice = Array.prototype.slice;
     }
   }());
-});
+

--- a/src/core/structure.js
+++ b/src/core/structure.js
@@ -4,11 +4,10 @@
  * @for p5
  * @requires core
  */
-define(function (require) {
 
   'use strict';
 
-  var p5 = require('core/core');
+  var p5 = require('./core');
 
   p5.prototype.exit = function() {
     throw 'exit() not implemented, see remove()';
@@ -311,6 +310,4 @@ define(function (require) {
   };
 
 
-  return p5;
-
-});
+  module.exports = p5;

--- a/src/core/transform.js
+++ b/src/core/transform.js
@@ -6,12 +6,11 @@
  * @requires constants
  */
 
-define(function(require) {
 
   'use strict';
 
-  var p5 = require('core/core');
-  var constants = require('core/constants');
+  var p5 = require('./core');
+  var constants = require('./constants');
 
   /**
    * Multiplies the current matrix by the one specified through the parameters.
@@ -311,6 +310,4 @@ define(function(require) {
     return this;
   };
 
-  return p5;
-
-});
+  module.exports = p5;

--- a/src/core/vertex.js
+++ b/src/core/vertex.js
@@ -5,12 +5,11 @@
  * @requires core
  * @requires constants
  */
-define(function (require) {
 
   'use strict';
 
-  var p5 = require('core/core');
-  var constants = require('core/constants');
+  var p5 = require('./core');
+  var constants = require('./constants');
   var shapeKind = null;
   var vertices = [];
   var contourVertices = [];
@@ -566,6 +565,4 @@ define(function (require) {
     return this;
   };
 
-  return p5;
-
-});
+  module.exports = p5;

--- a/src/events/acceleration.js
+++ b/src/events/acceleration.js
@@ -4,11 +4,10 @@
  * @for p5
  * @requires core
  */
-define(function (require){
 
   'use strict';
 
-  var p5 = require('core/core');
+  var p5 = require('../core/core');
 
   /**
    * The system variable deviceOrientation always contains the orientation of
@@ -206,5 +205,4 @@ define(function (require){
   };
 
 
-  return p5;
-});
+  module.exports = p5;

--- a/src/events/keyboard.js
+++ b/src/events/keyboard.js
@@ -4,11 +4,10 @@
  * @for p5
  * @requires core
  */
-define(function (require) {
 
   'use strict';
 
-  var p5 = require('core/core');
+  var p5 = require('../core/core');
 
   /**
    * Holds the key codes of currently pressed keys.
@@ -307,6 +306,4 @@ define(function (require) {
     return downKeys[code];
   };
 
-  return p5;
-
-});
+  module.exports = p5;

--- a/src/events/mouse.js
+++ b/src/events/mouse.js
@@ -6,12 +6,11 @@
  * @requires constants
  */
 
-define(function (require) {
 
   'use strict';
 
-  var p5 = require('core/core');
-  var constants = require('core/constants');
+  var p5 = require('../core/core');
+  var constants = require('../core/constants');
 
   /**
    * The system variable mouseX always contains the current horizontal
@@ -680,6 +679,4 @@ define(function (require) {
     }
   };
 
-  return p5;
-
-});
+  module.exports = p5;

--- a/src/events/touch.js
+++ b/src/events/touch.js
@@ -4,11 +4,10 @@
  * @for p5
  * @requires core
  */
-define(function (require) {
 
   'use strict';
 
-  var p5 = require('core/core');
+  var p5 = require('../core/core');
 
 /**
    * The system variable touchX always contains the horizontal position of
@@ -275,6 +274,4 @@ define(function (require) {
     }
   };
 
-  return p5;
-
-});
+  module.exports = p5;

--- a/src/image/filters.js
+++ b/src/image/filters.js
@@ -1,7 +1,5 @@
 /*global ImageData:false */
 
-define(function (require) {
-
   /**
    * This module defines the filters for use with image buffers.
    *
@@ -18,7 +16,6 @@ define(function (require) {
    */
 
   'use strict';
-
 
   var Filters = {};
 
@@ -601,6 +598,4 @@ define(function (require) {
   };
 
 
-  return Filters;
-
-});
+  module.exports = Filters;

--- a/src/image/image.js
+++ b/src/image/image.js
@@ -9,12 +9,17 @@
    * This module defines the p5 methods for the p5.Image class
    * for drawing images to the main display canvas.
    */
-
   'use strict';
 
 
   var p5 = require('../core/core');
   var constants = require('../core/constants');
+
+  /* global frames:true */// This is not global, but JSHint is not aware that
+  // this module is implicitly enclosed with Browserify: this overrides the
+  // redefined-global error and permits using the name "frames" for the array
+  // of saved animation frames.
+  var frames = [];
 
   p5.prototype._imageMode = constants.CORNER;
   p5.prototype._tint = null;
@@ -92,15 +97,6 @@
   p5.prototype.createImage = function(width, height) {
     return new p5.Image(width, height);
   };
-
-
-  /**
-   * @module Image
-   * @submodule Output
-   * @for p5
-   * @requires core
-   */
-  var frames = [];
 
   /**
    *  Save the current canvas as an image. In Safari, will open the

--- a/src/image/image.js
+++ b/src/image/image.js
@@ -4,7 +4,6 @@
  * @for p5
  * @requires core
  */
-define(function (require) {
 
   /**
    * This module defines the p5 methods for the p5.Image class
@@ -14,8 +13,8 @@ define(function (require) {
   'use strict';
 
 
-  var p5 = require('core/core');
-  var constants = require('core/constants');
+  var p5 = require('../core/core');
+  var constants = require('../core/constants');
 
   p5.prototype._imageMode = constants.CORNER;
   p5.prototype._tint = null;
@@ -249,7 +248,5 @@ define(function (require) {
     thisFrame.ext = extension;
     frames.push(thisFrame);
   };
-  return p5;
-});
 
-
+  module.exports = p5;

--- a/src/image/loading_displaying.js
+++ b/src/image/loading_displaying.js
@@ -4,16 +4,15 @@
  * @for p5
  * @requires core
  */
-define(function (require) {
 
   'use strict';
 
-  var p5 = require('core/core');
-  var Filters = require('image/filters');
-  var canvas = require('core/canvas');
-  var constants = require('core/constants');
+  var p5 = require('../core/core');
+  var Filters = require('./filters');
+  var canvas = require('../core/canvas');
+  var constants = require('../core/constants');
 
-  require('core/error_helpers');
+  require('../core/error_helpers');
 
   /**
    * Loads an image from a path and creates a p5.Image from it.
@@ -341,6 +340,4 @@ define(function (require) {
   };
 
 
-  return p5;
-
-});
+  module.exports = p5;

--- a/src/image/p5.Image.js
+++ b/src/image/p5.Image.js
@@ -5,7 +5,6 @@
  * @requires constants
  * @requires filters
  */
-define(function (require) {
 
   /**
    * This module defines the p5.Image class and P5 methods for
@@ -14,8 +13,8 @@ define(function (require) {
 
   'use strict';
 
-  var p5 = require('core/core');
-  var Filters = require('image/filters');
+  var p5 = require('../core/core');
+  var Filters = require('./filters');
 
   /*
    * Class methods
@@ -422,5 +421,5 @@ define(function (require) {
     //Make the browser download the file
     p5.prototype.downloadFile(imageData, filename, extension);
   };
-  return p5.Image;
-});
+
+  module.exports = p5.Image;

--- a/src/image/pixels.js
+++ b/src/image/pixels.js
@@ -4,13 +4,12 @@
  * @for p5
  * @requires core
  */
-define(function (require) {
 
   'use strict';
 
-  var p5 = require('core/core');
-  var Filters = require('image/filters');
-  require('color/p5.Color');
+  var p5 = require('../core/core');
+  var Filters = require('./filters');
+  require('../color/p5.Color');
 
   /**
    * <a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference
@@ -549,6 +548,4 @@ define(function (require) {
     this._graphics.updatePixels(x, y, w, h);
   };
 
-  return p5;
-
-});
+  module.exports = p5;

--- a/src/io/files.js
+++ b/src/io/files.js
@@ -1031,6 +1031,19 @@
 
   };
 
+  // =======
+  // HELPERS
+  // =======
+
+  function escapeHelper(content) {
+    return content
+      .replace(/&/g, '&amp;')
+      .replace(/</g, '&lt;')
+      .replace(/>/g, '&gt;')
+      .replace(/"/g, '&quot;')
+      .replace(/'/g, '&#039;');
+  }
+
   /**
    *  Writes the contents of a Table object to a file. Defaults to a
    *  text file with comma-separated-values ('csv') but can also
@@ -1146,19 +1159,6 @@
     pWriter.close();
     pWriter.flush();
   }; // end saveTable()
-
-  // =======
-  // HELPERS
-  // =======
-
-  var escapeHelper = function(content) {
-    return content
-      .replace(/&/g, '&amp;')
-      .replace(/</g, '&lt;')
-      .replace(/>/g, '&gt;')
-      .replace(/"/g, '&quot;')
-      .replace(/'/g, '&#039;');
-  };
 
   /**
    *  Generate a blob of file data as a url to prepare for download.

--- a/src/io/files.js
+++ b/src/io/files.js
@@ -7,13 +7,12 @@
  * @requires core
  * @requires reqwest
  */
-define(function (require) {
 
   'use strict';
 
-  var p5 = require('core/core');
+  var p5 = require('../core/core');
   var reqwest = require('reqwest');
-  require('core/error_helpers');
+  require('../core/error_helpers');
 
 
   /**
@@ -66,8 +65,8 @@ define(function (require) {
    *
    */
 
-  
-  
+
+
 
   p5.prototype.loadFont = function(path, callback) {
 
@@ -303,37 +302,37 @@ define(function (require) {
    *                                     loadTable() completes, Table object is
    *                                     passed in as first argument
    * @return {Object}                    Table object containing data
-   *  
+   *
    * @example
 	* <div class="norender">
 	* <code>
-	* // Given the following CSV file called "mammals.csv" 
+	* // Given the following CSV file called "mammals.csv"
    * // located in the project's "assets" folder:
-   * // 
+   * //
 	* // id,species,name
 	* // 0,Capra hircus,Goat
 	* // 1,Panthera pardus,Leopard
 	* // 2,Equus zebra,Zebra
-	* 
+	*
 	* var table;
-	* 
+	*
 	* function preload() {
 	*   //my table is comma separated value "csv"
 	*   //and has a header specifying the columns labels
 	*   table = loadTable("assets/mammals.csv", "csv", "header");
 	*   //the file can be remote
-	*   //table = loadTable("http://p5js.org/reference/assets/mammals.csv", 
+	*   //table = loadTable("http://p5js.org/reference/assets/mammals.csv",
 	*   //                  "csv", "header");
 	* }
-	* 
+	*
 	* function setup() {
 	*   //count the columns
 	*   print(table.getRowCount() + " total rows in table");
 	*   print(table.getColumnCount() + " total columns in table");
-	* 
+	*
 	*   print(table.getColumn("name"));
 	*   //["Goat", "Leopard", "Zebra"]
-	* 
+	*
 	*   //cycle through the table
 	*   for (var r = 0; r < table.getRowCount(); r++)
 	*     for (var c = 0; c < table.getColumnCount(); c++) {
@@ -1273,5 +1272,4 @@ define(function (require) {
     document.body.removeChild(event.target);
   }
 
-  return p5;
-});
+  module.exports = p5;

--- a/src/io/p5.Table.js
+++ b/src/io/p5.Table.js
@@ -3,11 +3,10 @@
  * @submodule Table
  * @requires core
  */
-define(function (require) {
 
   'use strict';
 
-  var p5 = require('core/core');
+  var p5 = require('../core/core');
 
 
   /**
@@ -73,29 +72,29 @@ define(function (require) {
    * @example
 	* <div class="norender">
 	* <code>
-	* // Given the CSV file "mammals.csv" 
+	* // Given the CSV file "mammals.csv"
 	* // in the project's "assets" folder:
 	* //
 	* // id,species,name
 	* // 0,Capra hircus,Goat
 	* // 1,Panthera pardus,Leopard
 	* // 2,Equus zebra,Zebra
-	* 
+	*
 	* var table;
-	* 
+	*
 	* function preload() {
 	*   //my table is comma separated value "csv"
 	*   //and has a header specifying the columns labels
 	*   table = loadTable("assets/mammals.csv", "csv", "header");
 	* }
-	* 
+	*
 	* function setup() {
 	*   //add a row
 	*   var newRow = table.addRow();
 	*   newRow.setString("id", table.getRowCount() - 1);
 	*   newRow.setString("species", "Canis Lupus");
 	*   newRow.setString("name", "Wolf");
-	* 
+	*
 	*   //print the results
 	*   for (var r = 0; r < table.getRowCount(); r++)
 	*     for (var c = 0; c < table.getColumnCount(); c++)
@@ -126,26 +125,26 @@ define(function (require) {
    * @example
 	* <div class="norender">
 	* <code>
-	* // Given the CSV file "mammals.csv" 
+	* // Given the CSV file "mammals.csv"
 	* // in the project's "assets" folder:
 	* //
 	* // id,species,name
 	* // 0,Capra hircus,Goat
 	* // 1,Panthera pardus,Leopard
 	* // 2,Equus zebra,Zebra
-	* 
+	*
 	* var table;
-	* 
+	*
 	* function preload() {
 	*   //my table is comma separated value "csv"
 	*   //and has a header specifying the columns labels
 	*   table = loadTable("assets/mammals.csv", "csv", "header");
 	* }
-	* 
+	*
 	* function setup() {
 	*   //remove the first row
 	*   var r = table.removeRow(0);
-	* 
+	*
 	*   //print the results
 	*   for (var r = 0; r < table.getRowCount(); r++)
 	*     for (var c = 0; c < table.getColumnCount(); c++)
@@ -173,22 +172,22 @@ define(function (require) {
    * @example
 	* <div class="norender">
 	* <code>
-	* // Given the CSV file "mammals.csv" 
+	* // Given the CSV file "mammals.csv"
 	* // in the project's "assets" folder:
 	* //
 	* // id,species,name
 	* // 0,Capra hircus,Goat
 	* // 1,Panthera pardus,Leopard
 	* // 2,Equus zebra,Zebra
-	* 
+	*
 	* var table;
-	* 
+	*
 	* function preload() {
 	*   //my table is comma separated value "csv"
 	*   //and has a header specifying the columns labels
 	*   table = loadTable("assets/mammals.csv", "csv", "header");
 	* }
-	* 
+	*
 	* function setup() {
 	*   var row = table.getRow(1);
 	*   //print it column by column
@@ -212,29 +211,29 @@ define(function (require) {
    * @example
 	* <div class="norender">
 	* <code>
-	* // Given the CSV file "mammals.csv" 
+	* // Given the CSV file "mammals.csv"
 	* // in the project's "assets" folder:
 	* //
 	* // id,species,name
 	* // 0,Capra hircus,Goat
 	* // 1,Panthera pardus,Leopard
 	* // 2,Equus zebra,Zebra
-	* 
+	*
 	* var table;
-	* 
+	*
 	* function preload() {
 	*   //my table is comma separated value "csv"
 	*   //and has a header specifying the columns labels
 	*   table = loadTable("assets/mammals.csv", "csv", "header");
 	* }
-	* 
+	*
 	* function setup() {
 	*   var rows = table.getRows();
-	* 
+	*
 	*   //warning: rows is an array of objects
 	*   for (var r = 0; r < rows.length; r++)
 	*     rows[r].set("name", "Unicorn");
-	* 
+	*
 	*   //print the results
 	*   for (var r = 0; r < table.getRowCount(); r++)
 	*     for (var c = 0; c < table.getColumnCount(); c++)
@@ -263,22 +262,22 @@ define(function (require) {
    * @example
 	* <div class="norender">
 	* <code>
-	* // Given the CSV file "mammals.csv" 
+	* // Given the CSV file "mammals.csv"
 	* // in the project's "assets" folder:
 	* //
 	* // id,species,name
 	* // 0,Capra hircus,Goat
 	* // 1,Panthera pardus,Leopard
 	* // 2,Equus zebra,Zebra
-	* 
+	*
 	* var table;
-	* 
+	*
 	* function preload() {
 	*   //my table is comma separated value "csv"
 	*   //and has a header specifying the columns labels
 	*   table = loadTable("assets/mammals.csv", "csv", "header");
 	* }
-	* 
+	*
 	* function setup() {
 	*   //find the animal named zebra
 	*   var row = table.findRow("Zebra", "name");
@@ -325,29 +324,29 @@ define(function (require) {
    * @example
 	* <div class="norender">
 	* <code>
-	* // Given the CSV file "mammals.csv" 
+	* // Given the CSV file "mammals.csv"
 	* // in the project's "assets" folder:
 	* //
 	* // id,species,name
 	* // 0,Capra hircus,Goat
 	* // 1,Panthera pardus,Leopard
 	* // 2,Equus zebra,Zebra
-	* 
+	*
 	* var table;
-	* 
+	*
 	* function preload() {
 	*   //my table is comma separated value "csv"
 	*   //and has a header specifying the columns labels
 	*   table = loadTable("assets/mammals.csv", "csv", "header");
 	* }
-	* 
+	*
 	* function setup() {
 	*   //add another goat
 	*   var newRow = table.addRow();
 	*   newRow.setString("id", table.getRowCount() - 1);
 	*   newRow.setString("species", "Scape Goat");
 	*   newRow.setString("name", "Goat");
-	* 
+	*
 	*   //find the rows containing animals named Goat
 	*   var rows = table.findRows("Goat", "name");
 	*   print(rows.length + " Goats found");
@@ -452,22 +451,22 @@ define(function (require) {
    * @example
 	* <div class="norender">
 	* <code>
-	* // Given the CSV file "mammals.csv" 
+	* // Given the CSV file "mammals.csv"
 	* // in the project's "assets" folder:
 	* //
 	* // id,species,name
 	* // 0,Capra hircus,Goat
 	* // 1,Panthera pardus,Leopard
 	* // 2,Equus zebra,Zebra
-	* 
+	*
 	* var table;
-	* 
+	*
 	* function preload() {
 	*   //my table is comma separated value "csv"
 	*   //and has a header specifying the columns labels
 	*   table = loadTable("assets/mammals.csv", "csv", "header");
 	* }
-	* 
+	*
 	* function setup() {
 	*   //getColumn returns an array that can be printed directly
 	*   print(table.getColumn("species"));
@@ -499,22 +498,22 @@ define(function (require) {
    * @example
 	* <div class="norender">
 	* <code>
-	* // Given the CSV file "mammals.csv" 
+	* // Given the CSV file "mammals.csv"
 	* // in the project's "assets" folder:
 	* //
 	* // id,species,name
 	* // 0,Capra hircus,Goat
 	* // 1,Panthera pardus,Leopard
 	* // 2,Equus zebra,Zebra
-	* 
+	*
 	* var table;
-	* 
+	*
 	* function preload() {
 	*   //my table is comma separated value "csv"
 	*   //and has a header specifying the columns labels
 	*   table = loadTable("assets/mammals.csv", "csv", "header");
 	* }
-	* 
+	*
 	* function setup() {
 	*   table.clearRows();
 	*   print(table.getRowCount() + " total rows in table");
@@ -540,28 +539,28 @@ define(function (require) {
    * @example
 	* <div class="norender">
 	* <code>
-	* // Given the CSV file "mammals.csv" 
+	* // Given the CSV file "mammals.csv"
 	* // in the project's "assets" folder:
 	* //
 	* // id,species,name
 	* // 0,Capra hircus,Goat
 	* // 1,Panthera pardus,Leopard
 	* // 2,Equus zebra,Zebra
-	* 
+	*
 	* var table;
-	* 
+	*
 	* function preload() {
 	*   //my table is comma separated value "csv"
 	*   //and has a header specifying the columns labels
 	*   table = loadTable("assets/mammals.csv", "csv", "header");
 	* }
-	* 
+	*
 	* function setup() {
 	*   table.addColumn("carnivore");
 	*   table.set(0, "carnivore", "no");
 	*   table.set(1, "carnivore", "yes");
 	*   table.set(2, "carnivore", "no");
-	* 
+	*
 	*   //print the results
 	*   for (var r = 0; r < table.getRowCount(); r++)
 	*     for (var c = 0; c < table.getColumnCount(); c++)
@@ -589,7 +588,7 @@ define(function (require) {
    *
    *  @method  getRowCount
    *  @return {Number} Number of rows in this table
-   
+
    */
   p5.Table.prototype.getRowCount = function() {
     return this.rows.length;
@@ -701,22 +700,22 @@ define(function (require) {
    * @example
 	* <div class="norender">
 	* <code>
-	* // Given the CSV file "mammals.csv" 
+	* // Given the CSV file "mammals.csv"
 	* // in the project's "assets" folder:
 	* //
 	* // id,species,name
 	* // 0,Capra hircus,Goat
 	* // 1,Panthera pardus,Leopard
 	* // 2,Equus zebra,Zebra
-	* 
+	*
 	* var table;
-	* 
+	*
 	* function preload() {
 	*   //my table is comma separated value "csv"
 	*   //and has a header specifying the columns labels
 	*   table = loadTable("assets/mammals.csv", "csv", "header");
 	* }
-	* 
+	*
 	* function setup() {
 	*   table.removeColumn("id");
 	*   print(table.getColumnCount());
@@ -766,26 +765,26 @@ define(function (require) {
    * @example
 	* <div class="norender">
 	* <code>
-	* // Given the CSV file "mammals.csv" 
+	* // Given the CSV file "mammals.csv"
 	* // in the project's "assets" folder:
 	* //
 	* // id,species,name
 	* // 0,Capra hircus,Goat
 	* // 1,Panthera pardus,Leopard
 	* // 2,Equus zebra,Zebra
-	* 
+	*
 	* var table;
-	* 
+	*
 	* function preload() {
 	*   //my table is comma separated value "csv"
 	*   //and has a header specifying the columns labels
 	*   table = loadTable("assets/mammals.csv", "csv", "header");
 	* }
-	* 
+	*
 	* function setup() {
 	*   table.set(0, "species", "Canis Lupus");
 	*   table.set(0, "name", "Wolf");
-	* 
+	*
 	*   //print the results
 	*   for (var r = 0; r < table.getRowCount(); r++)
 	*     for (var c = 0; c < table.getColumnCount(); c++)
@@ -812,25 +811,25 @@ define(function (require) {
    * @example
 	* <div class="norender">
 	* <code>
-	* // Given the CSV file "mammals.csv" 
+	* // Given the CSV file "mammals.csv"
 	* // in the project's "assets" folder:
 	* //
 	* // id,species,name
 	* // 0,Capra hircus,Goat
 	* // 1,Panthera pardus,Leopard
 	* // 2,Equus zebra,Zebra
-	* 
+	*
 	* var table;
-	* 
+	*
 	* function preload() {
 	*   //my table is comma separated value "csv"
 	*   //and has a header specifying the columns labels
 	*   table = loadTable("assets/mammals.csv", "csv", "header");
 	* }
-	* 
+	*
 	* function setup() {
 	*   table.setNum(1, "id", 1);
-	* 
+	*
 	*   print(table.getColumn(0));
 	*   //["0", 1, "2"]
 	* }
@@ -871,22 +870,22 @@ define(function (require) {
    * @example
 	* <div class="norender">
 	* <code>
-	* // Given the CSV file "mammals.csv" 
+	* // Given the CSV file "mammals.csv"
 	* // in the project's "assets" folder:
 	* //
 	* // id,species,name
 	* // 0,Capra hircus,Goat
 	* // 1,Panthera pardus,Leopard
 	* // 2,Equus zebra,Zebra
-	* 
+	*
 	* var table;
-	* 
+	*
 	* function preload() {
 	*   //my table is comma separated value "csv"
 	*   //and has a header specifying the columns labels
 	*   table = loadTable("assets/mammals.csv", "csv", "header");
 	* }
-	* 
+	*
 	* function setup() {
 	*   print(table.get(0, 1));
 	*   //Capra hircus
@@ -914,22 +913,22 @@ define(function (require) {
    * @example
 	* <div class="norender">
 	* <code>
-	* // Given the CSV file "mammals.csv" 
+	* // Given the CSV file "mammals.csv"
 	* // in the project's "assets" folder:
 	* //
 	* // id,species,name
 	* // 0,Capra hircus,Goat
 	* // 1,Panthera pardus,Leopard
 	* // 2,Equus zebra,Zebra
-	* 
+	*
 	* var table;
-	* 
+	*
 	* function preload() {
 	*   //my table is comma separated value "csv"
 	*   //and has a header specifying the columns labels
 	*   table = loadTable("assets/mammals.csv", "csv", "header");
 	* }
-	* 
+	*
 	* function setup() {
 	*   print(table.getNum(1, 0) + 100);
 	*   //id 1 + 100 = 101
@@ -955,25 +954,25 @@ define(function (require) {
    * @example
 	* <div class="norender">
 	* <code>
-	* // Given the CSV file "mammals.csv" 
+	* // Given the CSV file "mammals.csv"
 	* // in the project's "assets" folder:
 	* //
 	* // id,species,name
 	* // 0,Capra hircus,Goat
 	* // 1,Panthera pardus,Leopard
 	* // 2,Equus zebra,Zebra
-	* 
+	*
 	* var table;
-	* 
+	*
 	* function preload() {
 	*   //my table is comma separated value "csv"
 	*   //and has a header specifying the columns labels
 	*   table = loadTable("assets/mammals.csv", "csv", "header");
 	* }
-	* 
+	*
 	* function setup() {
 	*   var tableArray = table.getArray();
-	* 
+	*
 	*   //output each row as array
 	*   for (var i = 0; i < tableArray.length; i++)
 	*     print(tableArray[i]);
@@ -998,25 +997,25 @@ define(function (require) {
    * @example
 	* <div class="norender">
 	* <code>
-	* // Given the CSV file "mammals.csv" 
+	* // Given the CSV file "mammals.csv"
 	* // in the project's "assets" folder:
 	* //
 	* // id,species,name
 	* // 0,Capra hircus,Goat
 	* // 1,Panthera pardus,Leopard
 	* // 2,Equus zebra,Zebra
-	* 
+	*
 	* var table;
-	* 
+	*
 	* function preload() {
 	*   //my table is comma separated value "csv"
 	*   //and has a header specifying the columns labels
 	*   table = loadTable("assets/mammals.csv", "csv", "header");
 	* }
-	* 
+	*
 	* function setup() {
 	*   var tableObject = table.getObject();
-	* 
+	*
 	*   print(tableObject);
 	*   //outputs an object
 	* }
@@ -1060,6 +1059,4 @@ define(function (require) {
     return tableArray;
   };
 
-  return p5.Table;
-
-});
+  module.exports = p5.Table;

--- a/src/io/p5.TableRow.js
+++ b/src/io/p5.TableRow.js
@@ -3,11 +3,10 @@
  * @submodule Table
  * @requires core
  */
-define(function (require) {
 
   'use strict';
 
-  var p5 = require('core/core');
+  var p5 = require('../core/core');
 
   /**
    *  A TableRow object represents a single row of data values,
@@ -166,6 +165,4 @@ define(function (require) {
     }
   };
 
-  return p5.TableRow;
-
-});
+  module.exports = p5.TableRow;

--- a/src/math/calculation.js
+++ b/src/math/calculation.js
@@ -4,11 +4,10 @@
  * @for p5
  * @requires core
  */
-define(function (require) {
 
   'use strict';
 
-  var p5 = require('core/core');
+  var p5 = require('../core/core');
 
   /**
    * Calculates the absolute value (magnitude) of a number. Maps to Math.abs().
@@ -668,6 +667,4 @@ define(function (require) {
    */
   p5.prototype.sqrt = Math.sqrt;
 
-  return p5;
-
-});
+  module.exports = p5;

--- a/src/math/math.js
+++ b/src/math/math.js
@@ -4,11 +4,10 @@
  * @for p5
  * @requires core
  */
-define(function (require) {
 
   'use strict';
 
-  var p5 = require('core/core');
+  var p5 = require('../core/core');
 
 
   /**
@@ -30,6 +29,4 @@ define(function (require) {
     }
   };
 
-  return p5;
-
-});
+  module.exports = p5;

--- a/src/math/noise.js
+++ b/src/math/noise.js
@@ -17,11 +17,10 @@
  * @for p5
  * @requires core
  */
-define(function (require) {
 
   'use strict';
 
-  var p5 = require('core/core');
+  var p5 = require('../core/core');
 
   var PERLIN_YWRAPB = 4;
   var PERLIN_YWRAP = 1<<PERLIN_YWRAPB;
@@ -313,7 +312,4 @@ define(function (require) {
     }
   };
 
-  return p5;
-});
-
-
+  module.exports = p5;

--- a/src/math/p5.Vector.js
+++ b/src/math/p5.Vector.js
@@ -3,13 +3,12 @@
  * @submodule Math
  * @requires constants
  */
-define(function (require) {
 
   'use strict';
 
-  var p5 = require('core/core');
-  var polarGeometry = require('math/polargeometry');
-  var constants = require('core/constants');
+  var p5 = require('../core/core');
+  var polarGeometry = require('./polargeometry');
+  var constants = require('../core/constants');
 
   /**
    * A class to describe a two or three dimensional vector, specifically
@@ -1034,6 +1033,4 @@ define(function (require) {
     return angle;
   };
 
-  return p5.Vector;
-
-});
+  module.exports = p5.Vector;

--- a/src/math/polargeometry.js
+++ b/src/math/polargeometry.js
@@ -1,6 +1,5 @@
-define(function(require) {
 
-  return {
+  module.exports = {
 
     degreesToRadians: function(x) {
       return 2 * Math.PI * x / 360;
@@ -11,5 +10,3 @@ define(function(require) {
     }
 
   };
-
-});

--- a/src/math/random.js
+++ b/src/math/random.js
@@ -4,11 +4,10 @@
  * @for p5
  * @requires core
  */
-define(function (require) {
 
   'use strict';
 
-  var p5 = require('core/core');
+  var p5 = require('../core/core');
 
   var seeded = false;
 
@@ -211,9 +210,4 @@ define(function (require) {
     return y1*s + m;
   };
 
-  return p5;
-
-});
-
-
-
+  module.exports = p5;

--- a/src/math/trigonometry.js
+++ b/src/math/trigonometry.js
@@ -6,13 +6,12 @@
  * @requires polargeometry
  * @requires constants
  */
-define(function (require) {
 
   'use strict';
 
-  var p5 = require('core/core');
-  var polarGeometry = require('math/polargeometry');
-  var constants = require('core/constants');
+  var p5 = require('../core/core');
+  var polarGeometry = require('./polargeometry');
+  var constants = require('../core/constants');
 
   p5.prototype._angleMode = constants.RADIANS;
 
@@ -334,6 +333,4 @@ define(function (require) {
     }
   };
 
-  return p5;
-
-});
+  module.exports = p5;

--- a/src/typography/attributes.js
+++ b/src/typography/attributes.js
@@ -5,12 +5,11 @@
  * @requires core
  * @requires constants
  */
-define(function(require) {
 
   'use strict';
 
-  var p5 = require('core/core');
-  var constants = require('core/constants');
+  var p5 = require('../core/core');
+  var constants = require('../core/constants');
 
   p5.prototype._textSize = 12;
   p5.prototype._textLeading = 15;
@@ -353,6 +352,4 @@ define(function(require) {
     return [currentLeft, currentTop];
   };
 
-  return p5;
-
-});
+  module.exports = p5;

--- a/src/typography/loading_displaying.js
+++ b/src/typography/loading_displaying.js
@@ -4,14 +4,13 @@
  * @for p5
  * @requires core
  */
-define(function(require) {
 
   'use strict';
 
-  var p5 = require('core/core');
-  var constants = require('core/constants');
+  var p5 = require('../core/core');
+  var constants = require('../core/constants');
 
-  require('core/error_helpers');
+  require('../core/error_helpers');
 
 
   /**
@@ -138,6 +137,4 @@ define(function(require) {
     return this;
   };
 
-  return p5;
-
-});
+  module.exports = p5;

--- a/src/typography/p5.Font.js
+++ b/src/typography/p5.Font.js
@@ -6,7 +6,6 @@
  * @requires core
  * @requires constants
  */
-define(function(require) {
 
   /*
    * TODO:
@@ -24,8 +23,8 @@ define(function(require) {
 
   'use strict';
 
-  var p5 = require('core/core');
-  var constants = require('core/constants');
+  var p5 = require('../core/core');
+  var constants = require('../core/constants');
 
   /**
    * Base class for font handling
@@ -449,5 +448,4 @@ define(function(require) {
     return hash;
   }
 
-  return p5.Font;
-});
+  module.exports = p5.Font;

--- a/src/utilities/array_functions.js
+++ b/src/utilities/array_functions.js
@@ -4,11 +4,10 @@
  * @for p5
  * @requires core
  */
-define(function (require) {
 
   'use strict';
 
-  var p5 = require('core/core');
+  var p5 = require('../core/core');
 
   /**
    * Adds a value to the end of an array. Extends the length of
@@ -344,6 +343,4 @@ define(function (require) {
     }
   };
 
-  return p5;
-
-});
+  module.exports = p5;

--- a/src/utilities/conversion.js
+++ b/src/utilities/conversion.js
@@ -4,11 +4,10 @@
  * @for p5
  * @requires core
  */
-define(function (require) {
 
   'use strict';
 
-  var p5 = require('core/core');
+  var p5 = require('../core/core');
 
   /**
    * Converts a string to its floating point representation. The contents of a
@@ -257,5 +256,4 @@ define(function (require) {
     }
   };
 
-  return p5;
-});
+  module.exports = p5;

--- a/src/utilities/string_functions.js
+++ b/src/utilities/string_functions.js
@@ -4,11 +4,10 @@
  * @for p5
  * @requires core
  */
-define(function (require) {
 
   'use strict';
 
-  var p5 = require('core/core');
+  var p5 = require('../core/core');
 
   //return p5; //LM is this a mistake?
 
@@ -478,6 +477,4 @@ define(function (require) {
     }
   };
 
-  return p5;
-
-});
+  module.exports = p5;

--- a/src/utilities/time_date.js
+++ b/src/utilities/time_date.js
@@ -4,11 +4,10 @@
  * @for p5
  * @requires core
  */
-define(function (require) {
 
   'use strict';
 
-  var p5 = require('core/core');
+  var p5 = require('../core/core');
 
   /**
    * p5.js communicates with the clock on your computer. The day() function
@@ -137,6 +136,4 @@ define(function (require) {
     return new Date().getFullYear();
   };
 
-  return p5;
-
-});
+  module.exports = p5;


### PR DESCRIPTION
You said you wanted a PR that touched every file in the app, sooo.... :smile: 

Summary of changes:

- Changes all AMD module definitions to CommonJS
- Updates all required module paths to be relative
- Adds Browserify task to Gruntfile, to build the CommonJS modules
- Adds Concat task to Gruntfile, to combine the built file w/ OpenType
- Turns off JSHint TEMPORARILY because this introduced some errors

Re: that last point, most of them are issues where JSHint doesn't "get" browserify—updating to the latest and making some jshintrc changes will resolve them, and that's In Progress this evening.

However, I do need clarification on one point: why are we doing `.bind(this)` in this code from `core/core.js`?:
```js
p5.prototype.registerPreloadMethod = function(m) {
    p5.prototype._preloadMethods.push(m);
  }.bind(this);

  p5.prototype.registerMethod = function(name, m) {
    if (!p5.prototype._registeredMethods.hasOwnProperty(name)) {
      p5.prototype._registeredMethods[name] = [];
    }
    p5.prototype._registeredMethods[name].push(m);
  }.bind(this);
```
Thanks!