### PR TITLE
fix ambient light, gl error when lighting is set but no texture

### DIFF
--- a/src/webgl/light.js
+++ b/src/webgl/light.js
@@ -76,6 +76,7 @@ p5.prototype.ambientLight = function(v1, v2, v3, a){
   var colors = new Float32Array(color._array.slice(0,3));
   shader.setUniform('uAmbientColor', colors);
   shader.setUniform('uUseLighting', true);
+  renderer.ambientLightCount++;
   //in case there's no material color for the geometry
   shader.setUniform('uMaterialColor', [1,1,1,1]);
   shader.setUniform('uAmbientLightCount', renderer.ambientLightCount);

--- a/src/webgl/p5.RendererGL.js
+++ b/src/webgl/p5.RendererGL.js
@@ -633,6 +633,16 @@ p5.RendererGL.prototype._getColorShader = function () {
   return this._defaultColorShader;
 };
 
+p5.RendererGL.prototype._getEmptyTexture = function () {
+  if (this._emptyTexture === undefined) {
+    // a plain white texture RGBA, full alpha, single pixel.
+    var im = new p5.Image(1, 1);
+    im.set(0, 0, 255);
+    this._emptyTexture = new p5.Texture(this, im);
+  }
+  return this._emptyTexture;
+};
+
 p5.RendererGL.prototype.getTexture = function (img) {
   var checkSource = function(element) {
     return element.src === img;

--- a/src/webgl/p5.Shader.js
+++ b/src/webgl/p5.Shader.js
@@ -213,12 +213,17 @@ p5.Shader.prototype.bindTextures = function () {
   var gl = this._renderer.GL;
   for (var i = 0;  i < this.samplers.length; i++) {
     var uniform = this.samplers[i];
-    if (uniform.texture !== undefined) {
-      gl.activeTexture(gl.TEXTURE0 + uniform.samplerIndex);
-      uniform.texture.bindTexture();
-      uniform.texture.update();
-      gl.uniform1i(uniform.location, uniform.samplerIndex);
+    var tex = uniform.texture;
+    if (tex === undefined) {
+      // user hasn't yet supplied a texture for this slot.
+      // (or there may not be one--maybe just lighting),
+      // so we supply a default texture instead.
+      tex = this._renderer._getEmptyTexture();
     }
+    gl.activeTexture(gl.TEXTURE0 + uniform.samplerIndex);
+    tex.bindTexture();
+    tex.update();
+    gl.uniform1i(uniform.location, uniform.samplerIndex);
   }
 };
 

--- a/test/manual-test-examples/webgl/material/texture/index.html
+++ b/test/manual-test-examples/webgl/material/texture/index.html
@@ -6,7 +6,6 @@
   <title></title>
   <link rel="stylesheet" href="">
   <script language="javascript" type="text/javascript" src="../../../../../lib/p5.js"></script>
-  <script src="../../../../lib/addons/p5.dom.js"></script>
   <script language="javascript" type="text/javascript" src="sketch.js"></script>
   <style>
     html, body {margin:0; padding:0;}


### PR DESCRIPTION
ambientLight was not incrementing the # of lights in the scene as it
should have been. must have been accidentally deleted during code cleanup
from a prior patch, oops!

and: importantly, restores the empty texture work Stalgia had added but
using the new p5.Texture architecture. a default texture is loaded
and used (pure white, 1x1 pixels from an in-memory p5.Image) when the
user has not supplied a texture to the shader.

ran all the manual tests with the debugger open this time. :)