### PR TITLE
Fix manual-test examples with wrong lib destination

### DIFF
--- a/test/manual-test-examples/3d/geometry/index.html
+++ b/test/manual-test-examples/3d/geometry/index.html
@@ -5,17 +5,17 @@
   <meta http-equiv="X-UA-Compatible" content="IE=edge">
   <title></title>
   <link rel="stylesheet" href="">
-  <script language="javascript" type="text/javascript" src="../../../../../lib/p5.js"></script>
+  <script language="javascript" type="text/javascript" src="../../../../lib/p5.js"></script>
   <script language="javascript" type="text/javascript" src="sketch.js"></script>
   <style>
     html, body {margin:0; padding:0;}
-  </style> 
+  </style>
 </head>
 <body>
 <p style="width:1000px; margin:10px auto; text-align: center; color:black;">Move mouse to spin geometries</p>
 <script>
 (function(){var script=document.createElement('script');script.onload=function(){var stats=new Stats();stats.domElement.style.cssText='position:fixed;left:0;top:0;z-index:10000';document.body.appendChild(stats.domElement);requestAnimationFrame(function loop(){stats.update();requestAnimationFrame(loop)});};script.src='http://rawgit.com/mrdoob/stats.js/master/build/stats.min.js';document.head.appendChild(script);})()
 </script>
-  
+
 </body>
 </html>

--- a/test/manual-test-examples/3d/interaction/index.html
+++ b/test/manual-test-examples/3d/interaction/index.html
@@ -5,17 +5,17 @@
   <meta http-equiv="X-UA-Compatible" content="IE=edge">
   <title></title>
   <link rel="stylesheet" href="">
-  <script language="javascript" type="text/javascript" src="../../../../../lib/p5.js"></script>
+  <script language="javascript" type="text/javascript" src="../../../../lib/p5.js"></script>
   <script language="javascript" type="text/javascript" src="sketch.js"></script>
   <style>
     html, body {margin:0; padding:0;}
-  </style> 
+  </style>
 </head>
 <body>
 <p style="position: absolute; width:300px; left:50%; margin-left: -150px; color:black; text-align: center;">Press mouse to toggle the world</p>
 <script>
 (function(){var script=document.createElement('script');script.onload=function(){var stats=new Stats();stats.domElement.style.cssText='position:fixed;left:0;top:0;z-index:10000';document.body.appendChild(stats.domElement);requestAnimationFrame(function loop(){stats.update();requestAnimationFrame(loop)});};script.src='http://rawgit.com/mrdoob/stats.js/master/build/stats.min.js';document.head.appendChild(script);})()
 </script>
-  
+
 </body>
 </html>

--- a/test/manual-test-examples/3d/mixedMode/index.html
+++ b/test/manual-test-examples/3d/mixedMode/index.html
@@ -5,11 +5,11 @@
   <meta http-equiv="X-UA-Compatible" content="IE=edge">
   <title></title>
   <link rel="stylesheet" href="">
-  <script language="javascript" type="text/javascript" src="../../../../../lib/p5.js"></script>
+  <script language="javascript" type="text/javascript" src="../../../../lib/p5.js"></script>
   <script language="javascript" type="text/javascript" src="sketch.js"></script>
   <style>
     html, body {margin:0; padding:0;}
-  </style> 
+  </style>
 </head>
 <body>
 <p style="width:1000px; margin:10px auto; text-align: center; color:black;">Drag mouse to toggle the world</p>
@@ -17,6 +17,6 @@
 <script>
 (function(){var script=document.createElement('script');script.onload=function(){var stats=new Stats();stats.domElement.style.cssText='position:fixed;left:0;top:0;z-index:10000';document.body.appendChild(stats.domElement);requestAnimationFrame(function loop(){stats.update();requestAnimationFrame(loop)});};script.src='http://rawgit.com/mrdoob/stats.js/master/build/stats.min.js';document.head.appendChild(script);})()
 </script>
