### PR TITLE
webgl: use right lefthand coordinate system; add more camera api.

### DIFF
--- a/src/webgl/camera.js
+++ b/src/webgl/camera.js
@@ -34,9 +34,113 @@ var p5 = require('../core/core');
  * blue square shrinks in size grows to fill canvas. disappears then loops.
  *
  */
-p5.prototype.camera = function(x, y, z){
-  //what it manipulates is the model view matrix
-  this._renderer.translate(-x, -y, -z);
+p5.prototype.camera = function(){
+  this._renderer.camera.apply(this._renderer, arguments);
+};
+
+p5.RendererGL.prototype.camera = function () {
+  var eyeX, eyeY, eyeZ;
+  var centerX, centerY, centerZ;
+  var upX, upY, upZ;
+  if (arguments.length === 0) {
+    eyeX = this.defaultCameraX;
+    eyeY = this.defaultCameraY;
+    eyeZ = this.defaultCameraZ;
+    centerX = eyeX;
+    centerY = eyeY;
+    centerZ = 0;
+    upX = 0;
+    upY = 1;
+    upZ = 0;
+  } else {
+    eyeX = arguments[0];
+    eyeY = arguments[1];
+    eyeZ = arguments[2];
+    centerX = arguments[3];
+    centerY = arguments[4];
+    centerZ = arguments[5];
+    upX = arguments[6];
+    upY = arguments[7];
+    upZ = arguments[8];
+  }
+
+  this.cameraX = eyeX;
+  this.cameraY = eyeY;
+  this.cameraZ = eyeZ;
+
+  // calculate camera Z vector
+  var z0 = eyeX - centerX;
+  var z1 = eyeY - centerY;
+  var z2 = eyeZ - centerZ;
+
+  this.eyeDist = Math.sqrt(z0 * z0 + z1 * z1 + z2 * z2);
+  if (this.eyeDist !== 0) {
+    z0 /= this.eyeDist;
+    z1 /= this.eyeDist;
+    z2 /= this.eyeDist;
+  }
+
+  // calculate camera Y vector
+  var y0 = upX;
+  var y1 = upY;
+  var y2 = upZ;
+
+  // computer x vector as y cross z
+  var x0 =  y1 * z2 - y2 * z1;
+  var x1 = -y0 * z2 + y2 * z0;
+  var x2 =  y0 * z1 - y1 * z0;
+
+  // recomputer y = z cross x
+  y0 =  z1 * x2 - z2 * x1;
+  y1 = -z0 * x2 + z2 * x0;
+  y2 =  z0 * x1 - z1 * x0;
+
+  // cross product gives area of parallelogram, which is < 1.0 for
+  // non-perpendicular unit-length vectors; so normalize x, y here:
+  var xmag = Math.sqrt (x0 * x0 + x1 * x1 + x2 * x2);
+  if (xmag !== 0) {
+    x0 /= xmag;
+    x1 /= xmag;
+    x2 /= xmag;
+  }
+
+  var ymag = Math.sqrt (y0 * y0 + y1 * y1 + y2 * y2);
+  if (ymag !== 0) {
+    y0 /= ymag;
+    y1 /= ymag;
+    y2 /= ymag;
+  }
+
+  // the camera affects the model view matrix, insofar as it
+  // inverse translates the world to the eye position of the camera
+  // and rotates it.
+  this.cameraMatrix.set(x0, y0, z0, 0,
+                        x1, y1, z1, 0,
+                        x2, y2, z2, 0,
+                         0,  0,  0, 1);
+
+  var tx = -eyeX;
+  var ty = -eyeY;
+  var tz = -eyeZ;
+
+  this.cameraMatrix.translate([tx, ty, tz]);
+  this.uMVMatrix.set(this.cameraMatrix.mat4[0],
+                     this.cameraMatrix.mat4[1],
+                     this.cameraMatrix.mat4[2],
+                     this.cameraMatrix.mat4[3],
+                     this.cameraMatrix.mat4[4],
+                     this.cameraMatrix.mat4[5],
+                     this.cameraMatrix.mat4[6],
+                     this.cameraMatrix.mat4[7],
+                     this.cameraMatrix.mat4[8],
+                     this.cameraMatrix.mat4[9],
+                     this.cameraMatrix.mat4[10],
+                     this.cameraMatrix.mat4[11],
+                     this.cameraMatrix.mat4[12],
+                     this.cameraMatrix.mat4[13],
+                     this.cameraMatrix.mat4[14],
+                     this.cameraMatrix.mat4[15]
+                     );
 };
 
 /**
@@ -78,14 +182,33 @@ p5.prototype.camera = function(x, y, z){
  * colored 3d boxes toggleable with mouse position
  *
  */
-p5.prototype.perspective = function(fovy,aspect,near,far) {
-  fovy = fovy || (60 / 180 * this.PI);
-  aspect = aspect || (this.width/this.height);
-  near = near || ((this.height/2.0) / this.tan(fovy/2.0) * 0.1);
-  far = far || ((this.height/2.0) / this.tan(fovy/2.0) * 10);
-  this._renderer.uPMatrix = p5.Matrix.identity();
-  this._renderer.uPMatrix.perspective(fovy,aspect,near,far);
-  this._renderer._curCamera = 'custom';
+p5.prototype.perspective = function() {
+  this._renderer.perspective.apply(this._renderer, arguments);
+};
+
+p5.RendererGL.prototype.perspective = function() {
+  var fovy = arguments[0] || this.defaultCameraFOV;
+  var aspect = arguments[1] || this.defaultCameraAspect;
+  var near = arguments[2] || this.defaultCameraNear;
+  var far = arguments[3] || this.defaultCameraFar;
+
+  this.cameraFOV = fovy;
+  this.cameraAspect = aspect;
+  this.cameraNear = near;
+  this.cameraFar = far;
+
+  this.uPMatrix = p5.Matrix.identity();
+
+  var f = 1.0 / Math.tan(this.cameraFOV / 2);
+  var nf = 1.0 / (this.cameraNear - this.cameraFar);
+
+  this.uPMatrix.set(
+         f / aspect,  0,                     0,  0,
+                  0, -f,                     0,  0,
+                  0,  0,     (far + near) * nf, -1,
+                  0,  0, (2 * far * near) * nf,  0);
+
+  this._curCamera = 'custom';
 };
 
 /**
@@ -134,7 +257,26 @@ p5.prototype.ortho = function(left,right,bottom,top,near,far) {
   near = near || 0;
   far = far || Math.max(this.width, this.height);
   this._renderer.uPMatrix = p5.Matrix.identity();
-  this._renderer.uPMatrix.ortho(left,right,bottom,top,near,far);
+  //this._renderer.uPMatrix.ortho(left,right,bottom,top,near,far);
+
+  var w = right - left;
+  var h = top - bottom;
+  var d = far - near;
+
+  var x =  2.0 / w;
+  var y =  2.0 / h;
+  var z = -2.0 / d;
+
+  var tx = -(right + left) / w;
+  var ty = -(top + bottom) / h;
+  var tz = -(far + near)   / d;
+
+  // The minus sign is needed to invert the Y axis.
+  this._renderer.uPMatrix.set( x,  0,  0, 0,
+                               0, -y,  0, 0,
+                               0,  0,  z, 0,
+                              tx, ty, tz,  1);
+
   this._renderer._curCamera = 'custom';
 };
 

--- a/src/webgl/camera.js
+++ b/src/webgl/camera.js
@@ -10,12 +10,24 @@
 var p5 = require('../core/core');
 
 /**
- * Sets camera position
+ * Sets camera position for a 3D sketch. The function behaves similarly
+ * gluLookAt, except that it replaces the existing modelview matrix instead
+ * of applying any transformations calculated here on top of the existing
+ * model view.
+ * When called with no arguments, this function
+ * sets a default camera equivalent to calling
+ * camera(0, 0, (height/2.0) / tan(PI*30.0 / 180.0), 0, 0, 0, 0, 1, 0);
  * @method camera
- * @param  {Number} x  camera position value on x axis
- * @param  {Number} y  camera position value on y axis
- * @param  {Number} z  camera position value on z axis
- * @return {p5}        the p5 object
+ * @param  {Number} [x]        camera position value on x axis
+ * @param  {Number} [y]        camera position value on y axis
+ * @param  {Number} [z]        camera position value on z axis
+ * @param  {Number} [centerX]  x coordinate representing center of the sketch
+ * @param  {Number} [centerY]  y coordinate representing center of the sketch
+ * @param  {Number} [centerZ]  z coordinate representing center of the sketch
+ * @param  {Number} [upX]      x component of direction 'up' from camera
+ * @param  {Number} [upY]      y component of direction 'up' from camera
+ * @param  {Number} [upZ]      z component of direction 'up' from camera
+ * @return {p5}                the p5 object
  * @example
  * <div>
  * <code>
@@ -24,7 +36,7 @@ var p5 = require('../core/core');
  * }
  * function draw(){
  *  //move the camera away from the plane by a sin wave
- *  camera(0, 0, sin(frameCount * 0.01) * 100);
+ *  camera(0, 0, sin(frameCount * 0.01) * 100, 0, 0, 0, 0, 1, 0);
  *  plane(120, 120);
  * }
  * </code>
@@ -36,6 +48,7 @@ var p5 = require('../core/core');
  */
 p5.prototype.camera = function(){
   this._renderer.camera.apply(this._renderer, arguments);
+  return this;
 };
 
 p5.RendererGL.prototype.camera = function () {
@@ -141,17 +154,21 @@ p5.RendererGL.prototype.camera = function () {
                      this.cameraMatrix.mat4[14],
                      this.cameraMatrix.mat4[15]
                      );
+  return this;
 };
 
 /**
- * Sets perspective camera
+ * Sets perspective camera. When called with no arguments, the defaults
+ * provided are equivalent to
+ * perspective(PI/3.0, width/height, cameraZ/10.0, cameraZ*10.0)
+ * where cameraZ is ((height/2.0) / tan(PI*60.0/360.0));
  * @method  perspective
- * @param  {Number} fovy   camera frustum vertical field of view,
- *                         from bottom to top of view, in degrees
- * @param  {Number} aspect camera frustum aspect ratio
- * @param  {Number} near   frustum near plane length
- * @param  {Number} far    frustum far plane length
- * @return {p5}            the p5 object
+ * @param  {Number} [fovy]   camera frustum vertical field of view,
+ *                           from bottom to top of view, in degrees
+ * @param  {Number} [aspect] camera frustum aspect ratio
+ * @param  {Number} [near]   frustum near plane length
+ * @param  {Number} [far]    frustum far plane length
+ * @return {p5}              the p5 object
  * @example
  * <div>
  * <code>
@@ -184,6 +201,7 @@ p5.RendererGL.prototype.camera = function () {
  */
 p5.prototype.perspective = function() {
   this._renderer.perspective.apply(this._renderer, arguments);
+  return this;
 };
 
 p5.RendererGL.prototype.perspective = function() {

--- a/src/webgl/p5.Matrix.js
+++ b/src/webgl/p5.Matrix.js
@@ -82,10 +82,26 @@ p5.Matrix.prototype.set = function (inMatrix) {
   if (inMatrix instanceof p5.Matrix) {
     this.mat4 = inMatrix.mat4;
     return this;
-  }
-  else if (inMatrix instanceof GLMAT_ARRAY_TYPE) {
+  } else if (inMatrix instanceof GLMAT_ARRAY_TYPE) {
     this.mat4 = inMatrix;
     return this;
+  } else if (arguments.length === 16) {
+    this.mat4[0] = arguments[0];
+    this.mat4[1] = arguments[1];
+    this.mat4[2] = arguments[2];
+    this.mat4[3] = arguments[3];
+    this.mat4[4] = arguments[4];
+    this.mat4[5] = arguments[5];
+    this.mat4[6] = arguments[6];
+    this.mat4[7] = arguments[7];
+    this.mat4[8] = arguments[8];
+    this.mat4[9] = arguments[9];
+    this.mat4[10] = arguments[10];
+    this.mat4[11] = arguments[11];
+    this.mat4[12] = arguments[12];
+    this.mat4[13] = arguments[13];
+    this.mat4[14] = arguments[14];
+    this.mat4[15] = arguments[15];
   }
   return this;
 };
@@ -570,14 +586,14 @@ p5.Matrix.prototype.translate = function(v){
   var x = v[0],
     y = v[1],
     z = v[2] || 0;
-  this.mat4[12] =
-    this.mat4[0] * x +this.mat4[4] * y +this.mat4[8] * z +this.mat4[12];
-  this.mat4[13] =
-    this.mat4[1] * x +this.mat4[5] * y +this.mat4[9] * z +this.mat4[13];
-  this.mat4[14] =
-    this.mat4[2] * x +this.mat4[6] * y +this.mat4[10] * z +this.mat4[14];
-  this.mat4[15] =
-    this.mat4[3] * x +this.mat4[7] * y +this.mat4[11] * z +this.mat4[15];
+  this.mat4[12] +=
+    this.mat4[0] * x +this.mat4[4] * y +this.mat4[8] * z;
+  this.mat4[13] +=
+    this.mat4[1] * x +this.mat4[5] * y +this.mat4[9] * z;
+  this.mat4[14] +=
+    this.mat4[2] * x +this.mat4[6] * y +this.mat4[10] * z;
+  this.mat4[15] +=
+    this.mat4[3] * x +this.mat4[7] * y +this.mat4[11] * z;
 };
 
 p5.Matrix.prototype.rotateX = function(a){

--- a/src/webgl/p5.Matrix.js
+++ b/src/webgl/p5.Matrix.js
@@ -77,6 +77,8 @@ p5.Matrix = function() {
  *
  * @param {p5.Matrix|Array} [inMatrix] the input p5.Matrix or
  *                                     an Array of length 16
+ * @param {Number}          [n00..n33] 16 numbers passed by value to avoid
+ *                                     array copying.
  */
 p5.Matrix.prototype.set = function (inMatrix) {
   if (inMatrix instanceof p5.Matrix) {

--- a/src/webgl/p5.RendererGL.js
+++ b/src/webgl/p5.RendererGL.js
@@ -7,6 +7,7 @@ require('./p5.Matrix');
 var fs = require('fs');
 
 var uMVMatrixStack = [];
+var cameraMatrixStack = [];
 
 var defaultShaders = {
   immediateVert:
@@ -55,12 +56,11 @@ p5.RendererGL = function(elt, pInst, isMainCanvas, attr) {
   this._initContext();
   this.isP3D = true; //lets us know we're in 3d mode
   this.GL = this.drawingContext;
-  //lights
+  // lights
   this.ambientLightCount = 0;
   this.directionalLightCount = 0;
   this.pointLightCount = 0;
-  //camera
-  this._curCamera = null;
+
   /**
    * model view, projection, & normal
    * matrices
@@ -68,9 +68,25 @@ p5.RendererGL = function(elt, pInst, isMainCanvas, attr) {
   this.uMVMatrix = new p5.Matrix();
   this.uPMatrix  = new p5.Matrix();
   this.uNMatrix = new p5.Matrix('mat3');
-  //Geometry & Material hashes
+
+  // Camera
+  this._curCamera = null;
+  // default camera settings, then use those to populate camera fields.
+  this._computeCameraDefaultSettings();
+  this.cameraFOV = this.defaultCameraFOV;
+  this.cameraAspect = this.defaultAspect;
+  this.cameraX = this.defaultCameraX;
+  this.cameraY = this.defaultCameraY;
+  this.cameraZ = this.defaultCameraZ;
+  this.cameraNear = this.defaultCameraNear;
+  this.cameraFar = this.defaultCameraFar;
+  this.cameraMatrix = new p5.Matrix();
+  this.camera(); // set default camera matrices
+
+  // Geometry Hash
   this.gHash = {};
 
+  // Shader
   this.curShader = null;
 
   this._defaultLightShader = undefined;
@@ -244,23 +260,59 @@ p5.prototype.setAttributes = function() {
   this._renderer._resetContext(attr);
 };
 
+p5.RendererGL.prototype._computeCameraDefaultSettings = function () {
+  this.defaultCameraFOV = 60 / 180 * Math.PI;
+  this.defaultCameraAspect = this.width / this.height;
+  this.defaultCameraX = 0;
+  this.defaultCameraY = 0;
+  this.defaultCameraZ =
+    (this.height / 2.0) / Math.tan(this.defaultCameraFOV / 2.0);
+  this.defaultCameraNear = this.defaultCameraZ * 0.1;
+  this.defaultCameraFar = this.defaultCameraZ * 10;
+};
+
 //detect if user didn't set the camera
 //then call this function below
 p5.RendererGL.prototype._setDefaultCamera = function(){
   if(this._curCamera === null){
-    var _w = this.width;
-    var _h = this.height;
-    this.uPMatrix = p5.Matrix.identity();
-    var cameraZ = (this.height / 2) / Math.tan(Math.PI * 30 / 180);
-    this.uPMatrix.perspective(60 / 180 * Math.PI, _w / _h,
-                              cameraZ * 0.1, cameraZ * 10);
+
+    this._computeCameraDefaultSettings();
+    this.cameraFOV = this.defaultCameraFOV;
+    this.cameraAspect = this.defaultAspect;
+    this.cameraX = this.defaultCameraX;
+    this.cameraY = this.defaultCameraY;
+    this.cameraZ = this.defaultCameraZ;
+    this.cameraNear = this.defaultCameraNear;
+    this.cameraFar = this.defaultCameraFar;
+
+    this.perspective();
+    this.camera();
     this._curCamera = 'default';
   }
 };
 
 p5.RendererGL.prototype._update = function() {
-  this.uMVMatrix = p5.Matrix.identity();
-  this.translate(0, 0, -(this.height / 2) / Math.tan(Math.PI * 30 / 180));
+  // reset model view and apply initial camera transform
+  // (containing only look at info; no projection).
+  this.uMVMatrix.set(this.cameraMatrix.mat4[0],
+                     this.cameraMatrix.mat4[1],
+                     this.cameraMatrix.mat4[2],
+                     this.cameraMatrix.mat4[3],
+                     this.cameraMatrix.mat4[4],
+                     this.cameraMatrix.mat4[5],
+                     this.cameraMatrix.mat4[6],
+                     this.cameraMatrix.mat4[7],
+                     this.cameraMatrix.mat4[8],
+                     this.cameraMatrix.mat4[9],
+                     this.cameraMatrix.mat4[10],
+                     this.cameraMatrix.mat4[11],
+                     this.cameraMatrix.mat4[12],
+                     this.cameraMatrix.mat4[13],
+                     this.cameraMatrix.mat4[14],
+                     this.cameraMatrix.mat4[15]
+                     );
+
+  // reset light counters for new frame.
   this.ambientLightCount = 0;
   this.directionalLightCount = 0;
   this.pointLightCount = 0;
@@ -463,8 +515,10 @@ p5.RendererGL.prototype.resize = function(w,h) {
   p5.Renderer.prototype.resize.call(this, w, h);
   gl.viewport(0, 0, gl.drawingBufferWidth, gl.drawingBufferHeight);
   // If we're using the default camera, update the aspect ratio
-  if(this._curCamera === 'default') {
+  if(this._curCamera === null || this._curCamera === 'default') {
     this._curCamera = null;
+    // camera defaults are dependent on the width & height of the screen,
+    // so we'll want to update them if the size of the screen changes.
     this._setDefaultCamera();
   }
 };
@@ -500,7 +554,7 @@ p5.RendererGL.prototype.translate = function(x, y, z) {
     y = x.y;
     x = x.x;
   }
-  this.uMVMatrix.translate([x,-y,z]);
+  this.uMVMatrix.translate([x,y,z]);
   return this;
 };
 
@@ -542,6 +596,7 @@ p5.RendererGL.prototype.rotateZ = function(rad) {
  */
 p5.RendererGL.prototype.push = function() {
   uMVMatrixStack.push(this.uMVMatrix.copy());
+  cameraMatrixStack.push(this.cameraMatrix.copy());
 };
 
 /**
@@ -553,11 +608,14 @@ p5.RendererGL.prototype.pop = function() {
     throw new Error('Invalid popMatrix!');
   }
   this.uMVMatrix = uMVMatrixStack.pop();
+  if (cameraMatrixStack.length === 0) {
+    throw new Error('Invalid popMatrix!');
+  }
+  this.cameraMatrix = cameraMatrixStack.pop();
 };
 
 p5.RendererGL.prototype.resetMatrix = function() {
   this.uMVMatrix = p5.Matrix.identity();
-  this.translate(0, 0, -800);
   return this;
 };
 

--- a/src/webgl/p5.Texture.js
+++ b/src/webgl/p5.Texture.js
@@ -75,7 +75,7 @@ p5.Texture.prototype.init = function(data) {
   this.glTex = gl.createTexture();
   this.bindTexture();
 
-  gl.pixelStorei(gl.UNPACK_FLIP_Y_WEBGL, true);
+  //gl.pixelStorei(gl.UNPACK_FLIP_Y_WEBGL, true);
   gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MAG_FILTER, this.glMagFilter);
   gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MIN_FILTER, this.glMinFilter);
   gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_WRAP_S, this.glWrapS);

--- a/src/webgl/shaders/immediate.vert
+++ b/src/webgl/shaders/immediate.vert
@@ -8,7 +8,7 @@ uniform float uPointSize;
 
 varying vec4 vColor;
 void main(void) {
-  vec4 positionVec4 = vec4(aPosition * vec3(1.0, -1.0, 1.0), 1.0);
+  vec4 positionVec4 = vec4(aPosition, 1.0);
   gl_Position = uProjectionMatrix * uModelViewMatrix * positionVec4;
   vColor = aVertexColor;
   gl_PointSize = uPointSize;

--- a/src/webgl/shaders/normal.vert
+++ b/src/webgl/shaders/normal.vert
@@ -10,7 +10,7 @@ varying vec3 vVertexNormal;
 varying highp vec2 vVertTexCoord;
 
 void main(void) {
-  vec4 positionVec4 = vec4(aPosition * vec3(1.0, -1.0, 1.0), 1.0);
+  vec4 positionVec4 = vec4(aPosition, 1.0);
   gl_Position = uProjectionMatrix * uModelViewMatrix * positionVec4;
   vVertexNormal = vec3( uNormalMatrix * aNormal );
   vVertTexCoord = aTexCoord;

--- a/src/webgl/shaders/vertexColor.vert
+++ b/src/webgl/shaders/vertexColor.vert
@@ -7,7 +7,7 @@ uniform mat4 uProjectionMatrix;
 varying vec4 vColor;
 
 void main(void) {
-  vec4 positionVec4 = vec4(aPosition * vec3(1.0, -1.0, 1.0), 1.0);
+  vec4 positionVec4 = vec4(aPosition, 1.0);
   gl_Position = uProjectionMatrix * uModelViewMatrix * positionVec4;
   vColor = aVertexColor;
 }

--- a/test/manual-test-examples/webgl/camera/box/index.html
+++ b/test/manual-test-examples/webgl/camera/box/index.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8">
+  <meta http-equiv="X-UA-Compatible" content="IE=edge">
+  <title></title>
+  <link rel="stylesheet" href="">
+  <script language="javascript" type="text/javascript" src="../../../../../lib/p5.js"></script>
+  <script language="javascript" type="text/javascript" src="sketch.js"></script>
+  <style>
+    html, body {margin:0; padding:0;}
+  </style> 
+</head>
+<body>
+<p style="position: absolute; width:300px; left:50%; margin-left: -150px; color:white; text-align: center;">Perspective camera</p>
+<script>
+(function(){var script=document.createElement('script');script.onload=function(){var stats=new Stats();stats.domElement.style.cssText='position:fixed;left:0;top:0;z-index:10000';document.body.appendChild(stats.domElement);requestAnimationFrame(function loop(){stats.update();requestAnimationFrame(loop)});};script.src='http://rawgit.com/mrdoob/stats.js/master/build/stats.min.js';document.head.appendChild(script);})()
+</script>
+  
+</body>
+</html>

--- a/test/manual-test-examples/webgl/camera/box/sketch.js
+++ b/test/manual-test-examples/webgl/camera/box/sketch.js
@@ -1,0 +1,35 @@
+function setup(){
+  createCanvas(windowWidth, windowHeight, WEBGL);
+}
+
+function draw(){
+  background(0);
+
+  normalMaterial();
+  var tx = map(mouseX, 0, width, -width/2, width/2);
+  var ty = map(mouseY, 0, height, -height/2, height/2);
+
+  push();
+  translate(tx, ty);
+  noStroke();
+  cone(90);
+  pop();
+
+  fill(255);
+  rect(0, 0, width/4, height/4);
+  fill(0, 255, 0);
+  ellipse(width/4, height/4, width/4, height/4);
+
+  push();
+  translate(width/4, height/4);
+  fill(0, 0, 255);
+  ellipse(0, 0, width/4, height/4);
+  pop();
+
+  fill(255, 0, 0);
+  beginShape();
+  vertex(0, 0);
+  vertex(0, height/4);
+  vertex(-width/4, 0);
+  endShape(CLOSE);
+}


### PR DESCRIPTION
this should fix issue #1696 with coordinate system rotation.

CAMERA:
can now supply a eye coord, center coord, and up vector.

COORDINATE SYSTEM:
when applying the perspective and orthographic transformations for
the camera, we now negate the y-component of the projection transform
in webgl mode. this results in a left-handed coordinate system through
and through: whereas before, the y-coordinates for positions were
inverted in the vertex shaders and in translate(). the result was
something that behaved like 2d-mode in mapping the positive y-direction
downward, but handled rotation differently. now everything should
match up and more closely match behavior from Processing, too.

so with that, changes include:
- update default vertex shader .glsl files to not negate y-coordinate
- implement custom perspective and orthographic handling of camera
  outside of the matrix class, so as to apply our little y-coordinate
  trick in the same way Processing does.
- implement a camera matrix that includes the lookAt information,
  which is persistent between frames. that matrix is then the
  first thing applied to the modelview matrix in subsequent frames;
  it will clobber any existing things in the modelview matrix if
  called by a user mid-draw.

there is more documentation and clean-up to do here, but I want to
get this in so that Stalgia can use it!