### PR TITLE
[WIP] Add experimental type-checker for reference tests

### DIFF
--- a/src/color/creating_reading.js
+++ b/src/color/creating_reading.js
@@ -332,8 +332,8 @@ p5.prototype.hue = function(c) {
  * The way that colours are interpolated depends on the current color mode.
  *
  * @method lerpColor
- * @param  {Array|Number} c1  interpolate from this color
- * @param  {Array|Number} c2  interpolate to this color
+ * @param  {Array|Number|p5.Color} c1  interpolate from this color
+ * @param  {Array|Number|p5.Color} c2  interpolate to this color
  * @param  {Number}       amt number between 0 and 1
  * @return {Array|Number}     interpolated color
  * @example

--- a/src/color/creating_reading.js
+++ b/src/color/creating_reading.js
@@ -332,10 +332,10 @@ p5.prototype.hue = function(c) {
  * The way that colours are interpolated depends on the current color mode.
  *
  * @method lerpColor
- * @param  {Array/Number} c1  interpolate from this color
- * @param  {Array/Number} c2  interpolate to this color
+ * @param  {Array|Number} c1  interpolate from this color
+ * @param  {Array|Number} c2  interpolate to this color
  * @param  {Number}       amt number between 0 and 1
- * @return {Array/Number}     interpolated color
+ * @return {Array|Number}     interpolated color
  * @example
  * <div>
  * <code>

--- a/src/color/setting.js
+++ b/src/color/setting.js
@@ -164,16 +164,16 @@ p5.prototype.clear = function() {
  * so you can change modes as you like without affecting their appearance.
  *
  * @method colorMode
- * @param {Number|Constant} mode   either RGB or HSB, corresponding to
+ * @param {Number/Constant} mode   either RGB or HSB, corresponding to
  *                                 Red/Green/Blue and Hue/Saturation/Brightness
  *                                 (or Lightness)
- * @param {Number|Constant} [max1] range for the red or hue depending on the
+ * @param {Number/Constant} [max1] range for the red or hue depending on the
  *                                 current color mode, or range for all values
- * @param {Number|Constant} [max2] range for the green or saturation depending
+ * @param {Number/Constant} [max2] range for the green or saturation depending
  *                                 on the current color mode
- * @param {Number|Constant} [max3] range for the blue or brightness/lighntess
+ * @param {Number/Constant} [max3] range for the blue or brightness/lighntess
  *                                 depending on the current color mode
- * @param {Number|Constant} [maxA] range for the alpha
+ * @param {Number/Constant} [maxA] range for the alpha
  * @example
  * <div>
  * <code>

--- a/src/core/transform.js
+++ b/src/core/transform.js
@@ -202,7 +202,7 @@ p5.prototype.rotateZ = function(rad) {
  * can be further controlled with push() and pop().
  *
  * @method scale
- * @param  {Number | p5.Vector | Array} s
+ * @param  {Number|p5.Vector|Array} s
  *                      percent to scale the object, or percentage to
  *                      scale the object in the x-axis if multiple arguments
  *                      are given

--- a/src/image/image.js
+++ b/src/image/image.js
@@ -101,10 +101,10 @@ p5.prototype.createImage = function(width, height) {
  *  file immediately, or prompt the user with a dialogue window.
  *
  *  @method saveCanvas
- *  @param  {[selectedCanvas]} canvas a variable representing a
- *                             specific html5 canvas (optional)
- *  @param  {[String]} filename
- *  @param  {[String]} extension 'jpg' or 'png'
+ *  @param  {Canvas} [canvas] a variable representing a
+ *                            specific html5 canvas (optional)
+ *  @param  {String} filename
+ *  @param  {String} extension 'jpg' or 'png'
  *  @example
  *  <div class='norender'><code>
  *  function setup() {

--- a/src/image/loading_displaying.js
+++ b/src/image/loading_displaying.js
@@ -29,10 +29,10 @@ require('../core/error_helpers');
  *
  * @method loadImage
  * @param  {String} path Path of the image to be loaded
- * @param  {Function(p5.Image)} [successCallback] Function to be called once
+ * @param  {Function} [successCallback] Function to be called once
  *                                the image is loaded. Will be passed the
  *                                p5.Image.
- * @param  {Function(Event)}    [failureCallback] called with event error if
+ * @param  {Function}    [failureCallback] called with error event if
  *                                the image fails to load.
  * @return {p5.Image}             the p5.Image object
  * @example

--- a/src/typography/attributes.js
+++ b/src/typography/attributes.js
@@ -43,7 +43,7 @@ p5.prototype.textAlign = function(horizAlign, vertAlign) {
  * setting will be used in all subsequent calls to the text() function.
  *
  * @method textLeading
- * @param {Number} leading the size in pixels for spacing between lines
+ * @param {Number} [leading] the size in pixels for spacing between lines
  * @return {Object|Number}
  * @example
  * <div>

--- a/test/js/typeChecker.js
+++ b/test/js/typeChecker.js
@@ -1,0 +1,251 @@
+var typeChecker = (function() {
+  var P5_CLASS_RE = /^p5\.([^.]+)$/;
+  var FILES_TO_IGNORE_FOR_NOW = [
+    // TODO: Eventually we shouldn't ignore these, but they're raising
+    // weird errors for now so we'll skip them.
+    'lib/addons/p5.sound.js'
+  ];
+  var METHODS_TO_IGNORE_FOR_NOW = [
+    // TODO: Eventually we shouldn't ignore these, or we should define
+    // some custom yuidoc tag on them to indicate that they do their own
+    // validation or something.
+
+    // This one can take any number of strings in the middle as args.
+    'p5.loadTable',
+
+    // This one is just complicated.
+    'p5.save',
+
+    // This one connects to p5.sound, which we're ignoring for now.
+    'p5.MediaElement.connect',
+
+    // Another odd one, might have incorrect docs for args.
+    'p5.dom.createCapture',
+  ];
+  var P5_ALIASES = [
+    'p5',
+    // These are supposedly "classes" in our docs, but they don't exist
+    // as objects, and their methods are all defined on p5.
+    'p5.dom',
+    'p5.sound'
+  ];
+  var OK_UNDEFINED_METHODS = [
+    // These are user-defined.
+    'p5.preload',
+    'p5.setup',
+    'p5.draw',
+    'p5.windowResized',
+    'p5.deviceMoved',
+    'p5.deviceTurned',
+    'p5.deviceShaken',
+    'p5.keyPressed',
+    'p5.keyReleased',
+    'p5.keyTyped',
+    'p5.mouseMoved',
+    'p5.mouseDragged',
+    'p5.mousePressed',
+    'p5.mouseReleased',
+    'p5.mouseClicked',
+    'p5.mouseWheel',
+    'p5.touchStarted',
+    'p5.touchMoved',
+    'p5.touchEnded',
+    // These are defined at construction time or something else dynamic.
+    'p5.remove',
+  ];
+  var typeValidators = {
+    'Number': function(value) {
+      return typeof(value) === 'number';
+    },
+    'String': function(value) {
+      return typeof(value) === 'string';
+    },
+    'Array': function(value) {
+      return Array.isArray(value);
+    },
+    'Object': function(value) {
+      return typeof(value) === 'object';
+    },
+    'Any': function(value) {
+      return true;
+    },
+    'Boolean': function(value) {
+      return typeof(value) === 'boolean';
+    },
+    'Function': function(value) {
+      return typeof(value) === 'function';
+    },
+    'Canvas': function(value) {
+      return value instanceof HTMLCanvasElement;
+    },
+    'Integer': function(value) {
+      return Number.isInteger(value);
+    },
+    'String/Constant': function(value) {
+      // TODO: Consider actually parsing the docs description to extract
+      // the names of constants out of it.
+      return typeof(value) === 'string';
+    },
+    'Number/Constant': function(value) {
+      // TODO: Consider actually parsing the docs description to extract
+      // the names of constants out of it.
+      return typeof(value) === 'number';
+    },
+    'p5.Table': function(value) {
+      return value instanceof p5.Table;
+    },
+    'p5.Vector': function(value) {
+      return value instanceof p5.Vector;
+    },
+    'p5.Color': function(value) {
+      return value instanceof p5.Color;
+    },
+    'p5.Image': function(value) {
+      return value instanceof p5.Image;
+    },
+    'p5.Element': function(value) {
+      return value instanceof p5.Element;
+    },
+    'p5.TableRow': function(value) {
+      return value instanceof p5.TableRow;
+    },
+    'undefined': function(value) {
+      // TODO: Investigate docs that mention this as a type, it's fishy.
+      return typeof(value) === 'undefined';
+    }
+  };
+
+  function log(msg) {
+  }
+
+  function buildTypeValidator(type, classitem) {
+    var fullName = classitem.class + '.' + classitem.name;
+    var validators = type.split('|').map(function(type) {
+      if (typeof(typeValidators[type]) !== 'function') {
+        throw new Error('Unknown type "' + type + '" documented as part of ' +
+                        fullName + '() in ' +
+                        classitem.file + " near line " + classitem.line);
+      }
+      return typeValidators[type];
+    });
+
+    return function(value) {
+      return validators.some(function(typeValidator) {
+        return typeValidator(value);
+      });
+    };
+  }
+
+  function buildParamValidator(classitem, param, argIndex) {
+    var isValidType = buildTypeValidator(param.type, classitem);
+
+    return function(value) {
+      if (!isValidType(value)) {
+        if (!param.optional) {
+          log("Invalid value for arg #" + (argIndex + 1) + " (" +
+              param.name + ") of " + classitem.name + "()");
+        }
+      }
+    };
+  }
+
+  function buildValidator(classitem) {
+    var name = classitem.name;
+    var paramValidators = (classitem.params || [])
+      .map(buildParamValidator.bind(null, classitem));
+
+    return {
+      validate: function(target, thisArg, argumentsList) {
+        paramValidators.forEach(function(paramValidator, i) {
+          paramValidator(argumentsList[i], i);
+        });
+      }
+    };
+  };
+
+  function decorateMethod(className, classObj, classitem) {
+    var fullName = className + "." + classitem.name;
+    var thisObj, target, validator;
+
+    if (METHODS_TO_IGNORE_FOR_NOW.indexOf(fullName) !== -1) {
+      return;
+    }
+
+    if (classitem.static) {
+      thisObj = classObj;
+      target = thisObj[classitem.name];
+      if (typeof(target) !== 'function') {
+          throw new Error(fullName + " is documented as a static method in " +
+                          classitem.file + ", but " +
+                          "is not a function defined on " +
+                          className);
+      }
+    } else {
+      thisObj = classObj.prototype;
+      target = thisObj[classitem.name];
+      if (typeof(target) !== 'function') {
+        if (OK_UNDEFINED_METHODS.indexOf(fullName) !== -1) {
+          return;
+        } else {
+          throw new Error(fullName + " is documented as an instance " +
+                          "method in " + classitem.file + ", but " +
+                          "is not a function defined on " +
+                          className + ".prototype");
+        }
+      }
+    }
+
+    validator = buildValidator(classitem);
+
+    thisObj[classitem.name] = function() {
+      validator.validate(target, this, [].slice.call(arguments));
+      return target.apply(this, arguments);
+    };
+  }
+
+  function decorateMethods(className, classObj, classitems) {
+    var proto = classObj.prototype;
+    var classitemMap = {};
+
+    classitems.forEach(function(classitem) {
+      // Note that we check for classitem.name because some methods
+      // don't appear to define them... Filed this as
+      // https://github.com/processing/p5.js/issues/1252.
+      if (classitem.class === className && classitem.name) {
+        if (classitemMap.hasOwnProperty(classitem.name)) {
+          throw new Error("Duplicate definition for " + className + "." +
+                          classitem.name);
+        }
+        classitemMap[classitem.name] = classitem;
+        if (classitem.itemtype === 'method' &&
+            FILES_TO_IGNORE_FOR_NOW.indexOf(classitem.file) === -1) {
+          decorateMethod(className, classObj, classitem);
+        }
+      }
+    });
+  }
+
+  function install(p5, yuidocs) {
+    Object.keys(yuidocs.classes).forEach(function(className) {
+      var target;
+
+      if (P5_ALIASES.indexOf(className) !== -1) {
+        target = p5;
+      } else if (P5_CLASS_RE.test(className)) {
+        target = p5[className.match(P5_CLASS_RE)[1]];
+        if (!target) {
+          throw new Error(className + " is documented as a class but " +
+                          "does not seem to exist");
+        }
+      } else {
+        throw new Error("Unrecognized class: " + className);
+      }
+
+      decorateMethods(className, target, yuidocs.classitems);
+    });
+  }
+
+  return {
+    install: install
+  };
+})();

--- a/test/test-reference.html
+++ b/test/test-reference.html
@@ -25,6 +25,7 @@
   <script src="js/bind.js" type="text/javascript" ></script>
   <script src="js/sinon.js" type="text/javascript" ></script>
   <script src="js/testRender.js" type="text/javascript" ></script>
+  <script src="js/typeChecker.js" type="text/javascript" ></script>
   <script type="text/javascript" >
     // Setup chai
     var expect = chai.expect;
@@ -216,6 +217,8 @@
             files[filename].forEach(defineTest);
           });
         });
+
+      //typeChecker.install(p5, data);
 
       mocha.run();
     };


### PR DESCRIPTION
**This is a [work-in-progress pull request](http://vrybas.github.io/blog/2014/04/11/wip-pull-requests/), please don't merge it yet.**

@lmccart: let me know if it's annoying to have a WIP PR lying about here--it's fine if that's the case, I can just move it over to my fork. I thought it might be nice to have it in the p5.js PR list so others can participate.

This is an attempt to use p5's own yuidocs to actively type-check its own examples. This can be beneficial for a number of reasons:
- It ensures that our documentation is accurate. For example, if `lerpColor()` can actually take a `p5.Color` as a first argument--_and_ it's likely that users will want to do this--but it isn't documented, then we should document it. Or if the argument type `Number` is misspelled as `Nimber`, we should throw an error at build or test time.
- It means that we can _potentially_ use our yuidoc metadata to build a more robust friendly error system, as per #759.

Limitations of this PR:
- Eventually, we should support some way of providing custom validation for methods that have complicated or problematic signatures, like [`save()`](http://p5js.org/reference/#/p5/save). There's a number of ways we can do this but for now we'll use one of two strategies:
  - Store a blacklist that excludes such methods, or even entire files, from validation entirely. This is defined as `FILES_TO_IGNORE_FOR_NOW` and `METHODS_TO_IGNORE_FOR_NOW` in `test/js/typeChecker.js`.
  - If the custom validation isn't very complex, we can write our own custom validator for now by adding an entry to the `customValidators` mapping in `test/js/typeChecker.js`.
- Ideally, we'd also type-check against the standard test suite, but this introduces complications to the build system, since it means that we'd have to generate yuidocs metadata before running tests, so we'll deal with that later if this PR is successful.
- This doesn't actually implement #759, it just lays some groundwork for doing so, while also providing the benefit of ensuring the continual correctness of our documentation. After all, before actually implementing #759, we need to make sure that the advice we're giving users in our friendly error system is actually accurate! :grin: 
- This PR doesn't currently check that the _return value_ of methods is actually what they're documented to be; this can be added in a future PR too.

Other concerns:
- It's possible that some methods may _secretly_ accept parameters that we want to _keep_ undocumented. For example, `p5.color()` can actually take a `p5.Color` instance as its single argument, and internal p5 methods do this all the time. I'm not entirely sure what the point of this is, and it may be too confusing for beginners to document this in our yuidocs, so I wrote a custom validator for this method that makes it not complain if the first argument is a `p5.Color`.
- In order for this to be really useful as p5 evolves, we need to actually document the functionality well and provide useful error feedback. Otherwise contributors will just get confused when they change the code and this particular test suite barfs at them with no guidance on how to fix things.
- If folks generally think this PR is a good idea, it'd be nice to figure out a way to get it into the codebase sooner rather than later. Making _all_ examples pass type-checking appears to be quite a task, which would result in a potentially massive PR; one alternative may be to _whitelist_ the examples we type-check at first, so that we start out by type-checking just a few of them, and slowly expand the coverage through subsequent PRs, until finally we switch from whitelisting to blacklisting.

Finally, note that this PR is an experiment! It's okay if it ends up being rejected. Hopefully we can learn from its mistakes, at least.
