### PR TITLE
Initial implementation of custom shaders.

### DIFF
--- a/src/core/core.js
+++ b/src/core/core.js
@@ -571,7 +571,8 @@ p5.prototype._preloadMethods = {
   loadShape: p5.prototype,
   loadTable: p5.prototype,
   loadFont: p5.prototype,
-  loadModel: p5.prototype
+  loadModel: p5.prototype,
+  loadShader: p5.prototype
 };
 
 p5.prototype._registeredMethods = { init: [], pre: [], post: [], remove: [] };

--- a/src/webgl/light.js
+++ b/src/webgl/light.js
@@ -63,8 +63,9 @@ var p5 = require('../core/core');
  *
  */
 p5.prototype.ambientLight = function(v1, v2, v3, a){
-  var renderer = this._renderer;
-  var shader = renderer.setShader(renderer._getLightShader());
+  if (! this._renderer.curShader.isLightShader()) {
+    this._renderer.shader(this._renderer._getLightShader());
+  }
 
   var color = this._renderer._pInst.color.apply(
     this._renderer._pInst, arguments);
@@ -74,12 +75,14 @@ p5.prototype.ambientLight = function(v1, v2, v3, a){
   //a preallocated Float32Array(24) that we copy into
   //would be better
   var colors = new Float32Array(color._array.slice(0,3));
-  shader.setUniform('uAmbientColor', colors);
-  shader.setUniform('uUseLighting', true);
-  renderer.ambientLightCount++;
+  this._renderer.curShader.setUniform('uAmbientColor', colors);
+  this._renderer.curShader.setUniform('uUseLighting', true);
+  this._renderer.ambientLightCount++;
   //in case there's no material color for the geometry
-  shader.setUniform('uMaterialColor', [1,1,1,1]);
-  shader.setUniform('uAmbientLightCount', renderer.ambientLightCount);
+  this._renderer.curShader.setUniform('uMaterialColor',
+    this._renderer.curFillColor);
+  this._renderer.curShader.setUniform('uAmbientLightCount',
+    this._renderer.ambientLightCount);
   return this;
 };
 
@@ -119,15 +122,16 @@ p5.prototype.ambientLight = function(v1, v2, v3, a){
  *
  */
 p5.prototype.directionalLight = function(v1, v2, v3, a, x, y, z) {
-  var renderer = this._renderer;
-  var shader = renderer.setShader(renderer._getLightShader());
+  if (! this._renderer.curShader.isLightShader()) {
+    this._renderer.shader(this._renderer._getLightShader());
+  }
 
   //@TODO: check parameters number
-  var color = renderer._pInst.color.apply(
-    renderer._pInst, [v1, v2, v3]);
+  var color = this._renderer._pInst.color.apply(
+    this._renderer._pInst, [v1, v2, v3]);
 
   var colors = new Float32Array(color._array.slice(0,3));
-  renderer.curShader.setUniform('uDirectionalColor', colors);
+  this._renderer.curShader.setUniform('uDirectionalColor', colors);
 
   var _x, _y, _z;
 
@@ -150,13 +154,14 @@ p5.prototype.directionalLight = function(v1, v2, v3, a, x, y, z) {
       throw error;
     }
   }
-  shader.setUniform('uUseLighting', true);
+  this._renderer.curShader.setUniform('uUseLighting', true);
   //in case there's no material color for the geometry
-  shader.setUniform('uMaterialColor', [1,1,1,1]);
-  shader.setUniform('uLightingDirection', [_x, _y, _z]);
-  renderer.directionalLightCount ++;
-  shader.setUniform('uDirectionalLightCount',
-    renderer.directionalLightCount);
+  this._renderer.curShader.setUniform('uMaterialColor',
+    this._renderer.curFillColor);
+  this._renderer.curShader.setUniform('uLightingDirection', [_x, _y, _z]);
+  this._renderer.directionalLightCount ++;
+  this._renderer.curShader.setUniform('uDirectionalLightCount',
+    this._renderer.directionalLightCount);
   return this;
 };
 
@@ -203,15 +208,16 @@ p5.prototype.directionalLight = function(v1, v2, v3, a, x, y, z) {
  *
  */
 p5.prototype.pointLight = function(v1, v2, v3, a, x, y, z) {
-  var renderer = this._renderer;
-  var shader = renderer.setShader(renderer._getLightShader());
+  if (! this._renderer.curShader.isLightShader()) {
+    this._renderer.shader(this._renderer._getLightShader());
+  }
 
   //@TODO: check parameters number
   var color = this._renderer._pInst.color.apply(
     this._renderer._pInst, [v1, v2, v3]);
 
   var colors = new Float32Array(color._array.slice(0,3));
-  shader.setUniform('uPointLightColor', colors);
+  this._renderer.curShader.setUniform('uPointLightColor', colors);
 
   var _x, _y, _z;
 
@@ -234,12 +240,14 @@ p5.prototype.pointLight = function(v1, v2, v3, a, x, y, z) {
       throw error;
     }
   }
-  shader.setUniform('uUseLighting', true);
+  this._renderer.curShader.setUniform('uUseLighting', true);
   //in case there's no material color for the geometry
-  shader.setUniform('uMaterialColor', [1,1,1,1]);
-  shader.setUniform('uPointLightLocation', [_x, _y, _z]);
+  this._renderer.curShader.setUniform('uMaterialColor',
+    this._renderer.curFillColor);
+  this._renderer.curShader.setUniform('uPointLightLocation', [_x, _y, _z]);
   this._renderer.pointLightCount++;
-  shader.setUniform('uPointLightCount', renderer.pointLightCount);
+  this._renderer.curShader.setUniform('uPointLightCount',
+    this._renderer.pointLightCount);
   return this;
 };
 

--- a/src/webgl/p5.RendererGL.Immediate.js
+++ b/src/webgl/p5.RendererGL.Immediate.js
@@ -100,26 +100,27 @@ p5.RendererGL.prototype.endShape =
 function(mode, isCurve, isBezier,isQuadratic, isContour, shapeKind){
 
   var gl = this.GL;
-  var shader = this.curShader;
-  if (shader === this._getColorShader()) {
+  if (this.curShader === this._getColorShader()) {
     // this is the fill/stroke shader for retain mode.
     // must switch to immediate mode shader before drawing!
-    shader = this.setShader(this._getImmediateModeShader());
+    this.shader(this._getImmediateModeShader());
 
     // note that if we're using the texture shader...
     // this shouldn't change. :)
   }
-  shader.bindShader();
+
+  this.curShader.bindShader();
   //vertex position Attribute
   this._bindBuffer(this.immediateMode.vertexBuffer, gl.ARRAY_BUFFER,
     this.immediateMode.vertexPositions, Float32Array, gl.DYNAMIC_DRAW);
-  shader.enableAttrib(shader.attributes.aPosition.location,
+  this.curShader.enableAttrib(this.curShader.attributes.aPosition.location,
     3, gl.FLOAT, false, 0, 0);
 
   if (this.drawMode === constants.FILL) {
     this._bindBuffer(this.immediateMode.colorBuffer, gl.ARRAY_BUFFER,
       this.immediateMode.vertexColors, Float32Array, gl.DYNAMIC_DRAW);
-    shader.enableAttrib(shader.attributes.aVertexColor.location,
+    this.curShader.enableAttrib(
+      this.curShader.attributes.aVertexColor.location,
       4, gl.FLOAT, false, 0, 0);
   }
 
@@ -127,7 +128,7 @@ function(mode, isCurve, isBezier,isQuadratic, isContour, shapeKind){
     //texture coordinate Attribute
     this._bindBuffer(this.immediateMode.uvBuffer, gl.ARRAY_BUFFER,
       this.immediateMode.uvCoords, Float32Array, gl.DYNAMIC_DRAW);
-    shader.enableAttrib(shader.attributes.aTexCoord.location,
+    this.curShader.enableAttrib(this.curShader.attributes.aTexCoord.location,
       2, gl.FLOAT, false, 0, 0);
   }
 
@@ -175,7 +176,7 @@ function(mode, isCurve, isBezier,isQuadratic, isContour, shapeKind){
   this.isImmediateDrawing = false;
 
   // todo / optimizations? leave bound until another shader is set?
-  shader.unbindShader();
+  this.curShader.unbindShader();
   return this;
 };
 

--- a/src/webgl/p5.RendererGL.Retained.js
+++ b/src/webgl/p5.RendererGL.Retained.js
@@ -44,18 +44,17 @@ p5.RendererGL.prototype.createBuffers = function(gId, obj) {
   //we mult the num geom faces by 3
   this.gHash[gId].numberOfItems = obj.faces.length * 3;
 
-  var shader = this.curShader;
-  if (shader === this._getImmediateModeShader()) {
+  if (this.curShader === this._getImmediateModeShader()) {
     // there are different immediate mode and retain mode color shaders.
     // if we're using the immediate mode one, we need to switch to
     // one that works for retain mode.
-    shader = this.setShader(this._getColorShader());
+    this.shader(this._getColorShader());
   }
 
   // allocate space for vertex positions
   this._bindBuffer(this.gHash[gId].vertexBuffer, gl.ARRAY_BUFFER,
     vToNArray(obj.vertices), Float32Array, gl.STATIC_DRAW);
-  shader.enableAttrib(shader.attributes.aPosition.location,
+  this.curShader.enableAttrib(this.curShader.attributes.aPosition.location,
     3, gl.FLOAT, false, 0, 0);
 
   // allocate space for faces
@@ -65,13 +64,13 @@ p5.RendererGL.prototype.createBuffers = function(gId, obj) {
   // allocate space for normals
   this._bindBuffer(this.gHash[gId].normalBuffer, gl.ARRAY_BUFFER,
     vToNArray(obj.vertexNormals), Float32Array, gl.STATIC_DRAW);
-  shader.enableAttrib(shader.attributes.aNormal.location,
+  this.curShader.enableAttrib(this.curShader.attributes.aNormal.location,
     3, gl.FLOAT, false, 0, 0);
 
   // tex coords
   this._bindBuffer(this.gHash[gId].uvBuffer, gl.ARRAY_BUFFER,
     flatten(obj.uvs), Float32Array, gl.STATIC_DRAW);
-  shader.enableAttrib(shader.attributes.aTexCoord.location,
+  this.curShader.enableAttrib(this.curShader.attributes.aTexCoord.location,
     2, gl.FLOAT, false, 0, 0);
 };
 
@@ -88,32 +87,31 @@ p5.RendererGL.prototype.drawBuffers = function(gId) {
     // sure why these are two different shaders. but, they are,
     // and if we're drawing in retain mode but the shader is the
     // immediate mode one, we need to switch.
-    this.setShader(this._getColorShader());
+    this.shader(this._getColorShader());
   }
-  var shader = this.curShader;
-  shader.bindShader();
+  this.curShader.bindShader();
 
   //vertex position buffer
   this._bindBuffer(this.gHash[gId].vertexBuffer, gl.ARRAY_BUFFER);
-  shader.enableAttrib(shader.attributes.aPosition.location,
+  this.curShader.enableAttrib(this.curShader.attributes.aPosition.location,
     3, gl.FLOAT, false, 0, 0);
   //vertex index buffer
   this._bindBuffer(this.gHash[gId].indexBuffer, gl.ELEMENT_ARRAY_BUFFER);
 
   this._bindBuffer(this.gHash[gId].normalBuffer, gl.ARRAY_BUFFER);
-  shader.enableAttrib(shader.attributes.aNormal.location,
+  this.curShader.enableAttrib(this.curShader.attributes.aNormal.location,
     3, gl.FLOAT, false, 0, 0);
   // uv buffer
   this._bindBuffer(this.gHash[gId].uvBuffer, gl.ARRAY_BUFFER);
-  shader.enableAttrib(
-    shader.attributes.aTexCoord.location, 2, gl.FLOAT, false, 0, 0);
+  this.curShader.enableAttrib(
+    this.curShader.attributes.aTexCoord.location, 2, gl.FLOAT, false, 0, 0);
 
   if(this.drawMode === constants.STROKE) {
     this._drawElements(gl.LINES, gId);
   } else {
     this._drawElements(gl.TRIANGLES, gId);
   }
-  shader.unbindShader();
+  this.curShader.unbindShader();
   return this;
 };
 

--- a/src/webgl/p5.RendererGL.js
+++ b/src/webgl/p5.RendererGL.js
@@ -79,7 +79,7 @@ p5.RendererGL = function(elt, pInst, isMainCanvas, attr) {
   this._defaultNormalShader = undefined;
   this._defaultColorShader = undefined;
 
-  this.setShader(this._getColorShader());
+  this.shader(this._getColorShader());
 
   //Imediate Mode
   //default drawing is done in Retained Mode
@@ -328,17 +328,17 @@ p5.RendererGL.prototype.fill = function(v1, v2, v3, a) {
   this.curFillColor = colors;
   this.drawMode = constants.FILL;
   if (this.isImmediateDrawing){
-    this.setShader(this._getImmediateModeShader());
+    this.shader(this._getImmediateModeShader());
   } else {
-    var shader = this.setShader(this._getColorShader());
-    shader.setUniform('uMaterialColor', colors);
+    this.shader(this._getColorShader());
+    this.curShader.setUniform('uMaterialColor', colors);
   }
   return this;
 };
 
 p5.RendererGL.prototype.noFill = function() {
   var gl = this.GL;
-  this.setShader(this._getColorShader());
+  this.shader(this._getColorShader());
   gl.enable(gl.BLEND);
   gl.blendFunc(gl.SRC_ALPHA, gl.ONE_MINUS_SRC_ALPHA);
   this.drawMode = constants.STROKE;
@@ -582,11 +582,11 @@ p5.RendererGL.prototype._applyTextProperties = function() {
  * so it is safe to call this method with the same shader multiple
  * times without a signficant performance hit).
  *
- * @method setShader
- * @param {p5.Shader} s a p5.Shader object
+ * @method shader
+ * @param {p5.Shader} [s] a p5.Shader object
  * @return {p5.Shader} the current, updated shader
  */
-p5.RendererGL.prototype.setShader = function (s) {
+p5.RendererGL.prototype.shader = function (s) {
   if (this.curShader !== s) {
     // only do setup etc. if shader is actually new.
     this.curShader = s;
@@ -605,6 +605,8 @@ p5.RendererGL.prototype.setShader = function (s) {
  * shaders are created and cached on a per-renderer basis,
  * on the grounds that each renderer will have its own gl context
  * and the shader must be valid in that context.
+ *
+ *
  */
 
 p5.RendererGL.prototype._getLightShader = function () {

--- a/src/webgl/p5.Shader.js
+++ b/src/webgl/p5.Shader.js
@@ -50,7 +50,7 @@ p5.Shader.prototype.init = function() {
   if (this._glProgram === 0 /* or context is stale? */) {
     var gl = this._renderer.GL;
 
-    // @todo: once customer shading is allowed,
+    // @todo: once custom shading is allowed,
     // friendly error messages should be used here to share
     // compiler and linker errors.
 
@@ -85,7 +85,8 @@ p5.Shader.prototype.init = function() {
     gl.attachShader(this._glProgram, this._fragShader);
     gl.linkProgram(this._glProgram);
     if (!gl.getProgramParameter(this._glProgram, gl.LINK_STATUS)) {
-      console.error('Snap! Error linking shader program');
+      console.error('Snap! Error linking shader program: ' +
+        gl.getProgramInfoLog(this._glProgram));
     }
 
     this._loadAttributes();
@@ -341,6 +342,41 @@ p5.Shader.prototype.setUniform = function(uniformName, data)
   return this;
 };
 
+/* NONE OF THIS IS FAST OR EFFICIENT BUT BEAR WITH ME
+ *
+ * these shader "type" query methods are used by various
+ * facilities of the renderer to determine if changing
+ * the shader type for the required action (for example,
+ * do we need to load the default lighting shader if the
+ * current shader cannot handle lighting?)
+ *
+ **/
+
+p5.Shader.prototype.isLightShader = function () {
+  return this.uniforms.uUseLighting !== undefined ||
+    this.uniforms.uAmbientLightCount !== undefined ||
+    this.uniforms.uDirectionalLightCount !== undefined ||
+    this.uniforms.uPointLightCount !== undefined ||
+    this.uniforms.uAmbientColor !== undefined ||
+    this.uniforms.uDirectionalColor !== undefined ||
+    this.uniforms.uPointLightLocation !== undefined ||
+    this.uniforms.uPointLightColor !== undefined ||
+    this.uniforms.uLightingDirection !== undefined ||
+    this.uniforms.uSpecular !== undefined;
+};
+
+p5.Shader.prototype.isTextureShader = function () {
+  return this.samplerIndex > 0;
+};
+
+p5.Shader.prototype.isColorShader = function () {
+  return this.attributes.aVertexColor !== undefined ||
+    this.uniforms.uMaterialColor !== undefined;
+};
+
+p5.Shader.prototype.isTexLightShader = function () {
+  return this.isLightShader() && this.isTextureShader();
+};
 
 /**
  * @method enableAttrib

--- a/test/manual-test-examples/webgl/customShader/toonShader/frag.glsl
+++ b/test/manual-test-examples/webgl/customShader/toonShader/frag.glsl
@@ -1,0 +1,29 @@
+#ifdef GL_ES
+precision mediump float;
+precision mediump int;
+#endif
+
+uniform float fraction;
+
+varying vec4 vertColor;
+varying vec3 vertNormal;
+varying vec3 vertLightDir;
+varying highp vec2 vertTexCoord;
+
+void main() {
+  float intensity;
+  vec4 color;
+  intensity = max(0.0, dot(vertLightDir, vertNormal));
+
+  if (intensity > pow(0.95, fraction)) {
+    color = vec4(vec3(1.0), 1.0);
+  } else if (intensity > pow(0.5, fraction)) {
+    color = vec4(vec3(0.6), 1.0);
+  } else if (intensity > pow(0.25, fraction)) {
+    color = vec4(vec3(0.4), 1.0);
+  } else {
+    color = vec4(vec3(0.2), 1.0);
+  }
+
+  gl_FragColor = color * vertColor;
+}

--- a/test/manual-test-examples/webgl/customShader/toonShader/index.html
+++ b/test/manual-test-examples/webgl/customShader/toonShader/index.html
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8">
+  <meta http-equiv="X-UA-Compatible" content="IE=edge">
+  <title></title>
+  <link rel="stylesheet" href="">
+  <script language="javascript" type="text/javascript" src="../../../../../lib/p5.js"></script>
+  <script language="javascript" type="text/javascript" src="../../../../../lib/addons/p5.dom.js"></script>
+  <script language="javascript" type="text/javascript" src="sketch.js"></script>
+  <style>
+    html, body {margin:0; padding:0;}
+  </style>
+</head>
+<body>
+<p style="position: absolute; width:300px; left:50%; margin-left: -150px; text-align: center; color:white;">move mouse to move light source</p>
+<script>
+(function(){var script=document.createElement('script');script.onload=function(){var stats=new Stats();stats.domElement.style.cssText='position:fixed;left:0;top:0;z-index:10000';document.body.appendChild(stats.domElement);requestAnimationFrame(function loop(){stats.update();requestAnimationFrame(loop)});};script.src='http://rawgit.com/mrdoob/stats.js/master/build/stats.min.js';document.head.appendChild(script);})()
+</script>
+
+</body>
+</html>

--- a/test/manual-test-examples/webgl/customShader/toonShader/sketch.js
+++ b/test/manual-test-examples/webgl/customShader/toonShader/sketch.js
@@ -1,0 +1,23 @@
+
+var toonShader;
+
+
+function preload() {
+  toonShader = loadShader('vert.glsl', 'frag.glsl');
+}
+
+function setup () {
+  createCanvas(windowWidth, windowHeight, WEBGL);
+  noStroke();
+  shader(toonShader);
+  toonShader.setUniform('fraction', 1.0);
+}
+
+function draw () {
+  background(0);
+  var dirY = (mouseY / height - 0.5) * 2;
+  var dirX = (mouseX / width - 0.5) * 2;
+  directionalLight(255, 204, 204, -dirX, dirY, -1);
+  ambientMaterial(0, 255, 255);
+  sphere(120);
+}

--- a/test/manual-test-examples/webgl/customShader/toonShader/vert.glsl
+++ b/test/manual-test-examples/webgl/customShader/toonShader/vert.glsl
@@ -1,0 +1,29 @@
+attribute vec3 aPosition;
+attribute vec3 aNormal;
+attribute vec2 aTexCoord;
+attribute vec4 aVertexColor;
+
+uniform mat4 uModelViewMatrix;
+uniform mat4 uProjectionMatrix;
+uniform mat3 uNormalMatrix;
+
+uniform int uDirectionalLightCount;
+uniform vec3 uLightingDirection;
+uniform vec3 uDirectionalColor;
+uniform vec4 uMaterialColor;
+
+varying vec4 vertColor;
+varying vec3 vertLightDir;
+varying vec3 vertNormal;
+varying vec2 vertTexCoord;
+
+void main() {
+  vec4 positionVec4 = vec4(aPosition, 1.0);
+  gl_Position = uProjectionMatrix * uModelViewMatrix * positionVec4;
+
+  vertNormal = normalize(uNormalMatrix * aNormal);
+  vertLightDir = -uLightingDirection;
+
+  vertColor = uMaterialColor;
+  vertTexCoord = aTexCoord;
+}

--- a/test/manual-test-examples/webgl/customShader/videoMultiTextureShader/frag.glsl
+++ b/test/manual-test-examples/webgl/customShader/videoMultiTextureShader/frag.glsl
@@ -1,0 +1,23 @@
+#ifdef GL_ES
+precision mediump float;
+precision mediump int;
+#endif
+
+uniform sampler2D uSampler;
+uniform sampler2D uSecondSampler;
+uniform float uRed;
+uniform float uGreen;
+
+varying vec4 vertColor;
+varying vec2 vertTexCoord;
+varying vec3 vertNormal;
+
+const vec4 lumcoeff = vec4(0.299, 0.587, 0.114, 0);
+
+void main() {
+  vec4 textureColor = texture2D(uSampler, vertTexCoord);
+  float a = dot(textureColor, lumcoeff);
+  vec4 secondTextureColor = texture2D(uSecondSampler, vertTexCoord);
+  float b = dot(secondTextureColor, lumcoeff);
+  gl_FragColor = vec4(uRed * vertTexCoord.s, uGreen * vertTexCoord.t, b, a);
+}

--- a/test/manual-test-examples/webgl/customShader/videoMultiTextureShader/index.html
+++ b/test/manual-test-examples/webgl/customShader/videoMultiTextureShader/index.html
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8">
+  <meta http-equiv="X-UA-Compatible" content="IE=edge">
+  <title></title>
+  <link rel="stylesheet" href="">
+  <script language="javascript" type="text/javascript" src="../../../../../lib/p5.js"></script>
+  <script language="javascript" type="text/javascript" src="../../../../../lib/addons/p5.dom.js"></script>
+  <script language="javascript" type="text/javascript" src="sketch.js"></script>
+  <style>
+    html, body {margin:0; padding:0;}
+  </style>
+</head>
+<body>
+<p style="position: absolute; width:300px; left:50%; margin-left: -150px; text-align: center; color:black;">press any key to toggle video play/pause</p>
+<script>
+(function(){var script=document.createElement('script');script.onload=function(){var stats=new Stats();stats.domElement.style.cssText='position:fixed;left:0;top:0;z-index:10000';document.body.appendChild(stats.domElement);requestAnimationFrame(function loop(){stats.update();requestAnimationFrame(loop)});};script.src='http://rawgit.com/mrdoob/stats.js/master/build/stats.min.js';document.head.appendChild(script);})()
+</script>
+
+</body>
+</html>

--- a/test/manual-test-examples/webgl/customShader/videoMultiTextureShader/sketch.js
+++ b/test/manual-test-examples/webgl/customShader/videoMultiTextureShader/sketch.js
@@ -1,0 +1,42 @@
+
+var sh, img, img2;
+var fingers;
+
+
+function preload() {
+  sh = loadShader('vert.glsl', 'frag.glsl');
+}
+
+function setup () {
+  createCanvas(windowWidth, windowHeight, WEBGL);
+  fingers = createVideo('../../../addons/p5.dom/fingers.mov');
+  fingers.hide();
+  fingers.loop();
+  img = loadImage('../../assets/UV_Grid_Sm.jpg');
+  //img2 = loadImage('../assets/cat.jpg');
+  shader(sh);
+  sh.setUniform('uSampler', fingers);
+  sh.setUniform('uSecondSampler', img);
+}
+
+function draw () {
+  sh.setUniform('uRed', map(mouseX, 0, width, 0.0, 1.0));
+  sh.setUniform('uGreen', map(mouseY, 0, height, 0.0, 1.0));
+
+  background(0);
+
+  var halfw = fingers.width / 2 * .5;
+  var halfh = fingers.height / 2 * .5;
+
+  for (var x = -width/2 + halfw;  x <= width/2 - halfw; x+= halfw * 2) {
+    for (var y = -height/2 + halfh;  y <= height/2 - halfh; y+= halfh * 2) {
+      push();
+      translate(x, y);
+      rotateZ(PI/6);
+      rotateY(frameCount * 0.01);
+      box(halfw, halfh);
+      pop();
+    }
+  }
+
+}

--- a/test/manual-test-examples/webgl/customShader/videoMultiTextureShader/vert.glsl
+++ b/test/manual-test-examples/webgl/customShader/videoMultiTextureShader/vert.glsl
@@ -1,0 +1,21 @@
+uniform mat4 uModelViewMatrix;
+uniform mat4 uProjectionMatrix;
+uniform mat3 uNormalMatrix;
+
+attribute vec3 aPosition;
+attribute vec3 aNormal;
+attribute vec4 aVertexColor;
+attribute vec2 aTexCoord;
+
+varying vec4 vertColor;
+varying vec2 vertTexCoord;
+varying vec3 vertNormal;
+
+void main() {
+  vec4 positionVec4 = vec4(aPosition, 1.0);
+  gl_Position = uProjectionMatrix * uModelViewMatrix * positionVec4;
+
+  vertNormal = vec3(uNormalMatrix * aNormal);
+  vertColor = aVertexColor;
+  vertTexCoord = aTexCoord;
+}

--- a/test/unit/webgl/p5.Shader.js
+++ b/test/unit/webgl/p5.Shader.js
@@ -45,14 +45,14 @@ suite('p5.Shader', function() {
   var testShader = function (shaderName, shader, expectedAttributes,
     expectedUniforms) {
 
-    var s = myp5._renderer.setShader(shader);
+    var s = myp5._renderer.shader(shader);
 
     assert(s !== null  &&  s === shader,
-      shaderName + ' was returned from p5.RendererGL.setShader');
+      shaderName + ' was returned from p5.RendererGL.shader');
 
     assert(myp5._renderer.curShader !== null &&
       myp5._renderer.curShader === shader,
-      shaderName + ' was not set as renderer\'s curShader in setShader');
+      shaderName + ' was not set as renderer\'s curShader in shader()');
 
     testAttributes(shaderName, s.attributes, expectedAttributes);
     testUniforms(shaderName, s.uniforms, expectedUniforms);


### PR DESCRIPTION
- loadShader implementation via preload
- shader must be called in setup or draw, once gl context is
  established (can't be called in preload).
- call shader before setting uniforms
- test multi-texturing, with video texture as one of them
- toon shader test
- updates lighting method to test shader type before
  switching to a new shader; allows lighting to be
  used with custom shader.
- adds a few methods to p5.Shader for checking the shader
  type (does it have lighting? textures? color?)
- optimizes shader code by avoiding complication of prototype
  chain with local variables within drawing related methods.

A few custom examples are provided in
test/manual-test-samples/customShader:
- toonShader, a classic toon shader applied to a sphere
- videoMultiTextureShader, a weird shader that combines
  two images (one from a p5.Image and another from a video)
  and changes aspects of the color with movement of the
  mouse.

There's still more to do, like:

- Linking to detailed tutorials about how to write one's own shader
  (which is beyond the scope of the inline docs).
- More robust tests for all of the possible built-in uniforms for
  all shaders.
- Allowing the user to only specify a fragment shader, using a default
  vertex shader (or: choosing an appropriate vertex shader based
  on the user's supplied fragment shader).
- Letting the user specify shader source inline in the code?
- Unit tests.