### PR TITLE
Fixes textBound() bug on fonts that don't have the proper Glyph Name
Tables.

### DIFF
--- a/src/core/p5.Renderer2D.js
+++ b/src/core/p5.Renderer2D.js
@@ -1189,6 +1189,10 @@ p5.Renderer2D.prototype._renderText = function(p, line, x, y, maxY) {
       this.drawingContext.fillStyle =  this._fillSet ?
         this.drawingContext.fillStyle : constants._DEFAULT_TEXT_FILL;
 
+      if(p._textStyle == 'Regular'){
+        p._textStyle = 'Normal'
+      }
+      this.drawingContext.font = p._textStyle + ' '+ p._textSize +'px '+ p._textFont;
       this.drawingContext.fillText(line, x, y);
     }
   }

--- a/src/core/p5.Renderer2D.js
+++ b/src/core/p5.Renderer2D.js
@@ -1189,10 +1189,6 @@ p5.Renderer2D.prototype._renderText = function(p, line, x, y, maxY) {
       this.drawingContext.fillStyle =  this._fillSet ?
         this.drawingContext.fillStyle : constants._DEFAULT_TEXT_FILL;
 
-      if(p._textStyle == 'Regular'){
-        p._textStyle = 'Normal'
-      }
-      this.drawingContext.font = p._textStyle + ' '+ p._textSize +'px '+ p._textFont;
       this.drawingContext.fillText(line, x, y);
     }
   }

--- a/src/typography/p5.Font.js
+++ b/src/typography/p5.Font.js
@@ -126,7 +126,7 @@ p5.Font.prototype.textBounds = function(str, x, y, fontSize, options) {
 
         var gm = glyph.getMetrics();
 
-        if (glyph.name !== 'space' && glyph.unicode !== 32) {
+        if (glyph.name !== 'space') {
 
           xCoords.push(gX + (gm.xMax * scale));
           yCoords.push(gY + (-gm.yMin * scale));

--- a/src/typography/p5.Font.js
+++ b/src/typography/p5.Font.js
@@ -126,7 +126,7 @@ p5.Font.prototype.textBounds = function(str, x, y, fontSize, options) {
 
         var gm = glyph.getMetrics();
 
-        if (glyph.name !== 'space') {
+        if (glyph.name !== 'space' && glyph.unicode !== 32) {
 
           xCoords.push(gX + (gm.xMax * scale));
           yCoords.push(gY + (-gm.yMin * scale));


### PR DESCRIPTION
Fixes textBound() bug on fonts that don't have the proper Glyph Name
Tables. Added to a conditional inside of textBounds to either look for
the glyph.name ‘space’ && glyph.unicode 32 to insure proper
calculations of the text bounding box when spaces are used.