### PR TITLE
splitTokens() delimeter issue #1004

### DIFF
--- a/src/utilities/string_functions.js
+++ b/src/utilities/string_functions.js
@@ -449,9 +449,25 @@ p5.prototype.split = function(str, delim) {
  * </code>
  */
 p5.prototype.splitTokens = function() {
-  var d;
+  var d,sqo,sqc,str;
+  str = arguments[1];
   if (arguments.length > 1) {
-    d = new RegExp('[' + arguments[1] + ']', 'g');
+    sqc = /\]/g.exec(str);
+    sqo = /\[/g.exec(str);
+    if ( sqo && sqc ) {
+      str = str.slice(0, sqc.index) + str.slice(sqc.index+1);
+      sqo = /\[/g.exec(str);
+      str = str.slice(0, sqo.index) + str.slice(sqo.index+1);
+      d = new RegExp('[\\['+str+'\\]]','g');
+    } else if ( sqc ) {
+      str = str.slice(0, sqc.index) + str.slice(sqc.index+1);
+      d = new RegExp('[' + str + '\\]]', 'g');
+    } else if(sqo) {
+      str = str.slice(0, sqo.index) + str.slice(sqo.index+1);
+      d = new RegExp('[' + str + '\\[]', 'g');
+    } else {
+      d = new RegExp('[' + str + ']', 'g');
+    }
   } else {
     d = /\s/g;
   }


### PR DESCRIPTION
Fixed the #1004 issue so that characters like "[" or "]" or even "[]" are completely acceptable as splitTokens() arguments!
