### PR TITLE
Add speed method to p5.MediaElement for playback speed

### DIFF
--- a/lib/addons/p5.dom.js
+++ b/lib/addons/p5.dom.js
@@ -1604,6 +1604,25 @@
   };
 
   /**
+   * If no arguments are given, returns the current playback speed of the
+   * element. The speed parameter sets the speed where 2.0 will play the
+   * element twice as fast, 0.5 will play at half the speed, and -1 will play
+   * the element in normal speed in reverse.(Note that not all browsers support
+   * backward playback and even if they do, playback might not be smooth.)
+   *
+   * @method speed
+   * @param {Number} [speed]  speed multiplier for element playback
+   * @return {Number|Object/p5.MediaElement} current playback speed or p5.MediaElement
+   */
+  p5.MediaElement.prototype.speed = function(val) {
+    if (typeof val === 'undefined') {
+      return this.elt.playbackRate;
+    } else {
+      this.elt.playbackRate = val;
+    }
+  };
+
+  /**
    * If no arguments are given, returns the current time of the element.
    * If an argument is given the current time of the element is set to it.
    *

--- a/test/manual-test-examples/addons/p5.dom/video_speed/index.html
+++ b/test/manual-test-examples/addons/p5.dom/video_speed/index.html
@@ -1,0 +1,9 @@
+<head>
+  <script language="javascript" type="text/javascript" src="../../../../../lib/p5.js"></script>
+  <script language="javascript" type="text/javascript" src="../../../../../lib/addons/p5.dom.js"></script>
+  <script language="javascript" type="text/javascript" src="sketch.js"></script>        
+</head>
+
+<body>
+	<div id="test"></div>
+</body>

--- a/test/manual-test-examples/addons/p5.dom/video_speed/sketch.js
+++ b/test/manual-test-examples/addons/p5.dom/video_speed/sketch.js
@@ -1,0 +1,42 @@
+var playing = false;
+var fingers, playbutton, slowButton, normalButton, fastButton;
+
+
+function setup() {
+  fingers = createVideo('../fingers.mov');
+
+  playButton = createButton('Play');
+  playButton.mousePressed(toggleVid);
+  slowButton = createButton('slow (x0.5)');
+  slowButton.mousePressed(slowSpeed);
+  normalButton = createButton('normal (x1)');
+  normalButton.mousePressed(normalSpeed);
+  fastButton = createButton('Fast (x2)');
+  fastButton.mousePressed(fastSpeed);
+}
+
+function toggleVid() {
+  if (playing) {
+    fingers.pause();
+    button.html('play');
+  } else {
+    fingers.loop();
+    button.html('pause');
+  }
+  playing = !playing;
+}
+
+function fastSpeed() {
+  fingers.speed(2);
+}
+
+function normalSpeed() {
+  fingers.speed(1);
+}
+
+function slowSpeed() {
+  fingers.speed(0.5);
+}
+
+
+

--- a/test/manual-test-examples/addons/p5.dom/video_speed/sketch.js
+++ b/test/manual-test-examples/addons/p5.dom/video_speed/sketch.js
@@ -37,6 +37,3 @@ function normalSpeed() {
 function slowSpeed() {
   fingers.speed(0.5);
 }
-
-
-


### PR DESCRIPTION
Fixes https://github.com/processing/p5.js/issues/1026.
This adds the functionality to adjust the rate or speed of playback in p5.MediaElement, also it contains a manual-test-example for the same.