### PR TITLE
fix typo in saveFrames documentation

### DIFF
--- a/src/image/image.js
+++ b/src/image/image.js
@@ -230,7 +230,7 @@ p5.prototype.saveCanvas = function() {
  *  @param  {Function} [callback] A callback function that will be executed
                                   to handle the image data. This function
                                   should accept an array as argument. The
-                                  array will contain the spcecified number of
+                                  array will contain the specified number of
                                   frames of objects. Each object has three
                                   properties: imageData - an
                                   image/octet-stream, filename and extension.


### PR DESCRIPTION
Changes "spcecified" to "specified" in saveFrames callback doc, which shows up on [p5 site.](https://p5js.org/reference/#/p5/saveFrames)