### PR TITLE
Fix loadFont() to not throw an exception on example.

### DIFF
--- a/src/io/files.js
+++ b/src/io/files.js
@@ -125,7 +125,7 @@ p5.prototype.loadFont = function(path, onSuccess, onError) {
     }
     /*jshint multistr: true */
     var exp =/\/[a-zA-Z]*((.ttf)|(.otf)|(.woff)|(.woff2))$/i;
-    if(!exp) {
+    if(!exp.test(path)) {
       return p5Font;
     }
     var i = (exp).exec( path ).index + 1;


### PR DESCRIPTION
I noticed that the [`loadFont()` example](http://p5js.org/reference/#/p5/loadFont) appears to work but the following error is logged to the console:

`TypeError: h.exec(...) is null`

I'm not very familiar with the related code, so this is a naive attempt to fix the problem.