### PR TITLE
Canvas Resizing (Fix windowWidth and windowHeight)

### DIFF
--- a/src/core/environment.js
+++ b/src/core/environment.js
@@ -392,14 +392,17 @@ p5.prototype._onresize = function(e){
 };
 
 function getWindowWidth() {
-  return Math.max(
-    document.documentElement.clientWidth,
-    window.innerWidth || 0);
+  return window.innerWidth ||
+         document.documentElement && document.documentElement.clientWidth ||
+         document.body && document.body.clientWidth ||
+         0;
 }
+
 function getWindowHeight() {
-  return Math.max(
-    document.documentElement.clientHeight,
-    window.innerHeight || 0);
+  return window.innerHeight ||
+         document.documentElement && document.documentElement.clientHeight ||
+         document.body && document.body.clientHeight ||
+         0;
 }
 
 /**


### PR DESCRIPTION
The implementation for assigning window dimensions to `windowWidth` and `windowHeight` introduced in #1494 does not work as expected.  As a result down-resizing the browser window to a smaller size will not resize the canvas appropriately, when using this snippet of code:

```js
function windowResized() {
  resizeCanvas(windowWidth, windowHeight);
}
```

The `windowWidth` and `windowHeight` variables should refer to the size of the viewport.
So we must use `window.innerWidth` and `window.innerHeight`.

Both `document.documentElement.clientWidth` and `document.body.clientHeight`
may be used as polyfill, but they refer to the dimensions of the body and the html element,
which may be greater than those of the actual viewport (!).
