### PR TITLE
When loadTable() errors, call callback if and only if it's a function

### DIFF
--- a/src/io/files.js
+++ b/src/io/files.js
@@ -410,8 +410,10 @@ p5.prototype.loadStrings = function (path, callback, errorCallback) {
  * @param  {String}         filename   name of the file or URL to load
  * @param  {String|Strings} [options]  "header" "csv" "tsv"
  * @param  {Function}       [callback] function to be executed after
- *                                     loadTable() completes, Table object is
- *                                     passed in as first argument
+ *                                     loadTable() completes. On success, the
+ *                                     Table object is passed in as the
+ *                                     first argument; otherwise, false
+ *                                     is passed in.
  * @return {Object}                    Table object containing data
  *
  * @example
@@ -628,7 +630,7 @@ p5.prototype.loadTable = function (path) {
     .fail(function (err, msg) {
       p5._friendlyFileLoadError(2, path);
       // don't get error callback mixed up with decrementPreload
-      if ((typeof callback !== 'undefined') &&
+      if ((typeof callback === 'function') &&
         (callback !== decrementPreload)) {
         callback(false);
       }


### PR DESCRIPTION
In #1481, @mikashin was understandably confused when their `loadTable()` call failed with the error `22462: Uncaught TypeError: object is not a function`.

This is actually a bug in p5 and it's happening because the code in `loadTable` that checks to see if a callback was passed-in is checking to see if it's not `undefined`; however, internally the function defaults the value to `null`, which isn't the same thing as `undefined`, so the browser was trying to call the null callback and failing.

This PR fixes the bug by checking to see if `callback` is specifically a function. It also improves the documentation by documenting what's passed in to the callback if an error occurred.
