### PR TITLE
Fix broken tests on non-PhantomJS browsers.

### DIFF
--- a/src/io/files.js
+++ b/src/io/files.js
@@ -24,7 +24,7 @@ p5._getDecrementPreload = function() {
 
   // when in preload decrementPreload will always be the last arg as it is set
   // with args.push() before invocation in _wrapPreload
-  if ((window.preload || this.preload) &&
+  if ((window.preload || (this && this.preload)) &&
     typeof decrementPreload === 'function') {
     return decrementPreload;
   } else {

--- a/test/test-minified.html
+++ b/test/test-minified.html
@@ -60,7 +60,9 @@
     // If tests run in a real browser
     // Can alternatively do a check on window.PHANTOMJS
     if (navigator.userAgent.indexOf('PhantomJS') < 0) {
+      window.addEventListener('load', function() {
         mocha.run();
+      }, false);
     }
   </script>
 </body>

--- a/test/test.html
+++ b/test/test.html
@@ -63,7 +63,9 @@
     // If tests run in a real browser
     // Can alternatively do a check on window.PHANTOMJS
     if (navigator.userAgent.indexOf('PhantomJS') < 0) {
+      window.addEventListener('load', function() {
         mocha.run();
+      }, false);
     }
   </script>
 </body>


### PR DESCRIPTION
This fixes #1070.

* **For all browsers**, the problem was that a number of IO-related functions were being called by tests without having an explicit `this`. Because all of p5's source files are defined with [`"use strict"`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Strict_mode) this means that all browsers which support it will set `this` to `undefined` rather than to the global window object. Since the p5 code was examining `this.preload`, an exception was thrown. I suspect this worked fine on PhantomJS because PhantomJS 1.9 probably doesn't support this particular feature of strict mode, so `this` was being set to the global window object instead of `undefined`.
* **For Firefox**, the problem was that the tests started running while `document.readyState` was `"interactive"` rather than `"complete"` (it's `"complete"` on all other browsers). This meant that some tests which expected p5's renderer to be initialized synchronously broke; the remedy was simply to call `mocha.run()` in the page's `load` event handler, so that all browsers ran the tests with `document.readyState == "complete"`.
