### PR TITLE
avoid use of 'arguments' object where possible

### DIFF
--- a/src/color/creating_reading.js
+++ b/src/color/creating_reading.js
@@ -440,28 +440,28 @@ p5.prototype.lerpColor = function(c1, c2, amt) {
   var fromArray, toArray;
 
   if (mode === constants.RGB) {
-    fromArray = arguments[0].levels.map(function(level) {
+    fromArray = c1.levels.map(function(level) {
       return level / 255;
     });
-    toArray = arguments[1].levels.map(function(level) {
+    toArray = c2.levels.map(function(level) {
       return level / 255;
     });
   } else if (mode === constants.HSB) {
-    arguments[0]._getBrightness(); // Cache hsba so it definitely exists.
-    arguments[1]._getBrightness();
-    fromArray = arguments[0].hsba;
-    toArray = arguments[1].hsba;
+    c1._getBrightness(); // Cache hsba so it definitely exists.
+    c2._getBrightness();
+    fromArray = c1.hsba;
+    toArray = c2.hsba;
   } else if (mode === constants.HSL) {
-    arguments[0]._getLightness(); // Cache hsla so it definitely exists.
-    arguments[1]._getLightness();
-    fromArray = arguments[0].hsla;
-    toArray = arguments[1].hsla;
+    c1._getLightness(); // Cache hsla so it definitely exists.
+    c2._getLightness();
+    fromArray = c1.hsla;
+    toArray = c2.hsla;
   } else {
     throw new Error(mode + 'cannot be used for interpolation.');
   }
 
   // Prevent extrapolation.
-  amt = Math.max(Math.min(arguments[2], 1), 0);
+  amt = Math.max(Math.min(amt, 1), 0);
 
   // Define lerp here itself if user isn't using math module.
   // Maintains the definition as found in math/calculation.js

--- a/src/color/p5.Color.js
+++ b/src/color/p5.Color.js
@@ -7,6 +7,8 @@
  * @requires color_conversion
  */
 
+'use strict';
+
 var p5 = require('../core/core');
 var constants = require('../core/constants');
 var color_conversion = require('./color_conversion');
@@ -600,7 +602,7 @@ var colorPatterns = {
  * //todo
  *
  */
-p5.Color._parseInputs = function() {
+p5.Color._parseInputs = function(r, g, b, a) {
   var numArgs = arguments.length;
   var mode = this.mode;
   var maxes = this.maxes;
@@ -609,13 +611,13 @@ p5.Color._parseInputs = function() {
   if (numArgs >= 3) {
     // Argument is a list of component values.
 
-    results[0] = arguments[0] / maxes[mode][0];
-    results[1] = arguments[1] / maxes[mode][1];
-    results[2] = arguments[2] / maxes[mode][2];
+    results[0] = r / maxes[mode][0];
+    results[1] = g / maxes[mode][1];
+    results[2] = b / maxes[mode][2];
 
     // Alpha may be undefined, so default it to 100%.
-    if (typeof arguments[3] === 'number') {
-      results[3] = arguments[3] / maxes[mode][3];
+    if (typeof a === 'number') {
+      results[3] = a / maxes[mode][3];
     } else {
       results[3] = 1;
     }
@@ -633,8 +635,8 @@ p5.Color._parseInputs = function() {
     } else {
       return results;
     }
-  } else if (numArgs === 1 && typeof arguments[0] === 'string') {
-    var str = arguments[0].trim().toLowerCase();
+  } else if (numArgs === 1 && typeof r === 'string') {
+    var str = r.trim().toLowerCase();
 
     // Return if string is a named colour.
     if (namedColors[str]) {
@@ -785,10 +787,7 @@ p5.Color._parseInputs = function() {
 
     // Input did not match any CSS color pattern: default to white.
     results = [1, 1, 1, 1];
-  } else if (
-    (numArgs === 1 || numArgs === 2) &&
-    typeof arguments[0] === 'number'
-  ) {
+  } else if ((numArgs === 1 || numArgs === 2) && typeof r === 'number') {
     // 'Grayscale' mode.
 
     /**
@@ -796,13 +795,13 @@ p5.Color._parseInputs = function() {
      * value (they are equivalent when chroma is zero). For RGB, normalize the
      * gray level according to the blue maximum.
      */
-    results[0] = arguments[0] / maxes[mode][2];
-    results[1] = arguments[0] / maxes[mode][2];
-    results[2] = arguments[0] / maxes[mode][2];
+    results[0] = r / maxes[mode][2];
+    results[1] = r / maxes[mode][2];
+    results[2] = r / maxes[mode][2];
 
     // Alpha may be undefined, so default it to 100%.
-    if (typeof arguments[1] === 'number') {
-      results[3] = arguments[1] / maxes[mode][3];
+    if (typeof g === 'number') {
+      results[3] = g / maxes[mode][3];
     } else {
       results[3] = 1;
     }

--- a/src/color/setting.js
+++ b/src/color/setting.js
@@ -300,31 +300,31 @@ p5.prototype.clear = function() {
  * @param {Number} [maxA]   range for the alpha
  * @chainable
  */
-p5.prototype.colorMode = function() {
+p5.prototype.colorMode = function(mode, max1, max2, max3, maxA) {
   if (
-    arguments[0] === constants.RGB ||
-    arguments[0] === constants.HSB ||
-    arguments[0] === constants.HSL
+    mode === constants.RGB ||
+    mode === constants.HSB ||
+    mode === constants.HSL
   ) {
     // Set color mode.
-    this._renderer._colorMode = arguments[0];
+    this._renderer._colorMode = mode;
 
     // Set color maxes.
-    var maxes = this._renderer._colorMaxes[this._renderer._colorMode];
+    var maxes = this._renderer._colorMaxes[mode];
     if (arguments.length === 2) {
-      maxes[0] = arguments[1]; // Red
-      maxes[1] = arguments[1]; // Green
-      maxes[2] = arguments[1]; // Blue
-      maxes[3] = arguments[1]; // Alpha
+      maxes[0] = max1; // Red
+      maxes[1] = max1; // Green
+      maxes[2] = max1; // Blue
+      maxes[3] = max1; // Alpha
     } else if (arguments.length === 4) {
-      maxes[0] = arguments[1]; // Red
-      maxes[1] = arguments[2]; // Green
-      maxes[2] = arguments[3]; // Blue
+      maxes[0] = max1; // Red
+      maxes[1] = max2; // Green
+      maxes[2] = max3; // Blue
     } else if (arguments.length === 5) {
-      maxes[0] = arguments[1]; // Red
-      maxes[1] = arguments[2]; // Green
-      maxes[2] = arguments[3]; // Blue
-      maxes[3] = arguments[4]; // Alpha
+      maxes[0] = max1; // Red
+      maxes[1] = max2; // Green
+      maxes[2] = max3; // Blue
+      maxes[3] = maxA; // Alpha
     }
   }
 

--- a/src/core/2d_primitives.js
+++ b/src/core/2d_primitives.js
@@ -78,12 +78,7 @@ require('./error_helpers');
  *
  */
 p5.prototype.arc = function(x, y, w, h, start, stop, mode) {
-  var args = new Array(arguments.length);
-  for (var i = 0; i < args.length; ++i) {
-    args[i] = arguments[i];
-  }
-
-  p5._validateParameters('arc', args);
+  p5._validateParameters('arc', arguments);
   if (!this._renderer._doStroke && !this._renderer._doFill) {
     return this;
   }
@@ -161,39 +156,26 @@ p5.prototype.arc = function(x, y, w, h, start, stop, mode) {
  *white ellipse with black outline in middle-right of canvas that is 55x55.
  *
  */
-p5.prototype.ellipse = function() {
-  var args = new Array(arguments.length);
-  for (var i = 0; i < args.length; ++i) {
-    args[i] = arguments[i];
-  }
-  // Duplicate 3rd argument if only 3 given.
-  if (args.length === 3) {
-    args.push(args[2]);
+p5.prototype.ellipse = function(x, y, w, h) {
+  p5._validateParameters('ellipse', arguments);
+
+  // p5 supports negative width and heights for rects
+  if (w < 0) {
+    w = Math.abs(w);
   }
 
-  p5._validateParameters('ellipse', args);
-  // p5 supports negative width and heights for rects
-  if (args[2] < 0) {
-    args[2] = Math.abs(args[2]);
+  if (typeof h === 'undefined') {
+    // Duplicate 3rd argument if only 3 given.
+    h = w;
+  } else if (h < 0) {
+    h = Math.abs(h);
   }
-  if (args[3] < 0) {
-    args[3] = Math.abs(args[3]);
+
+  if (this._renderer._doStroke || this._renderer._doFill) {
+    var vals = canvas.modeAdjust(x, y, w, h, this._renderer._ellipseMode);
+    this._renderer.ellipse([vals.x, vals.y, vals.w, vals.h]);
   }
-  if (!this._renderer._doStroke && !this._renderer._doFill) {
-    return this;
-  }
-  var vals = canvas.modeAdjust(
-    args[0],
-    args[1],
-    args[2],
-    args[3],
-    this._renderer._ellipseMode
-  );
-  args[0] = vals.x;
-  args[1] = vals.y;
-  args[2] = vals.w;
-  args[3] = vals.h;
-  this._renderer.ellipse(args);
+
   return this;
 };
 /**
@@ -233,21 +215,12 @@ p5.prototype.ellipse = function() {
  *
  */
 p5.prototype.line = function() {
-  if (!this._renderer._doStroke) {
-    return this;
-  }
-  var args = new Array(arguments.length);
-  for (var i = 0; i < args.length; ++i) {
-    args[i] = arguments[i];
+  p5._validateParameters('line', arguments);
+
+  if (this._renderer._doStroke) {
+    this._renderer.line.apply(this._renderer, arguments);
   }
 
-  p5._validateParameters('line', args);
-  //check whether we should draw a 3d line or 2d
-  if (this._renderer.isP3D) {
-    this._renderer.line.apply(this, args);
-  } else {
-    this._renderer.line(args[0], args[1], args[2], args[3]);
-  }
   return this;
 };
 
@@ -260,6 +233,7 @@ p5.prototype.line = function() {
  * @method point
  * @param  {Number} x the x-coordinate
  * @param  {Number} y the y-coordinate
+ * @param  {Number} [z] the z-coordinate (for WEBGL mode)
  * @chainable
  * @example
  * <div>
@@ -276,21 +250,12 @@ p5.prototype.line = function() {
  *
  */
 p5.prototype.point = function() {
-  if (!this._renderer._doStroke) {
-    return this;
-  }
-  var args = new Array(arguments.length);
-  for (var i = 0; i < args.length; ++i) {
-    args[i] = arguments[i];
+  p5._validateParameters('point', arguments);
+
+  if (this._renderer._doStroke) {
+    this._renderer.point.apply(this._renderer, arguments);
   }
 
-  p5._validateParameters('point', args);
-  //check whether we should draw a 3d line or 2d
-  if (this._renderer.isP3D) {
-    this._renderer.point(args[0], args[1], args[2]);
-  } else {
-    this._renderer.point(args[0], args[1]);
-  }
   return this;
 };
 
@@ -335,42 +300,12 @@ p5.prototype.point = function() {
  * @chainable
  */
 p5.prototype.quad = function() {
-  if (!this._renderer._doStroke && !this._renderer._doFill) {
-    return this;
-  }
-  var args = new Array(arguments.length);
-  for (var i = 0; i < args.length; ++i) {
-    args[i] = arguments[i];
+  p5._validateParameters('quad', arguments);
+
+  if (this._renderer._doStroke || this._renderer._doFill) {
+    this._renderer.quad.apply(this._renderer, arguments);
   }
 
-  p5._validateParameters('quad', args);
-  if (this._renderer.isP3D) {
-    this._renderer.quad(
-      args[0],
-      args[1],
-      args[2],
-      args[3],
-      args[4],
-      args[5],
-      args[6],
-      args[7],
-      args[8],
-      args[9],
-      args[10],
-      args[11]
-    );
-  } else {
-    this._renderer.quad(
-      args[0],
-      args[1],
-      args[2],
-      args[3],
-      args[4],
-      args[5],
-      args[6],
-      args[7]
-    );
-  }
   return this;
 };
 
@@ -434,28 +369,14 @@ p5.prototype.quad = function() {
  * @param  {Number} [detailY]
  * @chainable
  */
-p5.prototype.rect = function() {
-  var args = new Array(arguments.length);
-  for (var i = 0; i < args.length; ++i) {
-    args[i] = arguments[i];
-  }
-  if (!this._renderer._doStroke && !this._renderer._doFill) {
-    return this;
+p5.prototype.rect = function(x, y, w, h, detailX, detailY) {
+  p5._validateParameters('rect', arguments);
+
+  if (this._renderer._doStroke || this._renderer._doFill) {
+    var vals = canvas.modeAdjust(x, y, w, h, this._renderer._rectMode);
+    this._renderer.rect([vals.x, vals.y, vals.w, vals.h]);
   }
 
-  p5._validateParameters('rect', args);
-  var vals = canvas.modeAdjust(
-    args[0],
-    args[1],
-    args[2],
-    args[3],
-    this._renderer._rectMode
-  );
-  args[0] = vals.x;
-  args[1] = vals.y;
-  args[2] = vals.w;
-  args[3] = vals.h;
-  this._renderer.rect(args);
   return this;
 };
 
@@ -484,16 +405,12 @@ p5.prototype.rect = function() {
  *
  */
 p5.prototype.triangle = function() {
-  if (!this._renderer._doStroke && !this._renderer._doFill) {
-    return this;
-  }
-  var args = new Array(arguments.length);
-  for (var i = 0; i < args.length; ++i) {
-    args[i] = arguments[i];
+  p5._validateParameters('triangle', arguments);
+
+  if (this._renderer._doStroke || this._renderer._doFill) {
+    this._renderer.triangle(arguments);
   }
 
-  p5._validateParameters('triangle', args);
-  this._renderer.triangle(args);
   return this;
 };
 

--- a/src/core/canvas.js
+++ b/src/core/canvas.js
@@ -2,6 +2,8 @@
  * @requires constants
  */
 
+'use strict';
+
 var constants = require('./constants');
 
 module.exports = {

--- a/src/core/constants.js
+++ b/src/core/constants.js
@@ -4,6 +4,8 @@
  * @for p5
  */
 
+'use strict';
+
 var PI = Math.PI;
 
 module.exports = {

--- a/src/core/core.js
+++ b/src/core/core.js
@@ -36,7 +36,7 @@ var constants = require('./constants');
  * @return {p5}                 a p5 instance
  */
 var p5 = function(sketch, node, sync) {
-  if (arguments.length === 2 && typeof node === 'boolean') {
+  if (typeof node === 'boolean' && typeof sync === 'undefined') {
     sync = node;
     node = undefined;
   }
@@ -179,6 +179,8 @@ var p5 = function(sketch, node, sync) {
   this._preloadCount = 0;
   this._isGlobal = false;
   this._loop = true;
+  this._bezierDetail = 20;
+  this._curveDetail = 20;
   this._styles = [];
   this._defaultCanvasSize = {
     width: 100,
@@ -296,12 +298,7 @@ var p5 = function(sketch, node, sync) {
       //increment counter
       this._incrementPreload();
       //call original function
-      var args = new Array(arguments.length);
-      for (var i = 0; i < args.length; ++i) {
-        args[i] = arguments[i];
-      }
-      // args.push(this._decrementPreload.bind(this));
-      return this._registeredPreloadMethods[fnName].apply(obj, args);
+      return this._registeredPreloadMethods[fnName].apply(obj, arguments);
     }.bind(this);
   };
 

--- a/src/core/curves.js
+++ b/src/core/curves.js
@@ -10,9 +10,6 @@
 var p5 = require('./core');
 require('./error_helpers');
 
-var bezierDetail = 20;
-var curveDetail = 20;
-
 /**
  * Draws a cubic Bezier curve on the screen. These curves are defined by a
  * series of anchor and control points. The first two parameters specify
@@ -74,25 +71,10 @@ var curveDetail = 20;
  * </div>
  */
 p5.prototype.bezier = function() {
-  var args = new Array(arguments.length);
-  for (var i = 0; i < args.length; ++i) {
-    args[i] = arguments[i];
-  }
+  p5._validateParameters('bezier', arguments);
 
-  p5._validateParameters('bezier', args);
-  if (!this._renderer._doStroke && !this._renderer._doFill) {
-    return this;
-  }
-  if (this._renderer.isP3D) {
-    args.push(bezierDetail); //adding value of bezier detail to the args array
-    this._renderer.bezier(args);
-  } else {
-    // prettier-ignore
-    this._renderer.bezier(
-      args[0], args[1],
-      args[2], args[3],
-      args[4], args[5],
-      args[6], args[7]);
+  if (this._renderer._doStroke || this._renderer._doFill) {
+    this._renderer.bezier.apply(this._renderer, arguments);
   }
 
   return this;
@@ -120,7 +102,7 @@ p5.prototype.bezier = function() {
  *
  */
 p5.prototype.bezierDetail = function(d) {
-  bezierDetail = d;
+  this._bezierDetail = d;
   return this;
 };
 
@@ -168,18 +150,14 @@ p5.prototype.bezierDetail = function(d) {
  *
  */
 p5.prototype.bezierPoint = function(a, b, c, d, t) {
-  var args = new Array(arguments.length);
-  for (var i = 0; i < args.length; ++i) {
-    args[i] = arguments[i];
-  }
+  p5._validateParameters('bezierPoint', arguments);
 
-  p5._validateParameters('bezierPoint', args);
-  var adjustedT = 1 - args[4];
+  var adjustedT = 1 - t;
   return (
-    Math.pow(adjustedT, 3) * args[0] +
-    3 * Math.pow(adjustedT, 2) * args[4] * args[1] +
-    3 * adjustedT * Math.pow(args[4], 2) * args[2] +
-    Math.pow(args[4], 3) * args[3]
+    Math.pow(adjustedT, 3) * a +
+    3 * Math.pow(adjustedT, 2) * t * b +
+    3 * adjustedT * Math.pow(t, 2) * c +
+    Math.pow(t, 3) * d
   );
 };
 
@@ -249,20 +227,16 @@ p5.prototype.bezierPoint = function(a, b, c, d, t) {
  *
  */
 p5.prototype.bezierTangent = function(a, b, c, d, t) {
-  var args = new Array(arguments.length);
-  for (var i = 0; i < args.length; ++i) {
-    args[i] = arguments[i];
-  }
+  p5._validateParameters('bezierTangent', arguments);
 
-  p5._validateParameters('bezierTangent', args);
-  var adjustedT = 1 - args[4];
+  var adjustedT = 1 - t;
   return (
-    3 * args[3] * Math.pow(args[4], 2) -
-    3 * args[2] * Math.pow(args[4], 2) +
-    6 * args[2] * adjustedT * args[4] -
-    6 * args[1] * adjustedT * args[4] +
-    3 * args[1] * Math.pow(adjustedT, 2) -
-    3 * args[0] * Math.pow(adjustedT, 2)
+    3 * d * Math.pow(t, 2) -
+    3 * c * Math.pow(t, 2) +
+    6 * c * adjustedT * t -
+    6 * b * adjustedT * t +
+    3 * b * Math.pow(adjustedT, 2) -
+    3 * a * Math.pow(adjustedT, 2)
   );
 };
 
@@ -344,26 +318,12 @@ p5.prototype.bezierTangent = function(a, b, c, d, t) {
  * curving black and orange lines.
  */
 p5.prototype.curve = function() {
-  var args = new Array(arguments.length);
-  for (var i = 0; i < args.length; ++i) {
-    args[i] = arguments[i];
+  p5._validateParameters('curve', arguments);
+
+  if (this._renderer._doStroke) {
+    this._renderer.curve.apply(this._renderer, arguments);
   }
 
-  p5._validateParameters('curve', args);
-  if (!this._renderer._doStroke) {
-    return this;
-  }
-  if (this._renderer.isP3D) {
-    args.push(curveDetail);
-    this._renderer.curve(args);
-  } else {
-    // prettier-ignore
-    this._renderer.curve(
-      args[0], args[1],
-      args[2], args[3],
-      args[4], args[5],
-      args[6], args[7]);
-  }
   return this;
 };
 
@@ -389,7 +349,7 @@ p5.prototype.curve = function() {
  *
  */
 p5.prototype.curveDetail = function(d) {
-  curveDetail = d;
+  this._curveDetail = d;
   return this;
 };
 
@@ -476,19 +436,15 @@ p5.prototype.curveTightness = function(t) {
  *line hooking down to right-bottom with 13 5x5 white ellipse points
  */
 p5.prototype.curvePoint = function(a, b, c, d, t) {
-  var args = new Array(arguments.length);
-  for (var i = 0; i < args.length; ++i) {
-    args[i] = arguments[i];
-  }
+  p5._validateParameters('curvePoint', arguments);
 
-  p5._validateParameters('curvePoint', args);
-  var t3 = args[4] * args[4] * args[4],
-    t2 = args[4] * args[4],
-    f1 = -0.5 * t3 + t2 - 0.5 * args[4],
+  var t3 = t * t * t,
+    t2 = t * t,
+    f1 = -0.5 * t3 + t2 - 0.5 * t,
     f2 = 1.5 * t3 - 2.5 * t2 + 1.0,
-    f3 = -1.5 * t3 + 2.0 * t2 + 0.5 * args[4],
+    f3 = -1.5 * t3 + 2.0 * t2 + 0.5 * t,
     f4 = 0.5 * t3 - 0.5 * t2;
-  return args[0] * f1 + args[1] * f2 + args[2] * f3 + args[3] * f4;
+  return a * f1 + b * f2 + c * f3 + d * f4;
 };
 
 /**
@@ -527,18 +483,14 @@ p5.prototype.curvePoint = function(a, b, c, d, t) {
  *right curving line mid-right of canvas with 7 short lines radiating from it.
  */
 p5.prototype.curveTangent = function(a, b, c, d, t) {
-  var args = new Array(arguments.length);
-  for (var i = 0; i < args.length; ++i) {
-    args[i] = arguments[i];
-  }
+  p5._validateParameters('curveTangent', arguments);
 
-  p5._validateParameters('curveTangent', args);
-  var t2 = args[4] * args[4],
-    f1 = -3 * t2 / 2 + 2 * args[4] - 0.5,
-    f2 = 9 * t2 / 2 - 5 * args[4],
-    f3 = -9 * t2 / 2 + 4 * args[4] + 0.5,
-    f4 = 3 * t2 / 2 - args[4];
-  return args[0] * f1 + args[1] * f2 + args[2] * f3 + args[3] * f4;
+  var t2 = t * t,
+    f1 = -3 * t2 / 2 + 2 * t - 0.5,
+    f2 = 9 * t2 / 2 - 5 * t,
+    f3 = -9 * t2 / 2 + 4 * t + 0.5,
+    f4 = 3 * t2 / 2 - t;
+  return a * f1 + b * f2 + c * f3 + d * f4;
 };
 
 module.exports = p5;

--- a/src/core/environment.js
+++ b/src/core/environment.js
@@ -39,7 +39,7 @@ var _windowPrint = window.print;
  * default grey canvas
  */
 p5.prototype.print = function(args) {
-  if (arguments.length === 0) {
+  if (typeof args === 'undefined') {
     _windowPrint();
   } else {
     console.log.apply(console, arguments);

--- a/src/core/init.js
+++ b/src/core/init.js
@@ -1,3 +1,5 @@
+'use strict';
+
 var p5 = require('../core/core');
 
 /**

--- a/src/core/p5.Element.js
+++ b/src/core/p5.Element.js
@@ -4,6 +4,8 @@
  * @for p5.Element
  */
 
+'use strict';
+
 var p5 = require('./core');
 
 /**
@@ -85,20 +87,20 @@ p5.Element = function(elt, pInst) {
  *
  */
 p5.Element.prototype.parent = function(p) {
-  if (arguments.length === 0) {
+  if (typeof p === 'undefined') {
     return this.elt.parentNode;
-  } else {
-    if (typeof p === 'string') {
-      if (p[0] === '#') {
-        p = p.substring(1);
-      }
-      p = document.getElementById(p);
-    } else if (p instanceof p5.Element) {
-      p = p.elt;
-    }
-    p.appendChild(this.elt);
-    return this;
   }
+
+  if (typeof p === 'string') {
+    if (p[0] === '#') {
+      p = p.substring(1);
+    }
+    p = document.getElementById(p);
+  } else if (p instanceof p5.Element) {
+    p = p.elt;
+  }
+  p.appendChild(this.elt);
+  return this;
 };
 
 /**
@@ -128,14 +130,14 @@ p5.Element.prototype.parent = function(p) {
  * @return {String} the id of the element
  */
 p5.Element.prototype.id = function(id) {
-  if (arguments.length === 0) {
+  if (typeof id === 'undefined') {
     return this.elt.id;
-  } else {
-    this.elt.id = id;
-    this.width = this.elt.offsetWidth;
-    this.height = this.elt.offsetHeight;
-    return this;
   }
+
+  this.elt.id = id;
+  this.width = this.elt.offsetWidth;
+  this.height = this.elt.offsetHeight;
+  return this;
 };
 
 /**
@@ -152,12 +154,12 @@ p5.Element.prototype.id = function(id) {
  * @return {String} the class of the element
  */
 p5.Element.prototype.class = function(c) {
-  if (arguments.length === 0) {
+  if (typeof c === 'undefined') {
     return this.elt.className;
-  } else {
-    this.elt.className = c;
-    return this;
   }
+
+  this.elt.className = c;
+  return this;
 };
 
 /**
@@ -961,7 +963,7 @@ p5.Element.prototype.drop = function(callback, fxn) {
     );
 
     // If just one argument it's the callback for the files
-    if (arguments.length > 1) {
+    if (typeof fxn !== 'undefined') {
       attachListener('drop', fxn, this);
     }
 

--- a/src/core/p5.Graphics.js
+++ b/src/core/p5.Graphics.js
@@ -4,6 +4,8 @@
  * @for p5
  */
 
+'use strict';
+
 var p5 = require('./core');
 var constants = require('./constants');
 

--- a/src/core/p5.Renderer.js
+++ b/src/core/p5.Renderer.js
@@ -4,6 +4,8 @@
  * @for p5
  */
 
+'use strict';
+
 var p5 = require('./core');
 var constants = require('../core/constants');
 
@@ -81,9 +83,7 @@ p5.Renderer.prototype.resize = function(w, h) {
 };
 
 p5.Renderer.prototype.textLeading = function(l) {
-  if (arguments.length && typeof arguments[0] === 'number') {
-    // #2378
-
+  if (typeof l === 'number') {
     this._setProperty('_textLeading', l);
     return this;
   }
@@ -92,9 +92,7 @@ p5.Renderer.prototype.textLeading = function(l) {
 };
 
 p5.Renderer.prototype.textSize = function(s) {
-  if (arguments.length && typeof arguments[0] === 'number') {
-    // #2378
-
+  if (typeof s === 'number') {
     this._setProperty('_textSize', s);
     this._setProperty('_textLeading', s * constants._DEFAULT_LEADMULT);
     return this._applyTextProperties();
@@ -104,7 +102,7 @@ p5.Renderer.prototype.textSize = function(s) {
 };
 
 p5.Renderer.prototype.textStyle = function(s) {
-  if (arguments.length && arguments[0]) {
+  if (s) {
     if (
       s === constants.NORMAL ||
       s === constants.ITALIC ||

--- a/src/core/p5.Renderer2D.js
+++ b/src/core/p5.Renderer2D.js
@@ -1,3 +1,5 @@
+'use strict';
+
 var p5 = require('./core');
 var canvas = require('./canvas');
 var constants = require('./constants');
@@ -1305,7 +1307,7 @@ p5.Renderer2D.prototype.textWidth = function(s) {
 };
 
 p5.Renderer2D.prototype.textAlign = function(h, v) {
-  if (arguments.length) {
+  if (typeof h !== 'undefined' && typeof v !== 'undefined') {
     if (
       h === constants.LEFT ||
       h === constants.RIGHT ||

--- a/src/core/rendering.js
+++ b/src/core/rendering.js
@@ -4,6 +4,8 @@
  * @for p5
  */
 
+'use strict';
+
 var p5 = require('./core');
 var constants = require('./constants');
 require('./p5.Graphics');
@@ -57,8 +59,9 @@ p5.prototype.createCanvas = function(w, h, renderer) {
     if (c) {
       //if defaultCanvas already exists
       c.parentNode.removeChild(c); //replace the existing defaultCanvas
+      var thisRenderer = this._renderer;
       this._elements = this._elements.filter(function(e) {
-        return e !== this._renderer;
+        return e !== thisRenderer;
       });
     }
     c = document.createElement('canvas');
@@ -149,7 +152,11 @@ p5.prototype.resizeCanvas = function(w, h, noRedraw) {
     this._renderer.resize(w, h);
     // reset canvas properties
     for (var savedKey in props) {
-      this.drawingContext[savedKey] = props[savedKey];
+      try {
+        this.drawingContext[savedKey] = props[savedKey];
+      } catch (err) {
+        // ignore read-only property errors
+      }
     }
     if (!noRedraw) {
       this.redraw();

--- a/src/core/shim.js
+++ b/src/core/shim.js
@@ -1,3 +1,5 @@
+'use strict';
+
 // requestAnim shim layer by Paul Irish
 window.requestAnimationFrame = (function() {
   return (

--- a/src/core/structure.js
+++ b/src/core/structure.js
@@ -326,22 +326,17 @@ p5.prototype.popStyle = function() {
  * black line on far left of canvas
  *
  */
-p5.prototype.redraw = function() {
+p5.prototype.redraw = function(n) {
   this.resetMatrix();
   if (this._renderer.isP3D) {
     this._renderer._update();
   }
 
-  var numberOfRedraws = 1;
-  if (arguments.length === 1) {
-    try {
-      if (parseInt(arguments[0]) > 1) {
-        numberOfRedraws = parseInt(arguments[0]);
-      }
-    } catch (error) {
-      // Do nothing, because the default value didn't be changed.
-    }
+  var numberOfRedraws = parseInt(n);
+  if (isNaN(numberOfRedraws) || numberOfRedraws < 1) {
+    numberOfRedraws = 1;
   }
+
   var userSetup = this.setup || window.setup;
   var userDraw = this.draw || window.draw;
   if (typeof userDraw === 'function') {

--- a/src/core/transform.js
+++ b/src/core/transform.js
@@ -194,22 +194,13 @@ p5.prototype.resetMatrix = function() {
  *
  */
 p5.prototype.rotate = function(angle, axis) {
-  var args = new Array(arguments.length);
   var r;
-  for (var i = 0; i < args.length; ++i) {
-    args[i] = arguments[i];
-  }
   if (this._angleMode === constants.DEGREES) {
-    r = this.radians(args[0]);
+    r = this.radians(angle);
   } else if (this._angleMode === constants.RADIANS) {
-    r = args[0];
+    r = angle;
   }
-  //in webgl mode
-  if (args.length > 1) {
-    this._renderer.rotate(r, args[1]);
-  } else {
-    this._renderer.rotate(r);
-  }
+  this._renderer.rotate(r, axis);
   return this;
 };
 
@@ -353,36 +344,27 @@ p5.prototype.rotateZ = function(rad) {
  * @param  {p5.Vector|Array} scales per-axis percents to scale the object
  * @chainable
  */
-p5.prototype.scale = function() {
-  var x, y, z;
-  var args = new Array(arguments.length);
-  for (var i = 0; i < args.length; i++) {
-    args[i] = arguments[i];
-  }
+p5.prototype.scale = function(x, y, z) {
   // Only check for Vector argument type if Vector is available
-  if (typeof p5.Vector !== 'undefined' && args[0] instanceof p5.Vector) {
-    x = args[0].x;
-    y = args[0].y;
-    z = args[0].z;
-  } else if (args[0] instanceof Array) {
-    x = args[0][0];
-    y = args[0][1];
-    z = args[0][2] || 1;
-  } else {
-    if (args.length === 1) {
-      x = y = z = args[0];
-    } else {
-      x = args[0];
-      y = args[1];
-      z = args[2] || 1;
-    }
+  if (x instanceof p5.Vector) {
+    var v = x;
+    x = v.x;
+    y = v.y;
+    z = v.z;
+  } else if (x instanceof Array) {
+    var rg = x;
+    x = rg[0];
+    y = rg[1];
+    z = rg[2] || 1;
+  }
+  if (isNaN(y)) {
+    y = z = x;
+  } else if (isNaN(z)) {
+    z = 1;
   }
 
-  if (this._renderer.isP3D) {
-    this._renderer.scale.call(this._renderer, x, y, z);
-  } else {
-    this._renderer.scale.call(this._renderer, x, y);
-  }
+  this._renderer.scale.call(this._renderer, x, y, z);
+
   return this;
 };
 

--- a/src/data/p5.TypedDict.js
+++ b/src/data/p5.TypedDict.js
@@ -34,8 +34,8 @@ var p5 = require('../core/core');
  * </code></div>
  */
 
-p5.prototype.createStringDict = function() {
-  return new p5.StringDict(arguments[0], arguments[1]);
+p5.prototype.createStringDict = function(key, value) {
+  return new p5.StringDict(key, value);
 };
 
 /**
@@ -59,8 +59,8 @@ p5.prototype.createStringDict = function() {
  * </code></div>
  */
 
-p5.prototype.createNumberDict = function() {
-  return new p5.NumberDict(arguments[0], arguments[1]);
+p5.prototype.createNumberDict = function(key, value) {
+  return new p5.NumberDict(key, value);
 };
 
 /**
@@ -73,12 +73,12 @@ p5.prototype.createNumberDict = function() {
  *
  */
 
-p5.TypedDict = function() {
-  this.data = {};
-  if (arguments[0][0] instanceof Object) {
-    this.data = arguments[0][0];
+p5.TypedDict = function(key, value) {
+  if (key instanceof Object) {
+    this.data = key;
   } else {
-    this.data[arguments[0][0]] = arguments[0][1];
+    this.data = {};
+    this.data[key] = value;
   }
   return this;
 };
@@ -177,12 +177,10 @@ p5.TypedDict.prototype.get = function(key) {
  */
 
 p5.TypedDict.prototype.set = function(key, value) {
-  if (arguments.length === 2) {
-    if (!this.data.hasOwnProperty(key)) {
-      this.create(key, value);
-    } else {
-      this.data[key] = value;
-    }
+  if (this._validate(value)) {
+    this.data[key] = value;
+  } else {
+    console.log('Those values dont work for this dictionary type.');
   }
 };
 
@@ -193,11 +191,7 @@ p5.TypedDict.prototype.set = function(key, value) {
 
 p5.TypedDict.prototype._addObj = function(obj) {
   for (var key in obj) {
-    if (this._validate(obj[key])) {
-      this.data[key] = obj[key];
-    } else {
-      console.log('Those values dont work for this dictionary type.');
-    }
+    this.set(key, obj[key]);
   }
 };
 
@@ -224,13 +218,11 @@ p5.TypedDict.prototype._addObj = function(obj) {
  * @param {Object} obj key/value pair
  */
 
-p5.TypedDict.prototype.create = function() {
-  if (arguments.length === 1 && arguments[0] instanceof Object) {
-    this._addObj(arguments[0]);
-  } else if (arguments.length === 2) {
-    var obj = {};
-    obj[arguments[0]] = arguments[1];
-    this._addObj(obj);
+p5.TypedDict.prototype.create = function(key, value) {
+  if (key instanceof Object && typeof value === 'undefined') {
+    this._addObj(key);
+  } else if (typeof key !== 'undefined') {
+    this.set(key, value);
   } else {
     console.log(
       'In order to create a new Dictionary entry you must pass ' +
@@ -335,16 +327,15 @@ p5.TypedDict.prototype.print = function() {
  * </div>
  */
 
-p5.TypedDict.prototype.saveTable = function() {
+p5.TypedDict.prototype.saveTable = function(filename) {
   var output = '';
 
   for (var key in this.data) {
     output += key + ',' + this.data[key] + '\n';
   }
 
-  var filename = arguments[0] || 'mycsv';
   var blob = new Blob([output], { type: 'text/csv' });
-  p5.prototype.downloadFile(blob, filename, 'csv');
+  p5.prototype.downloadFile(blob, filename || 'mycsv', 'csv');
 };
 
 /**
@@ -378,7 +369,7 @@ p5.TypedDict.prototype.saveJSON = function(filename, opt) {
  * values for the Dictionary type
  */
 
-p5.TypedDict.prototype._validate = function(key, value) {
+p5.TypedDict.prototype._validate = function(value) {
   return true;
 };
 
@@ -394,7 +385,7 @@ p5.TypedDict.prototype._validate = function(key, value) {
  */
 
 p5.StringDict = function() {
-  p5.TypedDict.call(this, arguments);
+  p5.TypedDict.apply(this, arguments);
 };
 
 p5.StringDict.prototype = Object.create(p5.TypedDict.prototype);
@@ -415,7 +406,7 @@ p5.StringDict.prototype._validate = function(value) {
  */
 
 p5.NumberDict = function() {
-  p5.TypedDict.call(this, arguments);
+  p5.TypedDict.apply(this, arguments);
 };
 
 p5.NumberDict.prototype = Object.create(p5.TypedDict.prototype);

--- a/src/math/polargeometry.js
+++ b/src/math/polargeometry.js
@@ -1,3 +1,5 @@
+'use strict';
+
 module.exports = {
   degreesToRadians: function(x) {
     return 2 * Math.PI * x / 360;

--- a/src/typography/p5.Font.js
+++ b/src/typography/p5.Font.js
@@ -1230,14 +1230,10 @@ function base3(t, p1, p2, p3, p4) {
 }
 
 function cacheKey() {
-  var args = new Array(arguments.length);
-  for (var i = 0; i < args.length; ++i) {
-    args[i] = arguments[i];
-  }
-  i = args.length;
   var hash = '';
-  while (i--) {
-    hash += args[i] === Object(args[i]) ? JSON.stringify(args[i]) : args[i];
+  for (var i = arguments.length - 1; i >= 0; --i) {
+    var v = arguments[i];
+    hash += v === Object(v) ? JSON.stringify(v) : v;
   }
   return hash;
 }

--- a/src/utilities/string_functions.js
+++ b/src/utilities/string_functions.js
@@ -178,58 +178,55 @@ p5.prototype.matchAll = function(str, reg) {
  * @param {Number|String}       [right]
  * @return {Array}                formatted Strings\
  */
-p5.prototype.nf = function() {
+p5.prototype.nf = function(nums, left, right) {
   p5._validateParameters('nf', arguments);
-  if (arguments[0] instanceof Array) {
-    var a = arguments[1];
-    var b = arguments[2];
-    return arguments[0].map(function(x) {
-      return doNf(x, a, b);
+  if (nums instanceof Array) {
+    return nums.map(function(x) {
+      return doNf(x, left, right);
     });
   } else {
-    var typeOfFirst = Object.prototype.toString.call(arguments[0]);
+    var typeOfFirst = Object.prototype.toString.call(nums);
     if (typeOfFirst === '[object Arguments]') {
-      if (arguments[0].length === 3) {
-        return this.nf(arguments[0][0], arguments[0][1], arguments[0][2]);
-      } else if (arguments[0].length === 2) {
-        return this.nf(arguments[0][0], arguments[0][1]);
+      if (nums.length === 3) {
+        return this.nf(nums[0], nums[1], nums[2]);
+      } else if (nums.length === 2) {
+        return this.nf(nums[0], nums[1]);
       } else {
-        return this.nf(arguments[0][0]);
+        return this.nf(nums[0]);
       }
     } else {
-      return doNf.apply(this, arguments);
+      return doNf(nums, left, right);
     }
   }
 };
 
-function doNf() {
-  var num = arguments[0];
+function doNf(num, left, right) {
   var neg = num < 0;
   var n = neg ? num.toString().substring(1) : num.toString();
   var decimalInd = n.indexOf('.');
   var intPart = decimalInd !== -1 ? n.substring(0, decimalInd) : n;
   var decPart = decimalInd !== -1 ? n.substring(decimalInd + 1) : '';
   var str = neg ? '-' : '';
-  if (arguments.length === 3) {
+  if (typeof right !== 'undefined') {
     var decimal = '';
-    if (decimalInd !== -1 || arguments[2] - decPart.length > 0) {
+    if (decimalInd !== -1 || right - decPart.length > 0) {
       decimal = '.';
     }
-    if (decPart.length > arguments[2]) {
-      decPart = decPart.substring(0, arguments[2]);
+    if (decPart.length > right) {
+      decPart = decPart.substring(0, right);
     }
-    for (var i = 0; i < arguments[1] - intPart.length; i++) {
+    for (var i = 0; i < left - intPart.length; i++) {
       str += '0';
     }
     str += intPart;
     str += decimal;
     str += decPart;
-    for (var j = 0; j < arguments[2] - decPart.length; j++) {
+    for (var j = 0; j < right - decPart.length; j++) {
       str += '0';
     }
     return str;
   } else {
-    for (var k = 0; k < Math.max(arguments[1] - intPart.length, 0); k++) {
+    for (var k = 0; k < Math.max(left - intPart.length, 0); k++) {
       str += '0';
     }
     str += n;
@@ -281,34 +278,33 @@ function doNf() {
  * @param  {Number|String}   [right]
  * @return {Array}           formatted Strings
  */
-p5.prototype.nfc = function() {
+p5.prototype.nfc = function(num, right) {
   p5._validateParameters('nfc', arguments);
-  if (arguments[0] instanceof Array) {
-    var a = arguments[1];
-    return arguments[0].map(function(x) {
-      return doNfc(x, a);
+  if (num instanceof Array) {
+    return num.map(function(x) {
+      return doNfc(x, right);
     });
   } else {
-    return doNfc.apply(this, arguments);
+    return doNfc(num, right);
   }
 };
-function doNfc() {
-  var num = arguments[0].toString();
+function doNfc(num, right) {
+  num = num.toString();
   var dec = num.indexOf('.');
   var rem = dec !== -1 ? num.substring(dec) : '';
   var n = dec !== -1 ? num.substring(0, dec) : num;
   n = n.toString().replace(/\B(?=(\d{3})+(?!\d))/g, ',');
-  if (arguments[1] === 0) {
+  if (right === 0) {
     rem = '';
-  } else if (arguments[1] !== undefined) {
-    if (arguments[1] > rem.length) {
+  } else if (typeof right !== 'undefined') {
+    if (right > rem.length) {
       rem += dec === -1 ? '.' : '';
-      var len = arguments[1] - rem.length + 1;
+      var len = right - rem.length + 1;
       for (var i = 0; i < len; i++) {
         rem += '0';
       }
     } else {
-      rem = rem.substring(0, arguments[1] + 1);
+      rem = rem.substring(0, right + 1);
     }
   }
   return n + rem;
@@ -372,10 +368,8 @@ p5.prototype.nfp = function() {
   }
 };
 
-function addNfp() {
-  return parseFloat(arguments[0]) > 0
-    ? '+' + arguments[0].toString()
-    : arguments[0].toString();
+function addNfp(num) {
+  return parseFloat(num) > 0 ? '+' + num.toString() : num.toString();
 }
 
 /**
@@ -436,10 +430,8 @@ p5.prototype.nfs = function() {
   }
 };
 
-function addNfs() {
-  return parseFloat(arguments[0]) > 0
-    ? ' ' + arguments[0].toString()
-    : arguments[0].toString();
+function addNfs(num) {
+  return parseFloat(num) > 0 ? ' ' + num.toString() : num.toString();
 }
 
 /**
@@ -502,13 +494,13 @@ p5.prototype.split = function(str, delim) {
  * </code>
  * </div>
  */
-p5.prototype.splitTokens = function() {
+p5.prototype.splitTokens = function(value, delims) {
   p5._validateParameters('splitTokens', arguments);
-  var d, sqo, sqc, str;
-  str = arguments[1];
-  if (arguments.length > 1) {
-    sqc = /\]/g.exec(str);
-    sqo = /\[/g.exec(str);
+  var d;
+  if (typeof delims !== 'undefined') {
+    var str = delims;
+    var sqc = /\]/g.exec(str);
+    var sqo = /\[/g.exec(str);
     if (sqo && sqc) {
       str = str.slice(0, sqc.index) + str.slice(sqc.index + 1);
       sqo = /\[/g.exec(str);
@@ -526,7 +518,7 @@ p5.prototype.splitTokens = function() {
   } else {
     d = /\s/g;
   }
-  return arguments[0].split(d).filter(function(n) {
+  return value.split(d).filter(function(n) {
     return n;
   });
 };

--- a/src/webgl/camera.js
+++ b/src/webgl/camera.js
@@ -51,11 +51,18 @@ p5.prototype.camera = function() {
   return this;
 };
 
-p5.RendererGL.prototype.camera = function() {
-  var eyeX, eyeY, eyeZ;
-  var centerX, centerY, centerZ;
-  var upX, upY, upZ;
-  if (arguments.length === 0) {
+p5.RendererGL.prototype.camera = function(
+  eyeX,
+  eyeY,
+  eyeZ,
+  centerX,
+  centerY,
+  centerZ,
+  upX,
+  upY,
+  upZ
+) {
+  if (typeof eyeX === 'undefined') {
     eyeX = this.defaultCameraX;
     eyeY = this.defaultCameraY;
     eyeZ = this.defaultCameraZ;
@@ -65,16 +72,6 @@ p5.RendererGL.prototype.camera = function() {
     upX = 0;
     upY = 1;
     upZ = 0;
-  } else {
-    eyeX = arguments[0];
-    eyeY = arguments[1];
-    eyeZ = arguments[2];
-    centerX = arguments[3];
-    centerY = arguments[4];
-    centerZ = arguments[5];
-    upX = arguments[6];
-    upY = arguments[7];
-    upZ = arguments[8];
   }
 
   this.cameraX = eyeX;
@@ -206,11 +203,19 @@ p5.prototype.perspective = function() {
   return this;
 };
 
-p5.RendererGL.prototype.perspective = function() {
-  var fovy = arguments[0] || this.defaultCameraFOV;
-  var aspect = arguments[1] || this.defaultCameraAspect;
-  var near = arguments[2] || this.defaultCameraNear;
-  var far = arguments[3] || this.defaultCameraFar;
+p5.RendererGL.prototype.perspective = function(fovy, aspect, near, far) {
+  if (typeof fovy === 'undefined') {
+    fovy = this.defaultCameraFOV;
+  }
+  if (typeof aspect === 'undefined') {
+    aspect = this.defaultCameraAspect;
+  }
+  if (typeof near === 'undefined') {
+    near = this.defaultCameraNear;
+  }
+  if (typeof far === 'undefined') {
+    far = this.defaultCameraFar;
+  }
 
   this.cameraFOV = fovy;
   this.cameraAspect = aspect;

--- a/src/webgl/light.js
+++ b/src/webgl/light.js
@@ -167,23 +167,15 @@ p5.prototype.directionalLight = function(v1, v2, v3, x, y, z) {
   this._renderer.curFillShader.setUniform('uDirectionalColor', colors);
 
   var _x, _y, _z;
-
-  var args = new Array(arguments.length);
-  for (var i = 0; i < args.length; ++i) {
-    args[i] = arguments[i];
-  }
-  if (typeof args[args.length - 1] === 'number') {
-    _x = args[args.length - 3];
-    _y = args[args.length - 2];
-    _z = args[args.length - 1];
+  var v = arguments[arguments.length - 1];
+  if (typeof v === 'number') {
+    _x = arguments[arguments.length - 3];
+    _y = arguments[arguments.length - 2];
+    _z = arguments[arguments.length - 1];
   } else {
-    try {
-      _x = args[args.length - 1].x;
-      _y = args[args.length - 1].y;
-      _z = args[args.length - 1].z;
-    } catch (error) {
-      throw error;
-    }
+    _x = v.x;
+    _y = v.y;
+    _z = v.z;
   }
   this._renderer.curFillShader.setUniform('uUseLighting', true);
   //in case there's no material color for the geometry
@@ -281,23 +273,15 @@ p5.prototype.pointLight = function(v1, v2, v3, x, y, z) {
   this._renderer.curFillShader.setUniform('uPointLightColor', colors);
 
   var _x, _y, _z;
-
-  var args = new Array(arguments.length);
-  for (var i = 0; i < args.length; ++i) {
-    args[i] = arguments[i];
-  }
-  if (typeof args[args.length - 1] === 'number') {
-    _x = args[args.length - 3];
-    _y = args[args.length - 2];
-    _z = args[args.length - 1];
+  var v = arguments[arguments.length - 1];
+  if (typeof v === 'number') {
+    _x = arguments[arguments.length - 3];
+    _y = arguments[arguments.length - 2];
+    _z = arguments[arguments.length - 1];
   } else {
-    try {
-      _x = args[args.length - 1].x;
-      _y = args[args.length - 1].y;
-      _z = args[args.length - 1].z;
-    } catch (error) {
-      throw error;
-    }
+    _x = v.x;
+    _y = v.y;
+    _z = v.z;
   }
   this._renderer.curFillShader.setUniform('uUseLighting', true);
   //in case there's no material color for the geometry

--- a/src/webgl/loading.js
+++ b/src/webgl/loading.js
@@ -63,8 +63,7 @@ require('./p5.Geometry');
  * @param  {function(Event)} [failureCallback]
  * @return {p5.Geometry} the p5.Geometry object
  */
-p5.prototype.loadModel = function() {
-  var path = arguments[0];
+p5.prototype.loadModel = function(path) {
   var normalize;
   var successCallback;
   var failureCallback;

--- a/src/webgl/material.js
+++ b/src/webgl/material.js
@@ -183,11 +183,7 @@ p5.prototype.normalMaterial = function() {
  * black canvas
  *
  */
-p5.prototype.texture = function() {
-  var args = new Array(arguments.length);
-  for (var i = 0; i < args.length; ++i) {
-    args[i] = arguments[i];
-  }
+p5.prototype.texture = function(tex) {
   this._renderer.GL.depthMask(true);
   this._renderer.GL.enable(this._renderer.GL.BLEND);
   this._renderer.GL.blendFunc(
@@ -201,7 +197,7 @@ p5.prototype.texture = function() {
   }
   this._renderer.curFillShader.setUniform('uSpecular', false);
   this._renderer.curFillShader.setUniform('isTexture', true);
-  this._renderer.curFillShader.setUniform('uSampler', args[0]);
+  this._renderer.curFillShader.setUniform('uSampler', tex);
   this._renderer.noStroke();
   return this;
 };

--- a/src/webgl/p5.RendererGL.Immediate.js
+++ b/src/webgl/p5.RendererGL.Immediate.js
@@ -67,12 +67,10 @@ p5.RendererGL.prototype.beginShape = function(mode) {
  * @chainable
  * @TODO implement handling of p5.Vector args
  */
-p5.RendererGL.prototype.vertex = function() {
-  var x, y, z, u, v;
+p5.RendererGL.prototype.vertex = function(x, y) {
+  var z, u, v;
 
   // default to (x, y) mode: all other arugments assumed to be 0.
-  x = arguments[0];
-  y = arguments[1];
   z = u = v = 0;
 
   if (arguments.length === 3) {

--- a/src/webgl/p5.RendererGL.js
+++ b/src/webgl/p5.RendererGL.js
@@ -215,8 +215,8 @@ p5.RendererGL.prototype._resetContext = function(attr, options, callback) {
  * <br><br>
  * @method setAttributes
  * @for p5
- * @param  {String|Object}  String name of attribute or object with key-value pairs
- * @param  {Boolean}        New value of named attribute
+ * @param  {String}  key Name of attribute
+ * @param  {Boolean}        value New value of named attribute
  * @example
  * <div>
  * <code>
@@ -261,14 +261,20 @@ p5.RendererGL.prototype._resetContext = function(attr, options, callback) {
  *
  * @alt a rotating cube with smoother edges
  */
+/**
+ * @method setAttributes
+ * @for p5
+ * @param  {Object}  obj object with key-value pairs
+ */
 
-p5.prototype.setAttributes = function() {
+p5.prototype.setAttributes = function(key, value) {
   //@todo_FES
-  var attr = {};
-  if (arguments.length === 2) {
-    attr[arguments[0]] = arguments[1];
-  } else if (arguments.length === 1) {
-    attr = arguments[0];
+  var attr;
+  if (typeof value !== 'undefined') {
+    attr = {};
+    attr.key = value;
+  } else if (key instanceof Object) {
+    attr = key;
   }
   this._renderer._resetContext(attr);
 };

--- a/src/webgl/p5.Shader.js
+++ b/src/webgl/p5.Shader.js
@@ -6,6 +6,8 @@
  * @requires core
  */
 
+'use strict';
+
 var p5 = require('../core/core');
 
 /**

--- a/src/webgl/p5.Texture.js
+++ b/src/webgl/p5.Texture.js
@@ -6,6 +6,8 @@
  * @requires core
  */
 
+'use strict';
+
 var p5 = require('../core/core');
 
 /**

--- a/src/webgl/primitives.js
+++ b/src/webgl/primitives.js
@@ -44,15 +44,20 @@ require('./p5.Geometry');
  * 3d red and green gradient.
  * rotating view of a multi-colored cylinder with concave sides.
  */
-p5.prototype.plane = function() {
-  var args = new Array(arguments.length);
-  for (var i = 0; i < args.length; ++i) {
-    args[i] = arguments[i];
+p5.prototype.plane = function(width, height, detailX, detailY) {
+  if (typeof width === 'undefined') {
+    width = 50;
   }
-  var width = args[0] || 50;
-  var height = args[1] || width;
-  var detailX = typeof args[2] === 'number' ? args[2] : 1;
-  var detailY = typeof args[3] === 'number' ? args[3] : 1;
+  if (typeof height === 'undefined') {
+    height = width;
+  }
+
+  if (typeof detailX === 'undefined') {
+    detailX = 1;
+  }
+  if (typeof detailY === 'undefined') {
+    detailY = 1;
+  }
 
   var gId = 'plane|' + width + '|' + height + '|' + detailX + '|' + detailY;
 
@@ -114,17 +119,24 @@ p5.prototype.plane = function() {
  * </code>
  * </div>
  */
-p5.prototype.box = function() {
-  var args = new Array(arguments.length);
-  for (var i = 0; i < args.length; ++i) {
-    args[i] = arguments[i];
+p5.prototype.box = function(width, height, depth, detailX, detailY) {
+  if (typeof width === 'undefined') {
+    width = 50;
   }
-  var width = args[0] || 50;
-  var height = args[1] || width;
-  var depth = args[2] || width;
+  if (typeof height === 'undefined') {
+    height = width;
+  }
+  if (typeof depth === 'undefined') {
+    depth = height;
+  }
 
-  var detailX = typeof args[3] === 'number' ? args[3] : 4;
-  var detailY = typeof args[4] === 'number' ? args[4] : 4;
+  if (typeof detailX === 'undefined') {
+    detailX = 4;
+  }
+  if (typeof detailY === 'undefined') {
+    detailY = 4;
+  }
+
   var gId =
     'box|' + width + '|' + height + '|' + depth + '|' + detailX + '|' + detailY;
   if (!this._renderer.geometryInHash(gId)) {
@@ -220,14 +232,16 @@ p5.prototype.box = function() {
  * </code>
  * </div>
  */
-p5.prototype.sphere = function() {
-  var args = new Array(arguments.length);
-  for (var i = 0; i < args.length; ++i) {
-    args[i] = arguments[i];
+p5.prototype.sphere = function(radius, detailX, detailY) {
+  if (typeof radius === 'undefined') {
+    radius = 50;
   }
-  var radius = args[0] || 50;
-  var detailX = typeof args[1] === 'number' ? args[1] : 24;
-  var detailY = typeof args[2] === 'number' ? args[2] : 16;
+  if (typeof detailX === 'undefined') {
+    detailX = 24;
+  }
+  if (typeof detailY === 'undefined') {
+    detailY = 16;
+  }
 
   var gId = 'sphere|' + radius + '|' + detailX + '|' + detailY;
   if (!this._renderer.geometryInHash(gId)) {
@@ -387,15 +401,20 @@ var _truncatedCone = function(
  * </code>
  * </div>
  */
-p5.prototype.cylinder = function() {
-  var args = new Array(arguments.length);
-  for (var i = 0; i < args.length; ++i) {
-    args[i] = arguments[i];
+p5.prototype.cylinder = function(radius, height, detailX, detailY) {
+  if (typeof radius === 'undefined') {
+    radius = 50;
   }
-  var radius = args[0] || 50;
-  var height = args[1] || radius;
-  var detailX = typeof args[2] === 'number' ? args[2] : 24;
-  var detailY = typeof args[3] === 'number' ? args[3] : 16;
+  if (typeof height === 'undefined') {
+    height = radius;
+  }
+  if (typeof detailX === 'undefined') {
+    detailX = 24;
+  }
+  if (typeof detailY === 'undefined') {
+    detailY = 16;
+  }
+
   var gId = 'cylinder|' + radius + '|' + height + '|' + detailX + '|' + detailY;
   if (!this._renderer.geometryInHash(gId)) {
     var cylinderGeom = new p5.Geometry(detailX, detailY);
@@ -456,21 +475,26 @@ p5.prototype.cylinder = function() {
  * </code>
  * </div>
  */
-p5.prototype.cone = function() {
-  var args = new Array(arguments.length);
-  for (var i = 0; i < args.length; ++i) {
-    args[i] = arguments[i];
+p5.prototype.cone = function(radius, height, detailX, detailY) {
+  if (typeof radius === 'undefined') {
+    radius = 50;
   }
-  var baseRadius = args[0] || 50;
-  var height = args[1] || baseRadius;
-  var detailX = typeof args[2] === 'number' ? args[2] : 24;
-  var detailY = typeof args[3] === 'number' ? args[3] : 16;
-  var gId = 'cone|' + baseRadius + '|' + height + '|' + detailX + '|' + detailY;
+  if (typeof height === 'undefined') {
+    height = radius;
+  }
+  if (typeof detailX === 'undefined') {
+    detailX = 24;
+  }
+  if (typeof detailY === 'undefined') {
+    detailY = 16;
+  }
+
+  var gId = 'cone|' + radius + '|' + height + '|' + detailX + '|' + detailY;
   if (!this._renderer.geometryInHash(gId)) {
     var coneGeom = new p5.Geometry(detailX, detailY);
     _truncatedCone.call(
       coneGeom,
-      baseRadius,
+      radius,
       0, //top radius 0
       height,
       detailX,
@@ -527,16 +551,23 @@ p5.prototype.cone = function() {
  * </code>
  * </div>
  */
-p5.prototype.ellipsoid = function() {
-  var args = new Array(arguments.length);
-  for (var i = 0; i < args.length; ++i) {
-    args[i] = arguments[i];
+p5.prototype.ellipsoid = function(radiusX, radiusY, radiusZ, detailX, detailY) {
+  if (typeof radiusX === 'undefined') {
+    radiusX = 50;
   }
-  var detailX = typeof args[3] === 'number' ? args[3] : 24;
-  var detailY = typeof args[4] === 'number' ? args[4] : 24;
-  var radiusX = args[0] || 50;
-  var radiusY = args[1] || radiusX;
-  var radiusZ = args[2] || radiusX;
+  if (typeof radiusY === 'undefined') {
+    radiusY = radiusX;
+  }
+  if (typeof radiusZ === 'undefined') {
+    radiusZ = radiusX;
+  }
+
+  if (typeof detailX === 'undefined') {
+    detailX = 24;
+  }
+  if (typeof detailY === 'undefined') {
+    detailY = 16;
+  }
 
   var gId =
     'ellipsoid|' +
@@ -617,16 +648,20 @@ p5.prototype.ellipsoid = function() {
  * </code>
  * </div>
  */
-p5.prototype.torus = function() {
-  var args = new Array(arguments.length);
-  for (var i = 0; i < args.length; ++i) {
-    args[i] = arguments[i];
+p5.prototype.torus = function(radius, tubeRadius, detailX, detailY) {
+  if (typeof radius === 'undefined') {
+    radius = 50;
   }
-  var detailX = typeof args[2] === 'number' ? args[2] : 24;
-  var detailY = typeof args[3] === 'number' ? args[3] : 16;
+  if (typeof tubeRadius === 'undefined') {
+    tubeRadius = 10;
+  }
 
-  var radius = args[0] || 50;
-  var tubeRadius = args[1] || 10;
+  if (typeof detailX === 'undefined') {
+    detailX = 24;
+  }
+  if (typeof detailY === 'undefined') {
+    detailY = 16;
+  }
 
   var gId =
     'torus|' + radius + '|' + tubeRadius + '|' + detailX + '|' + detailY;
@@ -796,19 +831,7 @@ p5.RendererGL.prototype.rect = function(args) {
   return this;
 };
 
-p5.RendererGL.prototype.quad = function() {
-  var args = new Array(arguments.length);
-  for (var i = 0; i < args.length; ++i) {
-    args[i] = arguments[i];
-  }
-  var x1 = args[0],
-    y1 = args[1],
-    x2 = args[2],
-    y2 = args[3],
-    x3 = args[4],
-    y3 = args[5],
-    x4 = args[6],
-    y4 = args[7];
+p5.RendererGL.prototype.quad = function(x1, y1, x2, y2, x3, y3, x4, y4) {
   var gId =
     'quad|' +
     x1 +
@@ -847,63 +870,76 @@ p5.RendererGL.prototype.quad = function() {
 
 //this implementation of bezier curve
 //is based on Bernstein polynomial
-p5.RendererGL.prototype.bezier = function(args) {
-  var bezierDetail = args[12] || 20; //value of Bezier detail
+// pretier-ignore
+p5.RendererGL.prototype.bezier = function(
+  x1,
+  y1,
+  z1,
+  x2,
+  y2,
+  z2,
+  x3,
+  y3,
+  z3,
+  x4,
+  y4,
+  z4
+) {
+  var bezierDetail = this._pInst._bezierDetail || 20; //value of Bezier detail
   this.beginShape();
-  var coeff = [0, 0, 0, 0]; //  Bernstein polynomial coeffecients
-  var vertex = [0, 0, 0]; //(x,y,z) coordinates of points in bezier curve
   for (var i = 0; i <= bezierDetail; i++) {
-    coeff[0] = Math.pow(1 - i / bezierDetail, 3);
-    coeff[1] = 3 * (i / bezierDetail) * Math.pow(1 - i / bezierDetail, 2);
-    coeff[2] = 3 * Math.pow(i / bezierDetail, 2) * (1 - i / bezierDetail);
-    coeff[3] = Math.pow(i / bezierDetail, 3);
-    vertex[0] =
-      args[0] * coeff[0] +
-      args[3] * coeff[1] +
-      args[6] * coeff[2] +
-      args[9] * coeff[3];
-    vertex[1] =
-      args[1] * coeff[0] +
-      args[4] * coeff[1] +
-      args[7] * coeff[2] +
-      args[10] * coeff[3];
-    vertex[2] =
-      args[2] * coeff[0] +
-      args[5] * coeff[1] +
-      args[8] * coeff[2] +
-      args[11] * coeff[3];
-    this.vertex(vertex[0], vertex[1], vertex[2]);
+    var c1 = Math.pow(1 - i / bezierDetail, 3);
+    var c2 = 3 * (i / bezierDetail) * Math.pow(1 - i / bezierDetail, 2);
+    var c3 = 3 * Math.pow(i / bezierDetail, 2) * (1 - i / bezierDetail);
+    var c4 = Math.pow(i / bezierDetail, 3);
+    this.vertex(
+      x1 * c1 + x2 * c2 + x3 * c3 + x4 * c4,
+      y1 * c1 + y2 * c2 + y3 * c3 + y4 * c4,
+      z1 * c1 + z2 * c2 + z3 * c3 + z4 * c4
+    );
   }
   this.endShape();
   return this;
 };
 
-p5.RendererGL.prototype.curve = function(args) {
-  var curveDetail = args[12];
+// pretier-ignore
+p5.RendererGL.prototype.curve = function(
+  x1,
+  y1,
+  z1,
+  x2,
+  y2,
+  z2,
+  x3,
+  y3,
+  z3,
+  x4,
+  y4,
+  z4
+) {
+  var curveDetail = this._pInst._curveDetail;
   this.beginShape();
-  var coeff = [0, 0, 0, 0]; //coeffecients of the equation
-  var vertex = [0, 0, 0]; //(x,y,z) coordinates of points in bezier curve
   for (var i = 0; i <= curveDetail; i++) {
-    coeff[0] = Math.pow(i / curveDetail, 3) * 0.5;
-    coeff[1] = Math.pow(i / curveDetail, 2) * 0.5;
-    coeff[2] = i / curveDetail * 0.5;
-    coeff[3] = 0.5;
-    vertex[0] =
-      coeff[0] * (-args[0] + 3 * args[3] - 3 * args[6] + args[9]) +
-      coeff[1] * (2 * args[0] - 5 * args[3] + 4 * args[6] - args[9]) +
-      coeff[2] * (-args[0] + args[6]) +
-      coeff[3] * (2 * args[3]);
-    vertex[1] =
-      coeff[0] * (-args[1] + 3 * args[4] - 3 * args[7] + args[10]) +
-      coeff[1] * (2 * args[1] - 5 * args[4] + 4 * args[7] - args[10]) +
-      coeff[2] * (-args[1] + args[7]) +
-      coeff[3] * (2 * args[4]);
-    vertex[2] =
-      coeff[0] * (-args[2] + 3 * args[5] - 3 * args[8] + args[11]) +
-      coeff[1] * (2 * args[2] - 5 * args[5] + 4 * args[8] - args[11]) +
-      coeff[2] * (-args[2] + args[8]) +
-      coeff[3] * (2 * args[5]);
-    this.vertex(vertex[0], vertex[1], vertex[2]);
+    var c1 = Math.pow(i / curveDetail, 3) * 0.5;
+    var c2 = Math.pow(i / curveDetail, 2) * 0.5;
+    var c3 = i / curveDetail * 0.5;
+    var c4 = 0.5;
+    var vx =
+      c1 * (-x1 + 3 * x2 - 3 * x3 + x4) +
+      c2 * (2 * x1 - 5 * x2 + 4 * x3 - x4) +
+      c3 * (-x1 + x3) +
+      c4 * (2 * x2);
+    var vy =
+      c1 * (-y1 + 3 * y2 - 3 * y3 + y4) +
+      c2 * (2 * y1 - 5 * y2 + 4 * y3 - y4) +
+      c3 * (-y1 + y3) +
+      c4 * (2 * y2);
+    var vz =
+      c1 * (-z1 + 3 * z2 - 3 * z3 + z4) +
+      c2 * (2 * z1 - 5 * z2 + 4 * z3 - z4) +
+      c3 * (-z1 + z3) +
+      c4 * (2 * z2);
+    this.vertex(vx, vy, vz);
   }
   this.endShape();
   return this;


### PR DESCRIPTION
this PR redices the use of the `arguments` object wherever possible. it:
- uses declared parameters instead of indexing the `arguments` arrray
- checks parameter  using `typeof` instead of `arguments.length`
- avoids duplicating the `arguments` array

use of `arguments` is sometimes unavoidable, especially when handling overloads that include out-of-order optional parameters.