### PR TITLE
Documentation: gray argument in color() must be numeric, fixes #1869

### DIFF
--- a/src/color/creating_reading.js
+++ b/src/color/creating_reading.js
@@ -137,7 +137,7 @@ p5.prototype.brightness = function(c) {
  * Colors are stored as Numbers or Arrays.
  *
  * @method color
- * @param  {Number|String} gray    number specifying value between white
+ * @param  {Number}        gray    number specifying value between white
  *                                 and black.
  * @param  {Number}        [alpha] alpha value relative to current color range
  *                                 (default is 0-255)


### PR DESCRIPTION
You can create a color with two arguments only if the first argument is a gray value. The argument parser [requires `gray` to be a number](https://github.com/processing/p5.js/blob/master/src/color/p5.Color.js#L574), where the [reference](http://p5js.org/reference/#/p5/color) suggests that it may also be a string, which might be misleading:

> ### Syntax
>
> ```javascript
> color(gray,[alpha])
> color(v1,v2,v3,[alpha])
> ```
>
> ### Parameters
>
> - `gray`: Number **\| String**: number specifying value between white and black.
> - `[alpha]`: Number: alpha value relative to current color range (default is 0-255)
> - `v1`: Number|String: red or hue value relative to the current color range, or a color string
> - `v2`: Number: green or saturation value relative to the current color range
> - `v3`: Number: blue or brightness value relative to the current color range
