### PR TITLE
Aligned manual tests for webgl/origin

### DIFF
--- a/test/manual-test-examples/webgl/origin/center_origin/sketch.js
+++ b/test/manual-test-examples/webgl/origin/center_origin/sketch.js
@@ -14,17 +14,13 @@ function draw(){
 
   for(var i = -2; i < 3; i++){
     for(var j = -2; j < 3; j++){
-      fill((i+2) * 40, (j+2) * 40, 0);
-      push();
-      translate(i*gap, j*gap,0);
-      plane();
-      pop();
-      // quad(
-      //   i * gap, j * gap, 0,
-      //   i * gap + w, j * gap, 0,
-      //   i * gap, j * gap + h, 0,
-      //   i * gap + w, j * gap + h, 0
-      //   );
+      fill(i * 40, j * 40, 0);
+      quad(
+        i * gap, j * gap,
+        i * gap, j * gap + h,
+        i * gap + w, j * gap + h,
+        i * gap + w, j * gap,
+        );
     }
   }
 

--- a/test/manual-test-examples/webgl/origin/center_origin/sketch.js
+++ b/test/manual-test-examples/webgl/origin/center_origin/sketch.js
@@ -19,7 +19,7 @@ function draw(){
         i * gap, j * gap,
         i * gap, j * gap + h,
         i * gap + w, j * gap + h,
-        i * gap + w, j * gap,
+        i * gap + w, j * gap
         );
     }
   }

--- a/test/manual-test-examples/webgl/origin/topleft_origin/sketch.js
+++ b/test/manual-test-examples/webgl/origin/topleft_origin/sketch.js
@@ -19,7 +19,7 @@ function draw(){
         i * gap, j * gap,
         i * gap, j * gap + h,
         i * gap + w, j * gap + h,
-        i * gap + w, j * gap,
+        i * gap + w, j * gap
         );
     }
   }

--- a/test/manual-test-examples/webgl/origin/topleft_origin/sketch.js
+++ b/test/manual-test-examples/webgl/origin/topleft_origin/sketch.js
@@ -5,9 +5,7 @@ function setup(){
 function draw(){
 
   background(255);
-  noStroke();
   translate(-width/2, -height/2, 0);
-
   rotateY(frameCount * 0.01);
 
   var gap = 200;
@@ -18,10 +16,10 @@ function draw(){
     for(var j = 0; j < 5; j++){
       fill(i * 40, j * 40, 0);
       quad(
-        i * gap, j * gap, 0,
-        i * gap + w, j * gap, 0,
-        i * gap, j * gap + h, 0,
-        i * gap + w, j * gap + h, 0
+        i * gap, j * gap,
+        i * gap, j * gap + h,
+        i * gap + w, j * gap + h,
+        i * gap + w, j * gap,
         );
     }
   }


### PR DESCRIPTION
Aligned tests meant to be direct comparisons. Origin tests were inconsistent. Apparently written expecting quad to take 12 arguments, not 8. Corrected ordering of vertices in quad in topleft_origin