### PR TITLE
Added example to removeAttribute()

### DIFF
--- a/lib/addons/p5.dom.js
+++ b/lib/addons/p5.dom.js
@@ -1389,12 +1389,34 @@
 
   /**
    *
-   * Removes an attibute on the specified element.
+   * Removes an attribute on the specified element.
    *
    * @method removeAttribute
    * @param  {String} attr       attribute to remove
    * @return {Object/p5.Element}
    *
+   * @example
+   * <div><code>
+   * var button;
+   * var checkbox;
+   * 
+   * function setup() {
+   *   checkbox = createCheckbox('enable', true);
+   *   checkbox.changed(enableButton);
+   *   button = createButton('button');
+   *   button.position(10, 10);
+   * }
+   * 
+   * function enableButton() {
+   *   if( this.checked() ) {
+   *     // Re-enable the button
+   *     button.removeAttribute('disabled');
+   *   } else {
+   *     // Disable the button
+   *     button.attribute('disabled',''); 
+   *   }
+   * }
+   * </code></div>
    */
   p5.Element.prototype.removeAttribute = function(attr) {
     this.elt.removeAttribute(attr);


### PR DESCRIPTION
I added an example demonstrating how to enable/disable a button using the `changed()` method in a checkbox. It shows the maybe-non-intuitive way of disabling an input adding the `disabled` attribute without the need of arguments, and the maybe-less-intuitive way of re-enabling it by removing such attribute.