### PR TITLE
Fix alpha

### DIFF
--- a/src/color/setting.js
+++ b/src/color/setting.js
@@ -474,7 +474,6 @@ p5.prototype.colorMode = function() {
 /**
  * @method fill
  * @param  {p5.Color}      color   the fill color
- * @param  {Number}        [alpha]
  * @chainable
  */
 p5.prototype.fill = function() {
@@ -693,7 +692,6 @@ p5.prototype.noStroke = function() {
 /**
  * @method stroke
  * @param  {p5.Color}      color   the stroke color
- * @param  {Number}        [alpha]
  * @chainable
  */
 

--- a/src/color/setting.js
+++ b/src/color/setting.js
@@ -33,8 +33,6 @@ require('./p5.Color');
  *
  * @method background
  * @param {p5.Color} color     any value created by the color() function
- * @param {Number} [a]         opacity of the background relative to current
- *                             color range (default is 0-100)
  * @chainable
  *
  * @example
@@ -135,7 +133,8 @@ require('./p5.Color');
  * @param {String} colorstring color string, possible formats include: integer
  *                         rgb() or rgba(), percentage rgb() or rgba(),
  *                         3-digit hex, 6-digit hex
- * @param {Number} [a]
+ * @param {Number} [a]         opacity of the background relative to current
+ *                             color range (default is 0-100)
  * @chainable
  */
 

--- a/src/image/loading_displaying.js
+++ b/src/image/loading_displaying.js
@@ -372,7 +372,6 @@ p5.prototype.image =
 /**
  * @method tint
  * @param  {p5.Color}      color   the tint color
- * @param  {Number}        [alpha]
  */
 p5.prototype.tint = function () {
   var c = this.color.apply(this, arguments);

--- a/src/webgl/light.js
+++ b/src/webgl/light.js
@@ -59,7 +59,6 @@ var p5 = require('../core/core');
 /**
  * @method ambientLight
  * @param  {p5.Color}      color   the ambient light color
- * @param  {Number}        [alpha]
  * @chainable
  */
 p5.prototype.ambientLight = function(v1, v2, v3, a){


### PR DESCRIPTION
mea culpa, when separating the various color overloads in the docs, i mistakenly added an `alpha` parameter for those overloads that took a `p5.Color`. it turns out that `_parseInputs` doesn't support this case.

this PR just removes those parameters from the doc comments.

fixes #2380