### PR TITLE
Update core.js for passive MouseWheel event support

### DIFF
--- a/src/core/core.js
+++ b/src/core/core.js
@@ -510,7 +510,7 @@ var p5 = function(sketch, node, sync) {
     var f = this['_on'+e];
     if (f) {
       var m = f.bind(this);
-      window.addEventListener(e, m);
+      window.addEventListener(e, m, {passive: true});
       this._events[e] = m;
     }
   }


### PR DESCRIPTION
Passive event support for Chrome. 

Starting with MouseWheel as Chrome Dev 58.0.3018.3 is suggesting (via Violation text in the console) a possible performance improvement from it.  

Spot checked in Firefox and Edge without issues.