### PR TITLE
Pass generated browserify bundle through derequire

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -58,7 +58,10 @@ module.exports = function(grunt) {
         reporter: require('jscs-stylish').path
       },
       build: {
-        src: ['Gruntfile.js']
+        src: [
+          'Gruntfile.js',
+          'build/**/*.js'
+        ]
       },
       source: {
         src: [
@@ -77,7 +80,10 @@ module.exports = function(grunt) {
         options: {
           jshintrc: '.jshintrc'
         },
-        src: ['Gruntfile.js']
+        src: [
+          'Gruntfile.js',
+          'build/**/*.js'
+        ]
       },
       source: {
         options: {

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -259,8 +259,10 @@ module.exports = function(grunt) {
     }
   });
 
+  // Load task definitions
+  grunt.loadTasks('build/tasks');
+
   // Load the external libraries used.
-  grunt.loadNpmTasks('grunt-browserify');
   grunt.loadNpmTasks('grunt-jscs');
   grunt.loadNpmTasks('grunt-contrib-jshint');
   grunt.loadNpmTasks('grunt-contrib-watch');

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -162,21 +162,6 @@ module.exports = function(grunt) {
       }
     },
 
-    // Build p5 into a single, UMD-wrapped file
-    browserify: {
-      p5: {
-        options: {
-          transform: ['brfs'],
-          browserifyOptions: {
-            standalone: 'p5'
-          },
-          banner: '/*! p5.js v<%= pkg.version %> <%= grunt.template.today("mmmm dd, yyyy") %> */'
-        },
-        src: 'src/app.js',
-        dest: 'lib/p5.js'
-      }
-    },
-
     // The actual compile step:  This should collect all the dependencies
     // and compile them into a single file.
     requirejs: {

--- a/build/tasks/browserify.js
+++ b/build/tasks/browserify.js
@@ -1,0 +1,44 @@
+'use strict';
+
+var path = require('path');
+var fs = require('fs');
+var browserify = require('browserify');
+var derequire = require('derequire'); // This is a silly thing to type
+
+var bannerTemplate = '/*! p5.js v<%= pkg.version %> <%= grunt.template.today("mmmm dd, yyyy") %> */';
+
+module.exports = function(grunt) {
+
+  var libFilePath = path.join(process.cwd(), 'lib/p5.js');
+  var srcFilePath = path.join(process.cwd(), 'src/app.js');
+
+  grunt.registerTask('browserify', 'Compile the p5.js source with Browserify', function() {
+    // Reading and writing files is asynchronous
+    var done = this.async();
+
+    // Render the banner for the top of the file
+    var banner = grunt.template.process(bannerTemplate);
+
+    // Invoke Browserify programatically to bundle the code
+    var bundle = browserify(srcFilePath, {
+        standalone: 'p5'
+      })
+      .transform('brfs')
+      .bundle();
+
+    // Start the generated output with the banner comment,
+    var code = banner + '\n';
+
+    // Then read the bundle into memory so we can run it through derequire
+    bundle.on('data', function(data) {
+      code += data;
+    }).on('end', function() {
+      // "code" is complete: create the distributable UMD build by running
+      // the bundle through derequire, then write the bundle to disk.
+      // (Derequire changes the bundle's internal "require" function to
+      // something that will not interfere with this module being used
+      // within a separate browserify bundle.)
+      fs.writeFile(libFilePath, derequire(code), done);
+    });
+  });
+};

--- a/build/tasks/browserify.js
+++ b/build/tasks/browserify.js
@@ -1,16 +1,17 @@
 'use strict';
 
 var path = require('path');
-var fs = require('fs');
 var browserify = require('browserify');
-var derequire = require('derequire'); // This is a silly thing to type
+var derequire = require('derequire');
 
 var bannerTemplate = '/*! p5.js v<%= pkg.version %> <%= grunt.template.today("mmmm dd, yyyy") %> */';
 
 module.exports = function(grunt) {
 
-  var libFilePath = path.join(process.cwd(), 'lib/p5.js');
-  var srcFilePath = path.join(process.cwd(), 'src/app.js');
+  var srcFilePath = require.resolve('../../src/app.js');
+
+  // This file will not exist until it has been built
+  var libFilePath = path.resolve('lib/p5.js');
 
   grunt.registerTask('browserify', 'Compile the p5.js source with Browserify', function() {
     // Reading and writing files is asynchronous
@@ -33,12 +34,19 @@ module.exports = function(grunt) {
     bundle.on('data', function(data) {
       code += data;
     }).on('end', function() {
+
       // "code" is complete: create the distributable UMD build by running
       // the bundle through derequire, then write the bundle to disk.
       // (Derequire changes the bundle's internal "require" function to
       // something that will not interfere with this module being used
       // within a separate browserify bundle.)
-      fs.writeFile(libFilePath, derequire(code), done);
+      grunt.file.write(libFilePath, derequire(code));
+
+      // Print a success message
+      grunt.log.writeln('>>'.green + ' Bundle ' + 'lib/p5.js'.cyan + ' created.');
+
+      // Complete the task
+      done();
     });
   });
 };

--- a/package.json
+++ b/package.json
@@ -13,9 +13,10 @@
   "version": "0.4.7",
   "devDependencies": {
     "amdclean": "~0.3.3",
+    "browserify": "^11.0.1",
     "concat-files": "^0.1.0",
+    "derequire": "^2.0.0",
     "grunt": "^0.4.5",
-    "grunt-browserify": "^3.8.0",
     "grunt-cli": "^0.1.13",
     "grunt-contrib-concat": "^0.5.1",
     "grunt-contrib-connect": "^0.9.0",


### PR DESCRIPTION
**`--standalone` isn't**

Browserify's "Standalone" option is poorly named, as `--standalone`- generated bundles cannot be consumed within any other project that is build using browserify. The reason this is the case is that Browserify tries to parse any "require" calls that it finds in the source.

However, once Browserify has been used to build p5, those are not Node's `require` method anymore: they are an internal method defined within the bundled code. Browserify trips over itself by misinterpreting the purpose of the `require`s that it generated when we created the bundle.

[derequire](https://github.com/calvinmetcalf/derequire) is designed to solve this problem: it re-writes the generated bundle code to change all instances of "require" into "_dereq_". This "hides" them from subsequent runs of Browserify, and permits the library to be loaded as intended.

[Browserify issue 1151](https://github.com/substack/node-browserify/issues/1151) has more discussion of this issue, including a movement to implement the "derequire" behavior by default when using `--standalone`, which would (subjectively) make the flag function more predictably.

**Grunt changes**

Because `derequire` is designed either to function fully by use of its programmatic API, or fully from the command line, I was not able to get it integrated into the existing Grunt-Browserify task. Instead, I have written a new, bespoke Grunt task that will

- Read the source code into Browserify (with appropriate transforms)
- Run the bundled code through `derequire` to re-write the "require"s
- Prepend the same code comment banner we have been using
- Save the processed code to a file as `lib/p5.js`

This task lives in `build/tasks/browserify.js`, using the (that is to say, my) recommended approach of splitting more complex grunt tasks out into individual files for easier readability and maintenance.

This task runs slightly slower than the older `grunt-browserify` task, which I believe to be unavoidable due to the additional code processing that is required to make the build browserifiable.

A note on Webpack: I investigated using Webpack to create the bundle, as Webpack's UMD build target does not seem to share Browserify's `--standalone` quirks. For now we believe that adding Webpack would introduce more complexity and maintenance overhead than it removed,
however, so I opted for the custom Grunt task approach.

**Unresolved Issues**

This does nothing to address #785: we will likely need to adapt the browserify task to generate separate source builds for `p5.js` and `p5.min.js` before we can conditionally stub out behavior.

**Resolved Issues**

This fixes #818: I have copied the generated code into the [example repository](https://github.com/geekydatamonkey/test-p5-browserify) provided by @geekydatamonkey, and `browserify main.js -o bundle.js` worked as expected.

However, more testing is appreciated: use this branch to `grunt build` or `npm run build`, then copy the generated `lib/p5.js` file into a browserify project and see if it works or not.

**Review Requested**

Pinging @tbranyen for feedback on this implementation!