### PR TITLE
Gitattributes

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -11,7 +11,5 @@ indent_style = space
 indent_size = 2
 # No trailing spaces
 trim_trailing_whitespace = true
-# Unix-style newlines
-end_of_line = lf
 # Newline ending every file
 insert_final_newline = true

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+# Let git decide if a file is text or binary
+* text=auto


### PR DESCRIPTION
Adds .gitattributes to ensure that everyone performs automatic EOL conversion.
Also removes the line endings setting from the editorconfig, since it should be platform specific.
Replaces https://github.com/processing/p5.js/pull/2431.

I'll also add to the development wiki that Windows users are recommended to perform their pull requests using `git clone git@github.com:YOUR_USERNAME/p5.js.git --config core.autocrlf=true`. With the default command, a user like me could have accidentally turned off autocrlf. Having autocrlf off means that sample-linter breaks.

@Spongman looks OK?
Any precommit hook or similar that can ensure no CRLF gets commited?