### PR TITLE
Link to p5.dom/p5.sound docs from main reference

### DIFF
--- a/docs/yuidoc-p5-theme-src/scripts/tpl/menu.html
+++ b/docs/yuidoc-p5-theme-src/scripts/tpl/menu.html
@@ -1,3 +1,10 @@
+<p>
+  <small>
+    Can't find what you're looking for? You may want to check out
+    <a href="#/libraries/p5.dom">p5.dom</a> or
+    <a href="#/libraries/p5.sound">p5.sound</a>.
+  </small>
+</p>
 
 <% var i=0; %>
 <% var max=Math.floor(groups.length/4); %>


### PR DESCRIPTION
This fixes https://github.com/processing/p5.js-website/issues/184 by adding a little note at the top of the main reference section:

![2016-06-11_7-35-16](https://cloud.githubusercontent.com/assets/124687/15984834/141e51c2-2fa7-11e6-89fc-40eedf38110d.png)
