### PR TITLE
Improve reference (documentation) tests

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -147,6 +147,17 @@ module.exports = function(grunt) {
 
     // Set up the mocha task, used for running the automated tests.
     mocha: {
+      yui: {
+        options: {
+          urls: [
+            'http://localhost:9001/test/test-reference.html'
+          ],
+          reporter: reporter,
+          run: false,
+          log: true,
+          logErrors: true
+        }
+      },
       test: {
         options: {
           urls: [
@@ -317,6 +328,7 @@ module.exports = function(grunt) {
   grunt.registerTask('test', ['jshint', 'jscs', 'build', 'connect', 'mocha']);
   grunt.registerTask('test:nobuild', ['jshint:test', 'jscs:test', 'connect', 'mocha']);
   grunt.registerTask('yui', ['yuidoc']);
+  grunt.registerTask('yui:test', ['yuidoc', 'connect', 'mocha:yui']);
   grunt.registerTask('default', ['test']);
   grunt.registerTask('saucetest', ['connect', 'saucelabs-mocha']);
 };

--- a/test/test-reference.html
+++ b/test/test-reference.html
@@ -94,7 +94,7 @@
   }
 
   function defineTest(info) {
-    suite(info.name + " documentation @ " + info.file, function() {
+    suite(info.name + " documentation", function() {
       var myp5, myp5Div;
       var div = document.createElement('div');
       var examples;
@@ -157,11 +157,25 @@
     req.open('GET', '../docs/reference/data.json');
     req.onload = function() {
       var data = JSON.parse(req.responseText);
-      data.classitems.forEach(function(info) {
-        if (!info.example) return;
-        if (info.name && info.example.length)
-          defineTest(info);
+      var files = {};
+
+      data.classitems
+        .concat(Object.keys(data.classes).map(function(name) {
+          return data.classes[name];
+        })).filter(function(info) {
+          return info.name && info.example && info.example.length;
+        }).forEach(function(info) {
+          if (!files[info.file])
+            files[info.file] = [];
+          files[info.file].push(info);
+        });
+
+      Object.keys(files).forEach(function(filename) {
+        suite(filename, function() {
+          files[filename].forEach(defineTest);
+        });
       });
+
       mocha.run();
     };
     req.send(null);

--- a/test/test-reference.html
+++ b/test/test-reference.html
@@ -31,12 +31,38 @@
     var assert = chai.assert;
   </script>
 
+  <script>
+    // Because we load tests asynchronously, we need to manually load
+    // grunt-mocha's bridge.js here.
+    //
+    // For more information, see:
+    // https://github.com/kmiyashiro/grunt-mocha#option-2
+    if (window.PHANTOMJS)
+      document.write(
+        '<script src="' +
+        '../node_modules/grunt-mocha/phantomjs/bridge.js' +
+        '"></' + 'script>'
+      );
+  </script>
+
   <!-- Include anything you want to test -->
+  <script src="js/modernizr.js"></script>
   <script src="../lib/p5.js" type="text/javascript" ></script>
   <script src="../lib/addons/p5.dom.js" type="text/javascript" ></script>
-  <script src="../lib/addons/p5.sound.js" type="text/javascript" ></script>
+  <script>
+    if (Modernizr.webaudio)
+      document.write(
+        '<script src="' +
+        '../lib/addons/p5.sound.js' +
+        '"></' + 'script>'
+      );
+  </script>
 
   <script>
+  var TEST_FILENAME_FILTERS = [
+    {regex: /3d/, condition: Modernizr.webgl},
+    {regex: /sound/, condition: Modernizr.webaudio}
+  ];
   var MS_TIMEOUT = 2000;
 
   // TODO: This code has basically been harvested from
@@ -179,11 +205,16 @@
           files[info.file].push(info);
         });
 
-      Object.keys(files).forEach(function(filename) {
-        suite(filename, function() {
-          files[filename].forEach(defineTest);
+      Object.keys(files)
+        .filter(function excludeIfNoBrowserSupportFor(filename) {
+          return !TEST_FILENAME_FILTERS.some(function(filter) {
+            return filter.regex.test(filename) && !filter.condition;
+          });
+        }).forEach(function(filename) {
+          suite(filename, function() {
+            files[filename].forEach(defineTest);
+          });
         });
-      });
 
       mocha.run();
     };

--- a/test/test-reference.html
+++ b/test/test-reference.html
@@ -122,7 +122,7 @@
         var exampleCode = el.textContent
           .replace(/assets\//g, '../docs/reference/assets/');
 
-        test("example #" + (i + 1) + " works", function(done) {
+        var testFunc = function(done) {
           var startTime = Date.now();
 
           this.timeout(MS_TIMEOUT);
@@ -147,7 +147,16 @@
               done();
             };
           }), myp5Div);
-        });
+        };
+
+        testFunc.toString = function() {
+          // When a user clicks on a specific test, mocha shows its
+          // source code; in our case, we want the source of the example
+          // we're running to be shown, *not* the example runner code.
+          return exampleCode;
+        };
+
+        test("example #" + (i + 1) + " works", testFunc);
       });
     });
   }


### PR DESCRIPTION
This PR adds a few improvements to the reference test suite added in #1134:

* We now run tests for constructor examples, e.g. [`p5.Vector`](http://p5js.org/reference/#/p5.Vector), which we weren't doing before.
* Entire files can be skipped based on browser support via Modernizr detection.
* Tests are organized at the topmost level by filename, which should make it easier to e.g. run all the doctests in a single file.
* Clicking on the name of a test now shows the source code for the actual example code being tested, rather than the source for the test runner e.g.:
  ![2015-11-29_8-19-40](https://cloud.githubusercontent.com/assets/124687/11457271/7883b23e-9672-11e5-8a9c-cd4450b3c494.png)
* Added a `grunt yui:test` task that runs the doctests in PhantomJS. It runs in about 7 seconds on my system!

However, it should be noted that `grunt yui:test` currently fails on 4 tests! And it seems that `yui:test` is being run when `grunt` is run, which means that Travis probably won't like this PR until they're fixed... Ack.