### PR TITLE
Adding flag for disabling the friendly error system

### DIFF
--- a/src/core/core.js
+++ b/src/core/core.js
@@ -515,6 +515,10 @@ var p5 = function(sketch, node, sync) {
   }
 };
 
+// Allows for the friendly error system to be turned off when creating a sketch,
+// which can give a significant boost to performance when needed.
+p5.disableFriendlyErrors = false;
+
 // attach constants to p5 prototype
 for (var k in constants) {
   p5.prototype[k] = constants[k];
@@ -565,7 +569,8 @@ p5.prototype._createFriendlyGlobalFunctionBinder = function(options) {
   };
 
   return function(prop, value) {
-    if (typeof(IS_MINIFIED) === 'undefined' &&
+    if (!p5.disableFriendlyErrors &&
+        typeof(IS_MINIFIED) === 'undefined' &&
         typeof(value) === 'function' &&
         !(prop in p5.prototype._preloadMethods)) {
       try {


### PR DESCRIPTION
**Summary from #1512, #1329, #971:**  

The friendly error logging system causes a significant slowdown (e.g. 10x slowdown in Chrome for simple functions like `random` or `sin`).  

In global instance mode with unminified p5, p5 properties are added to the global scope using getters/setters via `Object.defineProperty` in [core.js#L593](https://github.com/processing/p5.js/blob/master/src/core/core.js#L593).  This makes it possible to log an error if a beginner (or not-so-beginner) inadvertently overrides a p5 property (e.g. `text`). This is a really helpful feature, but comes with a hefty performance cost.

**Proposed solution:**

Add a property to the p5 constructor function `disableFriendlyErrors` which can be used to prevent the friendly error getters/setters.  That way beginners get the friendly errors by default, but adding `p5.disableFriendlyErrors = true` to the top of a sketch will boost performance.  (I attached this property to the p5 constructor over p5.prototype - seems to make more sense that way.)

**Some Results:**

tl;dr: Huge gains in Chrome, reasonable gains in p5 editor & FF, no real gains in IE/Edge. I'm opening this PR as a solution to part of #1512, but it's disappointing that it's not a magic bullet for the p5 editor slowdown.  (Maybe that's because the chromium engine powering the editor is >1 year old?)

```
Calling p5 methods in global mode 10000000x times. 

Chrome, Windows:

Friendly Errors:  enabled       ->       disabled
random:           1518.62ms     ->       320.28md
abs:              1210.32ms     ->       91.99ms
sin:              1712.18ms     ->       478.58ms

Same thing in p5 Editor (built against this PR's p5.js):

Friendly Errors:  enabled       ->       disabled     
random:           3077.91ms     ->       1798.99ms
abs:              3153.38ms     ->       21935.76ms
sin:              3579.56ms     ->       2560.79ms


Times vary in FF but performance boost ranges from 2x-10x.
IE11/Edge minimal to zero gains.
```

Could use a better test (#1524), but for now, something manual:

```js
p5.disableFriendlyErrors = true;

var iterations = 10000000;

function setup() {
  console.log("Friendly Errors: " +
    (p5.disableFriendlyErrors) ? "disabled" : "enabled");

  var start = performance.now();
  for (var i = 0; i < iterations; i += 1) {
    random();
  }
  var elapsed = performance.now() - start;
  console.log("random: " + elapsed.toFixed(2) + "ms");

  var start = performance.now();
  for (var i = 0; i < iterations; i += 1) {
    abs(i);
  }
  var elapsed = performance.now() - start;
  console.log("abs: " + elapsed.toFixed(2) + "ms");

  var start = performance.now();
  for (var i = 0; i < iterations; i += 1) {
    sin(i/iterations * (15 * 3.14));
  }
  var elapsed = performance.now() - start;
  console.log("sin: " + elapsed.toFixed(2) + "ms");
}
```