### PR TITLE
Fixes for #2146

### DIFF
--- a/lib/addons/p5.dom.js
+++ b/lib/addons/p5.dom.js
@@ -967,10 +967,33 @@
   p5.prototype.VIDEO = 'video';
   p5.prototype.AUDIO = 'audio';
 
-  navigator.getUserMedia  = navigator.getUserMedia ||
-                            navigator.webkitGetUserMedia ||
-                            navigator.mozGetUserMedia ||
-                            navigator.msGetUserMedia;
+  // from: https://developer.mozilla.org/en-US/docs/Web/API/MediaDevices/getUserMedia
+  // Older browsers might not implement mediaDevices at all, so we set an empty object first
+  if (navigator.mediaDevices === undefined) {
+    navigator.mediaDevices = {};
+  }
+
+  // Some browsers partially implement mediaDevices. We can't just assign an object
+  // with getUserMedia as it would overwrite existing properties.
+  // Here, we will just add the getUserMedia property if it's missing.
+  if (navigator.mediaDevices.getUserMedia === undefined) {
+    navigator.mediaDevices.getUserMedia = function(constraints) {
+
+      // First get ahold of the legacy getUserMedia, if present
+      var getUserMedia = navigator.webkitGetUserMedia || navigator.mozGetUserMedia;
+
+      // Some browsers just don't implement it - return a rejected promise with an error
+      // to keep a consistent interface
+      if (!getUserMedia) {
+        return Promise.reject(new Error('getUserMedia is not implemented in this browser'));
+      }
+
+      // Otherwise, wrap the call to the old navigator.getUserMedia with a Promise
+      return new Promise(function(resolve, reject) {
+        getUserMedia.call(navigator, constraints, resolve, reject);
+      });
+    };
+  }
 
   /**
    * <p>Creates a new &lt;video&gt; element that contains the audio/video feed
@@ -1043,7 +1066,6 @@
         cb = arguments[i];
       }
     }
-
     if (navigator.getUserMedia) {
       var elt = document.createElement('video');
 
@@ -1051,11 +1073,20 @@
         constraints = {video: useVideo, audio: useAudio};
       }
 
-      navigator.getUserMedia(constraints, function(stream) {
-        elt.src = window.URL.createObjectURL(stream);
-          if (cb) {
-            cb(stream);
+      navigator.mediaDevices.getUserMedia(constraints)
+      .then( function(stream) {
+        try {
+          if("srcObject" in elt) {
+            elt.srcObject = stream;
+          } else {
+            elt.src = window.URL.createObjectURL(stream);
           }
+        } catch (err) {
+          elt.src = stream;
+        }
+        if (cb) {
+          cb(stream);
+        }
       }, function(e) { console.log(e); });
     } else {
       throw 'getUserMedia not supported in this browser';

--- a/test/manual-test-examples/addons/p5.dom/capture_video/index.html
+++ b/test/manual-test-examples/addons/p5.dom/capture_video/index.html
@@ -1,7 +1,7 @@
 <head>
   <script language="javascript" type="text/javascript" src="../../../../../lib/p5.js"></script>
   <script language="javascript" type="text/javascript" src="../../../../../lib/addons/p5.dom.js"></script>
-  <script language="javascript" type="text/javascript" src="sketch.js"></script>        
+  <script language="javascript" type="text/javascript" src="sketch.js"></script>
 </head>
 
 <body>


### PR DESCRIPTION
Allows iOS 11 Safari to access the camera for video capture. Based on [this similar patch](https://github.com/eduardolundgren/tracking.js/issues/228) for tracking.js . Tested on iOS latest beta, Mac OS X Chrome. (Note you have to have an HTTPS server booted for local development)

