### PR TITLE
Implementation of range()

### DIFF
--- a/src/.jshintrc
+++ b/src/.jshintrc
@@ -19,6 +19,7 @@
   "globals": {
     "require": false,
     "module": false,
+    "Symbol": false,
     "PImage": false
   }
 }

--- a/src/app.js
+++ b/src/app.js
@@ -48,6 +48,8 @@ require('./typography/loading_displaying');
 
 require('./data/p5.TypedDict');
 
+require('./utilities/iterators');
+
 require('./webgl/p5.RendererGL');
 require('./webgl/p5.Geometry');
 require('./webgl/p5.RendererGL.Retained');

--- a/src/utilities/iterators.js
+++ b/src/utilities/iterators.js
@@ -51,7 +51,7 @@ var p5 = require('../core/core');
  */
 p5.prototype.range = function(start, stop, step) {
   if(typeof start === 'undefined') {
-    throw new Error('Not enough parameters for range');
+    throw new TypeError('Not enough parameters for range');
   }
   if(typeof stop === 'undefined') {
     stop = start;
@@ -67,7 +67,7 @@ p5.prototype.range = function(start, stop, step) {
       var i = start;
       return {
         next: function() {
-          if(dir * (i - stop) >= 0) {
+          if(stop !== null && dir * (i - stop) >= 0) {
             return {
               done: true
             };

--- a/src/utilities/iterators.js
+++ b/src/utilities/iterators.js
@@ -1,0 +1,88 @@
+/**
+ * @module Utilities
+ * @submodule Iterators
+ * @for p5
+ * @requires core
+ */
+
+'use strict';
+
+var p5 = require('../core/core');
+
+
+/**
+ * Produces an iterator over the numbers in the range. The result is given by
+ * starting at start, and adding step repeatedly until the result has gone past
+ * stop.
+ * In the single parameter version, start is set to zero and step is set to one.
+ *
+ * @method range
+ * @param  {Number}  stop      Number to stop at
+ * @return {Iterator}          An iterator that returns the values sequentially
+ * @example
+ * <div>
+ * <code>
+ * for(var i of range(width)) {
+ *   line(i, 0, i, i);
+ * }
+ * </code>
+ * </div>
+ * <div>
+ * <code>
+ * var start = width / 4;
+ * var stop = 3 / 4 * width;
+ * for(var i of range(start, stop, 2)) {
+ *   line(i, start, i, i);
+ *   line(start, i, i, i);
+ * }
+ * </code>
+ * </div>
+ *
+ * @alt
+ * Triangle filling the top right corner of the canvas
+ * Square in the center of the canvas, with a striped effect
+ */
+/**
+ * @method range
+ * @param  {Number}  start       Number to start at (default 0)
+ * @param  {Number}  stop
+ * @param  {Number}  [step]      Amount to step by (default 1)
+ * @return {Iterator}
+ */
+p5.prototype.range = function(start, stop, step) {
+  if(typeof start === 'undefined') {
+    throw new Error('Not enough parameters for range');
+  }
+  if(typeof stop === 'undefined') {
+    stop = start;
+    start = 0;
+  }
+  if(typeof step === 'undefined') {
+    step = 1;
+  }
+  var dir = step < 0 ? -1 : 1;
+  if(Symbol && Symbol.iterator) {
+    var res = {};
+    res[Symbol.iterator] = function() {
+      var i = start;
+      return {
+        next: function() {
+          if(dir * (i - stop) >= 0) {
+            return {
+              done: true
+            };
+          } else {
+            i += step;
+            return {
+              value: i - step,
+              done: false
+            };
+          }
+        }
+      };
+    };
+    return res;
+  } else {
+    throw new Error('range() unsuported');
+  }
+};

--- a/test/test-reference.html
+++ b/test/test-reference.html
@@ -48,10 +48,20 @@
   </script>
 
   <script>
+  var can_do_for_of = false;
+  </script>
+
+  <script>
+  for(var i of []) {};
+  can_do_for_of = true;
+  </script>
+
+  <script>
   var TEST_FILENAME_FILTERS = [
     {regex: /webgl/, condition: Modernizr.webgl},
     {regex: /acceleration/, condition: Modernizr.webgl},
-    {regex: /sound/, condition: Modernizr.webaudio}
+    {regex: /sound/, condition: Modernizr.webaudio},
+    {regex: /iterators/, condition: can_do_for_of}
   ];
   var MS_TIMEOUT = 4000;
 

--- a/test/unit/spec.js
+++ b/test/unit/spec.js
@@ -40,6 +40,7 @@ var spec = {
   'utilities': [
     'array_functions',
     'string_functions',
+    'iterators',
     'time_date'
   ],
   'webgl': [

--- a/test/unit/utilities/iterators.js
+++ b/test/unit/utilities/iterators.js
@@ -52,5 +52,29 @@ suite('Iterators', function() {
         i++;
       }
     });
+
+    test('no result if start is past end', function() {
+      assert.deepEqual(
+        Array.from(myp5.range(0, 10, -1)),
+        []);
+      assert.deepEqual(
+        Array.from(myp5.range(0, -10, 1)),
+        []);
+    });
+
+    test('never ends if applicable', function() {
+      function never_ends(range) {
+        var iter = range[Symbol.iterator]();
+        for(var i = 0; i < 1000; i++) {
+          var res = iter.next();
+          assert.equal(res.done, false);
+        }
+      }
+      never_ends(myp5.range(0, null));
+      never_ends(myp5.range(0, null, 1));
+      never_ends(myp5.range(0, null, -1));
+      never_ends(myp5.range(0, null, 0));
+      never_ends(myp5.range(0, 10, 0));
+    });
   });
 });

--- a/test/unit/utilities/iterators.js
+++ b/test/unit/utilities/iterators.js
@@ -1,0 +1,56 @@
+suite('Iterators', function() {
+  var myp5;
+
+  setup(function(done) {
+    new p5(function(p){
+      p.setup = function() {
+        myp5 = p;
+        done();
+      };
+    });
+  });
+
+  teardown(function() {
+    myp5.remove();
+  });
+
+  suite('range', function() {
+    test('passes examples', function() {
+      // These are the examples from python's range documentation.
+      assert.deepEqual(
+        Array.from(myp5.range(10)),
+        [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]);
+      assert.deepEqual(
+        Array.from(myp5.range(1, 11)),
+        [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]);
+      assert.deepEqual(
+        Array.from(myp5.range(0, 30, 5)),
+        [0, 5, 10, 15, 20, 25]);
+      assert.deepEqual(
+        Array.from(myp5.range(0, 10, 3)),
+        [0, 3, 6, 9]);
+      assert.deepEqual(
+        Array.from(myp5.range(0, -10, -1)),
+        [0, -1, -2, -3, -4, -5, -6, -7, -8, -9]);
+      assert.deepEqual(
+        Array.from(myp5.range(0)),
+        []);
+      assert.deepEqual(
+        Array.from(myp5.range(1, 0)),
+        []);
+    });
+
+    test('can be used twice', function() {
+      var range = myp5.range(0, 100);
+      assert.deepEqual(Array.from(range), Array.from(range));
+    });
+
+    test('iterates correctly', function() {
+      var i = 0;
+      for(var j of myp5.range(0, 10)) {
+        assert.equal(i, j);
+        i++;
+      }
+    });
+  });
+});


### PR DESCRIPTION
This is my suggestion for a `range()` implementation as discussed in #2305 & #1990 

Potential points of thought:

You cannot do the following:
```javascript
var iter = range(10);
iter.next(); // 0
iter.next(); // 1
```
You can do the following:
```javascript
var my_range = range(10);
for(var i of my_range) {...}
for(var i of my_range) {...}
```
and both iterate [0, 10)

I think this is how JS iterators are intended to operate, that is dissimilar from python iterators. It would be possible to make it only iterate once, but I am unsure if that would be better. I can see uses for both cases really and the way iterators are designed made me lean this way. Discussion is very welcome!

Oh, and the documentation is excluded from automatic testing because PhantomJS doesn't support `for..of` (See #2174)