### PR TITLE
strip tags from tooltip descriptions.

### DIFF
--- a/docs/yuidoc-p5-theme-src/scripts/tpl/list.html
+++ b/docs/yuidoc-p5-theme-src/scripts/tpl/list.html
@@ -7,7 +7,7 @@
         <dt class="subgroup-<%=subgroup.name%>"><%=subgroup.name%></dt>
     <% } %>
     <% _.each(subgroup.items, function(item) { %>
-    <dd><a href="<%=item.hash%>" title="<%=item.description%>"><%=item.name%><% if (item.itemtype === 'method') { %>()<%}%></a></dd>
+    <dd><a href="<%=item.hash%>" title="<%- striptags(item.description) %>"><%=item.name%><% if (item.itemtype === 'method') { %>()<%}%></a></dd>
     <% }); %>
     </dl>
   <% }); %>

--- a/docs/yuidoc-p5-theme-src/scripts/views/listView.js
+++ b/docs/yuidoc-p5-theme-src/scripts/views/listView.js
@@ -5,6 +5,11 @@ define([
   // Templates
   'text!tpl/list.html'
 ], function (_, Backbone, App, listTpl) {
+  var striptags = function(html) {
+    var div = document.createElement('div');
+    div.innerHTML = html;
+    return div.textContent;
+  };
 
   var listView = Backbone.View.extend({
     el: '#list',
@@ -79,6 +84,7 @@ define([
 
         // Put the <li> items html into the list <ul>
         var listHtml = self.listTpl({
+          'striptags': striptags,
           'title': self.capitalizeFirst(listCollection),
           'groups': self.groups,
           'listCollection': listCollection


### PR DESCRIPTION
This fixes #1289.

![untitled](https://cloud.githubusercontent.com/assets/124687/13550413/564dc180-e2eb-11e5-846e-0643090288ff.png)
