### PR TITLE
loadPixels cleanup

### DIFF
--- a/src/webgl/p5.RendererGL.js
+++ b/src/webgl/p5.RendererGL.js
@@ -624,7 +624,7 @@ p5.RendererGL.prototype.loadPixels = function() {
   h *= pd;
   //if there isn't a renderer-level temporary pixels buffer
   //make a new one
-  if (this.pixels === undefined) {
+  if (typeof this.pixels === 'undefined') {
     this.pixels = new Uint8Array(
       this.GL.drawingBufferWidth * this.GL.drawingBufferHeight * 4
     );
@@ -672,7 +672,7 @@ p5.RendererGL.prototype.resize = function(w, h) {
     this._setDefaultCamera();
   }
   //resize pixels buffer
-  if (this.pixels !== undefined) {
+  if (typeof this.pixels !== 'undefined') {
     this.pixels = new Uint8Array(
       this.GL.drawingBufferWidth * this.GL.drawingBufferHeight * 4
     );

--- a/src/webgl/p5.RendererGL.js
+++ b/src/webgl/p5.RendererGL.js
@@ -604,10 +604,6 @@ p5.RendererGL.prototype.get = function(x, y, w, h) {
  * Any pixel manipulation must be done directly to the pixels[] array.
  *
  * @method loadPixels
- * @param {Number} [x] starting pixel x position, defaults to 0
- * @param {Number} [y] starting pixel y position, defaults to 0
- * @param {Number} [w] width of pixels to load, defaults to sketch width
- * @param {Number} [h] height of pixels to load, defaults to sketch height
  *
  */
 
@@ -620,17 +616,29 @@ p5.RendererGL.prototype.loadPixels = function() {
     return;
   }
   var pd = this._pInst._pixelDensity;
-  var x = arguments[0] || 0;
-  var y = arguments[1] || 0;
-  var w = arguments[2] || this.width;
-  var h = arguments[3] || this.height;
+  var x = 0;
+  var y = 0;
+  var w = this.width;
+  var h = this.height;
   w *= pd;
   h *= pd;
-  var pixels = new Uint8Array(
-    this.GL.drawingBufferWidth * this.GL.drawingBufferHeight * 4
+  //if there isn't a renderer-level temporary pixels buffer
+  //make a new one
+  if (this.pixels === undefined) {
+    this.pixels = new Uint8Array(
+      this.GL.drawingBufferWidth * this.GL.drawingBufferHeight * 4
+    );
+  }
+  this.GL.readPixels(
+    x,
+    y,
+    w,
+    h,
+    this.GL.RGBA,
+    this.GL.UNSIGNED_BYTE,
+    this.pixels
   );
-  this.GL.readPixels(x, y, w, h, this.GL.RGBA, this.GL.UNSIGNED_BYTE, pixels);
-  this._pInst._setProperty('pixels', pixels);
+  this._pInst._setProperty('pixels', this.pixels);
 };
 
 //////////////////////////////////////////////
@@ -662,6 +670,12 @@ p5.RendererGL.prototype.resize = function(w, h) {
     // camera defaults are dependent on the width & height of the screen,
     // so we'll want to update them if the size of the screen changes.
     this._setDefaultCamera();
+  }
+  //resize pixels buffer
+  if (this.pixels !== undefined) {
+    this.pixels = new Uint8Array(
+      this.GL.drawingBufferWidth * this.GL.drawingBufferHeight * 4
+    );
   }
 };
 


### PR DESCRIPTION
Okay actually just had a second to glance over this and I remembered that the reason that `gl.readPixels` doesn't deposit data directly into the p5 instance's `pixels` is because it needs to write into a Uint8Array. So instead of making a renderer-level `pixels` that would need to be resized with calls to `loadPixels` I just opted for temporary array creation but now I realize that GC would be slow for an array of that size if it is being created and discarded rapidly.

So this PR adds a renderer-level array buffer for grabbing pixel data from the GL drawing context before pushing it up to `_pInst`'s pixels array. This also gets rid of the x, y, width, height parameters for `loadPixels`. It would be possible to check if the array needs to be resized based on the arguments but just grabbing the whole canvas at once in the same way as the 2D renderer seems better for simplicity.

closes #2539 