### PR TITLE
Fixed incorrectly refreshed p5.Element size

### DIFF
--- a/src/core/p5.Element.js
+++ b/src/core/p5.Element.js
@@ -95,6 +95,8 @@ p5.Element.prototype.parent = function(p) {
  */
 p5.Element.prototype.id = function(id) {
   this.elt.id = id;
+  this.width = this.elt.offsetWidth;
+  this.height = this.elt.offsetHeight;
   return this;
 };
 
@@ -108,6 +110,8 @@ p5.Element.prototype.id = function(id) {
  */
 p5.Element.prototype.class = function(c) {
   this.elt.className = c;
+  this.width = this.elt.offsetWidth;
+  this.height = this.elt.offsetHeight;
   return this;
 };
 


### PR DESCRIPTION
This will make sure that `p5.Element' size properties will be refreshed if a CSS styles changes the size of the DOM element.

This code is also duplicated in `p5.Element` constructor. This object is still quite small so it easy to keep track of but I was wondering if refactoring the size update in a function would be beneficial here.