### PR TITLE
Fix comment in p5.Oscillator reference example

### DIFF
--- a/lib/addons/p5.sound.js
+++ b/lib/addons/p5.sound.js
@@ -44,7 +44,7 @@
  */
 
 /**
- *  p5.sound 
+ *  p5.sound
  *  https://p5js.org/reference/#/libraries/p5.sound
  *
  *  From the Processing Foundation and contributors
@@ -72,7 +72,7 @@
   else
     factory(root['p5']);
 }(this, function (p5) {
-  
+
 var sndcore;
 'use strict';
 sndcore = function () {
@@ -610,7 +610,7 @@ errorHandler = function () {
       Helper function to generate an error
       with a custom stack trace that points to the sketch
       and removes other parts of the stack trace.
-  
+
       @private
       @class customError
       @constructor
@@ -2846,7 +2846,7 @@ fft = function () {
      *    var rectangle_width = (log(i+1)-log(i))*(width/log(spectrum.length));
      *    rect(x, height, rectangle_width, -h )
      *  }
-  
+
      *  var nyquist = 22050;
      *
      *  // get the centroid
@@ -4461,7 +4461,7 @@ oscillator = function () {
    *  function mouseClicked() {
    *    if (mouseX > 0 && mouseX < width && mouseY < height && mouseY > 0) {
    *      if (!playing) {
-   *        // ramp amplitude to 0.5 over 0.1 seconds
+   *        // ramp amplitude to 0.5 over 0.05 seconds
    *        osc.amp(0.5, 0.05);
    *        playing = true;
    *        backgroundColor = color(0,255,255);
@@ -7693,14 +7693,14 @@ effect = function () {
   var CrossFade = Tone_component_CrossFade;
   /**
   * Effect is a base class for audio effects in p5. <br>
-  * This module handles the nodes and methods that are 
+  * This module handles the nodes and methods that are
   * common and useful for current and future effects.
   *
   *
-  * This class is extended by <a href="reference/#/p5.Distortion">p5.Distortion</a>, 
+  * This class is extended by <a href="reference/#/p5.Distortion">p5.Distortion</a>,
   * <a href="reference/#/p5.Compressor">p5.Compressor</a>,
-  * <a href="reference/#/p5.Delay">p5.Delay</a>, 
-  * <a href="reference/#/p5.Filter">p5.Filter</a>, 
+  * <a href="reference/#/p5.Delay">p5.Delay</a>,
+  * <a href="reference/#/p5.Filter">p5.Filter</a>,
   * <a href="reference/#/p5.Reverb">p5.Reverb</a>.
   *
   * @class  p5.Effect
@@ -7711,7 +7711,7 @@ effect = function () {
   * @param {WebAudioNode} [output] Gain Node effect wrapper
   * @param {Object} [_drywet]   Tone.JS CrossFade node (defaults to value: 1)
   * @param {WebAudioNode} [wet]  Effects that extend this class should connect
-  *                              to the wet signal to this gain node, so that dry and wet 
+  *                              to the wet signal to this gain node, so that dry and wet
   *                              signals are mixed properly.
   */
   p5.Effect = function () {
@@ -7739,10 +7739,10 @@ effect = function () {
   };
   /**
   *  Set the output volume of the filter.
-  *  
+  *
   *  @method  amp
   *  @param {Number} [vol] amplitude between 0 and 1.0
-  *  @param {Number} [rampTime] create a fade that lasts until rampTime 
+  *  @param {Number} [rampTime] create a fade that lasts until rampTime
   *  @param {Number} [tFromNow] schedule this event to happen in tFromNow seconds
   */
   p5.Effect.prototype.amp = function (vol, rampTime, tFromNow) {
@@ -7755,12 +7755,12 @@ effect = function () {
     this.output.gain.linearRampToValueAtTime(vol, now + tFromNow + rampTime + 0.001);
   };
   /**
-  * Link effects together in a chain  
+  * Link effects together in a chain
   * Example usage: filter.chain(reverb, delay, panner);
   * May be used with an open-ended number of arguments
   *
-  * @method chain 
-     *  @param {Object} [arguments]  Chain together multiple sound objects  
+  * @method chain
+     *  @param {Object} [arguments]  Chain together multiple sound objects
   */
   p5.Effect.prototype.chain = function () {
     if (arguments.length > 0) {
@@ -7772,8 +7772,8 @@ effect = function () {
     return this;
   };
   /**
-  * Adjust the dry/wet value. 
-  * 
+  * Adjust the dry/wet value.
+  *
   * @method drywet
   * @param {Number} [fade] The desired drywet value (0 - 1.0)
   */
@@ -7785,19 +7785,19 @@ effect = function () {
   };
   /**
   * Send output to a p5.js-sound, Web Audio Node, or use signal to
-  * control an AudioParam 
-  * 
-  * @method connect 
-  * @param {Object} unit 
+  * control an AudioParam
+  *
+  * @method connect
+  * @param {Object} unit
   */
   p5.Effect.prototype.connect = function (unit) {
     var u = unit || p5.soundOut.input;
     this.output.connect(u.input ? u.input : u);
   };
   /**
-  * Disconnect all output.  
-  * 
-  * @method disconnect 
+  * Disconnect all output.
+  *
+  * @method disconnect
   */
   p5.Effect.prototype.disconnect = function () {
     this.output.disconnect();
@@ -7838,9 +7838,9 @@ filter = function () {
    *  The <code>.res()</code> method controls either width of the
    *  bandpass, or resonance of the low/highpass cutoff frequency.
    *
-   *  This class extends <a href = "/reference/#/p5.Effect">p5.Effect</a>.  
-   *  Methods <a href = "/reference/#/p5.Effect/amp">amp()</a>, <a href = "/reference/#/p5.Effect/chain">chain()</a>, 
-   *  <a href = "/reference/#/p5.Effect/drywet">drywet()</a>, <a href = "/reference/#/p5.Effect/connect">connect()</a>, and 
+   *  This class extends <a href = "/reference/#/p5.Effect">p5.Effect</a>.
+   *  Methods <a href = "/reference/#/p5.Effect/amp">amp()</a>, <a href = "/reference/#/p5.Effect/chain">chain()</a>,
+   *  <a href = "/reference/#/p5.Effect/drywet">drywet()</a>, <a href = "/reference/#/p5.Effect/connect">connect()</a>, and
    *  <a href = "/reference/#/p5.Effect/disconnect">disconnect()</a> are available.
    *
    *  @class p5.Filter
@@ -8072,9 +8072,9 @@ delay = function () {
    *  original source.
    *
    *
-   *  This class extends <a href = "/reference/#/p5.Effect">p5.Effect</a>.  
-   *  Methods <a href = "/reference/#/p5.Effect/amp">amp()</a>, <a href = "/reference/#/p5.Effect/chain">chain()</a>, 
-   *  <a href = "/reference/#/p5.Effect/drywet">drywet()</a>, <a href = "/reference/#/p5.Effect/connect">connect()</a>, and 
+   *  This class extends <a href = "/reference/#/p5.Effect">p5.Effect</a>.
+   *  Methods <a href = "/reference/#/p5.Effect/amp">amp()</a>, <a href = "/reference/#/p5.Effect/chain">chain()</a>,
+   *  <a href = "/reference/#/p5.Effect/drywet">drywet()</a>, <a href = "/reference/#/p5.Effect/connect">connect()</a>, and
    *  <a href = "/reference/#/p5.Effect/disconnect">disconnect()</a> are available.
    *  @class p5.Delay
    *  @extends p5.Effect
@@ -8347,9 +8347,9 @@ reverb = function () {
    *  extends p5.Reverb allowing you to recreate the sound of actual physical
    *  spaces through convolution.
    *
-   *  This class extends <a href = "/reference/#/p5.Effect">p5.Effect</a>.  
-   *  Methods <a href = "/reference/#/p5.Effect/amp">amp()</a>, <a href = "/reference/#/p5.Effect/chain">chain()</a>, 
-   *  <a href = "/reference/#/p5.Effect/drywet">drywet()</a>, <a href = "/reference/#/p5.Effect/connect">connect()</a>, and 
+   *  This class extends <a href = "/reference/#/p5.Effect">p5.Effect</a>.
+   *  Methods <a href = "/reference/#/p5.Effect/amp">amp()</a>, <a href = "/reference/#/p5.Effect/chain">chain()</a>,
+   *  <a href = "/reference/#/p5.Effect/drywet">drywet()</a>, <a href = "/reference/#/p5.Effect/connect">connect()</a>, and
    *  <a href = "/reference/#/p5.Effect/disconnect">disconnect()</a> are available.
    *
    *  @class p5.Reverb
@@ -9544,31 +9544,31 @@ compressor = function () {
   /**
    * Compressor is an audio effect class that performs dynamics compression
    * on an audio input source. This is a very commonly used technique in music
-   * and sound production. Compression creates an overall louder, richer, 
+   * and sound production. Compression creates an overall louder, richer,
    * and fuller sound by lowering the volume of louds and raising that of softs.
-   * Compression can be used to avoid clipping (sound distortion due to 
-   * peaks in volume) and is especially useful when many sounds are played 
+   * Compression can be used to avoid clipping (sound distortion due to
+   * peaks in volume) and is especially useful when many sounds are played
    * at once. Compression can be used on indivudal sound sources in addition
-   * to the master output.  
+   * to the master output.
    *
-   * This class extends <a href = "/reference/#/p5.Effect">p5.Effect</a>.  
-   * Methods <a href = "/reference/#/p5.Effect/amp">amp()</a>, <a href = "/reference/#/p5.Effect/chain">chain()</a>, 
-   * <a href = "/reference/#/p5.Effect/drywet">drywet()</a>, <a href = "/reference/#/p5.Effect/connect">connect()</a>, and 
+   * This class extends <a href = "/reference/#/p5.Effect">p5.Effect</a>.
+   * Methods <a href = "/reference/#/p5.Effect/amp">amp()</a>, <a href = "/reference/#/p5.Effect/chain">chain()</a>,
+   * <a href = "/reference/#/p5.Effect/drywet">drywet()</a>, <a href = "/reference/#/p5.Effect/connect">connect()</a>, and
    * <a href = "/reference/#/p5.Effect/disconnect">disconnect()</a> are available.
    *
    * @class p5.Compressor
    * @constructor
    * @extends p5.Effect
    *
-   * 
+   *
    */
   p5.Compressor = function () {
     Effect.call(this);
     /**
-       * The p5.Compressor is built with a <a href="https://www.w3.org/TR/webaudio/#the-dynamicscompressornode-interface" 
+       * The p5.Compressor is built with a <a href="https://www.w3.org/TR/webaudio/#the-dynamicscompressornode-interface"
      *   target="_blank" title="W3 spec for Dynamics Compressor Node">Web Audio Dynamics Compressor Node
      *   </a>
-       * @property {WebAudioNode} compressor 
+       * @property {WebAudioNode} compressor
        */
     this.compressor = this.ac.createDynamicsCompressor();
     this.input.connect(this.compressor);
@@ -9578,13 +9578,13 @@ compressor = function () {
   /**
   * Performs the same function as .connect, but also accepts
   * optional parameters to set compressor's audioParams
-  * @method process 
+  * @method process
   *
   * @param {Object} src         Sound source to be connected
-  * 
+  *
   * @param {Number} [attack]     The amount of time (in seconds) to reduce the gain by 10dB,
   *                            default = .003, range 0 - 1
-  * @param {Number} [knee]       A decibel value representing the range above the 
+  * @param {Number} [knee]       A decibel value representing the range above the
   *                            threshold where the curve smoothly transitions to the "ratio" portion.
   *                            default = 30, range 0 - 40
   * @param {Number} [ratio]      The amount of dB change in input for a 1 dB change in output
@@ -9599,11 +9599,11 @@ compressor = function () {
     this.set(attack, knee, ratio, threshold, release);
   };
   /**
-   * Set the paramters of a compressor. 
+   * Set the paramters of a compressor.
    * @method  set
    * @param {Number} attack     The amount of time (in seconds) to reduce the gain by 10dB,
    *                            default = .003, range 0 - 1
-   * @param {Number} knee       A decibel value representing the range above the 
+   * @param {Number} knee       A decibel value representing the range above the
    *                            threshold where the curve smoothly transitions to the "ratio" portion.
    *                            default = 30, range 0 - 40
    * @param {Number} ratio      The amount of dB change in input for a 1 dB change in output
@@ -9632,8 +9632,8 @@ compressor = function () {
   };
   /**
    * Get current attack or set value w/ time ramp
-   * 
-   * 
+   *
+   *
    * @method attack
    * @param {Number} [attack] Attack is the amount of time (in seconds) to reduce the gain by 10dB,
    *                          default = .003, range 0 - 1
@@ -9652,9 +9652,9 @@ compressor = function () {
   };
   /**
    * Get current knee or set value w/ time ramp
-   * 
+   *
    * @method knee
-   * @param {Number} [knee] A decibel value representing the range above the 
+   * @param {Number} [knee] A decibel value representing the range above the
    *                        threshold where the curve smoothly transitions to the "ratio" portion.
    *                        default = 30, range 0 - 40
    * @param {Number} [time]  Assign time value to schedule the change in value
@@ -9675,7 +9675,7 @@ compressor = function () {
    * @method ratio
    *
    * @param {Number} [ratio]      The amount of dB change in input for a 1 dB change in output
-   *                            default = 12, range 1 - 20 
+   *                            default = 12, range 1 - 20
    * @param {Number} [time]  Assign time value to schedule the change in value
    */
   p5.Compressor.prototype.ratio = function (ratio, time) {
@@ -10411,12 +10411,12 @@ distortion = function () {
    * A Distortion effect created with a Waveshaper Node,
    * with an approach adapted from
    * [Kevin Ennis](http://stackoverflow.com/questions/22312841/waveshaper-node-in-webaudio-how-to-emulate-distortion)
-   * 
-   * This class extends <a href = "/reference/#/p5.Effect">p5.Effect</a>.  
-   * Methods <a href = "/reference/#/p5.Effect/amp">amp()</a>, <a href = "/reference/#/p5.Effect/chain">chain()</a>, 
-   * <a href = "/reference/#/p5.Effect/drywet">drywet()</a>, <a href = "/reference/#/p5.Effect/connect">connect()</a>, and 
+   *
+   * This class extends <a href = "/reference/#/p5.Effect">p5.Effect</a>.
+   * Methods <a href = "/reference/#/p5.Effect/amp">amp()</a>, <a href = "/reference/#/p5.Effect/chain">chain()</a>,
+   * <a href = "/reference/#/p5.Effect/drywet">drywet()</a>, <a href = "/reference/#/p5.Effect/connect">connect()</a>, and
    * <a href = "/reference/#/p5.Effect/disconnect">disconnect()</a> are available.
-   * 
+   *
    * @class p5.Distortion
    * @extends p5.Effect
    * @constructor


### PR DESCRIPTION
Fix comment in p5.Oscillator reference example, https://p5js.org/reference/#/p5.Oscillator.

(Add ?w=1 to the Github diff URL to hide the trailing spaces deletions that my IDE automatically made.)