### PR TITLE
docs/httpDo

### DIFF
--- a/src/io/files.js
+++ b/src/io/files.js
@@ -774,6 +774,7 @@ p5.prototype.httpPost = function () {
  *    var feature = earthquakes.features[eqFeatureIndex];
  *    var mag = feature.properties.mag;
  *    var rad = mag / 11 * ((width + height) / 2);
+ *    fill(255, 0, 0, 100);
  *    ellipse(
  *      width / 2 + random(-2, 2),
  *      height / 2 + random(-2, 2),

--- a/src/io/files.js
+++ b/src/io/files.js
@@ -767,7 +767,7 @@ p5.prototype.httpPost = function () {
  *
  * function draw() {
  *    // wait until the data is loaded
- *    if (!earthquakes) {
+ *    if (!earthquakes || !earthquakes.features[eqFeatureIndex]) {
  *      return;
  *    }
  *    clear();

--- a/src/io/files.js
+++ b/src/io/files.js
@@ -757,7 +757,8 @@ p5.prototype.httpPost = function () {
  *    httpDo(url,
  *      {
  *        method: 'GET',  // http method - "GET", "PUT", "POST", etc.
- *        headers: { authorization: 'Bearer secretKey' } // Other Request options, like special headers for apis
+ *          // Other Request options, like special headers for apis
+ *        headers: { authorization: 'Bearer secretKey' }
  *      },
  *      function(res) {
  *        earthquakes = res;

--- a/src/io/files.js
+++ b/src/io/files.js
@@ -740,6 +740,54 @@ p5.prototype.httpPost = function () {
  * @param  {function}      [errorCallback] function to be executed if
  *                                    there is an error, response is passed
  *                                    in as first argument
+ *
+ *
+ * @example
+ * <div>
+ * <code>
+ * // Examples use USGS Earthquake API:
+ * // https://earthquake.usgs.gov/fdsnws/event/1/#methods
+ *
+ * // displays an animation of all USGS earthquakes
+ * var earthquakes;
+ * var eqFeatureIndex = 0;
+ *
+ * function preload() {
+ *    var url = 'https://earthquake.usgs.gov/fdsnws/event/1/query?format=geojson';
+ *    httpDo(url,
+ *      {
+ *        method: 'GET',  // http method - "GET", "PUT", "POST", etc.
+ *        headers: { authorization: 'Bearer secretKey' } // Other Request options, like special headers for apis
+ *      },
+ *      function(res) {
+ *        earthquakes = res;
+ *      });
+ * }
+ *
+ * function draw() {
+ *    // wait until the data is loaded
+ *    if (!earthquakes) {
+ *      return;
+ *    }
+ *    clear();
+ *
+ *    var feature = earthquakes.features[eqFeatureIndex];
+ *    var mag = feature.properties.mag;
+ *    var rad = mag / 11 * ((width + height) / 2);
+ *    ellipse(
+ *      width / 2 + random(-2, 2),
+ *      height / 2 + random(-2, 2),
+ *      rad, rad
+ *    );
+ *
+ *    if (eqFeatureIndex >= earthquakes.features.length) {
+ *      eqFeatureIndex = 0;
+ *    } else {
+ *      eqFeatureIndex += 1;
+ *    }
+ * }
+ * </code>
+ * </div>
  */
 
 /**

--- a/src/io/files.js
+++ b/src/io/files.js
@@ -756,8 +756,8 @@ p5.prototype.httpPost = function () {
  *    var url = 'https://earthquake.usgs.gov/fdsnws/event/1/query?format=geojson';
  *    httpDo(url,
  *      {
- *        method: 'GET',  // http method - "GET", "PUT", "POST", etc.
- *          // Other Request options, like special headers for apis
+ *        method: 'GET',
+ *        // Other Request options, like special headers for apis
  *        headers: { authorization: 'Bearer secretKey' }
  *      },
  *      function(res) {


### PR DESCRIPTION
Working on documentation from this issue: https://github.com/processing/p5.js/issues/1954

Only added one example, using the `Request` options, but did something more creative with the data. Could do an example of `PUT` but I feel like it's better to let users get nifty with it. 

Using the same earthquake data api as used in the `httpGet` example; 