### PR TITLE
Minor correction to pixels documentation example

### DIFF
--- a/src/image/pixels.js
+++ b/src/image/pixels.js
@@ -29,7 +29,7 @@ require('../color/p5.Color');
  * contain the R, G, B, A values of the pixel at (1, 0). More generally, to
  * set values for a pixel at (x, y):
  * ```javascript
- * var d = pixelDensity;
+ * var d = pixelDensity();
  * for (var i = 0; i < d; i++) {
  *   for (var j = 0; j < d; j++) {
  *     // loop over


### PR DESCRIPTION
The documented example for changing a pixel's color used `var d = pixelDensity` which wouldn't work because pixelDensity is a function. I would like to add the `()` afterwards. This line is already correct in other examples in the same file.