### PR TITLE
Bugfix for color issues from fcd82ab

### DIFF
--- a/src/core/p5.Renderer2D.js
+++ b/src/core/p5.Renderer2D.js
@@ -25,8 +25,9 @@ p5.Renderer2D = function(elt, pInst, isMainCanvas){
 p5.Renderer2D.prototype = Object.create(p5.Renderer.prototype);
 
 p5.Renderer2D.prototype._applyDefaults = function() {
-  this._setFill(constants._DEFAULT_FILL, true);
-  this._setStroke(constants._DEFAULT_STROKE, true);
+  this._cachedFillStyle = this._cachedStrokeStyle = undefined;
+  this._setFill(constants._DEFAULT_FILL);
+  this._setStroke(constants._DEFAULT_STROKE);
   this.drawingContext.lineCap = constants.ROUND;
   this.drawingContext.font = 'normal 12px sans-serif';
 };
@@ -956,24 +957,30 @@ p5.Renderer2D.prototype.strokeWeight = function(w) {
 };
 
 p5.Renderer2D.prototype._getFill = function(){
+  if (!this._cachedFillStyle) {
+    this._cachedFillStyle = this.drawingContext.fillStyle;
+  }
   return this._cachedFillStyle;
 };
 
-p5.Renderer2D.prototype._setFill = function(fillStyle, nocache){
+p5.Renderer2D.prototype._setFill = function(fillStyle){
   if (fillStyle !== this._cachedFillStyle) {
     this.drawingContext.fillStyle = fillStyle;
-    this._cachedFillStyle = nocache || fillStyle;
+    this._cachedFillStyle = fillStyle;
   }
 };
 
 p5.Renderer2D.prototype._getStroke = function(){
+  if (!this._cachedStrokeStyle) {
+    this._cachedStrokeStyle = this.drawingContext.strokeStyle;
+  }
   return this._cachedStrokeStyle;
 };
 
-p5.Renderer2D.prototype._setStroke = function(strokeStyle, nocache){
+p5.Renderer2D.prototype._setStroke = function(strokeStyle){
   if (strokeStyle !== this._cachedStrokeStyle) {
     this.drawingContext.strokeStyle = strokeStyle;
-    this._cachedStrokeStyle = nocache || strokeStyle;
+    this._cachedStrokeStyle = strokeStyle;
   }
 };
 

--- a/test/unit/core/renderer.js
+++ b/test/unit/core/renderer.js
@@ -12,6 +12,22 @@ suite('Renderer', function() {
     myp5.remove();
   });
 
+  suite('p5.prototype.createCanvas', function() {
+    test('should have correct initial colors', function() {
+      var white = myp5.color(255, 255, 255).levels;
+      var black = myp5.color(0, 0, 0).levels;
+      assert.deepEqual(myp5.color(myp5._renderer._getFill()).levels, white);
+      assert.deepEqual(myp5.color(myp5._renderer._getStroke()).levels, black);
+      assert.deepEqual(myp5.color(myp5.drawingContext.fillStyle).levels, white);
+      assert.deepEqual(myp5.color(myp5.drawingContext.strokeStyle).levels, black);
+      myp5.createCanvas(100, 100);
+      assert.deepEqual(myp5.color(myp5._renderer._getFill()).levels, white);
+      assert.deepEqual(myp5.color(myp5._renderer._getStroke()).levels, black);
+      assert.deepEqual(myp5.color(myp5.drawingContext.fillStyle).levels, white);
+      assert.deepEqual(myp5.color(myp5.drawingContext.strokeStyle).levels, black);
+    });
+  });
+
   suite('p5.prototype.resizeCanvas' , function() {
     test('should resize canvas', function() {
       myp5.resizeCanvas(10, 20);


### PR DESCRIPTION
Re-fixes #2156 in a way that doesn't break some other tests (Boolean leaking into `color()`). Related to #2169.

Adds a test for the #2156 to prevent regression.