### PR TITLE
get() returns blank image if metadata not loaded and no arguments

### DIFF
--- a/lib/addons/p5.dom.js
+++ b/lib/addons/p5.dom.js
@@ -1766,7 +1766,11 @@
   p5.MediaElement.prototype.get = function(x, y, w, h){
     if (this.loadedmetadata) { // wait for metadata
       return p5.Renderer2D.prototype.get.call(this, x, y, w, h);
-    } else return [0, 0, 0, 255];
+    } else if (!x) {
+      return new p5.Image(1, 1);
+    } else {
+      return [0, 0, 0, 255];
+    }
   };
   p5.MediaElement.prototype.set = function(x, y, imgOrCol){
     if (this.loadedmetadata) { // wait for metadata


### PR DESCRIPTION
`get()` return as `p5.Image` if no arguments are passed in.  For examples that are copying from a video element, this fix allows `get()` to return a blank image while waiting for the `loadedmetadata`