### PR TITLE
webgl Renderer3D attribute alpha defaults true

### DIFF
--- a/src/3d/p5.Renderer3D.js
+++ b/src/3d/p5.Renderer3D.js
@@ -9,7 +9,7 @@ var RESOLUTION = 1000;
 
 //@TODO should probably implement an override for these attributes
 var attributes = {
-  alpha: false,
+  alpha: true,
   depth: true,
   stencil: true,
   antialias: false,


### PR DESCRIPTION
alpha is now true by default.  Fixes #1064 