### PR TITLE
cached get image reference

### DIFF
--- a/src/core/p5.Renderer2D.js
+++ b/src/core/p5.Renderer2D.js
@@ -242,11 +242,10 @@ p5.Renderer2D.prototype.get = function(x, y, w, h) {
     var sw = dw * pd;
     var sh = dh * pd;
 
-    var region;
     if(this.cachedGetImage === null) {
       this.cachedGetImage = new p5.Image(dw, dh);
     }
-    region = this.cachedGetImage;
+    var region = this.cachedGetImage;
     region.canvas.getContext('2d').drawImage(this.canvas, sx, sy, sw, sh,
       0, 0, dw, dh);
 

--- a/src/core/p5.Renderer2D.js
+++ b/src/core/p5.Renderer2D.js
@@ -17,6 +17,7 @@ var styleEmpty = 'rgba(0,0,0,0)';
 p5.Renderer2D = function(elt, pInst, isMainCanvas){
   p5.Renderer.call(this, elt, pInst, isMainCanvas);
   this.drawingContext = this.canvas.getContext('2d');
+  this.cachedGetImage = null;
   this._pInst._setProperty('drawingContext', this.drawingContext);
   return this;
 };
@@ -241,7 +242,12 @@ p5.Renderer2D.prototype.get = function(x, y, w, h) {
     var sw = dw * pd;
     var sh = dh * pd;
 
-    var region = new p5.Image(dw, dh);
+    var region;
+    if(this.cachedGetImage === null) {
+      region = new p5.Image(dw, dh);
+    } else {
+      region = this.cachedGetImage;
+    }
     region.canvas.getContext('2d').drawImage(this.canvas, sx, sy, sw, sh,
       0, 0, dw, dh);
 

--- a/src/core/p5.Renderer2D.js
+++ b/src/core/p5.Renderer2D.js
@@ -244,10 +244,9 @@ p5.Renderer2D.prototype.get = function(x, y, w, h) {
 
     var region;
     if(this.cachedGetImage === null) {
-      region = new p5.Image(dw, dh);
-    } else {
-      region = this.cachedGetImage;
+      this.cachedGetImage = new p5.Image(dw, dh);
     }
+    region = this.cachedGetImage;
     region.canvas.getContext('2d').drawImage(this.canvas, sx, sy, sw, sh,
       0, 0, dw, dh);
 


### PR DESCRIPTION
I am still not 100% sure that this is what is being looked for.

I tested this with
```
var b;
var c;

function setup() {
	createCanvas(600, 200);
	background(0);
	fill(0,0,255);
	rect(0,0,200,200);
	b = get();
	c = get();
	c.loadPixels();
	for (i = 0; i < 100; i++) {
	  for (j = 0; j < 100; j++) {
	    c.set(i, j, color(255));
	  }
	}
   	c.updatePixels();
}

function draw() {
    image(b, 200, 0);
    image(c, 400, 0);
}
```
and the original p5.image stored in `b` was not changed.

Let me know if this is way off base.

closes #1935 

