### PR TITLE
fix fill/stroke order bug

### DIFF
--- a/src/color/setting.js
+++ b/src/color/setting.js
@@ -507,7 +507,7 @@ p5.prototype.fill = function() {
  * </code>
  * </div>
  *
- * <div>
+ * <div modernizr='webgl'>
  * <code>
  * function setup() {
  *   createCanvas(100, 100, WEBGL);
@@ -547,7 +547,7 @@ p5.prototype.noFill = function() {
  * </code>
  * </div>
  *
- * <div>
+ * <div modernizr='webgl'>
  * <code>
  * function setup() {
  *   createCanvas(100, 100, WEBGL);

--- a/src/color/setting.js
+++ b/src/color/setting.js
@@ -506,13 +506,29 @@ p5.prototype.fill = function() {
  * rect(20, 20, 60, 60);
  * </code>
  * </div>
+ *
+ * <div>
+ * <code>
+ * function setup() {
+ *   createCanvas(100, 100, WEBGL);
+ * }
+ *
+ * function draw() {
+ *   background(0);
+ *   noFill();
+ *   stroke(100, 100, 240);
+ *   rotateX(frameCount * 0.01);
+ *   rotateY(frameCount * 0.01);
+ *   box(45, 45, 45);
+ * }
+ * </code>
+ * </div>
+ *
  * @alt
  * white rect top middle and noFill rect center. Both 60x60 with black outlines.
+ * black canvas with purple cube wireframe spinning
  */
 p5.prototype.noFill = function() {
-  if (this._renderer.isP3D) {
-    this._renderer.noFill();
-  }
   this._renderer._setProperty('_doFill', false);
   return this;
 };
@@ -531,16 +547,28 @@ p5.prototype.noFill = function() {
  * </code>
  * </div>
  *
+ * <div>
+ * <code>
+ * function setup() {
+ *   createCanvas(100, 100, WEBGL);
+ * }
+ *
+ * function draw() {
+ *   background(0);
+ *   noStroke();
+ *   fill(240, 150, 150);
+ *   rotateX(frameCount * 0.01);
+ *   rotateY(frameCount * 0.01);
+ *   box(45, 45, 45);
+ * }
+ * </code>
+ * </div>
  *
  * @alt
- *60x60 white rect at center. no outline.
- *
+ * 60x60 white rect at center. no outline.
+ * black canvas with pink cube spinning
  */
-
 p5.prototype.noStroke = function() {
-  if (this._renderer.isP3D) {
-    this._renderer.noStroke();
-  }
   this._renderer._setProperty('_doStroke', false);
   return this;
 };

--- a/src/webgl/material.js
+++ b/src/webgl/material.js
@@ -170,7 +170,8 @@ p5.prototype.shader = function(s) {
 p5.prototype.normalMaterial = function() {
   this._renderer.drawMode = constants.FILL;
   this._renderer.setFillShader(this._renderer._getNormalShader());
-  this._renderer.noStroke();
+  this._renderer.curFillColor = [1, 1, 1, 1];
+  this.noStroke();
   return this;
 };
 
@@ -262,7 +263,7 @@ p5.prototype.texture = function(tex) {
   shader.setUniform('uSpecular', false);
   shader.setUniform('isTexture', true);
   shader.setUniform('uSampler', tex);
-  this._renderer.noStroke();
+  this.noStroke();
   return this;
 };
 
@@ -303,10 +304,11 @@ p5.prototype.texture = function(tex) {
  * @chainable
  */
 p5.prototype.ambientMaterial = function(v1, v2, v3, a) {
-  var colors = this._renderer._applyColorBlend.apply(this._renderer, arguments);
+  var color = p5.prototype.color.apply(this, arguments);
+  this._renderer.curFillColor = color._array;
 
   var shader = this._renderer._useLightShader();
-  shader.setUniform('uMaterialColor', colors);
+  shader.setUniform('uMaterialColor', this._renderer.curFillColor);
   shader.setUniform('uSpecular', false);
   shader.setUniform('isTexture', false);
   return this;
@@ -349,10 +351,11 @@ p5.prototype.ambientMaterial = function(v1, v2, v3, a) {
  * @chainable
  */
 p5.prototype.specularMaterial = function(v1, v2, v3, a) {
-  var colors = this._renderer._applyColorBlend.apply(this._renderer, arguments);
+  var color = p5.prototype.color.apply(this, arguments);
+  this._renderer.curFillColor = color._array;
 
   var shader = this._renderer._useLightShader();
-  shader.setUniform('uMaterialColor', colors);
+  shader.setUniform('uMaterialColor', this._renderer.curFillColor);
   shader.setUniform('uSpecular', true);
   shader.setUniform('isTexture', false);
   return this;
@@ -362,16 +365,11 @@ p5.prototype.specularMaterial = function(v1, v2, v3, a) {
  * @private blends colors according to color components.
  * If alpha value is less than 1, we need to enable blending
  * on our gl context.  Otherwise opaque objects need to a depthMask.
- * @param  {Number} v1 [description]
- * @param  {Number} v2 [description]
- * @param  {Number} v3 [description]
- * @param  {Number} a  [description]
- * @return {[Number]}  Normalized numbers array
+ * @param  {Number[]} color [description]
+ * @return {Number[]]}  Normalized numbers array
  */
-p5.RendererGL.prototype._applyColorBlend = function(v1, v2, v3, a) {
+p5.RendererGL.prototype._applyColorBlend = function(colors) {
   var gl = this.GL;
-  var color = this._pInst.color.apply(this._pInst, arguments);
-  var colors = color._array;
   if (colors[colors.length - 1] < 1.0) {
     gl.depthMask(false);
     gl.enable(gl.BLEND);

--- a/src/webgl/p5.RendererGL.Immediate.js
+++ b/src/webgl/p5.RendererGL.Immediate.js
@@ -115,7 +115,7 @@ p5.RendererGL.prototype.endShape = function(
 ) {
   this._useImmediateModeShader();
 
-  if (this.curStrokeShader.active === true) {
+  if (this._doStroke && this.drawMode !== constants.TEXTURE) {
     for (var i = 0; i < this.immediateMode.vertices.length - 1; i++) {
       this.immediateMode.edges.push([i, i + 1]);
     }
@@ -129,7 +129,7 @@ p5.RendererGL.prototype.endShape = function(
     this._edgesToVertices(this.immediateMode);
     this._drawStrokeImmediateMode();
   }
-  if (this.curFillShader.active === true) {
+  if (this._doFill) {
     this._drawFillImmediateMode(
       mode,
       isCurve,
@@ -258,6 +258,7 @@ p5.RendererGL.prototype._drawFillImmediateMode = function(
         ' not yet implemented in webgl mode.'
     );
   } else {
+    this._applyColorBlend(this.curFillColor);
     gl.enable(gl.BLEND);
     gl.drawArrays(
       this.immediateMode.shapeMode,
@@ -312,6 +313,7 @@ p5.RendererGL.prototype._drawStrokeImmediateMode = function() {
     );
   }
 
+  this._applyColorBlend(this.curStrokeColor);
   gl.drawArrays(gl.TRIANGLES, 0, this.immediateMode.lineVertices.length);
 
   // todo / optimizations? leave bound until another shader is set?

--- a/src/webgl/p5.RendererGL.Retained.js
+++ b/src/webgl/p5.RendererGL.Retained.js
@@ -200,7 +200,7 @@ p5.RendererGL.prototype.drawBuffers = function(gId) {
   this._useColorShader();
   var geometry = this.gHash[gId];
 
-  if (this.curStrokeShader.active !== false && geometry.lineVertexCount > 0) {
+  if (this._doStroke && geometry.lineVertexCount > 0) {
     this.curStrokeShader.bindShader();
 
     // bind the stroke shader's 'aPosition' buffer
@@ -229,11 +229,12 @@ p5.RendererGL.prototype.drawBuffers = function(gId) {
       );
     }
 
+    this._applyColorBlend(this.curStrokeColor);
     this._drawArrays(gl.TRIANGLES, gId);
     this.curStrokeShader.unbindShader();
   }
 
-  if (this.curFillShader.active !== false) {
+  if (this._doFill !== false) {
     this.curFillShader.bindShader();
 
     // bind the fill shader's 'aPosition' buffer
@@ -282,6 +283,7 @@ p5.RendererGL.prototype.drawBuffers = function(gId) {
       );
     }
 
+    this._applyColorBlend(this.curFillColor);
     this._drawElements(gl.TRIANGLES, gId);
     this.curFillShader.unbindShader();
   }

--- a/test/unit/webgl/stroke.js
+++ b/test/unit/webgl/stroke.js
@@ -34,21 +34,21 @@ suite('stroke WebGL', function() {
     test('check activate and deactivating fill and stroke', function(done) {
       myp5.noStroke();
       assert(
-        myp5._renderer.curStrokeShader.active === false,
+        !myp5._renderer._doStroke,
         'stroke shader still active after noStroke()'
       );
       assert.isTrue(
-        myp5._renderer.curFillShader.active === true,
+        myp5._renderer._doFill,
         'fill shader deactivated by noStroke()'
       );
       myp5.stroke(0);
       myp5.noFill();
       assert(
-        myp5._renderer.curStrokeShader.active === true,
+        myp5._renderer._doStroke,
         'stroke shader not active after stroke()'
       );
       assert.isTrue(
-        myp5._renderer.curFillShader.active === false,
+        myp5._renderer._doFill,
         'fill shader still active after noFill()'
       );
       done();


### PR DESCRIPTION
this PR:
- removed the `shader.active` flag which was getting out of sync, and just uses the existing `_doFill`/`_doStroke` style properties instead.
- removed the redundant GL-specific `noFill`/`noStroke` methods.
- delays setting the blend stuff until just before the draw call (since it's a global setting shared between fill & edge shaders).
- removes some of the unnecessary `useProgram`s
- fixes #2509
  