### PR TITLE
checked() function works after using select() on a checkbox #933

### DIFF
--- a/lib/addons/p5.dom.js
+++ b/lib/addons/p5.dom.js
@@ -135,7 +135,9 @@
    * Helper function for getElement and getElements.
    */
   function wrapElement(elt) {
-    if (elt.tagName === "VIDEO" || elt.tagName === "AUDIO") {
+    if(elt.tagName === "INPUT" && elt.type === "checkbox") {
+      return new p5.CheckBox(elt);
+    } else if (elt.tagName === "VIDEO" || elt.tagName === "AUDIO") {
       return new p5.MediaElement(elt);
     } else {
       return new p5.Element(elt);
@@ -1810,5 +1812,38 @@
     // Data not loaded yet
     this.data = undefined;
   };
+
+// =============================================================================
+//                         p5.CheckBox
+// =============================================================================
+  
+  /**
+   * Base class for all checkbox elements
+   *
+   * @class p5.CheckBox
+   * @constructor
+   * @param {String} elt DOM node that is wrapped
+   * @param {Object} [pInst] pointer to p5 instance
+   */
+  p5.CheckBox = function(elt, pInst) {
+  /**
+   * Underlying HTML element. All normal HTML methods can be called on this.
+   *
+   * @property elt
+   */
+
+     p5.Element.call(this, elt, pInst);
+     this.checked = function(){
+      if (arguments.length === 0){
+        return this.elt.checked;
+      }else if(arguments[0]){
+        this.elt.checked = true;
+      }else{
+        this.elt.checked = false;
+      }
+      return this;
+    };
+  };
+  p5.CheckBox.prototype = Object.create(p5.Element.prototype);
 
 }));


### PR DESCRIPTION
Created a new base class for p5.CheckBox which will be wrapped to an Element if its an `<input>` tag and has the `type="checkbox"` inside the `wrapElement()` function as specified in the todo for #933. The `checked()` function now works as expected. 

Also, I feel similar stuff should be done with a radio-button Element (#1024) and a Select element too. Should I open an issue for that?