### PR TITLE
avoids infinite loop when saving canvas within mousepressed #1755

### DIFF
--- a/src/io/files.js
+++ b/src/io/files.js
@@ -1421,7 +1421,11 @@ p5.prototype.downloadFile = function (href, fName, extension) {
   a.download = filename;
 
   // Firefox requires the link to be added to the DOM before click()
-  a.onclick = destroyClickedElement;
+  a.onclick = function(e) {
+    destroyClickedElement(e);
+    e.stopPropagation();
+  };
+
   a.style.display = 'none';
   document.body.appendChild(a);
 


### PR DESCRIPTION
Fix to avoid the loop described in the issue #1755