### PR TITLE
Fix memory leak when running many p5 instances.

### DIFF
--- a/src/core/core.js
+++ b/src/core/core.js
@@ -204,6 +204,15 @@ var p5 = function(sketch, node, sync) {
   this._events.wheel = null;
   this._loadingScreenId = 'p5_loading';
 
+  // Allows methods to be registered on an instance that
+  // are instance-specific.
+  this._registeredMethods = {};
+  var methods = Object.getOwnPropertyNames(p5.prototype._registeredMethods);
+  for(var i = 0; i < methods.length; i++) {
+    var prop = methods[i];
+    this._registeredMethods[prop] = p5.prototype._registeredMethods[prop].slice();
+  }
+
   if (window.DeviceOrientationEvent) {
     this._events.deviceorientation = null;
   }
@@ -589,10 +598,11 @@ p5.prototype.registerPreloadMethod = function(fnString, obj) {
 };
 
 p5.prototype.registerMethod = function(name, m) {
-  if (!p5.prototype._registeredMethods.hasOwnProperty(name)) {
-    p5.prototype._registeredMethods[name] = [];
+  var target = this || p5.prototype;
+  if (!target._registeredMethods.hasOwnProperty(name)) {
+    target._registeredMethods[name] = [];
   }
-  p5.prototype._registeredMethods[name].push(m);
+  target._registeredMethods[name].push(m);
 };
 
 p5.prototype._createFriendlyGlobalFunctionBinder = function(options) {


### PR DESCRIPTION
Also resolves a problem where one sketch being removed would remove another sketch's things.
Fixes #2259 