### PR TITLE
Improve documentation for random()

### DIFF
--- a/src/math/random.js
+++ b/src/math/random.js
@@ -72,13 +72,13 @@ p5.prototype.randomSeed = function(seed) {
  * Return a random floating-point number.
  *
  * Takes either 0, 1 or 2 arguments.
- * 
+ *
  * If no argument is given, returns a random number from 0
  * up to (but not including) 1.
- * 
+ *
  * If one argument is given, returns a random number from 0 up to
  * (but not including) the number.
- * 
+ *
  * If two arguments are given, returns a random number from the
  * first argument up to (but not including) the second argument.
  *

--- a/src/math/random.js
+++ b/src/math/random.js
@@ -69,17 +69,22 @@ p5.prototype.randomSeed = function(seed) {
 };
 
 /**
- * Return a random number.
+ * Return a random floating-point number.
  *
  * Takes either 0, 1 or 2 arguments.
- * If no argument is given, returns a random number between 0 and 1.
- * If one argument is given, returns a random number between 0 and the number.
- * If two arguments are given, returns a random number between them,
- * inclusive.
+ * 
+ * If no argument is given, returns a random number from 0
+ * up to (but not including) 1.
+ * 
+ * If one argument is given, returns a random number from 0 up to
+ * (but not including) the number.
+ * 
+ * If two arguments are given, returns a random number from the
+ * first argument up to (but not including) the second argument.
  *
  * @method random
- * @param  {Number} min   the lower bound
- * @param  {Number} max   the upper bound
+ * @param  {Number} [min]   the lower bound (inclusive)
+ * @param  {Number} [max]   the upper bound (exclusive)
  * @return {Number} the random number
  * @example
  * <div>


### PR DESCRIPTION
This is an attempt to make some minor improvements to `random()`:

* Mention the fact that the lower bound is *inclusive* while the upper bound is *exclusive*. At least, um, that's how I *think* `random()` is working--someone may want to double-check, but it appears to be the way this works, especially given the third example in the docs. It's also how most random functions I know of work (e.g. in [JavaScript](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Math/random), [Python](https://docs.python.org/2/library/random.html#random.random), and [Ruby](http://ruby-doc.org/core-2.2.0/Random.html#method-i-rand)).
* Mark both arguments as optional.
* Mention that the return value is always a floating-point number. I'm not sure if "floating-point" might confuse beginners, but I couldn't think of a better word, and I thought it was important to note. @iamjessklein and I were actually thinking it might be nice to have a glossary in the docs, which terms like this can directly link to?
