### PR TITLE
Fixes for #1413: bugs when drawing opentype fonts with multiple renderers

### DIFF
--- a/src/core/p5.Renderer2D.js
+++ b/src/core/p5.Renderer2D.js
@@ -1195,7 +1195,7 @@ p5.Renderer2D.prototype.textWidth = function(s) {
 
   if (this._isOpenType()) {
 
-    return this._textFont._textWidth(s);
+    return this._textFont._textWidth(s, this._textSize);
   }
 
   return this.drawingContext.measureText(s).width;

--- a/src/typography/p5.Font.js
+++ b/src/typography/p5.Font.js
@@ -411,10 +411,10 @@ p5.Font.prototype._scale = function(fontSize) {
 };
 
 p5.Font.prototype._handleAlignment = function(p, ctx, line, x, y) {
-
-  var textWidth = this._textWidth(line),
-    textAscent = this._textAscent(),
-    textDescent = this._textDescent(),
+  var fontSize = p._renderer._textSize;
+  var textWidth = this._textWidth(line, fontSize),
+    textAscent = this._textAscent(fontSize),
+    textDescent = this._textDescent(fontSize),
     textHeight = textAscent + textDescent;
 
   if (ctx.textAlign === constants.CENTER) {

--- a/src/typography/p5.Font.js
+++ b/src/typography/p5.Font.js
@@ -225,7 +225,7 @@ p5.Font.prototype._getGlyphs = function(str) {
  */
 p5.Font.prototype._getPath = function(line, x, y, options) {
 
-  var p = this.parent,
+  var p = (options && options.renderer._pInst) || this.parent,
     ctx = p._renderer.drawingContext,
     pos = this._handleAlignment(p, ctx, line, x, y);
 
@@ -346,7 +346,7 @@ p5.Font.prototype._renderPath = function(line, x, y, options) {
   } else {
 
     //pos = handleAlignment(p, ctx, line, x, y);
-    pdata = this._getPath(line, x, y, pg._textSize, options).commands;
+    pdata = this._getPath(line, x, y, options).commands;
   }
 
   ctx.beginPath();

--- a/src/typography/p5.Font.js
+++ b/src/typography/p5.Font.js
@@ -225,7 +225,7 @@ p5.Font.prototype._getGlyphs = function(str) {
  */
 p5.Font.prototype._getPath = function(line, x, y, options) {
 
-  var p = (options && options.renderer._pInst) || this.parent,
+  var p = (options && options.renderer && options.renderer._pInst) || this.parent,
     ctx = p._renderer.drawingContext,
     pos = this._handleAlignment(p, ctx, line, x, y);
 

--- a/src/typography/p5.Font.js
+++ b/src/typography/p5.Font.js
@@ -225,7 +225,8 @@ p5.Font.prototype._getGlyphs = function(str) {
  */
 p5.Font.prototype._getPath = function(line, x, y, options) {
 
-  var p = (options && options.renderer && options.renderer._pInst) || this.parent,
+  var p = (options && options.renderer && options.renderer._pInst) ||
+    this.parent,
     ctx = p._renderer.drawingContext,
     pos = this._handleAlignment(p, ctx, line, x, y);
 


### PR DESCRIPTION
Fixes for #1413 (bug demos in issue): 

These changes fix some bugs that arise when using a p5.Font with multiple renderers.  The issues come from the font assuming it's `parent` property is the appropriate p5 instance to use to look up the font size & font alignment.

Changes:

- `Font._renderPath` now passes along the renderer that it receives (via `options`) to `Font._getPath`, so that the appropriate text size can be looked up and applied.  Without this, `Font._getPath` defaults to the renderer that is stored when the font was created (`font.parent`).  This caused the text size and text alignment to always be based on `font.parent`.
- `Font._getPath` was being called with an extra (old?) argument for text size that wasn't being handled, so I removed that.
- `Renderer2D.textWidth` was not specifying a fontSize when calling `Font.textWidth`.  This caused textWidth to always be based on the font's `parent`.
- `Font._handleAlignment` was not using it's p5 instance parameter to look up the font size.  Alignment was thus always based on `this.parent`'s font size.

I tested this locally and everything seems to be working.  Demos from #1413 now all work as expected.