### PR TITLE
Add an 'init' registerMethod() type.

### DIFF
--- a/src/core/core.js
+++ b/src/core/core.js
@@ -445,6 +445,13 @@ var p5 = function(sketch, node, sync) {
     p5.prototype[k] = constants[k];
   }
 
+  // call any registered init functions
+  this._registeredMethods.init.forEach(function (f) {
+    if (typeof(f) !== 'undefined') {
+      f.call(this);
+    }
+  }, this);
+
   // If the user has created a global setup or draw function,
   // assume "global" mode and make everything global (i.e. on the window)
   if (!sketch) {
@@ -523,7 +530,7 @@ p5.prototype._preloadMethods = {
   loadFont: p5.prototype
 };
 
-p5.prototype._registeredMethods = { pre: [], post: [], remove: [] };
+p5.prototype._registeredMethods = { init: [], pre: [], post: [], remove: [] };
 
 p5.prototype._registeredPreloadMethods = {};
 

--- a/test/unit/core/core.js
+++ b/test/unit/core/core.js
@@ -95,4 +95,33 @@ suite('Core', function(){
     });*/
   });
 
+  suite('p5.prototype.registerMethod', function() {
+    test('should register and call "init" methods', function() {
+      var originalInit = p5.prototype._registeredMethods.init;
+      var myp5, myInitCalled;
+
+      p5.prototype._registeredMethods.init = [];
+
+      try {
+        p5.prototype.registerMethod('init', function myInit() {
+          assert(!myInitCalled,
+                 'myInit should only be called once during test suite');
+          myInitCalled = true;
+
+          this.myInitCalled = true;
+        });
+
+        myp5 = new p5(function(sketch) {
+          assert(sketch.hasOwnProperty('myInitCalled'));
+          assert(sketch.myInitCalled);
+
+          sketch.sketchFunctionCalled = true;
+        });
+
+        assert(myp5.sketchFunctionCalled);
+      } finally {
+        p5.prototype._registeredMethods.init = originalInit;
+      }
+    });
+  });
 });


### PR DESCRIPTION
This fixes #1263.

I'm thinking this is the documentation that should be added to the [Libraries wiki page](https://github.com/processing/p5.js/wiki/Libraries#use-registermethod-to-register-functions-with-p5-that-should-be-called-at-various-times):

  * **init** — Called when the sketch is first initialized, just before the sketch initialization function (the one that was passed into the `p5` constructor) is executed. This is also called before any global mode setup, so your library can add anything to the sketch and it will automatically be copied to `window` if global mode is active.

Hmm, hopefully that isn't too confusing. I had to think a lot about where exactly to call the registered **init** methods so let me know if you think it should be moved.

I figure if library authors want to be able to do something later on in initialization, we could add yet another method type called **preSetup** that is executed just before `setup()` is called?