### PR TITLE
Fix example for createCapture()

### DIFF
--- a/lib/addons/p5.dom.js
+++ b/lib/addons/p5.dom.js
@@ -576,7 +576,7 @@
    *                                    stream has loaded
    * @return {Object/p5.Element} capture video p5.Element
    * @example
-   * <div><class='norender'><code>
+   * <div class='norender'><code>
    * var capture;
    *
    * function setup() {
@@ -589,7 +589,7 @@
    *   filter(INVERT);
    * }
    * </code></div>
-   * <div><class='norender'><code>
+   * <div class='norender'><code>
    * function setup() {
    *   createCanvas(480, 120);
    *   var constraints = {


### PR DESCRIPTION
Please see issue [#162](https://github.com/processing/p5.js-website/issues/162) on p5.js-website repo for more info. The class 'norender' is now properly added to the div containing the code.