### PR TITLE
webgl: Per pixel lighting

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -187,7 +187,12 @@ module.exports = function(grunt) {
       // Watch the codebase for doc updates
       // launch with 'grunt requirejs connect watch:yui'
       yui: {
-        files: ['src/**/*.js', 'lib/addons/*.js'],
+        files: [
+          'src/**/*.js',
+          'lib/addons/*.js',
+          'src/**/*.frag',
+          'src/**/*.vert'
+        ],
         tasks: ['browserify', 'yuidoc:prod', 'minjson', 'uglify'],
         options: {
           livereload: true

--- a/src/webgl/light.js
+++ b/src/webgl/light.js
@@ -137,8 +137,8 @@ p5.prototype.ambientLight = function(v1, v2, v3, a) {
  *   background(0);
  *   //move your mouse to change light direction
  *   var dirX = (mouseX / width - 0.5) * 2;
- *   var dirY = (mouseY / height - 0.5) * -2;
- *   directionalLight(250, 250, 250, dirX, dirY, 0.25);
+ *   var dirY = (mouseY / height - 0.5) * 2;
+ *   directionalLight(250, 250, 250, -dirX, -dirY, 0.25);
  *   ambientMaterial(250);
  *   sphere(50);
  * }

--- a/src/webgl/light.js
+++ b/src/webgl/light.js
@@ -170,7 +170,9 @@ p5.prototype.directionalLight = function(v1, v2, v3, x, y, z) {
   //in case there's no material color for the geometry
   shader.setUniform('uMaterialColor', this._renderer.curFillColor);
 
-  this._renderer.directionalLightDirections.push(_x, _y, _z);
+  // normalize direction
+  var l = Math.sqrt(_x * _x + _y * _y + _z * _z);
+  this._renderer.directionalLightDirections.push(_x / l, _y / l, _z / l);
   shader.setUniform(
     'uLightingDirection',
     this._renderer.directionalLightDirections

--- a/src/webgl/p5.RendererGL.js
+++ b/src/webgl/p5.RendererGL.js
@@ -195,9 +195,12 @@ p5.RendererGL.prototype._resetContext = function(attr, options, callback) {
     }, 0);
   }
 };
-
 /**
- *
+ * @module Rendering
+ * @submodule Rendering
+ * @for p5
+ */
+/**
  * Set attributes for the WebGL Drawing context.
  * This is a way of adjusting ways that the WebGL
  * renderer works to fine-tune the display and performance.
@@ -225,6 +228,10 @@ p5.RendererGL.prototype._resetContext = function(attr, options, callback) {
  * (note that p5 clears automatically on draw loop)
  * default is true
  * <br><br>
+ * perPixelLighting - if true, per-pixel lighting will be used in the
+ * lighting shader.
+ * default is false
+ * <br><br>
  * @method setAttributes
  * @for p5
  * @param  {String|Object}  String name of attribute or object with key-value pairs
@@ -233,7 +240,7 @@ p5.RendererGL.prototype._resetContext = function(attr, options, callback) {
  * <div>
  * <code>
  * function setup() {
- *   createCanvas(150, 150, WEBGL);
+ *   createCanvas(100, 100, WEBGL);
  * }
  *
  * function draw() {
@@ -254,7 +261,7 @@ p5.RendererGL.prototype._resetContext = function(attr, options, callback) {
  * <div>
  * <code>
  * function setup() {
- *   createCanvas(150, 150, WEBGL);
+ *   createCanvas(100, 100, WEBGL);
  *   setAttributes('antialias', true);
  * }
  *
@@ -267,6 +274,59 @@ p5.RendererGL.prototype._resetContext = function(attr, options, callback) {
  *   fill(0, 0, 0);
  *   box(50);
  *   pop();
+ * }
+ * </code>
+ * </div>
+ *
+ * <div>
+ * <code>
+ * // press the mouse button to enable perPixelLighting
+ * function setup() {
+ *   createCanvas(100, 100, WEBGL);
+ *   noStroke();
+ *   fill(255);
+ * }
+ *
+ * var lights = [
+ *   { c: '#f00', t: 1.12, p: 1.91, r: 0.2 },
+ *   { c: '#0f0', t: 1.21, p: 1.31, r: 0.2 },
+ *   { c: '#00f', t: 1.37, p: 1.57, r: 0.2 },
+ *   { c: '#ff0', t: 1.12, p: 1.91, r: 0.7 },
+ *   { c: '#0ff', t: 1.21, p: 1.31, r: 0.7 },
+ *   { c: '#f0f', t: 1.37, p: 1.57, r: 0.7 }
+ * ];
+ *
+ * function draw() {
+ *   var t = millis() / 1000 + 1000;
+ *   background(0);
+ *   directionalLight(color('#222'), -1, -1, 1);
+ *
+ *   for (var i = 0; i < lights.length; i++) {
+ *     var light = lights[i];
+ *     pointLight(
+ *       color(light.c),
+ *       p5.Vector.fromAngles(t * light.t, t * light.p, width * light.r)
+ *     );
+ *   }
+ *
+ *   specularMaterial(255);
+ *   sphere(width * 0.1);
+ *
+ *   rotateX(t * 0.77);
+ *   rotateY(t * 0.83);
+ *   rotateZ(t * 0.91);
+ *   torus(width * 0.3, width * 0.07, 30, 10);
+ * }
+ *
+ * function mousePressed() {
+ *   setAttributes('perPixelLighting', true);
+ *   noStroke();
+ *   fill(255);
+ * }
+ * function mouseReleased() {
+ *   setAttributes('perPixelLighting', false);
+ *   noStroke();
+ *   fill(255);
  * }
  * </code>
  * </div>
@@ -284,6 +344,10 @@ p5.prototype.setAttributes = function() {
   }
   this._renderer._resetContext(attr);
 };
+
+/**
+ * @class p5.RendererGL
+ */
 
 p5.RendererGL.prototype._computeCameraDefaultSettings = function() {
   this.defaultCameraFOV = 60 / 180 * Math.PI;
@@ -371,7 +435,6 @@ p5.RendererGL.prototype.background = function() {
 /**
  * Basic fill material for geometry with a given color
  * @method  fill
- * @class p5.RendererGL
  * @param  {Number|Array|String|p5.Color} v1  gray value,
  * red or hue value (depending on the current color mode),
  * or color Array, or CSS color string

--- a/src/webgl/p5.RendererGL.js
+++ b/src/webgl/p5.RendererGL.js
@@ -342,7 +342,7 @@ p5.prototype.setAttributes = function(key, value) {
   var attr;
   if (typeof value !== 'undefined') {
     attr = {};
-    attr.key = value;
+    attr[key] = value;
   } else if (key instanceof Object) {
     attr = key;
   }

--- a/src/webgl/p5.RendererGL.js
+++ b/src/webgl/p5.RendererGL.js
@@ -26,8 +26,13 @@ var defaultShaders = {
   normalVert: fs.readFileSync(__dirname + '/shaders/normal.vert', 'utf-8'),
   normalFrag: fs.readFileSync(__dirname + '/shaders/normal.frag', 'utf-8'),
   basicFrag: fs.readFileSync(__dirname + '/shaders/basic.frag', 'utf-8'),
-  lightVert: fs.readFileSync(__dirname + '/shaders/phong.vert', 'utf-8'),
-  lightTextureFrag: fs.readFileSync(__dirname + '/shaders/phong.frag', 'utf-8'),
+  lightVert: fs.readFileSync(__dirname + '/shaders/light.vert', 'utf-8'),
+  lightTextureFrag: fs.readFileSync(
+    __dirname + '/shaders/light_texture.frag',
+    'utf-8'
+  ),
+  phongVert: fs.readFileSync(__dirname + '/shaders/phong.vert', 'utf-8'),
+  phongFrag: fs.readFileSync(__dirname + '/shaders/phong.frag', 'utf-8'),
   lineVert: fs.readFileSync(__dirname + '/shaders/line.vert', 'utf-8'),
   lineFrag: fs.readFileSync(__dirname + '/shaders/line.frag', 'utf-8')
 };
@@ -56,6 +61,8 @@ p5.RendererGL = function(elt, pInst, isMainCanvas, attr) {
     attr.preserveDrawingBuffer === undefined
       ? true
       : attr.preserveDrawingBuffer;
+  this.attributes.perPixelLighting =
+    attr.perPixelLighting === undefined ? false : attr.perPixelLighting;
   this._initContext();
   this.isP3D = true; //lets us know we're in 3d mode
   this.GL = this.drawingContext;
@@ -872,11 +879,19 @@ p5.RendererGL.prototype._useImmediateModeShader = function() {
 
 p5.RendererGL.prototype._getLightShader = function() {
   if (!this._defaultLightShader) {
-    this._defaultLightShader = new p5.Shader(
-      this,
-      defaultShaders.lightVert,
-      defaultShaders.lightTextureFrag
-    );
+    if (this.attributes.perPixelLighting) {
+      this._defaultLightShader = new p5.Shader(
+        this,
+        defaultShaders.phongVert,
+        defaultShaders.phongFrag
+      );
+    } else {
+      this._defaultLightShader = new p5.Shader(
+        this,
+        defaultShaders.lightVert,
+        defaultShaders.lightTextureFrag
+      );
+    }
   }
   //this.drawMode = constants.FILL;
   return this._defaultLightShader;

--- a/src/webgl/p5.RendererGL.js
+++ b/src/webgl/p5.RendererGL.js
@@ -26,11 +26,8 @@ var defaultShaders = {
   normalVert: fs.readFileSync(__dirname + '/shaders/normal.vert', 'utf-8'),
   normalFrag: fs.readFileSync(__dirname + '/shaders/normal.frag', 'utf-8'),
   basicFrag: fs.readFileSync(__dirname + '/shaders/basic.frag', 'utf-8'),
-  lightVert: fs.readFileSync(__dirname + '/shaders/light.vert', 'utf-8'),
-  lightTextureFrag: fs.readFileSync(
-    __dirname + '/shaders/light_texture.frag',
-    'utf-8'
-  ),
+  lightVert: fs.readFileSync(__dirname + '/shaders/phong.vert', 'utf-8'),
+  lightTextureFrag: fs.readFileSync(__dirname + '/shaders/phong.frag', 'utf-8'),
   lineVert: fs.readFileSync(__dirname + '/shaders/line.vert', 'utf-8'),
   lineFrag: fs.readFileSync(__dirname + '/shaders/line.frag', 'utf-8')
 };

--- a/src/webgl/p5.RendererGL.js
+++ b/src/webgl/p5.RendererGL.js
@@ -297,7 +297,7 @@ p5.RendererGL.prototype._resetContext = function(attr, options, callback) {
  * function draw() {
  *   var t = millis() / 1000 + 1000;
  *   background(0);
- *   directionalLight(color('#222'), -1, -1, 1);
+ *   directionalLight(color('#222'), 1, 1, 1);
  *
  *   for (var i = 0; i < lights.length; i++) {
  *     var light = lights[i];

--- a/src/webgl/primitives.js
+++ b/src/webgl/primitives.js
@@ -232,29 +232,27 @@ p5.prototype.sphere = function() {
   var gId = 'sphere|' + radius + '|' + detailX + '|' + detailY;
   if (!this._renderer.geometryInHash(gId)) {
     var _sphere = function() {
-      var u, v, p;
       for (var i = 0; i <= this.detailY; i++) {
-        v = i / this.detailY;
+        var v = i / this.detailY;
+        var phi = Math.PI * v - Math.PI / 2;
+        var cosPhi = Math.cos(phi);
+        var sinPhi = Math.sin(phi);
         for (var j = 0; j <= this.detailX; j++) {
-          u = j / this.detailX;
+          var u = j / this.detailX;
           var theta = 2 * Math.PI * u;
-          var phi = Math.PI * v - Math.PI / 2;
-          p = new p5.Vector(
-            radius * Math.cos(phi) * Math.sin(theta),
-            radius * Math.sin(phi),
-            radius * Math.cos(phi) * Math.cos(theta)
+          var n = new p5.Vector(
+            cosPhi * Math.sin(theta),
+            sinPhi,
+            cosPhi * Math.cos(theta)
           );
-          this.vertices.push(p);
+          this.vertexNormals.push(n);
+          this.vertices.push(p5.Vector.mult(n, radius));
           this.uvs.push([u, v]);
         }
       }
     };
     var sphereGeom = new p5.Geometry(detailX, detailY, _sphere);
-    sphereGeom
-      .computeFaces()
-      .computeNormals()
-      .averageNormals()
-      .averagePoleNormals();
+    sphereGeom.computeFaces();
     if (detailX <= 24 && detailY <= 16) {
       sphereGeom._makeTriangleEdges();
       this._renderer._edgesToVertices(sphereGeom);
@@ -633,18 +631,24 @@ p5.prototype.torus = function() {
 
   if (!this._renderer.geometryInHash(gId)) {
     var _torus = function() {
-      var u, v, p;
       for (var i = 0; i <= this.detailY; i++) {
-        v = i / this.detailY;
+        var v = i / this.detailY;
+        var phi = 2 * Math.PI * v;
+        var cosPhi = Math.cos(phi);
+        var sinPhi = Math.sin(phi);
         for (var j = 0; j <= this.detailX; j++) {
-          u = j / this.detailX;
+          var u = j / this.detailX;
           var theta = 2 * Math.PI * u;
-          var phi = 2 * Math.PI * v;
-          p = new p5.Vector(
-            (radius + tubeRadius * Math.cos(phi)) * Math.cos(theta),
-            (radius + tubeRadius * Math.cos(phi)) * Math.sin(theta),
-            tubeRadius * Math.sin(phi)
+          var p = new p5.Vector(
+            (radius + tubeRadius * cosPhi) * Math.cos(theta),
+            (radius + tubeRadius * cosPhi) * Math.sin(theta),
+            tubeRadius * sinPhi
           );
+          this.vertexNormals.push(new p5.Vector(
+            tubeRadius * cosPhi * Math.cos(theta),
+            tubeRadius * cosPhi * Math.sin(theta),
+            tubeRadius * sinPhi
+          ));
           this.vertices.push(p);
           this.uvs.push([u, v]);
         }
@@ -652,9 +656,9 @@ p5.prototype.torus = function() {
     };
     var torusGeom = new p5.Geometry(detailX, detailY, _torus);
     torusGeom
-      .computeFaces()
+      .computeFaces()/*
       .computeNormals()
-      .averageNormals();
+      .averageNormals()*/;
     if (detailX <= 24 && detailY <= 16) {
       torusGeom._makeTriangleEdges();
       this._renderer._edgesToVertices(torusGeom);

--- a/src/webgl/primitives.js
+++ b/src/webgl/primitives.js
@@ -644,19 +644,20 @@ p5.prototype.torus = function() {
             (radius + tubeRadius * cosPhi) * Math.sin(theta),
             tubeRadius * sinPhi
           );
-          this.vertexNormals.push(new p5.Vector(
-            tubeRadius * cosPhi * Math.cos(theta),
-            tubeRadius * cosPhi * Math.sin(theta),
-            tubeRadius * sinPhi
-          ));
+          this.vertexNormals.push(
+            new p5.Vector(
+              tubeRadius * cosPhi * Math.cos(theta),
+              tubeRadius * cosPhi * Math.sin(theta),
+              tubeRadius * sinPhi
+            )
+          );
           this.vertices.push(p);
           this.uvs.push([u, v]);
         }
       }
     };
     var torusGeom = new p5.Geometry(detailX, detailY, _torus);
-    torusGeom
-      .computeFaces()/*
+    torusGeom.computeFaces() /*
       .computeNormals()
       .averageNormals()*/;
     if (detailX <= 24 && detailY <= 16) {

--- a/src/webgl/shaders/light.vert
+++ b/src/webgl/shaders/light.vert
@@ -50,7 +50,7 @@ void main(void){
   for (int j = 0; j < 8; j++) {
     if (uDirectionalLightCount == j) break;
     vec3 dir = uLightingDirection[j];
-    float directionalLightWeighting = max(dot(vertexNormal, dir), 0.0);
+    float directionalLightWeighting = max(dot(vertexNormal, -dir), 0.0);
     directionalLightFactor += uDirectionalColor[j] * directionalLightWeighting;
   }
 

--- a/src/webgl/shaders/phong.frag
+++ b/src/webgl/shaders/phong.frag
@@ -46,7 +46,7 @@ float phongSpecular(
 float lambertDiffuse(
   vec3 lightDirection,
   vec3 surfaceNormal) {
-  return max(0.0, dot(lightDirection, surfaceNormal));
+  return max(0.0, dot(-lightDirection, surfaceNormal));
 }
 
 LightResult light(vec3 lightVector) {

--- a/src/webgl/shaders/phong.frag
+++ b/src/webgl/shaders/phong.frag
@@ -25,8 +25,9 @@ varying vec3 vAmbientColor;
 vec3 V;
 vec3 N;
 
-const float specularScale = 0.75;
-const float shininess = 20.0;
+const float shininess = 32.0;
+const float specularFactor = 2.0;
+const float diffuseFactor = 0.73;
 
 struct LightResult {
 	float specular;
@@ -39,7 +40,7 @@ float phongSpecular(
   vec3 surfaceNormal,
   float shininess) {
 
-  vec3 R = normalize(reflect(lightDirection, surfaceNormal));  
+  vec3 R = normalize(reflect(-lightDirection, surfaceNormal));  
   return pow(max(0.0, dot(R, viewDirection)), shininess);
 }
 
@@ -56,7 +57,7 @@ LightResult light(vec3 lightVector) {
   //compute our diffuse & specular terms
   LightResult lr;
   if (uSpecular)
-    lr.specular = phongSpecular(L, V, N, shininess) * specularScale;
+    lr.specular = phongSpecular(L, V, N, shininess);
   lr.diffuse = lambertDiffuse(L, N);
   return lr;
 }
@@ -81,11 +82,11 @@ void main(void) {
     if (uPointLightCount == k) break;
 
     vec3 lightPosition = (uViewMatrix * vec4(uPointLightLocation[k], 1.0)).xyz;
-    vec3 lightVector = lightPosition - vViewPosition;
+    vec3 lightVector = vViewPosition - lightPosition;
 	
     //calculate attenuation
     float lightDistance = length(lightVector);
-    float falloff = 300.0 / (lightDistance + 300.0);
+    float falloff = 500.0 / (lightDistance + 500.0);
 
     LightResult result = light(lightVector);
     diffuse += result.diffuse * falloff * uPointLightColor[k];
@@ -93,5 +94,5 @@ void main(void) {
   }
 
   gl_FragColor = isTexture ? texture2D(uSampler, vTexCoord) : uMaterialColor;
-  gl_FragColor.rgb = gl_FragColor.rgb * (diffuse + vAmbientColor) + specular;
+  gl_FragColor.rgb = gl_FragColor.rgb * (diffuse * diffuseFactor + vAmbientColor) + specular * specularFactor;
 }

--- a/src/webgl/shaders/phong.frag
+++ b/src/webgl/shaders/phong.frag
@@ -1,0 +1,98 @@
+precision mediump float;
+
+uniform vec4 uMaterialColor;
+uniform sampler2D uSampler;
+uniform bool isTexture;
+uniform bool uUseLighting;
+
+uniform vec3 uLightingDirection[8];
+uniform vec3 uDirectionalColor[8];
+uniform vec3 uPointLightLocation[8];
+uniform vec3 uPointLightColor[8];
+uniform bool uSpecular;
+
+uniform int uDirectionalLightCount;
+uniform int uPointLightCount;
+
+varying vec3 vNormal;
+varying vec2 vTexCoord;
+varying vec3 vViewPosition;
+varying vec3 vAmbientColor;
+
+vec3 V;
+vec3 N;
+
+const float specularScale = 1.0;//0.65;
+const float shininess = 5.0;
+
+struct LightResult {
+	float specular;
+	vec3 diffuse;
+};
+
+float blinnPhongSpecular(
+  vec3 lightDirection,
+  vec3 viewDirection,
+  vec3 surfaceNormal,
+  float shininess) {
+
+  //Calculate Blinn-Phong power
+  vec3 H = normalize(viewDirection + lightDirection);
+  return pow(max(0.0, dot(surfaceNormal, H)), shininess);
+}
+
+float lambertDiffuse(
+  vec3 lightDirection,
+  vec3 surfaceNormal) {
+  return max(0.0, dot(lightDirection, surfaceNormal));
+}
+
+LightResult light(vec3 lightVector, vec3 lightColor, float falloff) {
+
+  //determine the type of normals for lighting
+  
+  vec3 L = normalize(lightVector);              //light direction
+
+  //compute our diffuse & specular terms
+  LightResult lr;
+  lr.specular = blinnPhongSpecular(L, V, N, shininess) * specularScale * falloff;
+  lr.diffuse = lightColor * lambertDiffuse(L, N) * falloff;
+  return lr;
+}
+
+void main(void) {
+
+  V = normalize(vViewPosition);
+  N = normalize(vNormal);
+
+  vec3 diffuse = vec3(0.0);
+  float specular = 0.0;
+
+  for (int j = 0; j < 8; j++) {
+    if (uDirectionalLightCount == j) break;
+
+	LightResult result = light(uLightingDirection[j], uDirectionalColor[j], 1.0);
+	diffuse += result.diffuse;
+	specular += result.specular;
+  }
+
+  for (int k = 0; k < 8; k++) {
+    if (uPointLightCount == k) break;
+
+    vec3 lightPosition = uPointLightLocation[k];
+    vec3 lightVector = lightPosition - vViewPosition;
+	
+	//calculate attenuation
+	float lightDistance = length(lightVector);
+	float falloff = 1.0;// / (lightDistance + 1.0);
+
+	LightResult result = light(lightVector, uPointLightColor[k], falloff);
+	diffuse += result.diffuse;
+	specular += result.specular;
+  }
+
+  vec4 diffuseColor = isTexture ? texture2D(uSampler, vTexCoord) : uMaterialColor;
+
+  gl_FragColor.rgb = diffuseColor.rgb * (diffuse + vAmbientColor) + specular;
+  gl_FragColor.a = diffuseColor.a;
+}

--- a/src/webgl/shaders/phong.frag
+++ b/src/webgl/shaders/phong.frag
@@ -1,5 +1,7 @@
 precision mediump float;
 
+uniform mat4 uModelViewMatrix;
+
 uniform vec4 uMaterialColor;
 uniform sampler2D uSampler;
 uniform bool isTexture;
@@ -22,23 +24,22 @@ varying vec3 vAmbientColor;
 vec3 V;
 vec3 N;
 
-const float specularScale = 1.0;//0.65;
-const float shininess = 5.0;
+const float specularScale = 0.65;
+const float shininess = 50.0;
 
 struct LightResult {
 	float specular;
 	vec3 diffuse;
 };
 
-float blinnPhongSpecular(
+float phongSpecular(
   vec3 lightDirection,
   vec3 viewDirection,
   vec3 surfaceNormal,
   float shininess) {
 
-  //Calculate Blinn-Phong power
-  vec3 H = normalize(viewDirection + lightDirection);
-  return pow(max(0.0, dot(surfaceNormal, H)), shininess);
+  vec3 R = normalize(reflect(lightDirection, surfaceNormal));  
+  return pow(max(0.0, dot(R, viewDirection)), shininess);
 }
 
 float lambertDiffuse(
@@ -49,13 +50,11 @@ float lambertDiffuse(
 
 LightResult light(vec3 lightVector, vec3 lightColor, float falloff) {
 
-  //determine the type of normals for lighting
-  
-  vec3 L = normalize(lightVector);              //light direction
+  vec3 L = normalize(lightVector);
 
   //compute our diffuse & specular terms
   LightResult lr;
-  lr.specular = blinnPhongSpecular(L, V, N, shininess) * specularScale * falloff;
+  lr.specular = phongSpecular(L, V, N, shininess) * specularScale * falloff;
   lr.diffuse = lightColor * lambertDiffuse(L, N) * falloff;
   return lr;
 }
@@ -63,7 +62,7 @@ LightResult light(vec3 lightVector, vec3 lightColor, float falloff) {
 void main(void) {
 
   V = normalize(vViewPosition);
-  N = normalize(vNormal);
+  N = vNormal;
 
   vec3 diffuse = vec3(0.0);
   float specular = 0.0;
@@ -71,24 +70,25 @@ void main(void) {
   for (int j = 0; j < 8; j++) {
     if (uDirectionalLightCount == j) break;
 
-	LightResult result = light(uLightingDirection[j], uDirectionalColor[j], 1.0);
-	diffuse += result.diffuse;
-	specular += result.specular;
+    LightResult result = light(uLightingDirection[j], uDirectionalColor[j], 1.0);
+    diffuse += result.diffuse;
+    specular += result.specular;
   }
 
   for (int k = 0; k < 8; k++) {
     if (uPointLightCount == k) break;
 
-    vec3 lightPosition = uPointLightLocation[k];
+    vec3 lightPosition = (uModelViewMatrix * vec4(uPointLightLocation[k], 1.0)).xyz;
+    //vec3 lightPosition = uPointLightLocation[k];
     vec3 lightVector = lightPosition - vViewPosition;
 	
-	//calculate attenuation
-	float lightDistance = length(lightVector);
-	float falloff = 1.0;// / (lightDistance + 1.0);
+    //calculate attenuation
+    float lightDistance = length(lightVector);
+    float falloff = 100.0 / (lightDistance + 100.0);
 
-	LightResult result = light(lightVector, uPointLightColor[k], falloff);
-	diffuse += result.diffuse;
-	specular += result.specular;
+    LightResult result = light(lightVector, uPointLightColor[k], falloff);
+    diffuse += result.diffuse;
+    specular += result.specular;
   }
 
   vec4 diffuseColor = isTexture ? texture2D(uSampler, vTexCoord) : uMaterialColor;

--- a/src/webgl/shaders/phong.vert
+++ b/src/webgl/shaders/phong.vert
@@ -1,3 +1,5 @@
+precision mediump float;
+
 attribute vec3 aPosition;
 attribute vec3 aNormal;
 attribute vec2 aTexCoord;
@@ -22,7 +24,7 @@ void main(void){
   vViewPosition = viewModelPosition.xyz;
   gl_Position = uProjectionMatrix * viewModelPosition;  
 
-  vNormal = normalize(uNormalMatrix * aNormal);
+  vNormal = normalize(uNormalMatrix * normalize(aNormal));
   vTexCoord = aTexCoord;
 
   vAmbientColor = vec3(0.0);

--- a/src/webgl/shaders/phong.vert
+++ b/src/webgl/shaders/phong.vert
@@ -1,0 +1,33 @@
+attribute vec3 aPosition;
+attribute vec3 aNormal;
+attribute vec2 aTexCoord;
+
+uniform vec3 uAmbientColor[8];
+
+uniform mat4 uModelViewMatrix;
+uniform mat4 uProjectionMatrix;
+uniform mat3 uNormalMatrix;
+uniform int uAmbientLightCount;
+
+varying vec3 vNormal;
+varying vec2 vTexCoord;
+varying vec3 vViewPosition;
+varying vec3 vAmbientColor;
+
+void main(void){
+
+  vec4 viewModelPosition = uModelViewMatrix * vec4(aPosition, 1.0);
+
+  // Pass varyings to fragment shader
+  vViewPosition = viewModelPosition.xyz;
+  gl_Position = uProjectionMatrix * viewModelPosition;  
+
+  vNormal = normalize(uNormalMatrix * aNormal);
+  vTexCoord = aTexCoord;
+
+  vAmbientColor = vec3(0.0);
+  for (int i = 0; i < 8; i++) {
+    if (uAmbientLightCount == i) break;
+    vAmbientColor += uAmbientColor[i];
+  }
+}

--- a/test/manual-test-examples/webgl/customShader/toonShader/sketch.js
+++ b/test/manual-test-examples/webgl/customShader/toonShader/sketch.js
@@ -17,7 +17,7 @@ function draw () {
   background(0);
   var dirY = (mouseY / height - 0.5) * 2;
   var dirX = (mouseX / width - 0.5) * 2;
-  directionalLight(255, 204, 204, -dirX, dirY, -1);
+  directionalLight(255, 204, 204, -dirX, -dirY, -1);
   ambientMaterial(0, 255, 255);
   sphere(120);
 }

--- a/test/manual-test-examples/webgl/lights/directionalLight/sketch.js
+++ b/test/manual-test-examples/webgl/lights/directionalLight/sketch.js
@@ -1,5 +1,6 @@
 function setup(){
   createCanvas(windowWidth, windowHeight, WEBGL);
+  //setAttributes('perPixelLighting', true);
 }
 
 function draw(){
@@ -9,7 +10,7 @@ function draw(){
   var dirX = (mouseX / width - 0.5) *2;
 
   ambientLight(50);
-  directionalLight(250, 250, 250, dirX, -dirY, 0.25);
+  directionalLight(250, 250, 250, -dirX, -dirY, 0);
 
   ambientMaterial(250);
   sphere(50, 64);

--- a/test/manual-test-examples/webgl/material/perPixelLighting/index.html
+++ b/test/manual-test-examples/webgl/material/perPixelLighting/index.html
@@ -12,6 +12,7 @@
   </style> 
 </head>
 <body>
+  <p style="position: absolute; width:300px; left:50%; margin-left: -150px; color:white; text-align: center;">Press mouse to enable per-pixel-lighting</p>
 <script>
 (function(){var script=document.createElement('script');script.onload=function(){var stats=new Stats();stats.domElement.style.cssText='position:fixed;left:0;top:0;z-index:10000';document.body.appendChild(stats.domElement);requestAnimationFrame(function loop(){stats.update();requestAnimationFrame(loop)});};script.src='http://rawgit.com/mrdoob/stats.js/master/build/stats.min.js';document.head.appendChild(script);})()
 </script>

--- a/test/manual-test-examples/webgl/material/perPixelLighting/index.html
+++ b/test/manual-test-examples/webgl/material/perPixelLighting/index.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8">
+  <meta http-equiv="X-UA-Compatible" content="IE=edge">
+  <title></title>
+  <link rel="stylesheet" href="">
+  <script language="javascript" type="text/javascript" src="../../../../../lib/p5.js"></script>
+  <script language="javascript" type="text/javascript" src="sketch.js"></script>
+  <style>
+    html, body {margin:0; padding:0;}
+  </style> 
+</head>
+<body>
+<script>
+(function(){var script=document.createElement('script');script.onload=function(){var stats=new Stats();stats.domElement.style.cssText='position:fixed;left:0;top:0;z-index:10000';document.body.appendChild(stats.domElement);requestAnimationFrame(function loop(){stats.update();requestAnimationFrame(loop)});};script.src='http://rawgit.com/mrdoob/stats.js/master/build/stats.min.js';document.head.appendChild(script);})()
+</script>
+  
+</body>
+</html>

--- a/test/manual-test-examples/webgl/material/perPixelLighting/sketch.js
+++ b/test/manual-test-examples/webgl/material/perPixelLighting/sketch.js
@@ -1,0 +1,57 @@
+var teapot;
+
+function setup() {
+  createCanvas(windowWidth, windowHeight, WEBGL);
+  teapot = loadModel('../wireframe/assets/teapot.obj', true);
+  noStroke();
+}
+
+var lights = [
+  { c: '#f00', t: 1.12, p: 1.91, r: 0.2 },
+  { c: '#0f0', t: 1.21, p: 1.31, r: 0.2 },
+  { c: '#00f', t: 1.37, p: 1.57, r: 0.2 },
+  { c: '#ff0', t: 1.12, p: 1.97, r: 0.7 },
+  { c: '#0ff', t: 1.21, p: 1.37, r: 0.7 },
+  { c: '#f0f', t: 1.37, p: 1.37, r: 0.7 }
+];
+
+function draw() {
+  var t = millis() / 1000 + 1000;
+  background(0);
+
+  directionalLight(color('#111'), -1, -1, -1);
+
+  for (var i = 0; i < lights.length; i++) {
+    var light = lights[i];
+    pointLight(
+      color(light.c),
+      p5.Vector.fromAngles(t * light.t, t * light.p, width * 2)
+    );
+  }
+
+  specularMaterial(255);
+
+  push();
+  rotateX(millis() / 1000);
+  rotateY(millis() / 987);
+  rotateZ(millis() / 1234);
+
+  scale(width / 250);
+  //sphere(100);
+  model(teapot);
+
+  pop();
+
+}
+
+function mousePressed() {
+  setAttributes('perPixelLighting', true);
+  noStroke();
+  specularMaterial(250);
+}
+
+function mouseReleased() {
+  setAttributes('perPixelLighting', false);
+  noStroke();
+  specularMaterial(250);
+}

--- a/test/manual-test-examples/webgl/material/perPixelLighting/sketch.js
+++ b/test/manual-test-examples/webgl/material/perPixelLighting/sketch.js
@@ -1,8 +1,11 @@
 var teapot;
 
+function preload() {
+  teapot = loadModel('../wireframe/assets/teapot.obj', true);
+}
+
 function setup() {
   createCanvas(windowWidth, windowHeight, WEBGL);
-  teapot = loadModel('../wireframe/assets/teapot.obj', true);
   noStroke();
 }
 

--- a/test/manual-test-examples/webgl/material/perPixelLighting/sketch.js
+++ b/test/manual-test-examples/webgl/material/perPixelLighting/sketch.js
@@ -19,7 +19,7 @@ function draw() {
   var t = millis() / 1000 + 1000;
   background(0);
 
-  directionalLight(color('#111'), -1, -1, -1);
+  directionalLight(color('#111'), 1, 1, 1);
 
   for (var i = 0; i < lights.length; i++) {
     var light = lights[i];

--- a/test/manual-test-examples/webgl/material/wireframe/sketch.js
+++ b/test/manual-test-examples/webgl/material/wireframe/sketch.js
@@ -5,9 +5,12 @@
 
 var teapot;
 
+function preload() {
+  teapot = loadModel('../wireframe/assets/teapot.obj', true);
+}
+
 function setup() {
   createCanvas(windowWidth, windowHeight, WEBGL);
-  teapot = loadModel('assets/teapot.obj', true);
 }
 
 


### PR DESCRIPTION
`setAttributes('perPixelLighting', true)` enables use of a Phong specular lighting model.

before & after:
![image](https://user-images.githubusercontent.com/1088194/34323507-b0f12efc-e801-11e7-80f3-67f792b75e45.png)


this PR includes and relies on some other PRs:
- #2428 lighting-fixes
- #2433 implicit normals (for primitive geometry)
- #2446 fromAngles (for the getAttributes sample)

this PR should simplify significantly if those are merged first.