### PR TITLE
fixing saveStrings() bug re: extraneous data saved in file

### DIFF
--- a/src/io/files.js
+++ b/src/io/files.js
@@ -1142,7 +1142,7 @@ p5.prototype.saveStream = function() {
 p5.prototype.saveStrings = function(list, filename, extension) {
   var ext = extension || 'txt';
   var pWriter = this.createWriter(filename, ext);
-  for (var i in list) {
+  for (var i = 0; i < list.length; i++) {
     if (i < list.length - 1) {
       pWriter.println(list[i]);
     } else {


### PR DESCRIPTION
The current implementation of `saveStrings()` allowed extra properties of the `list` array (like the function `indexOf()` to end up in the file, e.g.

```javascript
  var json = {}; // new JSON Object
  json.id = 0;
  json.species = 'Panthera leo';
  json.name = 'Lion';
  saveJSON(json, 'lion.json');
```

yielded:

```javascript
{
  "id": 0,
  "species": "Panthera leo",
  "name": "Lion"
}function (ele) {
  return (Array.prototype.indexOf(ele) > -1);
}
```

This patch should fix the issue.