### PR TITLE
Add NPM script aliases to simplify CI testing process

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: node_js
 node_js:
   - "0.10"
-before_install: npm install -g grunt-cli
+  - "0.12"
 install: npm install
-script: grunt
+script: npm run grunt

--- a/package.json
+++ b/package.json
@@ -4,12 +4,19 @@
     "type": "git",
     "url": "https://github.com/processing/p5.js.git"
   },
+  "scripts": {
+    "grunt": "grunt",
+    "build": "grunt build",
+    "docs": "grunt yui",
+    "test": "grunt"
+  },
   "version": "0.4.6",
   "devDependencies": {
     "amdclean": "~0.3.3",
     "concat-files": "^0.1.0",
     "grunt": "^0.4.5",
     "grunt-browserify": "^3.8.0",
+    "grunt-cli": "^0.1.13",
     "grunt-contrib-concat": "^0.5.1",
     "grunt-contrib-connect": "^0.9.0",
     "grunt-contrib-jshint": "^0.11.2",


### PR DESCRIPTION
By adding a "scripts" block to package.json, we can avoid the need to have grunt-cli installed on the testing server: NPM scripts have access to all locally-installed modules, so they can use that version of grunt directly. More info on this methodology: https://bocoup.com/weblog/a-facade-for-tooling-with-npm-scripts/

Changes:

- Install `grunt-cli` locally as a dev dependency
- Add NPM scripts to run common grunt commands: these are aliases, so   `npm run build` will have the exact same effect as `grunt build`, it   just doesn't depend on the global installation of the CLI
- Updates the Travis CI configuration to use `npm run grunt` to remove  the CLI dependency
- Adds the latest version of Node to the Travis configuration