### PR TITLE
add p5.MediaElement.src property in p5.dom

### DIFF
--- a/lib/addons/p5.dom.js
+++ b/lib/addons/p5.dom.js
@@ -1,4 +1,4 @@
-/*! p5.dom.js v0.2.6 November 10, 2015 */
+/*! p5.dom.js v0.2.6 November 16, 2015 */
 /**
  * <p>The web is much more than just canvas and p5.dom makes it easy to interact
  * with other HTML5 objects, including text, hyperlink, image, input, video,
@@ -743,6 +743,9 @@
 
   function createMedia(pInst, type, src, callback) {
     var elt = document.createElement(type);
+
+    // allow src to be empty
+    var src = src || '';
     if (typeof src === 'string') {
       src = [src];
     }
@@ -1520,6 +1523,18 @@
     this._cues = [];
     this._pixelDensity = 1;
 
+    /**
+     *  Path to the media element source.
+     *
+     *  @property src
+     *  @return {String} src
+     */
+    var self = this;
+    Object.defineProperty(self, 'src', {
+      get: function() { return self.elt.src; },
+      set: function(newValue) { self.elt.src = newValue; },
+    });
+
   };
   p5.MediaElement.prototype = Object.create(p5.Element.prototype);
 
@@ -1774,7 +1789,6 @@
   p5.MediaElement.prototype.hideControls = function() {
     this.elt.controls = false;
   };
-
 
   /*** SCHEDULE EVENTS ***/
 

--- a/test/manual-test-examples/addons/p5.dom/audioEltSpotify/index.html
+++ b/test/manual-test-examples/addons/p5.dom/audioEltSpotify/index.html
@@ -1,0 +1,11 @@
+<head>
+  <script language="javascript" type="text/javascript" src="../../../../../lib/p5.js"></script>
+  <script language="javascript" type="text/javascript" src="../../../../../lib/addons/p5.dom.js"></script>
+  <script language="javascript" type="text/javascript" src="sketch.js"></script>        
+  <style>
+  </style>
+
+</head>
+
+<body>
+</body>

--- a/test/manual-test-examples/addons/p5.dom/audioEltSpotify/sketch.js
+++ b/test/manual-test-examples/addons/p5.dom/audioEltSpotify/sketch.js
@@ -1,0 +1,51 @@
+/**
+ *  Get an array of songs from Spotify API based on a search query.
+ *  
+ *  Then, pick a random song, and change the src of an audio element
+ *  to the "preview_url" of that song.
+ *  
+ *  Note that we only need one audio element, but by changing its src,
+ *  we can use it to play multiple sources.
+ */
+
+var songs = [];
+var searchButton;
+var playButton;
+var queryField;
+var audioPlayer;
+
+function setup() {
+  noCanvas();
+
+  queryField = createInput();
+  queryField.elt.placeholder = 'Enter a search term'
+  searchButton = createButton('Search for songs');
+  searchButton.mousePressed(findSongs);
+
+  playButton = createButton('Play a new song');
+  playButton.mousePressed(playRandomSong);
+  playButton.hide();
+
+  audioPlayer = createAudio();
+}
+
+// callback when search button is pressed.
+function findSongs() {
+  var searchTerm = queryField.value();
+  loadJSON('https://api.spotify.com/v1/search?q=' + searchTerm + '&type=track', gotSongs);
+}
+
+// callback from loadJSON
+function gotSongs(data) {
+  playButton.show();
+  audioPlayer.showControls();
+  songs = data.tracks.items;
+}
+
+// when playButton is pressed, pick a random song and play it
+function playRandomSong() {
+  var i = floor( random(songs.length) );
+  var songPreview = songs[i].preview_url;
+  audioPlayer.src = songPreview;
+  audioPlayer.play();
+}


### PR DESCRIPTION
- add ``src`` as a public property of p5.MediaElement. It just points to the audio/video elt's src
- a p5.MediaElement can be initialized without an src
- add a test / example using a single audio element that toggles src at random from the Spotify API