### PR TITLE
Fix frameRate() example

### DIFF
--- a/src/core/environment.js
+++ b/src/core/environment.js
@@ -181,11 +181,12 @@ p5.prototype.cursor = function(type, x, y) {
  * <div><code>
  * var rectX = 0;
  * var fr = 30; //starting FPS
- * var clr = color(255,0,0);
+ * var clr;
  *
  * function setup() {
  *   background(200);
  *   frameRate(fr); // Attempt to refresh at starting FPS
+ *   clr = color(255,0,0);
  * }
  *
  * function draw() {


### PR DESCRIPTION
This fixes the `frameRate()` example mentioned in https://github.com/processing/p5.js-website/issues/196. I think.

If this is the "proper" fix, I'm not actually sure it's all that intuitive--I mean, I could easily see myself calling `color()` at my top-level code, and a thrown error like `TypeError: a._renderer is undefined` wouldn't really help me debug it--I wonder if there's a way the friendly error system could throw a less cryptic message?