### PR TITLE
yuidoc build improvements

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -50,7 +50,7 @@
  */
 
 function getYuidocOptions() {
-  const BASE_YUIDOC_OPTIONS = {
+  var BASE_YUIDOC_OPTIONS = {
     name: '<%= pkg.name %>',
     description: '<%= pkg.description %>',
     version: '<%= pkg.version %>',

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -9,11 +9,16 @@
  *                      using both jslint and mocha, and then minifies it.
  *
  *  grunt yui         - This will build the inline documentation for p5.js.
+ *                      The generated documentation is assumed to be
+ *                      served from the /reference/ folder of the p5js
+ *                      website (https://github.com/processing/p5.js-website).
  *
  *  grunt yui:dev     - This will build the inline documentation but linking to
  *                      remote JS/CSS and assets so pages look correct in local
- *                      testing. "grunt yui" should be run to build docs ready
- *                      for production.
+ *                      testing. The generated documentation is assumed
+ *                      to be served from a development web server running
+ *                      at the root of the repository. "grunt yui" should
+ *                      be run to build docs ready for production.
  *
  *  grunt test        - This rebuilds the source and runs the automated tests on
  *                     both the minified and unminified code. If you need to debug
@@ -43,6 +48,32 @@
  *  grunt update_json - This automates updating the bower file
  *                      to match the package.json
  */
+
+function getYuidocOptions() {
+  const BASE_YUIDOC_OPTIONS = {
+    name: '<%= pkg.name %>',
+    description: '<%= pkg.description %>',
+    version: '<%= pkg.version %>',
+    url: '<%= pkg.homepage %>',
+    options: {
+      paths: ['src/', 'lib/addons/'],
+      themedir: 'docs/yuidoc-p5-theme/',
+      helpers: [],
+      outdir: 'docs/reference/'
+    }
+  };
+
+  var o = {
+    prod: JSON.parse(JSON.stringify(BASE_YUIDOC_OPTIONS)),
+    dev: JSON.parse(JSON.stringify(BASE_YUIDOC_OPTIONS))
+  };
+
+  o.prod.options.helpers.push('docs/yuidoc-p5-theme/helpers/helpers_prod.js');
+  o.dev.options.helpers.push('docs/yuidoc-p5-theme/helpers/helpers_dev.js');
+
+  return o;
+}
+
 module.exports = function(grunt) {
 
   // Specify what reporter we'd like to use for Mocha
@@ -54,7 +85,6 @@ module.exports = function(grunt) {
   if (grunt.option('keepalive')) {
     keepalive = true;
   }
-
 
   grunt.initConfig({
 
@@ -222,44 +252,7 @@ module.exports = function(grunt) {
     },
 
     // this builds the documentation for the codebase.
-    yuidoc: {
-      prod: {
-        name: '<%= pkg.name %>',
-        description: '<%= pkg.description %>',
-        version: '<%= pkg.version %>',
-        url: '<%= pkg.homepage %>',
-        options: {
-          paths: ['src/', 'lib/addons/'],
-          themedir: 'docs/yuidoc-p5-theme/',
-
-          // These helpers define URL paths to p5js.org resources
-          // based on the value of the P5_SITE_ROOT environment variable.
-          // Set it to '..' for production and leave it blank or
-          // undefined for development.
-          helpers: ['docs/yuidoc-p5-theme/helpers/helpers_prod.js'],
-
-          outdir: 'docs/reference/'
-        }
-      },
-      dev: {
-        name: '<%= pkg.name %>',
-        description: '<%= pkg.description %>',
-        version: '<%= pkg.version %>',
-        url: '<%= pkg.homepage %>',
-        options: {
-          paths: ['src/', 'lib/addons/'],
-          themedir: 'docs/yuidoc-p5-theme/',
-
-          // These helpers define URL paths to p5js.org resources
-          // based on the value of the P5_SITE_ROOT environment variable.
-          // Set it to '..' for production and leave it blank or
-          // undefined for development.
-          helpers: ['docs/yuidoc-p5-theme/helpers/helpers_dev.js'],
-
-          outdir: 'docs/reference/'
-        }
-      }
-    },
+    yuidoc: getYuidocOptions(),
     'release-it': {
       options: {
         pkgFiles: ['package.json'],

--- a/docs/yuidoc-p5-theme/helpers/helpers_dev.js
+++ b/docs/yuidoc-p5-theme/helpers/helpers_dev.js
@@ -1,4 +1,9 @@
 var configHelpers = {};
+
+// For development, we want the links to parts of the p5 website to work,
+// so we make them absolute. However, we want links to the p5 libraries
+// to point to the generated files on our development server, so we'll
+// reference them accordingly.
 var config = {
   p5SiteRoot: 'http://p5js.org',
   p5Lib: '/lib/p5.js',

--- a/docs/yuidoc-p5-theme/helpers/helpers_prod.js
+++ b/docs/yuidoc-p5-theme/helpers/helpers_prod.js
@@ -1,9 +1,13 @@
 var configHelpers = {};
+
+// For production, the reference docs are put in the /reference/ folder
+// of the p5 website, so we'll define our paths with this assumption.
+// For more context, see https://github.com/processing/p5.js-website.
 var config = {
-  p5SiteRoot: 'http://p5js.org',
-  p5Lib: 'http://p5js.org/js/p5.min.js',
-  p5SoundLib: 'http://p5js.org/js/p5.sound.js',
-  p5DomLib: 'http://p5js.org/js/p5.dom.js'
+  p5SiteRoot: '..',
+  p5Lib: '../js/p5.min.js',
+  p5SoundLib: '../js/p5.sound.js',
+  p5DomLib: '../js/p5.dom.js'
 };
 
 Object.keys(config).forEach(function(key) {


### PR DESCRIPTION
This does a few things:

* Makes the yuidoc config in the gruntfile a bit more DRY-friendly, as per https://github.com/processing/p5.js/issues/1129#issuecomment-163412224.
* Adds some extra comments clarifying what's going on and why.
* Uses relative paths instead of absolute URLs to http://p5js.org when generating production docs. This was actually the behavior of `grunt yui` prior to #1124, and I think it's more flexible because it means the p5 website+reference can be deployed to multiple domains (e.g. staging/dev/whatever), not just p5js.org.
