### PR TITLE
Remove uses of Array.prototype.slice.call(arguments) in order to take…

### DIFF
--- a/src/3d/camera.js
+++ b/src/3d/camera.js
@@ -30,9 +30,13 @@ var p5 = require('../core/core');
  * </div>
  */
 p5.prototype.camera = function(x, y, z){
+  var args = new Array(arguments.length);
+  for (var i = 0; i < args.length; ++i) {
+    args[i] = arguments[i];
+  }
   this._validateParameters(
     'camera',
-    arguments,
+    args,
     ['Number', 'Number', 'Number']
   );
   //what it manipulates is the model view matrix
@@ -73,9 +77,13 @@ p5.prototype.camera = function(x, y, z){
  * </div>
  */
 p5.prototype.perspective = function(fovy,aspect,near,far) {
+  var args = new Array(arguments.length);
+  for (var i = 0; i < args.length; ++i) {
+    args[i] = arguments[i];
+  }
   this._validateParameters(
     'perspective',
-    arguments,
+    args,
     ['Number', 'Number', 'Number', 'Number']
   );
   this._renderer.uPMatrix = p5.Matrix.identity();
@@ -116,9 +124,13 @@ p5.prototype.perspective = function(fovy,aspect,near,far) {
  * </div>
  */
 p5.prototype.ortho = function(left,right,bottom,top,near,far) {
+  var args = new Array(arguments.length);
+  for (var i = 0; i < args.length; ++i) {
+    args[i] = arguments[i];
+  }
   this._validateParameters(
     'ortho',
-    arguments,
+    args,
       ['Number', 'Number', 'Number', 'Number', 'Number', 'Number']
   );
   left /= this.width;

--- a/src/3d/light.js
+++ b/src/3d/light.js
@@ -97,9 +97,14 @@ p5.prototype.ambientLight = function(v1, v2, v3, a){
  * </div>
  */
 p5.prototype.directionalLight = function(v1, v2, v3, a, x, y, z) {
+  // TODO(jgessner): Find an example using this and profile it.
+  // var args = new Array(arguments.length);
+  // for (var i = 0; i < args.length; ++i) {
+  //   args[i] = arguments[i];
+  // }
   // this._validateParameters(
   //   'directionalLight',
-  //   arguments,
+  //   args,
   //   [
   //     //rgbaxyz
   //     ['Number', 'Number', 'Number', 'Number', 'Number', 'Number', 'Number'],
@@ -219,6 +224,11 @@ p5.prototype.directionalLight = function(v1, v2, v3, a, x, y, z) {
  * </div>
  */
 p5.prototype.pointLight = function(v1, v2, v3, a, x, y, z) {
+  // TODO(jgessner): Find an example using this and profile it.
+  // var args = new Array(arguments.length);
+  // for (var i = 0; i < args.length; ++i) {
+  //   args[i] = arguments[i];
+  // }
   // this._validateParameters(
   //   'pointLight',
   //   arguments,

--- a/src/color/creating_reading.js
+++ b/src/color/creating_reading.js
@@ -242,12 +242,17 @@ p5.prototype.brightness = function(c) {
  * </div>
  */
 p5.prototype.color = function() {
-  if (arguments[0] instanceof p5.Color) {
-    return arguments[0];
-  } else if (arguments[0] instanceof Array) {
-    return new p5.Color(this, arguments[0]);
+  var args = new Array(arguments.length);
+
+  for (var i = 0; i < args.length; ++i) {
+    args[i] = arguments[i];
+  }
+
+  if (args[0] instanceof p5.Color) {
+    return args[0];
+  } else if (args[0] instanceof Array) {
+    return new p5.Color(this, args[0]);
   } else {
-    var args = Array.prototype.slice.call(arguments);
     return new p5.Color(this, args);
   }
 };

--- a/src/core/2d_primitives.js
+++ b/src/core/2d_primitives.js
@@ -64,9 +64,13 @@ require('./error_helpers');
  * </div>
  */
 p5.prototype.arc = function(x, y, w, h, start, stop, mode) {
+  var args = new Array(arguments.length);
+  for (var i = 0; i < args.length; ++i) {
+    args[i] = arguments[i];
+  }
   this._validateParameters(
     'arc',
-    arguments,
+    args,
     [
       ['Number', 'Number', 'Number', 'Number', 'Number', 'Number'],
       [ 'Number', 'Number', 'Number', 'Number',
@@ -141,9 +145,13 @@ p5.prototype.arc = function(x, y, w, h, start, stop, mode) {
  * </div>
  */
 p5.prototype.ellipse = function(x, y, w, h) {
+  var args = new Array(arguments.length);
+  for (var i = 0; i < args.length; ++i) {
+    args[i] = arguments[i];
+  }
   this._validateParameters(
     'ellipse',
-    arguments,
+    args,
     ['Number', 'Number', 'Number', 'Number']
   );
 
@@ -203,35 +211,39 @@ p5.prototype.line = function() {
   if (!this._renderer._doStroke) {
     return this;
   }
+  var args = new Array(arguments.length);
+  for (var i = 0; i < args.length; ++i) {
+    args[i] = arguments[i];
+  }
   //check whether we should draw a 3d line or 2d
   if(this._renderer.isP3D){
     this._validateParameters(
       'line',
-      arguments,
+      args,
       [
         ['Number', 'Number', 'Number', 'Number', 'Number', 'Number']
       ]
     );
     this._renderer.line(
-      arguments[0],
-      arguments[1],
-      arguments[2],
-      arguments[3],
-      arguments[4],
-      arguments[5]);
+      args[0],
+      args[1],
+      args[2],
+      args[3],
+      args[4],
+      args[5]);
   } else {
     this._validateParameters(
       'line',
-      arguments,
+      args,
       [
         ['Number', 'Number', 'Number', 'Number'],
       ]
     );
     this._renderer.line(
-      arguments[0],
-      arguments[1],
-      arguments[2],
-      arguments[3]);
+      args[0],
+      args[1],
+      args[2],
+      args[3]);
   }
   return this;
 };
@@ -260,31 +272,35 @@ p5.prototype.point = function() {
   if (!this._renderer._doStroke) {
     return this;
   }
+  var args = new Array(arguments.length);
+  for (var i = 0; i < args.length; ++i) {
+    args[i] = arguments[i];
+  }
   //check whether we should draw a 3d line or 2d
   if(this._renderer.isP3D){
     this._validateParameters(
       'point',
-      arguments,
+      args,
       [
         ['Number', 'Number', 'Number']
       ]
     );
     this._renderer.point(
-      arguments[0],
-      arguments[1],
-      arguments[2]
+      args[0],
+      args[1],
+      args[2]
       );
   } else {
     this._validateParameters(
       'point',
-      arguments,
+      args,
       [
         ['Number', 'Number']
       ]
     );
     this._renderer.point(
-      arguments[0],
-      arguments[1]
+      args[0],
+      args[1]
     );
   }
   return this;
@@ -319,10 +335,14 @@ p5.prototype.quad = function() {
   if (!this._renderer._doStroke && !this._renderer._doFill) {
     return this;
   }
+  var args = new Array(arguments.length);
+  for (var i = 0; i < args.length; ++i) {
+    args[i] = arguments[i];
+  }
   if(this._renderer.isP3D){
     this._validateParameters(
       'quad',
-      arguments,
+      args,
       [
         [ 'Number', 'Number', 'Number',
           'Number', 'Number', 'Number',
@@ -331,37 +351,37 @@ p5.prototype.quad = function() {
       ]
     );
     this._renderer.quad(
-      arguments[0],
-      arguments[1],
-      arguments[2],
-      arguments[3],
-      arguments[4],
-      arguments[5],
-      arguments[6],
-      arguments[7],
-      arguments[8],
-      arguments[9],
-      arguments[10],
-      arguments[11]
+      args[0],
+      args[1],
+      args[2],
+      args[3],
+      args[4],
+      args[5],
+      args[6],
+      args[7],
+      args[8],
+      args[9],
+      args[10],
+      args[11]
       );
   } else {
     this._validateParameters(
       'quad',
-      arguments,
+      args,
       [
         [ 'Number', 'Number', 'Number', 'Number',
           'Number', 'Number', 'Number', 'Number' ]
       ]
     );
     this._renderer.quad(
-     arguments[0],
-     arguments[1],
-     arguments[2],
-     arguments[3],
-     arguments[4],
-     arguments[5],
-     arguments[6],
-    arguments[7]
+     args[0],
+     args[1],
+     args[2],
+     args[3],
+     args[4],
+     args[5],
+     args[6],
+    args[7]
     );
   }
   return this;
@@ -412,9 +432,13 @@ p5.prototype.quad = function() {
 * </div>
 */
 p5.prototype.rect = function (x, y, w, h, tl, tr, br, bl) {
+  var args = new Array(arguments.length);
+  for (var i = 0; i < args.length; ++i) {
+    args[i] = arguments[i];
+  }
   this._validateParameters(
     'rect',
-    arguments,
+    args,
     [
       ['Number', 'Number', 'Number', 'Number'],
       ['Number', 'Number', 'Number', 'Number', 'Number'],
@@ -455,41 +479,45 @@ p5.prototype.triangle = function() {
   if (!this._renderer._doStroke && !this._renderer._doFill) {
     return this;
   }
+  var args = new Array(arguments.length);
+  for (var i = 0; i < args.length; ++i) {
+    args[i] = arguments[i];
+  }
   if(this._renderer.isP3D){
     this._validateParameters(
       'triangle',
-      arguments,
+      args,
       [
         ['Number', 'Number', 'Number', 'Number', 'Number', 'Number',
          'Number', 'Number', 'Number']
       ]
     );
     this._renderer.triangle(
-      arguments[0],
-      arguments[1],
-      arguments[2],
-      arguments[3],
-      arguments[4],
-      arguments[5],
-      arguments[6],
-      arguments[7],
-      arguments[8]
+      args[0],
+      args[1],
+      args[2],
+      args[3],
+      args[4],
+      args[5],
+      args[6],
+      args[7],
+      args[8]
       );
   } else {
     this._validateParameters(
       'triangle',
-      arguments,
+      args,
       [
         ['Number', 'Number', 'Number', 'Number', 'Number', 'Number']
       ]
     );
     this._renderer.triangle(
-     arguments[0],
-     arguments[1],
-     arguments[2],
-     arguments[3],
-     arguments[4],
-     arguments[5]
+     args[0],
+     args[1],
+     args[2],
+     args[3],
+     args[4],
+     args[5]
     );
   }
   return this;

--- a/src/core/curves.js
+++ b/src/core/curves.js
@@ -48,9 +48,13 @@ var curveDetail = 20;
  * </div>
  */
 p5.prototype.bezier = function(x1, y1, x2, y2, x3, y3, x4, y4) {
+  var args = new Array(arguments.length);
+  for (var i = 0; i < args.length; ++i) {
+    args[i] = arguments[i];
+  }
   this._validateParameters(
     'bezier',
-    arguments,
+    args,
     [ 'Number', 'Number', 'Number', 'Number',
       'Number', 'Number', 'Number', 'Number' ]
   );
@@ -243,9 +247,13 @@ p5.prototype.bezierTangent = function(a, b, c, d, t) {
  * </div>
  */
 p5.prototype.curve = function(x1, y1, x2, y2, x3, y3, x4, y4) {
+  var args = new Array(arguments.length);
+  for (var i = 0; i < args.length; ++i) {
+    args[i] = arguments[i];
+  }
   this._validateParameters(
     'curve',
-    arguments,
+    args,
     [ 'Number', 'Number', 'Number', 'Number',
       'Number', 'Number', 'Number', 'Number' ]
   );

--- a/src/core/transform.js
+++ b/src/core/transform.js
@@ -116,10 +116,14 @@ p5.prototype.rotate = function() {
  * @return {[type]}     [description]
  */
 p5.prototype.rotateX = function(rad) {
+  var args = new Array(arguments.length);
+  for (var i = 0; i < args.length; ++i) {
+    args[i] = arguments[i];
+  }
   if (this._renderer.isP3D) {
     this._validateParameters(
       'rotateX',
-      arguments,
+      args,
       [
         ['Number']
       ]
@@ -138,9 +142,13 @@ p5.prototype.rotateX = function(rad) {
  */
 p5.prototype.rotateY = function(rad) {
   if (this._renderer.isP3D) {
+    var args = new Array(arguments.length);
+    for (var i = 0; i < args.length; ++i) {
+      args[i] = arguments[i];
+    }
     this._validateParameters(
       'rotateY',
-      arguments,
+      args,
       [
         ['Number']
       ]
@@ -159,9 +167,13 @@ p5.prototype.rotateY = function(rad) {
  */
 p5.prototype.rotateZ = function(rad) {
   if (this._renderer.isP3D) {
+    var args = new Array(arguments.length);
+    for (var i = 0; i < args.length; ++i) {
+      args[i] = arguments[i];
+    }
     this._validateParameters(
       'rotateZ',
-      arguments,
+      args,
       [
         ['Number']
       ]
@@ -213,26 +225,30 @@ p5.prototype.rotateZ = function(rad) {
  * </div>
  */
 p5.prototype.scale = function() {
+  var args = new Array(arguments.length);
+  for (var i = 0; i < args.length; ++i) {
+    args[i] = arguments[i];
+  }
   if (this._renderer.isP3D) {
     this._validateParameters(
       'scale',
-      arguments,
+      args,
       [
         //p3d
         ['Number', 'Number', 'Number']
       ]
     );
-    this._renderer.scale(arguments[0], arguments[1], arguments[2]);
+    this._renderer.scale(args[0], args[1], args[2]);
   } else {
     this._validateParameters(
       'scale',
-      arguments,
+      args,
       [
         //p2d
         ['Number', 'Number']
       ]
     );
-    this._renderer.scale.apply(this._renderer, arguments);
+    this._renderer.scale.apply(this._renderer, args);
   }
   return this;
 };
@@ -346,10 +362,15 @@ p5.prototype.shearY = function(angle) {
  * </div>
  */
 p5.prototype.translate = function(x, y, z) {
+  var args = new Array(arguments.length);
+  for (var i = 0; i < args.length; ++i) {
+    args[i] = arguments[i];
+  }
+
   if (this._renderer.isP3D) {
     this._validateParameters(
       'translate',
-      arguments,
+      args,
       [
         //p3d
         ['Number', 'Number', 'Number']
@@ -359,7 +380,7 @@ p5.prototype.translate = function(x, y, z) {
   } else {
     this._validateParameters(
       'translate',
-      arguments,
+      args,
       [
         //p2d
         ['Number', 'Number']

--- a/src/core/vertex.js
+++ b/src/core/vertex.js
@@ -549,10 +549,14 @@ p5.prototype.quadraticVertex = function(cx, cy, x3, y3) {
  * </div>
  */
 p5.prototype.vertex = function(x, y, moveTo) {
+  var args = new Array(arguments.length);
+  for (var i = 0; i < args.length; ++i) {
+    args[i] = arguments[i];
+  }
   if(this._renderer.isP3D){
     this._validateParameters(
       'vertex',
-      arguments,
+      args,
       [
         ['Number', 'Number', 'Number']
       ]
@@ -562,7 +566,7 @@ p5.prototype.vertex = function(x, y, moveTo) {
   }else{
     this._validateParameters(
       'vertex',
-      arguments,
+      args,
       [
         ['Number', 'Number'],
         ['Number', 'Number', 'Number']

--- a/src/image/loading_displaying.js
+++ b/src/image/loading_displaying.js
@@ -129,9 +129,13 @@ p5.prototype.loadImage = function(path, successCallback, failureCallback) {
  */
 p5.prototype.image = function(img, x, y, width, height) {
   // Temporarily disabling until options for p5.Graphics are added.
+  // var args = new Array(arguments.length);
+  // for (var i = 0; i < args.length; ++i) {
+  //   args[i] = arguments[i];
+  // }
   // this._validateParameters(
   //   'image',
-  //   arguments,
+  //   args,
   //   [
   //     ['p5.Image', 'Number', 'Number'],
   //     ['p5.Image', 'Number', 'Number', 'Number', 'Number']

--- a/src/typography/loading_displaying.js
+++ b/src/typography/loading_displaying.js
@@ -60,10 +60,13 @@ require('../core/error_helpers');
  * </div>
  */
 p5.prototype.text = function(str, x, y, maxWidth, maxHeight) {
-
+  var args = new Array(arguments.length);
+  for (var i = 0; i < args.length; ++i) {
+    args[i] = arguments[i];
+  }
   this._validateParameters(
     'text',
-    arguments,
+    args,
     [
       ['*', 'Number', 'Number'],
       ['*', 'Number', 'Number', 'Number', 'Number']

--- a/src/typography/p5.Font.js
+++ b/src/typography/p5.Font.js
@@ -382,9 +382,12 @@ p5.Font.prototype._handleAlignment = function(p, ctx, line, x, y) {
 };
 
 function cacheKey() {
-  var args = Array.prototype.slice.call(arguments),
-    i = args.length,
-    hash = '';
+  var args = new Array(arguments.length);
+  for (var i = 0; i < args.length; ++i) {
+    args[i] = arguments[i];
+  }
+  i = args.length;
+  var hash = '';
 
   while (i--) {
     hash += (args[i] === Object(args[i])) ?


### PR DESCRIPTION
… advantage of more JS compiler optimizations.  See https://dockyard.com/blog/2014/09/22/javascript-performance-for-the-win for some more details.

My methodology here was:
 - run some of my own sketches and p5.js examples
 - record profiles in the chrome developer tools
 - look for the little yellow "Optimization disabled" warnings.

The tests all still pass and things look otherwise OK.

I'd *really* prefer to have some sort of macro expansion for taking care of this, but i am not super comfortable with grunt and its workflows, so I did the straightforward literal thing in the pile of files that had these warnings.