### PR TITLE
mouseClicked() documentation clarification for addressing #1960

### DIFF
--- a/src/events/mouse.js
+++ b/src/events/mouse.js
@@ -654,6 +654,9 @@ p5.prototype._ondragover = p5.prototype._onmousemove;
 /**
  * The mouseClicked() function is called once after a mouse button has been
  * pressed and then released.<br><br>
+ * Browsers handle clicks differently, so this function is only guaranteed to be
+ * run when the left mouse button is clicked. To handle other mouse buttons
+ * being pressed or released, see mousePressed() or mouseReleased().<br><br>
  * Browsers may have different default
  * behaviors attached to various mouse events. To prevent any default
  * behavior for this event, add "return false" to the end of the method.


### PR DESCRIPTION
Following up from #1960 where `mouseClicked` doesn't trigger with right and middle buttons in some browsers: 

Click events in vanilla JS are handled inconsistently across browsers and only guaranteed to run in response to the primary mouse button. Since p5 just wraps around the native click event, I figure the best fix is to update the docs and point users towards `mousePressed` and `mouseReleased` for handling non-primary mouse buttons.