### PR TITLE
Added example for MediaElement.autoplay()

### DIFF
--- a/lib/addons/p5.dom.js
+++ b/lib/addons/p5.dom.js
@@ -2143,7 +2143,29 @@
    *
    * @method duration
    * @return {Number} duration
+   * 
+   * @example
+   * <div><code>
+   *  var ele;
+   *  function setup(){
+   * 
+   *    //p5.MediaElement objects are usually created
+   *    //by calling the createAudio(), createVideo(),
+   *    //and createCapture() functions.
+   * 
+   *    //In this example we create
+   *    //a new p5.MediaElement via createAudio(). 
+   *   ele = createAudio('assets/beat.mp3');
+   * 
+   *   // here we set the element to autoplay 
+   *   // The element will play as soon 
+   *   // as it is able to do so. 
+   *   ele.autoplay(true);
+   *
+   *  }
+   * </code></div>
    */
+   
   p5.MediaElement.prototype.duration = function() {
     return this.elt.duration;
   };


### PR DESCRIPTION
Partial fix for #1954 - autoplay() example.