### PR TITLE
Run mocha specs against connect-served spec files

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -10,9 +10,15 @@
  *
  *  grunt yui   - This will build the inline documentation for p5.js.
  *
- *  grunt test  - This only runs the automated tests, which is faster than
- *                rebuilding entirely from source because it skips minification
- *                and concatination.
+ *  grunt test  - This rebuilds the source and runs the automated tests on
+ *                both the minified and unminified code. If you need to debug
+ *                a test suite in a browser, `grunt test --keepalive` will
+ *                start the connect server and leave it running; the tests
+ *                can then be opened at localhost:9001/test/test.html
+ *
+ *  Note: `grunt test:nobuild` will skip the build step when running the tests,
+ *  and only runs the test files themselves through the linter: this can save
+ *  a lot of time when authoring test specs without making any build changes.
  *
  *  And there are several secondary tasks:
  *
@@ -125,8 +131,11 @@ module.exports = function(grunt) {
     // Set up the mocha task, used for running the automated tests.
     mocha: {
       test: {
-        src: ['test/**/*.html'],
         options: {
+          urls: [
+            'http://localhost:9001/test/test.html',
+            'http://localhost:9001/test/test-minified.html'
+          ],
           reporter: reporter,
           run: true,
           log: true,
@@ -246,7 +255,7 @@ module.exports = function(grunt) {
     connect: {
       server: {
         options: {
-          base: './test',
+          base: './',
           port: 9001,
           keepalive: keepalive,
           middleware: function(connect, options, middlewares) {
@@ -279,7 +288,8 @@ module.exports = function(grunt) {
   // Create the multitasks.
   // TODO: "requirejs" is in here to run the "yuidoc_themes" subtask. Is this needed?
   grunt.registerTask('build', ['browserify', 'concat', 'uglify', 'requirejs']);
-  grunt.registerTask('test', ['connect', 'jshint', 'jscs', 'build', 'mocha']);
+  grunt.registerTask('test', ['jshint', 'jscs', 'build', 'connect', 'mocha']);
+  grunt.registerTask('test:nobuild', ['jshint:test', 'jscs:test', 'connect', 'mocha']);
   grunt.registerTask('yui', ['yuidoc']);
   grunt.registerTask('default', ['test']);
 };

--- a/test/unit/io/files_input.js
+++ b/test/unit/io/files_input.js
@@ -30,10 +30,9 @@ suite('Files', function() {
     });
 
     test('should return an object', function() {
-      result = loadFont(opentype, './acmesa.ttf');
+      result = loadFont('/test/unit/assets/acmesa.ttf');
       assert.ok(result);
       assert.isObject(result);
-      //assert.isObject(result.font);
     });
   });
 
@@ -45,7 +44,7 @@ suite('Files', function() {
     });
 
     test('should return an Array', function() {
-      result = loadJSON('../assets/array.json');
+      result = loadJSON('/test/unit/assets/array.json');
       assert.ok(result);
       // assert.isObject(result, 'result is an object');
       assert.typeOf(result, 'Array');


### PR DESCRIPTION
@iros reported issues running the p5 tests in a browser: because our connect server was loading `./test/` as the server root, the browser could not access the actual p5.js lib files (which were in `../lib/`, up one level relative to `./test/`).

Changing the connect server to use `.` as its root fixes this problem, but this issue demonstrates that our server tests and browser tests were not executing in comparable environments. To fix this, I configured Mocha to run the spec files via the actual spec URLs on the running connect server, so that the command line and the browser will be testing the exact same thing, with the same relative paths.

Changing these roots required adjusting a couple of paths in situations where we were loading files within our tests.

Finally, I added a new grunt command: `grunt test:nobuild`, which will lint the test files then run the mocha specs without rebuilding the whole project: this is a developer convenience, which can be useful if
we're only making updates to the test specs themselves and p5 itself has not changed. I also altered the existing `grunt test` command to lint the code prior to starting the connect server, as it is only needed for the mocha specs themselves.