### PR TITLE
fix bogus 'this' reference in createCanvas

### DIFF
--- a/src/core/rendering.js
+++ b/src/core/rendering.js
@@ -150,7 +150,9 @@ p5.prototype.resizeCanvas = function(w, h, noRedraw) {
     this._renderer.resize(w, h);
     // reset canvas properties
     for (var savedKey in props) {
-      this.drawingContext[savedKey] = props[savedKey];
+      try {
+        this.drawingContext[savedKey] = props[savedKey];
+      } catch (err) {}
     }
     if (!noRedraw) {
       this.redraw();

--- a/src/core/rendering.js
+++ b/src/core/rendering.js
@@ -152,7 +152,9 @@ p5.prototype.resizeCanvas = function(w, h, noRedraw) {
     for (var savedKey in props) {
       try {
         this.drawingContext[savedKey] = props[savedKey];
-      } catch (err) {}
+      } catch (err) {
+        // ignore read-only property errors
+      }
     }
     if (!noRedraw) {
       this.redraw();

--- a/src/core/rendering.js
+++ b/src/core/rendering.js
@@ -57,8 +57,9 @@ p5.prototype.createCanvas = function(w, h, renderer) {
     if (c) {
       //if defaultCanvas already exists
       c.parentNode.removeChild(c); //replace the existing defaultCanvas
+      var thisRenderer = this._renderer;
       this._elements = this._elements.filter(function(e) {
-        return e !== this._renderer;
+        return e !== thisRenderer;
       });
     }
     c = document.createElement('canvas');


### PR DESCRIPTION
there's an erroneous use of `this.` inside an anonymous function in `createCanvas()`.

this PR fixes this `this`.


also, fix a case where `resizeCanvas()` would crash trying to restore some read-only canvas properties.