### PR TITLE
Better error-handling on failed font load

### DIFF
--- a/src/core/error_helpers.js
+++ b/src/core/error_helpers.js
@@ -210,7 +210,12 @@ var errorCases = {
   '3': {
     fileType: 'text file',
     method: 'loadStrings'
-  }
+  },
+  '4': {
+    fileType: 'font',
+    method: 'loadFont',
+    message: ' hosting the font online,'
+  },
 };
 p5._friendlyFileLoadError = function (errorType, filePath) {
   var errorInfo = errorCases[ errorType ];

--- a/src/io/files.js
+++ b/src/io/files.js
@@ -117,7 +117,9 @@ p5.prototype.loadFont = function (path, onSuccess, onError) {
       if ((typeof onError !== 'undefined') && (onError !== decrementPreload)) {
         return onError(err);
       }
-      throw err;
+      p5._friendlyFileLoadError(4, path);
+      console.error(err, path);
+      return;
     }
 
     p5Font.font = font;


### PR DESCRIPTION
I'm not sure if there is some unified way to do error-handling when things (images, fonts, JSON, etc) fail to load, but currently we get a rather unhelpful error message. This PR adds a better console error message and also calls p5. _friendlyFileLoadError, though this doesn't produce any output in the browser.