### PR TITLE
Use hypot function to calculate distance between points

### DIFF
--- a/src/math/calculation.js
+++ b/src/math/calculation.js
@@ -148,11 +148,22 @@ p5.prototype.constrain = function(n, low, high) {
  * </code></div>
  */
 p5.prototype.dist = function(x1, y1, z1, x2, y2, z2) {
+  // Calculate the length of the hypotenuse of a right triangle
+  // This won't under- or overflow in intermediate steps
+  // https://en.wikipedia.org/wiki/Hypot
+  var hypot = function(x, y) {
+    x = Math.abs(x);
+    y = Math.abs(y);
+    var t = Math.min(x, y);
+    x = Math.max(x, y);
+    t /= x;
+    return x*Math.sqrt(1+t*t);
+  };
   if (arguments.length === 4) {
     // In the case of 2d: z1 means x2 and x2 means y2
-    return Math.sqrt( (z1-x1)*(z1-x1) + (x2-y1)*(x2-y1) );
+    return hypot(z1-x1, x2-y1);
   } else if (arguments.length === 6) {
-    return Math.sqrt( (x2-x1)*(x2-x1) + (y2-y1)*(y2-y1) + (z2-z1)*(z2-z1) );
+    return hypot(x2-x1, hypot(y2-y1, z2-z1));
   }
 };
 

--- a/src/math/calculation.js
+++ b/src/math/calculation.js
@@ -152,6 +152,9 @@ p5.prototype.dist = function(x1, y1, z1, x2, y2, z2) {
   // This won't under- or overflow in intermediate steps
   // https://en.wikipedia.org/wiki/Hypot
   var hypot = function(x, y) {
+    if (x === 0 && y === 0) {
+      return 0;
+    }
     x = Math.abs(x);
     y = Math.abs(y);
     var t = Math.min(x, y);

--- a/test/unit/math/calculation.js
+++ b/test/unit/math/calculation.js
@@ -57,19 +57,27 @@ suite('Calculation', function() {
       });
       test('should return correct distance', function() {
         result = dist(0, 0, 2, 3);
-        assert.equal(result, Math.sqrt(13));
+        assert.equal(result, 3.6055512754639896); // Math.hypot(13)
       });
       test('should return positive  distance', function() {
         result = dist(0, 0, -2, -3);
-        assert.equal(result, Math.sqrt(13));
+        assert.equal(result, 3.6055512754639896); // Math.hypot(13)
       });
       test('should return correct distance', function() {
         result = dist(0, 0, 0, 2, 3, 5);
-        assert.equal(result, Math.sqrt(38));
+        assert.equal(result, 6.164414002968976); // Math.hypot(2, Math.hypot(3, 5))
       });
       test('should return positive  distance', function() {
         result = dist(0, 0, 0, -2, -3, 5);
-        assert.equal(result, Math.sqrt(38));
+        assert.equal(result, 6.164414002968976); // Math.hypot(2, Math.hypot(3, 5))
+      });
+      test('should not underflow', function() {
+        result = dist(0, 0, 1e-200, 2e-200);
+        assert.notEqual(result, 0);
+      });
+      test('should not overflow', function() {
+        result = dist(0, 0, 1e200, 2e200);
+        assert.notEqual(result, Infinity);
       });
     });
   });

--- a/test/unit/math/calculation.js
+++ b/test/unit/math/calculation.js
@@ -57,11 +57,11 @@ suite('Calculation', function() {
       });
       test('should return correct distance', function() {
         result = dist(0, 0, 2, 3);
-        assert.equal(result, 3.6055512754639896); // Math.hypot(13)
+        assert.equal(result, 3.6055512754639896); // Math.hypot(2, 3)
       });
       test('should return positive  distance', function() {
         result = dist(0, 0, -2, -3);
-        assert.equal(result, 3.6055512754639896); // Math.hypot(13)
+        assert.equal(result, 3.6055512754639896); // Math.hypot(2, 3)
       });
       test('should return correct distance', function() {
         result = dist(0, 0, 0, 2, 3, 5);

--- a/test/unit/math/calculation.js
+++ b/test/unit/math/calculation.js
@@ -79,6 +79,14 @@ suite('Calculation', function() {
         result = dist(0, 0, 1e200, 2e200);
         assert.notEqual(result, Infinity);
       });
+      test('should return 0 for identical 2D points', function() {
+        result = dist(2, 3, 2, 3);
+        assert.equal(result, 0);
+      });
+      test('should return 0 for identical 3D points', function() {
+        result = dist(2, 3, 5, 2, 3, 5);
+        assert.equal(result, 0);
+      });
     });
   });
 

--- a/test/unit/math/calculation.js
+++ b/test/unit/math/calculation.js
@@ -65,11 +65,11 @@ suite('Calculation', function() {
       });
       test('should return correct distance', function() {
         result = dist(0, 0, 0, 2, 3, 5);
-        assert.equal(result, 6.164414002968976); // Math.hypot(2, Math.hypot(3, 5))
+        assert.equal(result, 6.164414002968977); // Math.hypot(2, 3, 5)
       });
       test('should return positive  distance', function() {
         result = dist(0, 0, 0, -2, -3, 5);
-        assert.equal(result, 6.164414002968976); // Math.hypot(2, Math.hypot(3, 5))
+        assert.equal(result, 6.164414002968977); // Math.hypot(2, 3, 5)
       });
       test('should not underflow', function() {
         result = dist(0, 0, 1e-200, 2e-200);
@@ -196,11 +196,11 @@ suite('Calculation', function() {
       });
       test('should return correct magitude', function() {
         result = mag(2, 3);
-        assert.equal(result, Math.sqrt(13));
+        assert.equal(result, 3.6055512754639896); // Math.hypot(2, 3)
       });
       test('should return positive magnitude given negative inputs', function() {
         result = mag(-2, -3);
-        assert.equal(result, Math.sqrt(13));
+        assert.equal(result, 3.6055512754639896); // Math.hypot(2, 3)
       });
     });
   });


### PR DESCRIPTION
The current `dist` function fails if the distance between two points is very small or very large. This change uses the [`hypot` function](https://en.wikipedia.org/wiki/Hypot) internally to avoid under- or overflow problems. `Math.hypot` [is in ES6](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Math/hypot), but until it's fully implemented this should behave better.

Also adds two tests: one to check for underflow, one for overflow. The current `dist` fails both.