### PR TITLE
Don't trigger warnings on preload().

### DIFF
--- a/src/core/core.js
+++ b/src/core/core.js
@@ -556,7 +556,9 @@ p5.prototype._createFriendlyGlobalFunctionBinder = function(options) {
   };
 
   return function(prop, value) {
-    if (typeof(IS_MINIFIED) === 'undefined' && typeof(value) === 'function') {
+    if (typeof(IS_MINIFIED) === 'undefined' &&
+        typeof(value) === 'function' &&
+        !(prop in p5.prototype._preloadMethods)) {
       try {
         // Because p5 has so many common function names, it's likely
         // that users may accidentally overwrite global p5 functions with

--- a/test/unit/core/core.js
+++ b/test/unit/core/core.js
@@ -206,6 +206,15 @@ suite('Core', function(){
       assert.isUndefined(logMsg);
     });
 
+    // This is a regression test for
+    // https://github.com/processing/p5.js/issues/1350.
+    test('should not warn about overwriting preload methods', function() {
+      globalObject.loadJSON = function() { throw new Error(); };
+      bind('loadJSON', noop);
+      assert.equal(globalObject.loadJSON, noop);
+      assert.isUndefined(logMsg);
+    });
+
     test('should not warn about overwriting non-functions', function() {
       bind('mouseX', 5);
       globalObject.mouseX = 50;


### PR DESCRIPTION
This fixes #1350.

It's not a completely optimal fix, because it actually completely disables warning messages for overwriting preload methods. This means that even in the case of legitimate user error like this:

```js
function preload() {
  loadJSON += "blah";
  loadJSON('http://stuff');
}

function setup() {}
```

the user won't get a warning. However, my hunch is that users are unlikely to accidentally overwrite the preload methods, since their names are more unusual than other p5 functions and thus a lot less likely to accidentally be overwritten. I could be wrong, though, in which case we could implement something a bit more complex (well, harder to unit test, at least) like https://github.com/processing/p5.js/issues/1350#issuecomment-204802589.