### PR TITLE
Added removeAttribute() function. Should fix #1499

### DIFF
--- a/lib/addons/p5.dom.js
+++ b/lib/addons/p5.dom.js
@@ -1385,6 +1385,21 @@
       return this;
     }
   };
+  
+  
+  /**
+   *
+   * Removes an attibute on the specified element.
+   *
+   * @method removeAttribute
+   * @param  {String} attr       attribute to remove
+   * @return {Object/p5.Element} 
+   *                             
+   */
+  p5.Element.prototype.removeAttribute = function(attr) {
+    this.elt.removeAttribute(attr);
+    return this;
+  };  
 
 
   /**


### PR DESCRIPTION
This is a simple wrapper for the [HTML DOM removeAttribute method](http://www.w3schools.com/jsref/met_element_removeattribute.asp). Apparently, using this method would be the only way of removing the [`disabled` attribute](http://www.w3schools.com/tags/att_input_disabled.asp) to re-enable an input.