### PR TITLE
new method for creating p5.Vector from polar coordinates

### DIFF
--- a/src/math/p5.Vector.js
+++ b/src/math/p5.Vector.js
@@ -1157,4 +1157,17 @@ p5.Vector.mag = function mag(vecT) {
   return Math.sqrt(magSq);
 };
 
+/**
+ * @method fromPolar
+ * @param {Number} radius
+ * @param {Number} angle
+ * @return {p5.Vector}
+ */
+p5.Vector.fromPolar = function(radius, angle) {
+  let x = radius * cos(angle);
+  let y = radius * sin(angle);
+  return new p5.Vector(x, y);
+}
+
 module.exports = p5.Vector;
+


### PR DESCRIPTION
Hey,

I thought it would be incredible useful to have a method to create vectors from polar coordinates
to be built into the p5 library.
I have added the method into the vector src file.
let me know if this is something that is worth adding or not, perhaps it could be improved...

`let myVector = p5.Vector.fromPolar(100, PI);`

best