### PR TITLE
add onended callback to p5dom media elements

### DIFF
--- a/lib/addons/p5.dom.js
+++ b/lib/addons/p5.dom.js
@@ -1720,11 +1720,10 @@
     }
   };
   /**
-   *  Schedule an event to be called when the soundfile
-   *  reaches the end of a buffer. If the soundfile is
-   *  playing through once, this will be called when it
-   *  ends. If it is looping, it will be called when
-   *  stop is called.
+   *  Schedule an event to be called when the audio or video
+   *  element reaches the end. If the element is looping,
+   *  this will not be called. The element is passed in
+   *  as the argument to the onended callback.
    *  
    *  @method  onended
    *  @param  {Function} callback function to call when the

--- a/lib/addons/p5.dom.js
+++ b/lib/addons/p5.dom.js
@@ -1521,6 +1521,7 @@
   p5.MediaElement = function(elt, pInst) {
     p5.Element.call(this, elt, pInst);
 
+    var self = this;
 
     this._prevTime = 0;
     this._cueIDCounter = 0;
@@ -1533,12 +1534,29 @@
      *  @property src
      *  @return {String} src
      */
-    var self = this;
     Object.defineProperty(self, 'src', {
-      get: function() { return self.elt.src; },
-      set: function(newValue) { self.elt.src = newValue; },
+      get: function() {
+        var firstChildSrc = self.elt.children[0].src;
+        var srcVal = self.elt.src === window.location.href ? '' : self.elt.src;
+        var ret = firstChildSrc === window.location.href ? srcVal : firstChildSrc;
+        return ret;
+      },
+      set: function(newValue) {
+        for (var i = 0; i < self.elt.children.length; i++) {
+          self.elt.removeChild(self.elt.children[i]);
+        }
+        var source = document.createElement('source');
+        source.src = newValue;
+        elt.appendChild(source);
+        self.elt.src = newValue;
+      },
     });
 
+    // private _onended callback, set by the method: onended(callback)
+    self._onended = function() {};
+    self.elt.onended = function() {
+      self._onended(self);
+    }
   };
   p5.MediaElement.prototype = Object.create(p5.Element.prototype);
 
@@ -1701,6 +1719,35 @@
       p5.Renderer2D.prototype.set.call(this, x, y, imgOrCol);
     }
   };
+  /**
+   *  Schedule an event to be called when the soundfile
+   *  reaches the end of a buffer. If the soundfile is
+   *  playing through once, this will be called when it
+   *  ends. If it is looping, it will be called when
+   *  stop is called.
+   *  
+   *  @method  onended
+   *  @param  {Function} callback function to call when the
+   *                              soundfile has ended.                            
+   *  @return {Object/p5.Element}
+   *  @example
+   *  <div><code>
+   *  function setup() {
+   *    audioEl = createAudio('assets/beat.mp3');
+   *    audioEl.showControls(true);
+   *    audioEl.onended(sayDone);
+   *  }
+   *
+   *  function sayDone(elt) {
+   *    alert('done playing ' + elt.src() );
+   *  }
+   *  </code></div>
+   */
+  p5.MediaElement.prototype.onended = function(callback) {
+    this._onended = callback;
+    return this;
+  };
+
 
   /*** CONNECT TO WEB AUDIO API / p5.sound.js ***/
 

--- a/lib/addons/p5.dom.js
+++ b/lib/addons/p5.dom.js
@@ -1728,7 +1728,10 @@
    *  
    *  @method  onended
    *  @param  {Function} callback function to call when the
-   *                              soundfile has ended.                            
+   *                              soundfile has ended. The
+   *                              media element will be passed
+   *                              in as the argument to the
+   *                              callback.                            
    *  @return {Object/p5.Element}
    *  @example
    *  <div><code>
@@ -1739,7 +1742,7 @@
    *  }
    *
    *  function sayDone(elt) {
-   *    alert('done playing ' + elt.src() );
+   *    alert('done playing ' + elt.src );
    *  }
    *  </code></div>
    */

--- a/lib/addons/p5.dom.js
+++ b/lib/addons/p5.dom.js
@@ -1731,7 +1731,7 @@
    *                              media element will be passed
    *                              in as the argument to the
    *                              callback.                            
-   *  @return {Object/p5.Element}
+   *  @return {Object/p5.MediaElement}
    *  @example
    *  <div><code>
    *  function setup() {

--- a/test/manual-test-examples/addons/p5.dom/audioelt_onended/index.html
+++ b/test/manual-test-examples/addons/p5.dom/audioelt_onended/index.html
@@ -1,0 +1,7 @@
+<head>
+  <script language="javascript" type="text/javascript" src="../../../../../lib/p5.js"></script>
+
+  <script language="javascript" type="text/javascript" src="../../../../../lib/addons/p5.dom.js"></script> 
+
+  <script language="javascript" type="text/javascript" src="sketch.js"></script> 
+</head>

--- a/test/manual-test-examples/addons/p5.dom/audioelt_onended/sketch.js
+++ b/test/manual-test-examples/addons/p5.dom/audioelt_onended/sketch.js
@@ -1,0 +1,9 @@
+function setup() {
+  audioEl = createAudio('../lucky_dragons_-_power_melody.mp3');
+  audioEl.showControls(true);
+  audioEl.onended(sayDone);
+}
+
+function sayDone(elt) {
+  alert('done playing ' + elt.src );
+}


### PR DESCRIPTION
- add onended callback to p5dom media elements
- add test example for onended callback

- tweak mediaElement.src so that it uses children --> source elements, rather than just the src property of the video/audio element.