### PR TITLE
fix to 1097

### DIFF
--- a/src/core/p5.Renderer2D.js
+++ b/src/core/p5.Renderer2D.js
@@ -1185,7 +1185,7 @@ p5.Renderer2D.prototype._renderText = function(p, line, x, y, maxY) {
   }
   else { // an opentype font, let it handle the rendering
 
-    this._textFont._renderPath(line, x, y);
+    this._textFont._renderPath(line, x, y, { renderer: this });
   }
 
   p.pop();

--- a/src/typography/p5.Font.js
+++ b/src/typography/p5.Font.js
@@ -285,8 +285,7 @@ p5.Font.prototype._getSVG = function(line, x, y, options) {
  */
 p5.Font.prototype._renderPath = function(line, x, y, options) {
 
-  // /console.log('_renderPath', typeof line);
-  var pdata, pg = this.parent._renderer,
+  var pdata, pg = (options && options.renderer) || this.parent._renderer,
     ctx = pg.drawingContext;
 
   if (typeof line === 'object' && line.commands) {


### PR DESCRIPTION
added optional renderer argument to p5.Font._renderPath
which is used when called from a renderer