### PR TITLE
Now able to use selected() in a user defined Select Box

### DIFF
--- a/lib/addons/p5.dom.js
+++ b/lib/addons/p5.dom.js
@@ -185,6 +185,30 @@
       return this;
       };
       return converted;
+    } else if (elt.tagName === "SELECT") {
+      var converted = new p5.Element(elt);
+      mult = elt.multiple;
+      converted.selected = function(value){
+        var arr = [];
+        if (arguments.length > 0){
+          for (var i = 0; i < this.elt.length; i++){
+            if (value.toString() === this.elt[i].value){
+              this.elt.selectedIndex = i;
+            }
+          }
+          return this;
+        }else{
+          if (mult){
+            for (var i = 0; i < this.elt.selectedOptions.length; i++){
+              arr.push(this.elt.selectedOptions[i].value);
+            }
+            return arr;
+          }else{
+            return this.elt.value;
+          }
+        }
+      };
+      return converted;
     } else if (elt.tagName === "VIDEO" || elt.tagName === "AUDIO") {
       return new p5.MediaElement(elt);
     } else {


### PR DESCRIPTION
In reference to an old issue, #933 . I thought something similar had to be done to `createSelect()` too.

When we do 

``` javascript
var select = createSelect("mult");
select.option("Hello");
select.option("World");
```

And we select "Hello" then `select.selected()` yields `[ "Hello" ]` .

But if we make a select box in the HTML document.

``` html
<select multiple="true" id="box">
  <option value="volvo">Volvo</option>
  <option value="saab">Saab</option>
  <option value="mercedes">Mercedes</option>
  <option value="audi">Audi</option>
</select>
```

And then we select the select box and try `selected()`, then it wont work.

``` javascript
var select = select("#box");
select.selected()
>>> undefined
```

This PR has fixed this. :)