-  
+
 </body>
 </html>

--- a/test/manual-test-examples/3d/mobile/index.html
+++ b/test/manual-test-examples/3d/mobile/index.html
@@ -5,16 +5,16 @@
   <meta http-equiv="X-UA-Compatible" content="IE=edge">
   <title></title>
   <link rel="stylesheet" href="">
-  <script language="javascript" type="text/javascript" src="../../../../../lib/p5.js"></script>
+  <script language="javascript" type="text/javascript" src="../../../../lib/p5.js"></script>
   <script language="javascript" type="text/javascript" src="sketch.js"></script>
   <style>
     html, body {margin:0; padding:0;}
-  </style> 
+  </style>
 </head>
 <body>
 <script>
 (function(){var script=document.createElement('script');script.onload=function(){var stats=new Stats();stats.domElement.style.cssText='position:fixed;left:0;top:0;z-index:10000';document.body.appendChild(stats.domElement);requestAnimationFrame(function loop(){stats.update();requestAnimationFrame(loop)});};script.src='http://rawgit.com/mrdoob/stats.js/master/build/stats.min.js';document.head.appendChild(script);})()
 </script>
-  
+
 </body>
 </html>

--- a/test/manual-test-examples/3d/performance/index.html
+++ b/test/manual-test-examples/3d/performance/index.html
@@ -5,17 +5,17 @@
   <meta http-equiv="X-UA-Compatible" content="IE=edge">
   <title></title>
   <link rel="stylesheet" href="">
-  <script language="javascript" type="text/javascript" src="../../../../../lib/p5.js"></script>
+  <script language="javascript" type="text/javascript" src="../../../../lib/p5.js"></script>
   <script language="javascript" type="text/javascript" src="sketch.js"></script>
   <style>
     html, body {margin:0; padding:0;}
-  </style> 
+  </style>
 </head>
 <p style="position: absolute; width:300px; left:50%; text-align: center; margin-left: -150px; color:black;">1000 spheres, how's the speed?</p>
 <body>
 <script>
 (function(){var script=document.createElement('script');script.onload=function(){var stats=new Stats();stats.domElement.style.cssText='position:fixed;left:0;top:0;z-index:10000';document.body.appendChild(stats.domElement);requestAnimationFrame(function loop(){stats.update();requestAnimationFrame(loop)});};script.src='http://rawgit.com/mrdoob/stats.js/master/build/stats.min.js';document.head.appendChild(script);})()
 </script>
-  
+
 </body>
 </html>

--- a/test/manual-test-examples/async/loadFont/instance/index.html
+++ b/test/manual-test-examples/async/loadFont/instance/index.html
@@ -1,5 +1,5 @@
 <head>
-  <script language="javascript" type="text/javascript" src="../../../../../../lib/p5.js"></script>
+  <script language="javascript" type="text/javascript" src="../../../../../lib/p5.js"></script>
   <script language="javascript" type="text/javascript" src="sketch.js"></script>
 </head>
 

--- a/test/manual-test-examples/async/loadImage/global/index.html
+++ b/test/manual-test-examples/async/loadImage/global/index.html
@@ -1,5 +1,5 @@
 <head>
-  <script language="javascript" type="text/javascript" src="../../../../../../lib/p5.js"></script>
+  <script language="javascript" type="text/javascript" src="../../../../../lib/p5.js"></script>
   <script language="javascript" type="text/javascript" src="sketch.js"></script>
 </head>
 

--- a/test/manual-test-examples/empty-example/index.html
+++ b/test/manual-test-examples/empty-example/index.html
@@ -1,6 +1,6 @@
 
 <head>
-  <script language="javascript" src="../../../../lib/p5.js"></script>
+  <script language="javascript" src="../../../lib/p5.js"></script>
   <!-- uncomment lines below to include extra p5 libraries -->
   <!--<script language="javascript" src="../addons/p5.dom.js"></script>-->
   <!--<script language="javascript" src="../addons/p5.sound.js"></script>-->

