### PR TITLE
Avoid .bind when assigning some methods to global object

### DIFF
--- a/src/core/core.js
+++ b/src/core/core.js
@@ -464,7 +464,11 @@ var p5 = function(sketch, node, sync) {
       if(typeof p5.prototype[p] === 'function') {
         var ev = p.substring(2);
         if (!this._events.hasOwnProperty(ev)) {
-          friendlyBindGlobal(p, p5.prototype[p].bind(this));
+          if (p5.prototype[p]._context !== false) {
+            friendlyBindGlobal(p, p5.prototype[p].bind(this));
+          } else {
+            friendlyBindGlobal(p, p5.prototype[p]);
+          }
         }
       } else {
         friendlyBindGlobal(p, p5.prototype[p]);

--- a/src/math/calculation.js
+++ b/src/math/calculation.js
@@ -28,6 +28,8 @@ var p5 = require('../core/core');
  * </code></div>
  */
 p5.prototype.abs = Math.abs;
+// Avoid `.bind`ing this method in global mode
+p5.prototype.abs._context = false;
 
 /**
  * Calculates the closest int value that is greater than or equal to the
@@ -64,6 +66,8 @@ p5.prototype.abs = Math.abs;
  * </code></div>
  */
 p5.prototype.ceil = Math.ceil;
+// Avoid `.bind`ing this method in global mode
+p5.prototype.ceil._context = false;
 
 /**
  * Constrains a value between a minimum and maximum value.
@@ -104,6 +108,8 @@ p5.prototype.ceil = Math.ceil;
 p5.prototype.constrain = function(n, low, high) {
   return Math.max(Math.min(n, high), low);
 };
+// Avoid `.bind`ing this method in global mode
+p5.prototype.constrain._context = false;
 
 /**
  * Calculates the distance between two points.
@@ -155,6 +161,8 @@ p5.prototype.dist = function(x1, y1, z1, x2, y2, z2) {
     return Math.sqrt( (x2-x1)*(x2-x1) + (y2-y1)*(y2-y1) + (z2-z1)*(z2-z1) );
   }
 };
+// Avoid `.bind`ing this method in global mode
+p5.prototype.dist._context = false;
 
 /**
  * Returns Euler's number e (2.71828...) raised to the power of the n
@@ -201,6 +209,8 @@ p5.prototype.dist = function(x1, y1, z1, x2, y2, z2) {
  * </code></div>
  */
 p5.prototype.exp = Math.exp;
+// Avoid `.bind`ing this method in global mode
+p5.prototype.exp._context = false;
 
 /**
  * Calculates the closest int value that is less than or equal to the
@@ -236,6 +246,8 @@ p5.prototype.exp = Math.exp;
  * </code></div>
  */
 p5.prototype.floor = Math.floor;
+// Avoid `.bind`ing this method in global mode
+p5.prototype.floor._context = false;
 
 /**
  * Calculates a number between two numbers at a specific increment. The amt
@@ -276,6 +288,8 @@ p5.prototype.floor = Math.floor;
 p5.prototype.lerp = function(start, stop, amt) {
   return amt*(stop-start)+start;
 };
+// Avoid `.bind`ing this method in global mode
+p5.prototype.lerp._context = false;
 
 /**
  * Calculates the natural logarithm (the base-e logarithm) of a number. This
@@ -326,6 +340,8 @@ p5.prototype.lerp = function(start, stop, amt) {
  * </code></div>
  */
 p5.prototype.log = Math.log;
+// Avoid `.bind`ing this method in global mode
+p5.prototype.log._context = false;
 
 /**
  * Calculates the magnitude (or length) of a vector. A vector is a direction
@@ -360,6 +376,8 @@ p5.prototype.log = Math.log;
 p5.prototype.mag = function(x, y) {
   return Math.sqrt(x*x+y*y);
 };
+// Avoid `.bind`ing this method in global mode
+p5.prototype.mag._context = false;
 
 /**
  * Re-maps a number from one range to another.
@@ -399,6 +417,8 @@ p5.prototype.mag = function(x, y) {
 p5.prototype.map = function(n, start1, stop1, start2, stop2) {
   return ((n-start1)/(stop1-start1))*(stop2-start2)+start2;
 };
+// Avoid `.bind`ing this method in global mode
+p5.prototype.map._context = false;
 
 /**
  * Determines the largest value in a sequence of numbers, and then returns
@@ -438,6 +458,8 @@ p5.prototype.max = function() {
     return Math.max.apply(null,arguments);
   }
 };
+// Avoid `.bind`ing this method in global mode
+p5.prototype.max._context = false;
 
 /**
  * Determines the smallest value in a sequence of numbers, and then returns
@@ -477,6 +499,8 @@ p5.prototype.min = function() {
     return Math.min.apply(null,arguments);
   }
 };
+// Avoid `.bind`ing this method in global mode
+p5.prototype.min._context = false;
 
 /**
  * Normalizes a number from another range into a value between 0 and 1.
@@ -555,6 +579,8 @@ p5.prototype.norm = function(n, start, stop) {
  * </code></div>
  */
 p5.prototype.pow = Math.pow;
+// Avoid `.bind`ing this method in global mode
+p5.prototype.pow._context = false;
 
 /**
  * Calculates the integer closest to the n parameter. For example,
@@ -590,6 +616,8 @@ p5.prototype.pow = Math.pow;
  * </code></div>
  */
 p5.prototype.round = Math.round;
+// Avoid `.bind`ing this method in global mode
+p5.prototype.round._context = false;
 
 /**
  * Squares a number (multiplies a number by itself). The result is always a
@@ -631,6 +659,8 @@ p5.prototype.round = Math.round;
  * </code></div>
  */
 p5.prototype.sq = function(n) { return n*n; };
+// Avoid `.bind`ing this method in global mode
+p5.prototype.sq._context = false;
 
 /**
  * Calculates the square root of a number. The square root of a number is
@@ -673,5 +703,7 @@ p5.prototype.sq = function(n) { return n*n; };
  * </code></div>
  */
 p5.prototype.sqrt = Math.sqrt;
+// Avoid `.bind`ing this method in global mode
+p5.prototype.sqrt._context = false;
 
 module.exports = p5;

--- a/src/math/noise.js
+++ b/src/math/noise.js
@@ -160,7 +160,8 @@ p5.prototype.noise = function(x,y,z) {
   }
   return r;
 };
-
+// Avoid `.bind`ing this method in global mode
+p5.prototype.noise._context = false;
 
 /**
  *
@@ -219,6 +220,8 @@ p5.prototype.noiseDetail = function(lod, falloff) {
   if (lod>0)     { perlin_octaves=lod; }
   if (falloff>0) { perlin_amp_falloff=falloff; }
 };
+// Avoid `.bind`ing this method in global mode
+p5.prototype.noiseDetail._context = false;
 
 /**
  * Sets the seed value for <b>noise()</b>. By default, <b>noise()</b>
@@ -283,5 +286,7 @@ p5.prototype.noiseSeed = function(seed) {
     perlin[i] = lcg.rand();
   }
 };
+// Avoid `.bind`ing this method in global mode
+p5.prototype.noiseSeed._context = false;
 
 module.exports = p5;

--- a/src/math/random.js
+++ b/src/math/random.js
@@ -67,6 +67,8 @@ p5.prototype.randomSeed = function(seed) {
   lcg.setSeed(seed);
   seeded = true;
 };
+// Avoid `.bind`ing this method in global mode
+p5.prototype.randomSeed._context = false;
 
 /**
  * Return a random floating-point number.
@@ -122,7 +124,7 @@ p5.prototype.randomSeed = function(seed) {
  * @return {mixed} the random element from the array
  * @example
  */
-p5.prototype.random = function (min, max) {
+function random(min, max) {
 
   var rand;
 
@@ -150,7 +152,10 @@ p5.prototype.random = function (min, max) {
 
     return rand * (max-min) + min;
   }
-};
+}
+p5.prototype.random = random;
+// Avoid `.bind`ing this method in global mode
+p5.prototype.random._context = false;
 
 
 /**
@@ -214,8 +219,8 @@ p5.prototype.randomGaussian = function(mean, sd)  {
     previous = false;
   } else {
     do {
-      x1 = this.random(2) - 1;
-      x2 = this.random(2) - 1;
+      x1 = random(2) - 1;
+      x2 = random(2) - 1;
       w = x1 * x1 + x2 * x2;
     } while (w >= 1);
     w = Math.sqrt((-2 * Math.log(w))/w);
@@ -228,5 +233,7 @@ p5.prototype.randomGaussian = function(mean, sd)  {
   var s = sd || 1;
   return y1*s + m;
 };
+// Avoid `.bind`ing this method in global mode
+p5.prototype.random._context = false;
 
 module.exports = p5;

--- a/src/math/trigonometry.js
+++ b/src/math/trigonometry.js
@@ -278,6 +278,8 @@ p5.prototype.tan = function(angle) {
 p5.prototype.degrees = function(angle) {
   return polarGeometry.radiansToDegrees(angle);
 };
+// Avoid `.bind`ing this method in global mode
+p5.prototype.degrees._context = false;
 
 /**
  * Converts a degree measurement to its corresponding value in radians.
@@ -302,6 +304,8 @@ p5.prototype.degrees = function(angle) {
 p5.prototype.radians = function(angle) {
   return polarGeometry.degreesToRadians(angle);
 };
+// Avoid `.bind`ing this method in global mode
+p5.prototype.radians._context = false;
 
 /**
  * Sets the current mode of p5 to given mode. Default mode is RADIANS.


### PR DESCRIPTION
Per #1512, there are significant slowdowns when using certain methods in global mode, such as `random()`. Part of the origin of this performance issue is that [methods are .bound to the p5 instance when being assigned to the global object](https://github.com/processing/p5.js/blob/d0cf66e2d2de3d26a2d3091cb0f0471a15675249/src/core/core.js#L467), and the use of the .bind (which is not needed for a pure function like `random`) impacts the method's speed. ([see explanation](http://stackoverflow.com/questions/17638305/why-is-bind-slower-than-a-closure))

This PR takes a crack at a solution proposed in #1512, specifically decorating methods which can be assigned to the global context without the use of `.bind` with a `._context = false` property. Core.js is then modified to respect this flag by only using `.bind` if `method._context !== false`.

This could use some thorough testing, I've only spot-checked&mdash;and this currently only accounts for the math utilities in the Calculation, Noise, Random and Trigonometry files. The `_context` argument can likely be rolled out more broadly, across any method of `p5.prototype` which does not utilize `this`.

Unfortunately, most trigonometry functions cannot be decorated in this way because they depend on the instance property `_angleMode` in order to return the proper value.
