### PR TITLE
Link doc entries to their definition in p5 source code.

### DIFF
--- a/docs/yuidoc-p5-theme-src/scripts/tpl/itemEnd.html
+++ b/docs/yuidoc-p5-theme-src/scripts/tpl/itemEnd.html
@@ -12,4 +12,8 @@
 
   <a style="border-bottom:none !important;" href="http://creativecommons.org/licenses/by-nc-sa/4.0/" target=_blank><img src="http://i.creativecommons.org/l/by-nc-sa/4.0/88x31.png" style="width:88px"/></a>
 
+  <% if (item.file && item.line) { %>
+  <p style="font-size: 0.75em">Find any typos or bugs? <code><%=item.name%><% if (item.isMethod) { %>()<% } %></code> is documented and defined in <a href="https://github.com/processing/p5.js/blob/master/<%= item.file %>#L<%= item.line %>" target="_blank" ><code><%= item.file %></code></a>. Please feel free to <a href="https://github.com/processing/p5.js/edit/master/<%= item.file %>#L<%= item.line %>" target="_blank" style="font-family: inherit">edit the file</a> and issue a pull request!</p>
+  <% } %>
+
 </p>


### PR DESCRIPTION
One of the hardest things about fixing a minor bug or typo is figuring out where it's located in a project's source code.

But one of the great things about YUIDoc is that it gives us that information in the `data.json` blob it builds for our reference docs!

So I thought that it might be nice to *unintrusively* link to the source code for a p5 API in its documentation. I stress the word *unintrusively* because I don't want to confuse the beginners who may be learning programming for the first time, and could be thrown off by the extra information.

Other benefits of linking to the source:
* It invites users of p5 to become contributors.
* It generally makes it easier to "pop open the hood" and see how p5 works.

Here's what it looks like--the example screenshot below is taken from the documentation for [`plane()`](http://p5js.org/reference/#/p5/plane):

![2016-02-11_8-58-28](https://cloud.githubusercontent.com/assets/124687/12978283/1200414c-d09e-11e5-8a68-4a3adaf97df2.png)

The first link there is to [view the source for `plane()`](https://github.com/processing/p5.js/blob/master/src/3d/3d_primitives.js#L14), while the second is to [edit it](https://github.com/processing/p5.js/edit/master/src/3d/3d_primitives.js#L14) (yay to GitHub for providing permalinks to edit files at a specific line number!). My hope is that beginners who don't know anything about git can fix simple typos and issue PRs for them.

Notes:

* Um, I couldn't easily figure out where the CSS for the docs were stored, so I've inlined the CSS for now. It is kind of gross but I should be able to fix it before merging.