### PR TITLE
Dragging affects mouseIsPressed, mouseX, mouseY. Fixes #1042.

### DIFF
--- a/src/core/core.js
+++ b/src/core/core.js
@@ -161,6 +161,8 @@ var p5 = function(sketch, node, sync) {
     'mousemove': null,
     'mousedown': null,
     'mouseup': null,
+    'dragend': null,
+    'dragover': null,
     'click': null,
     'mouseover': null,
     'mouseout': null,

--- a/src/events/mouse.js
+++ b/src/events/mouse.js
@@ -578,6 +578,9 @@ p5.prototype._onmouseup = function(e) {
   }
 };
 
+p5.prototype._ondragend = p5.prototype._onmouseup;
+p5.prototype._ondragover = p5.prototype._onmousemove;
+
 /**
  * The mouseClicked() function is called once after a mouse button has been
  * pressed and then released.<br><br>


### PR DESCRIPTION
This is an attempt to fix #1042. I tried it on Firefox 41, Chrome, and Microsoft Edge and it seems to work fine. I used the following slightly modified code from #1042 to test it:

```js
function setup() {
  createCanvas(800, 800);
  var img = createImg('someimage.jpg');
}

function draw() {
  if (mouseIsPressed) {
    print('pressed')
    ellipse(mouseX, mouseY, 5, 5);
  } else {
    print('not pressed')
  }
}
```

Notes:
* This is my first PR to p5.js; I'm also pretty unfamiliar with processing in general, so my apologies if I've messed anything up!
* I tried originally binding to the `dragleave` event as mentioned in https://github.com/processing/p5.js/issues/1042#issuecomment-151999083, but it turns out this is fired as the mouse moves from one element on the page to another, so I bound to `dragend` instead.
* This doesn't actually satisfy the case when ESC is pressed to cancel the drag and the mouse button is still held down; in that case, unfortunately, there doesn't seem to be a way to detect whether the button is still down (I tried `event.buttons` and it's always `0`), so `mouseIsPressed` can potentially be `false` when it should be `true`. However, I didn't even know it was *possible* to cancel a drag with ESC until about 10 minutes ago, so hopefully this use case is pretty rare--and even when it does happen, hopefully most users actually release the mouse button shortly after pressing ESC, thus making `mouseIsPressed` inaccurate for only a short period of time.
