### PR TITLE
Add example for MediaElement.clearCues() 

### DIFF
--- a/lib/addons/p5.dom.js
+++ b/lib/addons/p5.dom.js
@@ -2444,7 +2444,7 @@
    * 
    *  @example
    *  <div><code>
-   *   audioEl = createAudio('sax1.mp3');
+   *   audioEl = createAudio('assets/beat.mp3');
    *   // this call allows the mediaelement to 
    *   // play as soon as its loaded 
    *   // and sets it to loop indefinitley
@@ -2469,6 +2469,7 @@
    * }
    * </code></div>
    */
+   
   p5.MediaElement.prototype.clearCues = function() {
     this._cues = [];
     this.elt.ontimeupdate = null;

--- a/lib/addons/p5.dom.js
+++ b/lib/addons/p5.dom.js
@@ -2379,24 +2379,27 @@
    *                      useful for removeCue(id)
    *  @example
    *  <div><code>
-   *  function setup() {
-   *    background(255,255,255);
-   *
-   *    audioEl = createAudio('assets/beat.mp3');
-   *    audioEl.showControls();
-   *
-   *    // schedule three calls to changeBackground
-   *    audioEl.addCue(0.5, changeBackground, color(255,0,0) );
-   *    audioEl.addCue(1.0, changeBackground, color(0,255,0) );
-   *    audioEl.addCue(2.5, changeBackground, color(0,0,255) );
-   *    audioEl.addCue(3.0, changeBackground, color(0,255,255) );
-   *    audioEl.addCue(4.2, changeBackground, color(255,255,0) );
-   *    audioEl.addCue(5.0, changeBackground, color(255,255,0) );
-   *  }
-   *
-   *  function changeBackground(val) {
-   *    background(val);
-   *  }
+   *  function setup(){
+   *   background(255,255,255);
+   * 
+   *   audioEl = createAudio('sax1.mp3');
+   *   // this call allows the mediaelement to 
+   *   // play as soon as its loaded 
+   *   // and sets it to loop indefinitley
+   *   audioEl.autoplay(true).loop();
+   * 
+   *   // schedule three calls to changeBackground
+   *   audioEl.addCue(0.5, changeBackground, color(255,0,0) );
+   *   audioEl.addCue(1.0, changeBackground, color(0,255,0) );
+   *   audioEl.addCue(2.5, changeBackground, color(0,0,255) );
+   *   audioEl.addCue(3.0, changeBackground, color(0,255,255) );
+   *   audioEl.addCue(4.2, changeBackground, color(255,255,0) );
+   *   audioEl.addCue(5.0, changeBackground, color(255,255,0) );
+   * }
+   * 
+   * function changeBackground(val) {
+   *   background(val);
+   * }
    *  </code></div>
    */
   p5.MediaElement.prototype.addCue = function(time, callback, val) {

--- a/lib/addons/p5.dom.js
+++ b/lib/addons/p5.dom.js
@@ -2385,6 +2385,7 @@
    *   // this call allows the mediaelement to 
    *   // play as soon as its loaded 
    *   // and sets it to loop indefinitley
+   *   audioEl = createAudio('assets/beat.mp3');
    *   audioEl.autoplay(true).loop();
    * 
    *   // schedule three calls to changeBackground

--- a/lib/addons/p5.dom.js
+++ b/lib/addons/p5.dom.js
@@ -2383,6 +2383,7 @@
    *   background(255,255,255);
    * 
    *   audioEl = createAudio('sax1.mp3');
+   *
    *   // this call allows the mediaelement to 
    *   // play as soon as its loaded 
    *   // and sets it to loop indefinitley
@@ -2435,11 +2436,40 @@
     }
   };
 
-  /**
+  /*
    *  Remove all of the callbacks that had originally been scheduled
    *  via the addCue method.
    *
    *  @method  clearCues
+   *   function setup(){
+   *   background(255,255,255);
+   * 
+   *  @example
+   *  <div><code>
+   *   audioEl = createAudio('sax1.mp3');
+   *   // this call allows the mediaelement to 
+   *   // play as soon as its loaded 
+   *   // and sets it to loop indefinitley
+   *   audioEl.autoplay(true).loop();
+   * 
+   *   // schedule calls to changeBackground
+   *   audioEl.addCue(0.5, changeBackground, color(255,0,0) );
+   *   audioEl.addCue(1.0, changeBackground, color(0,255,0) );
+   *   audioEl.addCue(2.5, changeBackground, color(0,0,255) );
+   *   audioEl.addCue(3.0, changeBackground, color(0,255,255) );
+   *   audioEl.addCue(4.2, changeBackground, color(255,255,0) );
+   *   // here we clear the scheduled callbacks
+   *   audioEl.clearCues();
+   *   // then we add some more calbacks 
+   *   audioEl.addCue(0.5, changeBackground, color(0,0,255) );
+   *   audioEl.addCue(1.5, changeBackground, color(0,255,255) );
+   * 
+   * }
+   * 
+   * function changeBackground(val) {
+   *   background(val);
+   * }
+   * </code></div>
    */
   p5.MediaElement.prototype.clearCues = function() {
     this._cues = [];

--- a/lib/addons/p5.dom.js
+++ b/lib/addons/p5.dom.js
@@ -2381,8 +2381,6 @@
    *  <div><code>
    *  function setup(){
    *   background(255,255,255);
-   * 
-   *   audioEl = createAudio('sax1.mp3');
    *
    *   // this call allows the mediaelement to 
    *   // play as soon as its loaded 


### PR DESCRIPTION
Partial fix for #1954 - clearCues() example.
Change addCue() example to remove control that is obscuring code