--- a/test/manual-test-examples/env/cursor/index.html
+++ b/test/manual-test-examples/env/cursor/index.html
@@ -6,7 +6,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1">
   </head>
   <body>
-    <script language="javascript" type="text/javascript" src="../../../../../lib/p5.js"></script>
+    <script language="javascript" type="text/javascript" src="../../../../lib/p5.js"></script>
     <script language="javascript" type="text/javascript" src="cursor.js"></script>
   </body>
 </html>

--- a/test/manual-test-examples/keyboard/gamestyle.html
+++ b/test/manual-test-examples/keyboard/gamestyle.html
@@ -1,8 +1,8 @@
 <!DOCTYPE html>
 <html>
   <head>
-    <script language="javascript" type="text/javascript" src="../../../../lib/p5.js"></script>
-	<script language="javascript" type="text/javascript" src="gamestyle.js"></script>	
+    <script language="javascript" type="text/javascript" src="../../../lib/p5.js"></script>
+	<script language="javascript" type="text/javascript" src="gamestyle.js"></script>
   </head>
 
   <body>

--- a/test/manual-test-examples/loadingscreen/index.html
+++ b/test/manual-test-examples/loadingscreen/index.html
@@ -26,7 +26,7 @@
     <!-- <div id="p5_loading" class="loadingclass">this could be some sweet graphics loading lots of bits.</div> -->
     <!-- Empty loading screen, will overwrite the 'loading...' in core -->
     <!-- <div id="p5_loading" class="loadingclass"></div> -->
-    <script language="javascript" type="text/javascript" src="../../../../lib/p5.js"></script>
+    <script language="javascript" type="text/javascript" src="../../../lib/p5.js"></script>
     <script language="javascript" type="text/javascript" src="loadingscreen.js"></script>
   </body>
 </html>

--- a/test/manual-test-examples/loadingscreen/invalid_json.html
+++ b/test/manual-test-examples/loadingscreen/invalid_json.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="utf-8">
     <title>P5.js - Invalid JSON test</title>
-    <script language="javascript" type="text/javascript" src="../../../../lib/p5.js"></script>
+    <script language="javascript" type="text/javascript" src="../../../lib/p5.js"></script>
     <script language="javascript" type="text/javascript" src="invalid_json.js"></script>
 </head>
 <body>

--- a/test/manual-test-examples/loadingscreen/preload_success_callbacks.html
+++ b/test/manual-test-examples/loadingscreen/preload_success_callbacks.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="utf-8">
     <title>P5.js - preload with success callbacks</title>
-    <script language="javascript" type="text/javascript" src="../../../../lib/p5.js"></script>
+    <script language="javascript" type="text/javascript" src="../../../lib/p5.js"></script>
     <script language="javascript" type="text/javascript" src="preload_success_callbacks.js"></script>
   </head>
   <body>

--- a/test/manual-test-examples/p5.Image/animate.html
+++ b/test/manual-test-examples/p5.Image/animate.html
@@ -1,5 +1,5 @@
 <head>
-  <script language="javascript" type="text/javascript" src="../../../../lib/p5.js"></script>
+  <script language="javascript" type="text/javascript" src="../../../lib/p5.js"></script>
   <script language="javascript" type="text/javascript" src="animate-image.js"></script>
 </head>
 

--- a/test/manual-test-examples/p5.Image/copying.html
+++ b/test/manual-test-examples/p5.Image/copying.html
@@ -1,6 +1,6 @@
 <head>
-  <script language="javascript" type="text/javascript" src="../../../../lib/p5.js"></script>
-	<script language="javascript" type="text/javascript" src="copying-images.js"></script>	
+  <script language="javascript" type="text/javascript" src="../../../lib/p5.js"></script>
+	<script language="javascript" type="text/javascript" src="copying-images.js"></script>
 </head>
 
 <body>

