### PR TITLE
fixing chrome mobile 56 mousedown event fire issue

### DIFF
--- a/src/events/touch.js
+++ b/src/events/touch.js
@@ -234,6 +234,9 @@ p5.prototype._ontouchend = function(e) {
     if(executeDefault === false) {
       e.preventDefault();
     }
+  } else {
+    e.preventDefault();
+    return false;
   }
 };
 


### PR DESCRIPTION
As describe on issue #1811 & #1815

Preventing google chrome mobile for firing duplicated mousePressed event when taping on element.