### PR TITLE
Fix webkitImageSmoothingEnabled is deprecated

### DIFF
--- a/src/core/rendering.js
+++ b/src/core/rendering.js
@@ -146,6 +146,11 @@ p5.prototype.resizeCanvas = function (w, h, noRedraw) {
     // save canvas properties
     var props = {};
     for (var key in this.drawingContext) {
+      if (key === 'webkitImageSmoothingEnabled') {
+        if ('imageSmoothingEnabled' in this.drawingContext) {
+          continue;
+        }
+      }
       var val = this.drawingContext[key];
       if (typeof val !== 'object' && typeof val !== 'function') {
         props[key] = val;


### PR DESCRIPTION
Fix `'CanvasRenderingContext2D.webkitImageSmoothingEnabled' is deprecated` warning caused by p5.prototype.resizeCanvas.
