### PR TITLE
Fixed an IO issues for Windows, and closes #1630 as well

### DIFF
--- a/src/core/p5.Renderer2D.js
+++ b/src/core/p5.Renderer2D.js
@@ -900,30 +900,12 @@ p5.Renderer2D.prototype.noSmooth = function() {
   if ('imageSmoothingEnabled' in this.drawingContext) {
     this.drawingContext.imageSmoothingEnabled = false;
   }
-  else if ('mozImageSmoothingEnabled' in this.drawingContext) {
-    this.drawingContext.mozImageSmoothingEnabled = false;
-  }
-  else if ('webkitImageSmoothingEnabled' in this.drawingContext) {
-    this.drawingContext.webkitImageSmoothingEnabled = false;
-  }
-  else if ('msImageSmoothingEnabled' in this.drawingContext) {
-    this.drawingContext.msImageSmoothingEnabled = false;
-  }
   return this;
 };
 
 p5.Renderer2D.prototype.smooth = function() {
   if ('imageSmoothingEnabled' in this.drawingContext) {
     this.drawingContext.imageSmoothingEnabled = true;
-  }
-  else if ('mozImageSmoothingEnabled' in this.drawingContext) {
-    this.drawingContext.mozImageSmoothingEnabled = true;
-  }
-  else if ('webkitImageSmoothingEnabled' in this.drawingContext) {
-    this.drawingContext.webkitImageSmoothingEnabled = true;
-  }
-  else if ('msImageSmoothingEnabled' in this.drawingContext) {
-    this.drawingContext.msImageSmoothingEnabled = true;
   }
   return this;
 };

--- a/src/io/files.js
+++ b/src/io/files.js
@@ -444,6 +444,8 @@ p5.prototype.loadTable = function (path) {
             state.escaped = false;
             state.currentState = POST_TOKEN;
           }
+        } else if(currentChar === CR) {
+          continue;
         } else {
           state.token += currentChar;
         }


### PR DESCRIPTION
This addresses two separate issues :
1. Removes the prefixes for imageSmoothingEnabled property, as discussed in #1630 
2. Adds a fix specific to windows, for the case when a newline is encountered within quotes. 

This directly affects the loadTable API as any newline character (```\r\n``` if it's hosted on Windows, or ```\n``` otherwise) which is in between quotes of a CSV record WILL be converted to a ```\n``` by removing the ```\r``` if at all it is encountered. Suggestions welcome ! :smile: 