### PR TITLE
fix rendering bug with texture and alpha

### DIFF
--- a/src/webgl/material.js
+++ b/src/webgl/material.js
@@ -121,6 +121,7 @@ p5.prototype.texture = function(){
     args[i] = arguments[i];
   }
   var gl = this._renderer.GL;
+  gl.depthMask(true);
   gl.enable(gl.BLEND);
   gl.blendFunc(gl.SRC_ALPHA, gl.ONE_MINUS_SRC_ALPHA);
   this._renderer.drawMode = 'texture';


### PR DESCRIPTION
closes #2073 

This is a simple single line fix but it was hard to find. It was happening because _applyColorBlend was disabling the depthMask when any object had transparency but calls to texture never reset this.