### PR TITLE
yuidoc templates hide private stuff, link to extended classes

### DIFF
--- a/docs/yuidoc-p5-theme-src/scripts/tpl/class.html
+++ b/docs/yuidoc-p5-theme-src/scripts/tpl/class.html
@@ -6,7 +6,7 @@
 </div>
 <% } %>
 
-<% var fields = _.filter(things, function(item) { return item.itemtype === 'property' }); %>
+<% var fields = _.filter(things, function(item) { return item.itemtype === 'property' && item.access !== 'private' }); %>
 <% if (fields.length > 0) { %>
   <h4>Fields</h4>
   <p>
@@ -17,7 +17,7 @@
   </p>
 <% } %>
 
-<% var methods = _.filter(things, function(item) { return item.itemtype === 'method' }); %>
+<% var methods = _.filter(things, function(item) { return item.itemtype === 'method' && item.access !== 'private' }); %>
 <% if (methods.length > 0) { %>
   <h4>Methods</h4>
   <p>

--- a/docs/yuidoc-p5-theme-src/scripts/tpl/item.html
+++ b/docs/yuidoc-p5-theme-src/scripts/tpl/item.html
@@ -17,6 +17,10 @@
 
   <span class='description-text'><%= item.description %></span>
 
+  <% if (item.extends) { %>
+    <p>Extends <a href="/reference/#/<%=item.extends%>" title="<%=item.extends%> reference"><%=item.extends%></a></p>
+  <% } %>
+
   <% if (item.module === 'p5.dom') { %>
     <p>This function requires you include the p5.dom library.  Add the following into the head of your index.html file:
       <pre><code class="language-javascript">&lt;script language="javascript" type="text/javascript" src="path/to/p5.dom.js"&gt;&lt;/script&gt;</code></pre>

--- a/docs/yuidoc-p5-theme-src/scripts/tpl/library.html
+++ b/docs/yuidoc-p5-theme-src/scripts/tpl/library.html
@@ -13,7 +13,7 @@
   <% if (group.name !== module.name && group.name !== 'p5') { %>
     <a href="<%=group.hash%>" <% if (group.module !== module.name) { %>class="core"<% } %>><h4 class="group-name <% if (t == 0) { %> first<%}%>"><%=group.name%></h4></a>
   <% } %>
-  <% _.each(group.items, function(item) { %>
+  <% _.each(group.items.filter(function(item) {return item.access !== 'private'}), function(item) { %>
     <a href="<%=item.hash%>" <% if (item.module !== module.name) { %>class="core"<% } %>><%=item.name%><% if (item.itemtype === 'method') { %>()<%}%></a><br>
     <% t++; %>
   <% }); %>


### PR DESCRIPTION
Some changes so that we can utilize yuidoc tags in p5.sound reference pages (and I think they're helpful everywhere?):
- `@private` methods and properties don't show up on the library pages or class page
- child class that `@extends` another class automatically links to that class

This PR updates the Backbone.js templates that are used by the requirejs task to generate a reference.js file for the reference pages. Let me know if I also generate the new reference.js file and send a PR to the website repo?

cc @Spongman @jvntf