### PR TITLE
Fix sample-linter on Windows

### DIFF
--- a/utils/sample-linter.js
+++ b/utils/sample-linter.js
@@ -57,7 +57,9 @@ function splitLines(text) {
   return lines;
 }
 
-var EOL = require('os').EOL;
+// We're enforcing Unix line endings
+// See https://eslint.org/docs/rules/linebreak-style
+var EOL = '\n';
 
 var userFunctions = [
   'draw',


### PR DESCRIPTION
Without this, sample-linter will use `\r\n` on Windows, clashing with the [linebreak style rule](https://eslint.org/docs/rules/linebreak-style). To try it out yourself, set `var EOL = '\r\n'`.

@Spongman before this change I also got a crash in the linting rule from here:
```
var startLine = msg.line + sampleLine;
msg.column += this.lines[startLine].prefixLength;
```
This is because prettier was complaining about the `\r`, which is beyond the lines of the original file, causing `this.lines[startLine]` to be `undefined`. Do you think there is any point to checking that `startLine` is not out of bounds?