### PR TITLE
Fixing incorrect logic for checking that all keys have been released.

### DIFF
--- a/src/events/keyboard.js
+++ b/src/events/keyboard.js
@@ -226,15 +226,15 @@ p5.prototype._onkeydown = function (e) {
 p5.prototype._onkeyup = function (e) {
   var keyReleased = this.keyReleased || window.keyReleased;
   downKeys[e.which] = false;
-  //delete this._downKeys[e.which];
-  var key = String.fromCharCode(e.which);
 
-  if(areDownKeys()) {
+  if(!areDownKeys()) {
     this._setProperty('isKeyPressed', false);
     this._setProperty('keyIsPressed', false);
   }
 
   this._setProperty('_lastKeyCodeTyped', null);
+
+  var key = String.fromCharCode(e.which);
   if (!key) {
     key = e.which;
   }
@@ -369,7 +369,7 @@ p5.prototype.keyIsDown = function(code) {
 **/
 function areDownKeys() {
   for (var key in downKeys) {
-    if (downKeys[key] === true ) {
+    if (downKeys.hasOwnProperty(key) && downKeys[key] === true) {
       return true;
     }
   }

--- a/test/manual-test-examples/keyboard/keyIsPressed.html
+++ b/test/manual-test-examples/keyboard/keyIsPressed.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <script language="javascript" type="text/javascript" src="../../../lib/p5.js"></script>
+	<script language="javascript" type="text/javascript" src="keyIsPressed.js"></script>
+  </head>
+
+  <body>
+  </body>
+</html>

--- a/test/manual-test-examples/keyboard/keyIsPressed.js
+++ b/test/manual-test-examples/keyboard/keyIsPressed.js
@@ -1,0 +1,22 @@
+function setup() {
+  createCanvas(480, 480);
+}
+
+function draw() {
+  background(255);
+
+  if (keyIsPressed) {
+    if (keyCode == UP_ARROW) {
+      background(255, 0, 0); // red
+    }
+    if (keyCode == RIGHT_ARROW) {
+      background(255, 255, 0); // yellow
+    }
+    if (keyCode == DOWN_ARROW) {
+      background(0, 255, 0); // green
+    }
+    if (keyCode == LEFT_ARROW) {
+      background(0, 0, 255); // blue
+    }
+  }
+}


### PR DESCRIPTION
Allows `isKeyPressed` and `keyIsPressed` globals to reset properly.

Fixes: https://github.com/processing/p5.js/issues/1857