### PR TITLE
createCheckbox() select() fix #933

### DIFF
--- a/lib/addons/p5.dom.js
+++ b/lib/addons/p5.dom.js
@@ -135,7 +135,9 @@
    * Helper function for getElement and getElements.
    */
   function wrapElement(elt) {
-    if (elt.tagName === "VIDEO" || elt.tagName === "AUDIO") {
+    if(elt.tagName === "INPUT" && elt.type === "checkbox") {
+      return new p5.CheckBox(elt);
+    } else if (elt.tagName === "VIDEO" || elt.tagName === "AUDIO") {
       return new p5.MediaElement(elt);
     } else {
       return new p5.Element(elt);
@@ -1810,5 +1812,38 @@
     // Data not loaded yet
     this.data = undefined;
   };
+
+// =============================================================================
+//                         p5.CheckBox
+// =============================================================================
+  
+  /**
+   * Base class for all checkbox elements
+   *
+   * @class p5.CheckBox
+   * @constructor
+   * @param {String} elt DOM node that is wrapped
+   * @param {Object} [pInst] pointer to p5 instance
+   */
+  p5.CheckBox = function(elt, pInst) {
+  /**
+   * Underlying HTML element. All normal HTML methods can be called on this.
+   *
+   * @property elt
+   */
+
+     p5.Element.call(this, elt, pInst);
+     this.checked = function(){
+      if (arguments.length === 0){
+        return this.elt.checked;
+      }else if(arguments[0]){
+        this.elt.checked = true;
+      }else{
+        this.elt.checked = false;
+      }
+      return this;
+    };
+  };
+  p5.CheckBox.prototype = Object.create(p5.Element.prototype);
 
 }));

--- a/lib/addons/p5.dom.js
+++ b/lib/addons/p5.dom.js
@@ -136,7 +136,18 @@
    */
   function wrapElement(elt) {
     if(elt.tagName === "INPUT" && elt.type === "checkbox") {
-      return new p5.CheckBox(elt);
+      var converted = new p5.Element(elt);
+      converted.checked = function(){
+      if (arguments.length === 0){
+        return this.elt.checked;
+      } else if(arguments[0]) {
+        this.elt.checked = true;
+      } else {
+        this.elt.checked = false;
+      }
+      return this;
+      };
+      return converted;
     } else if (elt.tagName === "VIDEO" || elt.tagName === "AUDIO") {
       return new p5.MediaElement(elt);
     } else {
@@ -1812,38 +1823,5 @@
     // Data not loaded yet
     this.data = undefined;
   };
-
-// =============================================================================
-//                         p5.CheckBox
-// =============================================================================
-  
-  /**
-   * Base class for all checkbox elements
-   *
-   * @class p5.CheckBox
-   * @constructor
-   * @param {String} elt DOM node that is wrapped
-   * @param {Object} [pInst] pointer to p5 instance
-   */
-  p5.CheckBox = function(elt, pInst) {
-  /**
-   * Underlying HTML element. All normal HTML methods can be called on this.
-   *
-   * @property elt
-   */
-
-     p5.Element.call(this, elt, pInst);
-     this.checked = function(){
-      if (arguments.length === 0){
-        return this.elt.checked;
-      }else if(arguments[0]){
-        this.elt.checked = true;
-      }else{
-        this.elt.checked = false;
-      }
-      return this;
-    };
-  };
-  p5.CheckBox.prototype = Object.create(p5.Element.prototype);
 
 }));


### PR DESCRIPTION
In reference to the issue #933 and my previous pull-request #1025 I removed the extra p5.Checkbox wrapper class and I added the `checked()` functionality to the p5.Element as is. What I did is when the `select()` function is called I converted the normal element to a `p5.Element` and then added the `checked()` function to it. @lmccart @shiffman please do have a look at it and let me know if this is correct? :)