### PR TITLE
Render documentation descriptions as Markdown

### DIFF
--- a/docs/preprocessor.js
+++ b/docs/preprocessor.js
@@ -1,3 +1,5 @@
+var marked = require('marked');
+
 var DocumentedMethod = require('./yuidoc-p5-theme-src/scripts/documented-method');
 
 function smokeTestMethods(data) {
@@ -91,9 +93,32 @@ function mergeOverloadedMethods(data) {
   });
 }
 
+function renderItemDescriptionsAsMarkdown(item) {
+  if (item.description) {
+    item.description = marked(item.description);
+  }
+  if (item.params) {
+    item.params.forEach(renderItemDescriptionsAsMarkdown);
+  }
+}
+
+function renderDescriptionsAsMarkdown(data) {
+  Object.keys(data.modules).forEach(function(moduleName) {
+    renderItemDescriptionsAsMarkdown(data.modules[moduleName]);
+  });
+  Object.keys(data.classes).forEach(function(className) {
+    renderItemDescriptionsAsMarkdown(data.classes[className]);
+  });
+  data.classitems.forEach(function(classitem) {
+    renderItemDescriptionsAsMarkdown(classitem);
+  });
+}
+
 module.exports = function(data, options) {
+  renderDescriptionsAsMarkdown(data);
   mergeOverloadedMethods(data);
   smokeTestMethods(data);
 };
 
 module.exports.mergeOverloadedMethods = mergeOverloadedMethods;
+module.exports.renderDescriptionsAsMarkdown = renderDescriptionsAsMarkdown;

--- a/docs/yuidoc-p5-theme/assets/reference.css
+++ b/docs/yuidoc-p5-theme/assets/reference.css
@@ -1,0 +1,23 @@
+/**
+ * Note: most of the styling for the reference documentation is actually
+ * contained in the p5.js-website repository:
+ *
+ * https://github.com/processing/p5.js-website/blob/master/css/main.css
+ *
+ * However, some of it is located here so we can easily iterate on it
+ * in the same repository.
+ */
+
+#reference .params table p {
+  /* Recently-added support for Markdown means that every parameter
+   * description is wrapped in a paragraph element. (Previously, they weren't
+   * wrapped in any kind of element.)
+   *
+   * We may eventually want to display paragraphs as blocks, so that we
+   * can have lengthy descriptions for parameters, but for now we'll
+   * keep our pre-existing behavior and essentially make paragraphs
+   * "invisible" by rendering them inline. */
+  display: inline;
+
+  font-size: inherit;
+}

--- a/docs/yuidoc-p5-theme/layouts/main.handlebars
+++ b/docs/yuidoc-p5-theme/layouts/main.handlebars
@@ -26,6 +26,8 @@
     <!-- CSS (order matters): code highlighting -->
     <link rel="stylesheet" href="{{p5SiteRoot}}/css/prism.css">
 
+    <link rel="stylesheet" href="{{projectAssets}}/reference.css">
+
     <!-- modernizer (not leveraged, yet) 
     <script src="{{p5SiteRoot}}/js/vendor/modernizr-2.6.2.min.js"></script>-->
 

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "grunt-release-it": "^0.2.1",
     "grunt-update-json": "^0.2.1",
     "grunt-mocha-test": "^0.12.7",
+    "marked": "^0.3.5",
     "chai": "^3.5.0",
     "mocha": "^2.4.5",
     "jscs-stylish": "^0.3.1",

--- a/test/node/test-docs-preprocessor.js
+++ b/test/node/test-docs-preprocessor.js
@@ -68,4 +68,34 @@ describe('docs preprocessor', function() {
       });
     });
   });
+
+  describe('renderDescriptionsAsMarkdown', function() {
+    var render = preprocessor.renderDescriptionsAsMarkdown;
+
+    it('should work', function() {
+      var data = {
+        modules: {},
+        classes: {},
+        classitems: [{
+          description: 'hi `there`',
+          params: [{
+            description: 'what is *up*'
+          }]
+        }]
+      };
+
+      render(data);
+
+      expect(data).to.eql({
+        modules: {},
+        classes: {},
+        classitems: [{
+          description: '<p>hi <code>there</code></p>\n',
+          params: [{
+            description: '<p>what is <em>up</em></p>\n'
+          }]
+        }]
+      });
+    });
+  });
 });


### PR DESCRIPTION
While trying to fix #1337, I realized that our documentation descriptions aren't currently rendering as Markdown. p5's use of YUIDoc had led me to assume otherwise.

I believe the reason for this is because YUIDoc is built for *statically* generating documentation, and it renders Markdown during this static generation phase. However, p5's static generation phase is actually extremely simple, because its documentation is a single-page app, rendered at [`main.handlebars`](https://github.com/processing/p5.js/blob/master/docs/yuidoc-p5-theme/layouts/main.handlebars).

Instead, the majority of page rendering is actually done on the client-side via the Backbone app contained in [`docs/yuidoc-p5-theme-src`](https://github.com/processing/p5.js/tree/master/docs/yuidoc-p5-theme-src). This app looks at `data.json` directly to retrieve all the reference documentation data, and *that* file has the original, raw descriptions for our documentation--*not* rendered Markdown.

This is why we have to have `<br><br>`'s between every paragraph in our documentation, rather than simply inserting a blank line, as YUIDoc leads us to believe (which @limzykenneth has noted in #1190).

So this PR attempts to ease this difficulty by using our [YUIDoc preprocessor](https://github.com/processing/p5.js/pull/1295#issuecomment-201275694) to convert all descriptions in `data.json` to Markdown at build time (via the [marked](https://github.com/chjj/marked) npm module). I decided to take this approach rather than rendering the Markdown on the client-side for a few reasons:

* There isn't any dynamic functionality pertaining to Markdown rendering that actually *requires* it to be on the client side.
* Rendering it on the client-side means shipping a Markdown-rendering library to the user's browser, which isn't great given that the [docs already load slowly](https://github.com/processing/p5.js-website/issues/143). (According to GitHub, [`marked.min.js`](https://github.com/chjj/marked/blob/master/marked.min.js) weighs in at 19K.)
  * Actually, in retrospect, there is a tradeoff here: because Markdown is generally more compact than HTML, the `data.json` blob will be larger if we render the Markdown at build time. So not sure if this ends up being a net gain.
* Rendering it on the client-side potentially slows down the client/drains battery life.
* Rendering it at build time means we can (eventually) statically analyze it and ensure its correctness, e.g. that any internal links aren't broken.

That said, because this PR now renders everything as Markdown, it's quite likely that some documentation doesn't appear exactly like it used to.