### PR TITLE
Check extension for loadTable

### DIFF
--- a/src/io/files.js
+++ b/src/io/files.js
@@ -462,9 +462,14 @@ p5.prototype.loadTable = function (path) {
   var errorCallback = null;
   var options = [];
   var header = false;
+  var ext = path.substring(path.lastIndexOf('.')+1,path.length);
   var sep = ',';
   var separatorSet = false;
   var decrementPreload = p5._getDecrementPreload.apply(this, arguments);
+  
+  if(ext === 'tsv'){ //Only need to check if extension is tsv because csv is default
+    sep = '\t'; 
+  }
 
   for (var i = 1; i < arguments.length; i++) {
     if ((typeof (arguments[i]) === 'function') &&


### PR DESCRIPTION
Since loadTable() defaults to CSV even if it's not specified in the options, this will only affect loading TSV files.

Now `loadTable("table.tsv")` should work properly without defaulting to reading the table as CSV.