### PR TITLE
getCanvasImage() : new image.js function for screenshots

### DIFF
--- a/src/image/image.js
+++ b/src/image/image.js
@@ -343,24 +343,40 @@ p5.prototype._makeFrame = function(filename, extension, _cnv) {
 
 /**
  * Returns the current canvas as a loaded p5.Image. This allows an assignment
- * or immediate use in the users sketch as a canvas screenshot.
+ * or immediate use in the sketch as a canvas screenshot.
  *
  * @method getCanvasImage
- * @param none
- *
  * @example
- * // This example shows how a user can directly create a screenshot of his
- * // canvas and have it saved for future use or use immediately
- * draw() {
- *   // .. other code
- *   var screenshot = getCanvasImage();
- *   image(screenshot, 10, 10, 50, 50);
+ * <div>
+ * <code>
+ * var screenshot;
+ *
+ * function draw() {
+ *   background(237, 34, 93);
+ *
+ *   // Sample circle
+ *   strokeWeight(10);
+ *   ellipse(50, 50, 80, 80);
+ *
+ *   // Draw the screenshot if the screenshot has been made
+ *   if(!(screenshot == null)) {
+ *     image(screenshot, 5, 5, 60, 60);
+ *   }
  * }
  *
+ * // When a mouse button is pressed, the screenshot is captured
+ * function mousePressed() {
+ *   screenshot = getCanvasImage();
+ * }
+ * </code>
+ * </div>
+ *
+ * @alt
+ * Screenshots are made and displayed on mouse click
  */
 p5.prototype.getCanvasImage = function() {
   if (this._curElement && this._curElement.elt) {
-    return loadImage(this._curElement.elt.toDataURL('image/png'));
+    return this.loadImage(this._curElement.elt.toDataURL('image/png'));
   }
 };
 

--- a/src/image/image.js
+++ b/src/image/image.js
@@ -359,7 +359,9 @@ p5.prototype._makeFrame = function(filename, extension, _cnv) {
  *
  */
 p5.prototype.getCanvasImage = function() {
-  return loadImage(this._curElement.elt.toDataURL('image/png'));
+  if (this._curElement && this._curElement.elt) {
+    return loadImage(this._curElement.elt.toDataURL('image/png'));
+  }
 };
 
 module.exports = p5;

--- a/src/image/image.js
+++ b/src/image/image.js
@@ -341,4 +341,25 @@ p5.prototype._makeFrame = function(filename, extension, _cnv) {
   frames.push(thisFrame);
 };
 
+/**
+ * Returns the current canvas as a loaded p5.Image. This allows an assignment
+ * or immediate use in the users sketch as a canvas screenshot.
+ *
+ * @method getCanvasImage
+ * @param none
+ *
+ * @example
+ * // This example shows how a user can directly create a screenshot of his
+ * // canvas and have it saved for future use or use immediately
+ * draw() {
+ *   // .. other code
+ *   var screenshot = getCanvasImage();
+ *   image(screenshot, 10, 10, 50, 50);
+ * }
+ *
+ */
+p5.prototype.getCanvasImage = function() {
+  return loadImage(this._curElement.elt.toDataURL('image/png'));
+};
+
 module.exports = p5;


### PR DESCRIPTION
**Hi,** 

I've added a new function **getCanvasImage()** to image.js that **returns a P5.image object of the current canvas**. 

This can be considered as a **screenshot** of the current canvas and be **used in any way P5.image** would be used. I needed this functionality and was surprised this wasn't implemented _natively_ since I believe it's quite handy.

I didn't want the users to save the image locally - so saveCanvas() wasn't really helping and after longer search I found a single workaround from 2015 with saveFrames() and custom callback function that I found _difficult_ and _unintuitive_ to implement. So I went through the saveCanvas() function, found, extracted and edited a bit this one single line of code. 

Should you decide to merge it - I will prepare the documentation and working examples for the P5.js webpage.

**Thank you**

**Oliver**


