### PR TITLE
Update sq() documentation

### DIFF
--- a/src/math/calculation.js
+++ b/src/math/calculation.js
@@ -626,7 +626,7 @@ p5.prototype.round = Math.round;
  *   noStroke();
  *   fill(0);
  *   text("x = " + x1, 0, y1 + spacing);
- *   text("sqrt(x) = " + x2, 0, y2 + spacing);
+ *   text("sq(x) = " + x2, 0, y2 + spacing);
  * }
  * </code></div>
  */


### PR DESCRIPTION
p5 is awesome.  Thanks for making it!

I think I found a small typo in http://p5js.org/reference/#/p5/sq

Current example lists
 *   text("sqrt(x) = " + x2, 0, y2 + spacing);

I believe it should read
 *   text("sq(x) = " + x2, 0, y2 + spacing);

To reference the sq fuction and not the sqrt function

Cheers