### PR TITLE
Update .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,5 +5,5 @@ node_js:
   - "4.2"
   - "5.1"
 install: npm install
-script: npm run grunt
+script: npm run grunt --force 
 sudo: false


### PR DESCRIPTION
@ https://travis-ci.org/processing/p5.js/jobs/211537055: (bottom in the  log): 
>> 1/767 tests failed (4.61s)
Warning: Task "mocha:test" failed. Use --force to continue. // <<<figger maybe it could inherit?
Aborted due to warnings.
npm ERR! Linux 4.8.12-040812-generic
npm ERR! argv "/home/travis/.nvm/versions/node/v4.2.6/bin/node" "/home/travis/.nvm/versions/node/v4.2.6/bin/npm" "run" "grunt"
npm ERR! node v4.2.6
npm ERR! npm  v2.14.12
npm ERR! code ELIFECYCLE
npm ERR! p5@0.5.7 grunt: `grunt`
npm ERR! Exit status 3
npm ERR! 
npm ERR! Failed at the p5@0.5.7 grunt script 'grunt'.
npm ERR! This is most likely a problem with the p5 package,
npm ERR! not with npm itself.
npm ERR! Tell the author that this fails on your system:
npm ERR!     grunt
npm ERR! You can get their info via:
npm ERR!     npm owner ls p5
npm ERR! There is likely additional logging output above.
npm ERR! Please include the following file with any support request:
npm ERR!     /home/travis/build/processing/p5.js/npm-debug.log
The command "npm run grunt" exited with 1.