### PR TITLE
Add example for p5.MediaElement.speed()

### DIFF
--- a/lib/addons/p5.dom.js
+++ b/lib/addons/p5.dom.js
@@ -2112,6 +2112,49 @@
    * @method speed
    * @param {Number} [speed]  speed multiplier for element playback
    * @return {Number|Object|p5.MediaElement} current playback speed or p5.MediaElement
+   *
+   * @example
+   * <div><code>
+   * var ele;
+   * var slowPress = true;
+   * 
+   * function setup(){
+   * 
+   *   //p5.MediaElement objects are usually created
+   *   //by calling the createAudio(), createVideo(),
+   *   //and createCapture() functions.
+   * 
+   *   //In this example we create
+   *   //a new p5.MediaElement via createAudio().  
+   *   ele = createAudio('bloop.mp3');
+   *   background(250);
+   *   textAlign(CENTER);
+   *     text("Play half speed", width/2, height/2);
+   * }
+   * 
+   * function mouseClicked() {
+   *   //here we test if the mouse is over the
+   *   //canvas element when it's clicked
+   *   if(mouseX >= 0 && mouseX <= width &&
+   *     mouseY >= 0 && mouseY <= height) {
+   *     if(slowPress == true){
+   *       // here we set the playback speed 
+   *       // to be half speed
+   *       ele.play().speed(0.5);
+   *       background(200);
+   *       text("Play at double speed", width/2, height/2);
+   *       slowPress = false;
+   *     }else{ 
+   *       // here we set the playback speed 
+   *       //  to be double speed
+   *       ele.play().speed(2.0); 
+   *       background(250);
+   *       text("Play at half speed", width/2, height/2);
+   *       slowPress = true;
+   *     }
+   *   }
+   * }
+   * </code></div>
    */
   p5.MediaElement.prototype.speed = function(val) {
     if (typeof val === 'undefined') {

--- a/lib/addons/p5.dom.js
+++ b/lib/addons/p5.dom.js
@@ -2126,7 +2126,7 @@
    * 
    *   //In this example we create
    *   //a new p5.MediaElement via createAudio().  
-   *   ele = createAudio('bloop.mp3');
+   *   ele = createAudio('assets/lucky_dragons_-_power_melody.mp3');
    *   background(250);
    *   textAlign(CENTER);
    *     text("Play half speed", width/2, height/2);


### PR DESCRIPTION
Partial fix for #1954 - speed() example.