### PR TITLE
fix eslint:fix fix

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -334,7 +334,7 @@ module.exports = function(grunt) {
 
   // eslint fixes everything it checks:
   gruntConfig.eslint.fix.src = Object.keys(gruntConfig.eslint)
-    .map(s => s.src)
+    .map(s => gruntConfig.eslint[s].src)
     .reduce((a, b) => a.concat(b), [])
     .filter(a => a);
 


### PR DESCRIPTION
i noticed that in a52950c90423b64c5cbc03526adb609f1511d9dc `Object.values` was changed to `Object.keys`.

i'm guessing this was due to compatibility with older versions of node?

anyway, unfortunately `grunt eslint:fix` now does nothing. this PR fixes that (in a non-es2017-requiring fashion).