### PR TITLE
docs: disambiguate overloads

### DIFF
--- a/src/core/transform.js
+++ b/src/core/transform.js
@@ -276,11 +276,8 @@ p5.prototype.rotateZ = function(rad) {
  * This function can be further controlled with push() and pop().
  *
  * @method scale
- * @param  {Number|p5.Vector|Array} s
- *                      percent to scale the object, or percentage to
- *                      scale the object in the x-axis if multiple arguments
- *                      are given
- * @param  {Number} [y] percent to scale the object in the y-axis
+ * @param  {Number} x   percent to scale the object in the x-axis
+ * @param  {Number} y   percent to scale the object in the y-axis
  * @param  {Number} [z] percent to scale the object in the z-axis (webgl only)
  * @chainable
  * @example
@@ -304,6 +301,11 @@ p5.prototype.rotateZ = function(rad) {
  * white 52x52 rect with black outline at center rotated counter 45 degrees
  * 2 white rects with black outline- 1 50x50 at center. other 25x65 bottom left
  *
+ */
+/**
+ * @method scale
+ * @param  {p5.Vector|Array} scales per-axis percents to scale the object
+ * @chainable
  */
 p5.prototype.scale = function() {
   var x,y,z;

--- a/src/math/p5.Vector.js
+++ b/src/math/p5.Vector.js
@@ -106,10 +106,9 @@ p5.Vector.prototype.toString = function p5VectorToString() {
  * Sets the x, y, and z component of the vector using two or three separate
  * variables, the data from a p5.Vector, or the values from a float array.
  * @method set
- * @param {Number|p5.Vector|Array} [x] the x component of the vector or a
- *                                     p5.Vector or an Array
- * @param {Number}                 [y] the y component of the vector
- * @param {Number}                 [z] the z component of the vector
+ * @param {Number} [x] the x component of the vector
+ * @param {Number} [y] the y component of the vector
+ * @param {Number} [z] the z component of the vector
  * @chainable
  * @example
  * <div class="norender">
@@ -124,6 +123,11 @@ p5.Vector.prototype.toString = function p5VectorToString() {
  * }
  * </code>
  * </div>
+ */
+/**
+ * @method set
+ * @param {p5.Vector|Array} value the vector to set
+ * @chainable
  */
 p5.Vector.prototype.set = function (x, y, z) {
   if (x instanceof p5.Vector) {
@@ -174,12 +178,9 @@ p5.Vector.prototype.copy = function () {
  * acts directly on the vector. See the examples for more context.
  *
  * @method add
- * @param  {Number|p5.Vector|Array} x   the x component of the vector to be
- *                                      added or a p5.Vector or an Array
- * @param  {Number}                 [y] the y component of the vector to be
- *                                      added
- * @param  {Number}                 [z] the z component of the vector to be
- *                                      added
+ * @param  {Number} x   the x component of the vector to be added
+ * @param  {Number} [y] the y component of the vector to be added
+ * @param  {Number} [z] the z component of the vector to be added
  * @chainable
  * @example
  * <div class="norender">
@@ -199,6 +200,11 @@ p5.Vector.prototype.copy = function () {
  * // v3 has components [3, 5, 7]
  * </code>
  * </div>
+ */
+/**
+ * @method add
+ * @param  {p5.Vector|Array} value the vector to add
+ * @chainable
  */
 p5.Vector.prototype.add = function (x, y, z) {
   if (x instanceof p5.Vector) {
@@ -226,10 +232,9 @@ p5.Vector.prototype.add = function (x, y, z) {
  * other acts directly on the vector. See the examples for more context.
  *
  * @method sub
- * @param  {Number|p5.Vector|Array} x   the x component of the vector or a
- *                                      p5.Vector or an Array
- * @param  {Number}                 [y] the y component of the vector
- * @param  {Number}                 [z] the z component of the vector
+ * @param  {Number} x   the x component of the vector to subtract
+ * @param  {Number} [y] the y component of the vector to subtract
+ * @param  {Number} [z] the z component of the vector to subtract
  * @chainable
  * @example
  * <div class="norender">
@@ -250,6 +255,11 @@ p5.Vector.prototype.add = function (x, y, z) {
  * // v3 has components [1, 1, 1]
  * </code>
  * </div>
+ */
+/**
+ * @method sub
+ * @param  {p5.Vector|Array} value the vector to subtract
+ * @chainable
  */
 p5.Vector.prototype.sub = function (x, y, z) {
   if (x instanceof p5.Vector) {
@@ -383,10 +393,10 @@ p5.Vector.prototype.magSq = function () {
  *
  *
  * @method dot
- * @param  {Number|p5.Vector} x   x component of the vector or a p5.Vector
- * @param  {Number}           [y] y component of the vector
- * @param  {Number}           [z] z component of the vector
- * @return {Number}                 the dot product
+ * @param  {Number} x   x component of the vector
+ * @param  {Number} [y] y component of the vector
+ * @param  {Number} [z] z component of the vector
+ * @return {Number}       the dot product
  *
  * @example
  * <div class="norender">
@@ -406,6 +416,11 @@ p5.Vector.prototype.magSq = function () {
  * print (p5.Vector.dot(v1, v2)); // Prints "10"
  * </code>
  * </div>
+ */
+/**
+ * @method dot
+ * @param  {p5.Vector} value value component of the vector or a p5.Vector
+ * @return {Number}
  */
 p5.Vector.prototype.dot = function (x, y, z) {
   if (x instanceof p5.Vector) {
@@ -731,10 +746,9 @@ p5.Vector.prototype.array = function () {
  * Equality check against a p5.Vector
  *
  * @method equals
- * @param {Number|p5.Vector|Array} [x] the x component of the vector or a
- *                                     p5.Vector or an Array
- * @param {Number}                 [y] the y component of the vector
- * @param {Number}                 [z] the z component of the vector
+ * @param {Number} [x] the x component of the vector
+ * @param {Number} [y] the y component of the vector
+ * @param {Number} [z] the z component of the vector
  * @return {Boolean} whether the vectors are equals
  * @example
  * <div class = "norender"><code>
@@ -754,6 +768,11 @@ p5.Vector.prototype.array = function () {
  * print (v1.equals(v3)) // false
  * </code>
  * </div>
+ */
+/**
+ * @method equals
+ * @param {p5.Vector|Array} value the vector to compare
+ * @return {Boolean}
  */
 p5.Vector.prototype.equals = function (x, y, z) {
   var a, b, c;

--- a/src/webgl/material.js
+++ b/src/webgl/material.js
@@ -212,12 +212,11 @@ p5.prototype.texture = function(){
  * possible materials in this
  * <a href="https://p5js.org/examples/3d-materials.html">example</a>.
  * @method  ambientMaterial
- * @param  {Number|Array|String|p5.Color} v1  gray value,
- * red or hue value (depending on the current color mode),
- * or color Array, or CSS color string
- * @param  {Number}            [v2] green or saturation value
- * @param  {Number}            [v3] blue or brightness value
- * @param  {Number}            [a]  opacity
+ * @param  {Number} v1  gray value, red or hue value
+ *                         (depending on the current color mode)
+ * @param  {Number} [v2] green or saturation value
+ * @param  {Number} [v3] blue or brightness value
+ * @param  {Number} [a]  opacity
  * @chainable
  * @example
  * <div>
@@ -239,6 +238,11 @@ p5.prototype.texture = function(){
  * radiating light source from top right of canvas
  *
  */
+/**
+ * @method  ambientMaterial
+ * @param  {Array|String|p5.Color} color  color, color Array, or CSS color string
+ * @chainable
+ */
 p5.prototype.ambientMaterial = function(v1, v2, v3, a) {
   if (! this._renderer.curFillShader.isLightShader()) {
     this._renderer.setFillShader(this._renderer._getLightShader());
@@ -255,12 +259,11 @@ p5.prototype.ambientMaterial = function(v1, v2, v3, a) {
  * possible materials in this
  * <a href="https://p5js.org/examples/3d-materials.html">example</a>.
  * @method specularMaterial
- * @param  {Number|Array|String|p5.Color} v1  gray value,
- * red or hue value (depending on the current color mode),
- * or color Array, or CSS color string
- * @param  {Number}            [v2] green or saturation value
- * @param  {Number}            [v3] blue or brightness value
- * @param  {Number}            [a]  opacity
+ * @param  {Number} v1   gray value, red or hue value
+ *                        (depending on the current color mode),
+ * @param  {Number} [v2] green or saturation value
+ * @param  {Number} [v3] blue or brightness value
+ * @param  {Number} [a]  opacity
  * @chainable
  * @example
  * <div>
@@ -281,6 +284,11 @@ p5.prototype.ambientMaterial = function(v1, v2, v3, a) {
  * @alt
  * diffused radiating light source from top right of canvas
  *
+ */
+/**
+ * @method specularMaterial
+ * @param  {Array|String|p5.Color} color color Array, or CSS color string
+ * @chainable
  */
 p5.prototype.specularMaterial = function(v1, v2, v3, a) {
   if (! this._renderer.curFillShader.isLightShader()) {


### PR DESCRIPTION
if you look at the docs for `p5.Vector.add()` (https://p5js.org/reference/#/p5.Vector/add), you'll see that for the non-static overload, it's apparently ok to call it like this:

    var r = v.add([a,b,c], y, z);

because `x` can be a `{Number|p5.Vector|Array}`.

this PR splits those into separate overloads (all except `save()` !) so this ambiguity doesn't occur.