### PR TITLE
Fix for misusing println() instead of print()

### DIFF
--- a/test/manual-test-examples/addons/p5.sound/peakDetect/sketch.js
+++ b/test/manual-test-examples/addons/p5.sound/peakDetect/sketch.js
@@ -31,7 +31,7 @@ function setup() {
 
   src_length = source_file.duration();
   source_file.playMode('restart'); 
-  println("source duration: " +src_length);
+  print("source duration: " +src_length);
 
   // draw the waveform to an off-screen graphic
   var peaks = source_file.getPeaks(); // get an array of peaks

--- a/test/manual-test-examples/learningprocessing/chp10/example_10_4/example_10_4.js
+++ b/test/manual-test-examples/learningprocessing/chp10/example_10_4/example_10_4.js
@@ -20,7 +20,7 @@ function draw(){
   var passedTime = millis() - savedTime;
   // Has five seconds passed?
   if (passedTime > totalTime) {
-    println( " 5 seconds have passed! " );
+    print( " 5 seconds have passed! " );
     background(random(255)); // Color a new background
     savedTime = millis(); // Save the current time to restart the timer!
   }

--- a/test/manual-test-examples/learningprocessing/chp10/example_10_9/example_10_9.js
+++ b/test/manual-test-examples/learningprocessing/chp10/example_10_9/example_10_9.js
@@ -29,7 +29,7 @@ function draw(){
   // From Part 3. The Timer!
   // Check the timer
   if (timer.isFinished()) {
-    println( " 2 seconds have passed! " );
+    print( " 2 seconds have passed! " );
     timer.start();
   }
 

--- a/test/manual-test-examples/learningprocessing/chp3/example_3_6.js
+++ b/test/manual-test-examples/learningprocessing/chp3/example_3_6.js
@@ -45,5 +45,5 @@ function draw(){
 }
 
 function mousePressed() {
-  println("Take me to your leader!");
+  print("Take me to your leader!");
 }

--- a/test/manual-test-examples/learningprocessing/chp4/example_4_5.js
+++ b/test/manual-test-examples/learningprocessing/chp4/example_4_5.js
@@ -22,5 +22,5 @@ function draw(){
 }
 
 function keyPressed() {
-  println(key);
+  print(key);
 }

--- a/test/manual-test-examples/learningprocessing/chp6/example_6_4.js
+++ b/test/manual-test-examples/learningprocessing/chp6/example_6_4.js
@@ -11,7 +11,7 @@ var x = 0;
 function setup(){
 
 	while (x < 10) {
-	  println(x);
+	  print(x);
 	  // Decrementing x results in an infinite loop here because the value of x will never be 10 or greater. 
 	  // Be careful!
 	  x = x - 1; 

--- a/test/manual-test-examples/learningprocessing/chp6/example_6_7.js
+++ b/test/manual-test-examples/learningprocessing/chp6/example_6_7.js
@@ -26,5 +26,5 @@ function draw(){
 
 function mousePressed() {
   // x is not available! It is local to the draw( ) block of code.
-  println( " The mouse was pressed! " );
+  print( " The mouse was pressed! " );
 }

--- a/test/manual-test-examples/p5.Table/findRows/sketch.js
+++ b/test/manual-test-examples/p5.Table/findRows/sketch.js
@@ -25,7 +25,7 @@ function setup() {
 
   var rows = table.findRows('Reptile', 'type');
   for (var i = 0; i < rows.length; i++){
-    println(rows[i].getString('name') + ': ' + rows[i].getString('type'));
+    print(rows[i].getString('name') + ': ' + rows[i].getString('type'));
   }
 }
 

--- a/test/manual-test-examples/p5.Table/getColumn/sketch.js
+++ b/test/manual-test-examples/p5.Table/getColumn/sketch.js
@@ -19,7 +19,7 @@ function setup() {
   newRow.setString("name", "Mosquito");
   newRow.setString("type", "Insect");
   
-  println(table.getColumn("name"));
+  print(table.getColumn("name"));
 }
 
 // Sketch prints:

--- a/test/manual-test-examples/p5.Table/getObject/sketch.js
+++ b/test/manual-test-examples/p5.Table/getObject/sketch.js
@@ -19,8 +19,8 @@ function setup() {
   newRow.setString("name", "Mosquito");
   newRow.setString("type", "Insect");
   
-  println("Without a header column:", table.getObject());
-  println("With a header column:", table.getObject("name"));
+  print("Without a header column:", table.getObject());
+  print("With a header column:", table.getObject("name"));
 }
 
 // Sketch prints:

--- a/test/manual-test-examples/p5.Table/matchRow/sketch.js
+++ b/test/manual-test-examples/p5.Table/matchRow/sketch.js
@@ -20,6 +20,6 @@ function setup() {
   newRow.setString("type", "Insect");
 
   var result = table.matchRow("R.*", "type");
-  println(result.getString("name"));  // Prints "Snake"
+  print(result.getString("name"));  // Prints "Snake"
 
 }

--- a/test/manual-test-examples/p5.Table/matchRows/sketch.js
+++ b/test/manual-test-examples/p5.Table/matchRows/sketch.js
@@ -25,7 +25,7 @@ function setup() {
   
   var rows = table.matchRows("R.*", "type");
   for (var i = 0; i < rows.length; i++) {
-    println(rows[i].getString("name") + ": " + rows[i].getString("type"));
+    print(rows[i].getString("name") + ": " + rows[i].getString("type"));
   }
 }
 

--- a/test/manual-test-examples/p5.Table/removeTokens/sketch.js
+++ b/test/manual-test-examples/p5.Table/removeTokens/sketch.js
@@ -19,11 +19,11 @@ function setup() {
   newRow.setString("name", "  $Mosquito , ");
   newRow.setString("type", ",,,Insect");
   
-  println(table.getColumn("name"));
-  println(table.getColumn("type"));
+  print(table.getColumn("name"));
+  print(table.getColumn("type"));
   
   table.removeTokens(",$ ");
   
-  println(table.getColumn("name"));
-  println(table.getColumn("type"));
+  print(table.getColumn("name"));
+  print(table.getColumn("type"));
 }

--- a/test/manual-test-examples/p5.Table/trim/sketch.js
+++ b/test/manual-test-examples/p5.Table/trim/sketch.js
@@ -19,12 +19,12 @@ function setup() {
   newRow.setString("name", "  Mosquito  ");
   newRow.setString("type", "Insect    ");
   
-  println(table.getColumn("name"));
-  println(table.getColumn("type"));
+  print(table.getColumn("name"));
+  print(table.getColumn("type"));
   table.trim();
   
-  println(table.getColumn("name"));
-  println(table.getColumn("type"));
+  print(table.getColumn("name"));
+  print(table.getColumn("type"));
 }
 
 // Sketch prints:


### PR DESCRIPTION
Replace Java's println() method with p5's built-in print() method.