### PR TITLE
Improve example for p5.prototype.focused

### DIFF
--- a/src/core/environment.js
+++ b/src/core/environment.js
@@ -93,7 +93,7 @@ p5.prototype.frameCount = 0;
  * // To demonstrate, put two windows side by side.
  * // Click on the window that the p5 sketch isn't in!
  * function draw() {
- *   background(200);   
+ *   background(200);
  *   noStroke();
  *   fill(0, 200, 0);
  *   ellipse(25, 25, 50, 50);

--- a/src/core/environment.js
+++ b/src/core/environment.js
@@ -93,17 +93,17 @@ p5.prototype.frameCount = 0;
  * // To demonstrate, put two windows side by side.
  * // Click on the window that the p5 sketch isn't in!
  * function draw() {
- *   if (focused) {  // or "if (focused === true)"
- *     noStroke();
- *     fill(0, 200, 0);
- *     ellipse(25, 25, 50, 50);
- *   } else {
+ *   background(200);   
+ *   noStroke();
+ *   fill(0, 200, 0);
+ *   ellipse(25, 25, 50, 50);
+ *
+ *   if (!focused) {  // or "if (focused === false)"
  *     stroke(200,0,0);
  *     line(0, 0, 100, 100);
  *     line(100, 0, 0, 100);
  *   }
  * }
- *
  * </code></div>
  */
 p5.prototype.focused = (document.hasFocus());


### PR DESCRIPTION
The original example isn't wrong but a little bit confusing:
When we switch to other window, `focused` turns false and a red cross shows which overlaps the circle. But then if switch back, `focused` turns true again right. However, the red cross is still here, the only difference is, the green circle is now on top of red cross.

I think it's hard to notice the difference between two state for people, I just thought it's a bug when I first play with this example. So I try to improve it to be more logical and visual appealing.
![slice1](https://cloud.githubusercontent.com/assets/6561433/15643527/7965c4dc-2680-11e6-88d8-a071faabb0c8.png)


