### PR TITLE
Add preliminary Sauce Labs integration.

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -271,7 +271,7 @@ module.exports = function(grunt) {
     'saucelabs-mocha': {
       all: {
         options: {
-          urls: ["http://127.0.0.1:9001/test/test.html"],
+          urls: ['http://127.0.0.1:9001/test/test.html'],
           tunnelTimeout: 5,
           build: process.env.TRAVIS_JOB_ID,
           concurrency: 3,
@@ -280,8 +280,8 @@ module.exports = function(grunt) {
             {browserName: 'firefox', platform: 'Linux', version: '42.0'},
             {browserName: 'safari'},
           ],
-          testname: "p5.js mocha tests",
-          tags: ["master"]
+          testname: 'p5.js mocha tests',
+          tags: ['master']
         }
       }
     }

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -267,6 +267,23 @@ module.exports = function(grunt) {
           }
         }
       }
+    },
+    'saucelabs-mocha': {
+      all: {
+        options: {
+          urls: ["http://127.0.0.1:9001/test/test.html"],
+          tunnelTimeout: 5,
+          build: process.env.TRAVIS_JOB_ID,
+          concurrency: 3,
+          browsers: [
+            {browserName: 'chrome'},
+            {browserName: 'firefox', platform: 'Linux', version: '42.0'},
+            {browserName: 'safari'},
+          ],
+          testname: "p5.js mocha tests",
+          tags: ["master"]
+        }
+      }
     }
   });
 
@@ -285,6 +302,7 @@ module.exports = function(grunt) {
   grunt.loadNpmTasks('grunt-contrib-connect');
   grunt.loadNpmTasks('grunt-newer');
   grunt.loadNpmTasks('grunt-release-it');
+  grunt.loadNpmTasks('grunt-saucelabs');
 
   // Create the multitasks.
   // TODO: "requirejs" is in here to run the "yuidoc_themes" subtask. Is this needed?
@@ -293,4 +311,5 @@ module.exports = function(grunt) {
   grunt.registerTask('test:nobuild', ['jshint:test', 'jscs:test', 'connect', 'mocha']);
   grunt.registerTask('yui', ['yuidoc']);
   grunt.registerTask('default', ['test']);
+  grunt.registerTask('saucetest', ['connect', 'saucelabs-mocha']);
 };

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "grunt-contrib-uglify": "^0.7.0",
     "grunt-contrib-watch": "~0.5.3",
     "grunt-contrib-yuidoc": "0.5.2",
+    "grunt-saucelabs": "8.6.1",
     "grunt-jscs": "^1.8.0",
     "grunt-lib-phantomjs": "~0.4.0",
     "grunt-mocha": "~0.4.6",

--- a/test/test.html
+++ b/test/test.html
@@ -66,7 +66,37 @@
     // Can alternatively do a check on window.PHANTOMJS
     if (navigator.userAgent.indexOf('PhantomJS') < 0) {
       window.addEventListener('load', function() {
-        mocha.run();
+        var runner = mocha.run();
+
+        // This exposes our test results to Sauce Labs. For more
+        // details, see: https://github.com/axemclion/grunt-saucelabs.
+
+        var failedTests = [];
+        runner.on('end', function(){
+          window.mochaResults = runner.stats;
+          window.mochaResults.reports = failedTests;
+        });
+
+        runner.on('fail', logFailure);
+
+        function logFailure(test, err) {
+          var flattenTitles = function(test){
+            var titles = [];
+            while (test.parent.title){
+              titles.push(test.parent.title);
+              test = test.parent;
+            }
+            return titles.reverse();
+          };
+
+          failedTests.push({
+            name: test.title,
+            result: false,
+            message: err.message,
+            stack: err.stack,
+            titles: flattenTitles(test)
+          });
+        }
       }, false);
     }
   </script>


### PR DESCRIPTION
This helps with #1101 by adding a `grunt saucetest` task that runs the mocha tests on Chrome, Firefox, and Safari via the [grunt-saucelabs](https://github.com/axemclion/grunt-saucelabs) package:

![2015-11-15_8-35-00](https://cloud.githubusercontent.com/assets/124687/11168963/c57b5470-8b73-11e5-93b1-124bed23681b.png)

To run `grunt saucetest` yourself, you'll need to:

1. Sign up for an account at [saucelabs.com](http://saucelabs.com/).
2. Set `SAUCE_USERNAME` and `SAUCE_ACCESS_KEY` in your environment (visit the [onboarding page](https://saucelabs.com/docs/onboarding) and click the NodeJS logo for a quick copy-paste snippet).
3. If you haven't already, run `npm install` to install grunt-saucelabs, and run `grunt` to generate the p5 library.
4. Run `grunt saucetest`. You can see the status of your running tests, including live screencasts, at your [Sauce Labs Account Home](https://saucelabs.com/account).

Notes:
* Right now we're only running the **unminified** tests. To run the minified tests too, we should probably factor out the common test-running code in `test.html` and `test-minified.html` to a separate `run-tests.js` (or something similar) to stay [DRY](https://en.wikipedia.org/wiki/Don't_repeat_yourself).
* I'm not sure if we want `grunt saucetest` to also build p5.js or not. Currently, the job assumes that it's already been built, and just starts up the connect server and points Sauce Labs at it.

I think that's about it. Once this PR looks good we can proceed with [Sauce Labs Travis CI Integration](https://docs.saucelabs.com/ci-integrations/travis-ci/)!
