### PR TITLE
webgl: normalize normals

### DIFF
--- a/src/webgl/shaders/light.vert
+++ b/src/webgl/shaders/light.vert
@@ -30,7 +30,7 @@ void main(void){
   vec4 positionVec4 = vec4(aPosition, 1.0);
   gl_Position = uProjectionMatrix * uModelViewMatrix * positionVec4;
 
-  vec3 vertexNormal = vec3( uNormalMatrix * aNormal );
+  vec3 vertexNormal = normalize(vec3( uNormalMatrix * aNormal ));
   vVertexNormal = vertexNormal;
   vVertTexCoord = aTexCoord;
 


### PR DESCRIPTION
the face normals, after they have been transformed by the view matrix, need to be normalized. otherwise scaling effects in the view matrix will throw off the lighting calculation.

fixes #2420.