### PR TITLE
make select() and createRadio() accept exisiting radio elements

### DIFF
--- a/lib/addons/p5.dom.js
+++ b/lib/addons/p5.dom.js
@@ -683,7 +683,7 @@
    * }
    * </code></div>
    */
-  p5.prototype.createRadio = function() {
+  p5.prototype.createRadio = function(existing_radios) {
     p5._validateParameters('createRadio', arguments);
     // do some prep by counting number of radios on page
     var radios = document.querySelectorAll('input[type=radio]');
@@ -705,23 +705,28 @@
     }
     // see if we got an existing set of radios from callee
     var elt, self;
-    var arg = arguments[0];
-    if (typeof arg === 'object') {
+    if (typeof existing_radios === 'object') {
       // use existing elements
-      self = arg;
-      elt = this.elt = arg.elt;
+      self = existing_radios;
+      elt = this.elt = existing_radios.elt;
     } else {
       // create a set of radio buttons
       elt = document.createElement('div');
       self = addElement(elt, this);
     }
     // setup member functions
+    self._getInputChildrenArray = function() {
+      return Array.prototype.slice.call(this.elt.children).filter(function(c) {
+        return c.tagName === 'INPUT';
+      });
+    };
+
     var times = -1;
     self.option = function(name, value) {
       var opt = document.createElement('input');
       opt.type = 'radio';
       opt.innerHTML = name;
-      if (arguments.length > 1) opt.value = value;
+      if (value) opt.value = value;
       else opt.value = name;
       opt.setAttribute('name', 'defaultradio' + count);
       elt.appendChild(opt);
@@ -735,17 +740,12 @@
       }
       return opt;
     };
-    self.selected = function() {
+    self.selected = function(value) {
       var i;
-      var inputChildren = Array.prototype.slice
-        .call(this.elt.children)
-        .filter(function(c) {
-          return c.tagName === 'INPUT';
-        });
-      if (arguments.length === 1) {
+      var inputChildren = self._getInputChildrenArray();
+      if (value) {
         for (i = 0; i < inputChildren.length; i++) {
-          if (inputChildren[i].value === arguments[0])
-            inputChildren[i].checked = true;
+          if (inputChildren[i].value === value) inputChildren[i].checked = true;
         }
         return this;
       } else {
@@ -754,17 +754,12 @@
         }
       }
     };
-    self.value = function() {
+    self.value = function(value) {
       var i;
-      var inputChildren = Array.prototype.slice
-        .call(this.elt.children)
-        .filter(function(c) {
-          return c.tagName === 'INPUT';
-        });
-      if (arguments.length === 1) {
+      var inputChildren = self._getInputChildrenArray();
+      if (value) {
         for (i = 0; i < inputChildren.length; i++) {
-          if (inputChildren[i].value === arguments[0])
-            inputChildren[i].checked = true;
+          if (inputChildren[i].value === value) inputChildren[i].checked = true;
         }
         return this;
       } else {

--- a/lib/addons/p5.dom.js
+++ b/lib/addons/p5.dom.js
@@ -179,7 +179,7 @@
    * Helper function for getElement and getElements.
    */
   p5.prototype._wrapElement = function(elt) {
-    var children = Array.prototype.slice.call( elt.children )
+    var children = Array.prototype.slice.call(elt.children);
     if (elt.tagName === 'INPUT' && elt.type === 'checkbox') {
       var converted = new p5.Element(elt);
       converted.checked = function() {
@@ -195,12 +195,16 @@
       return converted;
     } else if (elt.tagName === 'VIDEO' || elt.tagName === 'AUDIO') {
       return new p5.MediaElement(elt);
-    } else if ( elt.tagName === "SELECT" ){
-      return this.createSelect( new p5.Element(elt) );
-    } else if (children.length > 0 && children.every(function(c) { return c.tagName === "INPUT" || c.tagName === "LABEL" })) {
-      return this.createRadio( new p5.Element(elt) );
-    }
-    else {
+    } else if (elt.tagName === 'SELECT') {
+      return this.createSelect(new p5.Element(elt));
+    } else if (
+      children.length > 0 &&
+      children.every(function(c) {
+        return c.tagName === 'INPUT' || c.tagName === 'LABEL';
+      })
+    ) {
+      return this.createRadio(new p5.Element(elt));
+    } else {
       return new p5.Element(elt);
     }
   };
@@ -702,7 +706,7 @@
     // see if we got an existing set of radios from callee
     var elt, self;
     var arg = arguments[0];
-    if( typeof arg === 'object' ) {
+    if (typeof arg === 'object') {
       // use existing elements
       self = arg;
       elt = this.elt = arg.elt;
@@ -731,35 +735,41 @@
       }
       return opt;
     };
-    self.selected = function(){
+    self.selected = function() {
       var i;
-      var inputChildren = Array.prototype.slice.call(this.elt.children).filter(function(c) { return c.tagName === "INPUT" });
-      if(arguments.length == 1) {
-        for (i = 0; i < inputChildren.length; i++){
-          if(inputChildren[i].value === arguments[0])
+      var inputChildren = Array.prototype.slice
+        .call(this.elt.children)
+        .filter(function(c) {
+          return c.tagName === 'INPUT';
+        });
+      if (arguments.length === 1) {
+        for (i = 0; i < inputChildren.length; i++) {
+          if (inputChildren[i].value === arguments[0])
             inputChildren[i].checked = true;
         }
         return this;
       } else {
-        for (i = 0; i < inputChildren.length; i++){
-          if(inputChildren[i].checked === true)
-            return inputChildren[i].value;
+        for (i = 0; i < inputChildren.length; i++) {
+          if (inputChildren[i].checked === true) return inputChildren[i].value;
         }
       }
     };
-    self.value = function(){
+    self.value = function() {
       var i;
-      var inputChildren = Array.prototype.slice.call(this.elt.children).filter(function(c) { return c.tagName === "INPUT" });
-      if(arguments.length == 1) {
-        for (i = 0; i < inputChildren.length; i++){
-          if(inputChildren[i].value == arguments[0])
+      var inputChildren = Array.prototype.slice
+        .call(this.elt.children)
+        .filter(function(c) {
+          return c.tagName === 'INPUT';
+        });
+      if (arguments.length === 1) {
+        for (i = 0; i < inputChildren.length; i++) {
+          if (inputChildren[i].value === arguments[0])
             inputChildren[i].checked = true;
         }
         return this;
       } else {
-        for (i = 0; i < inputChildren.length; i++){
-          if(inputChildren[i].checked == true)
-            return inputChildren[i].value;
+        for (i = 0; i < inputChildren.length; i++) {
+          if (inputChildren[i].checked === true) return inputChildren[i].value;
         }
         return '';
       }

--- a/lib/addons/p5.dom.js
+++ b/lib/addons/p5.dom.js
@@ -179,6 +179,7 @@
    * Helper function for getElement and getElements.
    */
   p5.prototype._wrapElement = function(elt) {
+    var children = Array.prototype.slice.call( elt.children )
     if (elt.tagName === 'INPUT' && elt.type === 'checkbox') {
       var converted = new p5.Element(elt);
       converted.checked = function() {
@@ -194,9 +195,12 @@
       return converted;
     } else if (elt.tagName === 'VIDEO' || elt.tagName === 'AUDIO') {
       return new p5.MediaElement(elt);
-    } else if (elt.tagName === 'SELECT') {
-      return this.createSelect(new p5.Element(elt));
-    } else {
+    } else if ( elt.tagName === "SELECT" ){
+      return this.createSelect( new p5.Element(elt) );
+    } else if (children.length > 0 && children.every(function(c) { return c.tagName === "INPUT" || c.tagName === "LABEL" })) {
+      return this.createRadio( new p5.Element(elt) );
+    }
+    else {
       return new p5.Element(elt);
     }
   };
@@ -677,6 +681,7 @@
    */
   p5.prototype.createRadio = function() {
     p5._validateParameters('createRadio', arguments);
+    // do some prep by counting number of radios on page
     var radios = document.querySelectorAll('input[type=radio]');
     var count = 0;
     if (radios.length > 1) {
@@ -694,8 +699,19 @@
     } else if (radios.length === 1) {
       count = 1;
     }
-    var elt = document.createElement('div');
-    var self = addElement(elt, this);
+    // see if we got an existing set of radios from callee
+    var elt, self;
+    var arg = arguments[0];
+    if( typeof arg === 'object' ) {
+      // use existing elements
+      self = arg;
+      elt = this.elt = arg.elt;
+    } else {
+      // create a set of radio buttons
+      elt = document.createElement('div');
+      self = addElement(elt, this);
+    }
+    // setup member functions
     var times = -1;
     self.option = function(name, value) {
       var opt = document.createElement('input');
@@ -715,35 +731,35 @@
       }
       return opt;
     };
-    self.selected = function() {
-      var i,
-        length = this.elt.childNodes.length;
-      if (arguments.length === 1) {
-        for (i = 0; i < length; i += 2) {
-          if (this.elt.childNodes[i].value === arguments[0])
-            this.elt.childNodes[i].checked = true;
+    self.selected = function(){
+      var i;
+      var inputChildren = Array.prototype.slice.call(this.elt.children).filter(function(c) { return c.tagName === "INPUT" });
+      if(arguments.length == 1) {
+        for (i = 0; i < inputChildren.length; i++){
+          if(inputChildren[i].value === arguments[0])
+            inputChildren[i].checked = true;
         }
         return this;
       } else {
-        for (i = 0; i < length; i += 2) {
-          if (this.elt.childNodes[i].checked)
-            return this.elt.childNodes[i].value;
+        for (i = 0; i < inputChildren.length; i++){
+          if(inputChildren[i].checked === true)
+            return inputChildren[i].value;
         }
       }
     };
-    self.value = function() {
-      var i,
-        length = this.elt.childNodes.length;
-      if (arguments.length === 1) {
-        for (i = 0; i < length; i += 2) {
-          if (this.elt.childNodes[i].value === arguments[0])
-            this.elt.childNodes[i].checked = true;
+    self.value = function(){
+      var i;
+      var inputChildren = Array.prototype.slice.call(this.elt.children).filter(function(c) { return c.tagName === "INPUT" });
+      if(arguments.length == 1) {
+        for (i = 0; i < inputChildren.length; i++){
+          if(inputChildren[i].value == arguments[0])
+            inputChildren[i].checked = true;
         }
         return this;
       } else {
-        for (i = 0; i < length; i += 2) {
-          if (this.elt.childNodes[i].checked)
-            return this.elt.childNodes[i].value;
+        for (i = 0; i < inputChildren.length; i++){
+          if(inputChildren[i].checked == true)
+            return inputChildren[i].value;
         }
         return '';
       }


### PR DESCRIPTION
Allow `Select()` to successfully `createRadio()` from existing elements.

Implementation
* add logic to `Select()` that inspects the given elements children to see if they are _only_ `input`s and `label`s
* modify `createRadio()` to take an element and use it instead of making new elements in the dom
* make `radio.selected()` and `radio.value()` more robust to different children configurations

Fixes #2299 