### PR TITLE
moving drawing properties to p5.Renderer obj from p5 obj

### DIFF
--- a/src/color/creating_reading.js
+++ b/src/color/creating_reading.js
@@ -349,15 +349,15 @@ p5.prototype.lerpColor = function(c1, c2, amt) {
   var l1, l2, l3, l4;
   var fromColor, toColor;
 
-  if(this._colorMode === constants.RGB) {
+  if(this._graphics._colorMode === constants.RGB) {
     fromColor = this.color(c1).rgba;
     toColor = this.color(c2).rgba;
   }
-  else if (this._colorMode === constants.HSB) {
+  else if (this._graphics._colorMode === constants.HSB) {
     fromColor = this.color(c1).hsba;
     toColor = this.color(c2).hsba;
   }
-  else if(this._colorMode === constants.HSL) {
+  else if(this._graphics._colorMode === constants.HSL) {
     fromColor = this.color(c1).hsla;
     toColor = this.color(c2).hsla;
   }

--- a/src/color/p5.Color.js
+++ b/src/color/p5.Color.js
@@ -16,8 +16,8 @@ var constants = require('../core/constants');
  * (1, 1, 1, 1)
  */
 p5.Color = function (pInst, vals) {
-  this.mode = pInst._colorMode;
-  this.maxes = pInst._colorMaxes;
+  this.mode = pInst._graphics._colorMode;
+  this.maxes = pInst._graphics._colorMaxes;
   var isHSB = this.mode === constants.HSB,
       isRGB = this.mode === constants.RGB,
       isHSL = this.mode === constants.HSL;
@@ -31,7 +31,7 @@ p5.Color = function (pInst, vals) {
     this.hsla = p5.Color._getFormattedColor.apply(pInst, vals);
     this._array = color_utils.hslaToRGBA(this.hsla);
   } else {
-    throw new Error(pInst._colorMode + ' is an invalid colorMode.');
+    throw new Error(pInst._graphics._colorMode + ' is an invalid colorMode.');
   }
 
   this.rgba = [ Math.round(this._array[0] * 255),
@@ -448,8 +448,8 @@ var colorPatterns = {
  */
 p5.Color._getFormattedColor = function () {
   var numArgs = arguments.length;
-  var mode    = this._colorMode;
-  var maxArr  = this._colorMaxes[this._colorMode];
+  var mode    = this._graphics._colorMode;
+  var maxArr  = this._graphics._colorMaxes[this._graphics._colorMode];
   var results = [];
 
   // Handle [r,g,b,a] or [h,s,l,a] color values

--- a/src/color/setting.js
+++ b/src/color/setting.js
@@ -12,17 +12,6 @@ var p5 = require('../core/core');
 var constants = require('../core/constants');
 require('./p5.Color');
 
-p5.prototype._doStroke = true;
-p5.prototype._doFill = true;
-p5.prototype._strokeSet = false;
-p5.prototype._fillSet = false;
-p5.prototype._colorMode = constants.RGB;
-p5.prototype._colorMaxes = {
-  rgb: [255, 255, 255, 255],
-  hsb: [360, 100, 100, 1],
-  hsl: [360, 100, 100, 1]
-};
-
 /**
  * The background() function sets the color used for the background of the
  * p5.js canvas. The default background is light gray. This function is
@@ -224,9 +213,9 @@ p5.prototype.colorMode = function() {
   if (arguments[0] === constants.RGB ||
       arguments[0] === constants.HSB ||
       arguments[0] === constants.HSL) {
-    this._colorMode = arguments[0];
+    this._graphics._colorMode = arguments[0];
 
-    var maxArr = this._colorMaxes[this._colorMode];
+    var maxArr = this._graphics._colorMaxes[this._graphics._colorMode];
 
     if (arguments.length === 2) {
       maxArr[0] = arguments[1];
@@ -361,8 +350,8 @@ p5.prototype.colorMode = function() {
  * </div>
  */
 p5.prototype.fill = function() {
-  this._setProperty('_fillSet', true);
-  this._setProperty('_doFill', true);
+  this._graphics._setProperty('_fillSet', true);
+  this._graphics._setProperty('_doFill', true);
   this._graphics.fill.apply(this._graphics, arguments);
   return this;
 };
@@ -382,7 +371,7 @@ p5.prototype.fill = function() {
  * </div>
  */
 p5.prototype.noFill = function() {
-  this._setProperty('_doFill', false);
+  this._graphics._setProperty('_doFill', false);
   return this;
 };
 
@@ -400,7 +389,7 @@ p5.prototype.noFill = function() {
  * </div>
  */
 p5.prototype.noStroke = function() {
-  this._setProperty('_doStroke', false);
+  this._graphics._setProperty('_doStroke', false);
   return this;
 };
 
@@ -527,8 +516,8 @@ p5.prototype.noStroke = function() {
  * </div>
  */
 p5.prototype.stroke = function() {
-  this._setProperty('_strokeSet', true);
-  this._setProperty('_doStroke', true);
+  this._graphics._setProperty('_strokeSet', true);
+  this._graphics._setProperty('_doStroke', true);
   this._graphics.stroke.apply(this._graphics, arguments);
   return this;
 };

--- a/src/core/2d_primitives.js
+++ b/src/core/2d_primitives.js
@@ -69,7 +69,7 @@ p5.prototype.arc = function(x, y, w, h, start, stop, mode) {
     ]
   );
 
-  if (!this._doStroke && !this._doFill) {
+  if (!this._graphics._doStroke && !this._graphics._doFill) {
     return this;
   }
   if (this._angleMode === constants.DEGREES) {
@@ -142,7 +142,7 @@ p5.prototype.ellipse = function(x, y, w, h) {
     ['Number', 'Number', 'Number', 'Number']
   );
 
-  if (!this._doStroke && !this._doFill) {
+  if (!this._graphics._doStroke && !this._graphics._doFill) {
     return this;
   }
   // p5 supports negative width and heights for ellipses
@@ -186,7 +186,7 @@ p5.prototype.ellipse = function(x, y, w, h) {
  */
 ////commented out original
 // p5.prototype.line = function(x1, y1, x2, y2) {
-//   if (!this._doStroke) {
+//   if (!this._graphics._doStroke) {
 //     return this;
 //   }
 //   if(this._graphics.isP3D){
@@ -195,7 +195,7 @@ p5.prototype.ellipse = function(x, y, w, h) {
 //   }
 // };
 p5.prototype.line = function() {
-  if (!this._doStroke) {
+  if (!this._graphics._doStroke) {
     return this;
   }
   //check whether we should draw a 3d line or 2d
@@ -252,7 +252,7 @@ p5.prototype.line = function() {
  * </div>
  */
 p5.prototype.point = function() {
-  if (!this._doStroke) {
+  if (!this._graphics._doStroke) {
     return this;
   }
   //check whether we should draw a 3d line or 2d
@@ -311,7 +311,7 @@ p5.prototype.point = function() {
  * </div>
  */
 p5.prototype.quad = function() {
-  if (!this._doStroke && !this._doFill) {
+  if (!this._graphics._doStroke && !this._graphics._doFill) {
     return this;
   }
   if(this._graphics.isP3D){
@@ -418,7 +418,7 @@ p5.prototype.rect = function (x, y, w, h, tl, tr, br, bl) {
     ]
   );
 
-  if (!this._doStroke && !this._doFill) {
+  if (!this._graphics._doStroke && !this._graphics._doFill) {
     return;
   }
   this._graphics.rect(x, y, w, h, tl, tr, br, bl);
@@ -447,7 +447,7 @@ p5.prototype.rect = function (x, y, w, h, tl, tr, br, bl) {
 */
 p5.prototype.triangle = function() {
 
-  if (!this._doStroke && !this._doFill) {
+  if (!this._graphics._doStroke && !this._graphics._doFill) {
     return this;
   }
   if(this._graphics.isP3D){

--- a/src/core/attributes.js
+++ b/src/core/attributes.js
@@ -11,9 +11,6 @@
 var p5 = require('./core');
 var constants = require('./constants');
 
-p5.prototype._rectMode = constants.CORNER;
-p5.prototype._ellipseMode = constants.CENTER;
-
 /**
  * Modifies the location from which ellipses are drawn by changing the way
  * in which parameters given to ellipse() are interpreted.
@@ -70,7 +67,7 @@ p5.prototype.ellipseMode = function(m) {
     m === constants.CORNERS ||
     m === constants.RADIUS ||
     m === constants.CENTER) {
-    this._ellipseMode = m;
+    this._graphics._ellipseMode = m;
   }
   return this;
 };
@@ -155,7 +152,7 @@ p5.prototype.rectMode = function(m) {
     m === constants.CORNERS ||
     m === constants.RADIUS ||
     m === constants.CENTER) {
-    this._rectMode = m;
+    this._graphics._rectMode = m;
   }
   return this;
 };

--- a/src/core/curves.js
+++ b/src/core/curves.js
@@ -13,7 +13,6 @@ require('./error_helpers');
 
 var bezierDetail = 20;
 var curveDetail = 20;
-p5.prototype._curveTightness = 0;
 
 /**
  * Draws a cubic Bezier curve on the screen. These curves are defined by a
@@ -318,7 +317,7 @@ p5.prototype.curveDetail = function(d) {
  * </div>
  */
 p5.prototype.curveTightness = function (t) {
-  this._setProperty('_curveTightness', t);
+  this._graphics._curveTightness = t;
 };
 
 /**

--- a/src/core/curves.js
+++ b/src/core/curves.js
@@ -55,7 +55,7 @@ p5.prototype.bezier = function(x1, y1, x2, y2, x3, y3, x4, y4) {
       'Number', 'Number', 'Number', 'Number' ]
   );
 
-  if (!this._doStroke) {
+  if (!this._graphics._doStroke) {
     return this;
   }
   this._graphics.bezier(x1, y1, x2, y2, x3, y3, x4, y4);
@@ -250,7 +250,7 @@ p5.prototype.curve = function(x1, y1, x2, y2, x3, y3, x4, y4) {
       'Number', 'Number', 'Number', 'Number' ]
   );
 
-  if (!this._doStroke) {
+  if (!this._graphics._doStroke) {
     return;
   }
   this._graphics.curve(x1, y1, x2, y2, x3, y3, x4, y4);

--- a/src/core/error_helpers.js
+++ b/src/core/error_helpers.js
@@ -104,6 +104,8 @@ function report(message, func, color) {
 
 /**
  * Validate all the parameters of a function for number and type
+ * NOTE THIS FUNCTION IS TEMPORARILY DISABLED UNTIL FURTHER WORK
+ * AND UPDATES ARE IMPLEMENTED. -LMCCART
  *
  * @param  {String} func  name of function we're checking
  * @param  {Array}  args  pass of the JS default arguments array
@@ -119,12 +121,9 @@ p5.prototype._validateParameters = function(func, args, types) {
   if (!isArray(types[0])) {
     types = [types];
   }
-  /**
-   * Check number of parameters
-   *
-   * Example: "You wrote ellipse(X,X,X). ellipse was expecting 4
-   *           parameters. Try ellipse(X,X,X,X)."
-   */
+  // Check number of parameters
+  // Example: "You wrote ellipse(X,X,X). ellipse was expecting 4
+  //          parameters. Try ellipse(X,X,X,X)."
   var diff = Math.abs(args.length-types[0].length);
   var message, tindex = 0;
   for (var i=1, len=types.length; i<len; i++) {
@@ -155,13 +154,10 @@ p5.prototype._validateParameters = function(func, args, types) {
     }
     report(message, func, PARAM_COUNT);
   }
-  /**
-   * Type checking
-   *
-   * Example: "It looks like ellipse received an empty variable in spot #2."
-   * Example: "ellipse was expecting a number for parameter #1,
-   *           received "foo" instead."
-   */
+  // Type checking
+  // Example: "It looks like ellipse received an empty variable in spot #2."
+  // Example: "ellipse was expecting a number for parameter #1,
+  //           received "foo" instead."
   for (var format=0; format<types.length; format++) {
     for (var p=0; p < types[format].length && p < args.length; p++) {
       var defType = types[format][p];
@@ -188,6 +184,14 @@ p5.prototype._validateParameters = function(func, args, types) {
     }
   }
 };
+/*
+ * NOTE THIS FUNCTION IS TEMPORARILY DISABLED UNTIL FURTHER WORK
+ * AND UPDATES ARE IMPLEMENTED. -LMCCART
+ */
+p5.prototype._validateParameters = function() {
+  return true;
+};
+
 var errorCases = {
   '0': {
     fileType: 'image',

--- a/src/core/p5.Renderer.js
+++ b/src/core/p5.Renderer.js
@@ -43,27 +43,28 @@ p5.Renderer = function(elt, pInst, isMainCanvas) {
   this._textAscent = null;
   this._textDescent = null;
 
+
+  this._rectMode = constants.CORNER;
+  this._ellipseMode = constants.CENTER;
+  this._curveTightness = 0;
+  this._imageMode = constants.CORNER;
+
+  this._tint = null;
+  this._doStroke = true;
+  this._doFill = true;
+  this._strokeSet = false;
+  this._fillSet = false;
+  this._colorMode = constants.RGB;
+  this._colorMaxes = {
+    rgb: [255, 255, 255, 255],
+    hsb: [360, 100, 100, 1],
+    hsl: [360, 100, 100, 1]
+  };
+
 };
 
 p5.Renderer.prototype = Object.create(p5.Element.prototype);
 
-
-p5.Renderer.prototype._rectMode = constants.CORNER;
-p5.Renderer.prototype._ellipseMode = constants.CENTER;
-p5.Renderer.prototype._curveTightness = 0;
-p5.Renderer.prototype._imageMode = constants.CORNER;
-p5.Renderer.prototype._tint = null;
-
-p5.Renderer.prototype._doStroke = true;
-p5.Renderer.prototype._doFill = true;
-p5.Renderer.prototype._strokeSet = false;
-p5.Renderer.prototype._fillSet = false;
-p5.Renderer.prototype._colorMode = constants.RGB;
-p5.Renderer.prototype._colorMaxes = {
-  rgb: [255, 255, 255, 255],
-  hsb: [360, 100, 100, 1],
-  hsl: [360, 100, 100, 1]
-};
 
 
 

--- a/src/core/p5.Renderer.js
+++ b/src/core/p5.Renderer.js
@@ -47,6 +47,26 @@ p5.Renderer = function(elt, pInst, isMainCanvas) {
 
 p5.Renderer.prototype = Object.create(p5.Element.prototype);
 
+
+p5.Renderer.prototype._rectMode = constants.CORNER;
+p5.Renderer.prototype._ellipseMode = constants.CENTER;
+p5.Renderer.prototype._curveTightness = 0;
+p5.Renderer.prototype._imageMode = constants.CORNER;
+p5.Renderer.prototype._tint = null;
+
+p5.Renderer.prototype._doStroke = true;
+p5.Renderer.prototype._doFill = true;
+p5.Renderer.prototype._strokeSet = false;
+p5.Renderer.prototype._fillSet = false;
+p5.Renderer.prototype._colorMode = constants.RGB;
+p5.Renderer.prototype._colorMaxes = {
+  rgb: [255, 255, 255, 255],
+  hsb: [360, 100, 100, 1],
+  hsl: [360, 100, 100, 1]
+};
+
+
+
 /**
  * Resize our canvas element.
  */

--- a/src/core/p5.Renderer.js
+++ b/src/core/p5.Renderer.js
@@ -112,7 +112,7 @@ p5.Renderer.prototype.resize = function(w, h) {
  */
 p5.Renderer.prototype.textLeading = function(l) {
 
-  if (arguments.length) {
+  if (arguments.length && arguments[0]) {
 
     this._setProperty('_textLeading', l);
     return this;
@@ -142,7 +142,7 @@ p5.Renderer.prototype.textLeading = function(l) {
  */
 p5.Renderer.prototype.textSize = function(s) {
 
-  if (arguments.length) {
+  if (arguments.length && arguments[0]) {
 
     this._setProperty('_textSize', s);
     this._setProperty('_textLeading', s * constants._DEFAULT_LEADMULT);
@@ -179,7 +179,7 @@ p5.Renderer.prototype.textSize = function(s) {
  */
 p5.Renderer.prototype.textStyle = function(s) {
 
-  if (arguments.length) {
+  if (arguments.length && arguments[0]) {
 
     if (s === constants.NORMAL ||
       s === constants.ITALIC ||

--- a/src/core/p5.Renderer2D.js
+++ b/src/core/p5.Renderer2D.js
@@ -1154,15 +1154,15 @@ p5.Renderer2D.prototype._renderText = function(p, line, x, y) {
   if (!this._isOpenType()) {  // a system/browser font
 
     // no stroke unless specified by user
-    if (p._doStroke && p._strokeSet) {
+    if (this._doStroke && this._strokeSet) {
 
       this.drawingContext.strokeText(line, x, y);
     }
 
-    if (p._doFill) {
+    if (this._doFill) {
 
       // if fill hasn't been set by user, use default text fill
-      this.drawingContext.fillStyle =  p._fillSet ?
+      this.drawingContext.fillStyle =  this._fillSet ?
         this.drawingContext.fillStyle : constants._DEFAULT_TEXT_FILL;
 
       this.drawingContext.fillText(line, x, y);
@@ -1180,9 +1180,9 @@ p5.Renderer2D.prototype._renderText = function(p, line, x, y) {
 
 p5.Renderer2D.prototype.textWidth = function(s) {
 
-  if (this._pInst._isOpenType()) {
+  if (this._isOpenType()) {
 
-    return this._pInst._textFont._textWidth(s);
+    return this._textFont._textWidth(s);
   }
 
   return this.drawingContext.measureText(s).width;

--- a/src/core/p5.Renderer2D.js
+++ b/src/core/p5.Renderer2D.js
@@ -110,7 +110,7 @@ p5.Renderer2D.prototype.stroke = function() {
 p5.Renderer2D.prototype.image = function (img, x, y, w, h) {
   var frame = img.canvas || img.elt;
   try {
-    if (this._pInst._tint && img.canvas) {
+    if (this._tint && img.canvas) {
       this.drawingContext.drawImage(this._getTintedImageCanvas(img),
         x, y, w, h);
     } else {
@@ -139,10 +139,10 @@ p5.Renderer2D.prototype._getTintedImageCanvas = function (img) {
     var g = pixels[i + 1];
     var b = pixels[i + 2];
     var a = pixels[i + 3];
-    newPixels[i] = r * this._pInst._tint[0] / 255;
-    newPixels[i + 1] = g * this._pInst._tint[1] / 255;
-    newPixels[i + 2] = b * this._pInst._tint[2] / 255;
-    newPixels[i + 3] = a * this._pInst._tint[3] / 255;
+    newPixels[i] = r * this._tint[0] / 255;
+    newPixels[i + 1] = g * this._tint[1] / 255;
+    newPixels[i + 2] = b * this._tint[2] / 255;
+    newPixels[i + 3] = a * this._tint[3] / 255;
   }
   tmpCtx.putImageData(id, 0, 0);
   return tmpCanvas;
@@ -385,7 +385,7 @@ p5.Renderer2D.prototype._acuteArcToBezier =
 p5.Renderer2D.prototype.arc =
   function(x, y, w, h, start, stop, mode) {
   var ctx = this.drawingContext;
-  var vals = canvas.arcModeAdjust(x, y, w, h, this._pInst._ellipseMode);
+  var vals = canvas.arcModeAdjust(x, y, w, h, this._ellipseMode);
   var rx = vals.w / 2.0;
   var ry = vals.h / 2.0;
   var epsilon = 0.00001;  // Smallest visible angle on displays up to 4K.
@@ -400,7 +400,7 @@ p5.Renderer2D.prototype.arc =
   }
 
   // Fill curves
-  if (this._pInst._doFill) {
+  if (this._doFill) {
     ctx.beginPath();
     curves.forEach(function (curve, index) {
       if (index === 0) {
@@ -418,7 +418,7 @@ p5.Renderer2D.prototype.arc =
   }
 
   // Stroke curves
-  if (this._pInst._doStroke) {
+  if (this._doStroke) {
     ctx.beginPath();
     curves.forEach(function (curve, index) {
       if (index === 0) {
@@ -441,7 +441,7 @@ p5.Renderer2D.prototype.arc =
 
 p5.Renderer2D.prototype.ellipse = function(x, y, w, h) {
   var ctx = this.drawingContext;
-  var doFill = this._pInst._doFill, doStroke = this._pInst._doStroke;
+  var doFill = this._doFill, doStroke = this._doStroke;
   if (doFill && !doStroke) {
     if(ctx.fillStyle === styleEmpty) {
       return this;
@@ -451,7 +451,7 @@ p5.Renderer2D.prototype.ellipse = function(x, y, w, h) {
       return this;
     }
   }
-  var vals = canvas.modeAdjust(x, y, w, h, this._pInst._ellipseMode);
+  var vals = canvas.modeAdjust(x, y, w, h, this._ellipseMode);
   var kappa = 0.5522847498,
     ox = (vals.w / 2) * kappa, // control point offset horizontal
     oy = (vals.h / 2) * kappa, // control point offset vertical
@@ -476,7 +476,7 @@ p5.Renderer2D.prototype.ellipse = function(x, y, w, h) {
 
 p5.Renderer2D.prototype.line = function(x1, y1, x2, y2) {
   var ctx = this.drawingContext;
-  if (!this._pInst._doStroke) {
+  if (!this._doStroke) {
     return this;
   } else if(ctx.strokeStyle === styleEmpty){
     return this;
@@ -499,7 +499,7 @@ p5.Renderer2D.prototype.point = function(x, y) {
   var ctx = this.drawingContext;
   var s = ctx.strokeStyle;
   var f = ctx.fillStyle;
-  if (!this._pInst._doStroke) {
+  if (!this._doStroke) {
     return this;
   } else if(ctx.strokeStyle === styleEmpty){
     return this;
@@ -527,7 +527,7 @@ p5.Renderer2D.prototype.point = function(x, y) {
 p5.Renderer2D.prototype.quad =
   function(x1, y1, x2, y2, x3, y3, x4, y4) {
   var ctx = this.drawingContext;
-  var doFill = this._pInst._doFill, doStroke = this._pInst._doStroke;
+  var doFill = this._doFill, doStroke = this._doStroke;
   if (doFill && !doStroke) {
     if(ctx.fillStyle === styleEmpty) {
       return this;
@@ -554,7 +554,7 @@ p5.Renderer2D.prototype.quad =
 
 p5.Renderer2D.prototype.rect = function(x, y, w, h, tl, tr, br, bl) {
   var ctx = this.drawingContext;
-  var doFill = this._pInst._doFill, doStroke = this._pInst._doStroke;
+  var doFill = this._doFill, doStroke = this._doStroke;
   if (doFill && !doStroke) {
     if(ctx.fillStyle === styleEmpty) {
       return this;
@@ -564,9 +564,9 @@ p5.Renderer2D.prototype.rect = function(x, y, w, h, tl, tr, br, bl) {
       return this;
     }
   }
-  var vals = canvas.modeAdjust(x, y, w, h, this._pInst._rectMode);
+  var vals = canvas.modeAdjust(x, y, w, h, this._rectMode);
   // Translate the line by (0.5, 0.5) to draw a crisp rectangle border
-  if (this._pInst._doStroke && ctx.lineWidth % 2 === 1) {
+  if (this._doStroke && ctx.lineWidth % 2 === 1) {
     ctx.translate(0.5, 0.5);
   }
   ctx.beginPath();
@@ -608,13 +608,13 @@ p5.Renderer2D.prototype.rect = function(x, y, w, h, tl, tr, br, bl) {
     ctx.arcTo(_x, _y, _x + _w, _y, tl);
     ctx.closePath();
   }
-  if (this._pInst._doFill) {
+  if (this._doFill) {
     ctx.fill();
   }
-  if (this._pInst._doStroke) {
+  if (this._doStroke) {
     ctx.stroke();
   }
-  if (this._pInst._doStroke && ctx.lineWidth % 2 === 1) {
+  if (this._doStroke && ctx.lineWidth % 2 === 1) {
     ctx.translate(-0.5, -0.5);
   }
   return this;
@@ -622,7 +622,7 @@ p5.Renderer2D.prototype.rect = function(x, y, w, h, tl, tr, br, bl) {
 
 p5.Renderer2D.prototype.triangle = function(x1, y1, x2, y2, x3, y3) {
   var ctx = this.drawingContext;
-  var doFill = this._pInst._doFill, doStroke = this._pInst._doStroke;
+  var doFill = this._doFill, doStroke = this._doStroke;
   if (doFill && !doStroke) {
     if(ctx.fillStyle === styleEmpty) {
       return this;
@@ -651,7 +651,7 @@ function (mode, vertices, isCurve, isBezier,
   if (vertices.length === 0) {
     return this;
   }
-  if (!this._pInst._doStroke && !this._pInst._doFill) {
+  if (!this._doStroke && !this._doFill) {
     return this;
   }
   var closeShape = mode === constants.CLOSE;
@@ -663,7 +663,7 @@ function (mode, vertices, isCurve, isBezier,
   var numVerts = vertices.length;
   if (isCurve && (shapeKind === constants.POLYGON || shapeKind === null)) {
     if (numVerts > 3) {
-      var b = [], s = 1 - this._pInst._curveTightness;
+      var b = [], s = 1 - this._curveTightness;
       this.drawingContext.beginPath();
       this.drawingContext.moveTo(vertices[1][0], vertices[1][1]);
       for (i = 1; i + 2 < numVerts; i++) {
@@ -728,7 +728,7 @@ function (mode, vertices, isCurve, isBezier,
     if (shapeKind === constants.POINTS) {
       for (i = 0; i < numVerts; i++) {
         v = vertices[i];
-        if (this._pInst._doStroke) {
+        if (this._doStroke) {
           this._pInst.stroke(v[6]);
         }
         this._pInst.point(v[0], v[1]);
@@ -736,7 +736,7 @@ function (mode, vertices, isCurve, isBezier,
     } else if (shapeKind === constants.LINES) {
       for (i = 0; i + 1 < numVerts; i += 2) {
         v = vertices[i];
-        if (this._pInst._doStroke) {
+        if (this._doStroke) {
           this._pInst.stroke(vertices[i + 1][6]);
         }
         this._pInst.line(v[0], v[1], vertices[i + 1][0], vertices[i + 1][1]);
@@ -749,11 +749,11 @@ function (mode, vertices, isCurve, isBezier,
         this.drawingContext.lineTo(vertices[i + 1][0], vertices[i + 1][1]);
         this.drawingContext.lineTo(vertices[i + 2][0], vertices[i + 2][1]);
         this.drawingContext.lineTo(v[0], v[1]);
-        if (this._pInst._doFill) {
+        if (this._doFill) {
           this._pInst.fill(vertices[i + 2][5]);
           this.drawingContext.fill();
         }
-        if (this._pInst._doStroke) {
+        if (this._doStroke) {
           this._pInst.stroke(vertices[i + 2][6]);
           this.drawingContext.stroke();
         }
@@ -765,18 +765,18 @@ function (mode, vertices, isCurve, isBezier,
         this.drawingContext.beginPath();
         this.drawingContext.moveTo(vertices[i + 1][0], vertices[i + 1][1]);
         this.drawingContext.lineTo(v[0], v[1]);
-        if (this._pInst._doStroke) {
+        if (this._doStroke) {
           this._pInst.stroke(vertices[i + 1][6]);
         }
-        if (this._pInst._doFill) {
+        if (this._doFill) {
           this._pInst.fill(vertices[i + 1][5]);
         }
         if (i + 2 < numVerts) {
           this.drawingContext.lineTo(vertices[i + 2][0], vertices[i + 2][1]);
-          if (this._pInst._doStroke) {
+          if (this._doStroke) {
             this._pInst.stroke(vertices[i + 2][6]);
           }
-          if (this._pInst._doFill) {
+          if (this._doFill) {
             this._pInst.fill(vertices[i + 2][5]);
           }
         }
@@ -788,10 +788,10 @@ function (mode, vertices, isCurve, isBezier,
         this.drawingContext.moveTo(vertices[0][0], vertices[0][1]);
         this.drawingContext.lineTo(vertices[1][0], vertices[1][1]);
         this.drawingContext.lineTo(vertices[2][0], vertices[2][1]);
-        if (this._pInst._doFill) {
+        if (this._doFill) {
           this._pInst.fill(vertices[2][5]);
         }
-        if (this._pInst._doStroke) {
+        if (this._doStroke) {
           this._pInst.stroke(vertices[2][6]);
         }
         this._doFillStrokeClose();
@@ -801,10 +801,10 @@ function (mode, vertices, isCurve, isBezier,
           this.drawingContext.moveTo(vertices[0][0], vertices[0][1]);
           this.drawingContext.lineTo(vertices[i - 1][0], vertices[i - 1][1]);
           this.drawingContext.lineTo(v[0], v[1]);
-          if (this._pInst._doFill) {
+          if (this._doFill) {
             this._pInst.fill(v[5]);
           }
-          if (this._pInst._doStroke) {
+          if (this._doStroke) {
             this._pInst.stroke(v[6]);
           }
           this._doFillStrokeClose();
@@ -819,10 +819,10 @@ function (mode, vertices, isCurve, isBezier,
           this.drawingContext.lineTo(vertices[i + j][0], vertices[i + j][1]);
         }
         this.drawingContext.lineTo(v[0], v[1]);
-        if (this._pInst._doFill) {
+        if (this._doFill) {
           this._pInst.fill(vertices[i + 3][5]);
         }
-        if (this._pInst._doStroke) {
+        if (this._doStroke) {
           this._pInst.stroke(vertices[i + 3][6]);
         }
         this._doFillStrokeClose();
@@ -837,10 +837,10 @@ function (mode, vertices, isCurve, isBezier,
             this.drawingContext.lineTo(v[0], v[1]);
             this.drawingContext.lineTo(vertices[i + 1][0], vertices[i+1][1]);
             this.drawingContext.lineTo(vertices[i + 3][0], vertices[i+3][1]);
-            if (this._pInst._doFill) {
+            if (this._doFill) {
               this._pInst.fill(vertices[i + 3][5]);
             }
-            if (this._pInst._doStroke) {
+            if (this._doStroke) {
               this._pInst.stroke(vertices[i + 3][6]);
             }
           } else {
@@ -973,10 +973,10 @@ p5.Renderer2D.prototype.curve = function (x1, y1, x2, y2, x3, y3, x4, y4) {
 //////////////////////////////////////////////
 
 p5.Renderer2D.prototype._doFillStrokeClose = function () {
-  if (this._pInst._doFill) {
+  if (this._doFill) {
     this.drawingContext.fill();
   }
-  if (this._pInst._doStroke) {
+  if (this._doStroke) {
     this.drawingContext.stroke();
   }
   this.drawingContext.closePath();
@@ -1081,7 +1081,7 @@ p5.Renderer2D.prototype.text = function (str, x, y, maxWidth, maxHeight) {
       }
     }
 
-    if (this._pInst._rectMode === constants.CENTER ){
+    if (this._rectMode === constants.CENTER ){
 
       x -= maxWidth / 2;
       y -= maxHeight / 2;

--- a/src/core/p5.Renderer2D.js
+++ b/src/core/p5.Renderer2D.js
@@ -1052,7 +1052,7 @@ p5.Renderer2D.prototype.text = function (str, x, y, maxWidth, maxHeight) {
   // Processing's vertical alignment implementation
   // for BASELINE vetical alignment in a boundings box
 
-  if (!(p._doFill || p._doStroke)) {
+  if (!(this._doFill || this._doStroke)) {
     return;
   }
 

--- a/src/core/structure.js
+++ b/src/core/structure.js
@@ -169,10 +169,10 @@ p5.prototype.push = function () {
     rectMode: this._graphics._rectMode,
     ellipseMode: this._graphics._ellipseMode,
     colorMode: this._graphics._colorMode,
-    textFont: this._graphics.textFont,
-    textLeading: this._graphics.textLeading,
-    textSize: this._graphics.textSize,
-    textStyle: this._graphics.textStyle
+    textFont: this._graphics._textFont,
+    textLeading: this._graphics._textLeading,
+    textSize: this._graphics._textSize,
+    textStyle: this._graphics._textStyle
   });
 };
 
@@ -237,10 +237,10 @@ p5.prototype.pop = function () {
   this._graphics._rectMode = lastS.rectMode;
   this._graphics._ellipseMode = lastS.ellipseMode;
   this._graphics._colorMode = lastS.colorMode;
-  this._graphics.textFont = lastS.textFont;
-  this._graphics.textLeading = lastS.textLeading;
-  this._graphics.textSize = lastS.textSize;
-  this._graphics.textStyle = lastS.textStyle;
+  this._graphics._textFont = lastS.textFont;
+  this._graphics._textLeading = lastS.textLeading;
+  this._graphics._textSize = lastS.textSize;
+  this._graphics._textStyle = lastS.textStyle;
 };
 
 p5.prototype.pushStyle = function() {

--- a/src/core/structure.js
+++ b/src/core/structure.js
@@ -162,17 +162,17 @@ p5.prototype.loop = function() {
 p5.prototype.push = function () {
   this._graphics.push();
   this._styles.push({
-    doStroke: this._doStroke,
-    doFill: this._doFill,
-    tint: this._tint,
-    imageMode: this._imageMode,
-    rectMode: this._rectMode,
-    ellipseMode: this._ellipseMode,
-    colorMode: this._colorMode,
-    textFont: this.textFont,
-    textLeading: this.textLeading,
-    textSize: this.textSize,
-    textStyle: this.textStyle
+    doStroke: this._graphics._doStroke,
+    doFill: this._graphics._doFill,
+    tint: this._graphics._tint,
+    imageMode: this._graphics._imageMode,
+    rectMode: this._graphics._rectMode,
+    ellipseMode: this._graphics._ellipseMode,
+    colorMode: this._graphics._colorMode,
+    textFont: this._graphics.textFont,
+    textLeading: this._graphics.textLeading,
+    textSize: this._graphics.textSize,
+    textStyle: this._graphics.textStyle
   });
 };
 
@@ -230,17 +230,17 @@ p5.prototype.push = function () {
 p5.prototype.pop = function () {
   this._graphics.pop();
   var lastS = this._styles.pop();
-  this._doStroke = lastS.doStroke;
-  this._doFill = lastS.doFill;
-  this._tint = lastS.tint;
-  this._imageMode = lastS.imageMode;
-  this._rectMode = lastS.rectMode;
-  this._ellipseMode = lastS.ellipseMode;
-  this._colorMode = lastS.colorMode;
-  this.textFont = lastS.textFont;
-  this.textLeading = lastS.textLeading;
-  this.textSize = lastS.textSize;
-  this.textStyle = lastS.textStyle;
+  this._graphics._doStroke = lastS.doStroke;
+  this._graphics._doFill = lastS.doFill;
+  this._graphics._tint = lastS.tint;
+  this._graphics._imageMode = lastS.imageMode;
+  this._graphics._rectMode = lastS.rectMode;
+  this._graphics._ellipseMode = lastS.ellipseMode;
+  this._graphics._colorMode = lastS.colorMode;
+  this._graphics.textFont = lastS.textFont;
+  this._graphics.textLeading = lastS.textLeading;
+  this._graphics.textSize = lastS.textSize;
+  this._graphics.textStyle = lastS.textStyle;
 };
 
 p5.prototype.pushStyle = function() {

--- a/src/core/vertex.js
+++ b/src/core/vertex.js
@@ -426,7 +426,7 @@ p5.prototype.endShape = function(mode) {
     this._graphics.endShape();
   }else{
     if (vertices.length === 0) { return this; }
-    if (!this._doStroke && !this._doFill) { return this; }
+    if (!this._graphics._doStroke && !this._graphics._doFill) { return this; }
 
     var closeShape = mode === constants.CLOSE;
 

--- a/src/image/image.js
+++ b/src/image/image.js
@@ -13,7 +13,6 @@
 
 
 var p5 = require('../core/core');
-var constants = require('../core/constants');
 
 /* global frames:true */// This is not global, but JSHint is not aware that
 // this module is implicitly enclosed with Browserify: this overrides the
@@ -21,8 +20,6 @@ var constants = require('../core/constants');
 // of saved animation frames.
 var frames = [];
 
-p5.prototype._imageMode = constants.CORNER;
-p5.prototype._tint = null;
 
 /**
  * Creates a new p5.Image (the datatype for storing images). This provides a

--- a/src/image/loading_displaying.js
+++ b/src/image/loading_displaying.js
@@ -138,7 +138,7 @@ p5.prototype.image = function(img, x, y, width, height) {
   y = y || 0;
   width = width || img.width;
   height = height || img.height;
-  var vals = canvas.modeAdjust(x, y, width, height, this._imageMode);
+  var vals = canvas.modeAdjust(x, y, width, height, this._graphics._imageMode);
   // tint the image if there is a tint
   this._graphics.image(img, vals.x, vals.y, vals.w, vals.h);
 };
@@ -209,7 +209,7 @@ p5.prototype.image = function(img, x, y, width, height) {
  */
 p5.prototype.tint = function () {
   var c = this.color.apply(this, arguments);
-  this._tint = c.rgba;
+  this._graphics._tint = c.rgba;
 };
 
 /**
@@ -234,7 +234,7 @@ p5.prototype.tint = function () {
  * </div>
  */
 p5.prototype.noTint = function() {
-  this._tint = null;
+  this._graphics._tint = null;
 };
 
 /**
@@ -263,10 +263,10 @@ p5.prototype._getTintedImageCanvas = function(img) {
     var b = pixels[i+2];
     var a = pixels[i+3];
 
-    newPixels[i] = r*this._tint[0]/255;
-    newPixels[i+1] = g*this._tint[1]/255;
-    newPixels[i+2] = b*this._tint[2]/255;
-    newPixels[i+3] = a*this._tint[3]/255;
+    newPixels[i] = r*this._graphics._tint[0]/255;
+    newPixels[i+1] = g*this._graphics._tint[1]/255;
+    newPixels[i+2] = b*this._graphics._tint[2]/255;
+    newPixels[i+3] = a*this._graphics._tint[3]/255;
   }
 
   tmpCtx.putImageData(id, 0, 0);
@@ -335,7 +335,7 @@ p5.prototype.imageMode = function(m) {
   if (m === constants.CORNER ||
     m === constants.CORNERS ||
     m === constants.CENTER) {
-    this._imageMode = m;
+    this._graphics._imageMode = m;
   }
 };
 

--- a/src/typography/loading_displaying.js
+++ b/src/typography/loading_displaying.js
@@ -70,7 +70,7 @@ p5.prototype.text = function(str, x, y, maxWidth, maxHeight) {
     ]
   );
 
-  return (!(this._doFill || this._doStroke)) ? this :
+  return (!(this._graphics._doFill || this._graphics._doStroke)) ? this :
     this._graphics.text.apply(this._graphics, arguments);
 };
 
@@ -122,12 +122,12 @@ p5.prototype.textFont = function(theFont, theSize) {
       throw Error('null font passed to textFont');
     }
 
-    this._setProperty('_textFont', theFont);
+    this._graphics._setProperty('_textFont', theFont);
 
     if (theSize) {
 
-      this._setProperty('_textSize', theSize);
-      this._setProperty('_textLeading',
+      this._graphics._setProperty('_textSize', theSize);
+      this._graphics._setProperty('_textLeading',
         theSize * constants._DEFAULT_LEADMULT);
     }
 

--- a/src/typography/p5.Font.js
+++ b/src/typography/p5.Font.js
@@ -353,7 +353,8 @@ p5.Font.prototype._textDescent = function(fontSize) {
 
 p5.Font.prototype._scale = function(fontSize) {
 
-  return (1 / this.font.unitsPerEm) * (fontSize || this.parent._textSize);
+  return (1 / this.font.unitsPerEm) * (fontSize ||
+    this.parent._graphics._textSize);
 };
 
 p5.Font.prototype._handleAlignment = function(p, ctx, line, x, y) {

--- a/src/typography/p5.Font.js
+++ b/src/typography/p5.Font.js
@@ -95,7 +95,7 @@ p5.Font.prototype.textBounds = function(str, x, y, fontSize, options) {
 
   x = x !== undefined ? x : 0;
   y = y !== undefined ? y : 0;
-  fontSize = fontSize || this.parent._textSize;
+  fontSize = fontSize || this.parent._graphics._textSize;
 
   var result = this.cache[cacheKey('textBounds', str, x, y, fontSize)];
   if (!result) {
@@ -176,7 +176,7 @@ p5.Font.prototype._getPath = function(line, x, y, options) {
     ctx = p._graphics.drawingContext,
     pos = this._handleAlignment(p, ctx, line, x, y);
 
-  return this.font.getPath(line, pos.x, pos.y, p._textSize, options);
+  return this.font.getPath(line, pos.x, pos.y, p._graphics._textSize, options);
 };
 
 /*
@@ -285,8 +285,7 @@ p5.Font.prototype._getSVG = function(line, x, y, options) {
 p5.Font.prototype._renderPath = function(line, x, y, options) {
 
   // /console.log('_renderPath', typeof line);
-  var pdata, p = this.parent,
-    pg = p._graphics,
+  var pdata, pg = this.parent._graphics,
     ctx = pg.drawingContext;
 
   if (typeof line === 'object' && line.commands) {
@@ -295,7 +294,7 @@ p5.Font.prototype._renderPath = function(line, x, y, options) {
   } else {
 
     //pos = handleAlignment(p, ctx, line, x, y);
-    pdata = this._getPath(line, x, y, p._textSize, options).commands;
+    pdata = this._getPath(line, x, y, pg._textSize, options).commands;
   }
 
   ctx.beginPath();
@@ -316,15 +315,15 @@ p5.Font.prototype._renderPath = function(line, x, y, options) {
   }
 
   // only draw stroke if manually set by user
-  if (p._doStroke && p._strokeSet) {
+  if (pg._doStroke && pg._strokeSet) {
 
     ctx.stroke();
   }
 
-  if (p._doFill) {
+  if (pg._doFill) {
 
     // if fill hasn't been set by user, use default-text-fill
-    ctx.fillStyle = p._fillSet ? ctx.fillStyle : constants._DEFAULT_TEXT_FILL;
+    ctx.fillStyle = pg._fillSet ? ctx.fillStyle : constants._DEFAULT_TEXT_FILL;
     ctx.fill();
   }
 

--- a/test/unit/color/setting.js
+++ b/test/unit/color/setting.js
@@ -7,7 +7,7 @@ suite('Color', function() {
   });
 
   suite('p5.prototype.colorMode', function() {
-    var colorMode = myp5._colorMode;
+    var colorMode = myp5.colorMode;
     suite('colorMode(RGB)', function() {
       test('should be a function', function() {
         assert.ok(colorMode);
@@ -15,48 +15,48 @@ suite('Color', function() {
 
       test('should set mode to RGB', function() {
         myp5.colorMode(myp5.RGB);
-        assert.equal(myp5._colorMode, myp5.RGB);
+        assert.equal(myp5._graphics._colorMode, myp5.RGB);
       });
 
       test('should correctly set color RGB maxes', function() {
-        assert.deepEqual(myp5._colorMaxes[myp5.RGB], [255, 255, 255, 255]);
+        assert.deepEqual(myp5._graphics._colorMaxes[myp5.RGB], [255, 255, 255, 255]);
         myp5.colorMode(myp5.RGB, 1, 1, 1);
-        assert.deepEqual(myp5._colorMaxes[myp5.RGB], [1, 1, 1, 255]);
+        assert.deepEqual(myp5._graphics._colorMaxes[myp5.RGB], [1, 1, 1, 255]);
         myp5.colorMode(myp5.RGB, 1);
-        assert.deepEqual(myp5._colorMaxes[myp5.RGB], [1, 1, 1, 1]);
+        assert.deepEqual(myp5._graphics._colorMaxes[myp5.RGB], [1, 1, 1, 1]);
         myp5.colorMode(myp5.RGB, 255, 255, 255, 1);
-        assert.deepEqual(myp5._colorMaxes[myp5.RGB], [255, 255, 255, 1]);
+        assert.deepEqual(myp5._graphics._colorMaxes[myp5.RGB], [255, 255, 255, 1]);
         myp5.colorMode(myp5.RGB, 255);
       });
 
       test('should set mode to HSL', function() {
         myp5.colorMode(myp5.HSL);
-        assert.equal(myp5._colorMode, myp5.HSL);
+        assert.equal(myp5._graphics._colorMode, myp5.HSL);
       });
 
       test('should correctly set color HSL maxes', function() {
-        assert.deepEqual(myp5._colorMaxes[myp5.HSL], [360, 100, 100, 1]);
+        assert.deepEqual(myp5._graphics._colorMaxes[myp5.HSL], [360, 100, 100, 1]);
         myp5.colorMode(myp5.HSL, 255, 255, 255);
-        assert.deepEqual(myp5._colorMaxes[myp5.HSL], [255, 255, 255, 1]);
+        assert.deepEqual(myp5._graphics._colorMaxes[myp5.HSL], [255, 255, 255, 1]);
         myp5.colorMode(myp5.HSL, 360);
-        assert.deepEqual(myp5._colorMaxes[myp5.HSL], [360, 360, 360, 360]);
+        assert.deepEqual(myp5._graphics._colorMaxes[myp5.HSL], [360, 360, 360, 360]);
         myp5.colorMode(myp5.HSL, 360, 100, 100, 1);
-        assert.deepEqual(myp5._colorMaxes[myp5.HSL], [360, 100, 100, 1]);
+        assert.deepEqual(myp5._graphics._colorMaxes[myp5.HSL], [360, 100, 100, 1]);
       });
 
       test('should set mode to HSB', function() {
         myp5.colorMode(myp5.HSB);
-        assert.equal(myp5._colorMode, myp5.HSB);
+        assert.equal(myp5._graphics._colorMode, myp5.HSB);
       });
 
       test('should correctly set color HSB maxes', function() {
-        assert.deepEqual(myp5._colorMaxes[myp5.HSB], [360, 100, 100, 1]);
+        assert.deepEqual(myp5._graphics._colorMaxes[myp5.HSB], [360, 100, 100, 1]);
         myp5.colorMode(myp5.HSB, 255, 255, 255);
-        assert.deepEqual(myp5._colorMaxes[myp5.HSB], [255, 255, 255, 1]);
+        assert.deepEqual(myp5._graphics._colorMaxes[myp5.HSB], [255, 255, 255, 1]);
         myp5.colorMode(myp5.HSB, 360);
-        assert.deepEqual(myp5._colorMaxes[myp5.HSB], [360, 360, 360, 360]);
+        assert.deepEqual(myp5._graphics._colorMaxes[myp5.HSB], [360, 360, 360, 360]);
         myp5.colorMode(myp5.HSB, 360, 100, 100, 1);
-        assert.deepEqual(myp5._colorMaxes[myp5.HSB], [360, 100, 100, 1]);
+        assert.deepEqual(myp5._graphics._colorMaxes[myp5.HSB], [360, 100, 100, 1]);
       });
     });
   });


### PR DESCRIPTION
This addresses https://github.com/processing/p5.js/issues/886.

I moved a number of properties that were previously attached to `p5.prototype` to `p5.Renderer` instead. This way, drawing properties relating to fill, stroke, modes, are all wrapped up with an individual render object, allowing p5.Graphics buffers to differ, which aligns with Processing behavior.

You can see most of the affected variables here: https://github.com/processing/p5.js/blob/render-props/src/core/p5.Renderer.js#L47. I then updated (hopefully) all references to these throughout the core API, drawing functions, and type functions. 

@dhowe I made changes to type and wanted to make sure you approve these.
@indefinit I didn't touch anything with 3D but I don't know if the changes to the base renderer would affect anything upstream for you, want to give it a look?

Everyone else... I touched a lot of files and I'm feeling a little nervous, especially since school has started, so if anyone else wants to give this a test and see if they find any problems, please do!

