### PR TITLE
Element.style() now works with loadFont() #1003

### DIFF
--- a/src/io/files.js
+++ b/src/io/files.js
@@ -111,6 +111,15 @@ p5.prototype.loadFont = function(path, onSuccess, onError) {
 
   });
 
+  var exp =/\/[a-zA-Z]*((.ttf)|(.otf)|(.woff)|(.woff2))$/i; 
+  var i = (exp).exec( path ).index + 1;
+  var font = path.substring(i);
+  font = font.match(/[A-Za-z]*/);
+  var fontFamily = font[0];
+  var newStyle = document.createElement('style');
+  newStyle.appendChild(document.createTextNode("\n@font-face {\nfont-family: "+fontFamily+";\nsrc: url("+path+");\n}\n"));
+  document.head.appendChild(newStyle);
+  
   return p5Font;
 };
 

--- a/src/io/files.js
+++ b/src/io/files.js
@@ -107,20 +107,20 @@ p5.prototype.loadFont = function(path, onSuccess, onError) {
     }
     if (decrementPreload && (onSuccess !== decrementPreload)) {
       decrementPreload();
-      /*jshint multistr: true */
-      var exp =/\/[a-zA-Z]*((.ttf)|(.otf)|(.woff)|(.woff2))$/i;
-      if(!exp) {
-        return p5Font;
-      }
-      var i = (exp).exec( path ).index + 1;
-      var fontName = path.substring(i);
-      fontName = font.match(/[A-Za-z]*/);
-      var fontFamily = font[0];
-      var newStyle = document.createElement('style');
-      newStyle.appendChild(document.createTextNode('\n@font-face {\
-        \nfont-family: '+fontFamily+';\nsrc: url('+path+');\n}\n'));
-      document.head.appendChild(newStyle);
     }
+    /*jshint multistr: true */
+    var exp =/\/[a-zA-Z]*((.ttf)|(.otf)|(.woff)|(.woff2))$/i;
+    if(!exp) {
+      return p5Font;
+    }
+    var i = (exp).exec( path ).index + 1;
+    var fontName = path.substring(i);
+    fontName = fontName.match(/[A-Za-z]*/);
+    var fontFamily = fontName[0];
+    var newStyle = document.createElement('style');
+    newStyle.appendChild(document.createTextNode('\n@font-face {\
+      \nfont-family: '+fontFamily+';\nsrc: url('+path+');\n}\n'));
+    document.head.appendChild(newStyle);
 
   });
 

--- a/src/io/files.js
+++ b/src/io/files.js
@@ -107,19 +107,23 @@ p5.prototype.loadFont = function(path, onSuccess, onError) {
     }
     if (decrementPreload && (onSuccess !== decrementPreload)) {
       decrementPreload();
+      /*jshint multistr: true */
+      var exp =/\/[a-zA-Z]*((.ttf)|(.otf)|(.woff)|(.woff2))$/i;
+      if(!exp) {
+        return p5Font;
+      }
+      var i = (exp).exec( path ).index + 1;
+      var fontName = path.substring(i);
+      fontName = font.match(/[A-Za-z]*/);
+      var fontFamily = font[0];
+      var newStyle = document.createElement('style');
+      newStyle.appendChild(document.createTextNode('\n@font-face {\
+        \nfont-family: '+fontFamily+';\nsrc: url('+path+');\n}\n'));
+      document.head.appendChild(newStyle);
     }
 
   });
 
-  var exp =/\/[a-zA-Z]*((.ttf)|(.otf)|(.woff)|(.woff2))$/i; 
-  var i = (exp).exec( path ).index + 1;
-  var font = path.substring(i);
-  font = font.match(/[A-Za-z]*/);
-  var fontFamily = font[0];
-  var newStyle = document.createElement('style');
-  newStyle.appendChild(document.createTextNode("\n@font-face {\nfont-family: "+fontFamily+";\nsrc: url("+path+");\n}\n"));
-  document.head.appendChild(newStyle);
-  
   return p5Font;
 };
 


### PR DESCRIPTION
@futuremarc Since using a custom font-family on an HTML element requires it to be defined in @font-face this PR will create a @font-face inside a `<style>` tag (inside `<head>`).

But this works correctly only on a running server (like python SimpleHTTPServer) , otherwise it runs into cross-origin issues.

Here's how it can be used:
```javascript
myFont = loadFont('assets/Avenir.otf');
```
How to apply it on another element?
```javascript
myDiv.style("font-family", "Avenir");
```

Another Example
```javascript
myFont = loadFont('assets/Italic.otf');
```
How to apply it on another element?
```javascript
myDiv.style("font-family", "Italic");
```

Basically, I have used regular expression to extract out "font-name" from `<font-name>.otf` (.ttf, .woff,etc) to be used as `font-family` .

