### PR TITLE
grunt/connect: rewrite requests to /lib/*.js

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -284,11 +284,17 @@ module.exports = function(grunt) {
           port: 9001,
           keepalive: keepalive,
           middleware: function(connect, options, middlewares) {
-            middlewares.unshift(function(req, res, next) {
-              res.setHeader('Access-Control-Allow-Origin', '*');
-              res.setHeader('Access-Control-Allow-Methods', '*');
-              return next();
-            });
+            middlewares.unshift(
+              require('connect-modrewrite')([
+                '^/assets/js/p5\\.min\\.js(.*) /lib/p5.min.js$1 [L]',
+                '^/assets/js/p5\\.(dom|sound)\\.min\\.js(.*) /lib/addons/p5.$1.min.js$2 [L]',
+              ]),
+              function(req, res, next) {
+                res.setHeader('Access-Control-Allow-Origin', '*');
+                res.setHeader('Access-Control-Allow-Methods', '*');
+                return next();
+              }
+            );
             return middlewares;
           }
         }

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "browserify": "^11.0.1",
     "chai": "^3.5.0",
     "concat-files": "^0.1.0",
+    "connect-modrewrite": "^0.10.1",
     "derequire": "^2.0.0",
     "grunt": "^0.4.5",
     "grunt-cli": "^0.1.13",


### PR DESCRIPTION
this add a redirect to the connect grunt task that allows the docs to use the locally-built p5.min.js (+ addons) when run locally on port 9001.

fixes https://github.com/processing/p5.js/issues/2243
