### PR TITLE
fixes bug where fill color not working in immediateMode; See details:

### DIFF
--- a/src/3d/material.js
+++ b/src/3d/material.js
@@ -146,54 +146,6 @@ function _isPowerOf2 (value){
 // }
 
 /**
- * Basic material for geometry with a given color
- * @method  basicMaterial
- * @param  {Number|Array|String|p5.Color} v1  gray value,
- * red or hue value (depending on the current color mode),
- * or color Array, or CSS color string
- * @param  {Number}            [v2] optional: green or saturation value
- * @param  {Number}            [v3] optional: blue or brightness value
- * @param  {Number}            [a]  optional: opacity
- * @return {p5}                the p5 object
- * @example
- * <div>
- * <code>
- * function setup(){
- *   createCanvas(100, 100, WEBGL);
- * }
- *
- * function draw(){
- *  background(0);
- *  basicMaterial(250, 0, 0);
- *  rotateX(frameCount * 0.01);
- *  rotateY(frameCount * 0.01);
- *  rotateZ(frameCount * 0.01);
- *  box(200, 200, 200);
- * }
- * </code>
- * </div>
- */
-p5.prototype.basicMaterial = function(v1, v2, v3, a){
-  var gl = this._renderer.GL;
-
-  var shaderProgram = this._renderer._getShader('normalVert', 'basicFrag');
-
-  gl.useProgram(shaderProgram);
-  shaderProgram.uMaterialColor = gl.getUniformLocation(
-    shaderProgram, 'uMaterialColor' );
-
-  var color = this._renderer._pInst.color.apply(
-    this._renderer._pInst, arguments);
-  var colors = color._array;
-
-  gl.uniform4f( shaderProgram.uMaterialColor,
-    colors[0], colors[1], colors[2], colors[3]);
-
-  return this;
-
-};
-
-/**
  * Ambient material for geometry with a given color
  * @method  ambientMaterial
  * @param  {Number|Array|String|p5.Color} v1  gray value,

--- a/src/3d/p5.Renderer3D.Immediate.js
+++ b/src/3d/p5.Renderer3D.Immediate.js
@@ -130,7 +130,6 @@ p5.Renderer3D.prototype._bindImmediateBuffers = function(vertices, colors){
   var shaderKey = this._getCurShaderId();
   var shaderProgram = this.mHash[shaderKey];
   //vertex position Attribute
-  //@todo refactor for elegance
   shaderProgram.vertexPositionAttribute =
     gl.getAttribLocation(shaderProgram, 'aPosition');
   gl.enableVertexAttribArray(shaderProgram.vertexPositionAttribute);
@@ -148,9 +147,9 @@ p5.Renderer3D.prototype._bindImmediateBuffers = function(vertices, colors){
     4, gl.FLOAT, false, 0, 0);
   //matrix
   this._setMatrixUniforms(shaderKey);
-  //@todo implement in shader
+  //@todo implement in all shaders (not just immediateVert)
   //set our default point size
-  // this._setUniform1f(mId,
+  // this._setUniform1f(shaderKey,
   //   'uPointSize',
   //   this.pointSize);
   return this;

--- a/src/3d/p5.Renderer3D.js
+++ b/src/3d/p5.Renderer3D.js
@@ -268,12 +268,61 @@ p5.Renderer3D.prototype._getCurShaderId = function(){
 //////////////////////////////////////////////
 // COLOR
 //////////////////////////////////////////////
-p5.Renderer3D.prototype.fill = function(r, g, b, a) {
+/**
+ * Basic fill material for geometry with a given color
+ * @method  fill
+ * @param  {Number|Array|String|p5.Color} v1  gray value,
+ * red or hue value (depending on the current color mode),
+ * or color Array, or CSS color string
+ * @param  {Number}            [v2] optional: green or saturation value
+ * @param  {Number}            [v3] optional: blue or brightness value
+ * @param  {Number}            [a]  optional: opacity
+ * @return {p5}                the p5 object
+ * @example
+ * <div>
+ * <code>
+ * function setup(){
+ *   createCanvas(100, 100, WEBGL);
+ * }
+ *
+ * function draw(){
+ *  background(0);
+ *  fill(250, 0, 0);
+ *  rotateX(frameCount * 0.01);
+ *  rotateY(frameCount * 0.01);
+ *  rotateZ(frameCount * 0.01);
+ *  box(200, 200, 200);
+ * }
+ * </code>
+ * </div>
+ */
+p5.Renderer3D.prototype.fill = function(v1, v2, v3, a) {
+  var gl = this.GL;
   var color = this._pInst.color.apply(this._pInst, arguments);
   //@type {Array}, length 4 : vals range 0->1
   var colorNormalized = color._array;
   this.curColor = colorNormalized;
   this.drawMode = 'fill';
+  var shaderProgram;
+  if(this.isImmediateDrawing){
+    shaderProgram =
+    this._getShader('immediateVert','vertexColorFrag');
+    gl.useProgram(shaderProgram);
+  } else {
+    shaderProgram =
+    this._getShader('normalVert', 'basicFrag');
+    gl.useProgram(shaderProgram);
+    //RetainedMode uses a webgl uniform to pass color vals
+    //in ImmediateMode, we want access to each vertex so therefore
+    //we cannot use a uniform.
+    shaderProgram.uMaterialColor = gl.getUniformLocation(
+      shaderProgram, 'uMaterialColor' );
+    gl.uniform4f( shaderProgram.uMaterialColor,
+      colorNormalized[0],
+      colorNormalized[1],
+      colorNormalized[2],
+      colorNormalized[3]);
+  }
   return this;
 };
 p5.Renderer3D.prototype.stroke = function(r, g, b, a) {


### PR DESCRIPTION
Removes basicMaterial() from webgl.  Note: this could potentially be a breaking change in some users code.  As an alternative users should now use fill(), which supersedes the former basicMaterial() function.