### PR TITLE
Handle ‘numeric’ strings for 2D primitives, closes #1792

### DIFF
--- a/src/core/2d_primitives.js
+++ b/src/core/2d_primitives.js
@@ -13,6 +13,10 @@ var constants = require('./constants');
 var canvas = require('./canvas');
 require('./error_helpers');
 
+// Make mode adjust functions available for testing.
+p5.prototype._modeAdjust = canvas.modeAdjust;
+p5.prototype._arcModeAdjust = canvas.arcModeAdjust;
+
 /**
  * Draw an arc to the screen. If called with only a, b, c, d, start, and
  * stop, the arc will be drawn as an open pie. If mode is provided, the arc

--- a/src/core/canvas.js
+++ b/src/core/canvas.js
@@ -8,25 +8,25 @@ module.exports = {
 
   modeAdjust: function(a, b, c, d, mode) {
     if (mode === constants.CORNER) {
-      return { x: a, y: b, w: c, h: d };
+      return { x: +a, y: +b, w: +c, h: +d };
     } else if (mode === constants.CORNERS) {
-      return { x: a, y: b, w: c-a, h: d-b };
+      return { x: +a, y: +b, w: c-a, h: d-b };
     } else if (mode === constants.RADIUS) {
       return { x: a-c, y: b-d, w: 2*c, h: 2*d };
     } else if (mode === constants.CENTER) {
-      return { x: a-c*0.5, y: b-d*0.5, w: c, h: d };
+      return { x: a-c*0.5, y: b-d*0.5, w: +c, h: +d };
     }
   },
 
   arcModeAdjust: function(a, b, c, d, mode) {
     if (mode === constants.CORNER) {
-      return { x: a+c*0.5, y: b+d*0.5, w: c, h: d };
+      return { x: +a+c*0.5, y: +b+d*0.5, w: +c, h: +d };
     } else if (mode === constants.CORNERS) {
-      return { x: a, y: b, w: c+a, h: d+b };
+      return { x: +a, y: +b, w: +c+(+a), h: +d+(+b) };
     } else if (mode === constants.RADIUS) {
-      return { x: a, y: b, w: 2*c, h: 2*d };
+      return { x: +a, y: +b, w: 2*c, h: 2*d };
     } else if (mode === constants.CENTER) {
-      return { x: a, y: b, w: c, h: d };
+      return { x: +a, y: +b, w: +c, h: +d };
     }
   }
 

--- a/test/test-minified.html
+++ b/test/test-minified.html
@@ -41,6 +41,7 @@
   <!-- Spec files -->
   <script src="unit/core/core.js" type="text/javascript" ></script>
   <!--<script src="unit/core/2d_primitives.js" type="text/javascript" ></script>-->
+  <script src="unit/core/canvas.js" type="text/javascript" ></script>
   <script src="unit/core/curves.js" type="text/javascript" ></script>
   <script src="unit/core/structure.js" type="text/javascript" ></script>
 

--- a/test/test.html
+++ b/test/test.html
@@ -37,6 +37,7 @@
   <script src="unit/addons/p5.dom.js" type="text/javascript" ></script>
   <script src="unit/core/core.js" type="text/javascript" ></script>
   <!--<script src="unit/core/2d_primitives.js" type="text/javascript" ></script>-->
+  <script src="unit/core/canvas.js" type="text/javascript" ></script>
   <script src="unit/core/curves.js" type="text/javascript" ></script>
   <script src="unit/core/error_helpers.js" type="text/javascript" ></script>
   <script src="unit/core/renderer.js" type="text/javascript" ></script>

--- a/test/unit/core/canvas.js
+++ b/test/unit/core/canvas.js
@@ -1,0 +1,66 @@
+suite('Canvas', function() {
+  var CORNER = p5.prototype.CORNER;
+  var CORNERS = p5.prototype.CORNERS;
+  var RADIUS = p5.prototype.RADIUS;
+  var CENTER = p5.prototype.CENTER;
+
+  var result;
+
+  suite('canvas.modeAdjust', function() {
+    var modeAdjust = p5.prototype._modeAdjust;
+
+    test('should be a function', function() {
+      assert.ok(modeAdjust);
+      assert.typeOf(modeAdjust, 'function');
+    });
+
+    test('should convert numeric strings when rectMode is CORNER', function(done) {
+      result = modeAdjust('10', '24', '32', '50', CORNER);
+      assert.deepEqual(result, { x: 10, y: 24, w: 32, h: 50 });
+    });
+
+    test('should convert numeric strings when rectMode is CORNERS', function(done) {
+      result = modeAdjust('10', '24', '32', '50', CORNERS);
+      assert.deepEqual(result, { x: 10, y: 24, w: 22, h: 26 });
+    });
+
+    test('should convert numeric strings when rectMode is RADIUS', function(done) {
+      result = modeAdjust('10', '24', '32', '50', RADIUS);
+      assert.deepEqual(result, { x: -22, y: -26, w: 64, h: 100 });
+    });
+
+    test('should convert numeric strings when rectMode is CENTER', function(done) {
+      result = modeAdjust('10', '24', '32', '50', CENTER);
+      assert.deepEqual(result, { x: -6, y: -1, w: 32, h: 50 });
+    });
+  });
+
+  suite('canvas.arcModeAdjust', function() {
+    var arcModeAdjust = p5.prototype._arcModeAdjust;
+
+    test('should be a function', function() {
+      assert.ok(arcModeAdjust);
+      assert.typeOf(arcModeAdjust, 'function');
+    });
+
+    test('should convert numeric strings when ellipseMode is CORNER', function(done) {
+      result = arcModeAdjust('10', '24', '32', '50', CORNER);
+      assert.deepEqual(result, { x: 26, y: 49, w: 32, h: 50 });
+    });
+
+    test('should convert numeric strings when ellipseMode is CORNERS', function(done) {
+      result = arcModeAdjust('10', '24', '32', '50', CORNERS);
+      assert.deepEqual(result, { x: 10, y: 24, w: 42, h: 74 });
+    });
+
+    test('should convert numeric strings when ellipseMode is RADIUS', function(done) {
+      result = arcModeAdjust('10', '24', '32', '50', RADIUS);
+      assert.deepEqual(result, { x: 10, y: 24, w: 64, h: 100 });
+    });
+
+    test('should convert numeric strings when ellipseMode is CENTER', function(done) {
+      result = arcModeAdjust('10', '24', '32', '50', CENTER);
+      assert.deepEqual(result, { x: 10, y: 24, w: 32, h: 50 });
+    });
+  });
+});

--- a/test/unit/core/canvas.js
+++ b/test/unit/core/canvas.js
@@ -14,22 +14,22 @@ suite('Canvas', function() {
       assert.typeOf(modeAdjust, 'function');
     });
 
-    test('should convert numeric strings when rectMode is CORNER', function(done) {
+    test('should convert numeric strings when rectMode is CORNER', function() {
       result = modeAdjust('10', '24', '32', '50', CORNER);
       assert.deepEqual(result, { x: 10, y: 24, w: 32, h: 50 });
     });
 
-    test('should convert numeric strings when rectMode is CORNERS', function(done) {
+    test('should convert numeric strings when rectMode is CORNERS', function() {
       result = modeAdjust('10', '24', '32', '50', CORNERS);
       assert.deepEqual(result, { x: 10, y: 24, w: 22, h: 26 });
     });
 
-    test('should convert numeric strings when rectMode is RADIUS', function(done) {
+    test('should convert numeric strings when rectMode is RADIUS', function() {
       result = modeAdjust('10', '24', '32', '50', RADIUS);
       assert.deepEqual(result, { x: -22, y: -26, w: 64, h: 100 });
     });
 
-    test('should convert numeric strings when rectMode is CENTER', function(done) {
+    test('should convert numeric strings when rectMode is CENTER', function() {
       result = modeAdjust('10', '24', '32', '50', CENTER);
       assert.deepEqual(result, { x: -6, y: -1, w: 32, h: 50 });
     });
@@ -43,22 +43,22 @@ suite('Canvas', function() {
       assert.typeOf(arcModeAdjust, 'function');
     });
 
-    test('should convert numeric strings when ellipseMode is CORNER', function(done) {
+    test('should convert numeric strings when ellipseMode is CORNER', function() {
       result = arcModeAdjust('10', '24', '32', '50', CORNER);
       assert.deepEqual(result, { x: 26, y: 49, w: 32, h: 50 });
     });
 
-    test('should convert numeric strings when ellipseMode is CORNERS', function(done) {
+    test('should convert numeric strings when ellipseMode is CORNERS', function() {
       result = arcModeAdjust('10', '24', '32', '50', CORNERS);
       assert.deepEqual(result, { x: 10, y: 24, w: 42, h: 74 });
     });
 
-    test('should convert numeric strings when ellipseMode is RADIUS', function(done) {
+    test('should convert numeric strings when ellipseMode is RADIUS', function() {
       result = arcModeAdjust('10', '24', '32', '50', RADIUS);
       assert.deepEqual(result, { x: 10, y: 24, w: 64, h: 100 });
     });
 
-    test('should convert numeric strings when ellipseMode is CENTER', function(done) {
+    test('should convert numeric strings when ellipseMode is CENTER', function() {
       result = arcModeAdjust('10', '24', '32', '50', CENTER);
       assert.deepEqual(result, { x: 10, y: 24, w: 32, h: 50 });
     });


### PR DESCRIPTION
- **Modifies `canvas.modeAdjust()` and `canvas.arcModeAdjust()` so that they always implicitly convert their arguments to numbers**  
This closes #1792 by ensuring that the calculations within the 2D primitive functions (which start by calling mode adjust) deal only with actual numbers. It also fixes some mode adjust-specific quirks that you might currently see if you pick unfortunate combinations of string arguments.  

- **Adds some mode adjust unit tests**  
Mode adjust isn’t currently tested because it resides in it’s own ‘canvas’ module that doesn’t get exported to `p5`. I had to export the mode adjust functions (e.g. `p5.prototype._modeAdjust()`) so that they could be tested for now (not sure if there is a better alternative for doing this?), but the tests cover the basic behaviour as well as the string argument handling.