### PR TITLE
Fixes for pixel array to match size() of p5.MediaElement #1022

### DIFF
--- a/examples/addons/p5.dom/brightness_mirror/index.html
+++ b/examples/addons/p5.dom/brightness_mirror/index.html
@@ -1,0 +1,9 @@
+<head>
+  <script language="javascript" type="text/javascript" src="../../../../lib/p5.js"></script>
+  <script language="javascript" type="text/javascript" src="../../../../lib/addons/p5.dom.js"></script>
+  <script language="javascript" type="text/javascript" src="sketch.js"></script>        
+</head>
+
+<body>
+	<div id="test"></div>
+</body>

--- a/examples/addons/p5.dom/brightness_mirror/sketch.js
+++ b/examples/addons/p5.dom/brightness_mirror/sketch.js
@@ -1,0 +1,59 @@
+// Learning Processing
+// Daniel Shiffman
+// http://www.learningprocessing.com
+
+// Example 16-6: Drawing a grid of squares
+
+// Size of each cell in the grid, ratio of window size to video size
+// 40 * 16 = 640
+// 30 * 16 = 480
+var videoScale = 16;
+
+// Number of columns and rows in our system
+var cols, rows;
+
+function setup() {
+  createCanvas(640, 480);
+
+  // Initialize columns and rows
+  cols = width/videoScale;
+  rows = height/videoScale;
+
+  devicePixelScaling(false);
+  video = createCapture(VIDEO);
+  video.size(cols,rows);
+  //video.hide();
+}
+
+function draw() {
+  background(0);
+  video.loadPixels();
+
+
+  // Begin loop for columns
+  for (var i = 0; i < cols; i++) {
+    // Begin loop for rows
+    for (var j = 0; j < rows; j++) {
+      // Reversing x to mirror the image
+      // In order to mirror the image, the column is reversed with the following formula:
+      // mirrored column = width - column - 1
+      var loc = ((cols - i - 1) + j * cols) * 4;
+
+      // The functions red(), green(), and blue() pull out the three color components from a pixel.
+      var r = video.pixels[loc   ];
+      var g = video.pixels[loc + 1];
+      var b = video.pixels[loc + 2];
+
+      // A rectangle size is calculated as a function of the pixel's brightness.
+      // A bright pixel is a large rectangle, and a dark pixel is a small one.
+      var sz = map((r+g+b)/3, 0, 255, 0, videoScale);
+      rectMode(CENTER);
+      fill(255);
+      noStroke();
+      // For every column and row, a rectangle is drawn at an (x,y) location scaled and sized by videoScale.
+      var x = i*videoScale;
+      var y = j*videoScale;
+      rect(x + videoScale/2, y + videoScale/2, sz, sz);
+    }
+  }
+}

--- a/examples/addons/p5.dom/capture_video_sizing/index.html
+++ b/examples/addons/p5.dom/capture_video_sizing/index.html
@@ -1,0 +1,9 @@
+<head>
+  <script language="javascript" type="text/javascript" src="../../../../lib/p5.js"></script>
+  <script language="javascript" type="text/javascript" src="../../../../lib/addons/p5.dom.js"></script>
+  <script language="javascript" type="text/javascript" src="sketch.js"></script>        
+</head>
+
+<body>
+	<div id="test"></div>
+</body>

--- a/examples/addons/p5.dom/capture_video_sizing/sketch.js
+++ b/examples/addons/p5.dom/capture_video_sizing/sketch.js
@@ -1,0 +1,20 @@
+var capture;
+
+function setup() {
+  createCanvas(390, 240);
+  capture = createCapture(VIDEO);
+  capture.size(320, 240);
+  devicePixelScaling(false);
+}
+
+function draw() {
+  background(255);
+  image(capture, 0, 0);
+
+  capture.loadPixels();
+  console.log(capture.pixels.length === 320*240*4);
+}
+
+function mousePressed() {
+  capture.size(32, 24);
+}

--- a/lib/addons/p5.dom.js
+++ b/lib/addons/p5.dom.js
@@ -1514,9 +1514,17 @@
         this.canvas = document.createElement('canvas');
         this.canvas.width = this.elt.clientWidth;
         this.canvas.height = this.elt.clientHeight;
+        this.width = this.canvas.width;
+        this.height = this.canvas.height;
         this.drawingContext = this.canvas.getContext('2d');
+      // Adding an extra check to see if size has changed
+      } else if (this.canvas.width !== this.elt.clientWidth) {
+        this.canvas.width = this.elt.clientWidth;
+        this.canvas.height = this.elt.clientHeight;
+        this.width = this.canvas.width;
+        this.height = this.canvas.height;
       }
