### PR TITLE
Fix missing content type headers

### DIFF
--- a/src/io/files.js
+++ b/src/io/files.js
@@ -792,12 +792,8 @@ p5.prototype.selectInput = function () {
  *                                    in as first argument
  */
 p5.prototype.httpGet = function () {
-  var args = new Array(arguments.length);
-  args[0] = arguments[0];
-  args[1] = 'GET';
-  for (var i = 1; i < arguments.length; ++i) {
-    args[i+1] = arguments[i];
-  }
+  var args = Array.prototype.slice.call(arguments);
+  args.splice(1, 0, 'GET');
   p5.prototype.httpDo.apply(this, args);
 };
 
@@ -818,12 +814,8 @@ p5.prototype.httpGet = function () {
  *                                    in as first argument
  */
 p5.prototype.httpPost = function () {
-  var args = new Array(arguments.length);
-  args[0] = arguments[0];
-  args[1] = 'POST';
-  for (var i = 1; i < arguments.length; ++i) {
-    args[i+1] = arguments[i];
-  }
+  var args = Array.prototype.slice.call(arguments);
+  args.splice(1, 0, 'POST');
   p5.prototype.httpDo.apply(this, args);
 };
 

--- a/src/io/files.js
+++ b/src/io/files.js
@@ -6,6 +6,7 @@
  */
 
 /* globals Request: false */
+/* globals Headers: false */
 
 'use strict';
 
@@ -863,6 +864,7 @@ p5.prototype.httpDo = function () {
   var request;
   var jsonpOptions = {};
   var cbCount = 0;
+  var contentType = 'text/plain';
   // Trim the callbacks off the end to get an idea of how many arguments are passed
   for (var i = arguments.length-1; i > 0; i--){
     if(typeof arguments[i] === 'function'){
@@ -914,6 +916,7 @@ p5.prototype.httpDo = function () {
           }
         }else{
           data = JSON.stringify(a);
+          contentType = 'application/json';
         }
       } else if (typeof a === 'function') {
         if (!callback) {
@@ -937,7 +940,10 @@ p5.prototype.httpDo = function () {
     request = new Request(path, {
       method: method,
       mode: 'cors',
-      body: data
+      body: data,
+      headers: new Headers({
+        'Content-Type': contentType
+      })
     });
   }
 


### PR DESCRIPTION
This should take care of #1898. @shiffman it will be great if you can test this out!

A few things to note (maybe add to docs as well): using `httpDo` if the second argument is an object, it will be treated as using native request object and NOT a GET request with body content, I feel that is the correct behaviour although httpDo defaults to GET, GET request is not supposed to have a body content while POST and PUT would have body content will require the method argument as the second argument which works fine.

Sidenote: @lmccart Do you think it is worth having a HEAD build hosted somewhere like cdnjs or Amazon AWS just so that it will be easier for people to test out the HEAD library build and potentially spot bugs like these before they went live? It probably can be automated whenever there's a commit to the master branch.