### PR TITLE
Issue #2203: Updated arc() reference documentation

### DIFF
--- a/src/core/2d_primitives.js
+++ b/src/core/2d_primitives.js
@@ -63,7 +63,6 @@ require('./error_helpers');
  * </code>
  * </div>
  *
- *
  * <div>
  * <code>
  * arc(50, 50, 80, 80, 0, PI+QUARTER_PI, PIE);


### PR DESCRIPTION
I have slightly expanded and reworded the documentation for the arc() reference in order to better explain the modes OPEN, CHORD and PIE. I have also added an example showing the default mode to show how it compares with the other modes.