### PR TITLE
keyTyped() is preventing keyboard input

### DIFF
--- a/src/events/keyboard.js
+++ b/src/events/keyboard.js
@@ -249,7 +249,8 @@ p5.prototype._onkeyup = function (e) {
  *   } else if (key === 'b') {
  *     value = 0;
  *   }
- *   return false; // prevent any default behavior
+ *   // uncomment to prevent any default behavior
+ *   // return false;
  * }
  * </code>
  * </div>


### PR DESCRIPTION
The search bar can't be used if the `return false;` wasn't commented out. Quick fix but should work.