### PR TITLE
Document overloaded methods nicely

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -181,6 +181,13 @@ module.exports = function(grunt) {
       }
     },
 
+    // Set up node-side (non-browser) mocha tests.
+    mochaTest: {
+      test: {
+        src: ['test/node/**/*.js']
+      }
+    },
+
     // Set up the mocha task, used for running the automated tests.
     mocha: {
       yui: {
@@ -340,11 +347,12 @@ module.exports = function(grunt) {
   grunt.loadNpmTasks('grunt-newer');
   grunt.loadNpmTasks('grunt-release-it');
   grunt.loadNpmTasks('grunt-saucelabs');
+  grunt.loadNpmTasks('grunt-mocha-test');
 
   // Create the multitasks.
   // TODO: "requirejs" is in here to run the "yuidoc_themes" subtask. Is this needed?
   grunt.registerTask('build', ['browserify', 'uglify', 'requirejs']);
-  grunt.registerTask('test', ['jshint', 'jscs', 'build', 'yuidoc:dev', 'connect', 'mocha']);
+  grunt.registerTask('test', ['jshint', 'jscs', 'build', 'yuidoc:dev', 'connect', 'mocha', 'mochaTest']);
   grunt.registerTask('test:nobuild', ['jshint:test', 'jscs:test', 'connect', 'mocha']);
   grunt.registerTask('yui', ['yuidoc:prod']);
   grunt.registerTask('yui:dev', ['yuidoc:dev']);

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -59,6 +59,7 @@ function getYuidocOptions() {
       paths: ['src/', 'lib/addons/'],
       themedir: 'docs/yuidoc-p5-theme/',
       helpers: [],
+      preprocessor: './docs/preprocessor.js',
       outdir: 'docs/reference/'
     }
   };

--- a/docs/preprocessor.js
+++ b/docs/preprocessor.js
@@ -1,0 +1,86 @@
+function mergeOverloadedMethods(data) {
+  var methodsByFullName = {};
+  var paramsForOverloadedMethods = {};
+
+  data.classitems = data.classitems.filter(function(classitem) {
+    var fullName, method;
+
+    var assertEqual = function(a, b, msg) {
+      if (a !== b) {
+        throw new Error(
+          'for ' + fullName + '() defined in ' + classitem.file + ':' +
+          classitem.line + ', ' +
+          msg + ' (' + JSON.stringify(a) + ' !== ' + JSON.stringify(b) + ')'
+        );
+      }
+    };
+
+    var processOverloadedParams = function(params) {
+      var paramNames;
+
+      if (!(fullName in paramsForOverloadedMethods)) {
+        paramsForOverloadedMethods[fullName] = {};
+      }
+
+      paramNames = paramsForOverloadedMethods[fullName];
+
+      params.forEach(function(param) {
+        var origParam = paramNames[param.name];
+
+        if (origParam) {
+          assertEqual(origParam.type, param.type,
+                      'types for param "' + param.name + '" must match ' +
+                      'across all overloads');
+          assertEqual(param.description, '',
+                      'description for param "' + param.name + '" should ' +
+                      'only be defined in its first use; subsequent ' +
+                      'overloads should leave it empty');
+        } else {
+          paramNames[param.name] = param;
+        }
+      });
+
+      return params;
+    };
+
+    if (classitem.itemtype && classitem.itemtype === 'method') {
+      fullName = classitem.class + '.' + classitem.name;
+      if (fullName in methodsByFullName) {
+        // It's an overloaded version of a method that we've already
+        // indexed. We need to make sure that we don't list it multiple
+        // times in our index pages and such.
+
+        method = methodsByFullName[fullName];
+
+        assertEqual(method.file, classitem.file,
+                    'all overloads must be defined in the same file');
+        assertEqual(method.module, classitem.module,
+                    'all overloads must be defined in the same module');
+        assertEqual(method.submodule, classitem.submodule,
+                    'all overloads must be defined in the same submodule');
+        assertEqual(classitem.description || '', '',
+                    'additional overloads should have no description');
+
+        if (!method.overloads) {
+          method.overloads = [{
+            line: method.line,
+            params: processOverloadedParams(method.params)
+          }];
+          delete method.params;
+        }
+        method.overloads.push({
+          line: classitem.line,
+          params: processOverloadedParams(classitem.params)
+        });
+        return false;
+      } else {
+        methodsByFullName[fullName] = classitem;
+      }
+    }
+    return true;
+  });
+}
+
+module.exports = function(data, options) {
+  mergeOverloadedMethods(data);
+};

--- a/docs/preprocessor.js
+++ b/docs/preprocessor.js
@@ -1,3 +1,13 @@
+var DocumentedMethod = require('./yuidoc-p5-theme-src/scripts/documented-method');
+
+function smokeTestMethods(data) {
+  data.classitems.forEach(function(classitem) {
+    if (classitem.itemtype === 'method') {
+      new DocumentedMethod(classitem);
+    }
+  });
+}
+
 function mergeOverloadedMethods(data) {
   var methodsByFullName = {};
   var paramsForOverloadedMethods = {};
@@ -83,6 +93,7 @@ function mergeOverloadedMethods(data) {
 
 module.exports = function(data, options) {
   mergeOverloadedMethods(data);
+  smokeTestMethods(data);
 };
 
 module.exports.mergeOverloadedMethods = mergeOverloadedMethods;

--- a/docs/preprocessor.js
+++ b/docs/preprocessor.js
@@ -84,3 +84,5 @@ function mergeOverloadedMethods(data) {
 module.exports = function(data, options) {
   mergeOverloadedMethods(data);
 };
+
+module.exports.mergeOverloadedMethods = mergeOverloadedMethods;

--- a/docs/yuidoc-p5-theme-src/scripts/documented-method.js
+++ b/docs/yuidoc-p5-theme-src/scripts/documented-method.js
@@ -1,0 +1,60 @@
+// https://github.com/umdjs/umd/blob/master/templates/returnExports.js
+(function (root, factory) {
+  if (typeof define === 'function' && define.amd) {
+    define([], factory);
+  } else if (typeof module === 'object' && module.exports) {
+    module.exports = factory();
+  } else {
+    root.DocumentedMethod = factory();
+  }
+}(this, function () {
+  function extend(target, src) {
+    Object.keys(src).forEach(function(prop) {
+      target[prop] = src[prop];
+    });
+    return target;
+  }
+
+  function DocumentedMethod(classitem) {
+    extend(this, classitem);
+
+    if (this.overloads) {
+      // Make each overload inherit properties from their parent
+      // classitem.
+      this.overloads = this.overloads.map(function(overload) {
+        return extend(Object.create(this), overload);
+      }, this);
+
+      if (this.params) {
+        throw new Error('params for overloaded methods should be undefined');
+      }
+
+      this.params = this._getMergedParams();
+    }
+  }
+
+  DocumentedMethod.prototype = {
+    // Merge parameters across all overloaded versions of this item.
+    _getMergedParams: function() {
+      var paramNames = {};
+      var params = [];
+
+      this.overloads.forEach(function(overload) {
+        if (!overload.params) {
+          return;
+        }
+        overload.params.forEach(function(param) {
+          if (param.name in paramNames) {
+            return;
+          }
+          paramNames[param.name] = param;
+          params.push(param);
+        });
+      });
+
+      return params;
+    }
+  };
+
+  return DocumentedMethod;
+}));

--- a/docs/yuidoc-p5-theme-src/scripts/main.js
+++ b/docs/yuidoc-p5-theme-src/scripts/main.js
@@ -34,6 +34,10 @@ require([
     App.modules = [];
     App.project = data.project;
 
+    // Keep track of all our methods by their fully-qualified name, e.g.
+    // 'p5.color'. This makes it easier for us to keep track of overloaded
+    // methods.
+    var methodsByFullName = {};
 
     var modules = data.modules;
 
@@ -62,11 +66,22 @@ require([
 
     // Get class items (methods, properties, events)
     _.each(items, function(el, idx, array) {
+      var fullName;
 
       if (el.itemtype) {
         if (el.itemtype === "method") {
-          App.methods.push(el);
-          App.allItems.push(el);
+          fullName = el.class + '.' + el.name;
+          if (fullName in methodsByFullName) {
+            // It's an overloaded version of a method that we've already
+            // indexed. We need to make sure that we don't list it multiple
+            // times in our index pages and such.
+            methodsByFullName[fullName].overloads.push(el);
+          } else {
+            methodsByFullName[fullName] = el;
+            methodsByFullName[fullName].overloads = [el];
+            App.methods.push(el);
+            App.allItems.push(el);
+          }
         } else if (el.itemtype === "property") {
           App.properties.push(el);
           App.allItems.push(el);

--- a/docs/yuidoc-p5-theme-src/scripts/main.js
+++ b/docs/yuidoc-p5-theme-src/scripts/main.js
@@ -34,10 +34,6 @@ require([
     App.modules = [];
     App.project = data.project;
 
-    // Keep track of all our methods by their fully-qualified name, e.g.
-    // 'p5.color'. This makes it easier for us to keep track of overloaded
-    // methods.
-    var methodsByFullName = {};
 
     var modules = data.modules;
 
@@ -66,22 +62,17 @@ require([
 
     // Get class items (methods, properties, events)
     _.each(items, function(el, idx, array) {
-      var fullName;
-
       if (el.itemtype) {
         if (el.itemtype === "method") {
-          fullName = el.class + '.' + el.name;
-          if (fullName in methodsByFullName) {
-            // It's an overloaded version of a method that we've already
-            // indexed. We need to make sure that we don't list it multiple
-            // times in our index pages and such.
-            methodsByFullName[fullName].overloads.push(el);
-          } else {
-            methodsByFullName[fullName] = el;
-            methodsByFullName[fullName].overloads = [el];
-            App.methods.push(el);
-            App.allItems.push(el);
+          if (el.overloads) {
+            // Make each overload inherit properties from their parent
+            // classitem.
+            el.overloads = el.overloads.map(function(overload) {
+              return _.extend(Object.create(el), overload);
+            });
           }
+          App.methods.push(el);
+          App.allItems.push(el);
         } else if (el.itemtype === "property") {
           App.properties.push(el);
           App.allItems.push(el);

--- a/docs/yuidoc-p5-theme-src/scripts/main.js
+++ b/docs/yuidoc-p5-theme-src/scripts/main.js
@@ -16,7 +16,8 @@ define('App', function() {
 require([
   'underscore',
   'backbone',
-  'App'], function(_, Backbone, App) {
+  'App',
+  './documented-method'], function(_, Backbone, App, DocumentedMethod) {
   
   // Set collections
   App.collections = ['allItems', 'classes', 'events', 'methods', 'properties', 'p5.sound', 'p5.dom'];
@@ -64,13 +65,7 @@ require([
     _.each(items, function(el, idx, array) {
       if (el.itemtype) {
         if (el.itemtype === "method") {
-          if (el.overloads) {
-            // Make each overload inherit properties from their parent
-            // classitem.
-            el.overloads = el.overloads.map(function(overload) {
-              return _.extend(Object.create(el), overload);
-            });
-          }
+          el = new DocumentedMethod(el);
           App.methods.push(el);
           App.allItems.push(el);
         } else if (el.itemtype === "property") {

--- a/docs/yuidoc-p5-theme-src/scripts/tpl/item.html
+++ b/docs/yuidoc-p5-theme-src/scripts/tpl/item.html
@@ -105,14 +105,14 @@
     {{/if}}
   </div>-->
 
-<% if (params) { %>
+<% if (item.params) { %>
 <div class="params">
   <h4>Parameters</h4>
   <table>
-  <% for (var i=0; i<params.length; i++) { %>
+  <% for (var i=0; i<item.params.length; i++) { %>
     <tr>
     <td>
-    <% var p = params[i] %>
+    <% var p = item.params[i] %>
     <% if (p.optional) { %>
       <code class="language-javascript">[<%=p.name%>]</code>
     <% } else { %>

--- a/docs/yuidoc-p5-theme-src/scripts/tpl/item.html
+++ b/docs/yuidoc-p5-theme-src/scripts/tpl/item.html
@@ -30,7 +30,11 @@
 
 <div>
   <h4>Syntax</h4>
-  <p><pre><code class="language-javascript"><%= syntax %></code></pre></p>
+  <p>
+    <% syntaxes.forEach(function(syntax) { %>
+    <pre><code class="language-javascript"><%= syntax %></code></pre>
+    <% }) %>
+  </p>
 </div>
 
 
@@ -101,14 +105,14 @@
     {{/if}}
   </div>-->
 
-<% if (item.params) { %>
+<% if (params) { %>
 <div class="params">
   <h4>Parameters</h4>
   <table>
-  <% for (var i=0; i<item.params.length; i++) { %>
+  <% for (var i=0; i<params.length; i++) { %>
     <tr>
     <td>
-    <% var p = item.params[i] %>
+    <% var p = params[i] %>
     <% if (p.optional) { %>
       <code class="language-javascript">[<%=p.name%>]</code>
     <% } else { %>

--- a/docs/yuidoc-p5-theme-src/scripts/views/itemView.js
+++ b/docs/yuidoc-p5-theme-src/scripts/views/itemView.js
@@ -25,6 +25,62 @@ define([
 
       return this;
     },
+    getSyntax: function(isMethod, cleanItem) {
+      var isConstructor = cleanItem.is_constructor;
+      var syntax = '';
+      if (isConstructor) syntax += 'new ';
+      syntax += cleanItem.name;
+
+      if (isMethod || isConstructor) {
+        syntax += '(';
+        if (cleanItem.params) {
+          for (var i=0; i<cleanItem.params.length; i++) { 
+            var p = cleanItem.params[i];
+            if (p.optional) syntax += '[';
+            syntax += p.name;
+            if (p.optdefault) syntax += '='+p.optdefault;
+            if (p.optional) syntax += ']';
+            if (i !== cleanItem.params.length-1) {
+              syntax += ',';
+            }
+          }
+        }
+        syntax += ')';
+      }
+
+      return syntax;
+    },
+    // Return a list of valid syntaxes across all overloaded versions of
+    // this item.
+    //
+    // For reference, we ultimately want to replicate something like this:
+    //
+    // https://processing.org/reference/color_.html
+    getSyntaxes: function(isMethod, cleanItem) {
+      var overloads = cleanItem.overloads || [cleanItem];
+      return overloads.map(this.getSyntax.bind(this, isMethod));
+    },
+    // Merge parameters across all overloaded versions of this item.
+    getParams: function(cleanItem) {
+      var overloads = cleanItem.overloads || [cleanItem];
+      var paramNames = {};
+      var params = [];
+
+      overloads.forEach(function(overload) {
+        if (!overload.params) {
+          return;
+        }
+        overload.params.forEach(function(param) {
+          if (param.name in paramNames) {
+            return;
+          }
+          paramNames[param.name] = param;
+          params.push(param);
+        });
+      });
+
+      return params;
+    },
     render: function (item) {
       if (item) {
         var itemHtml = '',
@@ -34,29 +90,8 @@ define([
             isConstructor = cleanItem.is_constructor;
         cleanItem.isMethod = collectionName === 'Method';
 
-
-        // create syntax string
-        var syntax = '';
-        if (isConstructor) syntax += 'new ';
-        syntax += cleanItem.name;
-
-        if (cleanItem.isMethod || isConstructor) {
-          syntax += '(';
-          if (cleanItem.params) {
-            for (var i=0; i<cleanItem.params.length; i++) { 
-              var p = cleanItem.params[i];
-              if (p.optional) syntax += '[';
-              syntax += p.name;
-              if (p.optdefault) syntax += '='+p.optdefault;
-              if (p.optional) syntax += ']';
-              if (i !== cleanItem.params.length-1) {
-                syntax += ',';
-              }
-            }
-          }
-          syntax += ')';
-        }
-
+        var syntaxes = this.getSyntaxes(cleanItem.isMethod, cleanItem);
+        var params = this.getParams(cleanItem);
 
         // Set the item header (title)
 
@@ -65,7 +100,8 @@ define([
           if (isConstructor) {
             var constructor = this.tpl({
               item: cleanItem,
-              syntax: syntax
+              syntaxes: syntaxes,
+              params: params
             });
             cleanItem.constructor = constructor;
           }
@@ -78,7 +114,8 @@ define([
         } else {
           itemHtml = this.tpl({
             item: cleanItem,
-            syntax: syntax
+            syntaxes: syntaxes,
+            params: params
           });
         }
 

--- a/docs/yuidoc-p5-theme-src/scripts/views/itemView.js
+++ b/docs/yuidoc-p5-theme-src/scripts/views/itemView.js
@@ -60,27 +60,6 @@ define([
       var overloads = cleanItem.overloads || [cleanItem];
       return overloads.map(this.getSyntax.bind(this, isMethod));
     },
-    // Merge parameters across all overloaded versions of this item.
-    getParams: function(cleanItem) {
-      var overloads = cleanItem.overloads || [cleanItem];
-      var paramNames = {};
-      var params = [];
-
-      overloads.forEach(function(overload) {
-        if (!overload.params) {
-          return;
-        }
-        overload.params.forEach(function(param) {
-          if (param.name in paramNames) {
-            return;
-          }
-          paramNames[param.name] = param;
-          params.push(param);
-        });
-      });
-
-      return params;
-    },
     render: function (item) {
       if (item) {
         var itemHtml = '',
@@ -91,7 +70,6 @@ define([
         cleanItem.isMethod = collectionName === 'Method';
 
         var syntaxes = this.getSyntaxes(cleanItem.isMethod, cleanItem);
-        var params = this.getParams(cleanItem);
 
         // Set the item header (title)
 
@@ -100,8 +78,7 @@ define([
           if (isConstructor) {
             var constructor = this.tpl({
               item: cleanItem,
-              syntaxes: syntaxes,
-              params: params
+              syntaxes: syntaxes
             });
             cleanItem.constructor = constructor;
           }
@@ -114,8 +91,7 @@ define([
         } else {
           itemHtml = this.tpl({
             item: cleanItem,
-            syntaxes: syntaxes,
-            params: params
+            syntaxes: syntaxes
           });
         }
 

--- a/package.json
+++ b/package.json
@@ -32,6 +32,9 @@
     "grunt-newer": "^1.1.0",
     "grunt-release-it": "^0.2.1",
     "grunt-update-json": "^0.2.1",
+    "grunt-mocha-test": "^0.12.7",
+    "chai": "^3.5.0",
+    "mocha": "^2.4.5",
     "jscs-stylish": "^0.3.1",
     "phantomjs": "~1.9.2-4"
   },

--- a/src/color/creating_reading.js
+++ b/src/color/creating_reading.js
@@ -109,13 +109,8 @@ p5.prototype.brightness = function(c) {
  * Colors are stored as Numbers or Arrays.
  *
  * @method color
- * @param  {Number|String} v1      gray value or red or hue value relative to
- *                                 the current color range, or a color string
- * @param  {Number}        [v2]    gray value or green or saturation value
- *                                 relative to the current color range (or
- *                                 alpha value if first param is gray value)
- * @param  {Number}        [v3]    gray value or blue or brightness value
- *                                 relative to the current color range
+ * @param  {Number|String} gray    number specifying value between white
+ *                                 and black.
  * @param  {Number}        [alpha] alpha value relative to current color range
  * @return {Array}                 resulting color
  *
@@ -242,6 +237,18 @@ p5.prototype.brightness = function(c) {
  * </code>
  * </div>
  */
+
+/**
+ * @method color
+ * @param  {Number|String} v1      red or hue value relative to
+ *                                 the current color range, or a color string
+ * @param  {Number}        v2      green or saturation value
+ *                                 relative to the current color range
+ * @param  {Number}        v3      blue or brightness value
+ *                                 relative to the current color range
+ * @param  {Number}        [alpha]
+ */
+
 p5.prototype.color = function() {
   if (arguments[0] instanceof p5.Color) {
     return arguments[0];  // Do nothing if argument is already a color object.

--- a/test/node/test-docs-preprocessor.js
+++ b/test/node/test-docs-preprocessor.js
@@ -1,0 +1,71 @@
+var expect = require('chai').expect;
+
+var preprocessor = require('../../docs/preprocessor');
+
+describe('docs preprocessor', function() {
+  describe('mergeOverloadedMethods()', function() {
+    var merge = preprocessor.mergeOverloadedMethods;
+
+    var ensureMergeDoesNothing = function(data) {
+      var dataCopy = JSON.parse(JSON.stringify(data));
+      merge(dataCopy);
+      expect(dataCopy).to.eql(data);
+    };
+
+    it('should merge methods with the same name', function() {
+      var data = {
+        classitems: [{
+          file: 'foo.js',
+          line: 1,
+          description: 'Does foo.',
+          itemtype: 'method',
+          name: 'foo',
+          params: [{name: 'bar', type: 'String'}]
+        }, {
+          file: 'foo.js',
+          line: 5,
+          itemtype: 'method',
+          name: 'foo',
+          params: [{name: 'baz', type: 'Number'}]
+        }],
+      };
+
+      merge(data);
+
+      expect(data).to.eql({
+        classitems: [{
+          file: 'foo.js',
+          line: 1,
+          description: 'Does foo.',
+          itemtype: 'method',
+          name: 'foo',
+          overloads: [{
+            line: 1,
+            params: [{name: 'bar', type: 'String'}]
+          }, {
+            line: 5,
+            params: [{name: 'baz', type: 'Number'}]
+          }]
+        }]
+      });
+    });
+
+    it('should not merge methods from different classes', function() {
+      ensureMergeDoesNothing({
+        classitems: [
+          {itemtype: 'method', class: 'Bar', name: 'foo'},
+          {itemtype: 'method', class: 'Baz', name: 'foo'},
+        ]
+      });
+    });
+
+    it('should not merge properties', function() {
+      ensureMergeDoesNothing({
+        classitems: [
+          {itemtype: 'property', name: 'foo'},
+          {itemtype: 'property', name: 'foo'},
+        ]
+      });
+    });
+  });
+});


### PR DESCRIPTION
**This is a [work-in-progress pull request](http://vrybas.github.io/blog/2014/04/11/wip-pull-requests/), please don't merge it yet.**

This is ~~an experimental proof-of-concept to see how feasible it may be~~ a PR to document overloaded methods in a way similar to [Java Processing's documentation](https://processing.org/reference/color_.html), as per @lmccart's explanation in https://github.com/processing/p5.js/pull/1287#issuecomment-192735393.

Here's what the new [`p5.color()`](http://p5js.org/reference/#/p5/color) docs look like in this PR: 

![overloads](https://cloud.githubusercontent.com/assets/124687/13569312/53f02d06-e435-11e5-80bc-29920ad94e85.png)

The good news is that YUIDoc already has a mechanism for recording information about overloaded methods: if you define a method *twice* with different params, it just adds both versions to `data.json`. We just need to add logic to our view layer to ensure that our index page doesn't contain a separate link for each overloaded version, and that the item detail view properly lists all the different method signatures and all the params. That's what this PR attempts to do.

Limitations:

* This PR makes things work with overloaded *methods*, but it may not work with overloaded *constructors* or other kinds of callables.
* Ideally I think that all the optional params would be listed after all the required params. Shouldn't be hard to fix.
* Unlike the [original Processing docs for `color()`](https://processing.org/reference/color_.html), I documented `[alpha]` as an optional param, which resulted in only two different signatures rather than four. There's no reason we can't document it the way Processing does--I was being a bit lazy, I guess. :grin:
* ~~A lot of logic for the overloading is done during render time, rather than during build time. It'll be better for QA to raise errors and such at build time instead. I'm thinking that we could do some kind of transformation to `data.json`, maybe, so that the item view just displays information rather than doing a bunch of the logic I've added in this PR. This will also probably make the information easier for the [experimental type-checker](https://github.com/processing/p5.js/pull/1287) and friendly error system to use, too.~~
* I'm not really sure how much I like the whole "just document multiple versions of the same method in separate comment blocks" approach of YUIDoc. As can be seen from the example of `p5.color()` that I've done for this PR, it reads a bit weird to have a comment block with just one version of the method's params and tons of examples, and then have little overloaded versions documented in separate comment blocks right after it. We might be able to experiment with this. But another alternative, if we *really* don't like this approach, may be to invent our own syntax for describing overloaded methods and bypass YUIDoc entirely.
