### PR TITLE
Fix rect() argument handling when rectMode === CORNERS

### DIFF
--- a/src/core/2d_primitives.js
+++ b/src/core/2d_primitives.js
@@ -438,7 +438,7 @@ p5.prototype.rect = function () {
     // p5 supports negative width and heights for rects
     if (args[3] < 0){args[3] = Math.abs(args[3]);}
     if (args[4] < 0){args[4] = Math.abs(args[4]);}
-  } else {
+  } else if (this._renderer._rectMode !== constants.CORNERS) {
     // p5 supports negative width and heights for rects
     if (args[2] < 0){args[2] = Math.abs(args[2]);}
     if (args[3] < 0){args[3] = Math.abs(args[3]);}


### PR DESCRIPTION
From what I understand of WebGL it doesn’t care about `rectMode` so [line 437](https://github.com/joecridge/p5.js/blob/120e85cb682e16b4a64f53f9885c94cf70481006/src/core/2d_primitives.js#L437) fine as is, but let me know if this is wrong...