### PR TITLE
Fix for textToPoints for text with whitespaces (#2069)

### DIFF
--- a/src/typography/p5.Font.js
+++ b/src/typography/p5.Font.js
@@ -617,6 +617,9 @@ function pointAtLength(path, length, istotal) {
 function pathToAbsolute(pathArray) {
 
   var res = [], x = 0, y = 0, mx = 0, my = 0, start = 0;
+  if (!pathArray) {
+    return res;
+  }
   if (pathArray[0][0] === 'M') {
     x = +pathArray[0][1];
     y = +pathArray[0][2];


### PR DESCRIPTION
Fix for issue #2069 

Return res straight away if pathArray is undefined.

This solution fixes the issue, although I could see that the underlying cause is found somewhere in a place I couldn't find in my stack traces. So people with an extensive knowledge of `p5.Font.js`, please weigh in if I'm the right track.