### PR TITLE
p5.Color & colorMode improvements!

### DIFF
--- a/src/color/p5.Color.js
+++ b/src/color/p5.Color.js
@@ -420,11 +420,11 @@ p5.Color._getFormattedColor = function () {
 
   // Handle [r,g,b,a] or [h,s,l,a] color values
   if (numArgs >= 3) {
-    first   = arguments[0];
-    second  = arguments[1];
-    third   = arguments[2];
+    first   = parseInt(arguments[0]) / this._colorMaxes[mode][0] * 255;
+    second  = parseInt(arguments[1]) / this._colorMaxes[mode][1] * 255;
+    third   = parseInt(arguments[2]) / this._colorMaxes[mode][2] * 255;
     alpha   = typeof arguments[3] === 'number' ?
-              arguments[3] : this._colorMaxes[mode][3];
+              arguments[3] / this._colorMaxes[mode][3] * 255 : this._colorMaxes[mode][3];
 
   // Handle strings: named colors, hex values, css strings
   } else if (numArgs === 1 && typeof arguments[0] === 'string') {


### PR DESCRIPTION
These should fix #842 problem to begin with.
But this is just a tip of the iceberg, there are a lot more to it. 
I will look into more issues mentioned by @sarahgp in #842 discussion and adjacent issue discussions and add them to this PR in the next few days!

Things like normalising R, G & B values against `colorMaxes` set by `colorMode()`, so users would be able to do some crazy stuff like 
```
colorMode(RGB, 100, 200, 300, 1)
```



I would love to get hear any kind of feedback, discuss ideas about `Color.toString` and `colorMode` and willing to implement them in this PR!


P.S. Please forgive me my poor knowledge of p5.js architecture, development flow and styleguides. 
I'm learning super quick though, so just ping my mistakes and I'll try my best to never repeat them again. he-he