### PR TITLE
Fix examples for style() and textBounds().

### DIFF
--- a/lib/addons/p5.dom.js
+++ b/lib/addons/p5.dom.js
@@ -1270,7 +1270,7 @@
    * myDiv.style("font-size", "18px");
    * myDiv.style("color", "#ff0000");
    * var col = color(25,23,200,50);
-   * createButton.style("background-color", col);
+   * createButton('button').style("background-color", col);
    * </code></div>
    */
   p5.Element.prototype.style = function(prop, val) {

--- a/src/typography/p5.Font.js
+++ b/src/typography/p5.Font.js
@@ -71,22 +71,23 @@ p5.Font.prototype.list = function() {
  * <div>
  * <code>
  * var font;
- * var text = 'Lorem ipsum dolor sit amet.';
+ * var textString = 'Lorem ipsum dolor sit amet.';
  * function preload() {
- *    font = loadFont('./assets/fonts/Regular.otf');
+ *    font = loadFont('./assets/Regular.otf');
  * };
  * function setup() {
  *    background(210);
-
- *    var bbox = font.textBounds(text, 10, 30, 12);
+ *
+ *    var bbox = font.textBounds(textString, 10, 30, 12);
  *    fill(255);
  *    stroke(0);
  *    rect(bbox.x, bbox.y, bbox.w, bbox.h);
  *    fill(0);
  *    noStroke();
- *     *    textFont(font);
-  *    textSize(12);
- *    text(text, 10, 30);
+ *     
+ *    textFont(font);
+ *    textSize(12);
+ *    text(textString, 10, 30);
  * };
  * </code>
  * </div>

--- a/src/typography/p5.Font.js
+++ b/src/typography/p5.Font.js
@@ -84,7 +84,7 @@ p5.Font.prototype.list = function() {
  *    rect(bbox.x, bbox.y, bbox.w, bbox.h);
  *    fill(0);
  *    noStroke();
- *     
+ *
  *    textFont(font);
  *    textSize(12);
  *    text(textString, 10, 30);


### PR DESCRIPTION
This fixes broken examples for [`style()`](http://p5js.org/reference/#/p5.Element/style) and [`textBounds()`](http://p5js.org/reference/#/p5.Font/textBounds) discovered by https://github.com/processing/p5.js/pull/1134#issuecomment-160300375.