### PR TITLE
fixes bug in splitTokens()

### DIFF
--- a/src/utilities/string_functions.js
+++ b/src/utilities/string_functions.js
@@ -449,7 +449,7 @@ p5.prototype.split = function(str, delim) {
  * </code>
  */
 p5.prototype.splitTokens = function() {
-  var d = (arguments.length > 0) ? arguments[1] : /\s/g;
+  var d = (arguments.length > 1) ? new RegExp('[' + arguments[1] + ']', 'g') : /\s/g;
   return arguments[0].split(d).filter(function(n){return n;});
 };
 


### PR DESCRIPTION
`splitTokens()` was working just as `split()`.  This fix turns the passed string of delimiters into a regex where each character is listed in a character class.   This is now working as expected, and I think this is a good way of doing it though I am completely open to other suggestions!