### PR TITLE
Switch license field in package.json to use SPDX identifier

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,12 +32,7 @@
     "jscs-stylish": "^0.3.1",
     "phantomjs": "~1.9.2-4"
   },
-  "licenses": [
-    {
-      "type": "LGPL",
-      "url": "https://www.gnu.org/licenses/lgpl-2.1.html"
-    }
-  ],
+  "license": "LGPL-2.1",
   "dependencies": {
     "brfs": "^1.4.0",
     "reqwest": "^1.1.5"


### PR DESCRIPTION
I noticed an NPM warning as I was working on another issue; this PR addresses that warning

Reference: https://docs.npmjs.com/files/package.json#license

The NPM documentation (link above) suggests that the license under which a project is released should be specified in the "license" field within package.json. Without the presence of this field, NPM will display an error whenever you add a package, reminding you that your code (as far as NPM knows) is not licensed:

![image](https://cloud.githubusercontent.com/assets/442115/8896912/69b19930-33d8-11e5-9d50-b094987b8890.png)

Additionally, the NPM docs recommend the use of an SPDX identifier (Software Package Data Exchange, https://spdx.org/, a standard for communicating the license & copyright of a code package) for the "license" field.

The license link in our "licenses" field is to the LGPL 2.1, so I have switched package.json to use the SPDX equivalent, "LGPL-2.1"