### PR TITLE
Improve performance of Random method by not using "arguments"

### DIFF
--- a/src/math/random.js
+++ b/src/math/random.js
@@ -131,13 +131,12 @@ p5.prototype.random = function (min, max) {
   } else {
     rand = Math.random();
   }
-
-  if (arguments.length === 0) {
+  if (typeof min === 'undefined') {
     return rand;
   } else
-  if (arguments.length === 1) {
-    if (arguments[0] instanceof Array) {
-      return arguments[0][Math.floor(rand * arguments[0].length)];
+  if (typeof max === 'undefined') {
+    if (min instanceof Array) {
+      return min[Math.floor(rand * min.length)];
     } else {
       return rand * min;
     }


### PR DESCRIPTION
In #1512 there's been a lot of discussion about the performance of various methods in P5, and what might contribute to them being faster or slower. While investigating, I did identify one major area of potential performance improvement on the random method specifically: the use of `arguments` significantly impacts the runtime speed of a method, and I recommend using the named arguments for the random method in lieu of the `arguments` keyword.

To test the hypothesis, I prepared this test harness:

http://bl.ocks.org/kadamwhite/raw/0e3240d7c475a91cb0fbbbc4a084e351/

using the code in [this gist](https://gist.github.com/kadamwhite/0e3240d7c475a91cb0fbbbc4a084e351)

If you visit that URL and open the console, you will see the browser run six tests:

1. The existing `random` implementation, called directly
2. The existing `random` implementation, called through Object lookup<sup>+</sup>
3. The existing `random` implementation, `.bind`ed to `window`
4. The new propose `random` implementation, called directly
5. The new propose `random` implementation, called through Object lookup<sup>+</sup>
6. The new propose `random` implementation, `.bind`ed to `window`

<sup>+</sup> There is additional overhead on this one of a second function being called; prior tests designed to avoid that caveat showed directionally similar results, so I opted in favor of code brevity

In Chrome, the avoidance of `arguments` drops the average run time (across many iterations) for the basic case (calling the method directly) from about 60ms to about 30ms, a 2x improvement.

Safari showed an improvement from about ~80ms to ~60ms, not as notable but still an improvement.

But on Firefox, the avoidance of `arguments` drops the average run time (for me, on OSX using Firefox ) from **250ms or more to less than 10ms**, over 40x faster.

This should be independently tested, but I propose the use of the named arguments is actually more readable than the use of the `arguments` keyword, and the performance seems to be dramatically improved through this approach.

Interestingly (given the discussion in #1512), the use of `.bind` had almost completely negligible effects on the function's execution time.

Sample output of script for Chrome:
```
(index):131 Average runtime for object lookup: 57.94ms
(index):131 Average runtime for bound function: 51.01ms
(index):131 Average runtime for basic without "arguments": 24.86ms
(index):131 Average runtime for object lookup without "arguments": 37.05ms
(index):131 Average runtime for bound function without "arguments": 24.94ms
```
Safari:
```
[Log] Average runtime for basic: 75.18ms
[Log] Average runtime for object lookup: 115.98ms
[Log] Average runtime for bound function: 79.85ms
[Log] Average runtime for basic without "arguments": 57.31ms
[Log] Average runtime for object lookup without "arguments": 92.23ms
[Log] Average runtime for bound function without "arguments": 57.37ms
```
Firefox:
```
Average runtime for basic: 248.97ms
Average runtime for object lookup: 246.36ms
Average runtime for bound function: 226.46ms
Average runtime for basic without "arguments": 5.89ms
Average runtime for object lookup without "arguments": 13.34ms
Average runtime for bound function without "arguments": 6.79ms
```