### PR TITLE
Issue #906 - mixing vertex() and curveVertex()

### DIFF
--- a/src/core/p5.Renderer2D.js
+++ b/src/core/p5.Renderer2D.js
@@ -645,7 +645,7 @@ p5.Renderer2D.prototype.triangle = function(x1, y1, x2, y2, x3, y3) {
 
 p5.Renderer2D.prototype.endShape =
 function (mode, vertices, isCurve, isBezier,
-    isQuadratic, isContour, shapeKind) {
+    isQuadratic, isContour, shapeKind, ar) {
   if (vertices.length === 0) {
     return this;
   }
@@ -657,13 +657,13 @@ function (mode, vertices, isCurve, isBezier,
   if (closeShape && !isContour) {
     vertices.push(vertices[0]);
   }
-  var i, j;
+  var i, j, k;
   var numVerts = vertices.length;
+  var numar=ar.length;
   if (isCurve && (shapeKind === constants.POLYGON || shapeKind === null)) {
-    if (numVerts > 3) {
-      var b = [], s = 1 - this._curveTightness;
+    var b = [], s = 1 - this._curveTightness;
+    if (numVerts > 3 && (numVerts===numar)) {
       this.drawingContext.beginPath();
-      this.drawingContext.moveTo(vertices[1][0], vertices[1][1]);
       for (i = 1; i + 2 < numVerts; i++) {
         v = vertices[i];
         b[0] = [
@@ -690,6 +690,68 @@ function (mode, vertices, isCurve, isBezier,
         this.drawingContext.lineTo(vertices[i + 1][0], vertices[i + 1][1]);
       }
       this._doFillStrokeClose();
+    }
+    else if(numVerts > 3 && (numVerts!==numar)){// issue #906
+      //var b = [], s = 1 - this._curveTightness;
+      j=0;
+      for(k=0;k+1<numVerts;k++){
+        if(k===ar[j]){
+          this.drawingContext.beginPath();
+          this.drawingContext.moveTo(vertices[k][0], vertices[k][1]);
+          for(j;(ar[j]+1)===(ar[j+1]) && (ar[j]+2<numVerts) ;j++){
+            k=k+1;
+            if(ar[j]+3===ar[j+3]){
+              i=ar[j+1];
+              v = vertices[i];
+              b[0] = [
+                v[0],
+                v[1]
+              ];
+              b[1] = [
+                v[0] + (s * vertices[i + 1][0] - s * vertices[i - 1][0]) / 6,
+                v[1] + (s * vertices[i + 1][1] - s * vertices[i - 1][1]) / 6
+              ];
+              b[2] = [
+                vertices[i + 1][0] +
+                (s * vertices[i][0]-s * vertices[i + 2][0]) / 6,
+            vertices[i + 1][1]+(s * vertices[i][1] - s*vertices[i + 2][1]) / 6
+              ];
+              b[3] = [
+                vertices[i + 1][0],
+                vertices[i + 1][1]
+              ];
+              this.drawingContext.bezierCurveTo(b[1][0],b[1][1],
+                b[2][0],b[2][1],b[3][0],b[3][1]);
+            }
+            else{
+
+            }
+          }
+          this._doFillStrokeClose();
+          if((ar[j]+1)!==(ar[j+1]) && (ar[j]<numVerts) ){
+            this.drawingContext.beginPath();
+            this.drawingContext.moveTo(vertices[k-1][0], vertices[k-1][1]);
+            v = vertices[k];
+            this.drawingContext.lineTo(v[0], v[1]);
+            this._doFillStrokeClose();
+          }
+          j=j+1;
+        }
+        if(ar[j]+3!==ar[j+3]){
+          this.drawingContext.beginPath();
+          this.drawingContext.moveTo(vertices[k][0], vertices[k][1]);
+          v = vertices[k+1];
+          this.drawingContext.lineTo(v[0], v[1]);
+          this._doFillStrokeClose();
+        }
+        else{
+          this.drawingContext.beginPath();
+          this.drawingContext.moveTo(vertices[k][0], vertices[k][1]);
+          v = vertices[k+1];
+          this.drawingContext.lineTo(v[0], v[1]);
+          this._doFillStrokeClose();
+        }
+      }
     }
   } else if (isBezier&&(shapeKind===constants.POLYGON ||shapeKind === null)) {
     this.drawingContext.beginPath();

--- a/src/core/p5.Renderer2D.js
+++ b/src/core/p5.Renderer2D.js
@@ -714,7 +714,7 @@ function (mode, vertices, isCurve, isBezier,
               b[2] = [
                 vertices[i + 1][0] +
                 (s * vertices[i][0]-s * vertices[i + 2][0]) / 6,
-            vertices[i + 1][1]+(s * vertices[i][1] - s*vertices[i + 2][1]) / 6
+          vertices[i + 1][1]+(s * vertices[i][1] - s*vertices[i + 2][1]) / 6
               ];
               b[3] = [
                 vertices[i + 1][0],

--- a/src/core/vertex.js
+++ b/src/core/vertex.js
@@ -17,6 +17,9 @@ var isBezier = false;
 var isCurve = false;
 var isQuadratic = false;
 var isContour = false;
+var curveVertices=[];
+var curveVerticesIndex=0;
+var VerticesIndex=0;
 
 /**
  * Use the beginContour() and endContour() functions to create negative
@@ -339,11 +342,24 @@ p5.prototype.bezierVertex = function(x2, y2, x3, y3, x4, y4) {
  * </code>
  * </div>
  */
+
+/*
 p5.prototype.curveVertex = function(x,y) {
   isCurve = true;
   this.vertex(x, y);
   return this;
 };
+*/
+
+
+p5.prototype.curveVertex = function(x,y) {
+  isCurve = true;
+  curveVertices[curveVerticesIndex]=VerticesIndex;
+  curveVerticesIndex=curveVerticesIndex+1;
+  this.vertex(x, y);
+  return this;
+};
+
 
 /**
  * Use the beginContour() and endContour() functions to create negative
@@ -440,7 +456,7 @@ p5.prototype.endShape = function(mode) {
     }
 
     this._renderer.endShape(mode, vertices, isCurve, isBezier,
-      isQuadratic, isContour, shapeKind);
+      isQuadratic, isContour, shapeKind, curveVertices);
 
     // Reset some settings
     isCurve = false;
@@ -553,6 +569,7 @@ p5.prototype.quadraticVertex = function(cx, cy, x3, y3) {
  * </div>
  */
 p5.prototype.vertex = function(x, y, moveTo) {
+  VerticesIndex=VerticesIndex+1;
   var args = new Array(arguments.length);
   for (var i = 0; i < args.length; ++i) {
     args[i] = arguments[i];

--- a/src/core/vertex.js
+++ b/src/core/vertex.js
@@ -344,7 +344,7 @@ p5.prototype.bezierVertex = function(x2, y2, x3, y3, x4, y4) {
  */
 
 /*
-p5.prototype.curveVertex = function(x,y) {
+p5.prototype.curveVertex = function(x,y) {// issue 906
   isCurve = true;
   this.vertex(x, y);
   return this;


### PR DESCRIPTION
I want to resolve #906. The current code is written such that if the variable isCurve is true, the endShape function (in Renderer2D.js) will not distinguish between the vertex and curveVertex since both the coordinates of vertex and curveVertex are stored in the same array i.e. vertices. So, I created another array(curveVertices) which stores the index of curveVertices in 'vertices' array and changed the code in Renderer2D.js such that it accounts for all test cases. Please give feedback :)