### PR TITLE
Added example to loadXML taken from p5.xml.js

### DIFF
--- a/src/io/files.js
+++ b/src/io/files.js
@@ -710,8 +710,8 @@ p5.prototype.parseXML = function (two) {
  * line in your sketch is executed. Calling loadXML() inside preload()
  * guarantees to complete the operation before setup() and draw() are called.
  *
- * <p>Outside of preload(), you may supply a callback function to handle the
- * object:</p>
+ * Outside of preload(), you may supply a callback function to handle the
+ * object.
  *
  * @method loadXML
  * @param  {String}   filename   name of the file or URL to load

--- a/src/io/files.js
+++ b/src/io/files.js
@@ -722,6 +722,44 @@ p5.prototype.parseXML = function (two) {
  *                               there is an error, response is passed
  *                               in as first argument
  * @return {Object}              XML object containing data
+ * @example
+ * <div class='norender'><code>
+ * // The following short XML file called "mammals.xml" is parsed
+ * // in the code below.
+ * //
+ * // <?xml version="1.0"?>
+ * // &lt;mammals&gt;
+ * //   &lt;animal id="0" species="Capra hircus">Goat&lt;/animal&gt;
+ * //   &lt;animal id="1" species="Panthera pardus">Leopard&lt;/animal&gt;
+ * //   &lt;animal id="2" species="Equus zebra">Zebra&lt;/animal&gt;
+ * // &lt;/mammals&gt;
+ *
+ * var xml;
+ *
+ * function preload() {
+ *   xml = loadXML("assets/mammals.xml");
+ * }
+ *
+ * function setup() {
+ *   var children = xml.getChildren("animal");
+ *
+ *   for (var i = 0; i < children.length; i++) {
+ *     var id = children[i].getNum("id");
+ *     var coloring = children[i].getString("species");
+ *     var name = children[i].getContent();
+ *     print(id + ", " + coloring + ", " + name);
+ *   }
+ * }
+ *
+ * // Sketch prints:
+ * // 0, Capra hircus, Goat
+ * // 1, Panthera pardus, Leopard
+ * // 2, Equus zebra, Zebra
+ * </code></div>
+  *
+  * @alt
+  * no image displayed
+  *
  */
 p5.prototype.loadXML = function() {
   var ret = {};


### PR DESCRIPTION
Hi all,

This is a partial (and I hope, temporary) fix for issue #1954. Specifically, it adds an example for loadXML.
This example is taken directly from io/p5.xml.js.

I've been working on this for a few days, and wanted to get _something_ submitted.

I've actually written a number of examples of loadXML calls (both invoked inside preload and with a callback), but I've had _real_ trouble getting them to work locally inside the p5.js-website framework. 
It's possible I'm building the documentation incorrectly, but every other example that _doesn't_ use loadXML seems to run just fine (I'm getting this weird error where the parseXML function isn't being found, but the examples run just fine if I run them outside of the docs).

It's my suspicion that this is why the only loadXML example we _do_ have is invoked with the "norender" class, and why the documentation for loadXML itself _mentions_ the existence of an example, even though there is no example to be had.

So I hope this will do for the moment, I'm going to try dig into the parseXML issue a little more, and if I can't work out what's going on I'll open a separate issue for that.

Thanks :)