### PR TITLE
p5.dom library link now points to its reference

### DIFF
--- a/src/core/p5.Element.js
+++ b/src/core/p5.Element.js
@@ -10,7 +10,7 @@ var p5 = require('./core');
  * Base class for all elements added to a sketch, including canvas,
  * graphics buffers, and other HTML elements. Methods in blue are
  * included in the core functionality, methods in brown are added
- * with the <a href="http://p5js.org/libraries/">p5.dom library</a>.
+ * with the <a href="http://p5js.org/reference/#/libraries/p5.dom">p5.dom library</a>.
  * It is not called directly, but p5.Element
  * objects are created by calling createCanvas, createGraphics,
  * or in the p5.dom library, createDiv, createImg, createInput, etc.


### PR DESCRIPTION
The p5.dom library in link in p5.Element page was pointing to the libraries page instead of the p5.dom one.