--- a/test/manual-test-examples/p5.Image/cropping.html
+++ b/test/manual-test-examples/p5.Image/cropping.html
@@ -1,5 +1,5 @@
 <head>
-  <script language="javascript" type="text/javascript" src="../../../../lib/p5.js"></script>
+  <script language="javascript" type="text/javascript" src="../../../lib/p5.js"></script>
 	<script language="javascript" type="text/javascript" src="cropping-images.js"></script>
 </head>
 

--- a/test/manual-test-examples/p5.Image/drawing.html
+++ b/test/manual-test-examples/p5.Image/drawing.html
@@ -1,6 +1,6 @@
 <head>
-  <script language="javascript" type="text/javascript" src="../../../../lib/p5.js"></script>
-	<script language="javascript" type="text/javascript" src="drawing-images.js"></script>	
+  <script language="javascript" type="text/javascript" src="../../../lib/p5.js"></script>
+	<script language="javascript" type="text/javascript" src="drawing-images.js"></script>
 </head>
 
 <body>

--- a/test/manual-test-examples/p5.Image/filter.html
+++ b/test/manual-test-examples/p5.Image/filter.html
@@ -1,6 +1,6 @@
 <head>
-  <script language="javascript" type="text/javascript" src="../../../../lib/p5.js"></script>
-	<script language="javascript" type="text/javascript" src="filter-images.js"></script>	
+  <script language="javascript" type="text/javascript" src="../../../lib/p5.js"></script>
+	<script language="javascript" type="text/javascript" src="filter-images.js"></script>
 </head>
 
 <body>

--- a/test/manual-test-examples/p5.Image/manipulate.html
+++ b/test/manual-test-examples/p5.Image/manipulate.html
@@ -1,6 +1,6 @@
 <head>
-  <script language="javascript" type="text/javascript" src="../../../../lib/p5.js"></script>
-	<script language="javascript" type="text/javascript" src="manipulate-images.js"></script>	
+  <script language="javascript" type="text/javascript" src="../../../lib/p5.js"></script>
+	<script language="javascript" type="text/javascript" src="manipulate-images.js"></script>
 </head>
 
 <body>

--- a/test/manual-test-examples/p5.Image/saving.html
+++ b/test/manual-test-examples/p5.Image/saving.html
@@ -1,6 +1,6 @@
 <head>
-  <script language="javascript" type="text/javascript" src="../../../../lib/p5.js"></script>
-	<script language="javascript" type="text/javascript" src="saving-images.js"></script>	
+  <script language="javascript" type="text/javascript" src="../../../lib/p5.js"></script>
+	<script language="javascript" type="text/javascript" src="saving-images.js"></script>
 </head>
 
 <body>

--- a/test/manual-test-examples/pixel/set-pixels.html
+++ b/test/manual-test-examples/pixel/set-pixels.html
@@ -1,6 +1,6 @@
 <head>
-  <script language="javascript" type="text/javascript" src="../../../../lib/p5.js"></script>
-	<script language="javascript" type="text/javascript" src="set-pixels.js"></script>	
+  <script language="javascript" type="text/javascript" src="../../../lib/p5.js"></script>
+	<script language="javascript" type="text/javascript" src="set-pixels.js"></script>
 </head>
 
 <body>

--- a/test/manual-test-examples/pixel/update-pixels.html
+++ b/test/manual-test-examples/pixel/update-pixels.html
@@ -1,6 +1,6 @@
 <head>
-  <script language="javascript" type="text/javascript" src="../../../../lib/p5.js"></script>
-	<script language="javascript" type="text/javascript" src="update-pixels.js"></script>	
+  <script language="javascript" type="text/javascript" src="../../../lib/p5.js"></script>
+	<script language="javascript" type="text/javascript" src="update-pixels.js"></script>
 </head>
 
 <body>


### PR DESCRIPTION
Fixes https://github.com/processing/p5.js/issues/1232.
Also fixes trailing whitespaces in these particular files.