### PR TITLE
renames this._graphics to this._renderers for api consistency

### DIFF
--- a/src/3d/3d_primitives.js
+++ b/src/3d/3d_primitives.js
@@ -44,7 +44,7 @@ p5.prototype.plane = function(width, height){
 
   var gId = 'plane|'+width+'|'+height+'|'+detailX+'|'+detailY;
 
-  if(!this._graphics.geometryInHash(gId)){
+  if(!this._renderer.geometryInHash(gId)){
 
     var geometry3d = new p5.Geometry3D();
 
@@ -59,11 +59,11 @@ p5.prototype.plane = function(width, height){
 
     var obj = geometry3d.generateObj();
 
-    this._graphics.initBuffer(gId, obj);
+    this._renderer.initBuffer(gId, obj);
 
   }
 
-  this._graphics.drawBuffer(gId);
+  this._renderer.drawBuffer(gId);
 
 };
 
@@ -99,7 +99,7 @@ p5.prototype.sphere = function(radius, detail){
 
   var gId = 'sphere|'+radius+'|'+detailX+'|'+detailY;
 
-  if(!this._graphics.geometryInHash(gId)){
+  if(!this._renderer.geometryInHash(gId)){
 
     var geometry3d = new p5.Geometry3D();
 
@@ -116,10 +116,10 @@ p5.prototype.sphere = function(radius, detail){
 
     var obj = geometry3d.generateObj();
 
-    this._graphics.initBuffer(gId, obj);
+    this._renderer.initBuffer(gId, obj);
   }
 
-  this._graphics.drawBuffer(gId);
+  this._renderer.drawBuffer(gId);
 
   return this;
 };
@@ -158,7 +158,7 @@ p5.prototype.cylinder = function(radius, height, detail){
 
   var gId = 'cylinder|'+radius+'|'+height+'|'+detailX+'|'+detailY;
 
-  if(!this._graphics.geometryInHash(gId)){
+  if(!this._renderer.geometryInHash(gId)){
 
     var geometry3d = new p5.Geometry3D();
 
@@ -206,10 +206,10 @@ p5.prototype.cylinder = function(radius, height, detail){
 
     var obj = geometry3d.generateObj(true);
 
-    this._graphics.initBuffer(gId, obj);
+    this._renderer.initBuffer(gId, obj);
   }
 
-  this._graphics.drawBuffer(gId);
+  this._renderer.drawBuffer(gId);
 
   return this;
 };
@@ -249,7 +249,7 @@ p5.prototype.cone = function(radius, height, detail){
 
   var gId = 'cone|'+radius+'|'+height+'|'+detailX+'|'+detailY;
 
-  if(!this._graphics.geometryInHash(gId)){
+  if(!this._renderer.geometryInHash(gId)){
 
     var geometry3d = new p5.Geometry3D();
 
@@ -277,10 +277,10 @@ p5.prototype.cone = function(radius, height, detail){
 
     var obj = geometry3d.generateObj(true);
 
-    this._graphics.initBuffer(gId, obj);
+    this._renderer.initBuffer(gId, obj);
   }
 
-  this._graphics.drawBuffer(gId);
+  this._renderer.drawBuffer(gId);
 
   return this;
 };
@@ -322,7 +322,7 @@ p5.prototype.torus = function(radius, tubeRadius, detail){
 
   var gId = 'torus|'+radius+'|'+tubeRadius+'|'+detailX+'|'+detailY;
 
-  if(!this._graphics.geometryInHash(gId)){
+  if(!this._renderer.geometryInHash(gId)){
 
     var geometry3d = new p5.Geometry3D();
 
@@ -339,10 +339,10 @@ p5.prototype.torus = function(radius, tubeRadius, detail){
 
     var obj = geometry3d.generateObj();
 
-    this._graphics.initBuffer(gId, obj);
+    this._renderer.initBuffer(gId, obj);
   }
 
-  this._graphics.drawBuffer(gId);
+  this._renderer.drawBuffer(gId);
 
   return this;
 };
@@ -383,7 +383,7 @@ p5.prototype.box = function(width, height, depth){
 
   var gId = 'cube|'+width+'|'+height+'|'+depth+'|'+detailX+'|'+detailY;
 
-  if(!this._graphics.geometryInHash(gId)){
+  if(!this._renderer.geometryInHash(gId)){
 
     var geometry3d = new p5.Geometry3D();
 
@@ -439,10 +439,10 @@ p5.prototype.box = function(width, height, depth){
 
     var obj = geometry3d.generateObj(true);
 
-    this._graphics.initBuffer(gId, obj);
+    this._renderer.initBuffer(gId, obj);
   }
 
-  this._graphics.drawBuffer(gId);
+  this._renderer.drawBuffer(gId);
 
   return this;
 

--- a/src/3d/camera.js
+++ b/src/3d/camera.js
@@ -36,7 +36,7 @@ p5.prototype.camera = function(x, y, z){
     ['Number', 'Number', 'Number']
   );
   //what it manipulates is the model view matrix
-  this._graphics.translate(-x, -y, -z);
+  this._renderer.translate(-x, -y, -z);
 };
 
 /**
@@ -78,9 +78,9 @@ p5.prototype.perspective = function(fovy,aspect,near,far) {
     arguments,
     ['Number', 'Number', 'Number', 'Number']
   );
-  this._graphics.uPMatrix = p5.Matrix.identity();
-  this._graphics.uPMatrix.perspective(fovy,aspect,near,far);
-  this._graphics._setCamera = true;
+  this._renderer.uPMatrix = p5.Matrix.identity();
+  this._renderer.uPMatrix.perspective(fovy,aspect,near,far);
+  this._renderer._setCamera = true;
 };
 
 /**
@@ -125,9 +125,9 @@ p5.prototype.ortho = function(left,right,bottom,top,near,far) {
   right /= this.width;
   top /= this.height;
   bottom /= this.height;
-  this._graphics.uPMatrix = p5.Matrix.identity();
-  this._graphics.uPMatrix.ortho(left,right,bottom,top,near,far);
-  this._graphics._setCamera = true;
+  this._renderer.uPMatrix = p5.Matrix.identity();
+  this._renderer.uPMatrix.ortho(left,right,bottom,top,near,far);
+  this._renderer._setCamera = true;
 };
 
 module.exports = p5;

--- a/src/3d/light.js
+++ b/src/3d/light.js
@@ -35,17 +35,17 @@ var p5 = require('../core/core');
  * </div>
  */
 p5.prototype.ambientLight = function(v1, v2, v3, a){
-  var gl = this._graphics.GL;
-  var shaderProgram = this._graphics._getShader(
+  var gl = this._renderer.GL;
+  var shaderProgram = this._renderer._getShader(
     'lightVert', 'lightFrag');
 
   gl.useProgram(shaderProgram);
   shaderProgram.uAmbientColor = gl.getUniformLocation(
     shaderProgram,
-    'uAmbientColor[' + this._graphics.ambientLightCount + ']');
+    'uAmbientColor[' + this._renderer.ambientLightCount + ']');
 
-  var color = this._graphics._pInst.color.apply(
-    this._graphics._pInst, arguments);
+  var color = this._renderer._pInst.color.apply(
+    this._renderer._pInst, arguments);
   var colors = color._normalize();
 
   gl.uniform3f( shaderProgram.uAmbientColor,
@@ -56,11 +56,11 @@ p5.prototype.ambientLight = function(v1, v2, v3, a){
     shaderProgram, 'uMaterialColor' );
   gl.uniform4f( shaderProgram.uMaterialColor, 1, 1, 1, 1);
 
-  this._graphics.ambientLightCount ++;
+  this._renderer.ambientLightCount ++;
   shaderProgram.uAmbientLightCount =
     gl.getUniformLocation(shaderProgram, 'uAmbientLightCount');
   gl.uniform1i(shaderProgram.uAmbientLightCount,
-    this._graphics.ambientLightCount);
+    this._renderer.ambientLightCount);
 
   return this;
 };
@@ -126,18 +126,18 @@ p5.prototype.directionalLight = function(v1, v2, v3, a, x, y, z) {
   //   ]
   // );
 
-  var gl = this._graphics.GL;
-  var shaderProgram = this._graphics._getShader(
+  var gl = this._renderer.GL;
+  var shaderProgram = this._renderer._getShader(
     'lightVert', 'lightFrag');
 
   gl.useProgram(shaderProgram);
   shaderProgram.uDirectionalColor = gl.getUniformLocation(
     shaderProgram,
-    'uDirectionalColor[' + this._graphics.directionalLightCount + ']');
+    'uDirectionalColor[' + this._renderer.directionalLightCount + ']');
 
   //@TODO: check parameters number
-  var color = this._graphics._pInst.color.apply(
-    this._graphics._pInst, [v1, v2, v3]);
+  var color = this._renderer._pInst.color.apply(
+    this._renderer._pInst, [v1, v2, v3]);
   var colors = color._normalize();
 
   gl.uniform3f( shaderProgram.uDirectionalColor,
@@ -163,7 +163,7 @@ p5.prototype.directionalLight = function(v1, v2, v3, a, x, y, z) {
 
   shaderProgram.uLightingDirection = gl.getUniformLocation(
     shaderProgram,
-    'uLightingDirection[' + this._graphics.directionalLightCount + ']');
+    'uLightingDirection[' + this._renderer.directionalLightCount + ']');
   gl.uniform3f( shaderProgram.uLightingDirection, _x, _y, _z);
 
   //in case there's no material color for the geometry
@@ -171,11 +171,11 @@ p5.prototype.directionalLight = function(v1, v2, v3, a, x, y, z) {
     shaderProgram, 'uMaterialColor' );
   gl.uniform4f( shaderProgram.uMaterialColor, 1, 1, 1, 1);
 
-  this._graphics.directionalLightCount ++;
+  this._renderer.directionalLightCount ++;
   shaderProgram.uDirectionalLightCount =
     gl.getUniformLocation(shaderProgram, 'uDirectionalLightCount');
   gl.uniform1i(shaderProgram.uDirectionalLightCount,
-    this._graphics.directionalLightCount);
+    this._renderer.directionalLightCount);
 
   return this;
 };
@@ -248,18 +248,18 @@ p5.prototype.pointLight = function(v1, v2, v3, a, x, y, z) {
   //   ]
   // );
 
-  var gl = this._graphics.GL;
-  var shaderProgram = this._graphics._getShader(
+  var gl = this._renderer.GL;
+  var shaderProgram = this._renderer._getShader(
     'lightVert', 'lightFrag');
 
   gl.useProgram(shaderProgram);
   shaderProgram.uPointLightColor = gl.getUniformLocation(
     shaderProgram,
-    'uPointLightColor[' + this._graphics.pointLightCount + ']');
+    'uPointLightColor[' + this._renderer.pointLightCount + ']');
 
   //@TODO: check parameters number
-  var color = this._graphics._pInst.color.apply(
-    this._graphics._pInst, [v1, v2, v3]);
+  var color = this._renderer._pInst.color.apply(
+    this._renderer._pInst, [v1, v2, v3]);
   var colors = color._normalize();
 
   gl.uniform3f( shaderProgram.uPointLightColor,
@@ -285,7 +285,7 @@ p5.prototype.pointLight = function(v1, v2, v3, a, x, y, z) {
 
   shaderProgram.uPointLightLocation = gl.getUniformLocation(
     shaderProgram,
-    'uPointLightLocation[' + this._graphics.pointLightCount + ']');
+    'uPointLightLocation[' + this._renderer.pointLightCount + ']');
   gl.uniform3f( shaderProgram.uPointLightLocation, _x, _y, _z);
 
   //in case there's no material color for the geometry
@@ -293,11 +293,11 @@ p5.prototype.pointLight = function(v1, v2, v3, a, x, y, z) {
     shaderProgram, 'uMaterialColor' );
   gl.uniform4f( shaderProgram.uMaterialColor, 1, 1, 1, 1);
 
-  this._graphics.pointLightCount ++;
+  this._renderer.pointLightCount ++;
   shaderProgram.uPointLightCount =
     gl.getUniformLocation(shaderProgram, 'uPointLightCount');
   gl.uniform1i(shaderProgram.uPointLightCount,
-    this._graphics.pointLightCount);
+    this._renderer.pointLightCount);
 
   return this;
 };

--- a/src/3d/material.js
+++ b/src/3d/material.js
@@ -30,7 +30,7 @@ var p5 = require('../core/core');
  * </div>
  */
 p5.prototype.normalMaterial = function(){
-  this._graphics._getShader('normalVert', 'normalFrag');
+  this._renderer._getShader('normalVert', 'normalFrag');
   return this;
 };
 
@@ -59,8 +59,8 @@ p5.prototype.normalMaterial = function(){
  * </div>
  */
 p5.prototype.texture = function(image){
-  var gl = this._graphics.GL;
-  var shaderProgram = this._graphics._getShader('normalVert',
+  var gl = this._renderer.GL;
+  var shaderProgram = this._renderer._getShader('normalVert',
     'textureFrag');
   gl.useProgram(shaderProgram);
   var tex = gl.createTexture();
@@ -162,16 +162,16 @@ function _nextHighestPOT (value){
  * </div>
  */
 p5.prototype.basicMaterial = function(v1, v2, v3, a){
-  var gl = this._graphics.GL;
+  var gl = this._renderer.GL;
 
-  var shaderProgram = this._graphics._getShader('normalVert', 'basicFrag');
+  var shaderProgram = this._renderer._getShader('normalVert', 'basicFrag');
 
   gl.useProgram(shaderProgram);
   shaderProgram.uMaterialColor = gl.getUniformLocation(
     shaderProgram, 'uMaterialColor' );
 
-  var color = this._graphics._pInst.color.apply(
-    this._graphics._pInst, arguments);
+  var color = this._renderer._pInst.color.apply(
+    this._renderer._pInst, arguments);
   var colors = color._normalize();
 
   gl.uniform4f( shaderProgram.uMaterialColor,
@@ -207,15 +207,15 @@ p5.prototype.basicMaterial = function(v1, v2, v3, a){
  * </div>
  */
 p5.prototype.ambientMaterial = function(v1, v2, v3, a) {
-  var gl = this._graphics.GL;
-  var shaderProgram = this._graphics._getShader('lightVert', 'lightFrag');
+  var gl = this._renderer.GL;
+  var shaderProgram = this._renderer._getShader('lightVert', 'lightFrag');
 
   gl.useProgram(shaderProgram);
   shaderProgram.uMaterialColor = gl.getUniformLocation(
     shaderProgram, 'uMaterialColor' );
 
-  var color = this._graphics._pInst.color.apply(
-    this._graphics._pInst, arguments);
+  var color = this._renderer._pInst.color.apply(
+    this._renderer._pInst, arguments);
   var colors = color._normalize();
 
   gl.uniform4f(shaderProgram.uMaterialColor,
@@ -254,15 +254,15 @@ p5.prototype.ambientMaterial = function(v1, v2, v3, a) {
  * </div>
  */
 p5.prototype.specularMaterial = function(v1, v2, v3, a) {
-  var gl = this._graphics.GL;
-  var shaderProgram = this._graphics._getShader('lightVert', 'lightFrag');
+  var gl = this._renderer.GL;
+  var shaderProgram = this._renderer._getShader('lightVert', 'lightFrag');
 
   gl.useProgram(shaderProgram);
   shaderProgram.uMaterialColor = gl.getUniformLocation(
     shaderProgram, 'uMaterialColor' );
 
-  var color = this._graphics._pInst.color.apply(
-    this._graphics._pInst, arguments);
+  var color = this._renderer._pInst.color.apply(
+    this._renderer._pInst, arguments);
   var colors = color._normalize();
 
   gl.uniform4f(shaderProgram.uMaterialColor,

--- a/src/color/creating_reading.js
+++ b/src/color/creating_reading.js
@@ -349,15 +349,15 @@ p5.prototype.lerpColor = function(c1, c2, amt) {
   var l1, l2, l3, l4;
   var fromColor, toColor;
 
-  if(this._graphics._colorMode === constants.RGB) {
+  if(this._renderer._colorMode === constants.RGB) {
     fromColor = this.color(c1).rgba;
     toColor = this.color(c2).rgba;
   }
-  else if (this._graphics._colorMode === constants.HSB) {
+  else if (this._renderer._colorMode === constants.HSB) {
     fromColor = this.color(c1).hsba;
     toColor = this.color(c2).hsba;
   }
-  else if(this._graphics._colorMode === constants.HSL) {
+  else if(this._renderer._colorMode === constants.HSL) {
     fromColor = this.color(c1).hsla;
     toColor = this.color(c2).hsla;
   }

--- a/src/color/p5.Color.js
+++ b/src/color/p5.Color.js
@@ -16,8 +16,8 @@ var constants = require('../core/constants');
  * (1, 1, 1, 1)
  */
 p5.Color = function (pInst, vals) {
-  this.mode = pInst._graphics._colorMode;
-  this.maxes = pInst._graphics._colorMaxes;
+  this.mode = pInst._renderer._colorMode;
+  this.maxes = pInst._renderer._colorMaxes;
   var isHSB = this.mode === constants.HSB,
       isRGB = this.mode === constants.RGB,
       isHSL = this.mode === constants.HSL;
@@ -31,7 +31,7 @@ p5.Color = function (pInst, vals) {
     this.hsla = p5.Color._getFormattedColor.apply(pInst, vals);
     this._array = color_utils.hslaToRGBA(this.hsla);
   } else {
-    throw new Error(pInst._graphics._colorMode + ' is an invalid colorMode.');
+    throw new Error(pInst._renderer._colorMode + ' is an invalid colorMode.');
   }
 
   this.rgba = [ Math.round(this._array[0] * 255),
@@ -448,8 +448,8 @@ var colorPatterns = {
  */
 p5.Color._getFormattedColor = function () {
   var numArgs = arguments.length;
-  var mode    = this._graphics._colorMode;
-  var maxArr  = this._graphics._colorMaxes[this._graphics._colorMode];
+  var mode    = this._renderer._colorMode;
+  var maxArr  = this._renderer._colorMaxes[this._renderer._colorMode];
   var results = [];
 
   // Handle [r,g,b,a] or [h,s,l,a] color values

--- a/src/color/setting.js
+++ b/src/color/setting.js
@@ -115,7 +115,7 @@ p5.prototype.background = function() {
   if (arguments[0] instanceof p5.Image) {
     this.image(arguments[0], 0, 0, this.width, this.height);
   } else {
-    this._graphics.background.apply(this._graphics, arguments);
+    this._renderer.background.apply(this._renderer, arguments);
   }
   return this;
 };
@@ -136,7 +136,7 @@ p5.prototype.background = function() {
  * </div>
  */
 p5.prototype.clear = function() {
-  this._graphics.clear();
+  this._renderer.clear();
   return this;
 };
 
@@ -213,9 +213,9 @@ p5.prototype.colorMode = function() {
   if (arguments[0] === constants.RGB ||
       arguments[0] === constants.HSB ||
       arguments[0] === constants.HSL) {
-    this._graphics._colorMode = arguments[0];
+    this._renderer._colorMode = arguments[0];
 
-    var maxArr = this._graphics._colorMaxes[this._graphics._colorMode];
+    var maxArr = this._renderer._colorMaxes[this._renderer._colorMode];
 
     if (arguments.length === 2) {
       maxArr[0] = arguments[1];
@@ -350,9 +350,9 @@ p5.prototype.colorMode = function() {
  * </div>
  */
 p5.prototype.fill = function() {
-  this._graphics._setProperty('_fillSet', true);
-  this._graphics._setProperty('_doFill', true);
-  this._graphics.fill.apply(this._graphics, arguments);
+  this._renderer._setProperty('_fillSet', true);
+  this._renderer._setProperty('_doFill', true);
+  this._renderer.fill.apply(this._renderer, arguments);
   return this;
 };
 
@@ -371,7 +371,7 @@ p5.prototype.fill = function() {
  * </div>
  */
 p5.prototype.noFill = function() {
-  this._graphics._setProperty('_doFill', false);
+  this._renderer._setProperty('_doFill', false);
   return this;
 };
 
@@ -389,7 +389,7 @@ p5.prototype.noFill = function() {
  * </div>
  */
 p5.prototype.noStroke = function() {
-  this._graphics._setProperty('_doStroke', false);
+  this._renderer._setProperty('_doStroke', false);
   return this;
 };
 
@@ -516,9 +516,9 @@ p5.prototype.noStroke = function() {
  * </div>
  */
 p5.prototype.stroke = function() {
-  this._graphics._setProperty('_strokeSet', true);
-  this._graphics._setProperty('_doStroke', true);
-  this._graphics.stroke.apply(this._graphics, arguments);
+  this._renderer._setProperty('_strokeSet', true);
+  this._renderer._setProperty('_doStroke', true);
+  this._renderer.stroke.apply(this._renderer, arguments);
   return this;
 };
 

--- a/src/core/2d_primitives.js
+++ b/src/core/2d_primitives.js
@@ -74,7 +74,7 @@ p5.prototype.arc = function(x, y, w, h, start, stop, mode) {
     ]
   );
 
-  if (!this._graphics._doStroke && !this._graphics._doFill) {
+  if (!this._renderer._doStroke && !this._renderer._doFill) {
     return this;
   }
   if (this._angleMode === constants.DEGREES) {
@@ -117,7 +117,7 @@ p5.prototype.arc = function(x, y, w, h, start, stop, mode) {
   // p5 supports negative width and heights for ellipses
   w = Math.abs(w);
   h = Math.abs(h);
-  this._graphics.arc(x, y, w, h, start, stop, mode);
+  this._renderer.arc(x, y, w, h, start, stop, mode);
   return this;
 };
 
@@ -147,15 +147,15 @@ p5.prototype.ellipse = function(x, y, w, h) {
     ['Number', 'Number', 'Number', 'Number']
   );
 
-  if (!this._graphics._doStroke && !this._graphics._doFill) {
+  if (!this._renderer._doStroke && !this._renderer._doFill) {
     return this;
   }
   // p5 supports negative width and heights for ellipses
   w = Math.abs(w);
   h = Math.abs(h);
-  //@TODO add catch block here if this._graphics
+  //@TODO add catch block here if this._renderer
   //doesn't have the method implemented yet
-  this._graphics.ellipse(x, y, w, h);
+  this._renderer.ellipse(x, y, w, h);
   return this;
 };
 /**
@@ -191,20 +191,20 @@ p5.prototype.ellipse = function(x, y, w, h) {
  */
 ////commented out original
 // p5.prototype.line = function(x1, y1, x2, y2) {
-//   if (!this._graphics._doStroke) {
+//   if (!this._renderer._doStroke) {
 //     return this;
 //   }
-//   if(this._graphics.isP3D){
+//   if(this._renderer.isP3D){
 //   } else {
-//     this._graphics.line(x1, y1, x2, y2);
+//     this._renderer.line(x1, y1, x2, y2);
 //   }
 // };
 p5.prototype.line = function() {
-  if (!this._graphics._doStroke) {
+  if (!this._renderer._doStroke) {
     return this;
   }
   //check whether we should draw a 3d line or 2d
-  if(this._graphics.isP3D){
+  if(this._renderer.isP3D){
     this._validateParameters(
       'line',
       arguments,
@@ -212,7 +212,7 @@ p5.prototype.line = function() {
         ['Number', 'Number', 'Number', 'Number', 'Number', 'Number']
       ]
     );
-    this._graphics.line(
+    this._renderer.line(
       arguments[0],
       arguments[1],
       arguments[2],
@@ -227,7 +227,7 @@ p5.prototype.line = function() {
         ['Number', 'Number', 'Number', 'Number'],
       ]
     );
-    this._graphics.line(
+    this._renderer.line(
       arguments[0],
       arguments[1],
       arguments[2],
@@ -257,11 +257,11 @@ p5.prototype.line = function() {
  * </div>
  */
 p5.prototype.point = function() {
-  if (!this._graphics._doStroke) {
+  if (!this._renderer._doStroke) {
     return this;
   }
   //check whether we should draw a 3d line or 2d
-  if(this._graphics.isP3D){
+  if(this._renderer.isP3D){
     this._validateParameters(
       'point',
       arguments,
@@ -269,7 +269,7 @@ p5.prototype.point = function() {
         ['Number', 'Number', 'Number']
       ]
     );
-    this._graphics.point(
+    this._renderer.point(
       arguments[0],
       arguments[1],
       arguments[2]
@@ -282,7 +282,7 @@ p5.prototype.point = function() {
         ['Number', 'Number']
       ]
     );
-    this._graphics.point(
+    this._renderer.point(
       arguments[0],
       arguments[1]
     );
@@ -316,10 +316,10 @@ p5.prototype.point = function() {
  * </div>
  */
 p5.prototype.quad = function() {
-  if (!this._graphics._doStroke && !this._graphics._doFill) {
+  if (!this._renderer._doStroke && !this._renderer._doFill) {
     return this;
   }
-  if(this._graphics.isP3D){
+  if(this._renderer.isP3D){
     this._validateParameters(
       'quad',
       arguments,
@@ -330,7 +330,7 @@ p5.prototype.quad = function() {
           'Number', 'Number', 'Number']
       ]
     );
-    this._graphics.quad(
+    this._renderer.quad(
       arguments[0],
       arguments[1],
       arguments[2],
@@ -353,7 +353,7 @@ p5.prototype.quad = function() {
           'Number', 'Number', 'Number', 'Number' ]
       ]
     );
-    this._graphics.quad(
+    this._renderer.quad(
      arguments[0],
      arguments[1],
      arguments[2],
@@ -423,10 +423,10 @@ p5.prototype.rect = function (x, y, w, h, tl, tr, br, bl) {
     ]
   );
 
-  if (!this._graphics._doStroke && !this._graphics._doFill) {
+  if (!this._renderer._doStroke && !this._renderer._doFill) {
     return;
   }
-  this._graphics.rect(x, y, w, h, tl, tr, br, bl);
+  this._renderer.rect(x, y, w, h, tl, tr, br, bl);
   return this;
 };
 
@@ -452,10 +452,10 @@ p5.prototype.rect = function (x, y, w, h, tl, tr, br, bl) {
 */
 p5.prototype.triangle = function() {
 
-  if (!this._graphics._doStroke && !this._graphics._doFill) {
+  if (!this._renderer._doStroke && !this._renderer._doFill) {
     return this;
   }
-  if(this._graphics.isP3D){
+  if(this._renderer.isP3D){
     this._validateParameters(
       'triangle',
       arguments,
@@ -464,7 +464,7 @@ p5.prototype.triangle = function() {
          'Number', 'Number', 'Number']
       ]
     );
-    this._graphics.triangle(
+    this._renderer.triangle(
       arguments[0],
       arguments[1],
       arguments[2],
@@ -483,7 +483,7 @@ p5.prototype.triangle = function() {
         ['Number', 'Number', 'Number', 'Number', 'Number', 'Number']
       ]
     );
-    this._graphics.triangle(
+    this._renderer.triangle(
      arguments[0],
      arguments[1],
      arguments[2],

--- a/src/core/attributes.js
+++ b/src/core/attributes.js
@@ -67,7 +67,7 @@ p5.prototype.ellipseMode = function(m) {
     m === constants.CORNERS ||
     m === constants.RADIUS ||
     m === constants.CENTER) {
-    this._graphics._ellipseMode = m;
+    this._renderer._ellipseMode = m;
   }
   return this;
 };
@@ -92,7 +92,7 @@ p5.prototype.ellipseMode = function(m) {
  * </div>
  */
 p5.prototype.noSmooth = function() {
-  this._graphics.noSmooth();
+  this._renderer.noSmooth();
   return this;
 };
 
@@ -152,7 +152,7 @@ p5.prototype.rectMode = function(m) {
     m === constants.CORNERS ||
     m === constants.RADIUS ||
     m === constants.CENTER) {
-    this._graphics._rectMode = m;
+    this._renderer._rectMode = m;
   }
   return this;
 };
@@ -178,7 +178,7 @@ p5.prototype.rectMode = function(m) {
  * </div>
  */
 p5.prototype.smooth = function() {
-  this._graphics.smooth();
+  this._renderer.smooth();
   return this;
 };
 
@@ -207,7 +207,7 @@ p5.prototype.strokeCap = function(cap) {
   if (cap === constants.ROUND ||
     cap === constants.SQUARE ||
     cap === constants.PROJECT) {
-    this._graphics.strokeCap(cap);
+    this._renderer.strokeCap(cap);
   }
   return this;
 };
@@ -265,7 +265,7 @@ p5.prototype.strokeJoin = function(join) {
   if (join === constants.ROUND ||
     join === constants.BEVEL ||
     join === constants.MITER) {
-    this._graphics.strokeJoin(join);
+    this._renderer.strokeJoin(join);
   }
   return this;
 };
@@ -290,7 +290,7 @@ p5.prototype.strokeJoin = function(join) {
  * </div>
  */
 p5.prototype.strokeWeight = function(w) {
-  this._graphics.strokeWeight(w);
+  this._renderer.strokeWeight(w);
   return this;
 };
 

--- a/src/core/core.js
+++ b/src/core/core.js
@@ -334,8 +334,8 @@ var p5 = function(sketch, node, sync) {
     }
 
     //mandatory update values(matrixs and stack) for 3d
-    if(this._graphics.isP3D){
-      this._graphics._update();
+    if(this._renderer.isP3D){
+      this._renderer._update();
     }
 
     // get notified the next time the browser gives us

--- a/src/core/curves.js
+++ b/src/core/curves.js
@@ -55,10 +55,10 @@ p5.prototype.bezier = function(x1, y1, x2, y2, x3, y3, x4, y4) {
       'Number', 'Number', 'Number', 'Number' ]
   );
 
-  if (!this._graphics._doStroke) {
+  if (!this._renderer._doStroke) {
     return this;
   }
-  this._graphics.bezier(x1, y1, x2, y2, x3, y3, x4, y4);
+  this._renderer.bezier(x1, y1, x2, y2, x3, y3, x4, y4);
   return this;
 };
 
@@ -250,10 +250,10 @@ p5.prototype.curve = function(x1, y1, x2, y2, x3, y3, x4, y4) {
       'Number', 'Number', 'Number', 'Number' ]
   );
 
-  if (!this._graphics._doStroke) {
+  if (!this._renderer._doStroke) {
     return;
   }
-  this._graphics.curve(x1, y1, x2, y2, x3, y3, x4, y4);
+  this._renderer.curve(x1, y1, x2, y2, x3, y3, x4, y4);
   return this;
 };
 
@@ -317,7 +317,7 @@ p5.prototype.curveDetail = function(d) {
  * </div>
  */
 p5.prototype.curveTightness = function (t) {
-  this._graphics._curveTightness = t;
+  this._renderer._curveTightness = t;
 };
 
 /**

--- a/src/core/p5.Graphics.js
+++ b/src/core/p5.Graphics.js
@@ -36,13 +36,13 @@ p5.Graphics = function(w, h, renderer, pInst) {
   this.pixelDensity = pInst.pixelDensity;
 
   if (r === constants.WEBGL) {
-    this._graphics = new p5.Renderer3D(c, pInst, false);
+    this._renderer = new p5.Renderer3D(c, pInst, false);
   } else {
-    this._graphics = new p5.Renderer2D(c, pInst, false);
+    this._renderer = new p5.Renderer2D(c, pInst, false);
   }
 
-  this._graphics.resize(w, h);
-  this._graphics._applyDefaults();
+  this._renderer.resize(w, h);
+  this._renderer._applyDefaults();
 
   pInst._elements.push(this);
 

--- a/src/core/rendering.js
+++ b/src/core/rendering.js
@@ -83,22 +83,22 @@ p5.prototype.createCanvas = function(w, h, renderer) {
   // Init our graphics renderer
   //webgl mode
   if (r === constants.WEBGL) {
-    this._setProperty('_graphics', new p5.Renderer3D(c, this, true));
+    this._setProperty('_renderer', new p5.Renderer3D(c, this, true));
     this._isdefaultGraphics = true;
   }
   //P2D mode
   else {
     if (!this._isdefaultGraphics) {
-      this._setProperty('_graphics', new p5.Renderer2D(c, this, true));
+      this._setProperty('_renderer', new p5.Renderer2D(c, this, true));
       this._isdefaultGraphics = true;
     }
   }
-  this._graphics.resize(w, h);
-  this._graphics._applyDefaults();
+  this._renderer.resize(w, h);
+  this._renderer._applyDefaults();
   if (isDefault) { // only push once
-    this._elements.push(this._graphics);
+    this._elements.push(this._renderer);
   }
-  return this._graphics;
+  return this._renderer;
 };
 
 /**
@@ -123,9 +123,9 @@ p5.prototype.createCanvas = function(w, h, renderer) {
  * </code></div>
  */
 p5.prototype.resizeCanvas = function (w, h, noRedraw) {
-  if (this._graphics) {
-    this._graphics.resize(w, h);
-    this._graphics._applyDefaults();
+  if (this._renderer) {
+    this._renderer.resize(w, h);
+    this._renderer._applyDefaults();
     if (!noRedraw) {
       this.redraw();
     }
@@ -253,7 +253,7 @@ p5.prototype.blendMode = function(mode) {
     mode === constants.SOFT_LIGHT || mode === constants.DODGE ||
     mode === constants.BURN || mode === constants.ADD ||
     mode === constants.NORMAL) {
-    this._graphics.blendMode(mode);
+    this._renderer.blendMode(mode);
   } else {
     throw new Error('Mode '+mode+' not recognized.');
   }

--- a/src/core/structure.js
+++ b/src/core/structure.js
@@ -160,19 +160,19 @@ p5.prototype.loop = function() {
  * </div>
  */
 p5.prototype.push = function () {
-  this._graphics.push();
+  this._renderer.push();
   this._styles.push({
-    doStroke: this._graphics._doStroke,
-    doFill: this._graphics._doFill,
-    tint: this._graphics._tint,
-    imageMode: this._graphics._imageMode,
-    rectMode: this._graphics._rectMode,
-    ellipseMode: this._graphics._ellipseMode,
-    colorMode: this._graphics._colorMode,
-    textFont: this._graphics._textFont,
-    textLeading: this._graphics._textLeading,
-    textSize: this._graphics._textSize,
-    textStyle: this._graphics._textStyle
+    doStroke: this._renderer._doStroke,
+    doFill: this._renderer._doFill,
+    tint: this._renderer._tint,
+    imageMode: this._renderer._imageMode,
+    rectMode: this._renderer._rectMode,
+    ellipseMode: this._renderer._ellipseMode,
+    colorMode: this._renderer._colorMode,
+    textFont: this._renderer._textFont,
+    textLeading: this._renderer._textLeading,
+    textSize: this._renderer._textSize,
+    textStyle: this._renderer._textStyle
   });
 };
 
@@ -228,19 +228,19 @@ p5.prototype.push = function () {
  * </div>
  */
 p5.prototype.pop = function () {
-  this._graphics.pop();
+  this._renderer.pop();
   var lastS = this._styles.pop();
-  this._graphics._doStroke = lastS.doStroke;
-  this._graphics._doFill = lastS.doFill;
-  this._graphics._tint = lastS.tint;
-  this._graphics._imageMode = lastS.imageMode;
-  this._graphics._rectMode = lastS.rectMode;
-  this._graphics._ellipseMode = lastS.ellipseMode;
-  this._graphics._colorMode = lastS.colorMode;
-  this._graphics._textFont = lastS.textFont;
-  this._graphics._textLeading = lastS.textLeading;
-  this._graphics._textSize = lastS.textSize;
-  this._graphics._textStyle = lastS.textStyle;
+  this._renderer._doStroke = lastS.doStroke;
+  this._renderer._doFill = lastS.doFill;
+  this._renderer._tint = lastS.tint;
+  this._renderer._imageMode = lastS.imageMode;
+  this._renderer._rectMode = lastS.rectMode;
+  this._renderer._ellipseMode = lastS.ellipseMode;
+  this._renderer._colorMode = lastS.colorMode;
+  this._renderer._textFont = lastS.textFont;
+  this._renderer._textLeading = lastS.textLeading;
+  this._renderer._textSize = lastS.textSize;
+  this._renderer._textStyle = lastS.textStyle;
 };
 
 p5.prototype.pushStyle = function() {

--- a/src/core/transform.js
+++ b/src/core/transform.js
@@ -33,7 +33,7 @@ var constants = require('./constants');
  * </div>
  */
 p5.prototype.applyMatrix = function(n00, n01, n02, n10, n11, n12) {
-  this._graphics.applyMatrix(n00, n01, n02, n10, n11, n12);
+  this._renderer.applyMatrix(n00, n01, n02, n10, n11, n12);
   return this;
 };
 
@@ -62,7 +62,7 @@ p5.prototype.pushMatrix = function() {
  * </div>
  */
 p5.prototype.resetMatrix = function() {
-  this._graphics.resetMatrix();
+  this._renderer.resetMatrix();
   return this;
 };
 
@@ -102,10 +102,10 @@ p5.prototype.rotate = function() {
   }
   //in webgl mode
   if(arguments.length > 1){
-    this._graphics.rotate(r, arguments[1]);
+    this._renderer.rotate(r, arguments[1]);
   }
   else {
-    this._graphics.rotate(r);
+    this._renderer.rotate(r);
   }
   return this;
 };
@@ -116,7 +116,7 @@ p5.prototype.rotate = function() {
  * @return {[type]}     [description]
  */
 p5.prototype.rotateX = function(rad) {
-  if (this._graphics.isP3D) {
+  if (this._renderer.isP3D) {
     this._validateParameters(
       'rotateX',
       arguments,
@@ -124,7 +124,7 @@ p5.prototype.rotateX = function(rad) {
         ['Number']
       ]
     );
-    this._graphics.rotateX(rad);
+    this._renderer.rotateX(rad);
   } else {
     throw 'not yet implemented.';
   }
@@ -137,7 +137,7 @@ p5.prototype.rotateX = function(rad) {
  * @return {[type]}     [description]
  */
 p5.prototype.rotateY = function(rad) {
-  if (this._graphics.isP3D) {
+  if (this._renderer.isP3D) {
     this._validateParameters(
       'rotateY',
       arguments,
@@ -145,7 +145,7 @@ p5.prototype.rotateY = function(rad) {
         ['Number']
       ]
     );
-    this._graphics.rotateY(rad);
+    this._renderer.rotateY(rad);
   } else {
     throw 'not yet implemented.';
   }
@@ -158,7 +158,7 @@ p5.prototype.rotateY = function(rad) {
  * @return {[type]}     [description]
  */
 p5.prototype.rotateZ = function(rad) {
-  if (this._graphics.isP3D) {
+  if (this._renderer.isP3D) {
     this._validateParameters(
       'rotateZ',
       arguments,
@@ -166,7 +166,7 @@ p5.prototype.rotateZ = function(rad) {
         ['Number']
       ]
     );
-    this._graphics.rotateZ(rad);
+    this._renderer.rotateZ(rad);
   } else {
     throw 'not supported in p2d. Please use webgl mode';
   }
@@ -213,7 +213,7 @@ p5.prototype.rotateZ = function(rad) {
  * </div>
  */
 p5.prototype.scale = function() {
-  if (this._graphics.isP3D) {
+  if (this._renderer.isP3D) {
     this._validateParameters(
       'scale',
       arguments,
@@ -222,7 +222,7 @@ p5.prototype.scale = function() {
         ['Number', 'Number', 'Number']
       ]
     );
-    this._graphics.scale(arguments[0], arguments[1], arguments[2]);
+    this._renderer.scale(arguments[0], arguments[1], arguments[2]);
   } else {
     this._validateParameters(
       'scale',
@@ -232,7 +232,7 @@ p5.prototype.scale = function() {
         ['Number', 'Number']
       ]
     );
-    this._graphics.scale.apply(this._graphics, arguments);
+    this._renderer.scale.apply(this._renderer, arguments);
   }
   return this;
 };
@@ -270,7 +270,7 @@ p5.prototype.shearX = function(angle) {
   if (this._angleMode === constants.DEGREES) {
     angle = this.radians(angle);
   }
-  this._graphics.shearX(angle);
+  this._renderer.shearX(angle);
   return this;
 };
 
@@ -307,7 +307,7 @@ p5.prototype.shearY = function(angle) {
   if (this._angleMode === constants.DEGREES) {
     angle = this.radians(angle);
   }
-  this._graphics.shearY(angle);
+  this._renderer.shearY(angle);
   return this;
 };
 
@@ -346,7 +346,7 @@ p5.prototype.shearY = function(angle) {
  * </div>
  */
 p5.prototype.translate = function(x, y, z) {
-  if (this._graphics.isP3D) {
+  if (this._renderer.isP3D) {
     this._validateParameters(
       'translate',
       arguments,
@@ -355,7 +355,7 @@ p5.prototype.translate = function(x, y, z) {
         ['Number', 'Number', 'Number']
       ]
     );
-    this._graphics.translate(x, y, z);
+    this._renderer.translate(x, y, z);
   } else {
     this._validateParameters(
       'translate',
@@ -365,7 +365,7 @@ p5.prototype.translate = function(x, y, z) {
         ['Number', 'Number']
       ]
     );
-    this._graphics.translate(x, y);
+    this._renderer.translate(x, y);
   }
   return this;
 };

--- a/src/core/vertex.js
+++ b/src/core/vertex.js
@@ -226,20 +226,20 @@ p5.prototype.beginContour = function() {
  * </div>
  */
 p5.prototype.beginShape = function(kind) {
-  if(this._graphics.isP3D){
-    this._graphics.beginShape(kind);
-  }else{
-    if (kind === constants.POINTS ||
-      kind === constants.LINES ||
-      kind === constants.TRIANGLES ||
-      kind === constants.TRIANGLE_FAN ||
-      kind === constants.TRIANGLE_STRIP ||
-      kind === constants.QUADS ||
-      kind === constants.QUAD_STRIP) {
-      shapeKind = kind;
-    } else {
-      shapeKind = null;
-    }
+  if (kind === constants.POINTS ||
+    kind === constants.LINES ||
+    kind === constants.TRIANGLES ||
+    kind === constants.TRIANGLE_FAN ||
+    kind === constants.TRIANGLE_STRIP ||
+    kind === constants.QUADS ||
+    kind === constants.QUAD_STRIP) {
+    shapeKind = kind;
+  } else {
+    shapeKind = null;
+  }
+  if(this._renderer.isP3D){
+    this._renderer.beginShape(kind);
+  } else {
     vertices = [];
     contourVertices = [];
   }
@@ -422,11 +422,11 @@ p5.prototype.endContour = function() {
  * </div>
  */
 p5.prototype.endShape = function(mode) {
-  if(this._graphics.isP3D){
-    this._graphics.endShape();
+  if(this._renderer.isP3D){
+    this._renderer.endShape();
   }else{
     if (vertices.length === 0) { return this; }
-    if (!this._graphics._doStroke && !this._graphics._doFill) { return this; }
+    if (!this._renderer._doStroke && !this._renderer._doFill) { return this; }
 
     var closeShape = mode === constants.CLOSE;
 
@@ -435,7 +435,7 @@ p5.prototype.endShape = function(mode) {
       vertices.push(vertices[0]);
     }
 
-    this._graphics.endShape(mode, vertices, isCurve, isBezier,
+    this._renderer.endShape(mode, vertices, isCurve, isBezier,
       isQuadratic, isContour, shapeKind);
 
     // Reset some settings
@@ -549,7 +549,7 @@ p5.prototype.quadraticVertex = function(cx, cy, x3, y3) {
  * </div>
  */
 p5.prototype.vertex = function(x, y, moveTo) {
-  if(this._graphics.isP3D){
+  if(this._renderer.isP3D){
     this._validateParameters(
       'vertex',
       arguments,
@@ -557,7 +557,7 @@ p5.prototype.vertex = function(x, y, moveTo) {
         ['Number', 'Number', 'Number']
       ]
     );
-    this._graphics.vertex
+    this._renderer.vertex
     (arguments[0], arguments[1], arguments[2]);
   }else{
     this._validateParameters(
@@ -575,8 +575,8 @@ p5.prototype.vertex = function(x, y, moveTo) {
     vert[2] = 0;
     vert[3] = 0;
     vert[4] = 0;
-    vert[5] = this._graphics._getFill();
-    vert[6] = this._graphics._getStroke();
+    vert[5] = this._renderer._getFill();
+    vert[6] = this._renderer._getStroke();
 
     if (moveTo) {
       vert.moveTo = moveTo;

--- a/src/typography/attributes.js
+++ b/src/typography/attributes.js
@@ -35,7 +35,7 @@ var p5 = require('../core/core');
  * </div>
  */
 p5.prototype.textAlign = function(horizAlign, vertAlign) {
-  return this._graphics.textAlign.apply(this._graphics, arguments);
+  return this._renderer.textAlign.apply(this._renderer, arguments);
 };
 
 /**
@@ -64,7 +64,7 @@ p5.prototype.textAlign = function(horizAlign, vertAlign) {
  * </div>
  */
 p5.prototype.textLeading = function(theLeading) {
-  return this._graphics.textLeading.apply(this._graphics, arguments);
+  return this._renderer.textLeading.apply(this._renderer, arguments);
 };
 
 /**
@@ -87,7 +87,7 @@ p5.prototype.textLeading = function(theLeading) {
  * </div>
  */
 p5.prototype.textSize = function(theSize) {
-  return this._graphics.textSize.apply(this._graphics, arguments);
+  return this._renderer.textSize.apply(this._renderer, arguments);
 };
 
 /**
@@ -114,7 +114,7 @@ p5.prototype.textSize = function(theSize) {
  * </div>
  */
 p5.prototype.textStyle = function(theStyle) {
-  return this._graphics.textStyle.apply(this._graphics, arguments);
+  return this._renderer.textStyle.apply(this._renderer, arguments);
 };
 
 /**
@@ -141,7 +141,7 @@ p5.prototype.textStyle = function(theStyle) {
  * </div>
  */
 p5.prototype.textWidth = function(theText) {
-  return this._graphics.textWidth.apply(this._graphics, arguments);
+  return this._renderer.textWidth.apply(this._renderer, arguments);
 };
 
 /**
@@ -169,7 +169,7 @@ p5.prototype.textWidth = function(theText) {
  * </div>
  */
 p5.prototype.textAscent = function() {
-  return this._graphics.textAscent();
+  return this._renderer.textAscent();
 };
 
 /**
@@ -197,14 +197,14 @@ p5.prototype.textAscent = function() {
  * </div>
  */
 p5.prototype.textDescent = function() {
-  return this._graphics.textDescent();
+  return this._renderer.textDescent();
 };
 
 /**
  * Helper function to measure ascent and descent.
  */
 p5.prototype._updateTextMetrics = function() {
-  return this._graphics._updateTextMetrics();
+  return this._renderer._updateTextMetrics();
 };
 
 module.exports = p5;

--- a/src/typography/loading_displaying.js
+++ b/src/typography/loading_displaying.js
@@ -70,8 +70,8 @@ p5.prototype.text = function(str, x, y, maxWidth, maxHeight) {
     ]
   );
 
-  return (!(this._graphics._doFill || this._graphics._doStroke)) ? this :
-    this._graphics.text.apply(this._graphics, arguments);
+  return (!(this._renderer._doFill || this._renderer._doStroke)) ? this :
+    this._renderer.text.apply(this._renderer, arguments);
 };
 
 /**
@@ -122,16 +122,16 @@ p5.prototype.textFont = function(theFont, theSize) {
       throw Error('null font passed to textFont');
     }
 
-    this._graphics._setProperty('_textFont', theFont);
+    this._renderer._setProperty('_textFont', theFont);
 
     if (theSize) {
 
-      this._graphics._setProperty('_textSize', theSize);
-      this._graphics._setProperty('_textLeading',
+      this._renderer._setProperty('_textSize', theSize);
+      this._renderer._setProperty('_textLeading',
         theSize * constants._DEFAULT_LEADMULT);
     }
 
-    return this._graphics._applyTextProperties();
+    return this._renderer._applyTextProperties();
   }
 
   return this;

--- a/src/typography/p5.Font.js
+++ b/src/typography/p5.Font.js
@@ -95,7 +95,7 @@ p5.Font.prototype.textBounds = function(str, x, y, fontSize, options) {
 
   x = x !== undefined ? x : 0;
   y = y !== undefined ? y : 0;
-  fontSize = fontSize || this.parent._graphics._textSize;
+  fontSize = fontSize || this.parent._renderer._textSize;
 
   var result = this.cache[cacheKey('textBounds', str, x, y, fontSize)];
   if (!result) {
@@ -173,10 +173,10 @@ p5.Font.prototype._getGlyphs = function(str) {
 p5.Font.prototype._getPath = function(line, x, y, options) {
 
   var p = this.parent,
-    ctx = p._graphics.drawingContext,
+    ctx = p._renderer.drawingContext,
     pos = this._handleAlignment(p, ctx, line, x, y);
 
-  return this.font.getPath(line, pos.x, pos.y, p._graphics._textSize, options);
+  return this.font.getPath(line, pos.x, pos.y, p._renderer._textSize, options);
 };
 
 /*
@@ -285,7 +285,7 @@ p5.Font.prototype._getSVG = function(line, x, y, options) {
 p5.Font.prototype._renderPath = function(line, x, y, options) {
 
   // /console.log('_renderPath', typeof line);
-  var pdata, pg = this.parent._graphics,
+  var pdata, pg = this.parent._renderer,
     ctx = pg.drawingContext;
 
   if (typeof line === 'object' && line.commands) {
@@ -354,7 +354,7 @@ p5.Font.prototype._textDescent = function(fontSize) {
 p5.Font.prototype._scale = function(fontSize) {
 
   return (1 / this.font.unitsPerEm) * (fontSize ||
-    this.parent._graphics._textSize);
+    this.parent._renderer._textSize);
 };
 
 p5.Font.prototype._handleAlignment = function(p, ctx, line, x, y) {

--- a/test/unit/color/setting.js
+++ b/test/unit/color/setting.js
@@ -15,48 +15,48 @@ suite('Color', function() {
 
       test('should set mode to RGB', function() {
         myp5.colorMode(myp5.RGB);
-        assert.equal(myp5._graphics._colorMode, myp5.RGB);
+        assert.equal(myp5._renderer._colorMode, myp5.RGB);
       });
 
       test('should correctly set color RGB maxes', function() {
-        assert.deepEqual(myp5._graphics._colorMaxes[myp5.RGB], [255, 255, 255, 255]);
+        assert.deepEqual(myp5._renderer._colorMaxes[myp5.RGB], [255, 255, 255, 255]);
         myp5.colorMode(myp5.RGB, 1, 1, 1);
-        assert.deepEqual(myp5._graphics._colorMaxes[myp5.RGB], [1, 1, 1, 255]);
+        assert.deepEqual(myp5._renderer._colorMaxes[myp5.RGB], [1, 1, 1, 255]);
         myp5.colorMode(myp5.RGB, 1);
-        assert.deepEqual(myp5._graphics._colorMaxes[myp5.RGB], [1, 1, 1, 1]);
+        assert.deepEqual(myp5._renderer._colorMaxes[myp5.RGB], [1, 1, 1, 1]);
         myp5.colorMode(myp5.RGB, 255, 255, 255, 1);
-        assert.deepEqual(myp5._graphics._colorMaxes[myp5.RGB], [255, 255, 255, 1]);
+        assert.deepEqual(myp5._renderer._colorMaxes[myp5.RGB], [255, 255, 255, 1]);
         myp5.colorMode(myp5.RGB, 255);
       });
 
       test('should set mode to HSL', function() {
         myp5.colorMode(myp5.HSL);
-        assert.equal(myp5._graphics._colorMode, myp5.HSL);
+        assert.equal(myp5._renderer._colorMode, myp5.HSL);
       });
 
       test('should correctly set color HSL maxes', function() {
-        assert.deepEqual(myp5._graphics._colorMaxes[myp5.HSL], [360, 100, 100, 1]);
+        assert.deepEqual(myp5._renderer._colorMaxes[myp5.HSL], [360, 100, 100, 1]);
         myp5.colorMode(myp5.HSL, 255, 255, 255);
-        assert.deepEqual(myp5._graphics._colorMaxes[myp5.HSL], [255, 255, 255, 1]);
+        assert.deepEqual(myp5._renderer._colorMaxes[myp5.HSL], [255, 255, 255, 1]);
         myp5.colorMode(myp5.HSL, 360);
-        assert.deepEqual(myp5._graphics._colorMaxes[myp5.HSL], [360, 360, 360, 360]);
+        assert.deepEqual(myp5._renderer._colorMaxes[myp5.HSL], [360, 360, 360, 360]);
         myp5.colorMode(myp5.HSL, 360, 100, 100, 1);
-        assert.deepEqual(myp5._graphics._colorMaxes[myp5.HSL], [360, 100, 100, 1]);
+        assert.deepEqual(myp5._renderer._colorMaxes[myp5.HSL], [360, 100, 100, 1]);
       });
 
       test('should set mode to HSB', function() {
         myp5.colorMode(myp5.HSB);
-        assert.equal(myp5._graphics._colorMode, myp5.HSB);
+        assert.equal(myp5._renderer._colorMode, myp5.HSB);
       });
 
       test('should correctly set color HSB maxes', function() {
-        assert.deepEqual(myp5._graphics._colorMaxes[myp5.HSB], [360, 100, 100, 1]);
+        assert.deepEqual(myp5._renderer._colorMaxes[myp5.HSB], [360, 100, 100, 1]);
         myp5.colorMode(myp5.HSB, 255, 255, 255);
-        assert.deepEqual(myp5._graphics._colorMaxes[myp5.HSB], [255, 255, 255, 1]);
+        assert.deepEqual(myp5._renderer._colorMaxes[myp5.HSB], [255, 255, 255, 1]);
         myp5.colorMode(myp5.HSB, 360);
-        assert.deepEqual(myp5._graphics._colorMaxes[myp5.HSB], [360, 360, 360, 360]);
+        assert.deepEqual(myp5._renderer._colorMaxes[myp5.HSB], [360, 360, 360, 360]);
         myp5.colorMode(myp5.HSB, 360, 100, 100, 1);
-        assert.deepEqual(myp5._graphics._colorMaxes[myp5.HSB], [360, 100, 100, 1]);
+        assert.deepEqual(myp5._renderer._colorMaxes[myp5.HSB], [360, 100, 100, 1]);
       });
     });
   });


### PR DESCRIPTION
Also includes sneaks a tiny change to beginShape() function in src/core/vertex.js to force argument check to be renderer agnostic.