### PR TITLE
Add unit tests for p5.prototype.select() and fix bugs

### DIFF
--- a/lib/addons/p5.dom.js
+++ b/lib/addons/p5.dom.js
@@ -64,7 +64,7 @@
     if (e[0] === '.'){
       str = e.slice(1);
       res = document.getElementsByClassName(str);
-      if (res) {
+      if (res.length) {
         return wrapElement(res[0]);
       }else {
         return null;
@@ -79,7 +79,7 @@
       }
     }else{
       res = document.getElementsByTagName(e);
-      if (res) {
+      if (res.length) {
         return wrapElement(res[0]);
       }else {
         return null;

--- a/test/test.html
+++ b/test/test.html
@@ -30,8 +30,10 @@
 
   <!-- Include anything you want to test -->
   <script src="../lib/p5.js" type="text/javascript" ></script>
+  <script src="../lib/addons/p5.dom.js" type="text/javascript" ></script>
 
   <!-- Spec files -->
+  <script src="unit/dom/dom.js" type="text/javascript" ></script>
   <script src="unit/core/core.js" type="text/javascript" ></script>
   <!--<script src="unit/core/2d_primitives.js" type="text/javascript" ></script>-->
   <script src="unit/core/curves.js" type="text/javascript" ></script>

--- a/test/unit/dom/dom.js
+++ b/test/unit/dom/dom.js
@@ -1,0 +1,51 @@
+suite('DOM', function(){
+  suite('p5.prototype.select', function() {
+    var select = p5.prototype.select;
+
+    suite('select()', function() {
+      var elt;
+
+      teardown(function() {
+        if (elt && elt.parentNode) {
+          elt.parentNode.removeChild(elt);
+          elt = null;
+        }
+      });
+
+      test('should find elements by ID', function() {
+        elt = document.createElement('div');
+        elt.setAttribute('id', 'blarg');
+        document.body.appendChild(elt);
+
+        assert.strictEqual(select('#blarg').elt, elt);
+      });
+
+      test('should return null when elements by ID are not found', function() {
+        assert.isNull(select('#blarg'));
+      });
+
+      test('should find elements by class', function() {
+        elt = document.createElement('div');
+        elt.setAttribute('class', 'blarg');
+        document.body.appendChild(elt);
+
+        assert.strictEqual(select('.blarg').elt, elt);
+      });
+
+      test('should return null when elements by class are not found', function() {
+        assert.isNull(select('.blarg'));
+      });
+
+      test('should find elements by tag name', function() {
+        elt = document.createElement('aside');
+        document.body.appendChild(elt);
+
+        assert.strictEqual(select('aside').elt, elt);
+      });
+
+      test('should return null when elements by tag name are not found', function() {
+        assert.isNull(select('aside'));
+      });
+    });
+  });
+});


### PR DESCRIPTION
This fixes #1061 by adding a simple unit test suite for p5.dom which currently just tests the `p5.prototype.select()` function. I actually ran into two bugs in the function while testing it, so I fixed those.

Notes:
* There aren't currently any test suites for anything in the `lib/addons` directory, so I wasn't sure how to name the directory containing the p5.dom tests, since `test/unit` mirrors the structure of the `src` directory. Then I noticed #645 is about moving P5.dom into the core library, so I just put the test suite in a folder called `test/unit/dom`, thinking that perhaps P5.dom will eventually be moved into `src/dom` and then everything will make sense. In any case, I'm probably overthinking this...
* I didn't add anything to `test-minified.html` since it seems like there's no minified version of p5.dom available.