### PR TITLE
Fetch API implementation 

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
   "license": "LGPL-2.1",
   "dependencies": {
     "brfs": "^1.4.0",
+    "es6-promise": "^4.0.5",
     "fetch-jsonp": "^1.0.6",
     "opentype.js": "^0.4.9",
     "whatwg-fetch": "^2.0.2"

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
   "dependencies": {
     "brfs": "^1.4.0",
     "opentype.js": "^0.4.9",
-    "reqwest": "^1.1.5"
+    "whatwg-fetch": "^2.0.2"
   },
   "main": "./lib/p5.js",
   "files": [

--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
   "license": "LGPL-2.1",
   "dependencies": {
     "brfs": "^1.4.0",
+    "fetch-jsonp": "^1.0.6",
     "opentype.js": "^0.4.9",
     "whatwg-fetch": "^2.0.2"
   },

--- a/src/core/environment.js
+++ b/src/core/environment.js
@@ -170,7 +170,8 @@ p5.prototype.cursor = function(type, x, y) {
       // https://developer.mozilla.org/en-US/docs/Web/CSS/cursor
       coords = x + ' ' + y;
     }
-    if (type.substring(0, 6) !== 'http://') {
+    if (type.substring(0, 6) === 'http://' ||
+        type.substring(0, 7) === 'https://') {
       // Image (absolute url)
       cursor = 'url(' + type + ') ' + coords + ', auto';
     } else if (/\.(cur|jpg|jpeg|gif|png|CUR|JPG|JPEG|GIF|PNG)$/.test(type)) {

--- a/src/core/environment.js
+++ b/src/core/environment.js
@@ -170,8 +170,8 @@ p5.prototype.cursor = function(type, x, y) {
       // https://developer.mozilla.org/en-US/docs/Web/CSS/cursor
       coords = x + ' ' + y;
     }
-    if (type.substring(0, 6) === 'http://' ||
-        type.substring(0, 7) === 'https://') {
+    if (type.substring(0, 7) === 'http://' ||
+        type.substring(0, 8) === 'https://') {
       // Image (absolute url)
       cursor = 'url(' + type + ') ' + coords + ', auto';
     } else if (/\.(cur|jpg|jpeg|gif|png|CUR|JPG|JPEG|GIF|PNG)$/.test(type)) {

--- a/src/io/files.js
+++ b/src/io/files.js
@@ -275,30 +275,6 @@ p5.prototype.loadJSON = function () {
     }
   }, errorCallback);
 
-  // fetch(path)
-  //   .then(function(res){
-  //     if(res.ok){
-  //       return res.json();
-  //     }
-
-  //     if (errorCallback) {
-  //       errorCallback(res);
-  //     } else { // otherwise log error msg
-  //       throw new Error(res.statusText);
-  //     }
-  //   })
-  //   .then(function(resp){
-  //     for (var k in resp) {
-  //       ret[k] = resp[k];
-  //     }
-  //     if (typeof callback !== 'undefined') {
-  //       callback(resp);
-  //     }
-  //     if (decrementPreload && (callback !== decrementPreload)) {
-  //       decrementPreload();
-  //     }
-  //   });
-
   return ret;
 };
 
@@ -757,33 +733,6 @@ p5.prototype.loadXML = function (path, callback, errorCallback) {
     }
   }, errorCallback);
 
-  // fetch(path)
-  //   .then(function(res){
-  //     if(res.ok){
-  //       return res.text();
-  //     }
-  //     if (errorCallback) {
-  //       errorCallback(res);
-  //     } else { // otherwise log error msg
-  //       throw new Error(res.statusText);
-  //     }
-  //   })
-  //   .then(function(resp){
-  //     var parser = new DOMParser();
-  //     var intermediate = parser.parseFromString(resp, 'text/xml');
-  //     var xml = parseXML(intermediate.documentElement);
-
-  //     for(var key in xml) {
-  //       ret[key] = xml[key];
-  //     }
-  //     if (typeof callback !== 'undefined') {
-  //       callback(ret);
-  //     }
-  //     if (decrementPreload && (callback !== decrementPreload)) {
-  //       decrementPreload();
-  //     }
-  //   });
-
   return ret;
 };
 
