### PR TITLE
Make loadPixels() work on hidden video elments. Fixes #1034.

### DIFF
--- a/lib/addons/p5.dom.js
+++ b/lib/addons/p5.dom.js
@@ -1508,10 +1508,16 @@
   };
   p5.MediaElement.prototype.pixels = [];
   p5.MediaElement.prototype.loadPixels = function() {
+    var reHideElt = false;
+
     if (this.loadedmetadata) { // wait for metadata for w/h
       if (!this.canvas) {
         this.canvas = document.createElement('canvas');
         this.drawingContext = this.canvas.getContext('2d');
+      }
+      if (this.elt.style.display == 'none') {
+        reHideElt = true;
+        this.elt.style.display = 'block';
       }
       if (this.canvas.width !== this.elt.clientWidth) {
         this.canvas.width = this.elt.clientWidth;
@@ -1521,6 +1527,9 @@
       }
       this.drawingContext.drawImage(this.elt, 0, 0, this.canvas.width, this.canvas.height);
       p5.Renderer2D.prototype.loadPixels.call(this);
+      if (reHideElt) {
+        this.elt.style.display = 'none';
+      }
     }
     return this;
   }


### PR DESCRIPTION
This is a potential fix for #1034 that works by momentarily showing the `<video>` element just before it loads the pixels, and then re-hiding the `<video>` element afterwards.

Notes:
* I'm not sure how this fix affects performance.
* While this fix *does* work for the code snippet in #1034, I doubt it would work if an *ancestor* of the `<video>` element has `display: none` set. Because of my unfamiliarity with p5.js, however, I'm not sure how likely this is to occur in practice.
