### PR TITLE
Support and test on-demand global mode

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -74,9 +74,10 @@ var _globalInit = function() {
   if (!window.PHANTOMJS && !window.mocha) {
     // If there is a setup or draw function on the window
     // then instantiate p5 in "global" mode
-    if((window.setup && typeof window.setup === 'function') ||
-      (window.draw && typeof window.draw === 'function')) {
-      p5.instance = new p5();
+    if(((window.setup && typeof window.setup === 'function') ||
+       (window.draw && typeof window.draw === 'function')) &&
+       !p5.instance) {
+      new p5();
     }
   }
 };

--- a/src/core/core.js
+++ b/src/core/core.js
@@ -471,6 +471,7 @@ var p5 = function(sketch, node, sync) {
   // assume "global" mode and make everything global (i.e. on the window)
   if (!sketch) {
     this._isGlobal = true;
+    p5.instance = this;
     // Loop through methods on the prototype and attach them to the window
     for (var p in p5.prototype) {
       if(typeof p5.prototype[p] === 'function') {
@@ -535,6 +536,10 @@ var p5 = function(sketch, node, sync) {
     }
   }
 };
+
+// This is a pointer to our global mode p5 instance, if we're in
+// global mode.
+p5.instance = null;
 
 // Allows for the friendly error system to be turned off when creating a sketch,
 // which can give a significant boost to performance when needed.

--- a/test/unit/color/p5.Color.js
+++ b/test/unit/color/p5.Color.js
@@ -781,7 +781,7 @@ suite('p5.Color', function() {
     });
   });
 
-  suite.only('p5.Color.prototype.toString', function() {
+  suite('p5.Color.prototype.toString', function() {
     var colorStr;
 
     setup(function() {

--- a/test/unit/io/files_input.js
+++ b/test/unit/io/files_input.js
@@ -21,11 +21,11 @@ suite('Files', function() {
       assert.typeOf(loadJSON, 'function');
     });
 
-    test('should return an Array', function() {
-      result = loadJSON('../assets/array.json');
+    test('should return an Object', function() {
+      result = loadJSON('unit/assets/array.json');
       assert.ok(result);
-      // assert.isObject(result, 'result is an object');
-      assert.typeOf(result, 'Array');
+      assert.isObject(result, 'result is an object');
+      // assert.typeOf(result, 'Array');
       // assert.lengthOf(result, 2);
     });
   });


### PR DESCRIPTION
This adds support and unit tests for on-demand global mode, fixing #1570.

In particular, it fixes a bug whereby p5 would actually initialize itself *twice*: once when on-demand global mode was triggered via an explicit `new p5()`, and again when the page's `load` event fired (i.e., "non-on-demand global mode").  This would then cause a bunch of warnings from #1318 to be logged.

Now `p5.instance` is always written when `_isGlobal` is set, and it's checked before initializing non-on-demand global mode.

Since there weren't already tests for non-on-demand global mode, I also added some.