### PR TITLE
added example for dragOver and dragLeave

### DIFF
--- a/src/core/p5.Element.js
+++ b/src/core/p5.Element.js
@@ -743,6 +743,35 @@ p5.Element.prototype.touchEnded = function (fxn) {
  * @param  {Function} fxn function to be fired when mouse is
  *                    dragged over the element.
  * @return {p5.Element}
+ * @example
+ * <div><code>
+ * // To test this sketch, simply drag a
+ * // file over the canvas
+ * function setup() {
+ *   var c = createCanvas(100, 100);
+ *   background(200);
+ *   textAlign(CENTER);
+ *   text('Drag file', width/2, height/2);
+ *   c.dragOver(dragOverCallback);
+ *   c.dragLeave(dragLeaveCallback);
+ * }
+ * 
+ * // This function will be called whenever
+ * // a file is dragged over the canvas
+ * function dragOverCallback() {
+ *   background(240);
+ *   text('Dragged over', width/2, height/2);
+ * }
+ * 
+ * // This function will be called whenever
+ * // a file is dragged out of the canvas 
+ * function dragLeaveCallback() {
+ *   background(200);
+ *   text('Dragged off', width/2, height/2);
+ * }
+ * </code></div>
+ * @alt
+ * nothing displayed
  */
 p5.Element.prototype.dragOver = function (fxn) {
   attachListener('dragover', fxn, this);
@@ -758,6 +787,35 @@ p5.Element.prototype.dragOver = function (fxn) {
  * @param  {Function} fxn function to be fired when mouse is
  *                    dragged over the element.
  * @return {p5.Element}
+ * @example
+ * <div><code>
+ * // To test this sketch, simply drag a
+ * // file over the canvas
+ * function setup() {
+ *   var c = createCanvas(100, 100);
+ *   background(200);
+ *   textAlign(CENTER);
+ *   text('Drag file', width/2, height/2);
+ *   c.dragOver(dragOverCallback);
+ *   c.dragLeave(dragLeaveCallback);
+ * }
+ * 
+ * // This function will be called whenever
+ * // a file is dragged over the canvas
+ * function dragOverCallback() {
+ *   background(240);
+ *   text('Dragged over', width/2, height/2);
+ * }
+ * 
+ * // This function will be called whenever
+ * // a file is dragged out of the canvas 
+ * function dragLeaveCallback() {
+ *   background(200);
+ *   text('Dragged off', width/2, height/2);
+ * }
+ * </code></div>
+ * @alt
+ * nothing displayed
  */
 p5.Element.prototype.dragLeave = function (fxn) {
   attachListener('dragleave', fxn, this);


### PR DESCRIPTION
Partially addresses #1954 - specifically, it adds examples for  [dragOver](https://p5js.org/reference/#/p5.Element/dragOver) and[dragLeave]( https://p5js.org/reference/#/p5.Element/dragLeave). 

I've used the same example for both, since in the example code I use both functions.
I'm happy to simplify and make each example only use the appropriate function, but I _think_ the example makes sense as it stands.