### PR TITLE
removing an extra console.log

### DIFF
--- a/src/io/files.js
+++ b/src/io/files.js
@@ -1249,7 +1249,6 @@ p5.prototype.saveJSON = function (json, filename, opt) {
   } else {
     stringify = JSON.stringify(json, undefined, 2);
   }
-  console.log(stringify);
   this.saveStrings(stringify.split('\n'), filename, 'json');
 };
 


### PR DESCRIPTION
While working on an example that saves a large JSON file, I noticed an extra console.log probably from earlier debugging.