### PR TITLE
Add fault tolerance for failed examples

### DIFF
--- a/docs/js/render.js
+++ b/docs/js/render.js
@@ -188,15 +188,22 @@ function renderCode(sel) {
 
     $( document ).ready(function() {
       setTimeout(function() {
-        var myp5 = new _p5(s, cnv);      
-        $( ".example-content" ).find('div').each(function() {
-          $this = $( this );
-          var pre = $this.find('pre')[0];
-          if (pre) {
-            $this.height( Math.max($(pre).height()*1.1, 100) + 20 );
-          }
-        });
-        instances[i] = myp5;
+        var myp5;
+        try {
+          myp5 = new _p5(s, cnv);
+        } finally {
+          // If the example code threw an exception, we still want to
+          // set the size of .example-content so it doesn't overflow
+          // into our description and make the documentation unreadable.
+          $( ".example-content" ).find('div').each(function() {
+            $this = $( this );
+            var pre = $this.find('pre')[0];
+            if (pre) {
+              $this.height( Math.max($(pre).height()*1.1, 100) + 20 );
+            }
+          });
+          instances[i] = myp5;
+        }
       }, 100); 
     });
 


### PR DESCRIPTION
This adds a bit of fault tolerance to the example renderer in the reference docs so that even if the example contains errors, it doesn't make the rest of the reference documentation unreadable like the screenshot from https://github.com/processing/p5.js-website/issues/188.

I'm not really sure how much I like the particular way I've fixed this, though. Any feedback is appreciated.

Oh, also, I noticed that this `render.js` file is very similar to the one on the p5.js-website repo? Should I port this fix over to that repo to close out https://github.com/processing/p5.js-website/issues/196?