### PR TITLE
Use YUIDoc theme helpers for local development.

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -226,6 +226,13 @@ module.exports = function(grunt) {
         options: {
           paths: ['src/', 'lib/addons/'],
           themedir: 'docs/yuidoc-p5-theme/',
+
+          // These helpers define URL paths to p5js.org resources
+          // based on the value of the P5_SITE_ROOT environment variable.
+          // Set it to '..' for production and leave it blank or
+          // undefined for development.
+          helpers: ['docs/yuidoc-p5-theme/helpers/helpers.js'],
+
           outdir: 'docs/reference/'
         }
       }

--- a/docs/yuidoc-p5-theme/helpers/helpers.js
+++ b/docs/yuidoc-p5-theme/helpers/helpers.js
@@ -1,0 +1,26 @@
+var config;
+var configHelpers = {};
+
+if (process.env.P5_SITE_ROOT) {
+  config = {
+    p5SiteRoot: process.env.P5_SITE_ROOT,
+    p5Lib: process.env.P5_SITE_ROOT + '/js/p5.min.js',
+    p5SoundLib: process.env.P5_SITE_ROOT + '/js/p5.sound.js',
+    p5DomLib: process.env.P5_SITE_ROOT + '/js/p5.dom.js'
+  };
+} else {
+  config = {
+    p5SiteRoot: 'http://p5js.org',
+    p5Lib: '/lib/p5.js',
+    p5SoundLib: '/lib/addons/p5.sound.js',
+    p5DomLib: '/lib/addons/p5.dom.js'
+  };
+}
+
+Object.keys(config).forEach(function(key) {
+  configHelpers[key] = function() {
+    return config[key];
+  };
+});
+
+module.exports = configHelpers;

--- a/docs/yuidoc-p5-theme/layouts/main.handlebars
+++ b/docs/yuidoc-p5-theme/layouts/main.handlebars
@@ -18,21 +18,21 @@
     <!-- Place favicon.ico and apple-touch-icon.png in the root directory -->
 
     <!-- CSS (order matters): normalize across browsers -->
-    <link rel="stylesheet" href="../css/normalize.css">
+    <link rel="stylesheet" href="{{p5SiteRoot}}/css/normalize.css">
 
     <!-- CSS (order matters): Site styles -->
-    <link rel="stylesheet" href="../css/main.css">
+    <link rel="stylesheet" href="{{p5SiteRoot}}/css/main.css">
 
     <!-- CSS (order matters): code highlighting -->
-    <link rel="stylesheet" href="../css/prism.css">
+    <link rel="stylesheet" href="{{p5SiteRoot}}/css/prism.css">
 
     <!-- modernizer (not leveraged, yet) 
-    <script src="../js/vendor/modernizr-2.6.2.min.js"></script>-->
+    <script src="{{p5SiteRoot}}/js/vendor/modernizr-2.6.2.min.js"></script>-->
 
     <!-- jquery-->
     <script src="//ajax.googleapis.com/ajax/libs/jquery/1.11.0/jquery.min.js"></script>
     <!--<script src="//ajax.googleapis.com/ajax/libs/jquery/1.9.1/jquery.min.js"></script>-->
-    <script>window.jQuery || document.write('../js/vendor/jquery-1.9.1.min.js"><\/script>')</script>
+    <script>window.jQuery || document.write('{{p5SiteRoot}}/js/vendor/jquery-1.9.1.min.js"><\/script>')</script>
 
   </head>
 
@@ -58,8 +58,7 @@
     <div id="container">
     <!-- identity -->
     <div id="lockup">
-      <a href="../">
-        <img type="image/svg+xml" src="../img/p5js-beta.svg" id="logo_image" class="logo"  />
+        <img type="image/svg+xml" src="{{p5SiteRoot}}/img/p5js-beta.svg" id="logo_image" class="logo"  />
         <div id='p5_logo'></div>
       </a>
       <p>Processing intuition times JavaScript power</p>
@@ -69,17 +68,17 @@
     <!-- site navigation -->
     <div class="column-span">
     <ul id="menu">
-      <li><a href="../">Home</a></li>
+      <li><a href="{{p5SiteRoot}}/">Home</a></li>
 
