### PR TITLE
Change Github to GitHub

### DIFF
--- a/docs/yuidoc-p5-theme/layouts/main.handlebars
+++ b/docs/yuidoc-p5-theme/layouts/main.handlebars
@@ -28,14 +28,14 @@
 
   <body id='reference'>
     <a href="#content" class="skip">Skip to content</a>
-    
+
     <!-- p5*js language buttons -->
     <div id="i18n-btn">
       <h1 class='visuallyhidden'>Language Settings</h1>
       <button data-lang="en">EN</button>
       <button data-lang="es">ES</button>
     </div>
-    
+
 
     <div id="reference-page" class="container">
 
@@ -62,7 +62,7 @@
             <li><a href="{{p5SiteRoot}}/books/">Books</a></li>
             <li><a href="{{p5SiteRoot}}/community/">Community</a></li>
             <li><a href="http://forum.processing.org/two/" target=_blank class="other-link">Forum</a></li>
-            <li><a href="http://github.com/processing/p5.js" target=_blank class="other-link">Github</a></li>
+            <li><a href="http://github.com/processing/p5.js" target=_blank class="other-link">GitHub</a></li>
             <li><a href="http://twitter.com/p5xjs" target=_blank class="other-link">Twitter</a></li>
           </ul>
         </nav>
@@ -88,7 +88,7 @@
         <footer>
           <p>p5.js was created by <a href='http://lauren-mccarthy.com' target="_blank">Lauren McCarthy</a> and is developed by a community of collaborators,
           with support from the <a href="https://processing.org/foundation/" target="_blank">Processing Foundation</a>
-          and <a href="http://itp.nyu.edu/itp/" target="_blank">NYU ITP</a>. Identity and graphic design by <a href="http://jereljohnson.com/" target="_blank">Jerel Johnson</a>. 
+          and <a href="http://itp.nyu.edu/itp/" target="_blank">NYU ITP</a>. Identity and graphic design by <a href="http://jereljohnson.com/" target="_blank">Jerel Johnson</a>.
           <a href="https://p5js.org/copyright.html">&copy; Info.</a></p>
         </footer>
       </div><!-- end column-span -->


### PR DESCRIPTION
👋 processing/p5.js-website#123 was just merged, changing all `Github` references to `GitHub`. Thanks to @lmccart, I [learned](https://github.com/processing/p5.js-website/pull/123#issuecomment-315741916) that the bulk majority of those originate from the `Github` reference in https://github.com/processing/p5.js/blob/dd416985e15be25bb762b60710da29bbf84f6b3b/docs/yuidoc-p5-theme/layouts/main.handlebars. So, I am also submitting this pull request to avoid introducing `Github` again in `processing/p5.js-website`.

🙇 🐹 

PS: The spaces were removed automatically by my editor. Let me know if you prefer I leave those alone 😄.