### PR TITLE
Automatically Inject FES

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -62,6 +62,7 @@ require('./webgl/camera');
 require('./webgl/interaction');
 
 require('./fes/error_helpers');
+require('./fes/inject');
 
 require('./core/init.js');
 

--- a/src/app.js
+++ b/src/app.js
@@ -61,6 +61,8 @@ require('./webgl/p5.Shader');
 require('./webgl/camera');
 require('./webgl/interaction');
 
+require('./fes/error_helpers');
+
 require('./core/init.js');
 
 

--- a/src/color/creating_reading.js
+++ b/src/color/creating_reading.js
@@ -11,7 +11,6 @@
 var p5 = require('../core/core');
 var constants = require('../core/constants');
 require('./p5.Color');
-require('../core/error_helpers');
 
 /**
  * Extracts the alpha value from a color or pixel array.
@@ -53,7 +52,6 @@ require('../core/error_helpers');
  * deep pink rect on left and grey rect on right, both 35x60.
  */
 p5.prototype.alpha = function(c) {
-  p5._validateParameters('alpha', arguments);
   return this.color(c)._getAlpha();
 };
 
@@ -82,7 +80,6 @@ p5.prototype.alpha = function(c) {
  *
  */
 p5.prototype.blue = function(c) {
-  p5._validateParameters('blue', arguments);
   return this.color(c)._getBlue();
 };
 
@@ -111,7 +108,6 @@ p5.prototype.blue = function(c) {
  *
  */
 p5.prototype.brightness = function(c) {
-  p5._validateParameters('brightness', arguments);
   return this.color(c)._getBrightness();
 };
 
@@ -314,7 +310,6 @@ p5.prototype.color = function() {
       return new p5.Color(this._renderer, arguments[0]);
     }
   } else {
-    p5._validateParameters('color', arguments);
     if (this instanceof p5.Renderer) {
       return new p5.Color(this, arguments);
     } else {
@@ -349,7 +344,6 @@ p5.prototype.color = function() {
  */
 
 p5.prototype.green = function(c) {
-  p5._validateParameters('green', arguments);
   return this.color(c)._getGreen();
 };
 
@@ -385,7 +379,6 @@ p5.prototype.green = function(c) {
  */
 
 p5.prototype.hue = function(c) {
-  p5._validateParameters('hue', arguments);
   return this.color(c)._getHue();
 };
 
@@ -433,7 +426,6 @@ p5.prototype.hue = function(c) {
  */
 
 p5.prototype.lerpColor = function(c1, c2, amt) {
-  p5._validateParameters('lerpColor', arguments);
   var mode = this._renderer._colorMode;
   var maxes = this._renderer._colorMaxes;
   var l0, l1, l2, l3;
@@ -511,7 +503,6 @@ p5.prototype.lerpColor = function(c1, c2, amt) {
  *
  */
 p5.prototype.lightness = function(c) {
-  p5._validateParameters('lightness', arguments);
   return this.color(c)._getLightness();
 };
 
@@ -550,7 +541,6 @@ p5.prototype.lightness = function(c) {
  * grey canvas
  */
 p5.prototype.red = function(c) {
-  p5._validateParameters('red', arguments);
   return this.color(c)._getRed();
 };
 
@@ -585,7 +575,6 @@ p5.prototype.red = function(c) {
  */
 
 p5.prototype.saturation = function(c) {
-  p5._validateParameters('saturation', arguments);
   return this.color(c)._getSaturation();
 };
 

--- a/src/core/2d_primitives.js
+++ b/src/core/2d_primitives.js
@@ -11,7 +11,6 @@
 var p5 = require('./core');
 var constants = require('./constants');
 var canvas = require('./canvas');
-require('./error_helpers');
 
 /**
  * Draw an arc to the screen. If called with only a, b, c, d, start, and
@@ -76,7 +75,6 @@ p5.prototype.arc = function(x, y, w, h, start, stop, mode) {
     args[i] = arguments[i];
   }
 
-  p5._validateParameters('arc', args);
   if (!this._renderer._doStroke && !this._renderer._doFill) {
     return this;
   }
@@ -164,7 +162,6 @@ p5.prototype.ellipse = function() {
     args.push(args[2]);
   }
 
-  p5._validateParameters('ellipse', args);
   // p5 supports negative width and heights for rects
   if (args[2] < 0){args[2] = Math.abs(args[2]);}
   if (args[3] < 0){args[3] = Math.abs(args[3]);}
@@ -239,7 +236,6 @@ p5.prototype.line = function() {
     args[i] = arguments[i];
   }
 
-  p5._validateParameters('line', args);
   //check whether we should draw a 3d line or 2d
   if (this._renderer.isP3D) {
     this._renderer.line(
@@ -292,7 +288,6 @@ p5.prototype.point = function() {
     args[i] = arguments[i];
   }
 
-  p5._validateParameters('point', args);
   //check whether we should draw a 3d line or 2d
   if (this._renderer.isP3D) {
     this._renderer.point(
@@ -359,7 +354,6 @@ p5.prototype.quad = function() {
     args[i] = arguments[i];
   }
 
-  p5._validateParameters('quad', args);
   if (this._renderer.isP3D) {
     this._renderer.quad(
       args[0],
@@ -459,7 +453,6 @@ p5.prototype.rect = function() {
     return this;
   }
 
-  p5._validateParameters('rect', args);
   var vals = canvas.modeAdjust(
     args[0],
     args[1],
@@ -508,7 +501,6 @@ p5.prototype.triangle = function() {
     args[i] = arguments[i];
   }
 
-  p5._validateParameters('triangle', args);
   this._renderer.triangle(args);
   return this;
 };

--- a/src/core/curves.js
+++ b/src/core/curves.js
@@ -8,7 +8,6 @@
 'use strict';
 
 var p5 = require('./core');
-require('./error_helpers');
 
 var bezierDetail = 20;
 var curveDetail = 20;
@@ -79,7 +78,6 @@ p5.prototype.bezier = function() {
     args[i] = arguments[i];
   }
 
-  p5._validateParameters('bezier', args);
   if (!this._renderer._doStroke && !this._renderer._doFill) {
     return this;
   }
@@ -164,7 +162,6 @@ p5.prototype.bezierPoint = function(a, b, c, d, t) {
     args[i] = arguments[i];
   }
 
-  p5._validateParameters('bezierPoint', args);
   var adjustedT = 1-args[4];
   return Math.pow(adjustedT,3)*args[0] +
    3*(Math.pow(adjustedT,2))*args[4]*args[1] +
@@ -243,7 +240,6 @@ p5.prototype.bezierTangent = function(a, b, c, d, t) {
     args[i] = arguments[i];
   }
 
-  p5._validateParameters('bezierTangent', args);
   var adjustedT = 1-args[4];
   return 3*args[3]*Math.pow(args[4],2) -
    3*args[2]*Math.pow(args[4],2) +
@@ -334,7 +330,6 @@ p5.prototype.curve = function() {
     args[i] = arguments[i];
   }
 
-  p5._validateParameters('curve', args);
   if (!this._renderer._doStroke) {
     return this;
   }
@@ -463,7 +458,6 @@ p5.prototype.curvePoint = function(a, b, c, d, t) {
     args[i] = arguments[i];
   }
 
-  p5._validateParameters('curvePoint', args);
   var t3 = args[4]*args[4]*args[4],
     t2 = args[4]*args[4],
     f1 = -0.5 * t3 + t2 - 0.5 * args[4],
@@ -514,7 +508,6 @@ p5.prototype.curveTangent = function(a, b, c, d, t) {
     args[i] = arguments[i];
   }
 
-  p5._validateParameters('curveTangent', args);
   var t2 = args[4]*args[4],
     f1 = (-3*t2)/2 + 2*args[4] - 0.5,
     f2 = (9*t2)/2 - 5*args[4],

--- a/src/fes/error_helpers.js
+++ b/src/fes/error_helpers.js
@@ -9,8 +9,6 @@
 var p5 = require('../core/core');
 var doFriendlyWelcome = false; // TEMP until we get it all working LM
 // for parameter validation
-var dataDoc = require('../../docs/reference/data.json');
-var arrDoc = JSON.parse(JSON.stringify(dataDoc));
 
 // -- Borrowed from jQuery 1.11.3 --
 var class2type = {};
@@ -121,12 +119,12 @@ p5._friendlyFileLoadError = function (errorType, filePath) {
 *  "ellipse was expecting a number for parameter #1,
 *           received "foo" instead."
 */
-p5.prototype._validateParameters = function validateParameters(func, args) {
+p5.prototype._validateParameters = function validateParameters(doc, args) {
   if (p5.disableFriendlyErrors ||
     typeof(IS_MINIFIED) !== 'undefined') {
     return; // skip FES
   }
-  var arrDoc = lookupParamDoc(func);
+  var arrDoc = lookupParamDoc(doc);
   var errorArray = [];
   var minErrCount = 999999;
   if (arrDoc.length > 1){   // func has multiple formats
@@ -143,29 +141,27 @@ p5.prototype._validateParameters = function validateParameters(func, args) {
     }
     // generate err msg
     for (var n = 0; n < errorArray.length; n++) {
-      this._friendlyParamError(errorArray[n], func);
+      this._friendlyParamError(errorArray[n], doc.name);
     }
   } else {                 // func has a single format
     errorArray = testParamFormat(args, arrDoc[0]);
     for(var m = 0; m < errorArray.length; m++) {
-      this._friendlyParamError(errorArray[m], func);
+      this._friendlyParamError(errorArray[m], doc.name);
     }
   }
 };
 // validateParameters() helper functions:
 // lookupParamDoc() for querying data.json
-function lookupParamDoc(func){
-  var queryResult = arrDoc.classitems.
-    filter(function (x) { return x.name === func; });
+function lookupParamDoc(doc){
   // different JSON structure for funct with multi-format
-  if (queryResult[0].hasOwnProperty('overloads')){
+  if (doc.hasOwnProperty('overloads')){
     var res = [];
-    for(var i = 0; i < queryResult[0].overloads.length; i++) {
-      res.push(queryResult[0].overloads[i].params);
+    for(var i = 0; i < doc.overloads.length; i++) {
+      res.push(doc.overloads[i].params);
     }
     return res;
   } else {
-    return [queryResult[0].params];
+    return [doc.params];
   }
 }
 function testParamFormat(args, format){

--- a/src/fes/error_helpers.js
+++ b/src/fes/error_helpers.js
@@ -170,6 +170,9 @@ function lookupParamDoc(func){
 }
 function testParamFormat(args, format){
   var errorArray = [];
+  if (!format) {
+    format = [];
+  }
   var error;
   for (var p = 0; p < format.length; p++) {
     var argType = typeof(args[p]);

--- a/src/fes/error_helpers.js
+++ b/src/fes/error_helpers.js
@@ -198,6 +198,13 @@ function testParamFormat(args, format){
       }
     }
   }
+  if(args.length > format.length) {
+    error = {
+      type: 'WRONG_ARGUMENT_COUNT',
+      counts: [args.length, format.length]
+    };
+    errorArray.push(error);
+  }
   return errorArray;
 }
 // testClass() for object type parameter validation
@@ -254,6 +261,12 @@ p5._friendlyParamError = function (errorObj, func) {
       // Wrap strings in quotes
       message += errorObj.wrongType + ' instead.';
       report(message, func, ERR_PARAMS);
+      break;
+    case 'WRONG_ARGUMENT_COUNT':
+      message = func + '() was expecting ' + errorObj.counts[1] +
+        ' arguments, but received ' + errorObj.counts[0];
+      report(message, func, ERR_PARAMS);
+      break;
   }
 };
 function friendlyWelcome() {

--- a/src/fes/error_helpers.js
+++ b/src/fes/error_helpers.js
@@ -211,7 +211,9 @@ function testParamFormat(args, format){
 // Returns true if PASS, false if FAIL
 function testParamClass(param, types){
   for (var i = 0; i < types.length; i++) {
-    if (types[i] === 'Array') {
+    if (types[i] === 'Any') {
+      return true;
+    } else if(types[i] === 'Array') {
       if(param instanceof Array) {
         return true;
       }
@@ -229,7 +231,9 @@ function testParamClass(param, types){
 // Returns true if PASS, false if FAIL
 function testParamType(param, types){
   for (var i = 0; i < types.length; i++) {
-    if (typeof(param) === types[i].toLowerCase()) {
+    if (types[i] === 'Any') {
+      return true;
+    } else if (typeof(param) === types[i].toLowerCase()) {
       return true;      // type match, pass
     } else if (types[i] === 'Constant') {
       return true;      // accepts any constant, pass

--- a/src/fes/error_helpers.js
+++ b/src/fes/error_helpers.js
@@ -121,7 +121,7 @@ p5._friendlyFileLoadError = function (errorType, filePath) {
 *  "ellipse was expecting a number for parameter #1,
 *           received "foo" instead."
 */
-p5._validateParameters = function validateParameters(func, args) {
+p5.prototype._validateParameters = function validateParameters(func, args) {
   if (p5.disableFriendlyErrors ||
     typeof(IS_MINIFIED) !== 'undefined') {
     return; // skip FES
@@ -143,12 +143,12 @@ p5._validateParameters = function validateParameters(func, args) {
     }
     // generate err msg
     for (var n = 0; n < errorArray.length; n++) {
-      p5._friendlyParamError(errorArray[n], func);
+      this._friendlyParamError(errorArray[n], func);
     }
   } else {                 // func has a single format
     errorArray = testParamFormat(args, arrDoc[0]);
     for(var m = 0; m < errorArray.length; m++) {
-      p5._friendlyParamError(errorArray[m], func);
+      this._friendlyParamError(errorArray[m], func);
     }
   }
 };
@@ -238,7 +238,7 @@ function testParamType(param, types){
   return false;
 }
 // function for generating console.log() msg
-p5._friendlyParamError = function (errorObj, func) {
+p5.prototype._friendlyParamError = function (errorObj, func) {
   var message;
   switch (errorObj.type){
     case 'EMPTY_VAR':
@@ -414,7 +414,7 @@ function helpForMisusedAtTopLevelCode(e, log) {
 
 // Exposing this primarily for unit testing.
 p5.prototype._helpForMisusedAtTopLevelCode = helpForMisusedAtTopLevelCode;
-p5.prototype._validateParameters = p5.validateParameters;
+// p5.prototype._validateParameters = p5.validateParameters;
 
 if (document.readyState !== 'complete') {
   window.addEventListener('error', helpForMisusedAtTopLevelCode, false);

--- a/src/fes/error_helpers.js
+++ b/src/fes/error_helpers.js
@@ -1,11 +1,12 @@
 /**
  * @for p5
+ * @submodule FES
  * @requires core
  */
 
 'use strict';
 
-var p5 = require('./core');
+var p5 = require('../core/core');
 var doFriendlyWelcome = false; // TEMP until we get it all working LM
 // for parameter validation
 var dataDoc = require('../../docs/reference/data.json');
@@ -341,7 +342,7 @@ function defineMisusedAtTopLevelCode() {
     // At present, p5 only adds its constants to p5.prototype during
     // construction, which may not have happened at the time a
     // ReferenceError is thrown, so we'll manually add them to our list.
-    getSymbols(require('./constants'))
+    getSymbols(require('../core/constants'))
   );
 
   // This will ultimately ensure that we report the most specific error

--- a/src/fes/inject.js
+++ b/src/fes/inject.js
@@ -1,0 +1,37 @@
+/**
+ * @for p5
+ * @submodule FES
+ * @requires core
+ */
+
+'use strict';
+
+var p5 = require('../core/core');
+
+var dataDoc = require('../../docs/reference/data.json');
+var arrDoc = JSON.parse(JSON.stringify(dataDoc));
+
+function inject(docItem) {
+  if (docItem.class !== 'p5') {
+    return;
+  }
+  if (!docItem.itemtype || docItem.itemtype !== 'method') {
+    return;
+  }
+  var original = p5.prototype[docItem.name];
+
+  if(original) {
+    p5.prototype[docItem.name] = function() {
+      p5._validateParameters(docItem.name, arguments);
+      return original.apply(this, arguments);
+    };
+  }
+}
+
+if (!p5.disableFriendlyErrors && typeof(IS_MINIFIED) === 'undefined') {
+  var items = arrDoc.classitems;
+  for(var i = 0; i < items.length; i++) {
+    var item = items[i];
+    inject(item);
+  }
+}

--- a/src/fes/inject.js
+++ b/src/fes/inject.js
@@ -22,7 +22,15 @@ function inject(docItem) {
 
   if(original) {
     p5.prototype[docItem.name] = function() {
-      p5._validateParameters(docItem.name, arguments);
+      if(!this || !(this instanceof p5)) {
+        // Maybe this should be warned about?
+        // throw new Error(
+        //   'This value is not p5 in ' + docItem.name + ', params: ' +
+        //   arguments + '. This value: ' + this
+        // );
+      } else {
+        this._validateParameters(docItem.name, arguments);
+      }
       return original.apply(this, arguments);
     };
   }

--- a/src/fes/inject.js
+++ b/src/fes/inject.js
@@ -29,7 +29,7 @@ function inject(docItem) {
         //   arguments + '. This value: ' + this
         // );
       } else {
-        this._validateParameters(docItem.name, arguments);
+        this._validateParameters(docItem, arguments);
       }
       return original.apply(this, arguments);
     };

--- a/src/image/loading_displaying.js
+++ b/src/image/loading_displaying.js
@@ -12,8 +12,6 @@ var Filters = require('./filters');
 var canvas = require('../core/canvas');
 var constants = require('../core/constants');
 
-require('../core/error_helpers');
-
 /**
  * Loads an image from a path and creates a p5.Image from it.
  * <br><br>

--- a/src/io/files.js
+++ b/src/io/files.js
@@ -14,7 +14,6 @@ var p5 = require('../core/core');
 require('whatwg-fetch');
 require('es6-promise').polyfill();
 var fetchJsonp = require('fetch-jsonp');
-require('../core/error_helpers');
 
 /**
  * Loads a JSON file from a file or a URL, and returns an Object or Array.

--- a/src/typography/loading_displaying.js
+++ b/src/typography/loading_displaying.js
@@ -11,8 +11,6 @@ var p5 = require('../core/core');
 var constants = require('../core/constants');
 var opentype = require('opentype.js');
 
-require('../core/error_helpers');
-
 /**
  * Loads an opentype font file (.otf, .ttf) from a file or a URL,
  * and returns a PFont Object. This method is asynchronous,

--- a/src/utilities/string_functions.js
+++ b/src/utilities/string_functions.js
@@ -8,7 +8,6 @@
 'use strict';
 
 var p5 = require('../core/core');
-require('../core/error_helpers');
 
 //return p5; //LM is this a mistake?
 
@@ -37,7 +36,6 @@ require('../core/error_helpers');
  *
  */
 p5.prototype.join = function(list, separator) {
-  p5._validateParameters('join', arguments);
   return list.join(separator);
 };
 
@@ -78,7 +76,6 @@ p5.prototype.join = function(list, separator) {
  *
  */
 p5.prototype.match =  function(str, reg) {
-  p5._validateParameters('match', arguments);
   return str.match(reg);
 };
 
@@ -115,7 +112,6 @@ p5.prototype.match =  function(str, reg) {
  * </div>
  */
 p5.prototype.matchAll = function(str, reg) {
-  p5._validateParameters('matchAll', arguments);
   var re = new RegExp(reg, 'g');
   var match = re.exec(str);
   var matches = [];
@@ -179,7 +175,6 @@ p5.prototype.matchAll = function(str, reg) {
  *
  */
 p5.prototype.nf = function () {
-  p5._validateParameters('nf', arguments);
   if (arguments[0] instanceof Array) {
     var a = arguments[1];
     var b = arguments[2];
@@ -287,7 +282,6 @@ function doNf() {
  *
  */
 p5.prototype.nfc = function () {
-  p5._validateParameters('nfc', arguments);
   if (arguments[0] instanceof Array) {
     var a = arguments[1];
     return arguments[0].map(function (x) {
@@ -370,7 +364,6 @@ function doNfc() {
  *
  */
 p5.prototype.nfp = function() {
-  p5._validateParameters('nfp', arguments);
   var nfRes = p5.prototype.nf.apply(this, arguments);
   if (nfRes instanceof Array) {
     return nfRes.map(addNfp);
@@ -435,7 +428,6 @@ function addNfp() {
  *
  */
 p5.prototype.nfs = function() {
-  p5._validateParameters('nfs', arguments);
   var nfRes = p5.prototype.nf.apply(this, arguments);
   if (nfRes instanceof Array) {
     return nfRes.map(addNfs);
@@ -481,7 +473,6 @@ function addNfs() {
  *
  */
 p5.prototype.split = function(str, delim) {
-  p5._validateParameters('split', arguments);
   return str.split(delim);
 };
 
@@ -512,7 +503,6 @@ p5.prototype.split = function(str, delim) {
  * </div>
  */
 p5.prototype.splitTokens = function() {
-  p5._validateParameters('splitTokens', arguments);
   var d,sqo,sqc,str;
   str = arguments[1];
   if (arguments.length > 1) {
@@ -564,7 +554,6 @@ p5.prototype.splitTokens = function() {
  *
  */
 p5.prototype.trim = function(str) {
-  p5._validateParameters('trim', arguments);
   if (str instanceof Array) {
     return str.map(this.trim);
   } else {

--- a/test/test-reference.html
+++ b/test/test-reference.html
@@ -153,6 +153,8 @@
               var oldSetup = p.setup || function() {};
               var oldDraw = p.draw || function() {};
 
+              sinon.spy(p, '_friendlyParamError');
+
               p.setup = function() {
                 try {
                   oldSetup();
@@ -171,6 +173,13 @@
                     // This can happen if the page contained processor-intensive
                     // code that blocked the UI for too long.
                     reject(new Error("code took too long to execute"));
+                    return;
+                  }
+
+                  if(p._friendlyParamError.called) {
+                    reject(new Error(
+                      "p5._friendlyParamError was called: " +
+                      p._friendlyParamError.getCalls()));
                     return;
                   }
 

--- a/test/unit/core/error_helpers.js
+++ b/test/unit/core/error_helpers.js
@@ -19,21 +19,21 @@ suite('Error Helpers', function() {
   suite('validateParameters: Numbers + optional Constant', function(){
     test('arc(): no friendly-err-msg', function() {
       assert.doesNotThrow(function() {
-          p5._validateParameters('arc',
+          myp5._validateParameters('arc',
             [1, 1, 10.5, 10, 0, Math.PI, 'pie']);
         },
         Error, 'got unwanted exception');
     });
     test('arc(): missing param #4, #5', function() {
       assert.doesNotThrow(function() {
-          p5._validateParameters('arc',
+          myp5._validateParameters('arc',
             [1, 1, 10.5, 10]);
         },
         Error, 'got unwanted exception');
     });
     test('arc(): wrong param type at #0', function() {
       assert.doesNotThrow(function() {
-          p5._validateParameters('arc',
+          myp5._validateParameters('arc',
             ['1', 1, 10.5, 10, 0, Math.PI, 'pie']);
         },
         Error, 'got unwanted exception');
@@ -43,21 +43,21 @@ suite('Error Helpers', function() {
   suite('validateParameters: Numbers + optional Constant', function(){
     test('rect(): no friendly-err-msg', function() {
       assert.doesNotThrow(function() {
-          p5._validateParameters('rect',
+          myp5._validateParameters('rect',
             [1, 1, 10.5, 10]);
         },
         Error, 'got unwanted exception');
     });
     test('rect(): missing param #3', function() {
       assert.doesNotThrow(function() {
-          p5._validateParameters('rect',
+          myp5._validateParameters('rect',
             [1, 1, 10.5]);
         },
         Error, 'got unwanted exception');
     });
     test('rect(): wrong param type at #0', function() {
       assert.doesNotThrow(function() {
-          p5._validateParameters('rect',
+          myp5._validateParameters('rect',
             ['1', 1, 10.5, 10, 0, Math.PI]);
         },
         Error, 'got unwanted exception');
@@ -68,7 +68,7 @@ suite('Error Helpers', function() {
     test('ambientLight(): no friendly-err-msg', function() {
       assert.doesNotThrow(function() {
           var c = myp5.color(255, 204, 0);
-          p5._validateParameters('ambientLight', [c]);
+          myp5._validateParameters('ambientLight', [c]);
         },
         Error, 'got unwanted exception');
     });
@@ -77,19 +77,19 @@ suite('Error Helpers', function() {
   suite('validateParameters: multi-format', function(){
     test('color(): no friendly-err-msg', function() {
       assert.doesNotThrow(function() {
-          p5._validateParameters('color', [65]);
+          myp5._validateParameters('color', [65]);
         },
         Error, 'got unwanted exception');
     });
     test('color(): no friendly-err-msg', function() {
       assert.doesNotThrow(function() {
-          p5._validateParameters('color', [65, 0.5]);
+          myp5._validateParameters('color', [65, 0.5]);
         },
         Error, 'got unwanted exception');
     });
     test('color(): no friendly-err-msg', function() {
       assert.doesNotThrow(function() {
-          p5._validateParameters('color', [255, 204, 0]);
+          myp5._validateParameters('color', [255, 204, 0]);
         },
         Error, 'got unwanted exception');
     });
@@ -102,7 +102,7 @@ suite('Error Helpers', function() {
         log.push(msg);
       };
 
-      p5.prototype._helpForMisusedAtTopLevelCode({message: msg}, logger);
+      myp5._helpForMisusedAtTopLevelCode({message: msg}, logger);
       assert.equal(log.length, 1);
       return log[0];
     };


### PR DESCRIPTION
I vaguely suggested this in #2167, but then I decided to see if it was possible and now this is the result.

**This is probably not ready for merging, this is just to see comments regarding this**

So, I removed all of the manual FES calls and instead injected them based on the documentation.

This of course means that we're relying on the documentation to be absolutely correct, and that's a problem. For example, `createCanvas` triggers a message by default simply because there's a hidden private 4th parameter. I think the way to fix that would be to mark it up as private, but the system doesn't seem to support that yet.

I would be interested in anyone trying this out with sketched to see if there are significant performance issues with using this compared to without.

For anyone who wants to try out a built version of this, I have it available at https://meiamso.me/p5.js