### PR TITLE
fixes seeding for randomGaussian() #1681

### DIFF
--- a/src/math/random.js
+++ b/src/math/random.js
@@ -70,6 +70,7 @@ var lcg = (function() {
 p5.prototype.randomSeed = function(seed) {
   lcg.setSeed(seed);
   seeded = true;
+  previous = false;
 };
 
 /**


### PR DESCRIPTION
`randomGaussian()` does not produce consistent values with `randomSeed()` unless `previous` is reset to `false` every time it's seeded.