### PR TITLE
Fix angleBetween for parallel and antiparallel vectors

### DIFF
--- a/src/math/p5.Vector.js
+++ b/src/math/p5.Vector.js
@@ -636,7 +636,13 @@ p5.Vector.prototype.rotate = function (a) {
  * </div>
  */
 p5.Vector.prototype.angleBetween = function (v) {
-  var angle = Math.acos(this.dot(v) / (this.mag() * v.mag()));
+  var dotmagmag = this.dot(v) / (this.mag() * v.mag());
+  // Mathematically speaking: the dotmagmag variable will be between -1 and 1
+  // inclusive. Practically though it could be slightly outside this range due
+  // to floating-point rounding issues. This can make Math.acos return NaN.
+  //
+  // Solution: we'll clamp the value to the -1,1 range
+  var angle = Math.acos(Math.min(1, Math.max(-1, dotmagmag)));
   if (this.p5) {
     if (this.p5._angleMode === constants.DEGREES) {
       angle = polarGeometry.radiansToDegrees(angle);

--- a/test/unit/math/p5.Vector.js
+++ b/test/unit/math/p5.Vector.js
@@ -114,6 +114,35 @@ suite('p5.Vector', function() {
       assert.closeTo(v.z, 0, 0.001);
     });
   });
+
+  suite('p5.prototype.angleBetween()', function() {
+    test('should not trip on rounding issues in 2D space', function() {
+      var v1 = myp5.createVector(-11, -20);
+      var v2 = myp5.createVector(-5.5, -10);
+      expect(v1.angleBetween(v2)).to.be.closeTo(0, 0.00001);
+
+      var v3 = myp5.createVector(-11, -20);
+      var v4 = myp5.createVector(5.5, 10);
+      expect(v3.angleBetween(v4)).to.be.closeTo(180, 0.00001);
+    });
+
+    test('should not trip on rounding issues in 3D space', function() {
+      var v1 = myp5.createVector(1, 1.1, 1.2);
+      var v2 = myp5.createVector(2, 2.2, 2.4);
+
+      var angle = v1.angleBetween(v2);
+      expect(angle).to.be.closeTo(0, 0.00001);
+    });
+
+    test('should return NaN for zero vector', function() {
+      var v1 = myp5.createVector(0, 0, 0);
+      var v2 = myp5.createVector(2, 3, 4);
+
+      expect(v1.angleBetween(v2)).to.be.NaN; // jshint ignore:line
+      expect(v2.angleBetween(v1)).to.be.NaN; // jshint ignore:line
+    });
+
+  });
 });
 
 //  describe('set()', function() {


### PR DESCRIPTION
Due to floating-point rounding issues `angleBetween` for parallel and antiparallel vectors sometimes returned NaN. Fixes #2135. If you want any changes before merging please let me know.

The `angleBetween` of a zero-vector still returns `NaN`, I've added a testcase for this. 

Something for a different PR, but I noticed the file `test/unit/math/p5.Vector.js` contains a lot of disabled testcases, written for Jasmine? I can take a look into making them functional again.

---

`npm test` fails but that seems unrelated to my work, `master` fails as well:
* always with "test: Files httpDo() should work when provided with just a path"
* randomly with "test-minified "Core new p5() / global mode is triggered when "draw" is in window"
* randomly with "test-minified: Files p5.prototype.loadTable using the csv option works"
* randomly with "test-minified: loading images should draw cropped image"

They don't provide any error messages, so I'm not sure if it's because of the cheap VM I'm working on.