### PR TITLE
Remove uResolution uniform

### DIFF
--- a/src/webgl/camera.js
+++ b/src/webgl/camera.js
@@ -148,10 +148,6 @@ p5.prototype.ortho = function(left,right,bottom,top,near,far) {
     args,
       ['Number', 'Number', 'Number', 'Number', 'Number', 'Number']
   );
-  left /= this.width;
-  right /= this.width;
-  top /= this.height;
-  bottom /= this.height;
   this._renderer.uPMatrix = p5.Matrix.identity();
   this._renderer.uPMatrix.ortho(left,right,bottom,top,near,far);
   this._renderer._curCamera = 'custom';

--- a/src/webgl/camera.js
+++ b/src/webgl/camera.js
@@ -64,7 +64,9 @@ p5.prototype.camera = function(x, y, z){
  * //you will see there's a vanish point
  * function setup(){
  *   createCanvas(100, 100, WEBGL);
- *   perspective(60 / 180 * PI, width/height, 0.1, 100);
+ *   var fov = 60 / 180 * PI;
+ *   var cameraZ = (height/2.0) / tan(fov/2.0);
+ *   perspective(60 / 180 * PI, width/height, cameraZ * 0.1, cameraZ * 10);
  * }
  * function draw(){
  *  background(200);
@@ -117,7 +119,7 @@ p5.prototype.perspective = function(fovy,aspect,near,far) {
  * //there's no vanish point
  * function setup(){
  *   createCanvas(100, 100, WEBGL);
- *   ortho(-width/2, width/2, height/2, -height/2, 0.1, 100);
+ *   ortho(-width/2, width/2, height/2, -height/2, 0, 500);
  * }
  * function draw(){
  *  background(200);

--- a/src/webgl/p5.RendererGL.js
+++ b/src/webgl/p5.RendererGL.js
@@ -5,7 +5,6 @@ var shader = require('./shader');
 require('../core/p5.Renderer');
 require('./p5.Matrix');
 var uMVMatrixStack = [];
-var RESOLUTION = 1000;
 
 //@TODO should implement public method
 //to override these attributes
@@ -180,9 +179,6 @@ p5.RendererGL.prototype._getLocation =
 function(shaderProgram, isImmediateMode) {
   var gl = this.GL;
   gl.useProgram(shaderProgram);
-  shaderProgram.uResolution =
-    gl.getUniformLocation(shaderProgram, 'uResolution');
-  gl.uniform1f(shaderProgram.uResolution, RESOLUTION);
 
   //projection Matrix uniform
   shaderProgram.uPMatrixUniform =
@@ -420,11 +416,7 @@ p5.RendererGL.prototype.clear = function() {
  * @todo implement handle for components or vector as args
  */
 p5.RendererGL.prototype.translate = function(x, y, z) {
-  //@TODO: figure out how to fit the resolution
-  x = x / RESOLUTION;
-  y = -y / RESOLUTION;
-  z = z / RESOLUTION;
-  this.uMVMatrix.translate([x,y,z]);
+  this.uMVMatrix.translate([x,-y,z]);
   return this;
 };
 

--- a/src/webgl/p5.RendererGL.js
+++ b/src/webgl/p5.RendererGL.js
@@ -90,7 +90,8 @@ p5.RendererGL.prototype._setDefaultCamera = function(){
     var _h = this.height;
     this.uPMatrix = p5.Matrix.identity();
     var cameraZ = (this.height / 2) / Math.tan(Math.PI * 30 / 180);
-    this.uPMatrix.perspective(60 / 180 * Math.PI, _w / _h, cameraZ * 0.1, cameraZ * 10);
+    this.uPMatrix.perspective(60 / 180 * Math.PI, _w / _h,
+                              cameraZ * 0.1, cameraZ * 10);
     this._curCamera = 'default';
   }
 };

--- a/src/webgl/p5.RendererGL.js
+++ b/src/webgl/p5.RendererGL.js
@@ -89,7 +89,8 @@ p5.RendererGL.prototype._setDefaultCamera = function(){
     var _w = this.width;
     var _h = this.height;
     this.uPMatrix = p5.Matrix.identity();
-    this.uPMatrix.perspective(60 / 180 * Math.PI, _w / _h, 0.0001, 100);
+    var cameraZ = (this.height / 2) / Math.tan(Math.PI * 30 / 180);
+    this.uPMatrix.perspective(60 / 180 * Math.PI, _w / _h, cameraZ * 0.1, cameraZ * 10);
     this._curCamera = 'default';
   }
 };

--- a/src/webgl/shaders/immediate.vert
+++ b/src/webgl/shaders/immediate.vert
@@ -8,7 +8,7 @@ uniform float uPointSize;
 
 varying vec4 vColor;
 void main(void) {
-  vec4 positionVec4 = vec4(aPosition / uResolution *vec3(1.0, -1.0, 1.0), 1.0);
+  vec4 positionVec4 = vec4(aPosition * vec3(1.0, -1.0, 1.0), 1.0);
   gl_Position = uProjectionMatrix * uModelViewMatrix * positionVec4;
   vColor = aVertexColor;
   gl_PointSize = uPointSize;

--- a/src/webgl/shaders/light.vert
+++ b/src/webgl/shaders/light.vert
@@ -5,7 +5,6 @@ attribute vec2 aTexCoord;
 uniform mat4 uModelViewMatrix;
 uniform mat4 uProjectionMatrix;
 uniform mat3 uNormalMatrix;
-uniform float uResolution;
 uniform int uAmbientLightCount;
 uniform int uDirectionalLightCount;
 uniform int uPointLightCount;
@@ -28,14 +27,14 @@ vec3 pointLightFactor2 = vec3(0.0, 0.0, 0.0);
 
 void main(void){
 
-  vec4 positionVec4 = vec4(aPosition / uResolution, 1.0);
+  vec4 positionVec4 = vec4(aPosition, 1.0);
   gl_Position = uProjectionMatrix * uModelViewMatrix * positionVec4;
 
   vec3 vertexNormal = vec3( uNormalMatrix * aNormal );
   vVertexNormal = vertexNormal;
   vVertTexCoord = aTexCoord;
 
-  vec4 mvPosition = uModelViewMatrix * vec4(aPosition / uResolution, 1.0);
+  vec4 mvPosition = uModelViewMatrix * vec4(aPosition, 1.0);
   vec3 eyeDirection = normalize(-mvPosition.xyz);
 
   float shininess = 32.0;
@@ -57,7 +56,6 @@ void main(void){
   for(int k = 0; k < 8; k++){
     if(uPointLightCount == k) break;
     vec3 loc = uPointLightLocation[k];
-    //loc = loc / uResolution;
     vec3 lightDirection = normalize(loc - mvPosition.xyz);
 
     float directionalLightWeighting = max(dot(vertexNormal, lightDirection), 0.0);

--- a/src/webgl/shaders/normal.vert
+++ b/src/webgl/shaders/normal.vert
@@ -5,13 +5,12 @@ attribute vec2 aTexCoord;
 uniform mat4 uModelViewMatrix;
 uniform mat4 uProjectionMatrix;
 uniform mat3 uNormalMatrix;
-uniform float uResolution;
 
 varying vec3 vVertexNormal;
 varying highp vec2 vVertTexCoord;
 
 void main(void) {
-  vec4 positionVec4 = vec4(aPosition / uResolution * vec3(1.0, -1.0, 1.0), 1.0);
+  vec4 positionVec4 = vec4(aPosition * vec3(1.0, -1.0, 1.0), 1.0);
   gl_Position = uProjectionMatrix * uModelViewMatrix * positionVec4;
   vVertexNormal = vec3( uNormalMatrix * aNormal );
   vVertTexCoord = aTexCoord;

--- a/src/webgl/shaders/vertexColor.vert
+++ b/src/webgl/shaders/vertexColor.vert
@@ -3,12 +3,11 @@ attribute vec4 aVertexColor;
 
 uniform mat4 uModelViewMatrix;
 uniform mat4 uProjectionMatrix;
-uniform float uResolution;
 
 varying vec4 vColor;
 
 void main(void) {
-  vec4 positionVec4 = vec4(aPosition / uResolution * vec3(1.0, -1.0, 1.0), 1.0);
+  vec4 positionVec4 = vec4(aPosition * vec3(1.0, -1.0, 1.0), 1.0);
   gl_Position = uProjectionMatrix * uModelViewMatrix * positionVec4;
   vColor = aVertexColor;
 }

--- a/test/manual-test-examples/webgl/camera/ortho/sketch.js
+++ b/test/manual-test-examples/webgl/camera/ortho/sketch.js
@@ -1,6 +1,6 @@
 function setup(){
   createCanvas(windowWidth, windowHeight, WEBGL);
-  ortho(-width/2, width/2, height/2, -height/2, 0.1, 100);
+  ortho(-width/2, width/2, height/2, -height/2, -500, 10000);
 }
 
 function draw(){

--- a/test/manual-test-examples/webgl/camera/perspective/sketch.js
+++ b/test/manual-test-examples/webgl/camera/perspective/sketch.js
@@ -1,6 +1,8 @@
 function setup(){
   createCanvas(windowWidth, windowHeight, WEBGL);
-  perspective(60 / 180 * PI, width/height, 0.1, 100);
+  var fov = PI/3.0;
+  var cameraZ = (height/2.0) / tan(fov/2.0);
+  perspective(fov, width/height, cameraZ * 0.1, cameraZ * 10);
 }
 
 function draw(){


### PR DESCRIPTION
The WebGL renderer and shaders apply a constant scaling factor called "resolution" to (almost) all position values. I can't quite tell what issues this was meant to resolve (most likely, they've been fixed in other ways as well), and in the interest of simplifying our shaders, I think we'd be better off removing it entirely.

This change does affect two existing pieces of API behavior, both of which I consider to be bugs. This PR fixes #1621 outright and slightly improves #1622, though there's still work to be done to fully address that issue.

@indefinit, let me know if you can think of any side-effects to this change that I may have missed. Thanks!