### PR TITLE
docs: added examples for p5.Element.class

### DIFF
--- a/src/core/p5.Element.js
+++ b/src/core/p5.Element.js
@@ -167,16 +167,16 @@ p5.Element.prototype.id = function(id) {
  * function setup() {
  *   createP('No matter how small.')
  *      .class('seuss')
- *      .mousePressed(clicked);
+ *      .mousePressed(pressed);
  *   createP("But someone, I ain't sayin' who, Has got a guilty face.")
  *      .class('shel')
- *      .mousePressed(clicked);
+ *      .mousePressed(pressed);
  * }
  *
- * function clicked() {
+ * function pressed() {
  *  // `this` refers to the clicked element
- *  // Sets the class name to the clicked element's name plus '-clicked'
- *  this.class(this.class() + '-clicked');
+ *  // Sets the class name to the pressed element's name plus '-pressed'
+ *  this.class(this.class() + '-pressed');
  * }
  * </code>
  * </div>
@@ -188,7 +188,6 @@ p5.Element.prototype.id = function(id) {
 /**
  * @method class
  * @return {String} the class of the element
- *
  */
 p5.Element.prototype.class = function(c) {
   if (arguments.length === 0) {

--- a/src/core/p5.Element.js
+++ b/src/core/p5.Element.js
@@ -145,10 +145,50 @@ p5.Element.prototype.id = function(id) {
  * @method class
  * @param  {String} class class to add
  * @chainable
+ *
+ * @example
+ * <div class='norender'>
+ * <code>
+ * function setup() {
+ *   const personText = createP("A person's a person");
+ *   personText.class('seuss');
+ *   createP('No matter how small.').class('seuss');
+ * }
+ * </code>
+ * </div>
+ *
+ * @alt
+ * no display.
+ *
+ *
+ * @example
+ * <div class='norender'>
+ * <code>
+ * function setup() {
+ *   createP('No matter how small.')
+ *      .class('seuss')
+ *      .mousePressed(clicked);
+ *   createP("But someone, I ain't sayin' who, Has got a guilty face.")
+ *      .class('shel')
+ *      .mousePressed(clicked);
+ * }
+ *
+ * function clicked() {
+ *  // `this` refers to the clicked element
+ *  // Sets the class name to the clicked element's name plus '-clicked'
+ *  this.class(this.class() + '-clicked');
+ * }
+ * </code>
+ * </div>
+ *
+ * @alt
+ * no display.
  */
+
 /**
  * @method class
  * @return {String} the class of the element
+ *
  */
 p5.Element.prototype.class = function(c) {
   if (arguments.length === 0) {

--- a/src/core/p5.Element.js
+++ b/src/core/p5.Element.js
@@ -165,16 +165,12 @@ p5.Element.prototype.id = function(id) {
  * <div class='norender'>
  * <code>
  * function setup() {
- *   createP('No matter how small.').
- *      class('seuss').
- *      mousePressed(pressed);
- *   createP("But someone, I ain't sayin' who, Has got a guilty face.").
- *      class('shel').
- *      mousePressed(pressed);
+ *   createP('No matter how small.').class('seuss').mousePressed(pressed);
+ *   createP("But someone, I ain't sayin' who, Has got a guilty face.").class('shel').mousePressed(pressed);
  * }
  *
  * function pressed() {
- *  // `this` refers to the clicked element
+ *  // `this` refers to the clicked element.
  *  // Sets the class name to the pressed element's name plus '-pressed'
  *  this.class(this.class() + '-pressed');
  * }

--- a/src/core/p5.Element.js
+++ b/src/core/p5.Element.js
@@ -165,12 +165,12 @@ p5.Element.prototype.id = function(id) {
  * <div class='norender'>
  * <code>
  * function setup() {
- *   createP('No matter how small.')
- *      .class('seuss')
- *      .mousePressed(pressed);
- *   createP("But someone, I ain't sayin' who, Has got a guilty face.")
- *      .class('shel')
- *      .mousePressed(pressed);
+ *   createP('No matter how small.').
+ *      class('seuss').
+ *      mousePressed(pressed);
+ *   createP("But someone, I ain't sayin' who, Has got a guilty face.").
+ *      class('shel').
+ *      mousePressed(pressed);
  * }
  *
  * function pressed() {


### PR DESCRIPTION
Adding two examples for `p5.Element.class` as listed here: #1954 🎊

Perhaps note in `pressed` doesn't belong here but I thought it was a nice way to show a way the zero-args overload was useful. Could make it more useful with `add/removeClass`
 