### PR TITLE
Chrome no texture bound error fix

### DIFF
--- a/src/webgl/material.js
+++ b/src/webgl/material.js
@@ -146,7 +146,7 @@ p5.prototype.texture = function(){
     }
     var tex = gl.createTexture();
     args[0]._setProperty('tex', tex);
-    args[0]._setProperty('isTexture', true);
+    //args[0]._setProperty('isTexture', true);
     this._renderer._bind.call(this, tex, textureData);
   }
   else {
@@ -168,6 +168,7 @@ p5.prototype.texture = function(){
   gl.bindTexture(gl.TEXTURE_2D, args[0].tex);
   gl.uniform1i(gl.getUniformLocation(shaderProgram, 'isTexture'), true);
   gl.uniform1i(gl.getUniformLocation(shaderProgram, 'uSampler'), 0);
+  this.emptyTexture = null;
   return this;
 };
 
@@ -264,11 +265,19 @@ p5.prototype.ambientMaterial = function(v1, v2, v3, a) {
     shaderProgram, 'uSpecular' );
   gl.uniform1i(shaderProgram.uSpecular, false);
 
-  gl.uniform1i(gl.getUniformLocation(shaderProgram, 'isTexture'), false);
-
+  this._renderer._createEmptyTexture(colors[0], colors[1], colors[2], colors[3]);
   return this;
 };
 
+p5.RendererGL.prototype._createEmptyTexture = function(r, g, b, a) {
+  var gl = this.GL;
+  var data = new Uint8Array([255,255,255,255]);
+  if(this.emptyTexture === null) {
+    this.emptyTexture = gl.createTexture();
+  }
+  gl.bindTexture(gl.TEXTURE_2D, this.emptyTexture);
+  gl.texImage2D(gl.TEXTURE_2D, 0, gl.RGBA, 1, 1, 0, gl.RGBA, gl.UNSIGNED_BYTE, data);
+};
 
 /**
  * Specular material for geometry with a given color. You can view all
@@ -307,7 +316,7 @@ p5.prototype.specularMaterial = function(v1, v2, v3, a) {
   var shaderProgram =
     this._renderer._getShader('lightVert', 'lightTextureFrag');
   gl.useProgram(shaderProgram);
-  gl.uniform1i(gl.getUniformLocation(shaderProgram, 'isTexture'), false);
+  //gl.uniform1i(gl.getUniformLocation(shaderProgram, 'isTexture'), false);
   shaderProgram.uMaterialColor = gl.getUniformLocation(
     shaderProgram, 'uMaterialColor' );
   var colors = this._renderer._applyColorBlend.apply(this._renderer, arguments);
@@ -316,7 +325,7 @@ p5.prototype.specularMaterial = function(v1, v2, v3, a) {
   shaderProgram.uSpecular = gl.getUniformLocation(
     shaderProgram, 'uSpecular' );
   gl.uniform1i(shaderProgram.uSpecular, true);
-
+  this._renderer._createEmptyTexture(colors[0], colors[1], colors[2], colors[3]);
   return this;
 };
 

--- a/src/webgl/material.js
+++ b/src/webgl/material.js
@@ -128,6 +128,9 @@ p5.prototype.texture = function(){
     'lightTextureFrag');
   gl.useProgram(shaderProgram);
   var textureData;
+  shaderProgram.uSpecular = gl.getUniformLocation(
+    shaderProgram, 'uSpecular' );
+  gl.uniform1i(shaderProgram.uSpecular, false);
   //if argument is not already a texture
   //create a new one
   if(!args[0].isTexture){
@@ -146,7 +149,7 @@ p5.prototype.texture = function(){
     }
     var tex = gl.createTexture();
     args[0]._setProperty('tex', tex);
-    //args[0]._setProperty('isTexture', true);
+    args[0]._setProperty('isTexture', true);
     this._renderer._bind.call(this, tex, textureData);
   }
   else {
@@ -168,7 +171,6 @@ p5.prototype.texture = function(){
   gl.bindTexture(gl.TEXTURE_2D, args[0].tex);
   gl.uniform1i(gl.getUniformLocation(shaderProgram, 'isTexture'), true);
   gl.uniform1i(gl.getUniformLocation(shaderProgram, 'uSampler'), 0);
-  this.emptyTexture = null;
   return this;
 };
 
@@ -265,18 +267,20 @@ p5.prototype.ambientMaterial = function(v1, v2, v3, a) {
     shaderProgram, 'uSpecular' );
   gl.uniform1i(shaderProgram.uSpecular, false);
 
-  this._renderer._createEmptyTexture(colors[0], colors[1], colors[2], colors[3]);
+  this._renderer._createEmptyTexture();
+  gl.uniform1i(gl.getUniformLocation(shaderProgram, 'isTexture'), false);
   return this;
 };
 
-p5.RendererGL.prototype._createEmptyTexture = function(r, g, b, a) {
-  var gl = this.GL;
-  var data = new Uint8Array([255,255,255,255]);
+p5.RendererGL.prototype._createEmptyTexture = function() {
   if(this.emptyTexture === null) {
+    var gl = this.GL;
+    var data = new Uint8Array([1,1,1,1]);
     this.emptyTexture = gl.createTexture();
+    gl.bindTexture(gl.TEXTURE_2D, this.emptyTexture);
+    gl.texImage2D(gl.TEXTURE_2D, 0, gl.RGBA, 1, 1, 0,
+      gl.RGBA, gl.UNSIGNED_BYTE, data);
   }
-  gl.bindTexture(gl.TEXTURE_2D, this.emptyTexture);
-  gl.texImage2D(gl.TEXTURE_2D, 0, gl.RGBA, 1, 1, 0, gl.RGBA, gl.UNSIGNED_BYTE, data);
 };
 
 /**
@@ -325,7 +329,8 @@ p5.prototype.specularMaterial = function(v1, v2, v3, a) {
   shaderProgram.uSpecular = gl.getUniformLocation(
     shaderProgram, 'uSpecular' );
   gl.uniform1i(shaderProgram.uSpecular, true);
-  this._renderer._createEmptyTexture(colors[0], colors[1], colors[2], colors[3]);
+  this._renderer._createEmptyTexture();
+  gl.uniform1i(gl.getUniformLocation(shaderProgram, 'isTexture'), false);
   return this;
 };
 

--- a/src/webgl/p5.RendererGL.js
+++ b/src/webgl/p5.RendererGL.js
@@ -56,6 +56,7 @@ p5.RendererGL = function(elt, pInst, isMainCanvas) {
   this.curFillColor = [0.5,0.5,0.5,1.0];
   this.curStrokeColor = [0.5,0.5,0.5,1.0];
   this.pointSize = 5.0;//default point/stroke
+  this.emptyTexture = null;
   return this;
 };
 


### PR DESCRIPTION
closes #1897 

This fixes the errors from Chrome regarding not having a bound texture. When using one of the materials with the lightVert - lightTextureFrag shaders an empty texture is generated and bound.

I uncovered a few other issues with materials and textures while looking into this but those are separate and I'll open new issues for them.

works with all manual tests, removes existing errors in chrome on all tests