### PR TITLE
Make winMouseX/winMouseY relative to window instead of document

### DIFF
--- a/src/events/mouse.js
+++ b/src/events/mouse.js
@@ -311,20 +311,26 @@ p5.prototype.isMousePressed = false; // both are supported
 p5.prototype._updateNextMouseCoords = function(e) {
   var x = this.mouseX;
   var y = this.mouseY;
+  var winX = this.winMouseX;
+  var winY = this.winMouseY;
   if(e.type === 'touchstart' ||
      e.type === 'touchmove' ||
      e.type === 'touchend' || e.touches) {
     x = this.touchX;
     y = this.touchY;
+    winX = this.winTouchX;
+    winY = this.winTouchY;
   } else if(this._curElement !== null) {
     var mousePos = getMousePos(this._curElement.elt, e);
     x = mousePos.x;
     y = mousePos.y;
+    winX = mousePos.winX;
+    winY = mousePos.winY;
   }
   this._setProperty('mouseX', x);
   this._setProperty('mouseY', y);
-  this._setProperty('winMouseX', e.pageX);
-  this._setProperty('winMouseY', e.pageY);
+  this._setProperty('winMouseX', winX);
+  this._setProperty('winMouseY', winY);
   if (!this._hasMouseInteracted) {
     // For first draw, make previous and next equal
     this._updateMouseCoords();
@@ -343,7 +349,9 @@ function getMousePos(canvas, evt) {
   var rect = canvas.getBoundingClientRect();
   return {
     x: evt.clientX - rect.left,
-    y: evt.clientY - rect.top
+    y: evt.clientY - rect.top,
+    winX: evt.clientX,
+    winY: evt.clientY
   };
 }
 

--- a/src/events/touch.js
+++ b/src/events/touch.js
@@ -90,6 +90,40 @@ p5.prototype.ptouchX = 0;
 p5.prototype.ptouchY = 0;
 
 /**
+ * The system variable winTouchX always contains the horizontal position of
+ * one finger, relative to (0, 0) of the window.
+ *
+ * @property winTouchX
+ */
+p5.prototype.winTouchX = 0;
+
+/**
+ * The system variable winTouchY always contains the vertical position of
+ * one finger, relative to (0, 0) of the window.
+ *
+ * @property winTouchY
+ */
+p5.prototype.winTouchY = 0;
+
+/**
+ * The system variable pwinTouchX always contains the horizontal position of
+ * one finger, relative to (0, 0) of the window, in the frame previous to the
+ * current frame.
+ *
+ * @property pwinTouchX
+ */
+p5.prototype.pwinTouchX = 0;
+
+/**
+ * The system variable pwinTouchY always contains the vertical position of
+ * one finger, relative to (0, 0) of the window, in the frame previous to the
+ * current frame.
+ *
+ * @property pwinTouchY
+ */
+p5.prototype.pwinTouchY = 0;
+
+/**
  * The system variable touches[] contains an array of the positions of all
  * current touch points, relative to (0, 0) of the canvas, and IDs identifying a
  * unique touch as it moves. Each element in the array is an object with x, y,
@@ -110,16 +144,22 @@ p5.prototype.touchIsDown = false;
 p5.prototype._updateNextTouchCoords = function(e) {
   var x = this.touchX;
   var y = this.touchY;
+  var winX = this.winTouchX;
+  var winY = this.winTouchY;
   if(e.type === 'mousedown' ||
      e.type === 'mousemove' ||
      e.type === 'mouseup' || !e.touches) {
     x = this.mouseX;
     y = this.mouseY;
+    winX = this.winMouseX;
+    winY = this.winMouseY;
   } else {
     if(this._curElement !== null) {
       var touchInfo = getTouchInfo(this._curElement.elt, e, 0);
       x = touchInfo.x;
       y = touchInfo.y;
+      winX = touchInfo.winX;
+      winY = touchInfo.winY;
 
       var touches = [];
       for(var i = 0; i < e.touches.length; i++){
@@ -130,6 +170,8 @@ p5.prototype._updateNextTouchCoords = function(e) {
   }
   this._setProperty('touchX', x);
   this._setProperty('touchY', y);
+  this._setProperty('winTouchX', winX);
+  this._setProperty('winTouchY', winY);
   if (!this._hasTouchInteracted) {
     // For first draw, make previous and next equal
     this._updateTouchCoords();
@@ -140,6 +182,8 @@ p5.prototype._updateNextTouchCoords = function(e) {
 p5.prototype._updateTouchCoords = function() {
   this._setProperty('ptouchX', this.touchX);
   this._setProperty('ptouchY', this.touchY);
+  this._setProperty('pwinTouchX', this.winTouchX);
+  this._setProperty('pwinTouchY', this.winTouchY);
 };
 
 function getTouchInfo(canvas, e, i) {
@@ -149,6 +193,8 @@ function getTouchInfo(canvas, e, i) {
   return {
     x: touch.clientX - rect.left,
     y: touch.clientY - rect.top,
+    winX: touch.clientX,
+    winY: touch.clientY,
     id: touch.identifier
   };
 }


### PR DESCRIPTION
This PR updates the variables `winMouseX/winMouseY` to be relative to the window instead of the document, by using `clientX/clientY` instead of `pageX/pageY`.

It also adds new corresponding touch variables: `winTouchX/winTouchY` and `pwinTouchX/pwinTouchY`.

