### PR TITLE
Fix selectAll() example

### DIFF
--- a/lib/addons/p5.dom.js
+++ b/lib/addons/p5.dom.js
@@ -109,7 +109,7 @@
    * @param  {String} [container] id, p5.Element, or HTML element to search within
    * @return {Array} Array of p5.Elements containing nodes found
    * @example
-   * <div ><code class='norender'>
+   * <div class='norender'><code>
    * function setup() {
    *   createButton('btn');
    *   createButton('2nd btn');
@@ -121,7 +121,7 @@
    *   }
    * }
    * </code></div>
-   * <div ><code class='norender'>
+   * <div class='norender'><code>
    * // these are all valid calls to selectAll()
    * var a = selectAll('.moo');
    * var b = selectAll('div');
@@ -895,8 +895,8 @@
    * <a href="http://w3c.github.io/mediacapture-main/getusermedia.html#media-track-constraints"> W3C
    * spec</a> for possible properties. Note that not all of these are supported
    * by all browsers.</p>
-   * <p>Security note: A new browser security specification requires that getUserMedia, 
-   * which is behind createCapture(), only works when you're running the code locally, 
+   * <p>Security note: A new browser security specification requires that getUserMedia,
+   * which is behind createCapture(), only works when you're running the code locally,
    * or on HTTPS. Learn more <a href="http://stackoverflow.com/questions/34197653/getusermedia-in-chrome-47-without-using-https">here</a>
    * and <a href="https://developer.mozilla.org/en-US/docs/Web/API/MediaDevices/getUserMedia">here</a>.</p>
    *


### PR DESCRIPTION
See [#246](https://github.com/processing/p5.js-website/issues/246) at website repo. Problem was due to misplaced `norender` class.