### PR TITLE
Chrome no texture bound error fix [MINOR CHANGE]

### DIFF
--- a/src/webgl/material.js
+++ b/src/webgl/material.js
@@ -266,8 +266,6 @@ p5.prototype.ambientMaterial = function(v1, v2, v3, a) {
   shaderProgram.uSpecular = gl.getUniformLocation(
     shaderProgram, 'uSpecular' );
   gl.uniform1i(shaderProgram.uSpecular, false);
-
-  this._renderer._createEmptyTexture();
   gl.uniform1i(gl.getUniformLocation(shaderProgram, 'isTexture'), false);
   return this;
 };
@@ -329,7 +327,6 @@ p5.prototype.specularMaterial = function(v1, v2, v3, a) {
   shaderProgram.uSpecular = gl.getUniformLocation(
     shaderProgram, 'uSpecular' );
   gl.uniform1i(shaderProgram.uSpecular, true);
-  this._renderer._createEmptyTexture();
   gl.uniform1i(gl.getUniformLocation(shaderProgram, 'isTexture'), false);
   return this;
 };

--- a/src/webgl/p5.RendererGL.js
+++ b/src/webgl/p5.RendererGL.js
@@ -172,7 +172,7 @@ function(vertId, fragId, isImmediateMode) {
     alert('Snap! Error linking shader program');
   }
   //END SHADERS SETUP
-
+  this._createEmptyTexture();
   this._getLocation(shaderProgram, isImmediateMode);
 
   return shaderProgram;


### PR DESCRIPTION
Just wanted to change where _createEmptyTexture is called because I realized there were some cases in which it wouldn't be called. Sorry for the annoyance!