### PR TITLE
select() and select all() issue #944

### DIFF
--- a/lib/addons/p5.dom.js
+++ b/lib/addons/p5.dom.js
@@ -61,44 +61,40 @@
   p5.prototype.select = function (e, p) {
     var res;
     var str;
-    if (typeof p !== 'undefined'){
-      if (typeof p === 'string'){
-        if(p[0] !== '#'){
-          p='#'+p;
-        }
-      }else if (typeof p === 'object'){
-        p='#'+p.elt.id;
+    var container = document;
+    if (typeof p === 'string'){
+      if(p[0] !== '#'){
+        container = document.getElementById(p);
+      }else {
+        p = p.slice(1);
+        container = document.getElementById(p);
       }
-      res = document.querySelector(p+" > "+e);
-      if(res){
-        return wrapElement(res); 
+    }else if (typeof p === 'object'){
+      container = document.getElementById(p.elt.id);
+    }
+    if (e[0] === '.'){
+      str = e.slice(1);
+      res = container.getElementsByClassName(str);
+      console.log(res);
+      if (res.length) {
+        return wrapElement(res[0]);
+      }else {
+        return null;
+      }
+    }else if (e[0] === '#'){
+      str = e.slice(1);
+      res = container.getElementById(str);
+      if (res) {
+        return wrapElement(res);
       }else {
         return null;
       }
     }else {
-      if (e[0] === '.'){
-        str = e.slice(1);
-        res = document.getElementsByClassName(str);
-        if (res.length) {
-          return wrapElement(res[0]);
-        }else {
-          return null;
-        }
-      }else if (e[0] === '#'){
-        str = e.slice(1);
-        res = document.getElementById(str);
-        if (res) {
-          return wrapElement(res);
-        }else {
-          return null;
-        }
+      res = container.getElementsByTagName(e);
+      if (res.length) {
+        return wrapElement(res[0]);
       }else {
-        res = document.getElementsByTagName(e);
-        if (res.length) {
-          return wrapElement(res[0]);
-        }else {
-          return null;
-        }
+        return null;
       }
     }
   };
@@ -132,22 +128,22 @@
     var arr = [];
     var res;
     var str;
-    if(typeof p !== 'undefined'){
-      if (typeof p === 'string'){
-        if(p[0] !== '#'){
-          p='#'+p;
-        }
-      }else if (typeof p === 'object'){
-        p='#'+p.elt.id;
-      }
-      res = document.querySelectorAll(p+" > "+e);
-    }else {
-      if (e[0] === '.'){
-        str = e.slice(1);
-        res = document.getElementsByClassName(str);
+    var container = document;
+    if (typeof p === 'string'){
+      if(p[0] !== '#'){
+        container = document.getElementById(p);
       }else {
-        res = document.getElementsByTagName(e);
-      } 
+        p = p.slice(1);
+        container = document.getElementById(p);
+      }
+    }else if (typeof p === 'object'){
+      container = document.getElementById(p.elt.id);
+    }
+    if (e[0] === '.'){
+      str = e.slice(1);
+      res = container.getElementsByClassName(str);
+    }else {
+      res = container.getElementsByTagName(e);
     }
     if (res) {
       for (var j = 0; j < res.length; j++) {

--- a/lib/addons/p5.dom.js
+++ b/lib/addons/p5.dom.js
@@ -63,14 +63,16 @@
     var str;
     var container = document;
     if (typeof p === 'string'){
-      if(p[0] !== '#'){
-        container = document.getElementById(p);
-      }else {
+      if(p[0] === '#'){
         p = p.slice(1);
-        container = document.getElementById(p);
       }
-    }else if (typeof p === 'object'){
-      container = document.getElementById(p.elt.id);
+      container = document.getElementById(p);
+      if(!container)
+        container = document;
+    }else if (p instanceof p5.Element){
+      container = p.elt;
+    }else if (p instanceof HTMLElement){
+      container = p;
     }
     if (e[0] === '.'){
       str = e.slice(1);
@@ -129,14 +131,16 @@
     var str;
     var container = document;
     if (typeof p === 'string'){
-      if(p[0] !== '#'){
-        container = document.getElementById(p);
-      }else {
+      if(p[0] === '#'){
         p = p.slice(1);
-        container = document.getElementById(p);
       }
-    }else if (typeof p === 'object'){
-      container = document.getElementById(p.elt.id);
+      container = document.getElementById(p);
+      if(!container)
+        container = document;
+    }else if (p instanceof p5.Element){
+      container = p.elt;
+    }else if (p instanceof HTMLElement){
+      container = p;
     }
     if (e[0] === '.'){
       str = e.slice(1);

--- a/lib/addons/p5.dom.js
+++ b/lib/addons/p5.dom.js
@@ -58,10 +58,25 @@
    * </code></div>
    *
    */
-  p5.prototype.select = function (e) {
+  p5.prototype.select = function (e, p) {
     var res;
     var str;
-    if (e[0] === '.'){
+    if (typeof p !== 'undefined'){
+      if (typeof p === 'string'){
+        if(p[0] !== '#'){
+          p='#'+p;
+        }
+      }else if (typeof p === 'object'){
+        p='#'+p.elt.id;
+      }
+      res = document.querySelector(p+" > "+e);
+      if(res){
+        return wrapElement(res); 
+      }else {
+        return null;
+      }
+    }else {
+      (e[0] === '.'){
       str = e.slice(1);
       res = document.getElementsByClassName(str);
       if (res.length) {
@@ -77,7 +92,7 @@
       }else {
         return null;
       }
-    }else{
+    }else {
       res = document.getElementsByTagName(e);
       if (res.length) {
         return wrapElement(res[0]);
@@ -85,6 +100,7 @@
         return null;
       }
     }
+  }
   };
 
   /**
@@ -112,17 +128,10 @@
    * </code></div>
    *
    */
-  p5.prototype.selectAll = function (e) {
+  p5.prototype.selectAll = function (e, p) {
     var arr = [];
     var res;
     var str;
-<<<<<<< HEAD
-    if (e[0] === '.'){
-      str = e.slice(1);
-      res = document.getElementsByClassName(str);
-    }else {
-      res = document.getElementsByTagName(e);
-=======
     if(typeof p !== 'undefined'){
       if (typeof p === 'string'){
         if(p[0] !== '#'){
@@ -139,7 +148,6 @@
       }else {
         res = document.getElementsByTagName(e);
       } 
->>>>>>> Whitespace and styling update
     }
     if (res) {
       for (var j = 0; j < res.length; j++) {

--- a/lib/addons/p5.dom.js
+++ b/lib/addons/p5.dom.js
@@ -116,11 +116,30 @@
     var arr = [];
     var res;
     var str;
+<<<<<<< HEAD
     if (e[0] === '.'){
       str = e.slice(1);
       res = document.getElementsByClassName(str);
     }else {
       res = document.getElementsByTagName(e);
+=======
+    if(typeof p !== 'undefined'){
+      if (typeof p === 'string'){
+        if(p[0] !== '#'){
+          p='#'+p;
+        }
+      }else if (typeof p === 'object'){
+        p='#'+p.elt.id;
+      }
+      res = document.querySelectorAll(p+" > "+e);
+    }else {
+      if (e[0] === '.'){
+        str = e.slice(1);
+        res = document.getElementsByClassName(str);
+      }else {
+        res = document.getElementsByTagName(e);
+      } 
+>>>>>>> Whitespace and styling update
     }
     if (res) {
       for (var j = 0; j < res.length; j++) {

--- a/lib/addons/p5.dom.js
+++ b/lib/addons/p5.dom.js
@@ -76,31 +76,31 @@
         return null;
       }
     }else {
-      (e[0] === '.'){
-      str = e.slice(1);
-      res = document.getElementsByClassName(str);
-      if (res.length) {
-        return wrapElement(res[0]);
+      if (e[0] === '.'){
+        str = e.slice(1);
+        res = document.getElementsByClassName(str);
+        if (res.length) {
+          return wrapElement(res[0]);
+        }else {
+          return null;
+        }
+      }else if (e[0] === '#'){
+        str = e.slice(1);
+        res = document.getElementById(str);
+        if (res) {
+          return wrapElement(res);
+        }else {
+          return null;
+        }
       }else {
-        return null;
-      }
-    }else if (e[0] === '#'){
-      str = e.slice(1);
-      res = document.getElementById(str);
-      if (res) {
-        return wrapElement(res);
-      }else {
-        return null;
-      }
-    }else {
-      res = document.getElementsByTagName(e);
-      if (res.length) {
-        return wrapElement(res[0]);
-      }else {
-        return null;
+        res = document.getElementsByTagName(e);
+        if (res.length) {
+          return wrapElement(res[0]);
+        }else {
+          return null;
+        }
       }
     }
-  }
   };
 
   /**

--- a/lib/addons/p5.dom.js
+++ b/lib/addons/p5.dom.js
@@ -75,7 +75,6 @@
     if (e[0] === '.'){
       str = e.slice(1);
       res = container.getElementsByClassName(str);
-      console.log(res);
       if (res.length) {
         return wrapElement(res[0]);
       }else {


### PR DESCRIPTION
select() and select all() are now able to accept two arguments solving #944. The second argument will denote the parent element inside which the search has to be performed. I haven't replaced `document.getElementById()` , `document.getElementsByClass()` ,`document.getElementsByTagName()`  for cases when only one argument is provided for performance and I have only used the `querySelector()`, and `querySelectorAll()` when two arguments are provided for `select()` and `selectAll()` respectively. Also the second argument works when it denotes the id of an element.