### PR TITLE
validateParameters() logic update and 2d_primitives test units

### DIFF
--- a/src/core/2d_primitives.js
+++ b/src/core/2d_primitives.js
@@ -246,7 +246,8 @@ p5.prototype.line = function() {
   for (var i = 0; i < args.length; ++i) {
     args[i] = arguments[i];
   }
-  // check with FES:validateParameters - not implemented yet
+  // check with FES:validateParameters
+  this._validateParameters('line', args);
   //check whether we should draw a 3d line or 2d
   if (this._renderer.isP3D) {
     this._renderer.line(

--- a/src/core/2d_primitives.js
+++ b/src/core/2d_primitives.js
@@ -299,7 +299,8 @@ p5.prototype.point = function() {
   for (var i = 0; i < args.length; ++i) {
     args[i] = arguments[i];
   }
-  // check with FES:validateParameters - not implemented yet
+  // check with FES:validateParameters
+  this._validateParameters('point', args);
   //check whether we should draw a 3d line or 2d
   if (this._renderer.isP3D) {
     this._renderer.point(
@@ -365,7 +366,8 @@ p5.prototype.quad = function() {
   for (var i = 0; i < args.length; ++i) {
     args[i] = arguments[i];
   }
-  // check with FES:validateParameters - not implemented yet
+  // check with FES:validateParameters
+  this._validateParameters('quad', args);
   if (this._renderer.isP3D) {
     this._renderer.quad(
       args[0],
@@ -464,7 +466,7 @@ p5.prototype.rect = function() {
   if (!this._renderer._doStroke && !this._renderer._doFill) {
     return;
   }
-  // check with FES:validateParameters - not implemented yet
+  // check with FES:validateParameters
   this._validateParameters('rect', args);
   var vals = canvas.modeAdjust(
     args[0],
@@ -513,7 +515,7 @@ p5.prototype.triangle = function() {
   for (var i = 0; i < args.length; ++i) {
     args[i] = arguments[i];
   }
-  // check with FES:validateParameters - not implemented yet
+  // check with FES:validateParameters
   this._validateParameters('triangle', args);
   this._renderer.triangle(args);
   return this;

--- a/src/core/error_helpers.js
+++ b/src/core/error_helpers.js
@@ -228,20 +228,20 @@ p5._friendlyParamError = function (errorObj, func) {
   switch (errorObj.type){
     case 'EMPTY_VAR':
       message = 'FES: It looks like ' + func +
-        ' received an empty variable in spot #' + errorObj.position +
+        '() received an empty variable in spot #' + errorObj.position +
         ' (zero-based index). If not intentional, this is often a problem' +
         ' with scope: [link to scope].';
       report(message, func, ERR_PARAMS);
       break;
     case 'WRONG_CLASS':
-      message = 'FES: ' + func + ' was expecting ' + errorObj.correctClass +
+      message = 'FES: ' + func + '() was expecting ' + errorObj.correctClass +
         ' for parameter #' + errorObj.position + ' (zero-based index), received ';
       // Wrap strings in quotes
       message += 'an object with name '+ errorObj.wrongClass +' instead.';
       report(message, func, ERR_PARAMS);
       break;
     case 'WRONG_TYPE':
-      message = 'FES: ' + func + ' was expecting ' + errorObj.correctType +
+      message = 'FES: ' + func + '() was expecting ' + errorObj.correctType +
         ' for parameter #' + errorObj.position + ' (zero-based index), received ';
       // Wrap strings in quotes
       message += errorObj.wrongType + ' instead.';

--- a/src/core/error_helpers.js
+++ b/src/core/error_helpers.js
@@ -128,31 +128,26 @@ p5._friendlyFileLoadError = function (errorType, filePath) {
 */
 function validateParameters(func, args) {
   var arrDoc = lookupParamDoc(func);
-  if (arrDoc.length > 1){   // multiple format?
-    var errorListArray = [];
+  var errorArray = [];
+  var minErrCount = 999999;
+  if (arrDoc.length > 1){   // func has multiple formats
     for (var i = 0; i < arrDoc.length; i++) {
-      errorListArray.push(testParamFormat(args, arrDoc[i]));
-    }
-    // compare errors from all formats
-    var minErrInd = -1;
-    var minErrCount = 999999;
-    for (var j = 0; j < errorListArray.length; j++) {
-      var numErr = errorListArray[j].length;
-      if (numErr >= arrDoc.length){   // exclude clean cases
-        if(minErrCount > numErr){
-          minErrInd = j;
-          minErrCount = numErr;
-        }
+      var arrError = testParamFormat(args, arrDoc[i]);
+      if( arrError.length === 0) {
+        return; // no error
+      }
+      // see if this is the format with min number of err
+      if( minErrCount > arrError.length) {
+        minErrCount = arrError.length;
+        errorArray = arrError;
       }
     }
-    if (minErrInd > -1){
-      // generate error msg with a smaller number of errors
-      for(var n = 0; n < errorListArray[minErrInd].length; n++) {
-        p5._friendlyParamError(errorListArray[minErrInd][n], func);
-      }
+    // generate err msg
+    for (var n = 0; n < errorArray.length; n++) {
+      p5._friendlyParamError(errorArray[n], func);
     }
-  } else {
-    var errorArray = testParamFormat(args, arrDoc[0]);
+  } else {                 // func has a single format
+    errorArray = testParamFormat(args, arrDoc[0]);
     for(var m = 0; m < errorArray.length; m++) {
       p5._friendlyParamError(errorArray[m], func);
     }
@@ -163,6 +158,7 @@ function validateParameters(func, args) {
 function lookupParamDoc(func){
   var queryResult = arrDoc.classitems.
     filter(function (x) { return x.name === func; });
+  // different JSON structure for funct with multi-format
   if (queryResult[0].hasOwnProperty('overloads')){
     var res = [];
     for(var i = 0; i < queryResult[0].overloads.length; i++) {
@@ -185,8 +181,7 @@ function testParamFormat(args, format){
       }
     } else {
       var types = format[p].type.split('|'); // case accepting multi-types
-      var pass;
-      if (argType === 'object'){             // if obejct, test for class
+      if (argType === 'object'){             // if object, test for class
         if (!testParamClass(args[p], types)) {  // if fails to pass
           error = {type:'WRONG_CLASS', position: p,
             correctClass: types[p], wrongClass: args[p].name};
@@ -227,6 +222,7 @@ function testParamType(param, types){
   }
   return false;
 }
+// function for generating console.log() msg
 p5._friendlyParamError = function (errorObj, func) {
   var message;
   switch (errorObj.type){

--- a/test/unit/core/2d_primitives.js
+++ b/test/unit/core/2d_primitives.js
@@ -16,6 +16,24 @@ suite('2D Primitives', function() {
         assert.ok(arc);
         assert.typeOf(arc, 'function');
       });
+      test('arc(): no friendly-err-msg', function() {
+        assert.doesNotThrow(function() {
+            myp5.arc(1, 1, 10.5, 10, 0, Math.PI, 'pie');
+          },
+          Error, 'got unwanted exception');
+      });
+      test('arc(): missing param #4, #5', function() {
+        assert.doesNotThrow(function() {
+            myp5.arc(1, 1, 10.5, 10);
+          },
+          Error, 'got unwanted exception');
+      });
+      test('arc(): wrong param type at #0', function() {
+        assert.doesNotThrow(function() {
+            myp5.arc('1', 1, 10.5, 10, 0, Math.PI, 'pie');
+          },
+          Error, 'got unwanted exception');
+      });
     });
   });
 
@@ -35,6 +53,31 @@ suite('2D Primitives', function() {
           assert.isTrue(res);
           done();
         });
+      });
+      test('ellipse(): no friendly-err-msg', function() {
+        assert.doesNotThrow(function() {
+            myp5.ellipse(0, 0, 100);
+          },
+          Error, 'got unwanted exception');
+      });
+      test('ellipse(): missing param #2', function() {
+        assert.doesNotThrow(function() {
+            myp5.ellipse(0, 0);
+          },
+          Error, 'got unwanted exception');
+      });
+      test('ellipse(): missing param #2', function() {
+        assert.doesNotThrow(function() {
+            var size;
+            myp5.ellipse(0, 0, size);
+          },
+          Error, 'got unwanted exception');
+      });
+      test('ellipse(): wrong param type at #0', function() {
+        assert.doesNotThrow(function() {
+            myp5.ellipse('0', 0, 100, 100);
+          },
+          Error, 'got unwanted exception');
       });
     });
   });

--- a/test/unit/core/2d_primitives.js
+++ b/test/unit/core/2d_primitives.js
@@ -181,6 +181,24 @@ suite('2D Primitives', function() {
         assert.ok(quad);
         assert.typeOf(quad, 'function');
       });
+      test('quad(): no friendly-err-msg, 2D', function() {
+        assert.doesNotThrow(function() {
+            myp5.quad(Math.PI, 0, Math.PI, 5.1, 10, 5.1, 10, 0);
+          },
+          Error, 'got unwanted exception');
+      });
+      test('quad(): missing param #7', function() {
+        assert.doesNotThrow(function() {
+            myp5.quad(Math.PI, 0, Math.PI, 5.1, 10, 5.1, 10);
+          },
+          Error, 'got unwanted exception');
+      });
+      test('quad(): wrong param type at #1', function() {
+        assert.doesNotThrow(function() {
+            myp5.quad(Math.PI, '0', Math.PI, 5.1, 10, 5.1, 10, 0);
+          },
+          Error, 'got unwanted exception');
+      });
     });
   });
 
@@ -231,6 +249,24 @@ suite('2D Primitives', function() {
       test('should be a function', function() {
         assert.ok(triangle);
         assert.typeOf(triangle, 'function');
+      });
+      test('triangle(): no friendly-err-msg', function() {
+        assert.doesNotThrow(function() {
+            myp5.triangle(Math.PI, 0, Math.PI, 5.1, 10, 5.1);
+          },
+          Error, 'got unwanted exception');
+      });
+      test('triangle(): missing param #5', function() {
+        assert.doesNotThrow(function() {
+            myp5.triangle(Math.PI, 0, Math.PI, 5.1, 10);
+          },
+          Error, 'got unwanted exception');
+      });
+      test('triangle(): wrong param type at #1', function() {
+        assert.doesNotThrow(function() {
+            myp5.triangle(Math.PI, '0', Math.PI, 5.1, 10, 5.1);
+          },
+          Error, 'got unwanted exception');
       });
     });
   });

--- a/test/unit/core/2d_primitives.js
+++ b/test/unit/core/2d_primitives.js
@@ -191,6 +191,37 @@ suite('2D Primitives', function() {
         assert.ok(rect);
         assert.typeOf(rect, 'function');
       });
+      test('rect(): no friendly-err-msg, format I', function() {
+        assert.doesNotThrow(function() {
+            myp5.rect(0, 0, 100, 100);
+          },
+          Error, 'got unwanted exception');
+      });
+      test('rect(): no friendly-err-msg, format II', function() {
+        assert.doesNotThrow(function() {
+            myp5.rect(0, 0, 100, 100, 1, Math.PI, 1, Math.PI);
+          },
+          Error, 'got unwanted exception');
+      });
+      test('rect(): missing param #3', function() {
+        assert.doesNotThrow(function() {
+            myp5.rect(0, 0, Math.PI);
+          },
+          Error, 'got unwanted exception');
+      });
+      test('rect(): missing param #4', function() { // this err case escapes
+        assert.doesNotThrow(function() {
+            var r1;
+            myp5.rect(0, 0, 100, 100, r1, Math.PI, 1, Math.PI);
+          },
+          Error, 'got unwanted exception');
+      });
+      test('rect(): wrong param type at #1', function() {
+        assert.doesNotThrow(function() {
+            myp5.rect(0, '0', 100, 100);
+          },
+          Error, 'got unwanted exception');
+      });
     });
   });
 

--- a/test/unit/core/2d_primitives.js
+++ b/test/unit/core/2d_primitives.js
@@ -99,6 +99,88 @@ suite('2D Primitives', function() {
           done();
         });
       });
+      test('line(): no friendly-err-msg, 2D', function() {
+        assert.doesNotThrow(function() {
+            myp5.line(0, 0, 100, 100);
+          },
+          Error, 'got unwanted exception');
+      });
+      test('line(): no friendly-err-msg, 3D', function() {
+        assert.doesNotThrow(function() {
+            myp5.line(0, 0, 100, 100, 20, Math.PI);
+          },
+          Error, 'got unwanted exception');
+      });
+      test('line(): missing param #3', function() {
+        assert.doesNotThrow(function() {
+            myp5.line(0, 0, Math.PI);
+          },
+          Error, 'got unwanted exception');
+      });
+      test('line(): missing param #4', function() { // this err case escapes
+        assert.doesNotThrow(function() {
+            var x3;
+            myp5.line(0, 0, 100, 100, x3, Math.PI);
+          },
+          Error, 'got unwanted exception');
+      });
+      test('line(): wrong param type at #1', function() {
+        assert.doesNotThrow(function() {
+            myp5.line(0, '0', 100, 100);
+          },
+          Error, 'got unwanted exception');
+      });
+    });
+  });
+
+  suite('p5.prototype.point', function() {
+    var point = p5.prototype.point;
+    suite('point()', function() {
+      test('should be a function', function() {
+        assert.ok(point);
+        assert.typeOf(point, 'function');
+      });
+      test('point(): no friendly-err-msg, 2D', function() {
+        assert.doesNotThrow(function() {
+            myp5.point(Math.PI, 0);
+          },
+          Error, 'got unwanted exception');
+      });
+      test('point(): no friendly-err-msg, 3D', function() {
+        assert.doesNotThrow(function() {
+            myp5.point(Math.PI, 0, 100);
+          },
+          Error, 'got unwanted exception');
+      });
+      test('point(): missing param #1', function() {
+        assert.doesNotThrow(function() {
+            myp5.point(0);
+          },
+          Error, 'got unwanted exception');
+      });
+      test('point(): missing param #3', function() { // this err case escapes
+        assert.doesNotThrow(function() {
+            var z;
+            myp5.point(0, Math.PI, z);
+          },
+          Error, 'got unwanted exception');
+      });
+      test('point(): wrong param type at #1', function() {
+        assert.doesNotThrow(function() {
+            myp5.point(Math.PI, '0');
+          },
+          Error, 'got unwanted exception');
+      });
+    });
+  });
+
+  suite('p5.prototype.quad', function() {
+    var quad = p5.prototype.quad;
+    suite('quad()', function() {
+      test('should be a function', function() {
+        assert.ok(quad);
+        assert.typeOf(quad, 'function');
+      });
     });
   });
 

--- a/test/unit/core/error_helpers.js
+++ b/test/unit/core/error_helpers.js
@@ -44,10 +44,10 @@ suite('Error Helpers', function() {
         },
         Error, 'got unwanted exception');
     });
-    test('rect(): wrong param type at #0,#6', function() {
+    test('rect(): wrong param type at #0', function() {
       assert.doesNotThrow(function() {
           p5.prototype._validateParameters('rect',
-            ['1', 1, 10.5, 10, 0, Math.PI, 'pie']);
+            ['1', 1, 10.5, 10, 0, Math.PI]);
         },
         Error, 'got unwanted exception');
     });


### PR DESCRIPTION
Updated flow in `validateParameters()` so we can exit the function whenever we find a matching parameter format. 

`validateParameters()` is also inserted into all 2d_primitives functions. All their unit tests are successfully running, but there are some minor false negative cases escaping the validation logic (only occurs for functions with multiple parameter formats).

Some of the remaining questions are:

1. Right now  `validateParameters()` is called inside the individual functions. Should we move it around so it can be turned on/off by setting a global parameter? Such as : https://github.com/processing/p5.js/issues/1329.

2. Not sure how our error msgs will be shown within the web editor.

Thank you!