### PR TITLE
Streamline Renderer2D.get()

### DIFF
--- a/src/core/p5.Renderer2D.js
+++ b/src/core/p5.Renderer2D.js
@@ -213,23 +213,23 @@ p5.Renderer2D.prototype.get = function(x, y, w, h) {
   var ctx = this._pInst || this;
 
   var pd = ctx._pixelDensity;
-  ctx.loadPixels();
 
   // round down to get integer numbers
   x = Math.floor(x);
   y = Math.floor(y);
 
+  var sx = x * pd;
+  var sy = y * pd;
   if (w === 1 && h === 1){
-    var startPoint = pd*pd*4*(y*this.width+x);
+    var imageData = this.drawingContext.getImageData(sx, sy, 1, 1).data;
+    //imageData = [0,0,0,0];
     return [
-      ctx.pixels[startPoint],
-      ctx.pixels[startPoint+1],
-      ctx.pixels[startPoint+2],
-      ctx.pixels[startPoint+3]
+      imageData[0],
+      imageData[1],
+      imageData[2],
+      imageData[3]
     ];
   } else {
-    var sx = x * pd;
-    var sy = y * pd;
     //auto constrain the width and height to
     //dimensions of the source image
     var dw = Math.min(w, ctx.width);


### PR DESCRIPTION
I'm new here! But this seemed like a pretty obvious improvement.


Don't call loadPixels(); we don't need it.
When getting a single pixel value, just use getImageData with
width/height 1.

Tests pass, and there's a get() test, but it seems to never run??
I could never get it to fail, so there's something not right there.
I tested with a local sketch and things seem fine.

An attempt to help with:
https://github.com/processing/p5.js/issues/1485