### PR TITLE
fix missing examples

### DIFF
--- a/docs/preprocessor.js
+++ b/docs/preprocessor.js
@@ -6,6 +6,16 @@ function smokeTestMethods(data) {
   data.classitems.forEach(function(classitem) {
     if (classitem.itemtype === 'method') {
       new DocumentedMethod(classitem);
+
+      if (classitem.access !== 'private' &&
+        classitem.file.substr(0, 3) === 'src' &&
+        classitem.name &&
+        !classitem.example) {
+        console.log(classitem.file + ':' + classitem.line +
+          ': ' + classitem.itemtype + ' ' +
+          classitem.class + '.' + classitem.name +
+          ' missing example');
+      }
     }
   });
 }

--- a/src/color/setting.js
+++ b/src/color/setting.js
@@ -231,18 +231,6 @@ p5.prototype.clear = function() {
  *                          (or Lightness)
  * @param {Number}  [max]  range for all values
  * @chainable
- */
-/**
- * @method colorMode
- * @param {Constant} mode
- * @param {Number} max1     range for the red or hue depending on the
- *                              current color mode
- * @param {Number} max2     range for the green or saturation depending
- *                              on the current color mode
- * @param {Number} max3     range for the blue or brightness/lighntess
- *                              depending on the current color mode
- * @param {Number} [maxA]   range for the alpha
- * @chainable
  *
  * @example
  * <div>
@@ -302,6 +290,18 @@ p5.prototype.clear = function() {
  *50x50 ellipse at middle L & 40x40 ellipse at center. Transluscent pink outlines.
  *
  */
+/**
+ * @method colorMode
+ * @param {Constant} mode
+ * @param {Number} max1     range for the red or hue depending on the
+ *                              current color mode
+ * @param {Number} max2     range for the green or saturation depending
+ *                              on the current color mode
+ * @param {Number} max3     range for the blue or brightness/lighntess
+ *                              depending on the current color mode
+ * @param {Number} [maxA]   range for the alpha
+ * @chainable
+ */
 p5.prototype.colorMode = function() {
   if (arguments[0] === constants.RGB ||
       arguments[0] === constants.HSB ||
@@ -354,28 +354,6 @@ p5.prototype.colorMode = function() {
  *                                 relative to the current color range
  * @param  {Number}        [alpha]
  * @chainable
- */
-
-/**
- * @method fill
- * @param  {String}        value   a color string
- * @param  {Number}        [alpha]
- * @chainable
- */
-
-/**
- * @method fill
- * @param  {Number[]}      values  an array containing the red,green,blue &
- *                                 and alpha components of the color
- * @chainable
- */
-
-/**
- * @method fill
- * @param  {p5.Color}      color   the fill color
- * @param  {Number}        [alpha]
- * @chainable
- *
  * @example
  * <div>
  * <code>
@@ -479,6 +457,26 @@ p5.prototype.colorMode = function() {
  * 60x60 blue rect with black outline in center of canvas.
  */
 
+/**
+ * @method fill
+ * @param  {String}        value   a color string
+ * @param  {Number}        [alpha]
+ * @chainable
+ */
+
+/**
+ * @method fill
+ * @param  {Number[]}      values  an array containing the red,green,blue &
+ *                                 and alpha components of the color
+ * @chainable
+ */
+
+/**
+ * @method fill
+ * @param  {p5.Color}      color   the fill color
+ * @param  {Number}        [alpha]
+ * @chainable
+ */
 p5.prototype.fill = function() {
   this._renderer._setProperty('_fillSet', true);
   this._renderer._setProperty('_doFill', true);
@@ -560,27 +558,6 @@ p5.prototype.noStroke = function() {
  *                                 relative to the current color range
  * @param  {Number}        v3      blue or brightness value
  *                                 relative to the current color range
- * @param  {Number}        [alpha]
- * @chainable
- */
-
-/**
- * @method stroke
- * @param  {String}        value   a color string
- * @param  {Number}        [alpha]
- * @chainable
- */
-
-/**
- * @method stroke
- * @param  {Number[]}      values  an array containing the red,green,blue &
- *                                 and alpha components of the color
- * @chainable
- */
-
-/**
- * @method stroke
- * @param  {p5.Color}      color   the stroke color
  * @param  {Number}        [alpha]
  * @chainable
  *
@@ -697,6 +674,27 @@ p5.prototype.noStroke = function() {
  * 60x60 white rect at center. Red outline.
  * 60x60 white rect at center. Dark fushcia outline.
  * 60x60 white rect at center. Blue outline.
+ */
+
+/**
+ * @method stroke
+ * @param  {String}        value   a color string
+ * @param  {Number}        [alpha]
+ * @chainable
+ */
+
+/**
+ * @method stroke
+ * @param  {Number[]}      values  an array containing the red,green,blue &
+ *                                 and alpha components of the color
+ * @chainable
+ */
+
+/**
+ * @method stroke
+ * @param  {p5.Color}      color   the stroke color
+ * @param  {Number}        [alpha]
+ * @chainable
  */
 
 p5.prototype.stroke = function() {

--- a/src/core/environment.js
+++ b/src/core/environment.js
@@ -184,10 +184,7 @@ p5.prototype.cursor = function(type, x, y) {
  * @method frameRate
  * @param  {Number} fps number of frames to be displayed every second
  * @chainable
- */
-/**
- * @method frameRate
- * @return {Number}       current frameRate
+ *
  * @example
  *
  * <div><code>
@@ -225,6 +222,10 @@ p5.prototype.cursor = function(type, x, y) {
  * @alt
  * blue rect moves left to right, followed by red rect moving faster. Loops.
  *
+ */
+/**
+ * @method frameRate
+ * @return {Number}       current frameRate
  */
 p5.prototype.frameRate = function(fps) {
   if (typeof fps !== 'number' || fps < 0) {

--- a/src/core/p5.Element.js
+++ b/src/core/p5.Element.js
@@ -49,10 +49,6 @@ p5.Element = function(elt, pInst) {
  * @param  {String|p5.Element|Object} parent the ID, DOM node, or p5.Element
  *                         of desired parent element
  * @chainable
- */
-/**
- * @method parent
- * @return {p5.Element}
  *
  * @example
  * <div class="norender"><code>
@@ -81,6 +77,10 @@ p5.Element = function(elt, pInst) {
  *
  * @alt
  * no display.
+ */
+/**
+ * @method parent
+ * @return {p5.Element}
  *
  */
 p5.Element.prototype.parent = function(p) {
@@ -108,10 +108,6 @@ p5.Element.prototype.parent = function(p) {
  * @method id
  * @param  {String} id ID of the element
  * @chainable
- */
-/**
- * @method id
- * @return {String} the id of the element
  *
  * @example
  * <div class='norender'><code>
@@ -125,7 +121,10 @@ p5.Element.prototype.parent = function(p) {
  *
  * @alt
  * no display.
- *
+ */
+/**
+ * @method id
+ * @return {String} the id of the element
  */
 p5.Element.prototype.id = function(id) {
   if (arguments.length === 0) {

--- a/src/data/p5.TypedDict.js
+++ b/src/data/p5.TypedDict.js
@@ -197,10 +197,6 @@ p5.TypedDict.prototype._addObj = function(obj) {
  * @method create
  * @param {Number|String} key
  * @param {Number|String} value
- */
-/**
- * @method create
- * @param {Object} obj key/value pair
  *
  * @example
  * <div class="norender">
@@ -214,7 +210,10 @@ p5.TypedDict.prototype._addObj = function(obj) {
  * }
  *
  * </code></div>
- *
+ */
+/**
+ * @method create
+ * @param {Object} obj key/value pair
  */
 
 p5.TypedDict.prototype.create = function() {

--- a/src/image/image.js
+++ b/src/image/image.js
@@ -111,11 +111,6 @@ p5.prototype.createImage = function(width, height) {
  *                                  representing a specific html5 canvas (optional)
  *  @param  {String} [filename]
  *  @param  {String} [extension]      'jpg' or 'png'
-*/
-/**
- *  @method saveCanvas
- *  @param  {String} [filename]
- *  @param  {String} [extension]
  *
  *  @example
  *  <div class='norender'><code>
@@ -148,7 +143,11 @@ p5.prototype.createImage = function(width, height) {
  * no image displayed
  * no image displayed
  * no image displayed
- *
+ */
+/**
+ *  @method saveCanvas
+ *  @param  {String} [filename]
+ *  @param  {String} [extension]
  */
 p5.prototype.saveCanvas = function() {
 

--- a/src/image/loading_displaying.js
+++ b/src/image/loading_displaying.js
@@ -308,24 +308,6 @@ p5.prototype.image =
  * @param  {Number}        v3      blue or brightness value
  *                                 relative to the current color range
  * @param  {Number}        [alpha]
- */
-
-/**
- * @method tint
- * @param  {String}        value   a color string
- * @param  {Number}        [alpha]
- */
-
-/**
- * @method tint
- * @param  {Number[]}      values  an array containing the red,green,blue &
- *                                 and alpha components of the color
- */
-
-/**
- * @method tint
- * @param  {p5.Color}      color   the tint color
- * @param  {Number}        [alpha]
  *
  * @example
  * <div>
@@ -375,6 +357,24 @@ p5.prototype.image =
  * Images of umbrella and ceiling, one half of image with blue tint
  * 2 side by side images of umbrella and ceiling, one image translucent
  *
+ */
+
+/**
+ * @method tint
+ * @param  {String}        value   a color string
+ * @param  {Number}        [alpha]
+ */
+
+/**
+ * @method tint
+ * @param  {Number[]}      values  an array containing the red,green,blue &
+ *                                 and alpha components of the color
+ */
+
+/**
+ * @method tint
+ * @param  {p5.Color}      color   the tint color
+ * @param  {Number}        [alpha]
  */
 p5.prototype.tint = function () {
   var c = this.color.apply(this, arguments);

--- a/src/image/p5.Image.js
+++ b/src/image/p5.Image.js
@@ -232,9 +232,6 @@ p5.Image.prototype.loadPixels = function(){
  *                              underlying canvas
  * @param {Integer} h height of the target update area for the
  *                              underlying canvas
- */
-/**
- * @method updatePixels
  * @example
  * <div><code>
  * var myImage;
@@ -261,6 +258,9 @@ p5.Image.prototype.loadPixels = function(){
  * @alt
  * 2 images of rocky mountains vertically stacked
  *
+ */
+/**
+ * @method updatePixels
  */
 p5.Image.prototype.updatePixels = function(x, y, w, h){
   p5.Renderer2D.prototype.updatePixels.call(this, x, y, w, h);

--- a/src/math/calculation.js
+++ b/src/math/calculation.js
@@ -126,16 +126,7 @@ p5.prototype.constrain = function(n, low, high) {
  * @param  {Number} x2 x-coordinate of the second point
  * @param  {Number} y2 y-coordinate of the second point
  * @return {Number}    distance between the two points
- */
-/**
- * @method dist
- * @param  {Number} x1
- * @param  {Number} y1
- * @param  {Number} z1 z-coordinate of the first point
- * @param  {Number} x2
- * @param  {Number} y2
- * @param  {Number} z2 z-coordinate of the second point
- * @return {Number}    distance between the two points
+ *
  * @example
  * <div><code>
  * // Move your mouse inside the canvas to see the
@@ -169,7 +160,16 @@ p5.prototype.constrain = function(n, low, high) {
  *
  * @alt
  * 2 ellipses joined by line. 1 ellipse moves with mouse X&Y. Distance displayed.
- *
+ */
+/**
+ * @method dist
+ * @param  {Number} x1
+ * @param  {Number} y1
+ * @param  {Number} z1 z-coordinate of the first point
+ * @param  {Number} x2
+ * @param  {Number} y2
+ * @param  {Number} z2 z-coordinate of the second point
+ * @return {Number}    distance between the two points
  */
 p5.prototype.dist = function() {
   if (arguments.length === 4) { //2D

--- a/src/math/p5.Vector.js
+++ b/src/math/p5.Vector.js
@@ -662,12 +662,6 @@ p5.Vector.prototype.angleBetween = function (v) {
  *                         (old vector) and 1.0 (new vector). 0.9 is very near
  *                         the new vector. 0.5 is halfway in between.
  * @chainable
- */
-/**
- * @method lerp
- * @param  {p5.Vector} v   the p5.Vector to lerp to
- * @param  {Number}    amt
- * @chainable
  *
  * @example
  * <div class="norender">
@@ -687,6 +681,12 @@ p5.Vector.prototype.angleBetween = function (v) {
  * // v3 has components [50,50,0]
  * </code>
  * </div>
+ */
+/**
+ * @method lerp
+ * @param  {p5.Vector} v   the p5.Vector to lerp to
+ * @param  {Number}    amt
+ * @chainable
  */
 p5.Vector.prototype.lerp = function (x, y, z, amt) {
   if (x instanceof p5.Vector) {

--- a/src/typography/attributes.js
+++ b/src/typography/attributes.js
@@ -59,10 +59,7 @@ p5.prototype.textAlign = function(horizAlign, vertAlign) {
  * @method textLeading
  * @param {Number} leading the size in pixels for spacing between lines
  * @chainable
- */
-/**
- * @method textLeading
- * @return {Number}
+ *
  * @example
  * <div>
  * <code>
@@ -83,7 +80,10 @@ p5.prototype.textAlign = function(horizAlign, vertAlign) {
  *
  * @alt
  *set L1 L2 & L3 displayed vertically 3 times. spacing increases for each set
- *
+ */
+/**
+ * @method textLeading
+ * @return {Number}
  */
 p5.prototype.textLeading = function(theLeading) {
   return this._renderer.textLeading.apply(this._renderer, arguments);
@@ -96,10 +96,7 @@ p5.prototype.textLeading = function(theLeading) {
  * @method textSize
  * @param {Number} theSize the size of the letters in units of pixels
  * @chainable
- */
-/**
- * @method textSize
- * @return {Number}
+ *
  * @example
  * <div>
  * <code>
@@ -114,7 +111,10 @@ p5.prototype.textLeading = function(theLeading) {
  *
  * @alt
  *Font Size 12 displayed small, Font Size 14 medium & Font Size 16 large
- *
+ */
+/**
+ * @method textSize
+ * @return {Number}
  */
 p5.prototype.textSize = function(theSize) {
   return this._renderer.textSize.apply(this._renderer, arguments);
@@ -129,10 +129,6 @@ p5.prototype.textSize = function(theSize) {
  * @param {Constant} theStyle styling for text, either NORMAL,
  *                            ITALIC, or BOLD
  * @chainable
- */
-/**
- * @method textStyle
- * @return {String}
  * @example
  * <div>
  * <code>
@@ -149,7 +145,10 @@ p5.prototype.textSize = function(theSize) {
  *
  * @alt
  *words Font Style Normal displayed normally, Italic in italic and bold in bold
- *
+ */
+/**
+ * @method textStyle
+ * @return {String}
  */
 p5.prototype.textStyle = function(theStyle) {
   return this._renderer.textStyle.apply(this._renderer, arguments);

--- a/src/typography/loading_displaying.js
+++ b/src/typography/loading_displaying.js
@@ -193,14 +193,7 @@ p5.prototype.text = function(str, x, y, maxWidth, maxHeight) {
  *
  * @method textFont
  * @return {Object} the current font
- */
-/**
- * @method textFont
- * @param {Object|String} font a font loaded via loadFont(), or a String
- * representing a <a href="https://mzl.la/2dOw8WD">web safe font</a> (a font
- * that is generally available across all systems)
- * @param {Number} [size] the font size to use
- * @chainable
+ *
  * @example
  * <div>
  * <code>
@@ -235,7 +228,14 @@ p5.prototype.text = function(str, x, y, maxWidth, maxHeight) {
  *
  * @alt
  *words Font Style Normal displayed normally, Italic in italic and bold in bold
- *
+ */
+/**
+ * @method textFont
+ * @param {Object|String} font a font loaded via loadFont(), or a String
+ * representing a <a href="https://mzl.la/2dOw8WD">web safe font</a> (a font
+ * that is generally available across all systems)
+ * @param {Number} [size] the font size to use
+ * @chainable
  */
 p5.prototype.textFont = function(theFont, theSize) {
 

--- a/src/utilities/array_functions.js
+++ b/src/utilities/array_functions.js
@@ -55,12 +55,6 @@ p5.prototype.append = function(array, value) {
  * @param {Array}  dst           the destination Array
  * @param {Number} dstPosition   starting position in the destination Array
  * @param {Number} length        number of Array elements to be copied
- */
-/**
- * @method arrayCopy
- * @param {Array}  src
- * @param {Array}  dst
- * @param {Number} [length]
  *
  * @example
  *  <div class="norender"><code>
@@ -80,6 +74,12 @@ p5.prototype.append = function(array, value) {
  *
  *    }
  *  </div></code>
+ */
+/**
+ * @method arrayCopy
+ * @param {Array}  src
+ * @param {Array}  dst
+ * @param {Number} [length]
  */
 p5.prototype.arrayCopy = function(
   src,

--- a/src/utilities/conversion.js
+++ b/src/utilities/conversion.js
@@ -47,11 +47,6 @@ p5.prototype.float = function(str) {
  * @method int
  * @param {String|Boolean|Number}       n value to parse
  * @return {Number}                     integer representation of value
- */
-/**
- * @method int
- * @param {Array} ns                    values to parse
- * @return {Number[]}                   integer representation of values
  *
  * @example
  * <div class='norender'><code>
@@ -62,6 +57,11 @@ p5.prototype.float = function(str) {
  * print(int(false)); // 0
  * print(int([false, true, "10.3", 9.8])); // [0, 1, 10, 9]
  * </code></div>
+ */
+/**
+ * @method int
+ * @param {Array} ns                    values to parse
+ * @return {Number[]}                   integer representation of values
  */
 p5.prototype.int = function(n, radix) {
   radix = radix || 10;
@@ -144,11 +144,7 @@ p5.prototype.boolean = function(n) {
  * @method byte
  * @param {String|Boolean|Number}       n value to parse
  * @return {Number}                     byte representation of value
- */
-/**
- * @method byte
- * @param {Array} ns                   values to parse
- * @return {Number[]}                  array of byte representation of values
+ *
  * @example
  * <div class='norender'><code>
  * print(byte(127));               // 127
@@ -158,6 +154,11 @@ p5.prototype.boolean = function(n) {
  * print(byte(true));              // 1
  * print(byte([0, 255, "100"]));   // [0, -1, 100]
  * </code></div>
+ */
+/**
+ * @method byte
+ * @param {Array} ns                   values to parse
+ * @return {Number[]}                  array of byte representation of values
  */
 p5.prototype.byte = function(n) {
   var nn = p5.prototype.int(n, 10);
@@ -178,11 +179,7 @@ p5.prototype.byte = function(n) {
  * @method char
  * @param {String|Number}       n value to parse
  * @return {String}             string representation of value
- */
-/**
- * @method char
- * @param {Array} ns              values to parse
- * @return {String[]}             array of string representation of values
+ *
  * @example
  * <div class='norender'><code>
  * print(char(65));                     // "A"
@@ -190,6 +187,11 @@ p5.prototype.byte = function(n) {
  * print(char([65, 66, 67]));           // [ "A", "B", "C" ]
  * print(join(char([65, 66, 67]), '')); // "ABC"
  * </code></div>
+ */
+/**
+ * @method char
+ * @param {Array} ns              values to parse
+ * @return {String[]}             array of string representation of values
  */
 p5.prototype.char = function(n) {
   if (typeof n === 'number' && !isNaN(n)) {
@@ -209,17 +211,18 @@ p5.prototype.char = function(n) {
  * @method unchar
  * @param {String} n     value to parse
  * @return {Number}      integer representation of value
- */
-/**
- * @method unchar
- * @param {Array} ns       values to parse
- * @return {Number[]}      integer representation of values
+ *
  * @example
  * <div class='norender'><code>
  * print(unchar("A"));               // 65
  * print(unchar(["A", "B", "C"]));   // [ 65, 66, 67 ]
  * print(unchar(split("ABC", "")));  // [ 65, 66, 67 ]
  * </code></div>
+ */
+/**
+ * @method unchar
+ * @param {Array} ns       values to parse
+ * @return {Number[]}      integer representation of values
  */
 p5.prototype.unchar = function(n) {
   if (typeof n === 'string' && n.length === 1) {
@@ -239,18 +242,19 @@ p5.prototype.unchar = function(n) {
  * @param {Number} n     value to parse
  * @param {Number} [digits]
  * @return {String}      hexadecimal string representation of value
- */
-/**
- * @method hex
- * @param {Number[]} ns    array of values to parse
- * @param {Number} [digits]
- * @return {String[]}      hexadecimal string representation of values
+ *
  * @example
  * <div class='norender'><code>
  * print(hex(255));               // "000000FF"
  * print(hex(255, 6));            // "0000FF"
  * print(hex([0, 127, 255], 6));  // [ "000000", "00007F", "0000FF" ]
  * </code></div>
+ */
+/**
+ * @method hex
+ * @param {Number[]} ns    array of values to parse
+ * @param {Number} [digits]
+ * @return {String[]}      hexadecimal string representation of values
  */
 p5.prototype.hex = function(n, digits) {
   digits = (digits === undefined || digits === null) ? digits = 8 : digits;
@@ -279,17 +283,18 @@ p5.prototype.hex = function(n, digits) {
  * @method unhex
  * @param {String} n value to parse
  * @return {Number}      integer representation of hexadecimal value
- */
-/**
- * @method unhex
- * @param {Array} ns values to parse
- * @return {Number[]}      integer representations of hexadecimal value
+ *
  * @example
  * <div class='norender'><code>
  * print(unhex("A"));                // 10
  * print(unhex("FF"));               // 255
  * print(unhex(["FF", "AA", "00"])); // [ 255, 170, 0 ]
  * </code></div>
+ */
+/**
+ * @method unhex
+ * @param {Array} ns values to parse
+ * @return {Number[]}      integer representations of hexadecimal value
  */
 p5.prototype.unhex = function(n) {
   if (n instanceof Array) {

--- a/src/utilities/string_functions.js
+++ b/src/utilities/string_functions.js
@@ -142,13 +142,7 @@ p5.prototype.matchAll = function(str, reg) {
  * @param {Number|String}       [right]  number of digits to the right of the
  *                                decimal point
  * @return {String}               formatted String
- */
-/**
- * @method nf
- * @param {Array}        nums     the Numbers to format
- * @param {Number|String}       [left]
- * @param {Number|String}       [right]
- * @return {Array}                formatted Strings\
+ *
  * @example
  * <div>
  * <code>
@@ -176,7 +170,13 @@ p5.prototype.matchAll = function(str, reg) {
  *
  * @alt
  * "0011253" top left, "0112.531" mid left, "112.531061" bottom left canvas
- *
+ */
+/**
+ * @method nf
+ * @param {Array}        nums     the Numbers to format
+ * @param {Number|String}       [left]
+ * @param {Number|String}       [right]
+ * @return {Array}                formatted Strings\
  */
 p5.prototype.nf = function () {
   p5._validateParameters('nf', arguments);
@@ -253,12 +253,7 @@ function doNf() {
  * @param  {Number|String}   [right] number of digits to the right of the
  *                                  decimal point
  * @return {String}           formatted String
- */
-/**
- * @method nfc
- * @param  {Array}    nums     the Numbers to format
- * @param  {Number|String}   [right]
- * @return {Array}           formatted Strings
+ *
  * @example
  * <div>
  * <code>
@@ -284,7 +279,12 @@ function doNf() {
  *
  * @alt
  * "11,253,106.115" top middle and "1.00,1.00,2.00" displayed bottom mid
- *
+ */
+/**
+ * @method nfc
+ * @param  {Array}    nums     the Numbers to format
+ * @param  {Number|String}   [right]
+ * @return {Array}           formatted Strings
  */
 p5.prototype.nfc = function () {
   p5._validateParameters('nfc', arguments);
@@ -335,13 +335,7 @@ function doNfc() {
  * @param {Number}       [right]  number of digits to the right of the
  *                                decimal point
  * @return {String}         formatted String
- */
-/**
- * @method nfp
- * @param {Number[]} nums      the Numbers to format
- * @param {Number}       [left]
- * @param {Number}       [right]
- * @return {String[]}         formatted Strings
+ *
  * @example
  * <div>
  * <code>
@@ -367,7 +361,13 @@ function doNfc() {
  *
  * @alt
  * "+11253106.11" top middle and "-11253106.11" displayed bottom middle
- *
+ */
+/**
+ * @method nfp
+ * @param {Number[]} nums      the Numbers to format
+ * @param {Number}       [left]
+ * @param {Number}       [right]
+ * @return {String[]}         formatted Strings
  */
 p5.prototype.nfp = function() {
   p5._validateParameters('nfp', arguments);
@@ -400,13 +400,7 @@ function addNfp() {
  * @param {Number}       [right]  number of digits to the right of the
  *                                decimal point
  * @return {String}         formatted String
- */
-/**
- * @method nfs
- * @param {Array}        nums     the Numbers to format
- * @param {Number}       [left]
- * @param {Number}       [right]
- * @return {Array}         formatted Strings
+ *
  * @example
  * <div>
  * <code>
@@ -432,7 +426,13 @@ function addNfp() {
  *
  * @alt
  * "11253106.11" top middle and "-11253106.11" displayed bottom middle
- *
+ */
+/**
+ * @method nfs
+ * @param {Array}        nums     the Numbers to format
+ * @param {Number}       [left]
+ * @param {Number}       [right]
+ * @return {Array}         formatted Strings
  */
 p5.prototype.nfs = function() {
   p5._validateParameters('nfs', arguments);
@@ -546,11 +546,7 @@ p5.prototype.splitTokens = function() {
  * @method trim
  * @param  {String} str a String to be trimmed
  * @return {String}       a trimmed String
- */
-/**
- * @method trim
- * @param  {Array} strs an Array of Strings to be trimmed
- * @return {Array}       an Array of trimmed Strings
+ *
  * @example
  * <div>
  * <code>
@@ -561,7 +557,11 @@ p5.prototype.splitTokens = function() {
  *
  * @alt
  * "No new lines here" displayed center canvas
- *
+ */
+/**
+ * @method trim
+ * @param  {Array} strs an Array of Strings to be trimmed
+ * @return {Array}       an Array of trimmed Strings
  */
 p5.prototype.trim = function(str) {
   p5._validateParameters('trim', arguments);

--- a/src/webgl/light.js
+++ b/src/webgl/light.js
@@ -21,6 +21,25 @@ var p5 = require('../core/core');
  *                                 relative to the current color range
  * @param  {Number}        [alpha]
  * @chainable
+ *
+ * @example
+ * <div>
+ * <code>
+ * function setup(){
+ *   createCanvas(100, 100, WEBGL);
+ * }
+ * function draw(){
+ *   background(0);
+ *   ambientLight(150);
+ *   ambientMaterial(250);
+ *   sphere(50);
+ * }
+ * </code>
+ * </div>
+ *
+ * @alt
+ * nothing displayed
+ *
  */
 
 /**
@@ -42,25 +61,6 @@ var p5 = require('../core/core');
  * @param  {p5.Color}      color   the ambient light color
  * @param  {Number}        [alpha]
  * @chainable
- *
- * @example
- * <div>
- * <code>
- * function setup(){
- *   createCanvas(100, 100, WEBGL);
- * }
- * function draw(){
- *   background(0);
- *   ambientLight(150);
- *   ambientMaterial(250);
- *   sphere(50);
- * }
- * </code>
- * </div>
- *
- * @alt
- * nothing displayed
- *
  */
 p5.prototype.ambientLight = function(v1, v2, v3, a){
   if (! this._renderer.curFillShader.isLightShader()) {

--- a/src/webgl/loading.js
+++ b/src/webgl/loading.js
@@ -31,13 +31,7 @@ require('./p5.Geometry');
  * @param  {function(Event)} [failureCallback] called with event error if
  *                                         the image fails to load.
  * @return {p5.Geometry} the p5.Geometry object
- */
-/**
- * @method loadModel
- * @param  {String} path
- * @param  {function(p5.Geometry)} [successCallback]
- * @param  {function(Event)} [failureCallback]
- * @return {p5.Geometry} the p5.Geometry object
+ *
  * @example
  * <div>
  * <code>
@@ -61,7 +55,13 @@ require('./p5.Geometry');
  *
  * @alt
  * Vertically rotating 3-d teapot with red, green and blue gradient.
- *
+ */
+/**
+ * @method loadModel
+ * @param  {String} path
+ * @param  {function(p5.Geometry)} [successCallback]
+ * @param  {function(Event)} [failureCallback]
+ * @return {p5.Geometry} the p5.Geometry object
  */
 p5.prototype.loadModel = function () {
   var path = arguments[0];


### PR DESCRIPTION
i just noticed that yui doesn't include the `@example` attributes unless it appears in the doc comment for the _first_ overload. (eg, https://p5js.org/reference/#/p5/fill has no examples)

this PR:
- ensures that all `@example` attributes appear in the first overload's doc comment.
- adds a warning to the doc preprocessor that lists any public p5 methods that _don't_ have examples.