### PR TITLE
Add a p5.js reference test suite

### DIFF
--- a/test/test-reference.html
+++ b/test/test-reference.html
@@ -60,7 +60,7 @@
         }
       });
 
-      it("should load " + url + " without errors", function(done) {
+      it("should load in " + url + " without errors", function(done) {
         var errors = 0;
         iframe.setAttribute("src", url);
         document.body.appendChild(iframe);

--- a/test/test-reference.html
+++ b/test/test-reference.html
@@ -1,0 +1,103 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta http-equiv="Content-type" content="text/html; charset=utf-8">
+  <link rel="stylesheet" href="mocha.css"/>
+  <style>
+  iframe { visibility: hidden; }
+  </style>
+  <title>p5 Reference Documentation Test</title>
+</head>
+<body>
+  <!-- Required for browser reporter -->
+  <div id="mocha"></div>
+
+  <!-- mocha -->
+  <script src="js/mocha.js" type="text/javascript" ></script>
+  <script type="text/javascript" >
+    // This will be overridden by mocha-helper if you run with grunt
+    mocha.setup('tdd');
+    mocha.reporter('html');
+  </script>
+
+  <!-- Include your assertion lib of choice -->
+  <script src="js/chai.js" type="text/javascript" ></script>
+  <script src="js/bind.js" type="text/javascript" ></script>
+  <script src="js/sinon.js" type="text/javascript" ></script>
+  <script src="js/testRender.js" type="text/javascript" ></script>
+  <script type="text/javascript" >
+    // Setup chai
+    var expect = chai.expect;
+    var assert = chai.assert;
+  </script>
+
+  <script>
+  var MS_TO_WAIT_AFTER_LOAD = 500;
+  var MS_TIMEOUT = 4500 + MS_TO_WAIT_AFTER_LOAD;
+  var MS_SLOW = 1000 + MS_TO_WAIT_AFTER_LOAD;
+
+  function absoluteURL(url) {
+    var a = document.createElement('a');
+    a.setAttribute('href', url);
+    return a.href;
+  }
+
+  function defineTest(info) {
+    describe(info.name + " example code @ " + info.file, function() {
+      var iframe;
+      var url = absoluteURL("../docs/reference/#/p5/" + info.name);
+
+      this.timeout(MS_TIMEOUT);
+      this.slow(MS_SLOW);
+
+      before(function() {
+        iframe = document.createElement("iframe");
+      });
+
+      after(function() {
+        if (iframe.parentNode) {
+          iframe.parentNode.removeChild(iframe);
+        }
+      });
+
+      it("should load " + url + " without errors", function(done) {
+        var errors = 0;
+        iframe.setAttribute("src", url);
+        document.body.appendChild(iframe);
+        iframe.contentWindow.addEventListener("error", function(e) {
+          errors++;
+        }, true);
+        iframe.contentWindow.addEventListener("load", function() {
+          var startTime = Date.now();
+          setTimeout(function() {
+            if (errors)
+              return done(new Error(errors + " error(s) logged"))
+            if (Date.now() - startTime > MS_TIMEOUT)
+              // This can happen if the page contained processor-intensive
+              // code that blocked the UI for too long.
+              return done(new Error("code took too long to execute"));
+            done();
+          }, MS_TO_WAIT_AFTER_LOAD);
+        });
+      });
+    });
+  }
+
+  var req = new XMLHttpRequest();
+  req.open('GET', '../docs/reference/data.json');
+  req.onload = function() {
+    var data = JSON.parse(req.responseText);
+    data.classitems.forEach(function(info) {
+      if (!info.example) return;
+      info.example = info.example.filter(function(code) {
+        return code.indexOf('norender') == -1;
+      });
+      if (info.name && info.example.length)
+        defineTest(info);
+    });
+    mocha.run();
+  };
+  req.send(null);
+  </script>
+</body>
+</html>

--- a/test/test-reference.html
+++ b/test/test-reference.html
@@ -31,73 +31,141 @@
     var assert = chai.assert;
   </script>
 
-  <script>
-  var MS_TO_WAIT_AFTER_LOAD = 500;
-  var MS_TIMEOUT = 4500 + MS_TO_WAIT_AFTER_LOAD;
-  var MS_SLOW = 1000 + MS_TO_WAIT_AFTER_LOAD;
+  <!-- Include anything you want to test -->
+  <script src="../lib/p5.js" type="text/javascript" ></script>
+  <script src="../lib/addons/p5.dom.js" type="text/javascript" ></script>
+  <script src="../lib/addons/p5.sound.js" type="text/javascript" ></script>
 
-  function absoluteURL(url) {
-    var a = document.createElement('a');
-    a.setAttribute('href', url);
-    return a.href;
+  <script>
+  var MS_TIMEOUT = 2000;
+
+  // TODO: This code has basically been harvested from
+  // https://github.com/processing/p5.js-website/blob/master/js/render.js.
+  // Ideally we should factor out this common code into a shared place
+  // where we're not duplicating code.
+  function createExampleSketch(exampleCode, cb) {
+    var runnable = exampleCode.replace(/^\s+|\s+$/g, '');
+
+    return function( p ) {
+      if (runnable.indexOf('setup()') === -1 &&
+          runnable.indexOf('draw()') === -1){
+        p.setup = function() {
+          p.createCanvas(100, 100);
+          p.background(200);
+          with (p) {
+            eval(runnable);
+          }
+        }
+      } else {
+        with (p) {
+          eval(runnable);
+        }
+
+        var fxns = [
+          'setup', 'draw', 'preload', 'mousePressed', 'mouseReleased', 
+          'mouseMoved', 'mouseDragged', 'mouseClicked', 'mouseWheel', 
+          'touchStarted', 'touchMoved', 'touchEnded', 
+          'keyPressed', 'keyReleased', 'keyTyped'
+        ];
+        fxns.forEach(function(f) { 
+          var ind = runnable.indexOf(f+'(');
+          // this is a gross hack within a hacky script that
+          // ensures the function names found are not substrings
+          // proper use of regex would be preferable...
+          if (ind !== -1 && runnable[ind+f.length] === '(' &&
+              eval('typeof ' + f) !== 'undefined') {
+            with (p) {
+              p[f] = eval(f);
+            }
+          }
+        });
+        if (typeof p.setup === 'undefined') {
+          p.setup = function() {
+            p.createCanvas(100, 100);
+            p.background(200);
+          }
+        }
+      }
+
+      if (cb) {
+        cb(p);
+      }
+    };
   }
 
   function defineTest(info) {
-    describe(info.name + " example code @ " + info.file, function() {
-      var iframe;
-      var url = absoluteURL("../docs/reference/#/p5/" + info.name);
+    suite(info.name + " documentation @ " + info.file, function() {
+      var myp5, myp5Div;
+      var div = document.createElement('div');
+      var examples;
 
-      this.timeout(MS_TIMEOUT);
-      this.slow(MS_SLOW);
-
-      before(function() {
-        iframe = document.createElement("iframe");
+      beforeEach(function() {
+        myp5 = null;
+        myp5Div = null;
       });
 
-      after(function() {
-        if (iframe.parentNode) {
-          iframe.parentNode.removeChild(iframe);
+      afterEach(function() {
+        if (myp5) {
+          myp5.remove();
+        }
+        if (myp5Div && myp5Div.parentNode) {
+          myp5Div.parentNode.removeChild(myp5Div);
         }
       });
 
-      it("should load in " + url + " without errors", function(done) {
-        var errors = 0;
-        iframe.setAttribute("src", url);
-        document.body.appendChild(iframe);
-        iframe.contentWindow.addEventListener("error", function(e) {
-          errors++;
-        }, true);
-        iframe.contentWindow.addEventListener("load", function() {
+      div.style.display = 'none';
+      div.innerHTML = info.example.join('');
+      document.body.appendChild(div);
+      examples = [].slice.call(div.querySelectorAll('div:not(.norender)'));
+
+      examples.forEach(function(el, i) {
+        var exampleCode = el.textContent
+          .replace(/assets\//g, '../docs/reference/assets/');
+
+        test("example #" + (i + 1) + " works", function(done) {
           var startTime = Date.now();
-          setTimeout(function() {
-            if (errors)
-              return done(new Error(errors + " error(s) logged"))
-            if (Date.now() - startTime > MS_TIMEOUT)
-              // This can happen if the page contained processor-intensive
-              // code that blocked the UI for too long.
-              return done(new Error("code took too long to execute"));
-            done();
-          }, MS_TO_WAIT_AFTER_LOAD);
+
+          this.timeout(MS_TIMEOUT);
+          myp5Div = document.createElement('div');
+          document.body.appendChild(myp5Div);
+
+          myp5 = new p5(createExampleSketch(exampleCode, function(p) {
+            var drawCalled = false;
+            var oldDraw = p.draw || function() {};
+
+            p.draw = function() {
+              oldDraw.call(p);
+              if (drawCalled) return;
+              drawCalled = true;
+
+              if (Date.now() - startTime > MS_TIMEOUT) {
+                // This can happen if the page contained processor-intensive
+                // code that blocked the UI for too long.
+                return done(new Error("code took too long to execute"));
+              }
+
+              done();
+            };
+          }), myp5Div);
         });
       });
     });
   }
 
-  var req = new XMLHttpRequest();
-  req.open('GET', '../docs/reference/data.json');
-  req.onload = function() {
-    var data = JSON.parse(req.responseText);
-    data.classitems.forEach(function(info) {
-      if (!info.example) return;
-      info.example = info.example.filter(function(code) {
-        return code.indexOf('norender') == -1;
+  onload = function() {
+    var req = new XMLHttpRequest();
+    req.open('GET', '../docs/reference/data.json');
+    req.onload = function() {
+      var data = JSON.parse(req.responseText);
+      data.classitems.forEach(function(info) {
+        if (!info.example) return;
+        if (info.name && info.example.length)
+          defineTest(info);
       });
-      if (info.name && info.example.length)
-        defineTest(info);
-    });
-    mocha.run();
+      mocha.run();
+    };
+    req.send(null);
   };
-  req.send(null);
   </script>
 </body>
 </html>


### PR DESCRIPTION
This is the page I used to find #1132 and #1133, so I thought it might be useful in the future to easily find any major bugs in example code.

It's a bit of a brute-force approach to testing the reference examples, though, as it just loads the relevant page in an iframe and waits half a second to make sure no errors were thrown. It doesn't catch 404s on images, though, and there's probably lots of other kinds of errors it doesn't catch.

It would be nice to run this as part of the normal test suite, but because it's so slow, I'm afraid that would just dissuade folks from running tests entirely. Maybe run it as part of travis jobs only? Or I could look into making it a lot more efficient by not running stuff in an iframe, and just leveraging [`render.js`'s `renderCode()`](https://github.com/processing/p5.js-website/blob/master/js/render.js) directly.