### PR TITLE
Cache strokeStyle and fillStyle for performance

### DIFF
--- a/src/core/p5.Renderer2D.js
+++ b/src/core/p5.Renderer2D.js
@@ -956,7 +956,7 @@ p5.Renderer2D.prototype._getFill = function(){
 p5.Renderer2D.prototype._setFill = function(fillStyle){
   if (fillStyle !== this._cachedFillStyle) {
     this.drawingContext.fillStyle = fillStyle;
-    this._cachedFillStyle = this.drawingContext.fillStyle;
+    this._cachedFillStyle = fillStyle;
   }
 };
 
@@ -967,7 +967,7 @@ p5.Renderer2D.prototype._getStroke = function(){
 p5.Renderer2D.prototype._setStroke = function(strokeStyle){
   if (strokeStyle !== this._cachedStrokeStyle) {
     this.drawingContext.strokeStyle = strokeStyle;
-    this._cachedStrokeStyle = this.drawingContext.strokeStyle;
+    this._cachedStrokeStyle = strokeStyle;
   }
 };
 
@@ -1301,8 +1301,8 @@ p5.Renderer2D.prototype.push = function() {
 p5.Renderer2D.prototype.pop = function() {
   this.drawingContext.restore();
   // Re-cache the fill / stroke state
-  this.cachedFillStyle = this.drawingContext.fillStyle;
-  this.cachedStrokeStyle = this.drawingContext.strokeStyle;
+  this._cachedFillStyle = this.drawingContext.fillStyle;
+  this._cachedStrokeStyle = this.drawingContext.strokeStyle;
 };
 
 module.exports = p5.Renderer2D;

--- a/src/typography/p5.Font.js
+++ b/src/typography/p5.Font.js
@@ -372,7 +372,9 @@ p5.Font.prototype._renderPath = function(line, x, y, options) {
   if (pg._doFill) {
 
     // if fill hasn't been set by user, use default-text-fill
-    ctx.fillStyle = pg._fillSet ? ctx.fillStyle : constants._DEFAULT_TEXT_FILL;
+    if (!pg._fillSet) {
+      pg._setFill(constants._DEFAULT_TEXT_FILL);
+    }
     ctx.fill();
   }
 

--- a/test/test-reference.html
+++ b/test/test-reference.html
@@ -58,7 +58,7 @@
     {regex: /events\/acceleration\.js/, condition: Modernizr.webgl},
     {regex: /sound/, condition: Modernizr.webaudio}
   ];
-  var MS_TIMEOUT = 2000;
+  var MS_TIMEOUT = 4000;
 
   // TODO: This code has basically been harvested from
   // https://github.com/processing/p5.js-website/blob/master/js/render.js.

--- a/test/unit/core/structure.js
+++ b/test/unit/core/structure.js
@@ -14,7 +14,7 @@ suite('Structure', function() {
       var state = {};
       for (var key in myp5._renderer) {
         var value = myp5._renderer[key];
-        if (typeof value !== 'function') {
+        if (typeof value !== 'function' && key !== '_cachedFillStyle' && key !== '_cachedStrokeStyle' ) {
           state[key] = value;
         }
       }


### PR DESCRIPTION
Fixes #2011 

Many code paths repeatedly reset or access the stroke or the fill, for
instance when drawing shapes every call to vertex() queries the fill and
stroke styles. This seems to be quite an expensive operation, and for
almost every use-case is not changing between calls to vertex.

Here I replace all direct accesses to the canvas' drawingContext's
strokeStyle and fillStyle to go through accessors that cache the result.
This shows significant performance improvements, at least on Chrome on
Mac.