### PR TITLE
use saveJSON() in its example

### DIFF
--- a/src/io/files.js
+++ b/src/io/files.js
@@ -1126,7 +1126,7 @@ p5.prototype.save = function (object, _filename, _options) {
  *    json.name = 'Lion';
  *
  *  // To save, un-comment the line below, then click 'run'
- *  // saveJSONObject(json, 'lion.json');
+ *  // saveJSON(json, 'lion.json');
  *  }
  *
  *  // Saves the following to a file called "lion.json":


### PR DESCRIPTION
The example of saveJSON() was using saveJSONObject() instead of the saveJSON().