### PR TITLE
Minor API change: textFont() should return current font

### DIFF
--- a/src/typography/loading_displaying.js
+++ b/src/typography/loading_displaying.js
@@ -76,7 +76,7 @@ p5.prototype.text = function(str, x, y, maxWidth, maxHeight) {
  * @param {Object|String} f a font loaded via loadFont(), or a String
  * representing a <a href="https://mzl.la/2dOw8WD">web safe font</a> (a font
  * that is generally available across all systems).
- * @return {Object} this
+ * @return {Object|String} the current font 
  * @example
  * <div>
  * <code>
@@ -134,7 +134,7 @@ p5.prototype.textFont = function(theFont, theSize) {
     return this._renderer._applyTextProperties();
   }
 
-  return this;
+  return this._renderer._textFont;
 };
 
 module.exports = p5;

--- a/src/typography/loading_displaying.js
+++ b/src/typography/loading_displaying.js
@@ -75,8 +75,8 @@ p5.prototype.text = function(str, x, y, maxWidth, maxHeight) {
  * @method textFont
  * @param {Object|String} f a font loaded via loadFont(), or a String
  * representing a <a href="https://mzl.la/2dOw8WD">web safe font</a> (a font
- * that is generally available across all systems).
- * @return {Object|String} the current font 
+ * that is generally available across all systems)
+ * @return {Object|String} the current font
  * @example
  * <div>
  * <code>


### PR DESCRIPTION
For consistency with other text functions (textSize(), textAlign(), textLeading()), textFont() called without arguments should return the current font (object or string) rather than 'this'. There are also use-cases where this call is needed as the current font cannot otherwise be accessed.