### PR TITLE
fix #1678 by setting default stroke and fill colors in 3d renderer.

### DIFF
--- a/src/webgl/p5.RendererGL.js
+++ b/src/webgl/p5.RendererGL.js
@@ -53,8 +53,8 @@ p5.RendererGL = function(elt, pInst, isMainCanvas) {
   //default drawing is done in Retained Mode
   this.isImmediateDrawing = false;
   this.immediateMode = {};
-  this.curFillColor = [0.5,0.5,0.5,1.0];
-  this.curStrokeColor = [0.5,0.5,0.5,1.0];
+  this.fill(255, 255, 255, 255);
+  this.stroke(0, 0, 0, 255);
   this.pointSize = 5.0;//default point/stroke
 
   this.emptyTexture = null;
@@ -138,8 +138,7 @@ p5.RendererGL.prototype.background = function() {
  * @param  {string} fragId [description]
  * @return {[type]}        [description]
  */
-p5.RendererGL.prototype._initShaders =
-function(vertId, fragId, isImmediateMode) {
+p5.RendererGL.prototype._initShaders = function(vertId, fragId, isImmediateMode) {
   var gl = this.GL;
   //set up our default shaders by:
   // 1. create the shader,
@@ -233,8 +232,7 @@ function(vertId, fragId, isImmediateMode) {
  * Wrapper around gl.useProgram to make sure
  * we only switch shaders when neccessary
  */
-p5.RendererGL.prototype._useShader =
-function(shaderProgram){
+p5.RendererGL.prototype._useShader = function(shaderProgram){
   var gl = this.GL;
   if(shaderProgram === this.curShader) {
     return;
@@ -244,8 +242,7 @@ function(shaderProgram){
   return shaderProgram;
 };
 
-p5.RendererGL.prototype._setMatrixUniforms =
-function(shaderKey) {
+p5.RendererGL.prototype._setMatrixUniforms = function(shaderKey) {
   var shaderProgram = this.mHash[shaderKey];
 
   this._useShader(shaderProgram);
@@ -365,17 +362,24 @@ p5.RendererGL.prototype._getShader = function(vertId, fragId, isImmediateMode) {
 
 p5.RendererGL.prototype._getCurShaderId = function(){
   //if the shader ID is not yet defined
-  if(this.drawMode !== 'fill' && this.curShaderId === undefined){
+  if (this.drawMode !== 'fill' && this.curShaderId === undefined){
     //default shader: normalMaterial()
     this._getShader('normalVert', 'normalFrag');
-  } else if(this.isImmediateDrawing && this.drawMode === 'fill'){
+  } else if (this.drawMode === 'fill'){
     // note that this._getShader will check if the shader already exists
     // by looking up the shader id (composed of vertexShaderId|fragmentShaderId)
     // in the material hash. If the material isn't found in the hash, it
     // creates a new one using this._initShaders--however, we'd like
     // use the cached version as often as possible, so we defer to this._getShader
     // here instead of calling this._initShaders directly.
-    this._getShader('immediateVert', 'vertexColorFrag', true);
+    var shaderProgram;
+    if (this.isImmediateDrawing) {
+      shaderProgram = this._getShader('immediateVert', 'vertexColorFrag', true);
+    } else {
+      shaderProgram = this._getShader('normalVert', 'basicFrag', false);
+    }
+    // this should be safe, but...
+    this._useShader(shaderProgram);
   }
 
   return this.curShaderId;
@@ -422,13 +426,11 @@ p5.RendererGL.prototype.fill = function(v1, v2, v3, a) {
   var colors = this._applyColorBlend.apply(this, arguments);
   this.curFillColor = colors;
   this.drawMode = 'fill';
-  if(this.isImmediateDrawing){
-    shaderProgram =
-    this._getShader('immediateVert','vertexColorFrag');
+  if (this.isImmediateDrawing){
+    shaderProgram = this._getShader('immediateVert','vertexColorFrag');
     this._useShader(shaderProgram);
   } else {
-    shaderProgram =
-    this._getShader('normalVert', 'basicFrag');
+    shaderProgram = this._getShader('normalVert', 'basicFrag');
     this._useShader(shaderProgram);
     //RetainedMode uses a webgl uniform to pass color vals
     //in ImmediateMode, we want access to each vertex so therefore
@@ -440,8 +442,7 @@ p5.RendererGL.prototype.fill = function(v1, v2, v3, a) {
 
 p5.RendererGL.prototype.noFill = function() {
   var gl = this.GL;
-  var shaderProgram =
-    this._getShader('normalVert', 'basicFrag');
+  var shaderProgram = this._getShader('normalVert', 'basicFrag');
   this._useShader(shaderProgram);
   gl.enable(gl.BLEND);
   gl.blendFunc(gl.SRC_ALPHA, gl.ONE_MINUS_SRC_ALPHA);

--- a/src/webgl/primitives.js
+++ b/src/webgl/primitives.js
@@ -671,8 +671,7 @@ p5.RendererGL.prototype.ellipse = function
   return this;
 };
 
-p5.RendererGL.prototype.rect = function
-(args){
+p5.RendererGL.prototype.rect = function(args) {
   var gId = 'rect|'+args[0]+'|'+args[1]+'|'+args[2]+'|'+
   args[3];
   var x = args[0];

--- a/test/manual-test-examples/webgl/camera/ortho/sketch.js
+++ b/test/manual-test-examples/webgl/camera/ortho/sketch.js
@@ -7,7 +7,8 @@ function draw(){
   background(0);
   rotateX(map(mouseY, 0, height, 0, TWO_PI));
   rotateY(map(mouseX, 0, width, 0, TWO_PI));
-  
+  normalMaterial();
+
   for(var i = -5; i < 6; i++){
     for(var j = -5; j < 6; j++){
       push();

--- a/test/manual-test-examples/webgl/camera/perspective/sketch.js
+++ b/test/manual-test-examples/webgl/camera/perspective/sketch.js
@@ -9,6 +9,8 @@ function draw(){
   background(0);
   rotateX(map(mouseY, 0, height, 0, TWO_PI));
   rotateY(map(mouseX, 0, width, 0, TWO_PI));
+  normalMaterial();
+
   for(var i = -5; i < 6; i++){
     for(var j = -5; j < 6; j++){
       push();

--- a/test/manual-test-examples/webgl/defaultFillAndStroke/index.html
+++ b/test/manual-test-examples/webgl/defaultFillAndStroke/index.html
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8">
+  <meta http-equiv="X-UA-Compatible" content="IE=edge">
+  <title></title>
+  <link rel="stylesheet" href="">
+  <script language="javascript" type="text/javascript" src="../../../../lib/p5.js"></script>
+  <script language="javascript" type="text/javascript" src="sketch.js"></script>
+  <style>
+    html, body {margin:0; padding:0;}
+  </style>
+</head>
+<body>
+<p style="width:1000px; margin:10px auto; text-align: center; color:black;">Drag mouse to toggle the world</p>
+<p style="width:1000px; margin:10px auto; text-align: center; color:black;">(3d primitives and 2d primitives can be used together)</p>
+<script>
+(function(){var script=document.createElement('script');script.onload=function(){var stats=new Stats();stats.domElement.style.cssText='position:fixed;left:0;top:0;z-index:10000';document.body.appendChild(stats.domElement);requestAnimationFrame(function loop(){stats.update();requestAnimationFrame(loop)});};script.src='http://rawgit.com/mrdoob/stats.js/master/build/stats.min.js';document.head.appendChild(script);})()
+</script>
+
+</body>
+</html>

--- a/test/manual-test-examples/webgl/defaultFillAndStroke/sketch.js
+++ b/test/manual-test-examples/webgl/defaultFillAndStroke/sketch.js
@@ -1,0 +1,27 @@
+
+function setup(){
+  createCanvas(windowWidth, windowHeight, WEBGL);
+}
+
+function draw(){
+  background(220);
+
+  // triangle with immediate mode
+  beginShape(TRIANGLES);
+  vertex(0, 25, 0);
+  vertex(-25, -25, 0);
+  vertex(25, -25, 0);
+  endShape();
+
+  // box with retain mode
+  push();
+  translate(-width/3, 0);
+  box(70);
+  pop();
+
+  // // regular drawing command
+  push();
+  translate(width / 3, 0);
+  rect(0, 0, 70, 70);
+  pop();
+}

--- a/test/manual-test-examples/webgl/material/simple/sketch.js
+++ b/test/manual-test-examples/webgl/material/simple/sketch.js
@@ -10,19 +10,19 @@ function draw(){
   ambientLight(50);
   pointLight(250, 250, 250, -70, 70, 0);
 
-  normalMaterial(250);
+  normalMaterial();
   sphere();
 
   translate(250, 0, 0);
 
-  normalMaterial(250);
+  normalMaterial();
   sphere();
-  
+
   translate(250, 0, 0);
 
   ambientMaterial(250);
   sphere(50, 128);
-  
+
   translate(250, 0, 0);
 
   specularMaterial(250);

--- a/test/manual-test-examples/webgl/mixedMode/sketch.js
+++ b/test/manual-test-examples/webgl/mixedMode/sketch.js
@@ -12,21 +12,17 @@ function draw(){
   orbitControl();
 
   for(var i = 0; i < 500; i+=100){
+    push();
+    translate(0, 0, i);
+    normalMaterial(i * 0.1, 100, 100);
 
-  push();
-  translate(0, 0, i);
-  normalMaterial(i * 0.1, 100, 100);
-
-  push();
-  translate(0, cos( i + frameCount * 0.1) * 10, 0);
-  box(20, 20, 20);
-  pop();
-  fill(i * 0.1, 100, 100);
-  line(
-  -100, sin( i + frameCount * 0.1) * 10, 0,
-  100, sin( i + frameCount * 0.1) * 10, 0
-  );
-  pop();
-
+    push();
+    translate(0, cos( i + frameCount * 0.1) * 10, 0);
+    box(20, 20, 20);
+    pop();
+    fill(i * 0.1, 100, 100);
+    line(-100, sin( i + frameCount * 0.1) * 10, 0,
+         100, sin( i + frameCount * 0.1) * 10, 0);
+    pop();
   }
 }

--- a/test/manual-test-examples/webgl/origin/center_origin/sketch.js
+++ b/test/manual-test-examples/webgl/origin/center_origin/sketch.js
@@ -14,7 +14,7 @@ function draw(){
 
   for(var i = -2; i < 3; i++){
     for(var j = -2; j < 3; j++){
-      normalMaterial( (i+2) * 40, (j+2) * 40, 0);
+      fill((i+2) * 40, (j+2) * 40, 0);
       push();
       translate(i*gap, j*gap,0);
       plane();
@@ -27,6 +27,5 @@ function draw(){
       //   );
     }
   }
-  
 
 }

--- a/test/manual-test-examples/webgl/origin/topleft_origin/sketch.js
+++ b/test/manual-test-examples/webgl/origin/topleft_origin/sketch.js
@@ -16,7 +16,7 @@ function draw(){
 
   for(var i = 0; i < 5; i++){
     for(var j = 0; j < 5; j++){
-      fill( i * 40, j * 40, 0);
+      fill(i * 40, j * 40, 0);
       quad(
         i * gap, j * gap, 0,
         i * gap + w, j * gap, 0,
@@ -25,6 +25,5 @@ function draw(){
         );
     }
   }
-  
 
 }

--- a/test/manual-test-examples/webgl/performance/sketch.js
+++ b/test/manual-test-examples/webgl/performance/sketch.js
@@ -6,7 +6,7 @@ function setup(){
 
 function draw(){
   background(250, 250, 250, 255);
- 
+
   normalMaterial();
   translate(0, 0, -800);
   rotateY(frameCount * 0.01);
@@ -17,7 +17,7 @@ function draw(){
       translate(sin(theta + j) * 100, sin(theta + j) * 100, i * 0.1);
       rotateZ(theta * 0.2);
       push();
-      sphere(8, 6, 4); 
+      sphere(8, 6, 4);
       pop();
     }
     pop();


### PR DESCRIPTION
updated this request to reflect lots of new changes. Some of this is formatting; let me know if you want me to save that for another commit!

uses this.stroke and this.fill methods when the renderer is initialized,
so that all necessary gl context side effects also happen.

clean up gl tests:

- made the camera tests use normalMaterial(), instead of default
  stroke and fill colors.
- some tests were using basicMaterial(), which no longer exists. Changed
  to fill() or normalMaterial() as appropriate.
- remove trailing whitespaces in tests.

update conditional in _getCurShader to reflect that interleaving
immediate mode and retain mode calls requires changing shaders,
even if no change is made to fill color.