### PR TITLE
color: red, green, blue, and alpha setters

### DIFF
--- a/src/color/p5.Color.js
+++ b/src/color/p5.Color.js
@@ -31,8 +31,7 @@ var color_conversion = require('./color_conversion');
 p5.Color = function(renderer, vals) {
 
   // Record color mode and maxes at time of construction.
-  this.mode = renderer._colorMode;
-  this.maxes = renderer._colorMaxes;
+  this._storeModeAndMaxes(renderer._colorMode, renderer._colorMaxes);
 
   // Calculate normalized RGBA values.
   if (this.mode !== constants.RGB &&
@@ -40,7 +39,7 @@ p5.Color = function(renderer, vals) {
       this.mode !== constants.HSB) {
     throw new Error(this.mode + ' is an invalid colorMode.');
   } else {
-    this._array = p5.Color._parseInputs.apply(renderer, vals);
+    this._array = p5.Color._parseInputs.apply(this, vals);
   }
 
   // Expose closest screen color.
@@ -61,7 +60,7 @@ p5.Color.prototype._getAlpha = function() {
 
 p5.Color.prototype.alpha = function(new_alpha) {
   this._array = p5.Color._parseInputs.apply(
-    {_colorMode: this.mode, _colorMaxes: this.maxes},
+    this,
     [this.levels[0],
     this.levels[1],
     this.levels[2],
@@ -74,6 +73,19 @@ p5.Color.prototype._calculateLevels = function() {
   this.levels = this._array.map(function(level) {
     return Math.round(level * 255);
   });
+};
+
+p5.Color.prototype._storeModeAndMaxes = function(new_mode, new_maxes) {
+  this.mode = new_mode;
+  this.maxes = new_maxes;
+};
+
+p5.Color.prototype._getMode = function() {
+  return this.mode;
+};
+
+p5.Color.prototype._getMaxes = function() {
+  return this.maxes;
 };
 
 p5.Color.prototype._getBlue = function() {
@@ -450,8 +462,8 @@ var colorPatterns = {
  */
 p5.Color._parseInputs = function() {
   var numArgs = arguments.length;
-  var mode = this._colorMode;
-  var maxes = this._colorMaxes;
+  var mode = this._getMode();
+  var maxes = this._getMaxes();
   var results = [];
 
   if (numArgs >= 3) {  // Argument is a list of component values.

--- a/src/color/p5.Color.js
+++ b/src/color/p5.Color.js
@@ -69,12 +69,15 @@ p5.Color.prototype.alpha = function(new_alpha) {
   this._calculateLevels();
 };
 
+// calculates and stores the closest screen levels
 p5.Color.prototype._calculateLevels = function() {
   this.levels = this._array.map(function(level) {
     return Math.round(level * 255);
   });
 };
 
+// stores the color mode and maxes in this instance of Color
+// for later use (by _parseInputs())
 p5.Color.prototype._storeModeAndMaxes = function(new_mode, new_maxes) {
   this.mode = new_mode;
   this.maxes = new_maxes;

--- a/src/color/p5.Color.js
+++ b/src/color/p5.Color.js
@@ -54,6 +54,21 @@ p5.Color.prototype.toString = function() {
   return 'rgba('+a[0]+','+a[1]+','+a[2]+','+ alpha +')';
 };
 
+p5.Color.prototype.setRed = function(new_red) {
+  this._array[0] = new_red / this.maxes[constants.RGB][0];
+  this._calculateLevels();
+};
+
+p5.Color.prototype.setGreen = function(new_green) {
+  this._array[1] = new_green / this.maxes[constants.RGB][1];
+  this._calculateLevels();
+};
+
+p5.Color.prototype.setBlue = function(new_blue) {
+  this._array[2] = new_blue / this.maxes[constants.RGB][2];
+  this._calculateLevels();
+};
+
 p5.Color.prototype.setAlpha = function(new_alpha) {
   this._array[3] = new_alpha / this.maxes[this.mode][3];
   this._calculateLevels();

--- a/src/color/p5.Color.js
+++ b/src/color/p5.Color.js
@@ -459,8 +459,8 @@ var colorPatterns = {
  */
 p5.Color._parseInputs = function() {
   var numArgs = arguments.length;
-  var mode = this._getMode();
-  var maxes = this._getMaxes();
+  var mode = this.mode;
+  var maxes = this.maxes;
   var results = [];
 
   if (numArgs >= 3) {  // Argument is a list of component values.

--- a/src/color/p5.Color.js
+++ b/src/color/p5.Color.js
@@ -59,13 +59,7 @@ p5.Color.prototype._getAlpha = function() {
 };
 
 p5.Color.prototype.setAlpha = function(new_alpha) {
-  this._array = p5.Color._parseInputs.apply(
-    this,
-    [this.levels[0],
-    this.levels[1],
-    this.levels[2],
-    new_alpha]
-  );
+  this._array[3] = new_alpha / this.maxes[this.mode][3];
   this._calculateLevels();
 };
 

--- a/src/color/p5.Color.js
+++ b/src/color/p5.Color.js
@@ -58,7 +58,7 @@ p5.Color.prototype._getAlpha = function() {
   return this._array[3] * this.maxes[this.mode][3];
 };
 
-p5.Color.prototype.alpha = function(new_alpha) {
+p5.Color.prototype.setAlpha = function(new_alpha) {
   this._array = p5.Color._parseInputs.apply(
     this,
     [this.levels[0],

--- a/src/color/p5.Color.js
+++ b/src/color/p5.Color.js
@@ -61,6 +61,16 @@ p5.Color.prototype._getAlpha = function() {
   return this._array[3] * this.maxes[this.mode][3];
 };
 
+p5.Color.prototype.alpha = function(new_alpha) {
+  console.log(new_alpha);
+  this._array = p5.Color._parseInputs(
+    this.levels[0],
+    this.levels[1],
+    this.levels[2],
+    new_alpha
+  );
+};
+
 p5.Color.prototype._getBlue = function() {
   return this._array[2] * this.maxes[constants.RGB][2];
 };

--- a/src/color/p5.Color.js
+++ b/src/color/p5.Color.js
@@ -54,10 +54,6 @@ p5.Color.prototype.toString = function() {
   return 'rgba('+a[0]+','+a[1]+','+a[2]+','+ alpha +')';
 };
 
-p5.Color.prototype._getAlpha = function() {
-  return this._array[3] * this.maxes[this.mode][3];
-};
-
 p5.Color.prototype.setAlpha = function(new_alpha) {
   this._array[3] = new_alpha / this.maxes[this.mode][3];
   this._calculateLevels();
@@ -68,6 +64,10 @@ p5.Color.prototype._calculateLevels = function() {
   this.levels = this._array.map(function(level) {
     return Math.round(level * 255);
   });
+};
+
+p5.Color.prototype._getAlpha = function() {
+  return this._array[3] * this.maxes[this.mode][3];
 };
 
 // stores the color mode and maxes in this instance of Color

--- a/src/color/p5.Color.js
+++ b/src/color/p5.Color.js
@@ -44,9 +44,7 @@ p5.Color = function(renderer, vals) {
   }
 
   // Expose closest screen color.
-  this.levels = this._array.map(function(level) {
-    return Math.round(level * 255);
-  });
+  this._calculateLevels();
   this.name = 'p5.Color';   // for friendly debugger system
   return this;
 };
@@ -69,6 +67,10 @@ p5.Color.prototype.alpha = function(new_alpha) {
     this.levels[2],
     new_alpha]
   );
+  this._calculateLevels();
+};
+
+p5.Color.prototype._calculateLevels = function() {
   this.levels = this._array.map(function(level) {
     return Math.round(level * 255);
   });

--- a/src/color/p5.Color.js
+++ b/src/color/p5.Color.js
@@ -62,13 +62,16 @@ p5.Color.prototype._getAlpha = function() {
 };
 
 p5.Color.prototype.alpha = function(new_alpha) {
-  console.log(new_alpha);
-  this._array = p5.Color._parseInputs(
-    this.levels[0],
+  this._array = p5.Color._parseInputs.apply(
+    {_colorMode: this.mode, _colorMaxes: this.maxes},
+    [this.levels[0],
     this.levels[1],
     this.levels[2],
-    new_alpha
+    new_alpha]
   );
+  this.levels = this._array.map(function(level) {
+    return Math.round(level * 255);
+  });
 };
 
 p5.Color.prototype._getBlue = function() {

--- a/src/color/p5.Color.js
+++ b/src/color/p5.Color.js
@@ -12,10 +12,10 @@ var constants = require('../core/constants');
 var color_conversion = require('./color_conversion');
 
 /**
- * We define colors to be immutable objects. Each color stores the color mode
- * and level maxes that applied at the time of its construction. These are
- * used to interpret the input arguments and to format the output e.g. when
- * saturation() is requested.
+ * Each color stores the color mode and level maxes that applied at the
+ * time of its construction. These are used to interpret the input arguments
+ * (at construction and later for that instance of color) and to format the
+ * output e.g. when saturation() is requested.
  *
  * Internally we store an array representing the ideal RGBA values in floating
  * point form, normalized from 0 to 1. From this we calculate the closest

--- a/test/unit/color/p5.Color.js
+++ b/test/unit/color/p5.Color.js
@@ -13,7 +13,7 @@ suite('p5.Color', function() {
 
     test('can be modified with alpha setter', function() {
       assert.deepEqual(c.levels, [255, 0, 102, 204]);
-      c.alpha(98);
+      c.setAlpha(98);
       assert.deepEqual(c.levels, [255, 0, 102, 98]);
     });
   });

--- a/test/unit/color/p5.Color.js
+++ b/test/unit/color/p5.Color.js
@@ -506,9 +506,20 @@ suite('p5.Color', function() {
     });
 
     test('can be modified with alpha setter', function() {
-      assert.deepEqual(c.levels, [255, 0, 102, 204]);
-      c.setAlpha(98);
-      assert.deepEqual(c.levels, [255, 0, 102, 98]);
+      var cc = myp5.color(255, 0, 102, 204);
+      assert.deepEqual(cc.levels, [255, 0, 102, 204]);
+      cc.setAlpha(98);
+      assert.deepEqual(cc.levels, [255, 0, 102, 98]);
+    });
+    test('can be modified with rgb setters', function() {
+      var cc = myp5.color(255, 0, 102, 204);
+      assert.deepEqual(cc.levels, [255, 0, 102, 204]);
+      cc.setRed(98);
+      assert.deepEqual(cc.levels, [98, 0, 102, 204]);
+      cc.setGreen(44);
+      assert.deepEqual(cc.levels, [98, 44, 102, 204]);
+      cc.setBlue(244);
+      assert.deepEqual(cc.levels, [98, 44, 244, 204]);
     });
   });
 
@@ -555,8 +566,19 @@ suite('p5.Color', function() {
       assert.deepEqual(c.levels, [255, 0, 102, 255]);
     });
     test('can be modified with alpha setter', function() {
-      c.setAlpha(0.73);
-      assert.deepEqual(c.levels, [255, 0, 102, 186]);
+      var cc = myp5.color(336, 100, 50);
+      cc.setAlpha(0.73);
+      assert.deepEqual(cc.levels, [255, 0, 102, 186]);
+    });
+    test('can be modified with rgb setters', function() {
+      var cc = myp5.color(336, 100, 50);
+      assert.deepEqual(cc.levels, [255, 0, 102, 255]);
+      cc.setRed(98);
+      assert.deepEqual(cc.levels, [98, 0, 102, 255]);
+      cc.setGreen(44);
+      assert.deepEqual(cc.levels, [98, 44, 102, 255]);
+      cc.setBlue(244);
+      assert.deepEqual(cc.levels, [98, 44, 244, 255]);
     });
   });
 
@@ -602,8 +624,19 @@ suite('p5.Color', function() {
     });
 
     test('can be modified with alpha setter', function() {
-      c.setAlpha(7.3);
-      assert.deepEqual(c.levels, [255, 0, 102, 186]);
+      var cc = myp5.color(93.33, 200, 150, 8);
+      cc.setAlpha(7.3);
+      assert.deepEqual(cc.levels, [255, 0, 102, 186]);
+    });
+    test('can be modified with rgb setters', function() {
+      var cc = myp5.color(93.33, 200, 150, 8);
+      assert.deepEqual(cc.levels, [255, 0, 102, 204]);
+      cc.setRed(98);
+      assert.deepEqual(cc.levels, [98, 0, 102, 204]);
+      cc.setGreen(44);
+      assert.deepEqual(cc.levels, [98, 44, 102, 204]);
+      cc.setBlue(244);
+      assert.deepEqual(cc.levels, [98, 44, 244, 204]);
     });
   });
 
@@ -684,10 +717,20 @@ suite('p5.Color', function() {
     test('should correctly set RGBA property', function() {
       assert.deepEqual(c.levels, [255, 0, 102, 255]);
     });
-
     test('can be modified with alpha setter', function() {
-      c.setAlpha(0.73);
-      assert.deepEqual(c.levels, [255, 0, 102, 186]);
+      var cc = myp5.color(336, 100, 100);
+      cc.setAlpha(0.73);
+      assert.deepEqual(cc.levels, [255, 0, 102, 186]);
+    });
+    test('can be modified with rgb setters', function() {
+      var cc = myp5.color(336, 100, 100);
+      assert.deepEqual(cc.levels, [255, 0, 102, 255]);
+      cc.setRed(98);
+      assert.deepEqual(cc.levels, [98, 0, 102, 255]);
+      cc.setGreen(44);
+      assert.deepEqual(cc.levels, [98, 44, 102, 255]);
+      cc.setBlue(244);
+      assert.deepEqual(cc.levels, [98, 44, 244, 255]);
     });
   });
 

--- a/test/unit/color/p5.Color.js
+++ b/test/unit/color/p5.Color.js
@@ -5,19 +5,6 @@ suite('p5.Color', function() {
   });
   var c;
 
-  // color level setters
-  suite('in default mode', function() {
-    setup(function() {
-      c = myp5.color(255, 0, 102, 204);
-    });
-
-    test('can be modified with alpha setter', function() {
-      assert.deepEqual(c.levels, [255, 0, 102, 204]);
-      c.setAlpha(98);
-      assert.deepEqual(c.levels, [255, 0, 102, 98]);
-    });
-  });
-
   suite('p5.prototype.color(r,g,b)', function() {
     setup(function() {
       c = myp5.color(255, 0, 102);
@@ -512,6 +499,19 @@ suite('p5.Color', function() {
     });
   });
 
+  // color level setters
+  suite('in default mode', function() {
+    setup(function() {
+      c = myp5.color(255, 0, 102, 204);
+    });
+
+    test('can be modified with alpha setter', function() {
+      assert.deepEqual(c.levels, [255, 0, 102, 204]);
+      c.setAlpha(98);
+      assert.deepEqual(c.levels, [255, 0, 102, 98]);
+    });
+  });
+
   // Color Mode
   suite('p5.Color in RGB mode with custom range', function() {
     setup(function() {
@@ -554,6 +554,10 @@ suite('p5.Color', function() {
     test('should correctly set RGBA property', function() {
       assert.deepEqual(c.levels, [255, 0, 102, 255]);
     });
+    test('can be modified with alpha setter', function() {
+      c.setAlpha(0.73);
+      assert.deepEqual(c.levels, [255, 0, 102, 186]);
+    });
   });
 
   suite('p5.Color in HSL mode with Alpha', function() {
@@ -595,6 +599,11 @@ suite('p5.Color', function() {
 
     test('should correctly render color string', function() {
       assert.equal(c.toString(), 'rgba(255,0,102,0.8)');
+    });
+
+    test('can be modified with alpha setter', function() {
+      c.setAlpha(7.3);
+      assert.deepEqual(c.levels, [255, 0, 102, 186]);
     });
   });
 
@@ -674,6 +683,11 @@ suite('p5.Color', function() {
     });
     test('should correctly set RGBA property', function() {
       assert.deepEqual(c.levels, [255, 0, 102, 255]);
+    });
+
+    test('can be modified with alpha setter', function() {
+      c.setAlpha(0.73);
+      assert.deepEqual(c.levels, [255, 0, 102, 186]);
     });
   });
 
@@ -872,19 +886,6 @@ suite('p5.Color', function() {
 
     test('should correctly set RGB levels', function() {
       assert.deepEqual(c.levels, [100, 100, 100, 70]);
-    });
-  });
-
-  suite('in HSL mode', function() {
-    setup(function() {
-      myp5.colorMode(myp5.HSL, 360, 100, 100, 1);
-      c = myp5.color(336, 100, 50, 0.8);
-    });
-
-    test('can be modified with alpha setter', function() {
-      assert.deepEqual(c.levels, [255, 0, 102, 204]);
-      c.setAlpha(0.98);
-      assert.deepEqual(c.levels, [255, 0, 102, 250]);
     });
   });
 

--- a/test/unit/color/p5.Color.js
+++ b/test/unit/color/p5.Color.js
@@ -875,6 +875,19 @@ suite('p5.Color', function() {
     });
   });
 
+  suite('in HSL mode', function() {
+    setup(function() {
+      myp5.colorMode(myp5.HSL, 360, 100, 100, 1);
+      c = myp5.color(336, 100, 50, 0.8);
+    });
+
+    test('can be modified with alpha setter', function() {
+      assert.deepEqual(c.levels, [255, 0, 102, 204]);
+      c.setAlpha(0.98);
+      assert.deepEqual(c.levels, [255, 0, 102, 250]);
+    });
+  });
+
   suite('p5.Color.prototype.toString', function() {
     var colorStr;
 

--- a/test/unit/color/p5.Color.js
+++ b/test/unit/color/p5.Color.js
@@ -6,7 +6,7 @@ suite('p5.Color', function() {
   var c;
 
   // color level setters
-  suite('p5.Color in default mode', function() {
+  suite('in default mode', function() {
     setup(function() {
       c = myp5.color(255, 0, 102, 204);
     });

--- a/test/unit/color/p5.Color.js
+++ b/test/unit/color/p5.Color.js
@@ -5,6 +5,19 @@ suite('p5.Color', function() {
   });
   var c;
 
+  // color level setters
+  suite('p5.Color in default mode', function() {
+    setup(function() {
+      c = myp5.color(255, 0, 102, 204);
+    });
+
+    test('can be modified with alpha setter', function() {
+      assert.deepEqual(c.levels, [255, 0, 102, 204]);
+      c.alpha(98);
+      assert.deepEqual(c.levels, [255, 0, 102, 98]);
+    });
+  });
+
   suite('p5.prototype.color(r,g,b)', function() {
     setup(function() {
       c = myp5.color(255, 0, 102);

--- a/test/unit/color/p5.Color.js
+++ b/test/unit/color/p5.Color.js
@@ -501,10 +501,6 @@ suite('p5.Color', function() {
 
   // color level setters
   suite('in default mode', function() {
-    setup(function() {
-      c = myp5.color(255, 0, 102, 204);
-    });
-
     test('can be modified with alpha setter', function() {
       var cc = myp5.color(255, 0, 102, 204);
       assert.deepEqual(cc.levels, [255, 0, 102, 204]);


### PR DESCRIPTION
Hi there! I've implemented setters for red, green, blue, and alpha values for `p5.Color`, similar to what was requested in #1517. There was a little refactoring in the process, mostly to make certain parts of the code reusable within the class (see `p5.Color._calculateLevels()`).

A few key choices I made:
* syntax is `p5.Color.setAlpha()` (instead of `p5.Color.alpha()`), etc so use for method is clearer
* the input for each setter is interpreted in the color mode and ranges defined in the color instance itself (we don't change that based on the current color mode and ranges of the renderer)
* red, green, and blue setters can be used on colors that have a HSB or HSL mode stored (the color's ranges for RGB mode that are stored at the time of construction are used)
* `p5.Color.levels` is automatically recalculated immediately after any setting using these methods

Let me know what you think!

PS—
I have another branch for hue, saturation, lightness, and brightness setters but that's a little more complicated so I'd like to submit it as a separate PR later.