### PR TITLE
Fixing call usage so it passes the actual p5 instance.

### DIFF
--- a/src/core/structure.js
+++ b/src/core/structure.js
@@ -294,12 +294,13 @@ p5.prototype.redraw = function () {
     if (typeof userSetup === 'undefined') {
       this.scale(this.pixelDensity, this.pixelDensity);
     }
+    var self = this;
     this._registeredMethods.pre.forEach(function (f) {
-      f.call(this);
+      f.call(self);
     });
     userDraw();
     this._registeredMethods.post.forEach(function (f) {
-      f.call(this);
+      f.call(self);
     });
     this.pop();
   }


### PR DESCRIPTION
The way the main branch is doing it, 'this' is undefined, so if the callee refers to 'this' he gets a reference exception. I added the line:
   var self = this;
to make it obvious what we're passing, as the foreach behavior is (obviously) confusing.