### PR TITLE
Add #rgba and #rrggbbaa support

### DIFF
--- a/src/color/p5.Color.js
+++ b/src/color/p5.Color.js
@@ -299,8 +299,14 @@ var colorPatterns = {
   // Match colors in format #XXX, e.g. #416.
   HEX3: /^#([a-f0-9])([a-f0-9])([a-f0-9])$/i,
 
+  // Match colors in format #XXXX, e.g. #5123.
+  HEX4: /^#([a-f0-9])([a-f0-9])([a-f0-9])([a-f0-9])$/i,
+
   // Match colors in format #XXXXXX, e.g. #b4d455.
   HEX6: /^#([a-f0-9]{2})([a-f0-9]{2})([a-f0-9]{2})$/i,
+
+  // Match colors in format #XXXXXXXX, e.g. #b4d45535.
+  HEX8: /^#([a-f0-9]{2})([a-f0-9]{2})([a-f0-9]{2})([a-f0-9]{2})$/i,
 
   // Match colors in format rgb(R, G, B), e.g. rgb(255, 0, 128).
   RGB: new RegExp([
@@ -481,6 +487,16 @@ p5.Color._parseInputs = function() {
         return parseInt(color, 16) / 255;
       });
       results[3] = 1;
+      return results;
+    } else if (colorPatterns.HEX4.test(str)) {  // #rgba
+      results = colorPatterns.HEX4.exec(str).slice(1).map(function(color) {
+        return parseInt(color + color, 16) / 255;
+      });
+      return results;
+    } else if (colorPatterns.HEX8.test(str)) {  // #rrggbbaa
+      results = colorPatterns.HEX8.exec(str).slice(1).map(function(color) {
+        return parseInt(color, 16) / 255;
+      });
       return results;
     } else if (colorPatterns.RGB.test(str)) {  // rgb(R,G,B)
       results = colorPatterns.RGB.exec(str).slice(1).map(function(color) {

--- a/test/unit/color/p5.Color.js
+++ b/test/unit/color/p5.Color.js
@@ -63,6 +63,43 @@ suite('p5.Color', function() {
     });
   });
 
+  suite('p5.prototype.color("#rgba")', function() {
+    setup(function() {
+      c = myp5.color('#f016');
+    });
+    test('should create instance of p5.Color', function() {
+      assert.instanceOf(c, p5.Color);
+    });
+
+    test('should correctly set RGBA property', function() {
+      assert.deepEqual(c.levels, [255, 0, 17, 102]);
+    });
+
+    suite('spot check', function() {
+      test('numeric hex values', function() {
+        c = myp5.color('#0000');
+        assert.deepEqual(c.levels, [0, 0, 0, 0]);
+      });
+
+      test('alphabetic hex values', function() {
+        c = myp5.color('#ffff');
+        assert.deepEqual(c.levels, [255, 255, 255, 255]);
+      });
+
+      test('alphanumeric hex values', function() {
+        c = myp5.color('#f007');
+        assert.deepEqual(c.levels, [255, 0, 0, 119]);
+        c = myp5.color('#f0e5');
+        assert.deepEqual(c.levels, [255, 0, 238, 85]);
+      });
+    });
+
+    test('invalid hex values resolve to white', function() {
+      c = myp5.color('#fire');
+      assert.deepEqual(c.levels, [255, 255, 255, 255]);
+    });
+  });
+
   suite('p5.prototype.color("#rrggbb")', function() {
     setup(function() {
       c = myp5.color('#ff0066');
@@ -97,6 +134,44 @@ suite('p5.Color', function() {
 
     test('invalid hex values resolve to white', function() {
       c = myp5.color('#zzztop');
+      assert.deepEqual(c.levels, [255, 255, 255, 255]);
+    });
+  });
+
+  suite('p5.prototype.color("#rrggbbaa")', function() {
+    setup(function() {
+      c = myp5.color('#f01dab1e');
+    });
+
+    test('should create instance of p5.Color', function() {
+      assert.instanceOf(c, p5.Color);
+    });
+
+    test('should correctly set RGBA property', function() {
+      assert.deepEqual(c.levels, [240, 29, 171, 30]);
+    });
+
+    suite('spot check', function() {
+      test('numeric hex values', function() {
+        c = myp5.color('#12345678');
+        assert.deepEqual(c.levels, [18, 52, 86, 120]);
+      });
+
+      test('alphabetic hex values', function() {
+        c = myp5.color('#abcdeffe');
+        assert.deepEqual(c.levels, [171, 205, 239, 254]);
+      });
+
+      test('alphanumeric hex values', function() {
+        c = myp5.color('#a1a1a1a1');
+        assert.deepEqual(c.levels, [161, 161, 161, 161]);
+        c = myp5.color('#14ffaca6');
+        assert.deepEqual(c.levels, [20, 255, 172, 166]);
+      });
+    });
+
+    test('invalid hex values resolve to white', function() {
+      c = myp5.color('#c0vfefed');
       assert.deepEqual(c.levels, [255, 255, 255, 255]);
     });
   });


### PR DESCRIPTION
Addresses Issue #2046. Adds support for creating colors with `#rgba` and `#rrggbbaa` strings.

Feedback is welcome.