### PR TITLE
Change mouseX/mouseY handling

### DIFF
--- a/src/core/core.js
+++ b/src/core/core.js
@@ -345,9 +345,9 @@ var p5 = function(sketch, node, sync) {
       }
 
       this._setProperty('frameCount', this.frameCount + 1);
+      this.redraw();
       this._updateMouseCoords();
       this._updateTouchCoords();
-      this.redraw();
       this._frameRate = 1000.0/(now - this._lastFrameTime);
       this._lastFrameTime = now;
     }

--- a/src/events/mouse.js
+++ b/src/events/mouse.js
@@ -13,15 +13,12 @@ var p5 = require('../core/core');
 var constants = require('../core/constants');
 
 /*
- * These are helper vars that store the mouseX and mouseY vals
- * between the time that a mouse event happens and the next frame
- * of draw. This is done to deal with the asynchronicity of event
- * calls interacting with the draw loop. When a mouse event occurs
- * the _nextMouseX/Y vars are updated, then on each call of draw, mouseX/Y
- * and pmouseX/Y are updated using the _nextMouseX/Y vals.
+ * This is a flag which is false until the first time
+ * we receive a mouse event. The pmouseX and pmouseY
+ * values will match the mouseX and mouseY values until
+ * this interaction takes place.
  */
-p5.prototype._nextMouseX = 0;
-p5.prototype._nextMouseY = 0;
+p5.prototype._hasMouseInteracted = false;
 
 /**
  * The system variable mouseX always contains the current horizontal
@@ -312,27 +309,32 @@ p5.prototype.mouseIsPressed = false;
 p5.prototype.isMousePressed = false; // both are supported
 
 p5.prototype._updateNextMouseCoords = function(e) {
+  var x = this.mouseX;
+  var y = this.mouseY;
   if(e.type === 'touchstart' ||
      e.type === 'touchmove' ||
      e.type === 'touchend' || e.touches) {
-    this._setProperty('_nextMouseX', this._nextTouchX);
-    this._setProperty('_nextMouseY', this._nextTouchY);
-  } else {
-    if(this._curElement !== null) {
-      var mousePos = getMousePos(this._curElement.elt, e);
-      this._setProperty('_nextMouseX', mousePos.x);
-      this._setProperty('_nextMouseY', mousePos.y);
-    }
+    x = this.touchX;
+    y = this.touchY;
+  } else if(this._curElement !== null) {
+    var mousePos = getMousePos(this._curElement.elt, e);
+    x = mousePos.x;
+    y = mousePos.y;
   }
+  this._setProperty('mouseX', x);
+  this._setProperty('mouseY', y);
   this._setProperty('winMouseX', e.pageX);
   this._setProperty('winMouseY', e.pageY);
+  if (!this._hasMouseInteracted) {
+    // For first draw, make previous and next equal
+    this._updateMouseCoords();
+    this._setProperty('_hasMouseInteracted', true);
+  }
 };
 
 p5.prototype._updateMouseCoords = function() {
   this._setProperty('pmouseX', this.mouseX);
   this._setProperty('pmouseY', this.mouseY);
-  this._setProperty('mouseX', this._nextMouseX);
-  this._setProperty('mouseY', this._nextMouseY);
   this._setProperty('pwinMouseX', this.winMouseX);
   this._setProperty('pwinMouseY', this.winMouseY);
 };


### PR DESCRIPTION
Hello!

This changes the way mouse and touch values are stored to address the following two tickets:
https://github.com/processing/p5.js/issues/1176
https://github.com/processing/p5.js/issues/1269

Currently, `mouseX` and `mouseY` values are always lagging behind the real system values when the mouse is moving.

The new approach works like this:

- On mouse events, set the `mouseX` and `mouseY` values so that they represent the actual mouse value at that event
- After we `draw()` a frame, we set the `pmouseX` and `pmouseY` to the value of `mouseX` and `mouseY`, the next time the draw is called it will have the previous mouse position
- The first time we change `mouseX` and `mouseY`, we also set the `pmouseX/pmouseY` to the same value. This way they don't start at (0, 0) which is a bit arbitrary.
- Same logic applied for touch events and `pwinMouseX` / `pwinMouseY`

Some tests, I'm using the p5js editor.

## Example 1

```js
function setup() {
  createCanvas(windowWidth, windowHeight);
}

function draw () {
  line(mouseX, mouseY, pmouseX, pmouseY);
}
```

Before PR:  
![screen shot 2016-06-16 at 12 03 32 pm](https://cloud.githubusercontent.com/assets/1383811/16123833/65df0c6a-33ba-11e6-8673-1af138bb8b9a.png)

After PR:  
![screen shot 2016-06-16 at 12 00 34 pm](https://cloud.githubusercontent.com/assets/1383811/16123843/700dcb5e-33ba-11e6-8b2b-52ac114adc64.png)

## Example 2

```js
function setup() {
  createCanvas(windowWidth, windowHeight);
}

function mouseMoved() {
  ellipse(mouseX, mouseY, 50, 50);
}
```

Before PR:  
![screen shot 2016-06-16 at 12 03 09 pm](https://cloud.githubusercontent.com/assets/1383811/16123882/8cffe0b2-33ba-11e6-8123-b62c50a23d36.png)

After PR:  
![screen shot 2016-06-16 at 12 00 51 pm](https://cloud.githubusercontent.com/assets/1383811/16123889/95ff46a8-33ba-11e6-8966-a57a49791f43.png)


Let me know what you think! :smile: 