@@ -930,11 +879,13 @@ p5.prototype.httpDo = function () {
       if (typeof a === 'string') {
         if (a === 'GET' || a === 'POST' || a === 'PUT' || a === 'DELETE') {
           method = a;
-        } else {
+        } else if(a === 'json' || a === 'jsonp' || a === 'xml' || a === 'text') {
           type = a;
+        } else {
+          data = a;
         }
       } else if (typeof a === 'object') {
-        data = a;
+        data = JSON.stringify(a);
       } else if (typeof a === 'function') {
         if (!callback) {
           callback = a;

--- a/src/io/files.js
+++ b/src/io/files.js
@@ -245,8 +245,7 @@ p5.prototype.loadJSON = function () {
   var decrementPreload = p5._getDecrementPreload.apply(this, arguments);
 
   var ret = {}; // object needed for preload
-  // assume jsonp for URLs
-  var t = 'json'; //= path.indexOf('http') === -1 ? 'json' : 'jsonp';
+  var t = 'json';
 
   // check for explicit data type argument
   for (var i = 2; i < arguments.length; i++) {
@@ -260,11 +259,17 @@ p5.prototype.loadJSON = function () {
     }
   }
 
+  if(t === 'jsonp'){
+    console.log('JSONP polyfill required');
+    return ret;
+  }
+
   fetch(path)
     .then(function(res){
       if(res.ok){
         return res.json();
       }
+
       if (errorCallback) {
         errorCallback(res);
       } else { // otherwise log error msg
@@ -282,31 +287,6 @@ p5.prototype.loadJSON = function () {
         decrementPreload();
       }
     });
-
-  // reqwest({
-  //   url: path,
-  //   type: t,
-  //   crossOrigin: true,
-  //   error: function (resp) {
-  //     // pass to error callback if defined
-  //     if (errorCallback) {
-  //       errorCallback(resp);
-  //     } else { // otherwise log error msg
-  //       console.log(resp.statusText);
-  //     }
-  //   },
-  //   success: function (resp) {
-  //     for (var k in resp) {
-  //       ret[k] = resp[k];
-  //     }
-  //     if (typeof callback !== 'undefined') {
-  //       callback(resp);
-  //     }
-  //     if (decrementPreload && (callback !== decrementPreload)) {
-  //       decrementPreload();
-  //     }
-  //   }
-  // });
 
   return ret;
 };
@@ -541,11 +521,11 @@ p5.prototype.loadTable = function (path) {
       if(res.ok){
         return res.text();
       }
-      // if (errorCallback) {
-      //   errorCallback(res);
-      // } else { // otherwise log error msg
-      //   throw new Error(res.statusText);
-      // }
+      if (errorCallback) {
+        errorCallback(res);
+      } else { // otherwise log error msg
+        throw new Error(res.statusText);
+      }
     })
     .then(function (resp) {
       var state = {};
@@ -1081,7 +1061,7 @@ p5.prototype.httpDo = function () {
   }
 
   var request = new Request(path, {
-    method: method,
+    // method: method,
     mode: 'cors',
     body: data
   });

--- a/src/io/files.js
+++ b/src/io/files.js
@@ -925,7 +925,7 @@ p5.prototype.httpDo = function () {
     var method = 'GET';
     var data = {};
 
-    for (var i = 1; i < arguments.length; i++) {
+    for (var j = 1; j < arguments.length; j++) {
       var a = arguments[i];
       if (typeof a === 'string') {
         if (a === 'GET' || a === 'POST' || a === 'PUT' || a === 'DELETE') {

--- a/src/io/files.js
+++ b/src/io/files.js
@@ -270,7 +270,7 @@ p5.prototype.loadJSON = function () {
     }
   }
 
-  this.httpDo(path, 'GET', options, t, function(resp){
+  p5.prototype.httpDo(path, 'GET', options, t, function(resp){
     for (var k in resp) {
       ret[k] = resp[k];
     }
@@ -349,7 +349,7 @@ p5.prototype.loadStrings = function (path, callback, errorCallback) {
   var ret = [];
   var decrementPreload = p5._getDecrementPreload.apply(this, arguments);
 
-  this.httpDo(path, 'GET', 'text', function(data){
+  p5.prototype.httpDo(path, 'GET', 'text', function(data){
     var arr = data.match(/[^\r\n]+/g);
     for (var k in arr) {
       ret[k] = arr[k];
@@ -497,7 +497,7 @@ p5.prototype.loadTable = function (path) {
 
   var t = new p5.Table();
 
-  this.httpDo(path, 'GET', 'text', function(resp){
+  p5.prototype.httpDo(path, 'GET', 'text', function(resp){
     var state = {};
 
     // define constants
@@ -713,7 +713,7 @@ p5.prototype.loadXML = function (path, callback, errorCallback) {
   var ret = {};
   var decrementPreload = p5._getDecrementPreload.apply(this, arguments);
 
-  this.httpDo(path, 'GET', 'xml', function(xml){
+  p5.prototype.httpDo(path, 'GET', 'xml', function(xml){
     for(var key in xml) {
       ret[key] = xml[key];
     }

--- a/src/io/files.js
+++ b/src/io/files.js
@@ -9,13 +9,8 @@
 
 var p5 = require('../core/core');
 var opentype = require('opentype.js');
-var fetchPolyfill = require('whatwg-fetch');
+require('whatwg-fetch');
 require('../core/error_helpers');
-
-// Use polyfill if fetch API not available
-if(!window.fetch){
-  window.fetch = fetchPolyfill;
-}
 
 /**
  * Checks if we are in preload and returns the last arg which will be the

--- a/src/io/files.js
+++ b/src/io/files.js
@@ -340,42 +340,22 @@ p5.prototype.loadJSON = function () {
  */
 p5.prototype.loadStrings = function (path, callback, errorCallback) {
   var ret = [];
-  var req = new XMLHttpRequest();
   var decrementPreload = p5._getDecrementPreload.apply(this, arguments);
 
-  req.addEventListener('error', function (resp) {
-    if (errorCallback) {
-      errorCallback(resp);
-    } else {
-      console.log(resp.responseText);
+  this.httpDo(path, 'GET', 'text', function(data){
+    var arr = data.match(/[^\r\n]+/g);
+    for (var k in arr) {
+      ret[k] = arr[k];
     }
-  });
 
-  req.open('GET', path, true);
-  req.onreadystatechange = function () {
-    if (req.readyState === 4) {
-      if (req.status === 200) {
-        var arr = req.responseText.match(/[^\r\n]+/g);
-        for (var k in arr) {
-          ret[k] = arr[k];
-        }
-        if (typeof callback !== 'undefined') {
-          callback(ret);
-        }
-        if (decrementPreload && (callback !== decrementPreload)) {
-          decrementPreload();
-        }
-      } else {
-        if (errorCallback) {
-          errorCallback(req);
-        } else {
-          console.log(req.statusText);
-        }
-        //p5._friendlyFileLoadError(3, path);
-      }
+    if (typeof callback !== 'undefined') {
+      callback(ret);
     }
-  };
-  req.send(null);
+    if (decrementPreload && (callback !== decrementPreload)) {
+      decrementPreload();
+    }
+  }, errorCallback);
+
   return ret;
 };
 

--- a/src/io/files.js
+++ b/src/io/files.js
@@ -175,17 +175,21 @@ p5.prototype.loadBytes = function () {
 /**
  * Loads a JSON file from a file or a URL, and returns an Object or Array.
  * This method is asynchronous, meaning it may not finish before the next
- * line in your sketch is executed.
+ * line in your sketch is executed. JSONP is supported via a polyfill and you
+ * can pass in as the second argument an object with definitions of the json
+ * callback following the syntax specified <a href="https://github.com/camsong/
+ * fetch-jsonp">here</a>.
  *
  * @method loadJSON
  * @param  {String}        path       name of the file or url to load
+ * @param  {Object}        [jsonpOptions] options object for jsonp related settings
+ * @param  {String}        [datatype] "json" or "jsonp"
  * @param  {Function}      [callback] function to be executed after
  *                                    loadJSON() completes, data is passed
  *                                    in as first argument
  * @param  {Function}      [errorCallback] function to be executed if
  *                                    there is an error, response is passed
  *                                    in as first argument
- * @param  {String}        [datatype] "json" or "jsonp"
  * @return {Object|Array}             JSON data
  * @example
  *
@@ -748,7 +752,8 @@ p5.prototype.selectInput = function () {
 
 /**
  * Method for executing an HTTP GET request. If data type is not specified,
- * p5 will try to guess based on the URL, defaulting to text.
+ * p5 will try to guess based on the URL, defaulting to text. This is equivalent to
+ * calling <code>httpDo(path, 'GET')</code>.
  *
  * @method httpGet
  * @param  {String}        path       name of the file or url to load
@@ -773,7 +778,8 @@ p5.prototype.httpGet = function () {
 
 /**
  * Method for executing an HTTP POST request. If data type is not specified,
- * p5 will try to guess based on the URL, defaulting to text.
+ * p5 will try to guess based on the URL, defaulting to text. This is equivalent to
+ * calling <code>httpDo(path, 'POST')</code>.
  *
  * @method httpPost
  * @param  {String}        path       name of the file or url to load
@@ -799,8 +805,8 @@ p5.prototype.httpPost = function () {
 /**
  * Method for executing an HTTP request. If data type is not specified,
  * p5 will try to guess based on the URL, defaulting to text.<br><br>
- * For more advanced use, you may also pass in a <a href="https://devel
- * oper.mozilla.org/en-US/docs/Web/API/Request">Request</a> object as specified
+ * For more advanced use, you may also pass in the path as the first argument
+ * and a object as the second argument, the signature follows the one specified
  * in the Fetch API specification.
  *
  * @method httpDo

--- a/src/io/files.js
+++ b/src/io/files.js
@@ -864,8 +864,8 @@ p5.prototype.httpPost = function () {
  * @param  {String}        path       name of the file or url to load
  * @param  {String}        [method]   either "GET", "POST", or "PUT",
  *                                    defaults to "GET"
- * @param  {Object}        [data]     param data passed sent with request
  * @param  {String}        [datatype] "json", "jsonp", "xml", or "text"
+ * @param  {Object}        [data]     param data passed sent with request
  * @param  {Function}      [callback] function to be executed after
  *                                    httpGet() completes, data is passed in
  *                                    as first argument
@@ -876,7 +876,8 @@ p5.prototype.httpPost = function () {
 
 /**
  * @method httpDo
- * @param {Object}         options   Request object options as documented in the
+ * @param  {String}        path
+ * @param  {Object}        options   Request object options as documented in the
  *                                    "fetch" API
  * <a href="https://developer.mozilla.org/en/docs/Web/API/Fetch_API">reference</a>
  * @param  {Function}      [callback]
@@ -898,11 +899,13 @@ p5.prototype.httpDo = function () {
   }
   // The number of arguments minus callbacks
   var argsCount = arguments.length - cbCount;
-  if(argsCount === 1 && typeof arguments[0] === 'object'){
-    // Intended for more advanced use, pass in Request object directly
-    request = arguments[0];
-    callback = arguments[1];
-    errorCallback = arguments[2];
+  if(argsCount === 2 &&
+     typeof arguments[0] === 'string' &&
+     typeof arguments[1] === 'object'){
+    // Intended for more advanced use, pass in Request parameters directly
+    request = new Request(arguments[0], arguments[1]);
+    callback = arguments[2];
+    errorCallback = arguments[3];
 
     // do some sort of smart type checking
     if (type === '') {
@@ -918,10 +921,10 @@ p5.prototype.httpDo = function () {
     // Provided with arguments
     var path = arguments[0];
     var method = 'GET';
-    var data = {};
+    var data;
 
     for (var j = 1; j < arguments.length; j++) {
-      var a = arguments[i];
+      var a = arguments[j];
       if (typeof a === 'string') {
         if (a === 'GET' || a === 'POST' || a === 'PUT' || a === 'DELETE') {
           method = a;

--- a/src/io/files.js
+++ b/src/io/files.js
@@ -811,8 +811,8 @@ p5.prototype.selectInput = function () {
  *
  * @method httpGet
  * @param  {String}        path       name of the file or url to load
- * @param  {Object}        [data]     param data passed sent with request
  * @param  {String}        [datatype] "json", "jsonp", "xml", or "text"
+ * @param  {Object}        [data]     param data passed sent with request
  * @param  {Function}      [callback] function to be executed after
  *                                    httpGet() completes, data is passed in
  *                                    as first argument
@@ -822,10 +822,11 @@ p5.prototype.selectInput = function () {
  */
 p5.prototype.httpGet = function () {
   var args = new Array(arguments.length);
-  for (var i = 0; i < args.length; ++i) {
+  args[0] = arguments[0];
+  args[1] = 'GET';
+  for (var i = 2; i < args.length; ++i) {
     args[i] = arguments[i];
   }
-  args.push('GET');
   p5.prototype.httpDo.apply(this, args);
 };
 
@@ -835,8 +836,8 @@ p5.prototype.httpGet = function () {
  *
  * @method httpPost
  * @param  {String}        path       name of the file or url to load
- * @param  {Object}        [data]     param data passed sent with request
  * @param  {String}        [datatype] "json", "jsonp", "xml", or "text"
+ * @param  {Object}        [data]     param data passed sent with request
  * @param  {Function}      [callback] function to be executed after
  *                                    httpGet() completes, data is passed in
  *                                    as first argument
@@ -846,10 +847,11 @@ p5.prototype.httpGet = function () {
  */
 p5.prototype.httpPost = function () {
   var args = new Array(arguments.length);
-  for (var i = 0; i < args.length; ++i) {
+  args[0] = arguments[0];
+  args[1] = 'POST';
+  for (var i = 2; i < args.length; ++i) {
     args[i] = arguments[i];
   }
-  args.push('POST');
   p5.prototype.httpDo.apply(this, args);
 };
 

--- a/src/io/files.js
+++ b/src/io/files.js
@@ -9,7 +9,13 @@
 
 var p5 = require('../core/core');
 var opentype = require('opentype.js');
+var fetchPolyfill = require('whatwg-fetch');
 require('../core/error_helpers');
+
+// Use polyfill if fetch API not available
+if(!window.fetch){
+  window.fetch = fetchPolyfill;
+}
 
 /**
  * Checks if we are in preload and returns the last arg which will be the

--- a/test/unit/assets/books.xml
+++ b/test/unit/assets/books.xml
@@ -1,0 +1,120 @@
+<?xml version="1.0"?>
+<catalog>
+   <book id="bk101">
+      <author>Gambardella, Matthew</author>
+      <title>XML Developer's Guide</title>
+      <genre>Computer</genre>
+      <price>44.95</price>
+      <publish_date>2000-10-01</publish_date>
+      <description>An in-depth look at creating applications
+      with XML.</description>
+   </book>
+   <book id="bk102">
+      <author>Ralls, Kim</author>
+      <title>Midnight Rain</title>
+      <genre>Fantasy</genre>
+      <price>5.95</price>
+      <publish_date>2000-12-16</publish_date>
+      <description>A former architect battles corporate zombies,
+      an evil sorceress, and her own childhood to become queen
+      of the world.</description>
+   </book>
+   <book id="bk103">
+      <author>Corets, Eva</author>
+      <title>Maeve Ascendant</title>
+      <genre>Fantasy</genre>
+      <price>5.95</price>
+      <publish_date>2000-11-17</publish_date>
+      <description>After the collapse of a nanotechnology
+      society in England, the young survivors lay the
+      foundation for a new society.</description>
+   </book>
+   <book id="bk104">
+      <author>Corets, Eva</author>
+      <title>Oberon's Legacy</title>
+      <genre>Fantasy</genre>
+      <price>5.95</price>
+      <publish_date>2001-03-10</publish_date>
+      <description>In post-apocalypse England, the mysterious
+      agent known only as Oberon helps to create a new life
+      for the inhabitants of London. Sequel to Maeve
+      Ascendant.</description>
+   </book>
+   <book id="bk105">
+      <author>Corets, Eva</author>
+      <title>The Sundered Grail</title>
+      <genre>Fantasy</genre>
+      <price>5.95</price>
+      <publish_date>2001-09-10</publish_date>
+      <description>The two daughters of Maeve, half-sisters,
+      battle one another for control of England. Sequel to
+      Oberon's Legacy.</description>
+   </book>
+   <book id="bk106">
+      <author>Randall, Cynthia</author>
+      <title>Lover Birds</title>
+      <genre>Romance</genre>
+      <price>4.95</price>
+      <publish_date>2000-09-02</publish_date>
+      <description>When Carla meets Paul at an ornithology
+      conference, tempers fly as feathers get ruffled.</description>
+   </book>
+   <book id="bk107">
+      <author>Thurman, Paula</author>
+      <title>Splish Splash</title>
+      <genre>Romance</genre>
+      <price>4.95</price>
+      <publish_date>2000-11-02</publish_date>
+      <description>A deep sea diver finds true love twenty
+      thousand leagues beneath the sea.</description>
+   </book>
+   <book id="bk108">
+      <author>Knorr, Stefan</author>
+      <title>Creepy Crawlies</title>
+      <genre>Horror</genre>
+      <price>4.95</price>
+      <publish_date>2000-12-06</publish_date>
+      <description>An anthology of horror stories about roaches,
+      centipedes, scorpions  and other insects.</description>
+   </book>
+   <book id="bk109">
+      <author>Kress, Peter</author>
+      <title>Paradox Lost</title>
+      <genre>Science Fiction</genre>
+      <price>6.95</price>
+      <publish_date>2000-11-02</publish_date>
+      <description>After an inadvertant trip through a Heisenberg
+      Uncertainty Device, James Salway discovers the problems
+      of being quantum.</description>
+   </book>
+   <book id="bk110">
+      <author>O'Brien, Tim</author>
+      <title>Microsoft .NET: The Programming Bible</title>
+      <genre>Computer</genre>
+      <price>36.95</price>
+      <publish_date>2000-12-09</publish_date>
+      <description>Microsoft's .NET initiative is explored in
+      detail in this deep programmer's reference.</description>
+   </book>
+   <book id="bk111">
+      <author>O'Brien, Tim</author>
+      <title>MSXML3: A Comprehensive Guide</title>
+      <genre>Computer</genre>
+      <price>36.95</price>
+      <publish_date>2000-12-01</publish_date>
+      <description>The Microsoft MSXML3 parser is covered in
+      detail, with attention to XML DOM interfaces, XSLT processing,
+      SAX and more.</description>
+   </book>
+   <book id="bk112">
+      <author>Galos, Mike</author>
+      <title>Visual Studio 7: A Comprehensive Guide</title>
+      <genre>Computer</genre>
+      <price>49.95</price>
+      <publish_date>2001-04-16</publish_date>
+      <description>Microsoft Visual Studio 7 is explored in depth,
+      looking at how Visual Basic, Visual C++, C#, and ASP+ are
+      integrated into a comprehensive development
+      environment.</description>
+   </book>
+</catalog>

--- a/test/unit/io/files_input.js
+++ b/test/unit/io/files_input.js
@@ -1,7 +1,7 @@
 suite('Files', function() {
 
   var loadJSON = p5.prototype.loadJSON;
-  // var loadStrings = p5.prototype.loadStrings;
+  var loadStrings = p5.prototype.loadStrings;
 
   //variable for preload
   var preload = p5.prototype.preload;
@@ -25,29 +25,21 @@ suite('Files', function() {
       result = loadJSON('unit/assets/array.json');
       assert.ok(result);
       assert.isObject(result, 'result is an object');
-      // assert.typeOf(result, 'Array');
-      // assert.lengthOf(result, 2);
     });
   });
 
-  //   test('should be a function', function( {
-  //     assert.ok(loadJSON);
-  //     assert.typeOf(loadJSON, 'function');
-  //   });
-  //   test('in preload, should return an object', function() {
-  //     result = loadJSON("../assets/array.json");
-  //     assert.typeOf(result, 'Object');
-  //   });
-  //   test('should return an error', function() {
-  //     result = loadJSON("../assets/arr.json");
-  //     assert.typeOf(result, 'nothing');
-  //   });
-  // });
+  suite('loadStrings() in Preload', function(){
+    test('should be a function', function() {
+      assert.ok(loadStrings);
+      assert.typeOf(loadStrings, 'function');
+    });
 
-  // test('loadStrings in preload without callback', function(
-  // result = loadStrings('../assets/sentences.txt');
-  // assert.ok(result);
-  // )};
+    test('should return an array', function(){
+      result = loadStrings('unit/assets/sentences.txt');
+      assert.ok(result);
+      assert.isArray(result, 'result is and array');
+    });
+  });
 
   //tests while preload is false with callbacks
   preload = false;
@@ -57,6 +49,37 @@ suite('Files', function() {
       assert.ok(loadJSON);
       assert.typeOf(loadJSON, 'function');
     });
+
+    test('should call callback function if provided', function(done){
+      result = loadJSON('unit/assets/array.json', function(data){
+        done();
+      });
+    });
+
+    test('should pass an Array to callback function', function(){
+      result = loadJSON('unit/assets/array.json', function(data){
+        assert.isArray(data, 'Array passed to callback function');
+        assert.lengthOf(data, 3, 'length of data is 3');
+      });
+    });
+
+    test('should call error callback function if provided', function(done){
+      result = loadJSON('unit/assets/arr.json', function(data){}, function(){
+        done();
+      });
+    });
+
+    test('should pass error object to error callback function', function() {
+      result = loadJSON('unit/assets/arr.json', function(data){
+        // should really be an empty object or never called
+        assert.isUndefined(data, 'data is undefined');
+      }, function(err){
+        assert.isObject(err, 'err is an object');
+        assert.isFalse(err.ok, 'err.ok is false');
+        assert.equal(err.status, 404, 'Error status is 404');
+      });
+    });
+
     /*test('should allow json to override jsonp in 3rd param',
       function(done){
 
@@ -69,7 +92,43 @@ suite('Files', function() {
         };
         result = loadJSON(url,myCallback,datatype);
     });*/
+  });
 
+  suite('p5.prototype.loadStrings', function() {
+    test('should be a function', function() {
+      assert.ok(loadStrings);
+      assert.typeOf(loadStrings, 'function');
+    });
+
+    test('should call callback function if provided', function(done){
+      result = loadStrings('unit/assets/sentences.txt', function(data){
+        done();
+      });
+    });
+
+    test('should pass an Array to callback function', function(){
+      result = loadStrings('unit/assets/sentences.txt', function(data){
+        assert.isArray(data, 'Array passed to callback function');
+        assert.lengthOf(data, 68, 'length of data is 68');
+      });
+    });
+
+    test('should call error callback function if provided', function(done){
+      result = loadStrings('unit/assets/sen.txt', function(data){}, function(){
+        done();
+      });
+    });
+
+    test('should pass error object to error callback function', function() {
+      result = loadStrings('unit/assets/sen.txt', function(data){
+        // should really be an empty object or never called
+        assert.isUndefined(data, 'data is undefined');
+      }, function(err){
+        assert.isObject(err, 'err is an object');
+        assert.isFalse(err.ok, 'err.ok is false');
+        assert.equal(err.status, 404, 'Error status is 404');
+      });
+    });
   });
   /*
   var loadTable = p5.prototype.loadTable;

--- a/test/unit/io/files_input.js
+++ b/test/unit/io/files_input.js
@@ -2,6 +2,7 @@ suite('Files', function() {
 
   var loadJSON = p5.prototype.loadJSON;
   var loadStrings = p5.prototype.loadStrings;
+  var loadXML = p5.prototype.loadXML;
 
   //variable for preload
   var preload = p5.prototype.preload;
@@ -15,6 +16,7 @@ suite('Files', function() {
     assert.typeOf(preload, 'Boolean');
   });
 
+  // loadJSON()
   suite('loadJSON() in Preload', function () {
     test('should be a function', function() {
       assert.ok(loadJSON);
@@ -28,6 +30,7 @@ suite('Files', function() {
     });
   });
 
+  // loadStrings()
   suite('loadStrings() in Preload', function(){
     test('should be a function', function() {
       assert.ok(loadStrings);
@@ -41,9 +44,24 @@ suite('Files', function() {
     });
   });
 
+  // loadXML()
+  suite('loadXML() in Preload', function(){
+    test('should be a function', function(){
+      assert.ok(loadXML);
+      assert.typeOf(loadXML, 'function');
+    });
+
+    // test('should return an Object', function() {
+    //   result = loadXML('unit/assets/test.xml');
+    //   assert.ok(result);
+    //   assert.isObject(result, 'result is an object');
+    // });
+  });
+
   //tests while preload is false with callbacks
   preload = false;
 
+  // loadJSON()
   suite('p5.prototype.loadJSON', function() {
     test('should be a function', function() {
       assert.ok(loadJSON);
@@ -94,6 +112,7 @@ suite('Files', function() {
     });*/
   });
 
+  // loadStrings()
   suite('p5.prototype.loadStrings', function() {
     test('should be a function', function() {
       assert.ok(loadStrings);
@@ -130,87 +149,95 @@ suite('Files', function() {
       });
     });
   });
-  /*
-  var loadTable = p5.prototype.loadTable;
 
-
-  suite('p5.prototype.loadTable',function(){
-    var url = 'http://localhost:9001/unit/assets/csv.csv';
-
+  // loadXML()
+  suite('p5.prototype.loadXML', function(){
     test('should be a function', function(){
-      assert.isFunction(loadTable);
-    });
-
-    test('should load a file without options',function(done) {
-      var myCallback = function(resp){
-        assert.ok(resp);
-        done();
-      };
-      loadTable(url,myCallback);
-    });
-
-    test('the loaded file should be correct',function(done){
-      var myCallback = function(resp){
-        assert.equal(resp.getRowCount(),4);
-        assert.strictEqual(resp.getRow(1).getString(0),'David');
-        assert.strictEqual(resp.getRow(1).getNum(1),31);
-        done();
-      };
-      loadTable(url,myCallback);
-    });
-
-    test('using the csv option works', function(done){
-      var myCallback = function(resp){
-        assert.equal(resp.getRowCount(),4);
-        assert.strictEqual(resp.getRow(1).getString(0),'David');
-        assert.strictEqual(resp.getRow(1).getNum(1),31);
-        done();
-      };
-      loadTable(url,'csv',myCallback);
-    });
-    test('using the csv and tsv options fails', function(){
-      var fn = function(){loadTable(url,'csv','tsv');};
-      assert.throw(fn,'Cannot set multiple separator types.');
-    });
-
-    test('using the header option works', function(done){
-      var myCallback = function(resp){
-        assert.equal(resp.getRowCount(),3);
-        assert.strictEqual(resp.getRow(0).getString('name'),'David');
-        assert.strictEqual(resp.getRow(0).getNum('age'),31);
-        done();
-      };
-      loadTable(url,'header',myCallback);
-    });
-    test('using the header and csv options together works', function(done){
-      var myCallback = function(resp){
-        assert.equal(resp.getRowCount(),3);
-        assert.strictEqual(resp.getRow(0).getString('name'),'David');
-        assert.strictEqual(resp.getRow(0).getNum('age'),31);
-        done();
-      };
-      loadTable(url,'header', 'csv', myCallback);
-    });
-
-    test('CSV files should handle commas within quoted fields',function(done){
-      var myCallback = function(resp){
-        assert.equal(resp.getRowCount(),4);
-        assert.equal(resp.getRow(2).get(0),'David, Jr.');
-        assert.equal(resp.getRow(2).getString(0),'David, Jr.');
-        assert.equal(resp.getRow(2).get(1),'11');
-        assert.equal(resp.getRow(2).getString(1),11);
-        done();
-      };
-      loadTable(url,myCallback);
-    });
-    test('CSV files should handle escaped quotes and returns within quoted fields',function(done){
-      var myCallback = function(resp){
-        assert.equal(resp.getRowCount(),4);
-        assert.equal(resp.getRow(3).get(0),'David,\nSr. "the boss"');
-        done();
-      };
-      loadTable(url,myCallback);
+      assert.ok(loadXML);
+      assert.typeOf(loadXML, 'function');
     });
   });
-  */
+
+
+  // var loadTable = p5.prototype.loadTable;
+
+  // suite('p5.prototype.loadTable',function(){
+  //   var url = 'unit/assets/csv.csv';
+
+  //   test('should be a function', function(){
+  //     assert.isFunction(loadTable);
+  //   });
+
+  //   test('should load a file without options',function(done) {
+  //     var myCallback = function(resp){
+  //       assert.ok(resp);
+  //       done();
+  //     };
+  //     loadTable(url,myCallback);
+  //   });
+
+  //   test('the loaded file should be correct',function(done){
+  //     var myCallback = function(resp){
+  //       assert.equal(resp.getRowCount(),4);
+  //       assert.strictEqual(resp.getRow(1).getString(0),'David');
+  //       assert.strictEqual(resp.getRow(1).getNum(1),31);
+  //       done();
+  //     };
+  //     loadTable(url,myCallback);
+  //   });
+
+  //   test('using the csv option works', function(done){
+  //     var myCallback = function(resp){
+  //       assert.equal(resp.getRowCount(),4);
+  //       assert.strictEqual(resp.getRow(1).getString(0),'David');
+  //       assert.strictEqual(resp.getRow(1).getNum(1),31);
+  //       done();
+  //     };
+  //     loadTable(url,'csv',myCallback);
+  //   });
+  //   test('using the csv and tsv options fails', function(){
+  //     var fn = function(){loadTable(url,'csv','tsv');};
+  //     assert.throw(fn,'Cannot set multiple separator types.');
+  //   });
+
+  //   test('using the header option works', function(done){
+  //     var myCallback = function(resp){
+  //       assert.equal(resp.getRowCount(),3);
+  //       assert.strictEqual(resp.getRow(0).getString('name'),'David');
+  //       assert.strictEqual(resp.getRow(0).getNum('age'),31);
+  //       done();
+  //     };
+  //     loadTable(url,'header',myCallback);
+  //   });
+  //   test('using the header and csv options together works', function(done){
+  //     var myCallback = function(resp){
+  //       assert.equal(resp.getRowCount(),3);
+  //       assert.strictEqual(resp.getRow(0).getString('name'),'David');
+  //       assert.strictEqual(resp.getRow(0).getNum('age'),31);
+  //       done();
+  //     };
+  //     loadTable(url,'header', 'csv', myCallback);
+  //   });
+
+  //   test('CSV files should handle commas within quoted fields',function(done){
+  //     var myCallback = function(resp){
+  //       assert.equal(resp.getRowCount(),4);
+  //       assert.equal(resp.getRow(2).get(0),'David, Jr.');
+  //       assert.equal(resp.getRow(2).getString(0),'David, Jr.');
+  //       assert.equal(resp.getRow(2).get(1),'11');
+  //       assert.equal(resp.getRow(2).getString(1),11);
+  //       done();
+  //     };
+  //     loadTable(url,myCallback);
+  //   });
+  //   test('CSV files should handle escaped quotes and returns within quoted fields',function(done){
+  //     var myCallback = function(resp){
+  //       assert.equal(resp.getRowCount(),4);
+  //       assert.equal(resp.getRow(3).get(0),'David,\nSr. "the boss"');
+  //       done();
+  //     };
+  //     loadTable(url,myCallback);
+  //   });
+  // });
+
 });

--- a/test/unit/io/files_input.js
+++ b/test/unit/io/files_input.js
@@ -1,5 +1,6 @@
 suite('Files', function() {
 
+  var httpDo = p5.prototype.httpDo;
   var loadJSON = p5.prototype.loadJSON;
   var loadStrings = p5.prototype.loadStrings;
   var loadXML = p5.prototype.loadXML;
@@ -7,6 +8,57 @@ suite('Files', function() {
   //variable for preload
   var preload = p5.prototype.preload;
   var result;
+
+  // httpDo
+  suite('httpDo()', function(){
+    test('should be a function', function(){
+      assert.ok(httpDo);
+      assert.isFunction(httpDo);
+    });
+
+    test('should work when provided with just a path', function(done){
+      httpDo('unit/assets/sentences.txt', function(data){
+        assert.ok(data);
+        assert.isString(data);
+        done();
+      });
+    });
+
+    test('should accept method parameter', function(done){
+      httpDo('unit/assets/sentences.txt', 'GET', function(data){
+        assert.ok(data);
+        assert.isString(data);
+        done();
+      });
+    });
+
+    test('should accept type parameter', function(done){
+      httpDo('unit/assets/array.json', 'text', function(data){
+        assert.ok(data);
+        assert.isString(data);
+        done();
+      });
+    });
+
+    test('should accept method and type parameter together', function(done){
+      httpDo('unit/assets/array.json', 'GET', 'text', function(data){
+        assert.ok(data);
+        assert.isString(data);
+        done();
+      });
+    });
+
+    test('should pass error object to error callback function', function(done){
+      httpDo('unit/assets/sen.txt', function(data){
+        // should not be called
+      }, function(err){
+        assert.isObject(err, 'err is an object');
+        assert.isFalse(err.ok, 'err.ok is false');
+        assert.equal(err.status, 404, 'Error status is 404');
+        done();
+      });
+    });
+  });
 
   // tests while preload is true without callbacks
   //p5.prototype.preload = function() {};
@@ -51,11 +103,11 @@ suite('Files', function() {
       assert.typeOf(loadXML, 'function');
     });
 
-    // test('should return an Object', function() {
-    //   result = loadXML('unit/assets/test.xml');
-    //   assert.ok(result);
-    //   assert.isObject(result, 'result is an object');
-    // });
+    test('should return an Object', function() {
+      result = loadXML('unit/assets/books.xml');
+      assert.ok(result);
+      assert.isObject(result, 'result is an object');
+    });
   });
 
   //tests while preload is false with callbacks
@@ -74,10 +126,11 @@ suite('Files', function() {
       });
     });
 
-    test('should pass an Array to callback function', function(){
+    test('should pass an Array to callback function', function(done){
       result = loadJSON('unit/assets/array.json', function(data){
         assert.isArray(data, 'Array passed to callback function');
         assert.lengthOf(data, 3, 'length of data is 3');
+        done();
       });
     });
 
@@ -87,14 +140,14 @@ suite('Files', function() {
       });
     });
 
-    test('should pass error object to error callback function', function() {
+    test('should pass error object to error callback function', function(done) {
       result = loadJSON('unit/assets/arr.json', function(data){
-        // should really be an empty object or never called
-        assert.isUndefined(data, 'data is undefined');
+        // should not be called
       }, function(err){
         assert.isObject(err, 'err is an object');
         assert.isFalse(err.ok, 'err.ok is false');
         assert.equal(err.status, 404, 'Error status is 404');
+        done();
       });
     });
 
@@ -138,14 +191,14 @@ suite('Files', function() {
       });
     });
 
-    test('should pass error object to error callback function', function() {
+    test('should pass error object to error callback function', function(done) {
       result = loadStrings('unit/assets/sen.txt', function(data){
-        // should really be an empty object or never called
-        assert.isUndefined(data, 'data is undefined');
+        // should not be called
       }, function(err){
         assert.isObject(err, 'err is an object');
         assert.isFalse(err.ok, 'err.ok is false');
         assert.equal(err.status, 404, 'Error status is 404');
+        done();
       });
     });
   });
@@ -156,88 +209,107 @@ suite('Files', function() {
       assert.ok(loadXML);
       assert.typeOf(loadXML, 'function');
     });
+
+    // Missing reference to parseXML, might need some test suite rethink
+    // test('should call callback function if provided', function(done){
+    //   result = loadXML('unit/assets/books.xml', function(data){
+    //     done();
+    //   });
+    // });
+
+    // test('should pass an Object to callback function', function(){
+    //   result = loadXML('unit/assets/books.xml', function(data){
+    //     console.log(data);
+    //     assert.isObject(data);
+    //   });
+    // });
   });
 
 
-  // var loadTable = p5.prototype.loadTable;
+  var loadTable = p5.prototype.loadTable;
 
-  // suite('p5.prototype.loadTable',function(){
-  //   var url = 'unit/assets/csv.csv';
+  suite('p5.prototype.loadTable',function(){
+    var url = 'unit/assets/csv.csv';
 
-  //   test('should be a function', function(){
-  //     assert.isFunction(loadTable);
-  //   });
+    test('should be a function', function(){
+      assert.isFunction(loadTable);
+    });
 
-  //   test('should load a file without options',function(done) {
-  //     var myCallback = function(resp){
-  //       assert.ok(resp);
-  //       done();
-  //     };
-  //     loadTable(url,myCallback);
-  //   });
+    test('should load a file without options',function(done) {
+      var myCallback = function(resp){
+        assert.ok(resp);
+        done();
+      };
+      loadTable(url, myCallback);
+    });
 
-  //   test('the loaded file should be correct',function(done){
-  //     var myCallback = function(resp){
-  //       assert.equal(resp.getRowCount(),4);
-  //       assert.strictEqual(resp.getRow(1).getString(0),'David');
-  //       assert.strictEqual(resp.getRow(1).getNum(1),31);
-  //       done();
-  //     };
-  //     loadTable(url,myCallback);
-  //   });
+    test('the loaded file should be correct',function(done){
+      var myCallback = function(resp){
+        assert.equal(resp.getRowCount(), 4);
+        assert.strictEqual(resp.getRow(1).getString(0), 'David');
+        assert.strictEqual(resp.getRow(1).getNum(1), 31);
+        done();
+      };
+      loadTable(url, myCallback);
+    });
 
-  //   test('using the csv option works', function(done){
-  //     var myCallback = function(resp){
-  //       assert.equal(resp.getRowCount(),4);
-  //       assert.strictEqual(resp.getRow(1).getString(0),'David');
-  //       assert.strictEqual(resp.getRow(1).getNum(1),31);
-  //       done();
-  //     };
-  //     loadTable(url,'csv',myCallback);
-  //   });
-  //   test('using the csv and tsv options fails', function(){
-  //     var fn = function(){loadTable(url,'csv','tsv');};
-  //     assert.throw(fn,'Cannot set multiple separator types.');
-  //   });
+    test('using the csv option works', function(done){
+      var myCallback = function(resp){
+        assert.equal(resp.getRowCount(), 4);
+        assert.strictEqual(resp.getRow(1).getString(0), 'David');
+        assert.strictEqual(resp.getRow(1).getNum(1), 31);
+        done();
+      };
+      loadTable(url, 'csv', myCallback);
+    });
 
-  //   test('using the header option works', function(done){
-  //     var myCallback = function(resp){
-  //       assert.equal(resp.getRowCount(),3);
-  //       assert.strictEqual(resp.getRow(0).getString('name'),'David');
-  //       assert.strictEqual(resp.getRow(0).getNum('age'),31);
-  //       done();
-  //     };
-  //     loadTable(url,'header',myCallback);
-  //   });
-  //   test('using the header and csv options together works', function(done){
-  //     var myCallback = function(resp){
-  //       assert.equal(resp.getRowCount(),3);
-  //       assert.strictEqual(resp.getRow(0).getString('name'),'David');
-  //       assert.strictEqual(resp.getRow(0).getNum('age'),31);
-  //       done();
-  //     };
-  //     loadTable(url,'header', 'csv', myCallback);
-  //   });
+    test('using the csv and tsv options fails', function(){
+      var fn = function(){
+        loadTable(url, 'csv', 'tsv');
+      };
+      assert.throw(fn, 'Cannot set multiple separator types.');
+    });
 
-  //   test('CSV files should handle commas within quoted fields',function(done){
-  //     var myCallback = function(resp){
-  //       assert.equal(resp.getRowCount(),4);
-  //       assert.equal(resp.getRow(2).get(0),'David, Jr.');
-  //       assert.equal(resp.getRow(2).getString(0),'David, Jr.');
-  //       assert.equal(resp.getRow(2).get(1),'11');
-  //       assert.equal(resp.getRow(2).getString(1),11);
-  //       done();
-  //     };
-  //     loadTable(url,myCallback);
-  //   });
-  //   test('CSV files should handle escaped quotes and returns within quoted fields',function(done){
-  //     var myCallback = function(resp){
-  //       assert.equal(resp.getRowCount(),4);
-  //       assert.equal(resp.getRow(3).get(0),'David,\nSr. "the boss"');
-  //       done();
-  //     };
-  //     loadTable(url,myCallback);
-  //   });
-  // });
+    test('using the header option works', function(done){
+      var myCallback = function(resp){
+        assert.equal(resp.getRowCount(), 3);
+        assert.strictEqual(resp.getRow(0).getString('name'), 'David');
+        assert.strictEqual(resp.getRow(0).getNum('age'), 31);
+        done();
+      };
+      loadTable(url, 'header', myCallback);
+    });
+
+    test('using the header and csv options together works', function(done){
+      var myCallback = function(resp){
+        assert.equal(resp.getRowCount(), 3);
+        assert.strictEqual(resp.getRow(0).getString('name'), 'David');
+        assert.strictEqual(resp.getRow(0).getNum('age'), 31);
+        done();
+      };
+      loadTable(url,'header', 'csv', myCallback);
+    });
+
+    test('CSV files should handle commas within quoted fields',function(done){
+      var myCallback = function(resp){
+        assert.equal(resp.getRowCount(), 4);
+        assert.equal(resp.getRow(2).get(0), 'David, Jr.');
+        assert.equal(resp.getRow(2).getString(0), 'David, Jr.');
+        assert.equal(resp.getRow(2).get(1), '11');
+        assert.equal(resp.getRow(2).getString(1), 11);
+        done();
+      };
+      loadTable(url, myCallback);
+    });
+
+    test('CSV files should handle escaped quotes and returns within quoted fields',function(done){
+      var myCallback = function(resp){
+        assert.equal(resp.getRowCount(), 4);
+        assert.equal(resp.getRow(3).get(0), 'David,\nSr. "the boss"');
+        done();
+      };
+      loadTable(url, myCallback);
+    });
+  });
 
 });

--- a/test/unit/io/files_input.js
+++ b/test/unit/io/files_input.js
@@ -103,11 +103,11 @@ suite('Files', function() {
       assert.typeOf(loadXML, 'function');
     });
 
-    test('should return an Object', function() {
-      result = loadXML('unit/assets/books.xml');
-      assert.ok(result);
-      assert.isObject(result, 'result is an object');
-    });
+    // test('should return an Object', function() {
+    //   result = loadXML('unit/assets/books.xml');
+    //   assert.ok(result);
+    //   assert.isObject(result, 'result is an object');
+    // });
   });
 
   //tests while preload is false with callbacks


### PR DESCRIPTION
Work in progress. **Do not merge this yet!**

As per discussed in #1694 and #968, this PR replaces all dependencies of reqwest with the new [Fetch API](https://developer.mozilla.org/en-US/docs/Web/API/Fetch_API/Using_Fetch), using [github's polyfill](https://github.com/github/fetch) where it is not available.

So far, `httpDo` `httpGet` `httpPost` `loadJSON` `loadXML` `loadTable` are all using the Fetch API. 
- everything here resolves to `httpDo` calls, hopefully that can help with unifying the API.
- for `loadJSON`, JSONP is not supported. A polyfill to implement JSONP support will be required if it is deemed necessary.
- `loadStrings` can be adapted from its current XMLHttpRequest to using Fetch API if desired. (It will make the source simpler I think)
- to get more advanced features (pass in headers, change cors rules etc) will require passing in a `Request` object to `httpDo`, syntax as follows:
```javascript
var myRequest = new Request("./pathToFile.txt", {
  method: "GET",
  mode: "cors",
  headers: new Headers({
    "Content-Type": "text/plain"
  })
});

httpDo(myRequest, function(data){
  // Work with returned data
}, function(err){
  // optional error callback
});
```
The only difference between the above and using the Fetch API directly is the above uses callback instead of Fetch API's promise and this utilises the automatic type check for JSON, XML and all others as text so the user don't need to worry about extra parsing steps.

---

I have yet to fully edit the tests and documentation yet as I think there are a lot of ways to implement this and I want the decision more or less made before those are changed. Do take some time to have a look. Let me know if there are some other preferred way some things are done, suggestion on function signatures, use cases, complete overhauls etc.