### PR TITLE
Define param as optional

### DIFF
--- a/src/core/core.js
+++ b/src/core/core.js
@@ -29,8 +29,8 @@ var constants = require('./constants');
  * @param  {Function}    sketch a closure that can set optional preload(),
  *                              setup(), and/or draw() properties on the
  *                              given p5 instance
- * @param  {HTMLElement|boolean} node element to attach canvas to, if a
- *                                    boolean is passed in use it as sync
+ * @param  {HTMLElement|boolean} [node] element to attach canvas to, if a
+ *                                      boolean is passed in use it as sync
  * @param  {boolean}     [sync] start synchronously (optional)
  * @return {p5}                 a p5 instance
  */


### PR DESCRIPTION
Currently I'm developing a library for p5.js. For that I tested different kinds of instantiation. Thereby I noticed, that the second parameter `node` of the method `window.p5()` is optional. So I changed the internal comments to improve the documentation quality. In fact it's a small detail.

Should we extend the current [example](https://p5js.org/examples/examples/Instance_Mode_Instantiation.php) with these examples?

Here you see the tested variants:

```html
<!DOCTYPE html>
<html lang="en">
<head>
  <meta charset="UTF-8">
  <title></title>
  <script language="javascript" type="text/javascript" src="https://ashleyjamesbrown.com/p5js/p5.js"></script>
</head>
<body>
  <script>
  var sketch = function(p) {
    p.setup = function(){
      p.createCanvas(100, 100);
      p.background(0);
    }
  };
  new window.p5(sketch);  // <--- That works.
  </script>
</body>
</html>
```

```html
<!DOCTYPE html>
<html lang="en">
<head>
  <meta charset="UTF-8">
  <title></title>
  <script language="javascript" type="text/javascript" src="https://ashleyjamesbrown.com/p5js/p5.js"></script>
</head>
<body>
  <div id="container"></div>
  <script>
  var sketch = function(p) {
    p.setup = function(){
      p.createCanvas(100, 100);
      p.background(0);
    }
  };
  new window.p5(sketch, window.document.getElementById('container'));  // <--- That works.
  </script>
</body>
</html>
```

```html
<!DOCTYPE html>
<html lang="en">
<head>
  <meta charset="UTF-8">
  <title></title>
  <script language="javascript" type="text/javascript" src="https://ashleyjamesbrown.com/p5js/p5.js"></script>
</head>
<body>
  <script>
  var sketch = function(p) {
    p.setup = function(){
      p.createCanvas(100, 100);
      p.background(0);
    }
  };
  var node = document.createElement("div");
  // console.log('node: ', typeof(node), node.__proto__, node);
  // HTMLDivElement <- HTMLElement
  window.document.getElementsByTagName('body')[0].appendChild(node);
  new window.p5(sketch, node);  // <--- That works.
  </script>
</body>
</html>
```

```html
<!DOCTYPE html>
<html lang="en">
<head>
  <meta charset="UTF-8">
  <title></title>
  <script language="javascript" type="text/javascript" src="https://ashleyjamesbrown.com/p5js/p5.js"></script>
</head>
<body>
  <script>
  var sketch = function(p) {
    p.setup = function(){
      p.createCanvas(100, 100);
      p.background(0);
    }
  };
  var node = document.createElement("div");
  // console.log('node: ', typeof(node), node.__proto__, node);
  // HTMLDivElement <- HTMLElement
  new window.p5(sketch, node);  // <--- Logically that works as well.
  window.document.getElementsByTagName('body')[0].appendChild(node);
  </script>
</body>
</html>
```