### PR TITLE
rgbaToHSLA fix, closes #1640

### DIFF
--- a/src/color/color_conversion.js
+++ b/src/color/color_conversion.js
@@ -229,7 +229,7 @@ p5.ColorConversion._rgbaToHSLA = function(rgba) {
     if (li < 1) {
       sat = chroma / li;
     } else {
-      sat = chroma / (2 - chroma);
+      sat = chroma / (2 - li);
     }
     if (red === val) {  // Magenta to yellow.
       hue = (green - blue) / chroma;

--- a/test/unit/color/color_conversion.js
+++ b/test/unit/color/color_conversion.js
@@ -1,5 +1,6 @@
 suite('p5.ColorConversion', function() {
   var rgba = [1, 0, 0.4, 0.8];
+  var rgbaWithHighLightness = [0.969, 0.753, 0.122, 0.8];
   var hsla = [336/360, 1, 0.5, 0.8];
   var hslaWithMaxHue = [1, 1, 0.5, 0.6];
   var hsba = [336/360, 1, 1, 0.8];
@@ -63,7 +64,7 @@ suite('p5.ColorConversion', function() {
   });
 
   suite('rgbaToHSLA', function() {
-    test('rgba converts to hsla', function() {
+    test('rgba converts to hsla (low lightness)', function() {
       result = p5.ColorConversion._rgbaToHSLA(rgba);
       assert.deepEqual([
         Math.round(result[0] * 360),
@@ -71,6 +72,16 @@ suite('p5.ColorConversion', function() {
         Math.round(result[2] * 100),
         result[3]
       ], [336, 100, 50, 0.8]);
+    });
+
+    test('rgba converts to hsla (high lightness)', function() {
+      result = p5.ColorConversion._rgbaToHSLA(rgbaWithHighLightness);
+      assert.deepEqual([
+        Math.round(result[0] * 360),
+        Math.round(result[1] * 100),
+        Math.round(result[2] * 100),
+        result[3]
+      ], [45, 93, 55, 0.8]);
     });
   });
 


### PR DESCRIPTION
This was a due to a typo that hadn’t been picked up by our unit tests. Ideally we should have a more comprehensive test suite that covers the various branches of colour conversion functions, but I don’t have time to implement that right now.