### PR TITLE
Add a "watch:quick" task to gruntfile.js

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -30,6 +30,11 @@
  *                      every file change, but does not rebuild the docs.
  *                      It's faster than the default watch.
  *
+ *  grunt watch:quick - This watches the source for changes and rebuilds
+ *                      p5.js on every file change, but does not rebuild
+ *                      docs, and does not perform linting, minification,
+ *                      or run tests. It's faster than watch:main.
+ *
  *  grunt update_json - This automates updating the bower file
  *                      to match the package.json
  */
@@ -104,6 +109,13 @@ module.exports = function(grunt) {
     // code touches files within the theme, so it will also recompile the
     // documentation.
     watch: {
+      quick: {
+        files: ['src/**/*.js'],
+        tasks: ['browserify'],
+        options: {
+          livereload: true
+        }
+      },
       // Watch the codebase for changes
       main: {
         files: ['src/**/*.js'],


### PR DESCRIPTION
Ok, this is probably going to get rejected as a PR, which is fine--I'm mainly using it as a way to show my thinking.

So when I was working on some of my earlier PRs, like #1052 and #1047, I went through the following process:

1. Start a webserver serving from the root of my p5.js repo checkout with e.g. `grunt connect -keepalive`.
2. Create an `example.html` file in the root directory with a sample sketch that surfaces the problem I'm trying to debug. This file has a `<script src="lib/p5.js">` in it.
3. Run `grunt build` every time I make a code change, so `lib/p5.js` is regenerated.

Manually doing step 3 is kind of annoying, so I decided to try `grunt watch` to auto-rebuild things for me. However, not only did it take a lot longer than `grunt:build`, it also tried to start a webserver on the same port as my `grunt connect -keepalive` (9001), which made the test suites explode.

I just noticed the docs for `watch:main` when perusing through the Gruntfile.js, but even it still does way more than I need when I'm just tinkering around to debug a problem, and it still has the same port conflict as the default `watch` task...

So this PR is one possible solution, `grunt watch:quick`, which *only* rebuilds `p5.js` and doesn't do any minification, testing, linting, or anything like that. It's purely intended for the earliest stages of debugging a problem and writing up an initial solution.

Ideally I wish this task could *also* do the same thing as `grunt connect -keepalive`, so that beginners could just run one task and get up-and-running ASAP without having to open multiple terminal windows, but I don't know enough about Grunt to do that yet, and I'm not even sure if this kind of thing is desired by others yet--for all I know, my development process is totally weird and there may be a much better way of doing things that I don't know about! :grin: 