### PR TITLE
Ensure pixelDensity is an integer.

### DIFF
--- a/src/core/core.js
+++ b/src/core/core.js
@@ -144,7 +144,7 @@ var p5 = function(sketch, node, sync) {
   //////////////////////////////////////////////
 
   this._setupDone = false;
-  this.pixelDensity = window.devicePixelRatio || 1; // for handling hidpi
+  this.pixelDensity = Math.ceil(window.devicePixelRatio) || 1; // for handling hidpi
   this._userNode = node;
   this._curElement = null;
   this._elements = [];

--- a/src/core/core.js
+++ b/src/core/core.js
@@ -144,7 +144,8 @@ var p5 = function(sketch, node, sync) {
   //////////////////////////////////////////////
 
   this._setupDone = false;
-  this.pixelDensity = Math.ceil(window.devicePixelRatio) || 1; // for handling hidpi
+  // for handling hidpi
+  this.pixelDensity = Math.ceil(window.devicePixelRatio) || 1;
   this._userNode = node;
   this._curElement = null;
   this._elements = [];

--- a/src/core/environment.js
+++ b/src/core/environment.js
@@ -445,7 +445,7 @@ p5.prototype.devicePixelScaling = function(val) {
       this.pixelDensity = val;
     }
     else {
-      this.pixelDensity = window.devicePixelRatio || 1;
+      this.pixelDensity = Math.ceil(window.devicePixelRatio) || 1;
     }
   } else {
     this.pixelDensity = 1;


### PR DESCRIPTION
This is an attempt to fix #974 by ensuring that auto-detected pixel density via querying `window.devicePixelRatio` is always an integer. This is because `set()`, and possibly other code I don't know about, seems to expect it to be an integer, yet Firefox sets it to a float depending on how zoomed-in the user is (to manually test this, use Ctrl +/- or Command +/- to zoom).
