### PR TITLE
keyPressed event: upper and lower case #536

### DIFF
--- a/src/events/keyboard.js
+++ b/src/events/keyboard.js
@@ -163,10 +163,10 @@ p5.prototype._onkeydown = function (e) {
 
   /* Assigning keyCode */
   tempKeyCode = e.keyCode;
-  if (e.key == 'CapsLock') {
+  if (e.key === 'CapsLock') {
     tempKeyCode = 20;
   }
-  if (e.key == 'Shift') {
+  if (e.key === 'Shift') {
     tempKeyCode = 16;
   }
   if (e.key >= 'a' && e.key <= 'z') {

--- a/src/events/keyboard.js
+++ b/src/events/keyboard.js
@@ -153,15 +153,36 @@ p5.prototype.keyCode = 0;
  * </div>
  */
 p5.prototype._onkeydown = function (e) {
+
+  /* Temporary Variable to store the keyCode and keyChar */  
+  var tempKeyCode = 0,
+    key = 0;
+
   this._setProperty('isKeyPressed', true);
   this._setProperty('keyIsPressed', true);
-  this._setProperty('keyCode', e.which);
+
+  /* Assigning keyCode */
+  tempKeyCode = e.keyCode;
+  if (e.key == 'CapsLock') {
+    tempKeyCode = 20;
+  }
+  if (e.key == 'Shift') {
+    tempKeyCode = 16;
+  }
+  if (e.key >= 'a' && e.key <= 'z') {
+    tempKeyCode = e.keyCode + 32;
+  }  
+  this._setProperty('keyCode', tempKeyCode); 
+
   downKeys[e.which] = true;
-  var key = String.fromCharCode(e.which);
+  //var key = String.fromCharCode(e.which);
+  /* Assigning the keyChar */
+  key = e.key;
   if (!key) {
-    key = e.which;
+    key = e.key;
   }
   this._setProperty('key', key);
+
   var keyPressed = this.keyPressed || window.keyPressed;
   if (typeof keyPressed === 'function' && !e.charCode) {
     var executeDefault = keyPressed(e);

--- a/src/events/keyboard.js
+++ b/src/events/keyboard.js
@@ -154,7 +154,7 @@ p5.prototype.keyCode = 0;
  */
 p5.prototype._onkeydown = function (e) {
 
-  /* Temporary Variable to store the keyCode and keyChar */  
+  /* Temporary Variable to store the keyCode and keyChar */
   var tempKeyCode = 0,
     key = 0;
 
@@ -171,8 +171,8 @@ p5.prototype._onkeydown = function (e) {
   }
   if (e.key >= 'a' && e.key <= 'z') {
     tempKeyCode = e.keyCode + 32;
-  }  
-  this._setProperty('keyCode', tempKeyCode); 
+  }
+  this._setProperty('keyCode', tempKeyCode);
 
   downKeys[e.which] = true;
   //var key = String.fromCharCode(e.which);


### PR DESCRIPTION
##### This patch is a fix to the issues -> https://github.com/processing/p5.js/issues/536

With this patch, the 'keyPressed()' function will display all the letters(both upper & lower case) with their respective keyCodes(both 65-90 & 97-122) depending the On/Off status of CapLock and Shift keys. :)