-      this.drawingContext.drawImage(this.elt, 0, 0, this.width, this.height);
+      this.drawingContext.drawImage(this.elt, 0, 0, this.canvas.width, this.canvas.height);
       p5.Renderer2D.prototype.loadPixels.call(this);
     }
     return this;

--- a/lib/addons/p5.dom.js
+++ b/lib/addons/p5.dom.js
@@ -38,11 +38,11 @@
 // =============================================================================
 
   /**
-   * Searches the page for an element with the given ID, class, or tag name (using the '#' or '.' 
+   * Searches the page for an element with the given ID, class, or tag name (using the '#' or '.'
    * prefixes to specify an ID or class respectively, and none for a tag) and returns it as
-   * a p5.Element. If a class or tag name is given with more than 1 element, 
+   * a p5.Element. If a class or tag name is given with more than 1 element,
    * only the first element will be returned.
-   * The DOM node itself can be accessed with .elt. 
+   * The DOM node itself can be accessed with .elt.
    * Returns null if none found.
    *
    * @method select
@@ -56,7 +56,7 @@
    *   select('canvas').translate(0,50);
    * }
    * </code></div>
-   *  
+   *
    */
   p5.prototype.select = function (e) {
     var res;
@@ -84,14 +84,14 @@
       }else {
         return null;
       }
-    } 
+    }
   };
 
   /**
-   * Searches the page for elements with the given class or tag name (using the '.' prefix 
-   * to specify a class and no prefix for a tag) and returns them as p5.Elements 
-   * in an array. 
-   * The DOM node itself can be accessed with .elt. 
+   * Searches the page for elements with the given class or tag name (using the '.' prefix
+   * to specify a class and no prefix for a tag) and returns them as p5.Elements
+   * in an array.
+   * The DOM node itself can be accessed with .elt.
    * Returns null if none found.
    *
    * @method selectAll
@@ -110,7 +110,7 @@
    *   }
    * }
    * </code></div>
-   *  
+   *
    */
   p5.prototype.selectAll = function (e) {
     var arr = [];
@@ -398,19 +398,19 @@
    * @example
    * <div class='norender'><code>
    * var checkbox;
-   * 
+   *
    * function setup() {
    *   checkbox = createCheckbox('label', false);
    *   checkbox.changed(myCheckedEvent);
    * }
-   * 
+   *
    * function myCheckedEvent() {
    *   if (this.checked()) {
    *     console.log("Unchecking!");
    *   } else {
    *     console.log("Checking!");
    *   }
-   * 
+   *
    * </code></div>
    */
   p5.prototype.createCheckbox = function() {
@@ -455,7 +455,7 @@
    * @example
    * <div class='norender'><code>
    * var checkbox;
-   * 
+   *
    * function setup() {
    *   sel = createSelect();
    *   sel.option('pear');
@@ -463,17 +463,17 @@
    *   sel.selected('pear');
    *   sel.changed(mySelectEvent);
    * }
-   * 
+   *
    * function mySelectEvent() {
    *   var selected = this.value();
    *   if (selected === 'pear') {
    *     console.log("it's a pear!");
    *   }
    * }
-   * 
+   *
    * </code></div>
    *
-   
+
    */
   p5.prototype.createSelect = function(mult) {
     var elt = document.createElement('select');
@@ -532,7 +532,7 @@
    * function myInputEvent(){
    *   console.log('you are typing: ', this.value());
    * }
-   * 
+   *
    * </code></div>
    */
   p5.prototype.createInput = function(value) {
@@ -543,13 +543,13 @@
   };
 
   /**
-   * Creates an &lt;input&gt;&lt;/input&gt; element in the DOM of type 'file'.  
+   * Creates an &lt;input&gt;&lt;/input&gt; element in the DOM of type 'file'.
    * This allows users to select local files for use in a sketch.
-   * 
+   *
    * @method createFileInput
    * @param  {Function} [callback] callback function for when a file loaded
    * @param  {String} [multiple] optional to allow multiple files selected
-   * @return {Object/p5.Element} pointer to p5.Element holding created DOM element                       
+   * @return {Object/p5.Element} pointer to p5.Element holding created DOM element
    */
   p5.prototype.createFileInput = function(callback, multiple) {
 
@@ -565,7 +565,7 @@
         // Anything gets the job done
         elt.multiple = 'multiple';
       }
-     
+
       // Now let's handle when a file was selected
       elt.addEventListener('change', handleFileSelect, false);
 
@@ -588,7 +588,7 @@
               callback(p5file);
             };
           };
-          
+
           // Text or data?
           // This should likely be improved
           if (f.type.indexOf('text') > -1) {
@@ -704,8 +704,8 @@
    * Creates a new &lt;video&gt; element that contains the audio/video feed
    * from a webcam. This can be drawn onto the canvas using video(). More
    * specific properties of the stream can be passing in a Constraints object.
-   * See the 
-   * <a href="http://w3c.github.io/mediacapture-main/getusermedia.html">W3C 
+   * See the
+   * <a href="http://w3c.github.io/mediacapture-main/getusermedia.html">W3C
    * spec</a> for possible properties. Note that not all of these are supported
    * by all browsers.
    *
@@ -918,7 +918,7 @@
    *   var div = createDiv('').size(10,10);
    *   div.style('background-color','orange');
    *   div.center();
-   *   
+   *
    * }
    * </code></div>
    */
@@ -930,7 +930,7 @@
 
     if (hidden) this.show();
 
-    this.elt.style.display = 'block'; 
+    this.elt.style.display = 'block';
     this.position(0,0);
 
     if (parentHidden) this.parent().style.display = 'block';
@@ -949,11 +949,11 @@
     }
 
     this.style('display', style);
-    
+
     if (hidden) this.hide();
 
     if (parentHidden) this.parent().style.display = 'none';
-    
+
     return this;
   };
 
