### PR TITLE
Expose the global p5 instance as `p5.instance` on `window`

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -74,7 +74,7 @@ var _globalInit = function() {
     // then instantiate p5 in "global" mode
     if((window.setup && typeof window.setup === 'function') ||
       (window.draw && typeof window.draw === 'function')) {
-      new p5();
+      p5.instance = new p5();
     }
   }
 };


### PR DESCRIPTION
This allows the p5 instance created in global mode to be accessed and manipulated outside of the sketch code.

See use case [here](https://github.com/yangsu/p5-live/blob/master/main.js)