### PR TITLE
Add example for p5.Image

### DIFF
--- a/src/image/p5.Image.js
+++ b/src/image/p5.Image.js
@@ -35,6 +35,52 @@ var Filters = require('./filters');
  * <br><br>
  * Before using the pixels[] array, be sure to use the loadPixels() method on
  * the image to make sure that the pixel data is properly loaded.
+ * @example
+ * <div><code>
+ *
+ * function setup() {
+ *   var img = createImage(100, 100); // same as new p5.Image(100, 100);
+ *   img.loadPixels();
+ *   createCanvas(100, 100);
+ *   background(0);
+ *
+ *   // helper for writing color to array
+ *   function writeColor(image, x, y, red, green, blue, alpha) {
+ *     var index = (x + (y * width)) * 4;
+ *     image.pixels[index]   = red;
+ *     image.pixels[index+1] = green;
+ *     image.pixels[index+2] = blue;
+ *     image.pixels[index+3] = alpha;
+ *   }
+ *
+ *   // fill with random colors
+ *   for (var y = 0; y < img.height; y++) {
+ *     for (var x = 0; x < img.width; x++) {
+ *       var red = random(255);
+ *       var green = random(255);
+ *       var blue = random(255);
+ *       var alpha = 255;
+ *       writeColor(img, x, y, red, green, blue, alpha);
+ *     }
+ *   }
+ *
+ *   // draw a red line
+ *   for (var x = 0; x < img.width; x++) {
+ *     var y = 0;
+ *     writeColor(img, x, y, 255, 0, 0, 255);
+ *   }
+ *
+ *   // draw a green line
+ *   for (var x = 0; x < img.width; x++) {
+ *     var y = img.height - 1;
+ *     writeColor(img, x, y, 0, 255, 0, 255);
+ *   }
+ *
+ *   img.updatePixels();
+ *   image(img, 0, 0);
+ * }
+ * </code></div>
+ *
  *
  * @class p5.Image
  * @constructor
@@ -118,7 +164,7 @@ p5.Image = function(width, height){
    * values of the pixel at (1, 0). More generally, to set values for a pixel
    * at (x, y):
    * ```javascript
-   * var d = pixelDensity;
+   * var d = pixelDensity();
    * for (var i = 0; i < d; i++) {
    *   for (var j = 0; j < d; j++) {
    *     // loop over


### PR DESCRIPTION
Closes #1988 

I don't think that the original example [1] is correct. I checked the array size on my phone with pixelDensity() === 3 and it's not larger than on my PC. If you can confirm it to be valid / invalid I can update the PR accordingly.

[1]:
```javascript
var d = pixelDensity();
for (var i = 0; i < d; i++) {
  for (var j = 0; j < d; j++) {
    // loop over
    idx = 4 * ((y * d + j) * width * d + (x * d + i));
    pixels[idx] = r;
    pixels[idx+1] = g;
    pixels[idx+2] = b;
    pixels[idx+3] = a;
  }
}
```