### PR TITLE
Continuous slider behavior when step=0

### DIFF
--- a/lib/addons/p5.dom.js
+++ b/lib/addons/p5.dom.js
@@ -375,7 +375,7 @@
    * @param  {Number} min minimum value of the slider
    * @param  {Number} max maximum value of the slider
    * @param  {Number} [value] default value of the slider
-   * @param  {Number} [step] step size for each tick of the slider
+   * @param  {Number} [step] step size for each tick of the slider (if step is set to 0, the slider will move continuously from the minimum to the maximum value)
    * @return {Object/p5.Element} pointer to p5.Element holding created node
    * @example
    * <div><code>
@@ -412,7 +412,11 @@
     elt.type = 'range';
     elt.min = min;
     elt.max = max;
-    if (step) elt.step = step;
+    if (step === 0) {
+      elt.step = .000000000000000001; // smallest valid step
+    } else if (step) {
+      elt.step = step;
+    }
     if (typeof(value) === "number") elt.value = value;
     return addElement(elt, this);
   };


### PR DESCRIPTION
Relevant issue: [issue 1580](https://github.com/processing/p5.js/issues/1580).
HTML range input doesn't have a continuous mode out of the box, so I did a little bit of testing ([jsfiddle](https://jsfiddle.net/brmscheiner/p2agoodt/9/)) and found the smallest valid slider increment. Step takes that value when the user sets step=0. 