### PR TITLE
webgl test: fix pointLight coordinate space

### DIFF
--- a/test/manual-test-examples/webgl/lights/pointLight/sketch.js
+++ b/test/manual-test-examples/webgl/lights/pointLight/sketch.js
@@ -5,12 +5,9 @@ function setup(){
 function draw(){
   background(0);
 
-  var locY = (mouseY / height - 0.5) * (-2);
-  var locX = (mouseX / width - 0.5) *2;
-
   ambientLight(50);
-  pointLight(250, 250, 250, locX, locY, 0);
-
+  pointLight(250, 250, 250, mouseX - width / 2, mouseY - height / 2, 0);
+  
   ambientMaterial(250);
   sphere(50, 64);
 }


### PR DESCRIPTION
fix pointLight coordinate space in manual `pointLight` test example.