### PR TITLE
Implement events to createCanvas, resizeCanvas and noCanvas

### DIFF
--- a/src/core/rendering.js
+++ b/src/core/rendering.js
@@ -113,6 +113,11 @@ p5.prototype.createCanvas = function(w, h, renderer) {
   if (isDefault) { // only push once
     this._elements.push(this._renderer);
   }
+
+  if (typeof p5.onCreateCanvas === 'function') {
+    p5.onCreateCanvas.call(this, w, h, r);
+  }
+
   return this._renderer;
 };
 
@@ -159,6 +164,10 @@ p5.prototype.resizeCanvas = function (w, h, noRedraw) {
     if (!noRedraw) {
       this.redraw();
     }
+
+    if (typeof p5.onResizeCanvas === 'function') {
+      p5.onResizeCanvas.call(this, w, h, noRedraw);
+    }
   }
 };
 
@@ -183,6 +192,9 @@ p5.prototype.resizeCanvas = function (w, h, noRedraw) {
 p5.prototype.noCanvas = function() {
   if (this.canvas) {
     this.canvas.parentNode.removeChild(this.canvas);
+  }
+  if (typeof p5.onNoCanvas === 'function') {
+    p5.onNoCanvas.call(this);
   }
 };
 


### PR DESCRIPTION
I have made this implementation to make it possible to bind functions to the `createCanvas`, `resizeCanvas` and `noCanvas` actions.

E.g.:

```js

function setup() {
	p5.onCreateCanvas = function(w,h) {
		console.log('HABEMUS CANVAS!', w, h)
	}
	p5.onResizeCanvas = function(w,h) {
		console.log('CANVAS RESIZED!', w, h)
	}
	p5.onNoCanvas = function() {
		console.log('NO CANVAS AT ALL!')
	}

	createCanvas(windowWidth, windowHeight);

}

```

It would be very useful for a library I'm working on, but please feel free to ignore if it's not of your interest or suggest amendments.

Thanks!

If accepted, it closes #1602