### PR TITLE
Changed print for cases when JSON.parse returns empty object

### DIFF
--- a/src/core/environment.js
+++ b/src/core/environment.js
@@ -58,7 +58,7 @@ if (window.console && console.log) {
         console.log.apply(console, arguments);
       } else {
         var newArgs = JSON.parse(JSON.stringify(args));
-        if (JSON.stringify(newArgs)=="{}"){
+        if (JSON.stringify(newArgs)==='{}'){
           console.log(args);
         } else {
           console.log(newArgs);

--- a/src/core/environment.js
+++ b/src/core/environment.js
@@ -58,7 +58,11 @@ if (window.console && console.log) {
         console.log.apply(console, arguments);
       } else {
         var newArgs = JSON.parse(JSON.stringify(args));
-        console.log(newArgs);
+        if (JSON.stringify(newArgs)=="{}"){
+          console.log(args);
+        } else {
+          console.log(newArgs);
+        }
       }
     } catch(err) {
       console.log(args);


### PR DESCRIPTION
I've come up with a small bug when using `print` to diagnose the canvas where printint `elt` of  canvas outputs an empty object while `console.log` produces the expected result. 

A sample code that reproduces this error is:

```javascript
var cv;
function setup() {
    cv = createCanvas(500,400);
    console.log(cv);
    console.log(cv.elt);
    print(cv);
    print(cv.elt);
}
```

And the output is 

![screen shot 2017-05-24 at 00 10 30](https://cloud.githubusercontent.com/assets/614881/26380262/76c145a8-4015-11e7-8d02-65facf571aa0.png)

My correction just checks the `JSON.strigify` version of the resulting object and compares it to an empty object and in that case sends the original arguments to console.log