### PR TITLE
Fix for Issue#1167

### DIFF
--- a/src/core/p5.Renderer2D.js
+++ b/src/core/p5.Renderer2D.js
@@ -237,6 +237,10 @@ p5.Renderer2D.prototype.get = function(x, y, w, h) {
 
   this.loadPixels.call(ctx);
 
+  // round down to get integer numbers
+  x = Math.floor(x);
+  y = Math.floor(y);
+
   if (w === 1 && h === 1){
 
     return [

--- a/test/unit/core/renderer.js
+++ b/test/unit/core/renderer.js
@@ -70,4 +70,42 @@ suite('Renderer', function() {
     });
   });
 
+  suite('p5.prototype.get', function() {
+    var img;
+
+    setup(function() {
+      //create a 50 x 50 half red half green image
+      img = myp5.createImage(50, 50);
+      img.loadPixels();
+
+      for (var i = 0; i < img.width; i++) {
+        for (var j = 0; j < img.height; j++) {
+          var col;
+
+          if (j <= 25) {
+            col = myp5.color(255, 0, 0);
+          } else {
+            col = myp5.color(0, 0, 255);
+          }
+
+          img.set(i, j, col);
+        }
+      }
+
+      img.updatePixels();
+    });
+
+
+
+    test('works with integers', function() {
+      assert.deepEqual(img.get(25, 25), [255, 0, 0, 255]);
+      assert.deepEqual(img.get(25, 26), [0, 0, 255, 255]);
+    });
+
+    test('rounds down when given decimal numbers',
+      function() {
+        assert.deepEqual(img.get(25, 25.999), img.get(25, 25));
+      });
+  });
+
 });


### PR DESCRIPTION
Fix to https://github.com/processing/p5.js/issues/1167 - get() returns unpredictiable results for non-integer
values

get() now floors any decimal values before attempting to use them in
the ctx array or to calculate image dimensions.

Relevant tests added to test/unit/core/renderer.js as suite "p5.prototype.get"