### PR TITLE
Improve docs for curve, bezier

### DIFF
--- a/src/core/2d_primitives.js
+++ b/src/core/2d_primitives.js
@@ -229,7 +229,8 @@ p5.prototype.line = function() {
 /**
  * Draws a point, a coordinate in space at the dimension of one pixel.
  * The first parameter is the horizontal value for the point, the second
- * value is the vertical value for the point.
+ * value is the vertical value for the point. The color of the point is
+ * determined by the current stroke.
  *
  * @method point
  * @param  {Number} x the x-coordinate

--- a/src/core/curves.js
+++ b/src/core/curves.js
@@ -16,12 +16,15 @@ var curveDetail = 20;
 p5.prototype._curveTightness = 0;
 
 /**
- * Draws a cubic Bezier curve on the screen. These curves are defined by a series
- * of anchor and control points. The first two parameters specify the first
- * anchor point and the last two parameters specify the other anchor point, which become the first and last points on the curve.
- * The middle parameters specify the two control points which define the shape
- * of the curve. Approximately speaking, control points "pull" the curve towards them.<br /><br />Bezier curves were developed by French automotive engineer Pierre
- * Bezier, and are commonly used in computer graphics to define gently sloping curves. See also curve().
+ * Draws a cubic Bezier curve on the screen. These curves are defined by a
+ * series of anchor and control points. The first two parameters specify
+ * the first anchor point and the last two parameters specify the other
+ * anchor point, which become the first and last points on the curve. The
+ * middle parameters specify the two control points which define the shape
+ * of the curve. Approximately speaking, control points "pull" the curve
+ * towards them.<br /><br />Bezier curves were developed by French
+ * automotive engineer Pierre Bezier, and are commonly used in computer
+ * graphics to define gently sloping curves. See also curve().
  *
  * @method bezier
  * @param  {Number} x1 x-coordinate for the first anchor point
@@ -196,8 +199,8 @@ p5.prototype.bezierTangent = function(a, b, c, d, t) {
  * middle four parameters. The first two parameters are a control point, as
  * if the curve came from this point even though it's not drawn. The last
  * two parameters similarly describe the other control point. <br /><br />
- * Longer curves can be created by putting a series of curve()
- * functions together or using curveVertex(). An additional function called
+ * Longer curves can be created by putting a series of curve() functions
+ * together or using curveVertex(). An additional function called
  * curveTightness() provides control for the visual quality of the curve.
  * The curve() function is an implementation of Catmull-Rom splines.
  *
@@ -349,8 +352,8 @@ p5.prototype.curvePoint = function(a, b, c, d, t) {
 
 /**
  * Evaluates the tangent to the curve at position t for points a, b, c, d.
- * The parameter t varies between 0 and 1, a and d are points
- * on the curve, and b and c are the control points
+ * The parameter t varies between 0 and 1, a and d are points on the curve,
+ * and b and c are the control points
  *
  * @method curveTangent
  * @param {Number} a coordinate of first point on the curve

--- a/src/core/curves.js
+++ b/src/core/curves.js
@@ -110,8 +110,8 @@ p5.prototype.bezierDetail = function(d) {
  * steps = 10;
  * for (i = 0; i <= steps; i++) {
  *   t = i / steps;
- *   x = bezierPoint(x1, x2, x3, x4);
- *   y = bezierPoint(y1, y2, y3, y4);
+ *   x = bezierPoint(x1, x2, x3, x4, t);
+ *   y = bezierPoint(y1, y2, y3, y4, t);
  *   ellipse(x, y, 5, 5);
  * }
  * </code>
@@ -219,6 +219,18 @@ p5.prototype.bezierTangent = function(a, b, c, d, t) {
  * @example
  * <div>
  * <code>
+ * noFill();
+ * stroke(255, 102, 0);
+ * curve(5, 26, 5, 26, 73, 24, 73, 61);
+ * stroke(0);
+ * curve(5, 26, 73, 24, 73, 61, 15, 65);
+ * stroke(255, 102, 0);
+ * curve(73, 24, 73, 61, 15, 65, 15, 65);
+ * </code>
+ * </div>
+ * <div>
+ * <code>
+ * // Define the curve points as JavaScript objects
  * p1 = {x: 5, y: 26}, p2 = {x: 73, y: 24}
  * p3 = {x: 73, y: 61}, p4 = {x: 15, y: 65}
  * noFill();

--- a/src/core/curves.js
+++ b/src/core/curves.js
@@ -16,12 +16,12 @@ var curveDetail = 20;
 p5.prototype._curveTightness = 0;
 
 /**
- * Draws a Bezier curve on the screen. These curves are defined by a series
+ * Draws a cubic Bezier curve on the screen. These curves are defined by a series
  * of anchor and control points. The first two parameters specify the first
- * anchor point and the last two parameters specify the other anchor point.
- * The middle parameters specify the control points which define the shape
- * of the curve. Bezier curves were developed by French engineer Pierre
- * Bezier.
+ * anchor point and the last two parameters specify the other anchor point, which become the first and last points on the curve.
+ * The middle parameters specify the two control points which define the shape
+ * of the curve. Approximately speaking, control points "pull" the curve towards them.<br /><br />Bezier curves were developed by French automotive engineer Pierre
+ * Bezier, and are commonly used in computer graphics to define gently sloping curves. See also curve().
  *
  * @method bezier
  * @param  {Number} x1 x-coordinate for the first anchor point

--- a/src/core/curves.js
+++ b/src/core/curves.js
@@ -219,13 +219,15 @@ p5.prototype.bezierTangent = function(a, b, c, d, t) {
  * @example
  * <div>
  * <code>
+ * p1 = {x: 5, y: 26}, p2 = {x: 73, y: 24}
+ * p3 = {x: 73, y: 61}, p4 = {x: 15, y: 65}
  * noFill();
  * stroke(255, 102, 0);
- * curve(5, 26, 5, 26, 73, 24, 73, 61);
+ * curve(p1.x, p1.y, p1.x, p1.y, p2.x, p2.y)
  * stroke(0);
- * curve(5, 26, 73, 24, 73, 61, 15, 65);
+ * curve(p1.x, p1.y, p2.x, p2.y, p3.x, p3.y, p4.x, p4.y)
  * stroke(255, 102, 0);
- * curve(73, 24, 73, 61, 15, 65, 15, 65);
+ * curve(p2.x, p2.y, p3.x, p3.y, p4.x, p4.y, p4.x, p4.y)
  * </code>
  * </div>
  */

--- a/src/core/curves.js
+++ b/src/core/curves.js
@@ -194,10 +194,11 @@ p5.prototype.bezierTangent = function(a, b, c, d, t) {
 };
 
 /**
- * Draws a curved line on the screen. The first and second parameters specify
- * the beginning control point and the last two parameters specify the ending
- * control point. The middle parameters specify the start and stop of the
- * curve. Longer curves can be created by putting a series of curve()
+ * Draws a curved line on the screen between two points, given as the
+ * middle four parameters. The first two parameters are a control point, as
+ * if the curve came from this point even though it's not drawn. The last
+ * two parameters similarly describe the other control point. <br /><br />
+ * Longer curves can be created by putting a series of curve()
  * functions together or using curveVertex(). An additional function called
  * curveTightness() provides control for the visual quality of the curve.
  * The curve() function is an implementation of Catmull-Rom splines.
@@ -340,7 +341,7 @@ p5.prototype.curveTightness = function (t) {
  * </code>
  * </div>
  */
-p5.prototype.curvePoint = function(a, b,c, d, t) {
+p5.prototype.curvePoint = function(a, b, c, d, t) {
   var t3 = t*t*t,
     t2 = t*t,
     f1 = -0.5 * t3 + t2 - 0.5 * t,

--- a/src/core/curves.js
+++ b/src/core/curves.js
@@ -82,11 +82,10 @@ p5.prototype.bezierDetail = function(d) {
 };
 
 /**
- * Calculate a point on the Bezier Curve
- *
- * Evaluates the Bezier at point t for points a, b, c, d.
- * The parameter t varies between 0 and 1, a and d are points
+ * Evaluates the Bezier at position t for points a, b, c, d.
+ * The parameters a and d are the first and last points
  * on the curve, and b and c are the control points.
+ * The final parameter t varies between 0 and 1.
  * This can be done once with the x coordinates and a second time
  * with the y coordinates to get the location of a bezier curve at t.
  *
@@ -96,7 +95,7 @@ p5.prototype.bezierDetail = function(d) {
  * @param {Number} c coordinate of second control point
  * @param {Number} d coordinate of second point on the curve
  * @param {Number} t value between 0 and 1
- * @return {Number} the value of the Bezier at point t
+ * @return {Number} the value of the Bezier at position t
  * @example
  * <div>
  * <code>
@@ -122,11 +121,10 @@ p5.prototype.bezierPoint = function(a, b, c, d, t) {
 };
 
 /**
- * Calculates the tangent of a point on a Bezier curve
- *
- * Evaluates the tangent at point t for points a, b, c, d.
- * The parameter t varies between 0 and 1, a and d are points
- * on the curve, and b and c are the control points
+ * Evaluates the tangent to the Bezier at position t for points a, b, c, d.
+ * The parameters a and d are the first and last points
+ * on the curve, and b and c are the control points.
+ * The final parameter t varies between 0 and 1.
  *
  * @method bezierTangent
  * @param {Number} a coordinate of first point on the curve
@@ -134,7 +132,7 @@ p5.prototype.bezierPoint = function(a, b, c, d, t) {
  * @param {Number} c coordinate of second control point
  * @param {Number} d coordinate of second point on the curve
  * @param {Number} t value between 0 and 1
- * @return {Number} the tangent at point t
+ * @return {Number} the tangent at position t
  * @example
  * <div>
  * <code>
@@ -305,9 +303,7 @@ p5.prototype.curveTightness = function (t) {
 };
 
 /**
- * Calculate a point on the Curve
- *
- * Evaluates the Bezier at point t for points a, b, c, d.
+ * Evaluates the curve at position t for points a, b, c, d.
  * The parameter t varies between 0 and 1, a and d are points
  * on the curve, and b and c are the control points.
  * This can be done once with the x coordinates and a second time
@@ -319,7 +315,7 @@ p5.prototype.curveTightness = function (t) {
  * @param {Number} c coordinate of second control point
  * @param {Number} d coordinate of second point on the curve
  * @param {Number} t value between 0 and 1
- * @return {Number} bezier value at point t
+ * @return {Number} bezier value at position t
  * @example
  * <div>
  * <code>
@@ -352,9 +348,7 @@ p5.prototype.curvePoint = function(a, b, c, d, t) {
 };
 
 /**
- * Calculates the tangent of a point on a curve
- *
- * Evaluates the tangent at point t for points a, b, c, d.
+ * Evaluates the tangent to the curve at position t for points a, b, c, d.
  * The parameter t varies between 0 and 1, a and d are points
  * on the curve, and b and c are the control points
  *
@@ -364,7 +358,7 @@ p5.prototype.curvePoint = function(a, b, c, d, t) {
  * @param {Number} c coordinate of second control point
  * @param {Number} d coordinate of second point on the curve
  * @param {Number} t value between 0 and 1
- * @return {Number} the tangent at point t
+ * @return {Number} the tangent at position t
  * @example
  * <div>
  * <code>

--- a/src/core/curves.js
+++ b/src/core/curves.js
@@ -103,13 +103,15 @@ p5.prototype.bezierDetail = function(d) {
  * <div>
  * <code>
  * noFill();
- * bezier(85, 20, 10, 10, 90, 90, 15, 80);
+ * x1 = 85, x2 = 10, x3 = 90, x4 = 15;
+ * y1 = 20, y2 = 10, y3 = 90, y4 = 80;
+ * bezier(x1, y1, x2, y2, x3, y3, x4, y4);
  * fill(255);
  * steps = 10;
  * for (i = 0; i <= steps; i++) {
  *   t = i / steps;
- *   x = bezierPoint(85, 10, 90, 15, t);
- *   y = bezierPoint(20, 10, 90, 80, t);
+ *   x = bezierPoint(x1, x2, x3, x4);
+ *   y = bezierPoint(y1, y2, y3, y4);
  *   ellipse(x, y, 5, 5);
  * }
  * </code>

--- a/src/math/noise.js
+++ b/src/math/noise.js
@@ -59,23 +59,23 @@ var perlin;
  * shapes, terrains etc.<br /><br /> The main difference to the
  * <b>random()</b> function is that Perlin noise is defined in an infinite
  * n-dimensional space where each pair of coordinates corresponds to a
- * fixed semi-random value (fixed only for the lifespan of the program; see the noiseSeed() function).
- * p5.js can compute 1D, 2D and 3D noise, depending on the number of coordinates given.
- * The resulting value will always be between 0.0 and 1.0.
- * The noise value can be animated by moving through the noise space
- * as demonstrated in the example above. The 2nd and 3rd dimension can also
- * be interpreted as time.<br /><br />The actual noise is structured
- * similar to an audio signal, in respect to the function's use of
- * frequencies. Similar to the concept of harmonics in physics, perlin
- * noise is computed over several octaves which are added together for the
- * final result. <br /><br />Another way to adjust the character of the
- * resulting sequence is the scale of the input coordinates. As the
- * function works within an infinite space the value of the coordinates
- * doesn't matter as such, only the distance between successive coordinates
- * does (eg. when using <b>noise()</b> within a loop). As a general rule
- * the smaller the difference between coordinates, the smoother the
- * resulting noise sequence will be. Steps of 0.005-0.03 work best for most
- * applications, but this will differ depending on use.
+ * fixed semi-random value (fixed only for the lifespan of the program; see
+ * the noiseSeed() function). p5.js can compute 1D, 2D and 3D noise,
+ * depending on the number of coordinates given. The resulting value will
+ * always be between 0.0 and 1.0. The noise value can be animated by moving
+ * through the noise space as demonstrated in the example above. The 2nd
+ * and 3rd dimension can also be interpreted as time.<br /><br />The actual
+ * noise is structured similar to an audio signal, in respect to the
+ * function's use of frequencies. Similar to the concept of harmonics in
+ * physics, perlin noise is computed over several octaves which are added
+ * together for the final result. <br /><br />Another way to adjust the
+ * character of the resulting sequence is the scale of the input
+ * coordinates. As the function works within an infinite space the value of
+ * the coordinates doesn't matter as such, only the distance between
+ * successive coordinates does (eg. when using <b>noise()</b> within a
+ * loop). As a general rule the smaller the difference between coordinates,
+ * the smoother the resulting noise sequence will be. Steps of 0.005-0.03
+ * work best for most applications, but this will differ depending on use.
  *
  *
  * @method noise

--- a/src/math/noise.js
+++ b/src/math/noise.js
@@ -59,10 +59,10 @@ var perlin;
  * shapes, terrains etc.<br /><br /> The main difference to the
  * <b>random()</b> function is that Perlin noise is defined in an infinite
  * n-dimensional space where each pair of coordinates corresponds to a
- * fixed semi-random value (fixed only for the lifespan of the program).
- * The resulting value will always be between 0.0 and 1.0. p5.js can
- * compute 1D, 2D and 3D noise, depending on the number of coordinates
- * given. The noise value can be animated by moving through the noise space
+ * fixed semi-random value (fixed only for the lifespan of the program; see the noiseSeed() function).
+ * p5.js can compute 1D, 2D and 3D noise, depending on the number of coordinates given.
+ * The resulting value will always be between 0.0 and 1.0.
+ * The noise value can be animated by moving through the noise space
  * as demonstrated in the example above. The 2nd and 3rd dimension can also
  * be interpreted as time.<br /><br />The actual noise is structured
  * similar to an audio signal, in respect to the function's use of


### PR DESCRIPTION
Several improvements to the docs, broken out into many commits. Linewrapping is its own commit at the end, so you can see the diffs more easily. Please refer to the commit messages for details about each commit.

I also modified two of the examples to make the pattern of repeated numbers more obvious. These are independent commits at the very end and can very easily be dropped. I'm also happy to rephrase anything else that the maintainers dislike.