### PR TITLE
Add non-recursive array flattening for larger models

### DIFF
--- a/src/webgl/p5.RendererGL.js
+++ b/src/webgl/p5.RendererGL.js
@@ -940,7 +940,30 @@ p5.RendererGL.prototype._bindBuffer = function(
  */
 p5.RendererGL.prototype._flatten = function(arr) {
   if (arr.length > 0) {
-    return [].concat.apply([], arr);
+    //big models , load slower to avoid stack overflow
+    //non-recursive flatten via axelduch
+    //stackoverflow.com/questions/27266550/how-to-flatten-nested-array-in-javascript
+    if (arr.length > 20000) {
+      var toString = Object.prototype.toString;
+      var arrayTypeStr = '[object Array]';
+      var result = [];
+      var nodes = arr.slice();
+      var node;
+      node = nodes.pop();
+      do {
+        if (toString.call(node) === arrayTypeStr) {
+          nodes.push.apply(nodes, node);
+        } else {
+          result.push(node);
+        }
+      } while (nodes.length && (node = nodes.pop()) !== undefined);
+      result.reverse(); // we reverse result to restore the original order
+      return result;
+    } else {
+      //otherwise if model within limits for browser
+      //use faster loading
+      return [].concat.apply([], arr);
+    }
   } else {
     return [];
   }


### PR DESCRIPTION
When the model or obj is dense does non-recursive flattening of the model vertices arrays instead to avoid stack overflow. This loading method is slower but necessary for bigger models. Tested loading models with 30k+ vertices.

closes #2263 
