### PR TITLE
Log helpful warnings if user overwrites p5 global functions.

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -252,6 +252,11 @@ module.exports = function(grunt) {
     // front of the file.
     uglify: {
       options: {
+        compress: {
+          global_defs: {
+            'IS_MINIFIED': true
+          }
+        },
         banner: '/*! p5.js v<%= pkg.version %> <%= grunt.template.today("mmmm dd, yyyy") %> */ ',
         footer: 'p5.prototype._validateParameters = function() {};'+
         'p5.prototype._friendlyFileLoadError = function() {};'

--- a/src/core/core.js
+++ b/src/core/core.js
@@ -556,7 +556,7 @@ p5.prototype._createFriendlyGlobalFunctionBinder = function(options) {
   };
 
   return function(prop, value) {
-    if (typeof(value) === 'function') {
+    if (typeof(IS_MINIFIED) === 'undefined' && typeof(value) === 'function') {
       try {
         // Because p5 has so many common function names, it's likely
         // that users may accidentally overwrite global p5 functions with

--- a/src/core/core.js
+++ b/src/core/core.js
@@ -571,6 +571,11 @@ p5.prototype._createFriendlyGlobalFunctionBinder = function(options) {
           throw new Error('global "' + prop + '" already exists');
         }
 
+        // It's possible that this might throw an error because there
+        // are a lot of edge-cases in which `Object.defineProperty` might
+        // not succeed; since this functionality is only intended to
+        // help beginners anyways, we'll just catch such an exception
+        // if it occurs, and fall back to legacy behavior.
         Object.defineProperty(globalObject, prop, {
           configurable: true,
           enumerable: true,
@@ -592,11 +597,6 @@ p5.prototype._createFriendlyGlobalFunctionBinder = function(options) {
           }
         });
       } catch (e) {
-        // It's likely that this is a TypeError due to us trying to
-        // redefine a non-configurable property, which can happen if
-        // the user already declared the property name as a global
-        // variable. Let's log a warning and fall back to our legacy
-        // behavior.
         log(
           'p5 had problems creating the global function "' + prop + '", ' +
           'possibly because your code is already using that name as ' +

--- a/test/test-minified.html
+++ b/test/test-minified.html
@@ -32,6 +32,12 @@
   <!-- Include anything you want to test -->
   <script src="../lib/p5.min.js" type="text/javascript" ></script>
 
+  <script type="text/javascript">
+    // Let unit tests know we're testing the minified version.
+
+    window.IS_TESTING_MINIFIED_VERSION = true;
+  </script>
+
   <!-- Spec files -->
   <script src="unit/core/core.js" type="text/javascript" ></script>
   <!--<script src="unit/core/2d_primitives.js" type="text/javascript" ></script>-->

--- a/test/unit/core/core.js
+++ b/test/unit/core/core.js
@@ -124,4 +124,75 @@ suite('Core', function(){
       }
     });
   });
+
+  suite('p5.prototype._createFriendlyGlobalFunctionBinder', function() {
+    var noop = function() {};
+    var createBinder = p5.prototype._createFriendlyGlobalFunctionBinder;
+    var logMsg, globalObject, bind;
+
+    beforeEach(function() {
+      globalObject = {};
+      logMsg = undefined;
+      bind = createBinder({
+        globalObject: globalObject,
+        log: function(msg) {
+          if (logMsg !== undefined) {
+            // For simplicity, we'll write each test so it's expected to
+            // log a message at most once.
+            throw new Error('log() was called more than once');
+          }
+          logMsg = msg;
+        }
+      });
+    });
+
+    test('should warn when globals already exist', function() {
+      globalObject.text = 'hi';
+      bind('text', noop);
+      assert.match(logMsg, /p5 had problems creating .+ "text"/);
+      assert.equal(globalObject.text, noop);
+    });
+
+    test('should warn when globals are overwritten', function() {
+      bind('text', noop);
+      globalObject.text = 'boop';
+
+      assert.match(logMsg, /You just changed the value of "text"/);
+      assert.equal(globalObject.text, 'boop');
+      assert.deepEqual(Object.keys(globalObject), ['text']);
+    });
+
+    test('should allow overwritten globals to be overwritten', function() {
+      bind('text', noop);
+      globalObject.text = 'boop';
+      globalObject.text += 'blap';
+      assert.equal(globalObject.text, 'boopblap');
+    });
+
+    test('should allow globals to be deleted', function() {
+      bind('text', noop);
+      delete globalObject.text;
+      assert.isUndefined(globalObject.text);
+      assert.isUndefined(logMsg);
+    });
+
+    test('should create enumerable globals', function() {
+      bind('text', noop);
+      assert.deepEqual(Object.keys(globalObject), ['text']);
+    });
+
+    test('should not warn about overwriting print()', function() {
+      globalObject.print = window.print;
+      bind('print', noop);
+      assert.equal(globalObject.print, noop);
+      assert.isUndefined(logMsg);
+    });
+
+    test('should not warn about overwriting non-functions', function() {
+      bind('mouseX', 5);
+      globalObject.mouseX = 50;
+      assert.equal(globalObject.mouseX, 50);
+      assert.isUndefined(logMsg);
+    });
+  });
 });

--- a/test/unit/core/core.js
+++ b/test/unit/core/core.js
@@ -146,21 +146,39 @@ suite('Core', function(){
       });
     });
 
-    test('should warn when globals already exist', function() {
-      globalObject.text = 'hi';
-      bind('text', noop);
-      assert.match(logMsg, /p5 had problems creating .+ "text"/);
-      assert.equal(globalObject.text, noop);
-    });
+    if (!window.IS_TESTING_MINIFIED_VERSION) {
+      test('should warn when globals already exist', function() {
+        globalObject.text = 'hi';
+        bind('text', noop);
+        assert.match(logMsg, /p5 had problems creating .+ "text"/);
+        assert.equal(globalObject.text, noop);
+      });
 
-    test('should warn when globals are overwritten', function() {
-      bind('text', noop);
-      globalObject.text = 'boop';
+      test('should warn when globals are overwritten', function() {
+        bind('text', noop);
+        globalObject.text = 'boop';
 
-      assert.match(logMsg, /You just changed the value of "text"/);
-      assert.equal(globalObject.text, 'boop');
-      assert.deepEqual(Object.keys(globalObject), ['text']);
-    });
+        assert.match(logMsg, /You just changed the value of "text"/);
+        assert.equal(globalObject.text, 'boop');
+        assert.deepEqual(Object.keys(globalObject), ['text']);
+      });
+    } else {
+      test('should NOT warn when globals already exist', function() {
+        globalObject.text = 'hi';
+        bind('text', noop);
+        assert.isUndefined(logMsg);
+        assert.equal(globalObject.text, noop);
+      });
+
+      test('should NOT warn when globals are overwritten', function() {
+        bind('text', noop);
+        globalObject.text = 'boop';
+
+        assert.isUndefined(logMsg);
+        assert.equal(globalObject.text, 'boop');
+        assert.deepEqual(Object.keys(globalObject), ['text']);
+      });
+    }
 
     test('should allow overwritten globals to be overwritten', function() {
       bind('text', noop);


### PR DESCRIPTION
This is an attempt to fix #1317 and prevent future occurrences of #1314 by allowing the overwriting of p5 globals, but logging helpful warning messages informing the user of what just happened.

### Example 1

```js
var text = "blarg";

function setup() {
}
```

This will cause the following message to be logged to the console:

```
p5 had problems creating the global function "text", possibly because your
code is already using that name as a variable. You may want to rename
your variable to something else.
```

### Example 2

```js
function setup() {
  text += "blarg";
}
```

This will cause the following message to be logged to the console:

```
You just changed the value of "text", which was a p5 function. This could cause
problems later if you're not careful.
```

### Limitations

* Modifying a global p5 function via [`delete`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/delete) or [`Object.defineProperty()`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/defineProperty) won't log any warnings, but it's unlikely that users--especially novices who could really use the assistance--will be using these.
* Warnings are only logged for p5 global *functions*, so the user won't see anything if e.g. their code conflicts with `mouseX` or `mouseIsPressed`. We might want to tackle those in a separate PR if we want to address them, since I think the implementation will be a bit different and independent of the changes in this PR.
* There's a potential performance hit from the fact that this mechanism adds the overhead of a function call every time a global p5 function is accessed. It'd be nice if we could add a build-time conditional that only adds this extra functionality for non-minified/non-optimized builds, as per the friendly error system. ~~I know how to do this kind of thing with webpack but not browserify.~~ Update: this is actually a feature of UglifyJS, which I mention in https://github.com/processing/p5.js/pull/1318#issuecomment-202081479.
* ~~This PR doesn't currently have any unit tests. I'd like to add some!~~ We have unit tests now!
