### PR TITLE
Fixes an issue where get() return single pixel when caller asks for image

### DIFF
--- a/lib/addons/p5.dom.js
+++ b/lib/addons/p5.dom.js
@@ -1839,6 +1839,8 @@
       return p5.Renderer2D.prototype.get.call(this, x, y, w, h);
     } else if (!x) {
       return new p5.Image(1, 1);
+    } else if (x && w > 1) {
+      return new p5.Image(x, y, w, h);
     } else {
       return [0, 0, 0, 255];
     }


### PR DESCRIPTION
If you ask for a section of the image like in the following code, when the video is not ready, `get()` now returns a single pixel which breaks a call to `image()`.  This could be solved with error handling in the end-user's code, but I'm adding something where `get()` returns a blank image until it's ready.  

```javascript
  var img = video.get(x, y, w, h);
  image(img, 0, 0);
```