### PR TITLE
Build reference docs before testing them

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -341,7 +341,7 @@ module.exports = function(grunt) {
   // Create the multitasks.
   // TODO: "requirejs" is in here to run the "yuidoc_themes" subtask. Is this needed?
   grunt.registerTask('build', ['browserify', 'uglify', 'requirejs']);
-  grunt.registerTask('test', ['jshint', 'jscs', 'build', 'connect', 'mocha']);
+  grunt.registerTask('test', ['jshint', 'jscs', 'build', 'yuidoc:dev', 'connect', 'mocha']);
   grunt.registerTask('test:nobuild', ['jshint:test', 'jscs:test', 'connect', 'mocha']);
   grunt.registerTask('yui', ['yuidoc:prod']);
   grunt.registerTask('yui:dev', ['yuidoc:dev']);


### PR DESCRIPTION
This should fix the broken build from #1144 by ensuring that reference documentation is built before their tests are run.