### PR TITLE
Made options argument unnecessary in saveTable

### DIFF
--- a/src/io/files.js
+++ b/src/io/files.js
@@ -1082,7 +1082,8 @@ p5.prototype.saveBytes = function () {
 
 };
 
-// object, filename, options --> saveJSON, saveStrings, saveTable
+// object, filename, options --> saveJSON, saveStrings, 
+
 // filename, [extension] [canvas] --> saveImage
 
 /**
@@ -1371,15 +1372,21 @@ function escapeHelper(content) {
  *
  */
 p5.prototype.saveTable = function (table, filename, options) {
-  var pWriter = this.createWriter(filename, options);
+  var ext;
+  if(options === undefined){
+    ext = filename.substring(filename.lastIndexOf(".")+1,filename.length);
+  }else{
+    ext = options; 
+  }
+  var pWriter = this.createWriter(filename, ext);
 
   var header = table.columns;
 
   var sep = ','; // default to CSV
-  if (options === 'tsv') {
+  if (ext === 'tsv') {
     sep = '\t';
   }
-  if (options !== 'html') {
+  if (ext !== 'html') {
     // make header if it has values
     if (header[0] !== '0') {
       for (var h = 0; h < header.length; h++) {


### PR DESCRIPTION
Closes #1929 
I still left the options argument in so that any sketches that use saveTable in this way will still function correctly; however, with this change you no longer need to include it.

Note: Tables still don't save correctly as TSV or CSV. My other pull request #1927 fixes this issue.