### PR TITLE
Add link from blend constant to blend() and blendMode()

### DIFF
--- a/src/core/constants.js
+++ b/src/core/constants.js
@@ -323,6 +323,12 @@ module.exports = {
 
   // RENDERING
   /**
+   * Defines the default image blending mode.
+   * For examples on how to use blend, see [blend()][] and [blendMode()][]
+   *
+   * [blend()]: #p5.Image/blend
+   * [blendMode()]: #p5/blendMode
+   *
    * @property {String} BLEND
    * @final
    * @default source-over


### PR DESCRIPTION
How do we feel about this? Is there a better way to link to other parts of the documentation, like with `@link p5.Image/color` or something...

<img width="1675" alt="screen shot 2017-12-04 at 11 34 04 am" src="https://user-images.githubusercontent.com/32407/33548317-1215b826-d8e7-11e7-87dc-553ec629bd41.png">
