### PR TITLE
Remove binding on native math methods

### DIFF
--- a/src/core/core.js
+++ b/src/core/core.js
@@ -467,7 +467,7 @@ var p5 = function(sketch, node, sync) {
           if (Math.hasOwnProperty(p) && (Math[p] === p5.prototype[p])) {
             // Multiple p5 methods are just native Math functions. These can be
             // called without any binding.
-            friendlyBindGlobal(p, p5.prototype[p]);   
+            friendlyBindGlobal(p, p5.prototype[p]);
           } else {
             friendlyBindGlobal(p, p5.prototype[p].bind(this));
           }

--- a/src/core/core.js
+++ b/src/core/core.js
@@ -464,7 +464,13 @@ var p5 = function(sketch, node, sync) {
       if(typeof p5.prototype[p] === 'function') {
         var ev = p.substring(2);
         if (!this._events.hasOwnProperty(ev)) {
-          friendlyBindGlobal(p, p5.prototype[p].bind(this));
+          if (Math.hasOwnProperty(p) && (Math[p] === p5.prototype[p])) {
+            // Multiple p5 methods are just native Math functions. These can be
+            // called without any binding.
+            friendlyBindGlobal(p, p5.prototype[p]);   
+          } else {
+            friendlyBindGlobal(p, p5.prototype[p].bind(this));
+          }
         }
       } else {
         friendlyBindGlobal(p, p5.prototype[p]);


### PR DESCRIPTION
Fix for part of #1512.  As @ofZach pointed out, some p5 math methods definitely don't need any binding.  This PR removes binding from p5 methods that are just wrappers around Math functions.  This makes abs, ceil, sqrt, etc. as fast as the native Math equivalents.

```
Calling p5 methods in global mode 100000000x times. 

Chrome, Windows:

                Before PR     ->    After PR    =   Native Math.XX 

abs:            911ms         ->    77ms        =   77ms
ceil:           1252ms        ->    865ms       =   886ms
sqrt:           972ms         ->    444ms       =   445ms


FF, Windows:

                Before PR     ->    After PR    =   Native Math.XX 

abs:            2604ms        ->    63ms        =   35ms
ceil:           3266ms        ->    34ms        =   34ms
sqrt:           3554ms        ->    34ms        =   34ms
```

All properties and methods on Math are static and shouldn't need the implicit binding that comes from calling them with `Math.XX`.  Proof:

```js
// No errors accessing any property or running any function w/o implicit Math binding
var props = Object.getOwnPropertyNames(Math);
for (var i = 0; i < props.length; i += 1) {
  var prop = Math[props[i]];
  if (typeof prop === "function") console.log(props[i] + " : " + prop(1, 0.5));
  else console.log(props[i] + " : " + prop)
}
```

Manual test code again:

```js
p5.disableFriendlyErrors = true;

var iterations = 100000000;

function setup() {
  var start = performance.now();
  for (var i = 0; i < iterations; i += 1) {
    Math.abs(i);
  }
  var elapsed = performance.now() - start;
  console.log("Math.abs: " + Math.round(elapsed) + "ms");

  var start = performance.now();
  for (var i = 0; i < iterations; i += 1) {
    abs(i);
  }
  var elapsed = performance.now() - start;
  console.log("p5 abs: " + Math.round(elapsed) + "ms");

  var start = performance.now();
  for (var i = 0; i < iterations; i += 1) {
    Math.ceil(i + 0.6);
  }
  var elapsed = performance.now() - start;
  console.log("Math.ceil: " + Math.round(elapsed) + "ms");;

  var start = performance.now();
  for (var i = 0; i < iterations; i += 1) {
    ceil(i + 0.6);
  }
  var elapsed = performance.now() - start;
  console.log("p5 ceil: " + Math.round(elapsed) + "ms");

  var start = performance.now();
  for (var i = 0; i < iterations; i += 1) {
    Math.sqrt(i);
  }
  var elapsed = performance.now() - start;
  console.log("Math.sqrt: " + Math.round(elapsed) + "ms");
  
  var start = performance.now();
  for (var i = 0; i < iterations; i += 1) {
    sqrt(i);
  }
  var elapsed = performance.now() - start;
  console.log("p5 sqrt: " + Math.round(elapsed) + "ms");
}
```