@@ -1072,7 +1072,7 @@
    * var x = 0,
    *     y = 0,
    *     z = 0;
-   *     
+   *
    * function draw(){
    *   x+=.5 % 360;
    *   y+=.5 % 360;
@@ -1193,7 +1193,7 @@
         this.elt.style[prop] = val;
         if (prop === 'width' || prop === 'height' || prop === 'left' || prop === 'top') {
           var numVal = val.replace(/\D+/g, '');
-          this[prop] = parseInt(numVal, 10); 
+          this[prop] = parseInt(numVal, 10);
         }
       }
     }
@@ -1317,7 +1317,7 @@
           this.width = aW;
           this.height = aH;
         }
-        
+
         this.width = this.elt.offsetWidth;
         this.height = this.elt.offsetHeight;
 
@@ -1512,8 +1512,8 @@
     if (this.loadedmetadata) { // wait for metadata for w/h
       if (!this.canvas) {
         this.canvas = document.createElement('canvas');
-        this.canvas.width = this.width;
-        this.canvas.height = this.height;
+        this.canvas.width = this.elt.clientWidth;
+        this.canvas.height = this.elt.clientHeight;
         this.drawingContext = this.canvas.getContext('2d');
       }
       this.drawingContext.drawImage(this.elt, 0, 0, this.width, this.height);
@@ -1545,7 +1545,7 @@
    *  p5.sound object. If no element is provided, connects to p5's master
    *  output. That connection is established when this method is first called.
    *  All connections are removed by the .disconnect() method.
-   *  
+   *
    *  This method is meant to be used with the p5.sound.js addon library.
    *
    *  @method  connect
@@ -1557,7 +1557,7 @@
 
     // if p5.sound exists, same audio context
     if (typeof p5.prototype.getAudioContext === 'function') {
-      audioContext = p5.prototype.getAudioContext(); 
+      audioContext = p5.prototype.getAudioContext();
       masterOutput = p5.soundOut.input;
     } else {
       try {
@@ -1596,7 +1596,7 @@
    *  Disconnect all Web Audio routing, including to master output.
    *  This is useful if you want to re-route the output through
    *  audio effects, for example.
-   *  
+   *
    *  @method  disconnect
    */
   p5.MediaElement.prototype.disconnect = function() {
@@ -1623,7 +1623,7 @@
 
   /**
    *  Hide the default mediaElement controls.
-   *  
+   *
    *  @method hideControls
    */
   p5.MediaElement.prototype.hideControls = function() {
@@ -1664,7 +1664,7 @@
    *  <div><code>
    *  function setup() {
    *    background(255,255,255);
-   *    
+   *
    *    audioEl = createAudio('assets/beat.mp3');
    *    audioEl.showControls();
    *
@@ -1808,7 +1808,7 @@
      * @property size
      */
     this.size = file.size;
-    
+
     // Data not loaded yet
     this.data = undefined;
   };


### PR DESCRIPTION
The pixel array of a p5.MediaElement array will always match the width and height specified by calls to `size()`.  This address #1022. 

@lmccart there is some weirdness here regarding how `loadPixels()` internally references `this.width`, resulting in code like the following:

```javascript
      if (!this.canvas) {
        this.canvas = document.createElement('canvas');
        this.canvas.width = this.elt.clientWidth;
        this.canvas.height = this.elt.clientHeight;
        this.width = this.canvas.width;
        this.height = this.canvas.height;
        this.drawingContext = this.canvas.getContext('2d');
```

I'm not sure if this opens up other problems.  I have a feeling this is related to #989.

I've also included two additional examples I'm using for testing with this request, but I can remove those if you prefer.

Also, a new bug has emerged from this that I will file separately.