### PR TITLE
Implement fillRule - NONZERO or EVENODD

### DIFF
--- a/src/core/attributes.js
+++ b/src/core/attributes.js
@@ -332,7 +332,39 @@ p5.prototype.strokeWeight = function(w) {
  *
  * @method fillRule
  * @param  {Number/Constant} fillRule either NONZERO, EVENODD
- * @return {p5}                   the p5 object
+ * @return {p5}                       the p5 object
+ * @example
+ * <div>
+ * <code>
+ * noStroke();
+ * fillRule(NONZERO);
+ * beginShape();
+ * vertex(20, 80);
+ * vertex(50, 20);
+ * vertex(80, 80);
+ * vertex(20, 40);
+ * vertex(80, 40);
+ * endShape();
+ * </code>
+ * </div>
+ *
+ * <div>
+ * <code>
+ * noStroke();
+ * fillRule(EVENODD);
+ * beginShape();
+ * vertex(20, 80);
+ * vertex(50, 20);
+ * vertex(80, 80);
+ * vertex(20, 40);
+ * vertex(80, 40);
+ * endShape();
+ * </code>
+ * </div>
+ *
+ * @alt
+ * Self-overlapping star shape with NONZERO fill rule.
+ * Self-overlapping star shape with EVENODD fill rule.
  *
  */
 p5.prototype.fillRule = function(fillRule) {

--- a/src/core/attributes.js
+++ b/src/core/attributes.js
@@ -326,4 +326,21 @@ p5.prototype.strokeWeight = function(w) {
   return this;
 };
 
+/**
+ * Sets the fill rule used when filling paths, either NONZERO or EVENODD.
+ * The default fill rule is NONZERO.
+ *
+ * @method fillRule
+ * @param  {Number/Constant} fillRule either NONZERO, EVENODD
+ * @return {p5}                   the p5 object
+ *
+ */
+p5.prototype.fillRule = function(fillRule) {
+  if (fillRule === constants.NONZERO ||
+    fillRule === constants.EVENODD) {
+    this._renderer.fillRule(fillRule);
+  }
+  return this;
+};
+
 module.exports = p5;

--- a/src/core/constants.js
+++ b/src/core/constants.js
@@ -143,6 +143,8 @@ module.exports = {
   ROUND: 'round',
   BEVEL: 'bevel',
   MITER: 'miter',
+  NONZERO: 'nonzero',
+  EVENODD: 'evenodd',
 
   // COLOR
   RGB: 'rgb',

--- a/src/core/p5.Renderer.js
+++ b/src/core/p5.Renderer.js
@@ -48,6 +48,7 @@ p5.Renderer = function(elt, pInst, isMainCanvas) {
   this._ellipseMode = constants.CENTER;
   this._curveTightness = 0;
   this._imageMode = constants.CORNER;
+  this._fillRule = constants.NONZERO;
 
   this._tint = null;
   this._doStroke = true;

--- a/src/core/p5.Renderer2D.js
+++ b/src/core/p5.Renderer2D.js
@@ -419,7 +419,7 @@ p5.Renderer2D.prototype.arc =
       ctx.lineTo(vals.x, vals.y);
     }
     ctx.closePath();
-    ctx.fill();
+    ctx.fill(this._fillRule);
   }
 
   // Stroke curves
@@ -475,7 +475,7 @@ p5.Renderer2D.prototype.ellipse = function(args) {
   ctx.bezierCurveTo(xm - ox, ye, x, ym + oy, x, ym);
   ctx.closePath();
   if (doFill) {
-    ctx.fill();
+    ctx.fill(this._fillRule);
   }
   if (doStroke) {
     ctx.stroke();
@@ -525,7 +525,7 @@ p5.Renderer2D.prototype.point = function(x, y) {
       constants.TWO_PI,
       false
     );
-    ctx.fill();
+    ctx.fill(this._fillRule);
   } else {
     ctx.fillRect(x, y, 1, 1);
   }
@@ -552,7 +552,7 @@ p5.Renderer2D.prototype.quad =
   ctx.lineTo(x4, y4);
   ctx.closePath();
   if (doFill) {
-    ctx.fill();
+    ctx.fill(this._fillRule);
   }
   if (doStroke) {
     ctx.stroke();
@@ -619,7 +619,7 @@ p5.Renderer2D.prototype.rect = function(args) {
     ctx.closePath();
   }
   if (this._doFill) {
-    ctx.fill();
+    ctx.fill(this._fillRule);
   }
   if (this._doStroke) {
     ctx.stroke();
@@ -651,7 +651,7 @@ p5.Renderer2D.prototype.triangle = function(args) {
   ctx.lineTo(x3, y3);
   ctx.closePath();
   if (doFill) {
-    ctx.fill();
+    ctx.fill(this._fillRule);
   }
   if (doStroke) {
     ctx.stroke();
@@ -764,7 +764,7 @@ function (mode, vertices, isCurve, isBezier,
         this.drawingContext.lineTo(v[0], v[1]);
         if (this._doFill) {
           this._pInst.fill(vertices[i + 2][5]);
-          this.drawingContext.fill();
+          this.drawingContext.fill(this._fillRule);
         }
         if (this._doStroke) {
           this._pInst.stroke(vertices[i + 2][6]);
@@ -952,6 +952,14 @@ p5.Renderer2D.prototype.strokeWeight = function(w) {
   return this;
 };
 
+p5.Renderer2D.prototype.fillRule = function(fillRule) {
+  if (fillRule === constants.NONZERO ||
+    fillRule === constants.EVENODD) {
+    this._fillRule = fillRule;
+  }
+  return this;
+};
+
 p5.Renderer2D.prototype._getFill = function(){
   return this.drawingContext.fillStyle;
 };
@@ -987,7 +995,7 @@ p5.Renderer2D.prototype.curve = function (x1, y1, x2, y2, x3, y3, x4, y4) {
 
 p5.Renderer2D.prototype._doFillStrokeClose = function () {
   if (this._doFill) {
-    this.drawingContext.fill();
+    this.drawingContext.fill(this._fillRule);
   }
   if (this._doStroke) {
     this.drawingContext.stroke();

--- a/test/unit/core/2d_primitives.js
+++ b/test/unit/core/2d_primitives.js
@@ -49,4 +49,46 @@ suite('2D Primitives', function() {
     });
   });
 
+  suite('p5.prototype.fillRule', function() {
+    var fillRule = p5.prototype.fillRule;
+    suite('fillRule()', function() {
+      test('should be a function', function() {
+        assert.ok(fillRule);
+        assert.typeOf(fillRule, 'function');
+      });
+      test('should draw', function(done) {
+        myp5.noStroke();
+        myp5.fillRule(myp5.NONZERO);
+        myp5.beginShape();
+        myp5.vertex(20, 80);
+        myp5.vertex(50, 20);
+        myp5.vertex(80, 80);
+        myp5.vertex(20, 40);
+        myp5.vertex(80, 40);
+        myp5.endShape();
+
+        testRender('unit/assets/renders/nonzero.png', myp5, function(res) {
+          assert.isTrue(res);
+          done();
+        });
+      });
+      test('should draw', function(done) {
+        myp5.noStroke();
+        myp5.fillRule(myp5.EVENODD);
+        myp5.beginShape();
+        myp5.vertex(20, 80);
+        myp5.vertex(50, 20);
+        myp5.vertex(80, 80);
+        myp5.vertex(20, 40);
+        myp5.vertex(80, 40);
+        myp5.endShape();
+
+        testRender('unit/assets/renders/evenodd.png', myp5, function(res) {
+          assert.isTrue(res);
+          done();
+        });
+      });
+    });
+  });
+
 });


### PR DESCRIPTION
This PR adds a fillRule() function and two constants, NONZERO and EVENODD, for controlling the fill rule used during fill operations.

@lmccart I have added an example and a unit test for each fill rule. Unfortunately I'm unable to run the docs locally. I get this when following the instructions:

![screen shot 2017-02-09 at 8 50 26 pm](https://cloud.githubusercontent.com/assets/520208/22811162/3420df20-ef0b-11e6-9fc8-9c57bf4026f3.png)

(I'm also running into issue #1784, where grunt hangs on mocha:yui) 

For the unit tests, I figured we'd want to do an image comparison like those in `test/unit/core/2d_primitives.js` - but then I discovered these tests are not being run - it's commented out in `test.html`. I left my test in, but it won't be run because of this. (And since I can't view the docs to see my examples, I don't have ground-truth imagery to compare to yet.)