-      <li><a href="../download/">Download</a></li> 
-      <li><a href="../gallery/">Gallery</a></li>
-      <li><a href="../get-started/">Get Started</a></li>
-      <li><a href="../reference/">Reference</a></li>
-      <li><a href="../libraries/">Libraries</a></li>
-      <li><a href="../tutorials/">Tutorials</a></li>
-      <li><a href="../examples/">Examples</a></li>
-      <li><a href="../community/">Community</a></li>
-      <li><a href="../contribute/">Contribute</a></li>
+      <li><a href="{{p5SiteRoot}}/download/">Download</a></li> 
+      <li><a href="{{p5SiteRoot}}/gallery/">Gallery</a></li>
+      <li><a href="{{p5SiteRoot}}/get-started/">Get Started</a></li>
+      <li><a href="{{p5SiteRoot}}/reference/">Reference</a></li>
+      <li><a href="{{p5SiteRoot}}/libraries/">Libraries</a></li>
+      <li><a href="{{p5SiteRoot}}/tutorials/">Tutorials</a></li>
+      <li><a href="{{p5SiteRoot}}/examples/">Examples</a></li>
+      <li><a href="{{p5SiteRoot}}/community/">Community</a></li>
+      <li><a href="{{p5SiteRoot}}/contribute/">Contribute</a></li>
       
       <li><a href="http://forum.processing.org/two/" target=_blank class="other-link">Forum</a></li>
       <li><a href="http://github.com/processing/p5.js" target=_blank class="other-link">Github</a></li>
@@ -120,24 +119,24 @@
 
     <p class="clearfix"> &nbsp; </p>
 
-    <object type="image/svg+xml" data="../img/thick-asterisk-alone.svg" id="asterisk-design-element">
+    <object type="image/svg+xml" data="{{p5SiteRoot}}/img/thick-asterisk-alone.svg" id="asterisk-design-element">
          *<!-- to do: add fallback image in CSS -->
     </object>
 
 
-    <script src="../js/p5.min.js"></script>
-    <script src="../js/p5.sound.js"></script>
-    <script src="../js/p5.dom.js"></script>
-    <script src="../js/render.js"></script>
+    <script src="{{p5Lib}}"></script>
+    <script src="{{p5SoundLib}}"></script>
+    <script src="{{p5DomLib}}"></script>
+    <script src="{{p5SiteRoot}}/js/render.js"></script>
     <!-- prism for code highlighting -->
-    <script src="../js/vendor/prism.js"></script>
+    <script src="{{p5SiteRoot}}/js/vendor/prism.js"></script>
 
-    <script src="../js/main.js"></script>
-    <script src="../js/scroll.js"></script>
+    <script src="{{p5SiteRoot}}/js/main.js"></script>
+    <script src="{{p5SiteRoot}}/js/scroll.js"></script>
 
     <script src="{{projectAssets}}/js/require.min.js"></script>
     <script src="{{projectAssets}}/js/reference.js"></script>
-    <script src="../js/logo.js"></script>
+    <script src="{{p5SiteRoot}}/js/logo.js"></script>
 
 
     <!-- Google Analytics: change UA-XXXXX-X to be your site's ID. 


### PR DESCRIPTION
It seems like 4de4a319abf38400f7d308a91fa0b163e98fb544 removed a bunch of duplicate files that are on [p5.js-website](https://github.com/processing/p5.js-website), which makes the project nice and [DRY](https://en.wikipedia.org/wiki/Don't_repeat_yourself), but this had the downside of making the generated yuidocs in `/docs/reference/` less useful, as the CSS is broken and example sketches don't render.

There's a few potential fixes to this that I can think of:
1. Add a step to `grunt yui` that downloads the required p5.js-website assets to the directories where the yuidoc theme expects them to be.
2. Document a process by which devs can manually check out p5.js-website on their own and copy/symlink the directories themselves.
3. Change the yuidoc theme so it can link directly to assets on p5js.org and the p5 libraries on the local dev server, with an option to link to assets the "old way" if the `P5_SITE_ROOT` environment variable is set to `..`.

This implements option (3), though I'm not sure how much I like it. For instance:
* Due to CORS issues, the fonts can't be loaded, so things still look a little bit broken. (Though this can be fixed if p5js.org adds CORS headers, that might not be preferable.)
* Because the theme links directly to p5js.org, the docs can't be browsed offline.
* It also adds a bit of complexity to the build process that may be a hassle to maintain in the future.

On the plus side, though, the docs now link directly to the fresh p5 libraries that were just built by grunt, which makes the docs and examples easier to test.

All that said, I'm fine with this PR being rejected if one of the alternatives is a better fit.