### PR TITLE
Fix some 3D examples to not hang or 404.

### DIFF
--- a/src/3d/light.js
+++ b/src/3d/light.js
@@ -91,7 +91,7 @@ p5.prototype.ambientLight = function(v1, v2, v3, a){
  *   var dirY = (mouseY / height - 0.5) *(-2);
  *   directionalLight(250, 250, 250, dirX, dirY, 0.25);
  *   ambientMaterial(250);
- *   sphere(200, 128);
+ *   sphere(200);
  * }
  * </code>
  * </div>
@@ -218,7 +218,7 @@ p5.prototype.directionalLight = function(v1, v2, v3, a, x, y, z) {
  *   // -1,-1---------1,-1
  *   pointLight(250, 250, 250, locX, locY, 0);
  *   ambientMaterial(250);
- *   sphere(200, 128);
+ *   sphere(200);
  * }
  * </code>
  * </div>

--- a/src/3d/material.js
+++ b/src/3d/material.js
@@ -44,7 +44,7 @@ p5.prototype.normalMaterial = function(){
  * var img;
  * function setup(){
  *   createCanvas(100, 100, WEBGL);
- *   img = loadImage("assets/cat.jpg");
+ *   img = loadImage("assets/laDefense.jpg");
  * }
  *
  * function draw(){
@@ -214,7 +214,7 @@ p5.prototype.basicMaterial = function(v1, v2, v3, a){
  *  ambientLight(100);
  *  pointLight(250, 250, 250, 100, 100, 0);
  *  ambientMaterial(250);
- *  sphere(200, 128);
+ *  sphere(200);
  * }
  * </code>
  * </div>
@@ -265,7 +265,7 @@ p5.prototype.ambientMaterial = function(v1, v2, v3, a) {
  *  ambientLight(100);
  *  pointLight(250, 250, 250, 100, 100, 0);
  *  specularMaterial(250);
- *  sphere(200, 128);
+ *  sphere(200);
  * }
  * </code>
  * </div>


### PR DESCRIPTION
* A number of 3D examples used `sphere(200, 128)` which took long enough to run on my browser that a "Do you want to stop this script from running" dialog was raised. I removed the second argument and this made everything run fine without a significant change in visual quality (to me, at least).

* The `texture()` example referenced `assets/cat.jpg`, which doesn't seem to exist, so I changed it to the `assets/laDefense.jpg` image that other examples use.