### PR TITLE
Canvas width should be 320 in capture video example

### DIFF
--- a/test/manual-test-examples/addons/p5.dom/capture_video/sketch.js
+++ b/test/manual-test-examples/addons/p5.dom/capture_video/sketch.js
@@ -1,7 +1,7 @@
 var capture;
 
 function setup() {
-  createCanvas(390, 240);
+  createCanvas(320, 240);
   capture = createCapture(VIDEO);
   capture.size(320, 240);
   //capture.hide();


### PR DESCRIPTION
Fixes #1745