### PR TITLE
Better friendly error help for using p5 globals in top-level code.

### DIFF
--- a/src/core/error_helpers.js
+++ b/src/core/error_helpers.js
@@ -265,27 +265,110 @@ function friendlyWelcome() {
   report(str, 'println', '#4DB200'); // auto dark green
 } */
 
-// This is a list of p5 functions/variables that are commonly misused
-// by beginners at top-level code, outside of setup/draw. We'd like to
-// detect these errors and help the user by suggesting they move them
+// This is a lazily-defined list of p5 symbols that may be
+// misused by beginners at top-level code, outside of setup/draw. We'd like
+// to detect these errors and help the user by suggesting they move them
 // into setup/draw.
 //
 // For more details, see https://github.com/processing/p5.js/issues/1121.
-var misusedAtTopLevelCode = [
-  'color',
-  'random'
-];
+var misusedAtTopLevelCode = null;
+var FAQ_URL = 'https://github.com/processing/p5.js/wiki/' +
+              'Frequently-Asked-Questions' +
+              '#why-cant-i-assign-variables-using-p5-functions-and-' +
+              'variables-before-setup';
 
-function helpForMisusedAtTopLevelCode(e) {
-  misusedAtTopLevelCode.forEach(function(name) {
-    if (e.message && e.message.indexOf(name) !== -1) {
-      console.log('%c Did you just try to use p5.js\'s \'' + name + '\' ' +
-                  'function or variable? If so, you may want to ' +
-                  'move it into your sketch\'s setup() function.',
-                  'color: #B40033' /* Dark magenta */);
+function defineMisusedAtTopLevelCode() {
+  var uniqueNamesFound = {};
+
+  var getSymbols = function(obj) {
+    return Object.getOwnPropertyNames(obj).filter(function(name) {
+      if (name[0] === '_') {
+        return false;
+      }
+      if (name in uniqueNamesFound) {
+        return false;
+      }
+
+      uniqueNamesFound[name] = true;
+
+      return true;
+    }).map(function(name) {
+      var type;
+
+      if (typeof(obj[name]) === 'function') {
+        type = 'function';
+      } else if (name === name.toUpperCase()) {
+        type = 'constant';
+      } else {
+        type = 'variable';
+      }
+
+      return {name: name, type: type};
+    });
+  };
+
+  misusedAtTopLevelCode = [].concat(
+    getSymbols(p5.prototype),
+    // At present, p5 only adds its constants to p5.prototype during
+    // construction, which may not have happened at the time a
+    // ReferenceError is thrown, so we'll manually add them to our list.
+    getSymbols(require('./constants'))
+  );
+
+  // This will ultimately ensure that we report the most specific error
+  // possible to the user, e.g. advising them about HALF_PI instead of PI
+  // when their code misuses the former.
+  misusedAtTopLevelCode.sort(function(a, b) {
+    return b.name.length - a.name.length;
+  });
+}
+
+function helpForMisusedAtTopLevelCode(e, log) {
+  if (!log) {
+    log = console.log.bind(console);
+  }
+
+  if (!misusedAtTopLevelCode) {
+    defineMisusedAtTopLevelCode();
+  }
+
+  // If we find that we're logging lots of false positives, we can
+  // uncomment the following code to avoid displaying anything if the
+  // user's code isn't likely to be using p5's global mode. (Note that
+  // setup/draw are more likely to be defined due to JS function hoisting.)
+  //
+  //if (!('setup' in window || 'draw' in window)) {
+  //  return;
+  //}
+
+  misusedAtTopLevelCode.some(function(symbol) {
+    // Note that while just checking for the occurrence of the
+    // symbol name in the error message could result in false positives,
+    // a more rigorous test is difficult because different browsers
+    // log different messages, and the format of those messages may
+    // change over time.
+    //
+    // For example, if the user uses 'PI' in their code, it may result
+    // in any one of the following messages:
+    //
+    //   * 'PI' is undefined                           (Microsoft Edge)
+    //   * ReferenceError: PI is undefined             (Firefox)
+    //   * Uncaught ReferenceError: PI is not defined  (Chrome)
+
+    if (e.message && e.message.indexOf(symbol.name) !== -1) {
+      log('%cDid you just try to use p5.js\'s ' + symbol.name +
+          (symbol.type === 'function' ? '() ' : ' ') + symbol.type +
+          '? If so, you may want to ' +
+          'move it into your sketch\'s setup() function.\n\n' +
+          'For more details, see: ' + FAQ_URL,
+          'color: #B40033' /* Dark magenta */);
+      return true;
     }
   });
 }
+
+// Exposing this primarily for unit testing.
+p5.prototype._helpForMisusedAtTopLevelCode = helpForMisusedAtTopLevelCode;
 
 if (document.readyState !== 'complete') {
   window.addEventListener('error', helpForMisusedAtTopLevelCode, false);

--- a/test/test.html
+++ b/test/test.html
@@ -38,6 +38,7 @@
   <script src="unit/core/core.js" type="text/javascript" ></script>
   <!--<script src="unit/core/2d_primitives.js" type="text/javascript" ></script>-->
   <script src="unit/core/curves.js" type="text/javascript" ></script>
+  <script src="unit/core/error_helpers.js" type="text/javascript" ></script>
   <script src="unit/core/renderer.js" type="text/javascript" ></script>
 
   <script src="unit/math/calculation.js" type="text/javascript" ></script>

--- a/test/unit/core/error_helpers.js
+++ b/test/unit/core/error_helpers.js
@@ -1,0 +1,35 @@
+suite('Error Helpers', function() {
+  suite('helpForMisusedAtTopLevelCode', function() {
+    var help = function(msg) {
+      var log = [];
+      var logger = function(msg) {
+        log.push(msg);
+      };
+
+      p5.prototype._helpForMisusedAtTopLevelCode({message: msg}, logger);
+      assert.equal(log.length, 1);
+      return log[0];
+    };
+
+    test('help for constants is shown', function() {
+      assert.match(
+        help('\'HALF_PI\' is undefined'),
+        /Did you just try to use p5\.js\'s HALF_PI constant\?/
+      );
+    });
+
+    test('help for functions is shown', function() {
+      assert.match(
+        help('\'random\' is undefined'),
+        /Did you just try to use p5\.js\'s random\(\) function\?/
+      );
+    });
+
+    test('help for variables is shown', function() {
+      assert.match(
+        help('\'mouseX\' is undefined'),
+        /Did you just try to use p5\.js\'s mouseX variable\?/
+      );
+    });
+  });
+});


### PR DESCRIPTION
This fixes #1247 by doing the following:

* Adding *everything* on `p5.prototype` (including constants like `PI`) on to the list of symbol names to search for in thrown error messages during page load. This should help with issues like #1237 and #903, and it will also help with some code that uses p5 addons too, e.g. using p5.dom's `select()` in top-level code. This might result in more false positives than are helpful, but maybe we should wait for bug reports to come in before deciding that?
* In the friendly error message, add a link to the helpful FAQ question [Why can't I assign variables using p5 functions and variables before `setup()`?](https://github.com/processing/p5.js/wiki/Frequently-Asked-Questions#why-cant-i-assign-variables-using-p5-functions-and-variables-before-setup) so users can get more details.
* Using more concise language to help the user, e.g.:
  * `Did you just try to use p5.js's HALF_PI constant?`
  * `Did you just try to use p5.js's random() function?`
  * `Did you just try to use p5.js's mouseX variable?`

Since this functionality is no longer really trivial, I also added a simple unit test suite.

I also added a bunch of comments in the code to explain some of the implementation decisions, as well as potential future workarounds.