### PR TITLE
hide private classes in docs

### DIFF
--- a/docs/preprocessor.js
+++ b/docs/preprocessor.js
@@ -41,6 +41,11 @@ function mergeOverloadedMethods(data) {
       return false;
     }
 
+    var itemClass = data.classes[classitem.class];
+    if (!itemClass || itemClass.private) {
+      return false;
+    }
+
     var methodConsts = {};
 
     var fullName, method;

--- a/docs/yuidoc-p5-theme-src/scripts/views/listView.js
+++ b/docs/yuidoc-p5-theme-src/scripts/views/listView.js
@@ -31,7 +31,8 @@ define([
         // module === group
         this.groups = {};
         _.each(items, function (item, i) {
-          if (item.file.indexOf('addons') === -1) { //addons don't get displayed on main page
+
+          if (!item.private && item.file.indexOf('addons') === -1) { //addons don't get displayed on main page
 
             var group = item.module || '_';
             var subgroup = item.submodule || '_';
@@ -54,13 +55,13 @@ define([
                 name: subgroup.replace('_', '&nbsp;'),
                 items: []
               };
-			}
-			
-			// hide the un-interesting constants  
-			if (group === 'Constants' && !item.example)
-				return;
+            }
 
-            if (item.file.indexOf('p5.') === -1) {
+            // hide the un-interesting constants  
+            if (group === 'Constants' && !item.example)
+              return;
+
+            if (item.class === 'p5') {
 
               self.groups[group].subgroups[subgroup].items.push(item);
 

--- a/test/node/test-docs-preprocessor.js
+++ b/test/node/test-docs-preprocessor.js
@@ -14,6 +14,10 @@ describe('docs preprocessor', function() {
 
     it('should merge methods with the same name', function() {
       var data = {
+        classes: {
+          Bar: {},
+          Baz: {}
+        },
         classitems: [
           {
             file: 'foo.js',
@@ -21,6 +25,7 @@ describe('docs preprocessor', function() {
             description: 'Does foo.',
             itemtype: 'method',
             name: 'foo',
+            class: 'Bar',
             params: [{ name: 'bar', type: 'String' }]
           },
           {
@@ -28,6 +33,7 @@ describe('docs preprocessor', function() {
             line: 5,
             itemtype: 'method',
             name: 'foo',
+            class: 'Bar',
             params: [{ name: 'baz', type: 'Number' }]
           }
         ],
@@ -37,6 +43,10 @@ describe('docs preprocessor', function() {
       merge(data);
 
       expect(data).to.eql({
+        classes: {
+          Bar: {},
+          Baz: {}
+        },
         classitems: [
           {
             file: 'foo.js',
@@ -44,6 +54,7 @@ describe('docs preprocessor', function() {
             description: 'Does foo.',
             itemtype: 'method',
             name: 'foo',
+            class: 'Bar',
             overloads: [
               {
                 line: 1,
@@ -62,6 +73,10 @@ describe('docs preprocessor', function() {
 
     it('should not merge methods from different classes', function() {
       ensureMergeDoesNothing({
+        classes: {
+          Bar: {},
+          Baz: {}
+        },
         classitems: [
           { itemtype: 'method', class: 'Bar', name: 'foo' },
           { itemtype: 'method', class: 'Baz', name: 'foo' }
@@ -72,9 +87,13 @@ describe('docs preprocessor', function() {
 
     it('should not merge properties', function() {
       ensureMergeDoesNothing({
+        classes: {
+          Bar: {},
+          Baz: {}
+        },
         classitems: [
-          { itemtype: 'property', name: 'foo' },
-          { itemtype: 'property', name: 'foo' }
+          { itemtype: 'property', class: 'Bar', name: 'foo' },
+          { itemtype: 'property', class: 'Baz', name: 'foo' }
         ],
         consts: {}
       });
@@ -87,7 +106,10 @@ describe('docs preprocessor', function() {
     it('should work', function() {
       var data = {
         modules: {},
-        classes: {},
+        classes: {
+          Bar: {},
+          Baz: {}
+        },
         classitems: [
           {
             description: 'hi `there`',
@@ -101,7 +123,10 @@ describe('docs preprocessor', function() {
 
       expect(data).to.eql({
         modules: {},
-        classes: {},
+        classes: {
+          Bar: {},
+          Baz: {}
+        },
         classitems: [
           {
             description: '<p>hi <code>there</code></p>\n',


### PR DESCRIPTION
this PR does a couple of things:
- ensures classes like `p5.Matrix` that are private, don't appear in the docs list view
- ensures that classes with methods in multiple files (eg, `p5` and `p5.Renderer`) don't appear multiple times in the docs list view. (there _was_ a check to prevent this, but it was based on filename, not on class name, and is now broken)