### PR TITLE
Added DELETE method to HttpDo(), fixes #653

### DIFF
--- a/src/io/files.js
+++ b/src/io/files.js
@@ -862,7 +862,7 @@ p5.prototype.httpDo = function () {
     for (var i = 1; i < arguments.length; i++) {
       var a = arguments[i];
       if (typeof a === 'string') {
-        if (a === 'GET' || a === 'POST' || a === 'PUT') {
+        if (a === 'GET' || a === 'POST' || a === 'PUT' || a === 'DELETE') {
           method = a;
         } else {
           type = a;


### PR DESCRIPTION
Went through #653 and reproduced it. Saw that GET, POST, PUT are the only ones considered, and other method or no mention of method defaults to GET. So, added DELETE to the same as well, and made a little stub too to test the same [here](https://github.com/sakshamsaxena/p5-io-test). Thanks to @tigoe! 