### PR TITLE
Added example for p5.MediaElement.volume()

### DIFF
--- a/lib/addons/p5.dom.js
+++ b/lib/addons/p5.dom.js
@@ -2086,13 +2086,47 @@
     return this;
   };
 
-  /**
+  /*
    * Sets volume for this HTML5 media element. If no argument is given,
    * returns the current volume.
    *
    * @param {Number}            [val] volume between 0.0 and 1.0
    * @return {Number|p5.MediaElement} current volume or p5.MediaElement
    * @method volume
+   *
+   * @example
+   * <div><code>
+   *  var ele;
+   * function setup(){
+
+   *  //p5.MediaElement objects are usually created
+   *  //by calling the createAudio(), createVideo(),
+   *  //and createCapture() functions.
+
+   *  //In this example we create
+   *  //a new p5.MediaElement via createAudio().  
+   *  ele = createAudio('assets/lucky_dragons_-_power_melody.mp3');
+   *  background(250);
+   *  textAlign(CENTER);
+   *    text("Click to Play!", width/2, height/2);
+      
+   * }
+
+   * function mouseClicked() {
+   *  //here we test if the mouse is over the
+   *  //canvas element when it's clicked
+   *  if(mouseX >= 0 && mouseX <= width &&
+   *    mouseY >= 0 && mouseY <= height) {
+   *   //Here we call the volume() function 
+   *   //on the sound element to set its volume
+   *   //Volume must be between 0.0 and 1.0
+   *   ele.volume(0.2)
+   *   ele.play();
+   *   background(200);
+   *   text("You clicked Play!", width/2, height/2);
+   *  }
+   * }
+   * </code></div>
    */
   p5.MediaElement.prototype.volume = function(val) {
     if (typeof val === 'undefined') {


### PR DESCRIPTION
Partial fix for #1954 - volume() example.