### PR TITLE
fix for ordering of test grunt task #2125

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -370,7 +370,7 @@ module.exports = function(grunt) {
 
   // Create the multitasks.
   grunt.registerTask('build', ['browserify', 'uglify', 'requirejs']);
-  grunt.registerTask('test', ['jshint', 'jscs', 'build', 'yuidoc:dev', 'connect', 'mocha', 'mochaTest']);
+  grunt.registerTask('test', ['jshint', 'jscs', 'yuidoc:dev', 'build', 'connect', 'mocha', 'mochaTest']);
   grunt.registerTask('test:nobuild', ['jshint:test', 'jscs:test', 'connect', 'mocha']);
   grunt.registerTask('yui', ['yuidoc:prod', 'minjson']);
   grunt.registerTask('yui:dev', ['yuidoc:dev', 'minjson']);


### PR DESCRIPTION
This is a proposed fix for #2125. It resolves the issue for me locally, but I don't know enough about the build ecosystem on this project to know if this might cause breakage elsewhere.

This fix places `yuidoc:dev` task before the `build` task in `grunt test`. It seems that the `build` task requires that `yuidoc:dev` has been run to produce a file it needs.

Let me know if there are any questions and of all feedback!