### PR TITLE
Fix value() index bug (#1514)

### DIFF
--- a/lib/addons/p5.dom.js
+++ b/lib/addons/p5.dom.js
@@ -678,7 +678,7 @@
     };
     self.selected = function(){
       var length = this.elt.childNodes.length;
-      if(arguments[0]) {
+      if(arguments.length == 1) {
         for (var i = 0; i < length; i+=2){
           if(this.elt.childNodes[i].value == arguments[0])
             this.elt.childNodes[i].checked = true;
@@ -693,7 +693,7 @@
     };
     self.value = function(){
       var length = this.elt.childNodes.length;
-      if(arguments[0]) {
+      if(arguments.length == 1) {
         for (var i = 0; i < length; i+=2){
           if(this.elt.childNodes[i].value == arguments[0])
             this.elt.childNodes[i].checked = true;
@@ -1385,21 +1385,21 @@
       return this;
     }
   };
-  
-  
+
+
   /**
    *
    * Removes an attibute on the specified element.
    *
    * @method removeAttribute
    * @param  {String} attr       attribute to remove
-   * @return {Object/p5.Element} 
-   *                             
+   * @return {Object/p5.Element}
+   *
    */
   p5.Element.prototype.removeAttribute = function(attr) {
     this.elt.removeAttribute(attr);
     return this;
-  };  
+  };
 
 
   /**


### PR DESCRIPTION
Related issue: https://github.com/processing/p5.js/issues/1514

Short description: The number `0` as value in an if-condition will be interpreted as `false`. Because of that nothing happens. Instead the fix uses the length of passed arguments.