### PR TITLE
fix typo in .checked() function

### DIFF
--- a/lib/addons/p5.dom.js
+++ b/lib/addons/p5.dom.js
@@ -466,7 +466,7 @@
    *
    * @method createCheckbox
    * @param  {String} [label] label displayed after checkbox
-   * @param  {boolean} [value] value of the checkbox; checked is true, unchecked is false.Unchecked if no value given
+   * @param  {boolean} [value] value of the checkbox; checked is true, unchecked is false
    * @return {Object|p5.Element} pointer to p5.Element holding created node
    * @example
    * <div class='norender'><code>


### PR DESCRIPTION
this change makes the parameter description clearer