### PR TITLE
Made regexp for reference test easier for Windows

### DIFF
--- a/test/test-reference.html
+++ b/test/test-reference.html
@@ -50,7 +50,7 @@
   <script>
   var TEST_FILENAME_FILTERS = [
     {regex: /webgl/, condition: Modernizr.webgl},
-    {regex: /events\/acceleration\.js/, condition: Modernizr.webgl},
+    {regex: /acceleration/, condition: Modernizr.webgl},
     {regex: /sound/, condition: Modernizr.webaudio}
   ];
   var MS_TIMEOUT = 4000;


### PR DESCRIPTION
On Windows, the acceleration examples were failing constantly, as the regexp to check for those files included forward slashes which are used only in Unix/BSD. 

(loadJSON still gives error randomly, working on that separately)