### PR TITLE
Fix order of parameter documentation for p5.prototype.image

### DIFF
--- a/src/image/loading_displaying.js
+++ b/src/image/loading_displaying.js
@@ -168,16 +168,6 @@ function _sAssign(sVal, iVal) {
 /**
  * @method image
  * @param  {p5.Image} img
- * @param  {Number}   dx     the x-coordinate in the destination canvas at
- *                           which to place the top-left corner of the
- *                           source image
- * @param  {Number}   dy     the y-coordinate in the destination canvas at
- *                           which to place the top-left corner of the
- *                           source image
- * @param  {Number}   dWidth the width to draw the image in the destination
- *                           canvas
- * @param  {Number}   dHeight the height to draw the image in the destination
- *                            canvas
  * @param  {Number}   sx     the x-coordinate of the top left corner of the
  *                           sub-rectangle of the source image to draw into
  *                           the destination canvas
@@ -189,6 +179,16 @@ function _sAssign(sVal, iVal) {
  *                           canvas
  * @param {Number}    [sHeight] the height of the sub-rectangle of the
  *                            source image to draw into the destination context
+ * @param  {Number}   dx     the x-coordinate in the destination canvas at
+ *                           which to place the top-left corner of the
+ *                           source image
+ * @param  {Number}   dy     the y-coordinate in the destination canvas at
+ *                           which to place the top-left corner of the
+ *                           source image
+ * @param  {Number}   dWidth the width to draw the image in the destination
+ *                           canvas
+ * @param  {Number}   dHeight the height to draw the image in the destination
+ *                            canvas
  */
 p5.prototype.image =
   function(img, dx, dy, dWidth, dHeight, sx, sy, sWidth, sHeight) {


### PR DESCRIPTION
fixes #1774 

The inline documentation had the parameters in the opposite order for p5.prototype.image.

```
There seems to be a disconnect between the documentation for p5.prototype.image and the code.

https://github.com/processing/p5.js/blob/master/src/image/loading_displaying.js#L127
has the destination parameters first and the source parameters second.

p5.prototype.image =
function(img, dx, dy, dWidth, dHeight, sx, sy, sWidth, sHeight) {
// set defaults per spec: https://goo.gl/3ykfOq

But the actual code in p5.js has them reversed.

p5.prototype.image =
function(img, sx, sy, sWidth, sHeight, dx, dy, dWidth, dHeight) {
// Temporarily disabling until options for p5.Graphics are added.
// var args = new Array(arguments.length);
```