### PR TITLE
Fixes reading text from dropzone

### DIFF
--- a/lib/addons/p5.dom.js
+++ b/lib/addons/p5.dom.js
@@ -450,9 +450,9 @@
             };
           };
           
-          // Text of data?
+          // Text or data?
           // This should likely be improved
-          if (f.type === 'text') {
+          if (f.type.indexOf('text') > -1) {
             reader.readAsText(f);
           } else {
             reader.readAsDataURL(f);

--- a/src/core/p5.Element.js
+++ b/src/core/p5.Element.js
@@ -477,9 +477,9 @@ p5.Element.prototype.drop = function (callback, fxn) {
         reader.onload = makeLoader(f);
 
 
-        // Text of data?
+        // Text or data?
         // This should likely be improved
-        if (f.type === 'text') {
+        if (f.type.indexOf('text') > -1) {
           reader.readAsText(f);
         } else {
           reader.readAsDataURL(f);


### PR DESCRIPTION
I'm working on some examples for class at ITP and noticed a problem where the `drop()` method on a div would improperly read text files.  This is a quick fix.  @lmccart it would be useful to have this for my class this coming Monday if that fits with a release schedule at all.  I'll be making more DOM examples on Friday so you might wait until I get through the day to see what else I find. . .