### PR TITLE
Generate TypeScript definitions

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -384,7 +384,7 @@ module.exports = function(grunt) {
   grunt.loadTasks('tasks/release');
 
   // Load typescript task
-  grunt.registerTask('typescript', function () {
+  grunt.registerTask('typescript', function() {
     require('./tasks/typescript/task.js')(grunt);
   });
 

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -383,6 +383,11 @@ module.exports = function(grunt) {
   // Load release task
   grunt.loadTasks('tasks/release');
 
+  // Load typescript task
+  grunt.registerTask('typescript', function () {
+    require('./tasks/typescript/task.js')(grunt);
+  });
+
   // Load the external libraries used.
   grunt.loadNpmTasks('grunt-contrib-compress');
   grunt.loadNpmTasks('grunt-contrib-connect');
@@ -426,7 +431,7 @@ module.exports = function(grunt) {
     'mochaTest'
   ]);
   grunt.registerTask('test:nobuild', ['eslint:test', 'connect', 'mocha']);
-  grunt.registerTask('yui', ['yuidoc:prod', 'minjson']);
+  grunt.registerTask('yui', ['yuidoc:prod', 'minjson', 'typescript']);
   grunt.registerTask('yui:test', ['yuidoc:prod', 'connect', 'mocha:yui']);
   grunt.registerTask('default', ['test']);
   grunt.registerTask('saucetest', ['connect', 'saucelabs-mocha']);

--- a/package.json
+++ b/package.json
@@ -100,6 +100,7 @@
     "whatwg-fetch": "^2.0.3"
   },
   "main": "./lib/p5.js",
+  "types": "./lib/p5.d.ts",
   "files": [
     "license.txt",
     "lib/p5.min.js",
@@ -107,7 +108,9 @@
     "lib/addons/p5.sound.js",
     "lib/addons/p5.sound.min.js",
     "lib/addons/p5.dom.js",
-    "lib/addons/p5.dom.min.js"
+    "lib/addons/p5.dom.min.js",
+    "lib/p5.d.ts",
+    "lib/p5.global-mode.d.ts"
   ],
   "description": "[![Build Status](https://travis-ci.org/processing/p5.js.svg?branch=master)](https://travis-ci.org/processing/p5.js) [![npm version](https://badge.fury.io/js/p5.svg)](https://www.npmjs.com/package/p5)",
   "bugs": {

--- a/package.json
+++ b/package.json
@@ -71,6 +71,7 @@
     "grunt-release-it": "^1.0.1",
     "grunt-saucelabs": "8.6.1",
     "grunt-update-json": "^0.2.1",
+    "html2plaintext": "^1.1.1",
     "husky": "^0.14.3",
     "jscs-stylish": "^0.3.1",
     "karma": "^1.7.1",
@@ -87,7 +88,8 @@
     "mocha": "^3.2.0",
     "phantomjs": "^2.1.7",
     "prettier": "^1.7.4",
-    "request": "^2.81.0"
+    "request": "^2.81.0",
+    "word-wrap": "^1.2.3"
   },
   "license": "LGPL-2.1",
   "dependencies": {

--- a/src/core/core.js
+++ b/src/core/core.js
@@ -26,13 +26,14 @@ var constants = require('./constants');
  * "global"   - all properties and methods are attached to the window
  * "instance" - all properties and methods are bound to this p5 object
  *
- * @private
+ * @class p5
+ * @constructor
  * @param  {function}    sketch a closure that can set optional preload(),
  *                              setup(), and/or draw() properties on the
  *                              given p5 instance
- * @param  {HTMLElement|boolean} [node] element to attach canvas to, if a
+ * @param  {HTMLElement|Boolean} [node] element to attach canvas to, if a
  *                                      boolean is passed in use it as sync
- * @param  {boolean}     [sync] start synchronously (optional)
+ * @param  {Boolean}     [sync] start synchronously (optional)
  * @return {p5}                 a p5 instance
  */
 var p5 = function(sketch, node, sync) {

--- a/tasks/release/release-github.js
+++ b/tasks/release/release-github.js
@@ -63,6 +63,12 @@ module.exports = function(grunt) {
         './lib/addons/p5.sound.min.js',
         'application/javascript'
       ],
+      p5ts: ['p5.d.ts', './lib/p5.d.ts', 'text/plain'],
+      p5globalts: [
+        'p5.global-mode.d.ts',
+        './lib/p5.global-mode.d.ts',
+        'text/plain'
+      ],
       p5zip: ['p5.zip', './p5.zip', 'application/zip']
     };
 

--- a/tasks/typescript/emit.js
+++ b/tasks/typescript/emit.js
@@ -1,0 +1,81 @@
+var fs = require('fs');
+
+function shortenDescription(desc) {
+  var match = desc.match(/^((.|\n)+?\.)\s/);
+
+  if (match) {
+    return match[1];
+  }
+  return desc;
+}
+
+function createEmitter(filename) {
+  var indentLevel = 0;
+  var lastText = '';
+  var currentSourceFile;
+  var fd = fs.openSync(filename, 'w');
+
+  var emit = function(text) {
+    var indentation = [];
+    var finalText;
+
+    for (var i = 0; i < indentLevel; i++) {
+      indentation.push('  ');
+    }
+
+    finalText = indentation.join('') + text + '\n';
+    fs.writeSync(fd, finalText);
+
+    lastText = text;
+  };
+
+  emit.description = function(desc) {
+    if (!desc) {
+      return;
+    }
+
+    emit.sectionBreak();
+    emit('/**');
+    shortenDescription(desc).split('\n').forEach(function(line) {
+      emit(' * ' + line);
+    });
+    emit(' */');
+  };
+
+  emit.setCurrentSourceFile = function(file) {
+    if (file !== currentSourceFile) {
+      currentSourceFile = file;
+      emit.sectionBreak();
+      emit('// ' + file);
+      emit.sectionBreak();
+    }
+  };
+
+  emit.sectionBreak = function() {
+    if (lastText !== '' && !/\{$/.test(lastText)) {
+      emit('');
+    }
+  };
+
+  emit.getIndentLevel = function() {
+    return indentLevel;
+  };
+
+  emit.indent = function() {
+    indentLevel++;
+  };
+
+  emit.dedent = function() {
+    indentLevel--;
+  };
+
+  emit.close = function() {
+    fs.closeSync(fd);
+  };
+
+  emit('// This file was auto-generated. Please do not edit it.\n');
+
+  return emit;
+}
+
+module.exports = createEmitter;

--- a/tasks/typescript/emit.js
+++ b/tasks/typescript/emit.js
@@ -4,7 +4,7 @@ var wrap = require('word-wrap');
 
 function shortenDescription(desc) {
 
-  return wrap(h2p(desc), {
+  return wrap(h2p(desc).replace(/[\r\n]+/, ''), {
     width: 50,
   });
 }
@@ -29,16 +29,51 @@ function createEmitter(filename) {
     lastText = text;
   };
 
-  emit.description = function(desc) {
+  emit.description = function(classitem, overload) {
+    var desc = classitem.description;
     if (!desc) {
       return;
     }
 
+    function emitDescription(desc) {
+      shortenDescription(desc).split('\n').forEach(function(line) {
+        emit(' * ' + line);
+      });
+    }
+
     emit.sectionBreak();
     emit('/**');
-    shortenDescription(desc).split('\n').forEach(function(line) {
-      emit(' * ' + line);
-    });
+    emitDescription(desc);
+    emit(' *');
+    if (overload) {
+      var alloverloads = [classitem];
+      if (classitem.overloads) {
+        alloverloads = alloverloads.concat(classitem.overloads);
+      }
+      if (overload.params) {
+        overload.params.forEach(function (p) {
+          var arg = p.name;
+          var p2;
+          for (var i = 0; !p2 && i < alloverloads.length; i ++) {
+            if (alloverloads[i].params) {
+              p2 = alloverloads[i].params.find(p3 => p3.description && p3.name === arg);
+              if (p2) {
+                if (p.optional) {
+                  arg = '[' + arg + ']';
+                }
+                emitDescription('@param ' + arg + ' ' + p2.description);
+                break;
+              }
+            }
+          }
+        });
+      }
+      if (overload.chainable) {
+        emitDescription('@chainable');
+      } else if (overload.return && overload.return.description) {
+        emitDescription('@return ' + overload.return.description);
+      }
+    }
     emit(' */');
   };
 

--- a/tasks/typescript/emit.js
+++ b/tasks/typescript/emit.js
@@ -3,9 +3,8 @@ var h2p = require('html2plaintext');
 var wrap = require('word-wrap');
 
 function shortenDescription(desc) {
-
   return wrap(h2p(desc).replace(/[\r\n]+/, ''), {
-    width: 50,
+    width: 50
   });
 }
 
@@ -36,9 +35,11 @@ function createEmitter(filename) {
     }
 
     function emitDescription(desc) {
-      shortenDescription(desc).split('\n').forEach(function(line) {
-        emit(' * ' + line);
-      });
+      shortenDescription(desc)
+        .split('\n')
+        .forEach(function(line) {
+          emit(' * ' + line);
+        });
     }
 
     emit.sectionBreak();
@@ -51,12 +52,14 @@ function createEmitter(filename) {
         alloverloads = alloverloads.concat(classitem.overloads);
       }
       if (overload.params) {
-        overload.params.forEach(function (p) {
+        overload.params.forEach(function(p) {
           var arg = p.name;
           var p2;
-          for (var i = 0; !p2 && i < alloverloads.length; i ++) {
+          for (var i = 0; !p2 && i < alloverloads.length; i++) {
             if (alloverloads[i].params) {
-              p2 = alloverloads[i].params.find(p3 => p3.description && p3.name === arg);
+              p2 = alloverloads[i].params.find(
+                p3 => p3.description && p3.name === arg
+              );
               if (p2) {
                 if (p.optional) {
                   arg = '[' + arg + ']';

--- a/tasks/typescript/emit.js
+++ b/tasks/typescript/emit.js
@@ -1,12 +1,12 @@
 var fs = require('fs');
+var h2p = require('html2plaintext');
+var wrap = require('word-wrap');
 
 function shortenDescription(desc) {
-  var match = desc.match(/^((.|\n)+?\.)\s/);
 
-  if (match) {
-    return match[1];
-  }
-  return desc;
+  return wrap(h2p(desc), {
+    width: 50,
+  });
 }
 
 function createEmitter(filename) {

--- a/tasks/typescript/generate-typescript-annotations.js
+++ b/tasks/typescript/generate-typescript-annotations.js
@@ -17,7 +17,6 @@ function overloadPosition(classitem, overload) {
 // This design was selected to avoid rewriting the whole file from
 // https://github.com/toolness/friendly-error-fellowship/blob/2093aee2acc53f0885fcad252a170e17af19682a/experiments/typescript/generate-typescript-annotations.js
 function mod(yuidocs, localFileame, globalFilename, sourcePath) {
-
   var emit;
   var constants = {};
   var missingTypes = {};
@@ -47,29 +46,29 @@ function mod(yuidocs, localFileame, globalFilename, sourcePath) {
   ]);
 
   var YUIDOC_TO_TYPESCRIPT_PARAM_MAP = {
-    'Object': 'object',
-    'Any': 'any',
-    'Number': 'number',
-    'Integer': 'number',
-    'String': 'string',
-    'Constant': 'any',
-    'undefined': 'undefined',
-    'Null': 'null',
-    'Array': 'any[]',
-    'Boolean': 'boolean',
+    Object: 'object',
+    Any: 'any',
+    Number: 'number',
+    Integer: 'number',
+    String: 'string',
+    Constant: 'any',
+    undefined: 'undefined',
+    Null: 'null',
+    Array: 'any[]',
+    Boolean: 'boolean',
     '*': 'any',
-    'Void': 'void',
-    'P5': 'p5',
+    Void: 'void',
+    P5: 'p5',
     // When the docs don't specify what kind of function we expect,
     // then we need to use the global type `Function`
-    'Function': 'Function',
+    Function: 'Function',
     // Special ignore for hard to fix YUIDoc from p5.sound
     'Tone.Signal': 'any',
-    'SoundObject': 'any',
+    SoundObject: 'any'
   };
 
   function getClassitems(className) {
-    return yuidocs.classitems.filter(function (classitem) {
+    return yuidocs.classitems.filter(function(classitem) {
       // Note that we first find items with the right class name,
       // but we also check for classitem.name because
       // YUIDoc includes classitems that we want to be undocumented
@@ -84,8 +83,11 @@ function mod(yuidocs, localFileame, globalFilename, sourcePath) {
   }
 
   function isValidP5ClassName(className) {
-    return P5_CLASS_RE.test(className) && className in yuidocs.classes ||
-      P5_CLASS_RE.test('p5.' + className) && ('p5.' + className) in yuidocs.classes;
+    return (
+      (P5_CLASS_RE.test(className) && className in yuidocs.classes) ||
+      (P5_CLASS_RE.test('p5.' + className) &&
+        'p5.' + className in yuidocs.classes)
+    );
   }
 
   /**
@@ -104,12 +106,13 @@ function mod(yuidocs, localFileame, globalFilename, sourcePath) {
       errors.push('"' + classitem.name + '" is not a valid JS symbol name');
     }
 
-    (overload.params || []).forEach(function (param) {
+    (overload.params || []).forEach(function(param) {
       if (param.optional) {
         optionalParamFound = true;
       } else if (optionalParamFound) {
-        errors.push('required param "' + param.name + '" follows an ' +
-          'optional param');
+        errors.push(
+          'required param "' + param.name + '" follows an ' + 'optional param'
+        );
       }
 
       if (param.name in paramNames) {
@@ -118,17 +121,16 @@ function mod(yuidocs, localFileame, globalFilename, sourcePath) {
       paramNames[param.name] = true;
 
       if (!JS_SYMBOL_RE.test(param.name)) {
-        errors.push('param "' + param.name +
-          '" is not a valid JS symbol name');
+        errors.push('param "' + param.name + '" is not a valid JS symbol name');
       }
 
       if (!validateType(param.type)) {
-        errors.push('param "' + param.name + '" has invalid type: ' +
-          param.type);
+        errors.push(
+          'param "' + param.name + '" has invalid type: ' + param.type
+        );
       }
 
       if (param.type === 'Constant') {
-
         var constantRe = /either\s+(?:[A-Z0-9_]+\s*,?\s*(?:or)?\s*)+/g;
         var execResult = constantRe.exec(param.description);
         var match;
@@ -139,7 +141,6 @@ function mod(yuidocs, localFileame, globalFilename, sourcePath) {
           match = 'CLOSE';
         }
         if (match) {
-
           var values = [];
 
           var reConst = /[A-Z0-9_]+/g;
@@ -147,16 +148,31 @@ function mod(yuidocs, localFileame, globalFilename, sourcePath) {
           while ((matchConst = reConst.exec(match)) !== null) {
             values.push(matchConst);
           }
-          var paramWords = param.name.split('.').pop().replace(/([A-Z])/g, ' $1').trim().toLowerCase().split(' ');
-          var propWords = classitem.name.split('.').pop().replace(/([A-Z])/g, ' $1').trim().toLowerCase().split(' ');
+          var paramWords = param.name
+            .split('.')
+            .pop()
+            .replace(/([A-Z])/g, ' $1')
+            .trim()
+            .toLowerCase()
+            .split(' ');
+          var propWords = classitem.name
+            .split('.')
+            .pop()
+            .replace(/([A-Z])/g, ' $1')
+            .trim()
+            .toLowerCase()
+            .split(' ');
 
           var constName;
           if (paramWords.length > 1 || propWords[0] === 'create') {
             constName = paramWords.join('_');
-          } else if (propWords[propWords.length - 1] === paramWords[paramWords.length - 1]) {
+          } else if (
+            propWords[propWords.length - 1] ===
+            paramWords[paramWords.length - 1]
+          ) {
             constName = propWords.join('_');
           } else {
-            constName = (propWords[0] + '_' + paramWords[paramWords.length - 1]);
+            constName = propWords[0] + '_' + paramWords[paramWords.length - 1];
           }
 
           constName = constName.toUpperCase();
@@ -198,10 +214,10 @@ function mod(yuidocs, localFileame, globalFilename, sourcePath) {
     if (matchFunction) {
       var paramTypes = matchFunction[1].split(',');
       const mappedParamTypes = paramTypes.map((t, i) => {
-        const paramName = 'p' + (i + 1)
-        const paramType = translateType(t, 'any')
-        return paramName+ ': ' + paramType
-      })
+        const paramName = 'p' + (i + 1);
+        const paramType = translateType(t, 'any');
+        return paramName + ': ' + paramType;
+      });
       return '(' + mappedParamTypes.join(',') + ') => any';
     }
 
@@ -237,34 +253,42 @@ function mod(yuidocs, localFileame, globalFilename, sourcePath) {
       name = 'theClass';
     }
 
-    return name + (param.optional ? '?' : '') + ': ' + translateType(param.type, 'any');
+    return (
+      name +
+      (param.optional ? '?' : '') +
+      ': ' +
+      translateType(param.type, 'any')
+    );
   }
 
   function generateClassMethod(className, classitem) {
     if (classitem.overloads) {
-      classitem.overloads.forEach(function (overload) {
+      classitem.overloads.forEach(function(overload) {
         generateClassMethodWithParams(className, classitem, overload);
       });
-    }
-    else {
+    } else {
       generateClassMethodWithParams(className, classitem, classitem);
     }
   }
 
-
   function generateClassMethodWithParams(className, classitem, overload) {
     var errors = validateMethod(classitem, overload);
     var params = (overload.params || []).map(translateParam);
-    var returnType = overload.chainable ? className
-      : overload.return ? translateType(overload.return.type, 'any')
-        : 'void';
+    var returnType = overload.chainable
+      ? className
+      : overload.return ? translateType(overload.return.type, 'any') : 'void';
     var decl;
 
     if (classitem.is_constructor) {
       decl = 'constructor(' + params.join(', ') + ')';
     } else {
-      decl = (overload.static ? 'static ' : '') + classitem.name + '(' +
-        params.join(', ') + '): ' + returnType;
+      decl =
+        (overload.static ? 'static ' : '') +
+        classitem.name +
+        '(' +
+        params.join(', ') +
+        '): ' +
+        returnType;
     }
 
     if (emit.getIndentLevel() === 0) {
@@ -273,11 +297,22 @@ function mod(yuidocs, localFileame, globalFilename, sourcePath) {
 
     if (errors.length) {
       emit.sectionBreak();
-      emit('// TODO: Fix ' + classitem.name + '() errors in ' +
-        overloadPosition(classitem, overload) + ':');
+      emit(
+        '// TODO: Fix ' +
+          classitem.name +
+          '() errors in ' +
+          overloadPosition(classitem, overload) +
+          ':'
+      );
       emit('//');
-      errors.forEach(function (error) {
-        console.log( classitem.name + '() ' + overloadPosition(classitem, overload) + ', ' + error);
+      errors.forEach(function(error) {
+        console.log(
+          classitem.name +
+            '() ' +
+            overloadPosition(classitem, overload) +
+            ', ' +
+            error
+        );
         emit('//   ' + error);
       });
       emit('//');
@@ -314,37 +349,38 @@ function mod(yuidocs, localFileame, globalFilename, sourcePath) {
       if (defaultValue) {
         decl = classitem.name + ': ';
         if (translatedType === 'string') {
-          decl += '\'' + defaultValue.replace(/'/g, '\\\'') + '\'';
-        }
-        else {
+          decl += "'" + defaultValue.replace(/'/g, "\\'") + "'";
+        } else {
           decl += defaultValue;
         }
       } else {
         decl = classitem.name + ': ' + translatedType;
       }
 
-
       emit.description(classitem);
 
       if (emit.getIndentLevel() === 0) {
-        const declarationType = (classitem.final ? 'const ' : 'var ');
+        const declarationType = classitem.final ? 'const ' : 'var ';
         emit('declare ' + declarationType + decl + ';');
       } else {
         const modifier = classitem.final ? 'readonly ' : '';
         emit(modifier + decl);
       }
-
     } else {
       emit.sectionBreak();
-      emit('// TODO: Property "' + classitem.name +
-        '", defined in ' + classitemPosition(classitem) +
-        ', is not a valid JS symbol name');
+      emit(
+        '// TODO: Property "' +
+          classitem.name +
+          '", defined in ' +
+          classitemPosition(classitem) +
+          ', is not a valid JS symbol name'
+      );
       emit.sectionBreak();
     }
   }
 
   function generateClassProperties(className) {
-    getClassitems(className).forEach(function (classitem) {
+    getClassitems(className).forEach(function(classitem) {
       classitem.file = classitem.file.replace(/\\/g, '/');
       emit.setCurrentSourceFile(classitem.file);
       if (classitem.itemtype === 'method') {
@@ -352,8 +388,14 @@ function mod(yuidocs, localFileame, globalFilename, sourcePath) {
       } else if (classitem.itemtype === 'property') {
         generateClassProperty(className, classitem);
       } else {
-        emit('// TODO: Annotate ' + classitem.itemtype + ' "' +
-          classitem.name + '", defined in ' + classitemPosition(classitem));
+        emit(
+          '// TODO: Annotate ' +
+            classitem.itemtype +
+            ' "' +
+            classitem.name +
+            '", defined in ' +
+            classitemPosition(classitem)
+        );
       }
     });
   }
@@ -373,8 +415,12 @@ function mod(yuidocs, localFileame, globalFilename, sourcePath) {
     info.file = info.file.replace(/\\/g, '/');
     emit.setCurrentSourceFile(info.file);
 
-    emit('class ' + nestedClassName +
-      (info.extends ? ' extends ' + info.extends : '') + ' {');
+    emit(
+      'class ' +
+        nestedClassName +
+        (info.extends ? ' extends ' + info.extends : '') +
+        ' {'
+    );
     emit.indent();
 
     generateClassConstructor(className);
@@ -386,11 +432,11 @@ function mod(yuidocs, localFileame, globalFilename, sourcePath) {
 
   function emitConstants() {
     emit('// Constants ');
-    Object.keys(constants).forEach(function (key) {
+    Object.keys(constants).forEach(function(key) {
       var values = constants[key];
 
       emit('type ' + key + ' =');
-      values.forEach(function (v, i) {
+      values.forEach(function(v, i) {
         var str = ' typeof ' + v;
         str = (i ? '|' : ' ') + str;
         if (i === values.length - 1) {
@@ -400,7 +446,6 @@ function mod(yuidocs, localFileame, globalFilename, sourcePath) {
       });
 
       emit('');
-
     });
   }
 
@@ -408,14 +453,17 @@ function mod(yuidocs, localFileame, globalFilename, sourcePath) {
     var p5Aliases = [];
     var p5Subclasses = [];
 
-    Object.keys(yuidocs.classes).forEach(function (className) {
+    Object.keys(yuidocs.classes).forEach(function(className) {
       if (P5_ALIASES.indexOf(className) !== -1) {
         p5Aliases.push(className);
       } else if (P5_CLASS_RE.test(className)) {
         p5Subclasses.push(className);
       } else {
-        throw new Error(className + ' is documented as a class but ' +
-          'I\'m not sure how to generate a type definition for it');
+        throw new Error(
+          className +
+            ' is documented as a class but ' +
+            "I'm not sure how to generate a type definition for it"
+        );
       }
     });
 

--- a/tasks/typescript/generate-typescript-annotations.js
+++ b/tasks/typescript/generate-typescript-annotations.js
@@ -1,0 +1,288 @@
+var createEmitter = require('./emit');
+
+// mod is used to make yuidocs "global". It actually just calls generate()
+// This design was selected to avoid rewriting the whole file from
+// https://github.com/toolness/friendly-error-fellowship/blob/2093aee2acc53f0885fcad252a170e17af19682a/experiments/typescript/generate-typescript-annotations.js
+function mod(yuidocs, localFileame, globalFilename) {
+
+  // http://stackoverflow.com/a/2008353/2422398
+  var JS_SYMBOL_RE = /^[$A-Z_][0-9A-Z_$]*$/i;
+
+  var P5_CLASS_RE = /^p5\.([^.]+)$/;
+
+  var P5_ALIASES = [
+    'p5',
+    // These are supposedly "classes" in our docs, but they don't exist
+    // as objects, and their methods are all defined on p5.
+    'p5.dom',
+    'p5.sound'
+  ];
+
+  var YUIDOC_TO_TYPESCRIPT_PARAM_MAP = {
+    // TODO: Not sure if there's a better type for generic Objects...
+    'Object': 'any',
+    'Any': 'any',
+    'Number': 'number',
+    'Integer': 'number',
+    'String': 'string',
+    'Array': 'any[]',
+    'Boolean': 'boolean',
+    'P5': 'p5',
+    // TODO: Not sure if there's a better type for functions. TypeScript's
+    // spec seems to mention something called "wildcard function types"
+    // here: https://github.com/Microsoft/TypeScript/issues/3970
+    'Function': '() => any',
+  };
+
+  function getClassitems(className) {
+    return yuidocs.classitems.filter(function(classitem) {
+      // Note that we check for classitem.name because some methods
+      // don't appear to define them... Filed this as
+      // https://github.com/processing/p5.js/issues/1252.
+      return classitem.class === className && classitem.name;
+    });
+  }
+
+  function isValidP5ClassName(className) {
+    return P5_CLASS_RE.test(className) && className in yuidocs.classes;
+  }
+
+  function validateType(type) {
+    var subtypes = type.split('|');
+    var subtype;
+
+    for (var i = 0; i < subtypes.length; i++) {
+      subtype = subtypes[i];
+      if (subtype in YUIDOC_TO_TYPESCRIPT_PARAM_MAP ||
+          isValidP5ClassName(subtype)) {
+        continue;
+      }
+      return false;
+    }
+
+    return true;
+  }
+
+  function validateMethod(classitem) {
+    var errors = [];
+    var paramNames = {};
+    var optionalParamFound = false;
+
+    if (!classitem.is_constructor && !JS_SYMBOL_RE.test(classitem.name)) {
+      errors.push('"' + classitem.name + '" is not a valid JS symbol name');
+    }
+
+    (classitem.params || []).forEach(function(param) {
+      if (param.optional) {
+        optionalParamFound = true;
+      } else if (optionalParamFound) {
+        errors.push('required param "' + param.name + '" follows an ' +
+                    'optional param');
+      }
+
+      if (param.name in paramNames) {
+        errors.push('param "' + param.name + '" is defined multiple times');
+      }
+      paramNames[param.name] = true;
+
+      if (param.name === 'class') {
+        errors.push('param "' + param.name + '" is a reserved word in JS');
+      }
+
+      if (!JS_SYMBOL_RE.test(param.name)) {
+        errors.push('param "' + param.name +
+                    '" is not a valid JS symbol name');
+      }
+
+      if (!validateType(param.type)) {
+        errors.push('param "' + param.name + '" has invalid type: ' +
+                    param.type);
+      }
+    });
+
+    if (classitem.return && !validateType(classitem.return.type)) {
+      errors.push('return has invalid type: ' + classitem.return.type);
+    }
+
+    return errors;
+  }
+
+  function translateType(type) {
+    return type.split('|').map(function(subtype) {
+      if (subtype in YUIDOC_TO_TYPESCRIPT_PARAM_MAP) {
+        return YUIDOC_TO_TYPESCRIPT_PARAM_MAP[subtype];
+      }
+      return subtype;
+    }).join('|');
+  }
+
+  function translateParam(param) {
+    return param.name + (param.optional ? '?' : '') + ': ' +
+           translateType(param.type);
+  }
+
+  function generateClassMethod(emit, className, classitem) {
+    var errors = validateMethod(classitem);
+    var params = (classitem.params || []).map(translateParam);
+    var returnType = classitem.return ? translateType(classitem.return.type) : 'void';
+    var decl;
+
+    if (classitem.is_constructor) {
+      decl = 'constructor(' + params.join(', ') + ')';
+    } else {
+      decl = (classitem.static ? 'static ' : '') + classitem.name + '(' +
+              params.join(', ') + '): ' + returnType;
+    }
+
+    if (emit.getIndentLevel() === 0) {
+      decl = 'declare function ' + decl + ';';
+    }
+
+    if (errors.length) {
+      emit.sectionBreak();
+      emit('// TODO: Fix ' + classitem.name + '() errors in ' +
+           classitem.file + ':');
+      emit('//');
+      errors.forEach(function(error) {
+        emit('//   ' + error);
+      });
+      emit('//');
+      emit('// ' + decl);
+      emit('');
+    } else {
+      emit.description(classitem.description);
+      emit(decl);
+    }
+  }
+
+  function generateClassConstructor(emit, className) {
+    var classitem = yuidocs.classes[className];
+
+    if (!classitem.is_constructor) {
+      throw new Error(className + ' is not a constructor');
+    }
+
+    generateClassMethod(emit, className, classitem);
+  }
+
+  function generateClassProperty(emit, className, classitem) {
+    var decl;
+
+    if (JS_SYMBOL_RE.test(classitem.name)) {
+      // TODO: It seems our properties don't carry any type information,
+      // which is unfortunate. YUIDocs supports the @type tag on properties,
+      // and even encourages using it, but we don't seem to use it.
+      decl = classitem.name + ': any';
+
+      emit.description(classitem.description);
+
+      if (emit.getIndentLevel() === 0) {
+        emit('declare var ' + decl + ';');
+      } else {
+        emit(decl);
+      }
+    } else {
+      emit.sectionBreak();
+      emit('// TODO: Property "' + classitem.name +
+           '", defined in ' + classitem.file +
+           ', is not a valid JS symbol name');
+      emit.sectionBreak();
+    }
+  }
+
+  function generateClassProperties(emit, className) {
+    getClassitems(className).forEach(function(classitem) {
+      emit.setCurrentSourceFile(classitem.file);
+      if (classitem.itemtype === 'method') {
+        generateClassMethod(emit, className, classitem);
+      } else if (classitem.itemtype === 'property') {
+        generateClassProperty(emit, className, classitem);
+      } else {
+        emit('// TODO: Annotate ' + classitem.itemtype + ' "' +
+             classitem.name + '"');
+      }
+    });
+  }
+
+  function generateP5Properties(emit, className) {
+    emit.sectionBreak();
+    emit('// Properties from ' + className);
+    emit.sectionBreak();
+
+    generateClassProperties(emit, className);
+  }
+
+  function generateP5Subclass(emit, className) {
+    var info = yuidocs.classes[className];
+    var nestedClassName = className.match(P5_CLASS_RE)[1];
+
+    emit.setCurrentSourceFile(info.file);
+
+    emit('class ' + nestedClassName +
+         (info.extends ? ' extends ' + info.extends : '') + ' {');
+    emit.indent();
+
+    generateClassConstructor(emit, className);
+    generateClassProperties(emit, className);
+
+    emit.dedent();
+    emit('}');
+  }
+
+  function emitLocal(p5Aliases, p5Subclasses) {
+    var emit = createEmitter(localFileame);
+
+    emit('declare class p5 {');
+    emit.indent();
+
+    p5Aliases.forEach(generateP5Properties.bind(undefined, emit));
+
+    emit.dedent();
+    emit('}\n');
+
+    emit('declare namespace p5 {');
+    emit.indent();
+
+    p5Subclasses.forEach(generateP5Subclass.bind(undefined, emit));
+
+    emit.dedent();
+    emit('}\n');
+
+    emit.close();
+  }
+
+  function emitGlobal(p5Aliases) {
+    var emit = createEmitter(globalFilename);
+
+    emit('///<reference path="p5.d.ts" />\n');
+
+    p5Aliases.forEach(generateP5Properties.bind(undefined, emit));
+
+    emit.close();
+  }
+
+  function generate() {
+    var p5Aliases = [];
+    var p5Subclasses = [];
+
+    Object.keys(yuidocs.classes).forEach(function(className) {
+      if (P5_ALIASES.indexOf(className) !== -1) {
+        p5Aliases.push(className);
+      } else if (P5_CLASS_RE.test(className)) {
+        p5Subclasses.push(className);
+      } else {
+        throw new Error(className + ' is documented as a class but ' +
+                        'I\'m not sure how to generate a type definition ' +
+                        'for it. I expect ' + className + ' to look like with p5.NAME');
+      }
+    });
+
+    emitLocal(p5Aliases, p5Subclasses);
+    emitGlobal(p5Aliases);
+  }
+
+  generate();
+}
+
+
+module.exports = mod;

--- a/tasks/typescript/generate-typescript-annotations.js
+++ b/tasks/typescript/generate-typescript-annotations.js
@@ -43,7 +43,8 @@ function mod(yuidocs, localFileame, globalFilename, sourcePath) {
     'GainNode',
     'DelayNode',
     'ConvolverNode',
-    'Event'
+    'Event',
+    'Blob'
   ]);
 
   var YUIDOC_TO_TYPESCRIPT_PARAM_MAP = {

--- a/tasks/typescript/generate-typescript-annotations.js
+++ b/tasks/typescript/generate-typescript-annotations.js
@@ -63,6 +63,9 @@ function mod(yuidocs, localFileame, globalFilename, sourcePath) {
     // When the docs don't specify what kind of function we expect,
     // then we need to use the global type `Function`
     'Function': 'Function',
+    // Special ignore for hard to fix YUIDoc from p5.sound
+    'Tone.Signal': 'any',
+    'SoundObject': 'any',
   };
 
   function getClassitems(className) {

--- a/tasks/typescript/generate-typescript-annotations.js
+++ b/tasks/typescript/generate-typescript-annotations.js
@@ -1,9 +1,14 @@
-var createEmitter = require('./emit');
+/// @ts-check
+const createEmitter = require('./emit');
 
 // mod is used to make yuidocs "global". It actually just calls generate()
 // This design was selected to avoid rewriting the whole file from
 // https://github.com/toolness/friendly-error-fellowship/blob/2093aee2acc53f0885fcad252a170e17af19682a/experiments/typescript/generate-typescript-annotations.js
-function mod(yuidocs, localFileame, globalFilename) {
+function mod(yuidocs, localFileame, globalFilename, sourcePath) {
+
+  var emit;
+  var constants = {};
+  var missingTypes = {};
 
   // http://stackoverflow.com/a/2008353/2422398
   var JS_SYMBOL_RE = /^[$A-Z_][0-9A-Z_$]*$/i;
@@ -18,6 +23,17 @@ function mod(yuidocs, localFileame, globalFilename) {
     'p5.sound'
   ];
 
+  var EXTERNAL_TYPES = [
+    'HTMLCanvasElement',
+    'Float32Array',
+    'AudioParam',
+    'AudioNode',
+    'GainNode',
+    'DelayNode',
+    'ConvolverNode',
+    'Event'
+  ];
+
   var YUIDOC_TO_TYPESCRIPT_PARAM_MAP = {
     // TODO: Not sure if there's a better type for generic Objects...
     'Object': 'any',
@@ -25,8 +41,14 @@ function mod(yuidocs, localFileame, globalFilename) {
     'Number': 'number',
     'Integer': 'number',
     'String': 'string',
+    'Constant': 'any',
+    //'Color': 'number',
+    'undefined': 'undefined',
+    'Null': 'null',
     'Array': 'any[]',
     'Boolean': 'boolean',
+    '*': 'any',
+    'Void': 'void',
     'P5': 'p5',
     // TODO: Not sure if there's a better type for functions. TypeScript's
     // spec seems to mention something called "wildcard function types"
@@ -35,7 +57,7 @@ function mod(yuidocs, localFileame, globalFilename) {
   };
 
   function getClassitems(className) {
-    return yuidocs.classitems.filter(function(classitem) {
+    return yuidocs.classitems.filter(function (classitem) {
       // Note that we check for classitem.name because some methods
       // don't appear to define them... Filed this as
       // https://github.com/processing/p5.js/issues/1252.
@@ -44,26 +66,18 @@ function mod(yuidocs, localFileame, globalFilename) {
   }
 
   function isValidP5ClassName(className) {
-    return P5_CLASS_RE.test(className) && className in yuidocs.classes;
+    return P5_CLASS_RE.test(className) && className in yuidocs.classes ||
+      P5_CLASS_RE.test('p5.' + className) && ('p5.' + className) in yuidocs.classes;
   }
 
+  /**
+   * @param {string} type
+   */
   function validateType(type) {
-    var subtypes = type.split('|');
-    var subtype;
-
-    for (var i = 0; i < subtypes.length; i++) {
-      subtype = subtypes[i];
-      if (subtype in YUIDOC_TO_TYPESCRIPT_PARAM_MAP ||
-          isValidP5ClassName(subtype)) {
-        continue;
-      }
-      return false;
-    }
-
-    return true;
+    return translateType(type);
   }
 
-  function validateMethod(classitem) {
+  function validateMethod(classitem, overload) {
     var errors = [];
     var paramNames = {};
     var optionalParamFound = false;
@@ -72,12 +86,12 @@ function mod(yuidocs, localFileame, globalFilename) {
       errors.push('"' + classitem.name + '" is not a valid JS symbol name');
     }
 
-    (classitem.params || []).forEach(function(param) {
+    (overload.params || []).forEach(function (param) {
       if (param.optional) {
         optionalParamFound = true;
       } else if (optionalParamFound) {
         errors.push('required param "' + param.name + '" follows an ' +
-                    'optional param');
+          'optional param');
       }
 
       if (param.name in paramNames) {
@@ -85,53 +99,154 @@ function mod(yuidocs, localFileame, globalFilename) {
       }
       paramNames[param.name] = true;
 
+      /*
       if (param.name === 'class') {
         errors.push('param "' + param.name + '" is a reserved word in JS');
       }
+      */
 
       if (!JS_SYMBOL_RE.test(param.name)) {
         errors.push('param "' + param.name +
-                    '" is not a valid JS symbol name');
+          '" is not a valid JS symbol name');
       }
 
       if (!validateType(param.type)) {
         errors.push('param "' + param.name + '" has invalid type: ' +
-                    param.type);
+          param.type);
+      }
+
+      if (param.type === 'Constant') {
+
+        var constantRe = /either\s+(?:[A-Z0-9_]+\s*,?\s*(?:or)?\s*)+/g;
+        var execResult = constantRe.exec(param.description);
+        var match;
+        if (execResult) {
+          match = execResult[0];
+        }
+        if (classitem.name === 'endShape' && param.name === 'mode') {
+          match = 'CLOSE';
+        }
+        if (match) {
+
+          var values = [];
+
+          var reConst = /[A-Z0-9_]+/g;
+          var matchConst;
+          while ((matchConst = reConst.exec(match)) !== null) {
+            values.push(matchConst);
+          }
+          var paramWords = param.name.split('.').pop().replace(/([A-Z])/g, ' $1').trim().toLowerCase().split(' ');
+          var propWords = classitem.name.split('.').pop().replace(/([A-Z])/g, ' $1').trim().toLowerCase().split(' ');
+
+          var constName;
+          if (paramWords.length > 1 || propWords[0] === 'create') {
+            constName = paramWords.join('_');
+          } else if (propWords[propWords.length - 1] === paramWords[paramWords.length - 1]) {
+            constName = propWords.join('_');
+          } else {
+            constName = (propWords[0] + '_' + paramWords[paramWords.length - 1]);
+          }
+
+          constName = constName.toUpperCase();
+          constants[constName] = values;
+
+          param.type = constName;
+        }
       }
     });
 
-    if (classitem.return && !validateType(classitem.return.type)) {
-      errors.push('return has invalid type: ' + classitem.return.type);
+    if (overload.return && !validateType(overload.return.type)) {
+      errors.push('return has invalid type: ' + overload.return.type);
     }
 
     return errors;
   }
 
-  function translateType(type) {
-    return type.split('|').map(function(subtype) {
-      if (subtype in YUIDOC_TO_TYPESCRIPT_PARAM_MAP) {
-        return YUIDOC_TO_TYPESCRIPT_PARAM_MAP[subtype];
-      }
-      return subtype;
-    }).join('|');
+  /**
+   *
+   * @param {string} type
+   * @param {string} [defaultType]
+   */
+  function translateType(type, defaultType) {
+    if (type === void 0) {
+      return defaultType;
+    }
+
+    if (type === '') {
+      return '';
+    }
+
+    if (type.length > 2 && type.substring(type.length - 2) === '[]') {
+      return translateType(type.substr(0, type.length - 2), defaultType) + '[]';
+    }
+
+    type = type.trim();
+
+    var matchFunction = type.match(/Function\(([^)]*)\)/i);
+    if (matchFunction) {
+      var paramTypes = matchFunction[1].split(',');
+      return '(' + paramTypes.map((t, i) => 'p' + (i + 1) + ':' + translateType(t, 'any')).join(',') + ') => any';
+    }
+
+    var parts = type.split('|');
+    if (parts.length > 1) {
+      return parts.map(t => translateType(t, defaultType)).join('|');
+    }
+
+    if (type in YUIDOC_TO_TYPESCRIPT_PARAM_MAP) {
+      return YUIDOC_TO_TYPESCRIPT_PARAM_MAP[type];
+    }
+
+    if (EXTERNAL_TYPES.indexOf(type) >= 0) {
+      return type;
+    }
+
+    if (isValidP5ClassName(type)) {
+      return type;
+    }
+
+    if (constants[type]) {
+      return type;
+    }
+
+    missingTypes[type] = true;
+    return defaultType;
   }
 
   function translateParam(param) {
-    return param.name + (param.optional ? '?' : '') + ': ' +
-           translateType(param.type);
+    var name = param.name;
+    if (name === 'class') {
+      name = 'theClass';
+    }
+
+    return name + (param.optional ? '?' : '') + ': ' + translateType(param.type, 'any');
   }
 
-  function generateClassMethod(emit, className, classitem) {
-    var errors = validateMethod(classitem);
-    var params = (classitem.params || []).map(translateParam);
-    var returnType = classitem.return ? translateType(classitem.return.type) : 'void';
+  function generateClassMethod(className, classitem) {
+    if (classitem.overloads) {
+      classitem.overloads.forEach(function (overload) {
+        generateClassMethodWithParams(className, classitem, overload);
+      });
+    }
+    else {
+      generateClassMethodWithParams(className, classitem, classitem);
+    }
+  }
+
+
+  function generateClassMethodWithParams(className, classitem, overload) {
+    var errors = validateMethod(classitem, overload);
+    var params = (overload.params || []).map(translateParam);
+    var returnType = overload.chainable ? className
+      : overload.return ? translateType(overload.return.type, 'any')
+        : 'void';
     var decl;
 
     if (classitem.is_constructor) {
       decl = 'constructor(' + params.join(', ') + ')';
     } else {
-      decl = (classitem.static ? 'static ' : '') + classitem.name + '(' +
-              params.join(', ') + '): ' + returnType;
+      decl = (overload.static ? 'static ' : '') + classitem.name + '(' +
+        params.join(', ') + '): ' + returnType;
     }
 
     if (emit.getIndentLevel() === 0) {
@@ -141,9 +256,10 @@ function mod(yuidocs, localFileame, globalFilename) {
     if (errors.length) {
       emit.sectionBreak();
       emit('// TODO: Fix ' + classitem.name + '() errors in ' +
-           classitem.file + ':');
+        classitem.file + ', line ' + overload.line + ':');
       emit('//');
-      errors.forEach(function(error) {
+      errors.forEach(function (error) {
+        console.log(classitem.file + ':' + overload.line + ', ' + error);
         emit('//   ' + error);
       });
       emit('//');
@@ -155,87 +271,123 @@ function mod(yuidocs, localFileame, globalFilename) {
     }
   }
 
-  function generateClassConstructor(emit, className) {
+  function generateClassConstructor(className) {
     var classitem = yuidocs.classes[className];
 
     if (!classitem.is_constructor) {
       throw new Error(className + ' is not a constructor');
     }
 
-    generateClassMethod(emit, className, classitem);
+    generateClassMethod(className, classitem);
   }
 
-  function generateClassProperty(emit, className, classitem) {
-    var decl;
-
+  function generateClassProperty(className, classitem) {
     if (JS_SYMBOL_RE.test(classitem.name)) {
       // TODO: It seems our properties don't carry any type information,
       // which is unfortunate. YUIDocs supports the @type tag on properties,
       // and even encourages using it, but we don't seem to use it.
-      decl = classitem.name + ': any';
+      var translatedType = translateType(classitem.type, 'any');
+      var defaultValue = classitem.default;
+      if (classitem.final && translatedType === 'string' && !defaultValue) {
+        defaultValue = classitem.name.toLowerCase().replace(/_/g, '-');
+      }
+
+      var decl;
+      if (defaultValue) {
+        decl = classitem.name + ': ';
+        if (translatedType === 'string') {
+          decl += '\'' + defaultValue.replace(/'/g, '\\\'') + '\'';
+        }
+        else {
+          decl += defaultValue;
+        }
+      } else {
+        decl = classitem.name + ': ' + translatedType;
+      }
+
 
       emit.description(classitem.description);
 
       if (emit.getIndentLevel() === 0) {
-        emit('declare var ' + decl + ';');
+        emit('declare ' + (classitem.final ? 'const ' : 'var ') + decl + ';');
       } else {
+        if (classitem.final) {
+          return;
+        }
         emit(decl);
       }
+
     } else {
       emit.sectionBreak();
       emit('// TODO: Property "' + classitem.name +
-           '", defined in ' + classitem.file +
-           ', is not a valid JS symbol name');
+        '", defined in ' + classitem.file +
+        ', is not a valid JS symbol name');
       emit.sectionBreak();
     }
   }
 
-  function generateClassProperties(emit, className) {
-    getClassitems(className).forEach(function(classitem) {
+  function generateClassProperties(className) {
+    getClassitems(className).forEach(function (classitem) {
+      classitem.file = classitem.file.replace(/\\/g, '/');
       emit.setCurrentSourceFile(classitem.file);
       if (classitem.itemtype === 'method') {
-        generateClassMethod(emit, className, classitem);
+        generateClassMethod(className, classitem);
       } else if (classitem.itemtype === 'property') {
-        generateClassProperty(emit, className, classitem);
+        generateClassProperty(className, classitem);
       } else {
         emit('// TODO: Annotate ' + classitem.itemtype + ' "' +
-             classitem.name + '"');
+          classitem.name + '"');
       }
     });
   }
 
-  function generateP5Properties(emit, className) {
+  function generateP5Properties(className) {
     emit.sectionBreak();
     emit('// Properties from ' + className);
     emit.sectionBreak();
 
-    generateClassProperties(emit, className);
+    generateClassProperties(className);
   }
 
-  function generateP5Subclass(emit, className) {
+  function generateP5Subclass(className) {
     var info = yuidocs.classes[className];
     var nestedClassName = className.match(P5_CLASS_RE)[1];
 
+    info.file = info.file.replace(/\\/g, '/');
     emit.setCurrentSourceFile(info.file);
 
     emit('class ' + nestedClassName +
-         (info.extends ? ' extends ' + info.extends : '') + ' {');
+      (info.extends ? ' extends ' + info.extends : '') + ' {');
     emit.indent();
 
-    generateClassConstructor(emit, className);
-    generateClassProperties(emit, className);
+    generateClassConstructor(className);
+    generateClassProperties(className);
 
     emit.dedent();
     emit('}');
   }
 
-  function emitLocal(p5Aliases, p5Subclasses) {
-    var emit = createEmitter(localFileame);
+  function generate() {
+    var p5Aliases = [];
+    var p5Subclasses = [];
+
+    Object.keys(yuidocs.classes).forEach(function (className) {
+      if (P5_ALIASES.indexOf(className) !== -1) {
+        p5Aliases.push(className);
+      } else if (P5_CLASS_RE.test(className)) {
+        p5Subclasses.push(className);
+      } else {
+        throw new Error(className + ' is documented as a class but ' +
+          'I\'m not sure how to generate a type definition for it');
+      }
+    });
+
+    emit = createEmitter(localFileame);
 
     emit('declare class p5 {');
     emit.indent();
 
-    p5Aliases.forEach(generateP5Properties.bind(undefined, emit));
+    p5Aliases.forEach(generateP5Properties);
 
     emit.dedent();
     emit('}\n');
@@ -243,46 +395,52 @@ function mod(yuidocs, localFileame, globalFilename) {
     emit('declare namespace p5 {');
     emit.indent();
 
-    p5Subclasses.forEach(generateP5Subclass.bind(undefined, emit));
+    p5Subclasses.forEach(generateP5Subclass);
 
     emit.dedent();
     emit('}\n');
 
     emit.close();
-  }
 
-  function emitGlobal(p5Aliases) {
-    var emit = createEmitter(globalFilename);
+    emit = createEmitter(globalFilename);
 
     emit('///<reference path="p5.d.ts" />\n');
 
-    p5Aliases.forEach(generateP5Properties.bind(undefined, emit));
+    p5Aliases.forEach(generateP5Properties);
 
-    emit.close();
-  }
+    emit('// Constants ');
+    Object.keys(constants).forEach(function (key) {
+      var values = constants[key];
 
-  function generate() {
-    var p5Aliases = [];
-    var p5Subclasses = [];
+      /*
+      emit('// ' + key);
+      values.forEach(function (v) {
+        emit('declare const ' + v + ': string;');
+      });
+      */
 
-    Object.keys(yuidocs.classes).forEach(function(className) {
-      if (P5_ALIASES.indexOf(className) !== -1) {
-        p5Aliases.push(className);
-      } else if (P5_CLASS_RE.test(className)) {
-        p5Subclasses.push(className);
-      } else {
-        throw new Error(className + ' is documented as a class but ' +
-                        'I\'m not sure how to generate a type definition ' +
-                        'for it. I expect ' + className + ' to look like with p5.NAME');
-      }
+      emit('type ' + key + ' =');
+      values.forEach(function (v, i) {
+        var str = ' typeof ' + v;
+        str = (i ? '|' : ' ') + str;
+        if (i === values.length - 1) {
+          str += ';';
+        }
+        emit('    ' + str);
+      });
+
+      emit('');
+
     });
 
-    emitLocal(p5Aliases, p5Subclasses);
-    emitGlobal(p5Aliases);
+    emit.close();
+
+    for (var t in missingTypes) {
+      console.log('MISSING: ', t);
+    }
   }
 
   generate();
 }
-
 
 module.exports = mod;

--- a/tasks/typescript/generate-typescript-annotations.js
+++ b/tasks/typescript/generate-typescript-annotations.js
@@ -266,7 +266,7 @@ function mod(yuidocs, localFileame, globalFilename, sourcePath) {
       emit('// ' + decl);
       emit('');
     } else {
-      emit.description(classitem.description);
+      emit.description(classitem, overload);
       emit(decl);
     }
   }
@@ -306,7 +306,7 @@ function mod(yuidocs, localFileame, globalFilename, sourcePath) {
       }
 
 
-      emit.description(classitem.description);
+      emit.description(classitem);
 
       if (emit.getIndentLevel() === 0) {
         emit('declare ' + (classitem.final ? 'const ' : 'var ') + decl + ';');

--- a/tasks/typescript/generate-typescript-annotations.js
+++ b/tasks/typescript/generate-typescript-annotations.js
@@ -36,6 +36,7 @@ function mod(yuidocs, localFileame, globalFilename, sourcePath) {
 
   var EXTERNAL_TYPES = new Set([
     'HTMLCanvasElement',
+    'HTMLElement',
     'Float32Array',
     'AudioParam',
     'AudioNode',
@@ -326,12 +327,9 @@ function mod(yuidocs, localFileame, globalFilename, sourcePath) {
 
   function generateClassConstructor(className) {
     var classitem = yuidocs.classes[className];
-
-    if (!classitem.is_constructor) {
-      throw new Error(className + ' is not a constructor');
+    if (classitem.is_constructor) {
+      generateClassMethod(className, classitem);
     }
-
-    generateClassMethod(className, classitem);
   }
 
   function generateClassProperty(className, classitem) {
@@ -405,6 +403,7 @@ function mod(yuidocs, localFileame, globalFilename, sourcePath) {
     emit('// Properties from ' + className);
     emit.sectionBreak();
 
+    generateClassConstructor(className);
     generateClassProperties(className);
   }
 

--- a/tasks/typescript/task.js
+++ b/tasks/typescript/task.js
@@ -4,5 +4,9 @@ var path = require('path');
 module.exports = function(grunt) {
   var yuidocs = require('../../docs/reference/data.json');
   var base = path.join(__dirname, '../../lib');
-  generate(yuidocs, path.join(base, 'p5.d.ts'), path.join(base, 'p5.global-mode.d.ts'));
+  generate(
+    yuidocs,
+    path.join(base, 'p5.d.ts'),
+    path.join(base, 'p5.global-mode.d.ts')
+  );
 };

--- a/tasks/typescript/task.js
+++ b/tasks/typescript/task.js
@@ -1,0 +1,8 @@
+var generate = require('./generate-typescript-annotations');
+var path = require('path');
+
+module.exports = function(grunt) {
+  var yuidocs = require('../../docs/reference/data.json');
+  var base = path.join(__dirname, '../../lib');
+  generate(yuidocs, path.join(base, 'p5.d.ts'), path.join(base, 'p5.global-mode.d.ts'));
+};


### PR DESCRIPTION
I've added a grunt-task that generates TypeScript definitions from the YUIDoc. It's probably not perfect, but on a glance it looks fine.
It uses the code by @toolness from http://processing.toolness.org/general/2016/03/16/typescript-to-the-rescue.html and depends on and includes the fixes in https://github.com/processing/p5.js-sound/pull/222.
Types that can't be modelled using YUIDoc could be manually modified using [declaration merging](https://www.typescriptlang.org/docs/handbook/declaration-merging.html).
I can maintain the type-generation in the future if there are missing features / enhancements needed.
Closes #1392