### PR TITLE
Fix 'renderer' yuidoc param for createCanvas().

### DIFF
--- a/src/core/rendering.js
+++ b/src/core/rendering.js
@@ -25,7 +25,7 @@ var defaultId = 'defaultCanvas0'; // this gets set again in createCanvas
  * @method createCanvas
  * @param  {Number} w width of the canvas
  * @param  {Number} h height of the canvas
- * @param  optional:{String} renderer 'p2d' | 'webgl'
+ * @param  {String} [renderer] 'p2d' | 'webgl'
  * @return {Object} canvas generated
  * @example
  * <div>


### PR DESCRIPTION
It seems the yuidoc docs for the `renderer` parameter of `createCanvas` are wrong, so I fixed them.

Old:

> ![2016-03-04_8-05-13](https://cloud.githubusercontent.com/assets/124687/13527821/ec162f98-e1df-11e5-849b-0c444caf43e3.png)

New:

> ![2016-03-04_8-05-36](https://cloud.githubusercontent.com/assets/124687/13527819/eaec05fc-e1df-11e5-9a1e-69bb4997874f.png)

