### PR TITLE
Specify 'type' for the removeEventListener method.

### DIFF
--- a/src/core/core.js
+++ b/src/core/core.js
@@ -489,8 +489,8 @@ var p5 = function(sketch, node, sync) {
   window.addEventListener('focus', focusHandler);
   window.addEventListener('blur', blurHandler);
   this.registerMethod('remove', function() {
-    window.removeEventListener(focusHandler);
-    window.removeEventListener(blurHandler);
+    window.removeEventListener('focus', focusHandler);
+    window.removeEventListener('blur', blurHandler);
   });
 
   // TODO: ???


### PR DESCRIPTION
Tried to remove canvas using remove() method, and the error below happened:
```
TypeError: Not enough arguments to EventTarget.removeEventListener.
```
Found that we need to specify the event type to remove([link](https://developer.mozilla.org/zh-TW/docs/Web/API/EventTarget/removeEventListener)).
Fixed the bug & ran the tests.