### PR TITLE
Documentation example for p5.MediaElement.pause()

### DIFF
--- a/lib/addons/p5.dom.js
+++ b/lib/addons/p5.dom.js
@@ -1889,6 +1889,61 @@
    *
    * @method pause
    * @return {Object|p5.Element}
+   * @example
+   * <div><code>
+   *
+   * //This example both starts 
+   * //and stops a sound sample
+   * //when the user clicks the canvas
+   *
+   * //We will store the p5.MediaElement
+   * //object in here
+   * var ele;
+   *
+   * //while our audio is playing,
+   * //this will be set to true
+   * var sampleIsPlaying = false;
+   *
+   * function setup() {
+   *   //Here we create a p5.MediaElement object
+   *   //using the createAudio() function.
+   *   ele = createAudio('assets/beat.mp3');
+   *   background(200);
+   *   textAlign(CENTER);
+   *   text("Click to play!", width/2, height/2);
+   * }
+   *
+   * function mouseClicked() {
+   *   //here we test if the mouse is over the
+   *   //canvas element when it's clicked
+   *   if(mouseX >= 0 && mouseX <= width &&
+   *     mouseY >= 0 && mouseY <= height) {
+   *     background(200);
+   *
+   *     if(sampleIsPlaying) {
+   *       //if the sample is currently playing
+   *       //calling the pause() function on
+   *       //our p5.MediaElement will stop
+   *       //it and reset its current
+   *       //time to 0 (i.e. it will start
+   *       //at the beginning the next time
+   *       //you play it)
+   *       ele.stop();
+   *
+   *       sampleIsPlaying = false;
+   *       text("Click to play!", width/2, height/2);
+   *     } else {
+   *       //loop our sound element until we
+   *       //call ele.stop() on it.
+   *       ele.loop(); 
+   *
+   *       sampleIsPlaying = true;
+   *       text("Click to stop!", width/2, height/2);
+   *     }
+   *   }
+   * }
+   *
+   * </code></div>
    */
   p5.MediaElement.prototype.pause = function() {
     this.elt.pause();

--- a/lib/addons/p5.dom.js
+++ b/lib/addons/p5.dom.js
@@ -1891,9 +1891,8 @@
    * @return {Object|p5.Element}
    * @example
    * <div><code>
-   *
-   * //This example both starts 
-   * //and stops a sound sample
+   * //This example both starts
+   * //and pauses a sound sample
    * //when the user clicks the canvas
    *
    * //We will store the p5.MediaElement
@@ -1907,7 +1906,7 @@
    * function setup() {
    *   //Here we create a p5.MediaElement object
    *   //using the createAudio() function.
-   *   ele = createAudio('assets/beat.mp3');
+   *   ele = createAudio('assets/lucky_dragons_-_power_melody.mp3');
    *   background(200);
    *   textAlign(CENTER);
    *   text("Click to play!", width/2, height/2);
@@ -1921,24 +1920,23 @@
    *     background(200);
    *
    *     if(sampleIsPlaying) {
-   *       //if the sample is currently playing
-   *       //calling the pause() function on
-   *       //our p5.MediaElement will stop
-   *       //it and reset its current
-   *       //time to 0 (i.e. it will start
-   *       //at the beginning the next time
-   *       //you play it)
-   *       ele.stop();
+   *       //Calling pause() on our
+   *       //p5.MediaElement will stop it
+   *       //playing, but when we call the
+   *       //loop() or play() functions
+   *       //the sample will start from
+   *       //where we paused it.
+   *       ele.pause();
    *
    *       sampleIsPlaying = false;
-   *       text("Click to play!", width/2, height/2);
+   *       text("Click to resume!", width/2, height/2);
    *     } else {
    *       //loop our sound element until we
-   *       //call ele.stop() on it.
+   *       //call ele.pause() on it.
    *       ele.loop(); 
    *
    *       sampleIsPlaying = true;
-   *       text("Click to stop!", width/2, height/2);
+   *       text("Click to pause!", width/2, height/2);
    *     }
    *   }
    * }


### PR DESCRIPTION
Partially addresses #1954 - it's pretty much a copy of the "stop()" example, except it uses a longer sound sample that makes it more obvious that the audio has been paused and resumed.