### PR TITLE
Render pipeline changes

### DIFF
--- a/src/core/2d_primitives.js
+++ b/src/core/2d_primitives.js
@@ -231,15 +231,7 @@ p5.prototype.ellipse = function(x, y, w, h, detailX) {
  * @param  {Number} z2 the z-coordinate of the second point
  * @chainable
  */
-p5.prototype.line = function() {
-  p5._validateParameters('line', arguments);
-
-  if (this._renderer._doStroke) {
-    this._renderer.line.apply(this._renderer, arguments);
-  }
-
-  return this;
-};
+// see thunkRendererMethods
 
 /**
  * Draws a point, a coordinate in space at the dimension of one pixel.
@@ -266,15 +258,7 @@ p5.prototype.line = function() {
  *4 points centered in the middle-right of the canvas.
  *
  */
-p5.prototype.point = function() {
-  p5._validateParameters('point', arguments);
-
-  if (this._renderer._doStroke) {
-    this._renderer.point.apply(this._renderer, arguments);
-  }
-
-  return this;
-};
+// see thunkRendererMethods
 
 /**
  * Draw a quad. A quad is a quadrilateral, a four sided polygon. It is
@@ -320,15 +304,7 @@ p5.prototype.point = function() {
  * @param {Number} z4
  * @chainable
  */
-p5.prototype.quad = function() {
-  p5._validateParameters('quad', arguments);
-
-  if (this._renderer._doStroke || this._renderer._doFill) {
-    this._renderer.quad.apply(this._renderer, arguments);
-  }
-
-  return this;
-};
+// see thunkRendererMethods
 
 /**
  * Draws a rectangle to the screen. A rectangle is a four-sided shape with
@@ -390,16 +366,7 @@ p5.prototype.quad = function() {
  * @param  {Integer} [detailY] number of segments in the y-direction
  * @chainable
  */
-p5.prototype.rect = function(x, y, w, h, detailX, detailY) {
-  p5._validateParameters('rect', arguments);
-
-  if (this._renderer._doStroke || this._renderer._doFill) {
-    var vals = canvas.modeAdjust(x, y, w, h, this._renderer._rectMode);
-    this._renderer.rect([vals.x, vals.y, vals.w, vals.h, detailX, detailY]);
-  }
-
-  return this;
-};
+// see thunkRendererMethods
 
 /**
  * A triangle is a plane created by connecting three points. The first two
@@ -425,14 +392,6 @@ p5.prototype.rect = function(x, y, w, h, detailX, detailY) {
  * white triangle with black outline in mid-right of canvas.
  *
  */
-p5.prototype.triangle = function() {
-  p5._validateParameters('triangle', arguments);
-
-  if (this._renderer._doStroke || this._renderer._doFill) {
-    this._renderer.triangle(arguments);
-  }
-
-  return this;
-};
+// see thunkRendererMethods
 
 module.exports = p5;

--- a/src/core/attributes.js
+++ b/src/core/attributes.js
@@ -103,10 +103,6 @@ p5.prototype.ellipseMode = function(m) {
  * 2 pixelated 36x36 white ellipses to left & right of center, black background
  *
  */
-p5.prototype.noSmooth = function() {
-  this._renderer.noSmooth();
-  return this;
-};
 
 /**
  * Modifies the location from which rectangles are drawn by changing the way
@@ -201,10 +197,7 @@ p5.prototype.rectMode = function(m) {
  * 2 pixelated 36x36 white ellipses one left one right of center. On black.
  *
  */
-p5.prototype.smooth = function() {
-  this._renderer.smooth();
-  return this;
-};
+// see thunkRendererMethods
 
 /**
  * Sets the style for rendering line endings. These ends are either squared,
@@ -231,17 +224,7 @@ p5.prototype.smooth = function() {
  * 3 lines. Top line: rounded ends, mid: squared, bottom:longer squared ends.
  *
  */
-p5.prototype.strokeCap = function(cap) {
-  p5._validateParameters('strokeCap', arguments);
-  if (
-    cap === constants.ROUND ||
-    cap === constants.SQUARE ||
-    cap === constants.PROJECT
-  ) {
-    this._renderer.strokeCap(cap);
-  }
-  return this;
-};
+// see thunkRendererMethods
 
 /**
  * Sets the style of the joints which connect line segments. These joints
@@ -298,17 +281,7 @@ p5.prototype.strokeCap = function(cap) {
  * Right-facing arrowhead shape with rounded tip in center of canvas.
  *
  */
-p5.prototype.strokeJoin = function(join) {
-  p5._validateParameters('strokeJoin', arguments);
-  if (
-    join === constants.ROUND ||
-    join === constants.BEVEL ||
-    join === constants.MITER
-  ) {
-    this._renderer.strokeJoin(join);
-  }
-  return this;
-};
+// see thunkRendererMethods
 
 /**
  * Sets the width of the stroke used for lines, points, and the border
@@ -333,10 +306,6 @@ p5.prototype.strokeJoin = function(join) {
  * 3 horizontal black lines. Top line: thin, mid: medium, bottom:thick.
  *
  */
-p5.prototype.strokeWeight = function(w) {
-  p5._validateParameters('strokeWeight', arguments);
-  this._renderer.strokeWeight(w);
-  return this;
-};
+// see thunkRendererMethods
 
 module.exports = p5;

--- a/src/core/curves.js
+++ b/src/core/curves.js
@@ -79,15 +79,7 @@ require('./error_helpers');
  * @param  {Number} z4 z-coordinate for the second anchor point
  * @chainable
  */
-p5.prototype.bezier = function() {
-  p5._validateParameters('bezier', arguments);
-
-  if (this._renderer._doStroke || this._renderer._doFill) {
-    this._renderer.bezier.apply(this._renderer, arguments);
-  }
-
-  return this;
-};
+// see thunkRendererMethods
 
 /**
  * Sets the resolution at which Beziers display.
@@ -331,15 +323,7 @@ p5.prototype.bezierTangent = function(a, b, c, d, t) {
  * @param  {Number} z4 z-coordinate for the ending control point
  * @chainable
  */
-p5.prototype.curve = function() {
-  p5._validateParameters('curve', arguments);
-
-  if (this._renderer._doStroke) {
-    this._renderer.curve.apply(this._renderer, arguments);
-  }
-
-  return this;
-};
+// see thunkRendererMethods
 
 /**
  * Sets the resolution at which curves display.

--- a/src/core/error_helpers.js
+++ b/src/core/error_helpers.js
@@ -160,15 +160,24 @@ if (typeof IS_MINIFIED !== 'undefined') {
   // lookupParamDoc() for querying data.json
   var lookupParamDoc = function(func) {
     var queryResult = arrDoc.classitems.filter(function(x) {
-      return x.name === func;
+      return x.name === func && x.class === 'p5';
     });
+    if (!queryResult.length) {
+      queryResult = arrDoc.classitems.filter(function(x) {
+        return x.name === func;
+      });
+    }
+    if (!queryResult.length) {
+      return null;
+    }
+
     // different JSON structure for funct with multi-format
     var overloads = [];
     if (queryResult[0].hasOwnProperty('overloads')) {
       for (var i = 0; i < queryResult[0].overloads.length; i++) {
         overloads.push(queryResult[0].overloads[i].params);
       }
-    } else {
+    } else if (queryResult[0].params) {
       overloads.push(queryResult[0].params);
     }
 
@@ -424,7 +433,14 @@ if (typeof IS_MINIFIED !== 'undefined') {
       return; // skip FES
     }
 
-    var docs = docCache[func] || (docCache[func] = lookupParamDoc(func));
+    var docs = docCache[func];
+    if (typeof docs === 'undefined') {
+      docs = docCache[func] = lookupParamDoc(func);
+    }
+    if (docs === null) {
+      return;
+    }
+
     var errorArray = [];
     var minErrCount = 999999;
     var overloads = docs.overloads;

--- a/src/core/init.js
+++ b/src/core/init.js
@@ -2,6 +2,79 @@
 
 var p5 = require('../core/core');
 
+(function thunkRendererMethods() {
+  // prettier-ignore
+  var rendererMethods = [
+    // attributes.js
+    'noSmooth', 'smooth', 'strokeCap', 'strokeJoin', 'strokeWeight',
+    // 2d_primitives.js
+    'line', 'point', 'quad', 'rect', 'triangle',
+    // curves.js
+    'bezier', 'curve',
+    // vertex.js
+    'normal', 'vertex', 'bezierVertex', 'beginShape',
+    // pixels.js
+    'copy', 'loadPixels', 'get', 'set', 'updatePixels',
+    // transform.js
+    'applyMatrix', 'resetMatrix', 'rotate', 'rotateX', 'rotateY', 'rotateZ',
+    'translate', 'shearX', 'shearY',
+    // typography/attributes.js
+    'textAlign', 'textLeading', 'textSize', 'textStyle', 'textWidth',
+    'textAscent', 'textDescent' /*"_updateTextMetrics", */,
+    // typography/loading_displaying.js
+    'text',
+    // webgl/p5.RendererGL.js 
+    'setAttributes',
+    // webgl/lights.js 
+    'lights', 'noLights', 'lightSpecular', 'lightFalloff', 'ambientLight',
+    'directionalLight', 'pointLight',
+    // webgl/camera.js 
+    'perspective', 'camera', 'ortho',
+    // webgl/loading.js 
+    'model',
+    // webgl/material.js 
+    'shader', 'normalMaterial', 'texture', 'ambient', 'ambientMaterial',
+    'specular', 'specularMaterial', 'shininess', 'resetShader',
+    'createShader',
+    // webgl/primitives.js 
+    'plane', 'box', 'sphere', 'cylinder', 'cone', 'ellipsoid', 'torus',
+    // webgl/interaction.js
+    'orbitControl'
+  ];
+  var rendererPrototype = p5.Renderer.prototype;
+  for (var im = 0; im < rendererMethods.length; im++) {
+    var m = rendererMethods[im];
+
+    if (typeof IS_MINIFIED === 'undefined' && p5.prototype[m]) {
+      console.warn('p5.' + m + '() already defined!');
+    }
+
+    // create the proxy in p5 that calls into the _renderer
+    p5.prototype[m] = (function(m) {
+      return function() {
+        // validate the parameters
+        p5._validateParameters(m, arguments);
+
+        // thunk through to the underlying renderer method
+        var ret = this._renderer[m].apply(this._renderer, arguments);
+
+        // if the renderer returned 'undefined', method is chainable
+        if (typeof ret === 'undefined') ret = this;
+        return ret;
+      };
+    })(m);
+
+    // add an unimplemented warning in the base class
+    if (!rendererPrototype.hasOwnProperty(m)) {
+      rendererPrototype[m] = (function(m) {
+        return function() {
+          console.warn(m + '() is not supported in this rendering mode.');
+        };
+      })(m);
+    }
+  }
+})();
+
 /**
  * _globalInit
  *

--- a/src/core/p5.Renderer.js
+++ b/src/core/p5.Renderer.js
@@ -60,6 +60,56 @@ p5.Renderer = function(elt, pInst, isMainCanvas) {
 
 p5.Renderer.prototype = Object.create(p5.Element.prototype);
 
+// the renderer should return a 'style' object that it wishes to
+// store on the push stack.
+p5.Renderer.prototype.push = function() {
+  return {
+    properties: {
+      _doStroke: this._doStroke,
+      _strokeSet: this._strokeSet,
+      _doFill: this._doFill,
+      _fillSet: this._fillSet,
+      _tint: this._tint,
+      _imageMode: this._imageMode,
+      _rectMode: this._rectMode,
+      _ellipseMode: this._ellipseMode,
+      _textFont: this._textFont,
+      _textLeading: this._textLeading,
+      _textSize: this._textSize,
+      _textStyle: this._textStyle
+    }
+  };
+};
+
+// this is implementation of Object.assign()
+// The assign() method is used to copy the values of all enumerable
+// own properties from one or more source objects to a target object.
+// It will return the target object.
+function assign(to, firstSource) {
+  for (var i = 1; i < arguments.length; i++) {
+    var nextSource = arguments[i];
+    if (nextSource === undefined || nextSource === null) {
+      continue;
+    }
+
+    for (var nextKey in nextSource)
+      if (nextSource.hasOwnProperty(nextKey)) {
+        to[nextKey] = nextSource[nextKey];
+      }
+  }
+  return to;
+}
+
+// a pop() operation is in progress
+// the renderer is passed the 'style' object that it returned
+// from its push() method.
+p5.Renderer.prototype.pop = function(style) {
+  if (style.properties) {
+    // copy the style properties back into the renderer
+    assign(this, style.properties);
+  }
+};
+
 /**
  * Resize our canvas element.
  */

--- a/src/core/p5.Renderer2D.js
+++ b/src/core/p5.Renderer2D.js
@@ -375,6 +375,12 @@ p5.Renderer2D.prototype.set = function(x, y, imgOrCol) {
 };
 
 p5.Renderer2D.prototype.updatePixels = function(x, y, w, h) {
+  if (this._pInst && this._pInst.pixels.length === 0) {
+    // graceful fail - if loadPixels() or set() has not been called, pixel
+    // array will be empty, ignore call to updatePixels()
+    return;
+  }
+
   var pd = this._pixelDensity || this._pInst._pixelDensity;
   if (
     x === undefined &&
@@ -534,13 +540,13 @@ p5.Renderer2D.prototype.ellipse = function(args) {
 };
 
 p5.Renderer2D.prototype.line = function(x1, y1, x2, y2) {
-  var ctx = this.drawingContext;
   if (!this._doStroke) {
     return this;
   } else if (this._getStroke() === styleEmpty) {
     return this;
   }
   // Translate the line by (0.5, 0.5) to draw it crisp
+  var ctx = this.drawingContext;
   if (ctx.lineWidth % 2 === 1) {
     ctx.translate(0.5, 0.5);
   }
@@ -555,12 +561,12 @@ p5.Renderer2D.prototype.line = function(x1, y1, x2, y2) {
 };
 
 p5.Renderer2D.prototype.point = function(x, y) {
-  var ctx = this.drawingContext;
   if (!this._doStroke) {
     return this;
   } else if (this._getStroke() === styleEmpty) {
     return this;
   }
+  var ctx = this.drawingContext;
   var s = this._getStroke();
   var f = this._getFill();
   x = Math.round(x);
@@ -578,7 +584,6 @@ p5.Renderer2D.prototype.point = function(x, y) {
 };
 
 p5.Renderer2D.prototype.quad = function(x1, y1, x2, y2, x3, y3, x4, y4) {
-  var ctx = this.drawingContext;
   var doFill = this._doFill,
     doStroke = this._doStroke;
   if (doFill && !doStroke) {
@@ -590,6 +595,7 @@ p5.Renderer2D.prototype.quad = function(x1, y1, x2, y2, x3, y3, x4, y4) {
       return this;
     }
   }
+  var ctx = this.drawingContext;
   ctx.beginPath();
   ctx.moveTo(x1, y1);
   ctx.lineTo(x2, y2);
@@ -605,15 +611,13 @@ p5.Renderer2D.prototype.quad = function(x1, y1, x2, y2, x3, y3, x4, y4) {
   return this;
 };
 
-p5.Renderer2D.prototype.rect = function(args) {
-  var x = args[0],
-    y = args[1],
-    w = args[2],
-    h = args[3],
-    tl = args[4],
-    tr = args[5],
-    br = args[6],
-    bl = args[7];
+p5.Renderer2D.prototype.rect = function(x, y, w, h, tl, tr, br, bl) {
+  var vals = canvas.modeAdjust(x, y, w, h, this._rectMode);
+  x = vals.x;
+  y = vals.y;
+  w = vals.w;
+  h = vals.h;
+
   var ctx = this.drawingContext;
   var doFill = this._doFill,
     doStroke = this._doStroke;
@@ -698,16 +702,9 @@ p5.Renderer2D.prototype.rect = function(args) {
   return this;
 };
 
-p5.Renderer2D.prototype.triangle = function(args) {
-  var ctx = this.drawingContext;
+p5.Renderer2D.prototype.triangle = function(x1, y1, x2, y2, x3, y3) {
   var doFill = this._doFill,
     doStroke = this._doStroke;
-  var x1 = args[0],
-    y1 = args[1];
-  var x2 = args[2],
-    y2 = args[3];
-  var x3 = args[4],
-    y3 = args[5];
   if (doFill && !doStroke) {
     if (this._getFill() === styleEmpty) {
       return this;
@@ -717,6 +714,7 @@ p5.Renderer2D.prototype.triangle = function(args) {
       return this;
     }
   }
+  var ctx = this.drawingContext;
   ctx.beginPath();
   ctx.moveTo(x1, y1);
   ctx.lineTo(x2, y2);
@@ -1070,21 +1068,25 @@ p5.Renderer2D.prototype._setStroke = function(strokeStyle) {
 // SHAPE | Curves
 //////////////////////////////////////////////
 p5.Renderer2D.prototype.bezier = function(x1, y1, x2, y2, x3, y3, x4, y4) {
+  if (!this._doStroke && !this._doFill) {
+    return;
+  }
   this._pInst.beginShape();
   this._pInst.vertex(x1, y1);
   this._pInst.bezierVertex(x2, y2, x3, y3, x4, y4);
   this._pInst.endShape();
-  return this;
 };
 
 p5.Renderer2D.prototype.curve = function(x1, y1, x2, y2, x3, y3, x4, y4) {
+  if (!this._doStroke && !this._doFill) {
+    return;
+  }
   this._pInst.beginShape();
   this._pInst.curveVertex(x1, y1);
   this._pInst.curveVertex(x2, y2);
   this._pInst.curveVertex(x3, y3);
   this._pInst.curveVertex(x4, y4);
   this._pInst.endShape();
-  return this;
 };
 
 //////////////////////////////////////////////
@@ -1118,8 +1120,8 @@ p5.Renderer2D.prototype.resetMatrix = function() {
   return this;
 };
 
-p5.Renderer2D.prototype.rotate = function(rad) {
-  this.drawingContext.rotate(rad);
+p5.Renderer2D.prototype.rotate = function(angle) {
+  this.drawingContext.rotate(this._pInst._toRadians(angle));
 };
 
 p5.Renderer2D.prototype.scale = function(x, y) {
@@ -1127,13 +1129,13 @@ p5.Renderer2D.prototype.scale = function(x, y) {
   return this;
 };
 
-p5.Renderer2D.prototype.shearX = function(rad) {
-  this.drawingContext.transform(1, 0, Math.tan(rad), 1, 0, 0);
+p5.Renderer2D.prototype.shearX = function(angle) {
+  this.drawingContext.transform(1, 0, this._pInst.tan(angle), 1, 0, 0);
   return this;
 };
 
-p5.Renderer2D.prototype.shearY = function(rad) {
-  this.drawingContext.transform(1, Math.tan(rad), 0, 1, 0, 0);
+p5.Renderer2D.prototype.shearY = function(angle) {
+  this.drawingContext.transform(1, this._pInst.tan(angle), 0, 1, 0, 0);
   return this;
 };
 
@@ -1302,6 +1304,9 @@ p5.Renderer2D.prototype._renderText = function(p, line, x, y, maxY) {
 };
 
 p5.Renderer2D.prototype.textWidth = function(s) {
+  if (s.length === 0) {
+    return 0;
+  }
   if (this._isOpenType()) {
     return this._textFont._textWidth(s, this._textSize);
   }

--- a/src/core/p5.Renderer2D.js
+++ b/src/core/p5.Renderer2D.js
@@ -1380,15 +1380,30 @@ p5.Renderer2D.prototype._applyTextProperties = function() {
 // STRUCTURE
 //////////////////////////////////////////////
 
+// a push() operation is in progress.
+// the renderer should return a 'style' object that it wishes to
+// store on the push stack.
+// derived renderers should call the base class' push() method
+// to fetch the base style object.
 p5.Renderer2D.prototype.push = function() {
   this.drawingContext.save();
+
+  // get the base renderer style
+  return p5.Renderer.prototype.push.apply(this);
 };
 
-p5.Renderer2D.prototype.pop = function() {
+// a pop() operation is in progress
+// the renderer is passed the 'style' object that it returned
+// from its push() method.
+// derived renderers should pass this object to their base
+// class' pop method
+p5.Renderer2D.prototype.pop = function(style) {
   this.drawingContext.restore();
   // Re-cache the fill / stroke state
   this._cachedFillStyle = this.drawingContext.fillStyle;
   this._cachedStrokeStyle = this.drawingContext.strokeStyle;
+
+  p5.Renderer.prototype.pop.call(this, style);
 };
 
 module.exports = p5.Renderer2D;

--- a/src/core/structure.js
+++ b/src/core/structure.js
@@ -186,25 +186,11 @@ function assign(dest, varArgs) {
  *
  */
 p5.prototype.push = function() {
-  this._renderer.push();
   this._styles.push({
     props: {
       _colorMode: this._colorMode
     },
-    renderer: {
-      _doStroke: this._renderer._doStroke,
-      _strokeSet: this._renderer._strokeSet,
-      _doFill: this._renderer._doFill,
-      _fillSet: this._renderer._fillSet,
-      _tint: this._renderer._tint,
-      _imageMode: this._renderer._imageMode,
-      _rectMode: this._renderer._rectMode,
-      _ellipseMode: this._renderer._ellipseMode,
-      _textFont: this._renderer._textFont,
-      _textLeading: this._renderer._textLeading,
-      _textSize: this._renderer._textSize,
-      _textStyle: this._renderer._textStyle
-    }
+    renderer: this._renderer.push()
   });
 };
 
@@ -265,10 +251,13 @@ p5.prototype.push = function() {
  *
  */
 p5.prototype.pop = function() {
-  this._renderer.pop();
-  var lastS = this._styles.pop();
-  assign(this._renderer, lastS.renderer);
-  assign(this, lastS.props);
+  var style = this._styles.pop();
+  if (style) {
+    this._renderer.pop(style.renderer);
+    assign(this, style.props);
+  } else {
+    console.warn('pop() was called without matching push()');
+  }
 };
 
 p5.prototype.pushStyle = function() {

--- a/src/core/transform.js
+++ b/src/core/transform.js
@@ -115,10 +115,7 @@ var p5 = require('./core');
  * A rectangle shearing
  *
  */
-p5.prototype.applyMatrix = function(a, b, c, d, e, f) {
-  this._renderer.applyMatrix(a, b, c, d, e, f);
-  return this;
-};
+// see thunkRendererMethods
 
 p5.prototype.popMatrix = function() {
   throw new Error('popMatrix() not used, see pop()');
@@ -153,10 +150,7 @@ p5.prototype.pushMatrix = function() {
  * A rotated retangle in the center with another at the top left corner
  *
  */
-p5.prototype.resetMatrix = function() {
-  this._renderer.resetMatrix();
-  return this;
-};
+// see thunkRendererMethods
 
 /**
  * Rotates a shape the amount specified by the angle parameter. This
@@ -192,11 +186,7 @@ p5.prototype.resetMatrix = function() {
  * white 52x52 rect with black outline at center rotated counter 45 degrees
  *
  */
-p5.prototype.rotate = function(angle, axis) {
-  p5._validateParameters('rotate', arguments);
-  this._renderer.rotate(this._toRadians(angle), axis);
-  return this;
-};
+// see thunkRendererMethods
 
 /**
  * Rotates around X axis.
@@ -221,15 +211,7 @@ p5.prototype.rotate = function(angle, axis) {
  * @alt
  * 3d box rotating around the x axis.
  */
-p5.prototype.rotateX = function(angle) {
-  p5._validateParameters('rotateX', arguments);
-  if (this._renderer.isP3D) {
-    this._renderer.rotateX(this._toRadians(angle));
-  } else {
-    throw 'not supported in p2d. Please use webgl mode';
-  }
-  return this;
-};
+// see thunkRendererMethods
 
 /**
  * Rotates around Y axis.
@@ -254,15 +236,7 @@ p5.prototype.rotateX = function(angle) {
  * @alt
  * 3d box rotating around the y axis.
  */
-p5.prototype.rotateY = function(angle) {
-  p5._validateParameters('rotateY', arguments);
-  if (this._renderer.isP3D) {
-    this._renderer.rotateY(this._toRadians(angle));
-  } else {
-    throw 'not supported in p2d. Please use webgl mode';
-  }
-  return this;
-};
+// see thunkRendererMethods
 
 /**
  * Rotates around Z axis. Webgl mode only.
@@ -287,15 +261,7 @@ p5.prototype.rotateY = function(angle) {
  * @alt
  * 3d box rotating around the z axis.
  */
-p5.prototype.rotateZ = function(angle) {
-  p5._validateParameters('rotateZ', arguments);
-  if (this._renderer.isP3D) {
-    this._renderer.rotateZ(this._toRadians(angle));
-  } else {
-    throw 'not supported in p2d. Please use webgl mode';
-  }
-  return this;
-};
+// see thunkRendererMethods
 
 /**
  * Increases or decreases the size of a shape by expanding and contracting
@@ -405,11 +371,7 @@ p5.prototype.scale = function(x, y, z) {
  * white irregular quadrilateral with black outline at top middle.
  *
  */
-p5.prototype.shearX = function(angle) {
-  p5._validateParameters('shearX', arguments);
-  this._renderer.shearX(this._toRadians(angle));
-  return this;
-};
+// see thunkRendererMethods
 
 /**
  * Shears a shape around the y-axis the amount specified by the angle
@@ -444,11 +406,7 @@ p5.prototype.shearX = function(angle) {
  * white irregular quadrilateral with black outline at middle bottom.
  *
  */
-p5.prototype.shearY = function(angle) {
-  p5._validateParameters('shearY', arguments);
-  this._renderer.shearY(this._toRadians(angle));
-  return this;
-};
+// see thunkRendererMethods
 
 /**
  * Specifies an amount to displace objects within the display window.
@@ -490,14 +448,6 @@ p5.prototype.shearY = function(angle) {
  * 3 white 55x55 rects with black outlines at top-l, center-r and bottom-r.
  *
  */
-p5.prototype.translate = function(x, y, z) {
-  p5._validateParameters('translate', arguments);
-  if (this._renderer.isP3D) {
-    this._renderer.translate(x, y, z);
-  } else {
-    this._renderer.translate(x, y);
-  }
-  return this;
-};
+// see thunkRendererMethods
 
 module.exports = p5;

--- a/src/core/vertex.js
+++ b/src/core/vertex.js
@@ -242,28 +242,24 @@ p5.prototype.beginContour = function() {
  * Thick white l-shape with black outline mid-top-left of canvas.
  *
  */
-p5.prototype.beginShape = function(kind) {
-  if (this._renderer.isP3D) {
-    this._renderer.beginShape.apply(this._renderer, arguments);
+// see thunkRendererMethods
+p5.Renderer2D.prototype.beginShape = function(kind) {
+  if (
+    kind === constants.POINTS ||
+    kind === constants.LINES ||
+    kind === constants.TRIANGLES ||
+    kind === constants.TRIANGLE_FAN ||
+    kind === constants.TRIANGLE_STRIP ||
+    kind === constants.QUADS ||
+    kind === constants.QUAD_STRIP
+  ) {
+    shapeKind = kind;
   } else {
-    if (
-      kind === constants.POINTS ||
-      kind === constants.LINES ||
-      kind === constants.TRIANGLES ||
-      kind === constants.TRIANGLE_FAN ||
-      kind === constants.TRIANGLE_STRIP ||
-      kind === constants.QUADS ||
-      kind === constants.QUAD_STRIP
-    ) {
-      shapeKind = kind;
-    } else {
-      shapeKind = null;
-    }
-
-    vertices = [];
-    contourVertices = [];
+    shapeKind = null;
   }
-  return this;
+
+  vertices = [];
+  contourVertices = [];
 };
 
 /**
@@ -312,8 +308,8 @@ p5.prototype.beginShape = function(kind) {
  * white crescent shape in middle of canvas. Points facing left.
  *
  */
-p5.prototype.bezierVertex = function(x2, y2, x3, y3, x4, y4) {
-  p5._validateParameters('bezierVertex', arguments);
+// see thunkRendererMethods
+p5.Renderer2D.prototype.bezierVertex = function(x2, y2, x3, y3, x4, y4) {
   if (vertices.length === 0) {
     throw 'vertex() must be used once before calling bezierVertex()';
   } else {
@@ -329,7 +325,6 @@ p5.prototype.bezierVertex = function(x2, y2, x3, y3, x4, y4) {
       vertices.push(vert);
     }
   }
-  return this;
 };
 
 /**
@@ -632,33 +627,29 @@ p5.prototype.quadraticVertex = function(cx, cy, x3, y3) {
  * @param  {Number} [u] the vertex's texture u-coordinate
  * @param  {Number} [v] the vertex's texture v-coordinate
  */
-p5.prototype.vertex = function(x, y, moveTo, u, v) {
-  if (this._renderer.isP3D) {
-    this._renderer.vertex.apply(this._renderer, arguments);
-  } else {
-    var vert = [];
-    vert.isVert = true;
-    vert[0] = x;
-    vert[1] = y;
-    vert[2] = 0;
-    vert[3] = 0;
-    vert[4] = 0;
-    vert[5] = this._renderer._getFill();
-    vert[6] = this._renderer._getStroke();
+// see thunkRendererMethods
+p5.Renderer2D.prototype.vertex = function(x, y, moveTo, u, v) {
+  var vert = [];
+  vert.isVert = true;
+  vert[0] = x;
+  vert[1] = y;
+  vert[2] = 0;
+  vert[3] = 0;
+  vert[4] = 0;
+  vert[5] = this._getFill();
+  vert[6] = this._getStroke();
 
-    if (moveTo) {
-      vert.moveTo = moveTo;
-    }
-    if (isContour) {
-      if (contourVertices.length === 0) {
-        vert.moveTo = true;
-      }
-      contourVertices.push(vert);
-    } else {
-      vertices.push(vert);
-    }
+  if (moveTo) {
+    vert.moveTo = moveTo;
   }
-  return this;
+  if (isContour) {
+    if (contourVertices.length === 0) {
+      vert.moveTo = true;
+    }
+    contourVertices.push(vert);
+  } else {
+    vertices.push(vert);
+  }
 };
 
 module.exports = p5;

--- a/src/image/loading_displaying.js
+++ b/src/image/loading_displaying.js
@@ -384,7 +384,7 @@ p5.prototype.image = function(
  */
 p5.prototype.tint = function() {
   p5._validateParameters('tint', arguments);
-  var c = this.color.apply(this, arguments);
+  var c = p5.prototype.color.apply(this, arguments);
   this._renderer._tint = c.levels;
 };
 

--- a/src/image/p5.Image.js
+++ b/src/image/p5.Image.js
@@ -368,8 +368,8 @@ p5.Image.prototype.get = function(x, y, w, h) {
  * @method set
  * @param {Number}              x x-coordinate of the pixel
  * @param {Number}              y y-coordinate of the pixel
- * @param {Number|Number[]|Object}   a grayscale value | pixel array |
- *                                a p5.Color | image to copy
+ * @param {Number|Number[]|p5.Color|p5.Image}   a grayscale value |
+ *                    pixel array | a p5.Color | image to copy
  * @example
  * <div>
  * <code>

--- a/src/image/pixels.js
+++ b/src/image/pixels.js
@@ -191,6 +191,7 @@ p5.prototype.blend = function() {
  * @param  {Integer} dy Y coordinate of the destination's upper left corner
  * @param  {Integer} dw destination image width
  * @param  {Integer} dh destination image height
+ * @chainable
  *
  * @example
  * <div><code>
@@ -226,11 +227,9 @@ p5.prototype.blend = function() {
  * @param  {Integer} dy
  * @param  {Integer} dw
  * @param  {Integer} dh
+ * @chainable
  */
-p5.prototype.copy = function() {
-  p5._validateParameters('copy', arguments);
-  p5.Renderer2D.prototype.copy.apply(this._renderer, arguments);
-};
+// see thunkRendererMethods
 
 /**
  * Applies a filter to the canvas.
@@ -482,9 +481,7 @@ p5.prototype.filter = function(operation, value) {
  * Image of the rocky mountains with 50x50 green rect in center of canvas
  *
  */
-p5.prototype.get = function(x, y, w, h) {
-  return this._renderer.get(x, y, w, h);
-};
+// see thunkRendererMethods
 
 /**
  * Loads the pixel data for the display window into the pixels[] array. This
@@ -493,6 +490,7 @@ p5.prototype.get = function(x, y, w, h) {
  * will occur.
  *
  * @method loadPixels
+ * @chainable
  * @example
  * <div>
  * <code>
@@ -518,9 +516,7 @@ p5.prototype.get = function(x, y, w, h) {
  * two images of the rocky mountains. one on top, one on bottom of canvas.
  *
  */
-p5.prototype.loadPixels = function() {
-  this._renderer.loadPixels();
-};
+// see thunkRendererMethods
 
 /**
  * <p>Changes the color of any pixel, or writes an image directly to the
@@ -546,8 +542,9 @@ p5.prototype.loadPixels = function() {
  * @method set
  * @param {Number}              x x-coordinate of the pixel
  * @param {Number}              y y-coordinate of the pixel
- * @param {Number|Number[]|Object} c insert a grayscale value | a pixel array |
- *                                a p5.Color object | a p5.Image to copy
+ * @param {Number|Number[]|p5.Color|p5.Image} c insert a grayscale value |
+ *                   a pixel array | a p5.Color object | a p5.Image to copy
+ * @chainable
  * @example
  * <div>
  * <code>
@@ -593,9 +590,8 @@ p5.prototype.loadPixels = function() {
  * square with orangey-brown gradient lightening at bottom right.
  * image of the rocky mountains. with lines like an 'x' through the center.
  */
-p5.prototype.set = function(x, y, imgOrCol) {
-  this._renderer.set(x, y, imgOrCol);
-};
+// see thunkRendererMethods
+
 /**
  * Updates the display window with the data in the pixels[] array.
  * Use in conjunction with loadPixels(). If you're only reading pixels from
@@ -634,13 +630,6 @@ p5.prototype.set = function(x, y, imgOrCol) {
  * @alt
  * two images of the rocky mountains. one on top, one on bottom of canvas.
  */
-p5.prototype.updatePixels = function(x, y, w, h) {
-  // graceful fail - if loadPixels() or set() has not been called, pixel
-  // array will be empty, ignore call to updatePixels()
-  if (this.pixels.length === 0) {
-    return;
-  }
-  this._renderer.updatePixels(x, y, w, h);
-};
+// see thunkRendererMethods
 
 module.exports = p5;

--- a/src/math/trigonometry.js
+++ b/src/math/trigonometry.js
@@ -289,9 +289,7 @@ p5.prototype.degrees = function(angle) {
  * </code>
  * </div>
  */
-p5.prototype.radians = function(angle) {
-  return polarGeometry.degreesToRadians(angle);
-};
+p5.prototype.radians = polarGeometry.degreesToRadians;
 
 /**
  * Sets the current mode of p5 to given mode. Default mode is RADIANS.

--- a/src/typography/attributes.js
+++ b/src/typography/attributes.js
@@ -52,9 +52,7 @@ var p5 = require('../core/core');
  * @method textAlign
  * @return {Object}
  */
-p5.prototype.textAlign = function(horizAlign, vertAlign) {
-  return this._renderer.textAlign.apply(this._renderer, arguments);
-};
+// see thunkRendererMethods
 
 /**
  * Sets/gets the spacing, in pixels, between lines of text. This
@@ -89,9 +87,7 @@ p5.prototype.textAlign = function(horizAlign, vertAlign) {
  * @method textLeading
  * @return {Number}
  */
-p5.prototype.textLeading = function(theLeading) {
-  return this._renderer.textLeading.apply(this._renderer, arguments);
-};
+// see thunkRendererMethods
 
 /**
  * Sets/gets the current font size. This size will be used in all subsequent
@@ -120,9 +116,7 @@ p5.prototype.textLeading = function(theLeading) {
  * @method textSize
  * @return {Number}
  */
-p5.prototype.textSize = function(theSize) {
-  return this._renderer.textSize.apply(this._renderer, arguments);
-};
+// see thunkRendererMethods
 
 /**
  * Sets/gets the style of the text for system fonts to NORMAL, ITALIC, or BOLD.
@@ -154,9 +148,7 @@ p5.prototype.textSize = function(theSize) {
  * @method textStyle
  * @return {String}
  */
-p5.prototype.textStyle = function(theStyle) {
-  return this._renderer.textStyle.apply(this._renderer, arguments);
-};
+// see thunkRendererMethods
 
 /**
  * Calculates and returns the width of any character or text string.
@@ -185,12 +177,7 @@ p5.prototype.textStyle = function(theStyle) {
  *Letter P and p5.js are displayed with vertical lines at end. P is wide
  *
  */
-p5.prototype.textWidth = function(theText) {
-  if (theText.length === 0) {
-    return 0;
-  }
-  return this._renderer.textWidth.apply(this._renderer, arguments);
-};
+// see thunkRendererMethods
 
 /**
  * Returns the ascent of the current font at its current size. The ascent
@@ -216,9 +203,7 @@ p5.prototype.textWidth = function(theText) {
  * </code>
  * </div>
  */
-p5.prototype.textAscent = function() {
-  return this._renderer.textAscent();
-};
+// see thunkRendererMethods
 
 /**
  * Returns the descent of the current font at its current size. The descent
@@ -244,9 +229,7 @@ p5.prototype.textAscent = function() {
  * </code>
  * </div>
  */
-p5.prototype.textDescent = function() {
-  return this._renderer.textDescent();
-};
+// see thunkRendererMethods
 
 /**
  * Helper function to measure ascent and descent.

--- a/src/typography/loading_displaying.js
+++ b/src/typography/loading_displaying.js
@@ -190,11 +190,7 @@ p5.prototype.loadFont = function(path, onSuccess, onError) {
  * The quick brown fox jumped over the lazy dog.
  *
  */
-p5.prototype.text = function(str, x, y, maxWidth, maxHeight) {
-  return !(this._renderer._doFill || this._renderer._doStroke)
-    ? this
-    : this._renderer.text.apply(this._renderer, arguments);
-};
+// see thunkRendererMethods
 
 /**
  * Sets the current font that will be drawn with the text() function.

--- a/src/webgl/camera.js
+++ b/src/webgl/camera.js
@@ -46,11 +46,7 @@ var p5 = require('../core/core');
  * blue square shrinks in size grows to fill canvas. disappears then loops.
  *
  */
-p5.prototype.camera = function() {
-  this._renderer.camera.apply(this._renderer, arguments);
-  return this;
-};
-
+// see thunkRendererMethods
 p5.RendererGL.prototype.camera = function(
   eyeX,
   eyeY,
@@ -153,7 +149,6 @@ p5.RendererGL.prototype.camera = function(
     this.cameraMatrix.mat4[14],
     this.cameraMatrix.mat4[15]
   );
-  return this;
 };
 
 /**
@@ -198,11 +193,7 @@ p5.RendererGL.prototype.camera = function(
  * colored 3d boxes toggleable with mouse position
  *
  */
-p5.prototype.perspective = function() {
-  this._renderer.perspective.apply(this._renderer, arguments);
-  return this;
-};
-
+// see thunkRendererMethods
 p5.RendererGL.prototype.perspective = function(fovy, aspect, near, far) {
   if (typeof fovy === 'undefined') {
     fovy = this.defaultCameraFOV;
@@ -275,11 +266,7 @@ p5.RendererGL.prototype.perspective = function(fovy, aspect, near, far) {
  * 3 3d boxes, reveal several more boxes on 3d plane when mouse used to toggle
  *
  */
-p5.prototype.ortho = function() {
-  this._renderer.ortho.apply(this._renderer, arguments);
-  return this;
-};
-
+// see thunkRendererMethods
 p5.RendererGL.prototype.ortho = function(left, right, bottom, top, near, far) {
   if (left === undefined) left = -this.width / 2;
   if (right === undefined) right = +this.width / 2;

--- a/src/webgl/interaction.js
+++ b/src/webgl/interaction.js
@@ -9,7 +9,7 @@ var p5 = require('../core/core');
  */
 //@TODO: implement full orbit controls including
 //pan, zoom, quaternion rotation, etc.
-p5.prototype.orbitControl = function() {
+p5.RendererGL.prototype.orbitControl = function() {
   if (this.mouseIsPressed) {
     this.rotateY((this.mouseX - this.width / 2) / (this.width / 2));
     this.rotateX((this.mouseY - this.height / 2) / (this.width / 2));

--- a/src/webgl/light.js
+++ b/src/webgl/light.js
@@ -231,7 +231,12 @@ p5.RendererGL.prototype.ambientLight = function(v1, v2, v3, a) {
  */
 p5.RendererGL.prototype.directionalLight = function(v1, v2, v3, x, y, z) {
   //@TODO: check parameters number
-  var color = p5.prototype.color.apply(this._pInst, [v1, v2, v3]);
+  var color;
+  if (v1 instanceof p5.Color) {
+    color = v1;
+  } else {
+    color = this._pInst.color(v1, v2, v3);
+  }
 
   var _x, _y, _z;
   var v = arguments[arguments.length - 1];
@@ -326,7 +331,12 @@ p5.RendererGL.prototype.directionalLight = function(v1, v2, v3, x, y, z) {
  */
 p5.RendererGL.prototype.pointLight = function(v1, v2, v3, x, y, z) {
   //@TODO: check parameters number
-  var color = p5.prototype.color.apply(this._pInst, [v1, v2, v3]);
+  var color;
+  if (v1 instanceof p5.Color) {
+    color = v1;
+  } else {
+    color = this._pInst.color(v1, v2, v3);
+  }
 
   var _x, _y, _z;
   var v = arguments[arguments.length - 1];

--- a/src/webgl/light.js
+++ b/src/webgl/light.js
@@ -42,30 +42,27 @@ var p5 = require('../core/core');
  * evenly distributed light across a sphere
  *
  */
-
 /**
  * @method ambientLight
- * @param  {String}        value   a color string
+ * @param  {String|Number}        value   a color string or grey value
  * @param  {Number}        [alpha]
  * @chainable
  */
-
 /**
  * @method ambientLight
  * @param  {Number[]}      values  an array containing the red,green,blue &
  *                                 and alpha components of the color
  * @chainable
  */
-
 /**
  * @method ambientLight
  * @param  {p5.Color}      color   the ambient light color
  * @chainable
  */
-p5.prototype.ambientLight = function(v1, v2, v3, a) {
-  var color = this.color.apply(this, arguments);
+p5.RendererGL.prototype.ambientLight = function(v1, v2, v3, a) {
+  var color = p5.prototype.color.apply(this._pInst, arguments);
 
-  var shader = this._renderer._useLightShader();
+  var shader = this._useLightShader();
 
   //@todo this is a bit icky. array uniforms have
   //to be multiples of the type 3(rgb) in this case.
@@ -73,21 +70,16 @@ p5.prototype.ambientLight = function(v1, v2, v3, a) {
   //would be better
   shader.setUniform('uUseLighting', true);
   //in case there's no material color for the geometry
-  shader.setUniform('uMaterialColor', this._renderer.curFillColor);
+  shader.setUniform('uMaterialColor', this.curFillColor);
 
-  this._renderer.ambientLightColors.push(
+  this.ambientLightColors.push(
     color._array[0],
     color._array[1],
     color._array[2]
   );
-  shader.setUniform('uAmbientColor', this._renderer.ambientLightColors);
+  shader.setUniform('uAmbientColor', this.ambientLightColors);
 
-  shader.setUniform(
-    'uAmbientLightCount',
-    this._renderer.ambientLightColors.length / 3
-  );
-
-  return this;
+  shader.setUniform('uAmbientLightCount', this.ambientLightColors.length / 3);
 };
 
 /**
@@ -122,7 +114,6 @@ p5.prototype.ambientLight = function(v1, v2, v3, a) {
  * light source on canvas changeable with mouse position
  *
  */
-
 /**
  * @method directionalLight
  * @param  {Number[]|String|p5.Color} color   color Array, CSS color string,
@@ -132,14 +123,12 @@ p5.prototype.ambientLight = function(v1, v2, v3, a) {
  * @param  {Number}                   z       z axis direction
  * @chainable
  */
-
 /**
  * @method directionalLight
  * @param  {Number[]|String|p5.Color} color
  * @param  {p5.Vector}                position
  * @chainable
  */
-
 /**
  * @method directionalLight
  * @param  {Number}    v1
@@ -150,11 +139,11 @@ p5.prototype.ambientLight = function(v1, v2, v3, a) {
  * @param  {Number}    z
  * @chainable
  */
-p5.prototype.directionalLight = function(v1, v2, v3, x, y, z) {
-  var shader = this._renderer._useLightShader();
+p5.RendererGL.prototype.directionalLight = function(v1, v2, v3, x, y, z) {
+  var shader = this._useLightShader();
 
   //@TODO: check parameters number
-  var color = this.color.apply(this, [v1, v2, v3]);
+  var color = p5.prototype.color.apply(this._pInst, [v1, v2, v3]);
 
   var _x, _y, _z;
   var v = arguments[arguments.length - 1];
@@ -169,29 +158,24 @@ p5.prototype.directionalLight = function(v1, v2, v3, x, y, z) {
   }
   shader.setUniform('uUseLighting', true);
   //in case there's no material color for the geometry
-  shader.setUniform('uMaterialColor', this._renderer.curFillColor);
+  shader.setUniform('uMaterialColor', this.curFillColor);
 
   // normalize direction
   var l = Math.sqrt(_x * _x + _y * _y + _z * _z);
-  this._renderer.directionalLightDirections.push(_x / l, _y / l, _z / l);
-  shader.setUniform(
-    'uLightingDirection',
-    this._renderer.directionalLightDirections
-  );
+  this.directionalLightDirections.push(_x / l, _y / l, _z / l);
+  shader.setUniform('uLightingDirection', this.directionalLightDirections);
 
-  this._renderer.directionalLightColors.push(
+  this.directionalLightColors.push(
     color._array[0],
     color._array[1],
     color._array[2]
   );
-  shader.setUniform('uDirectionalColor', this._renderer.directionalLightColors);
+  shader.setUniform('uDirectionalColor', this.directionalLightColors);
 
   shader.setUniform(
     'uDirectionalLightCount',
-    this._renderer.directionalLightColors.length / 3
+    this.directionalLightColors.length / 3
   );
-
-  return this;
 };
 
 /**
@@ -235,7 +219,6 @@ p5.prototype.directionalLight = function(v1, v2, v3, x, y, z) {
  * spot light on canvas changes position with mouse
  *
  */
-
 /**
  * @method pointLight
  * @param  {Number}    v1
@@ -244,7 +227,6 @@ p5.prototype.directionalLight = function(v1, v2, v3, x, y, z) {
  * @param  {p5.Vector} position the position of the light
  * @chainable
  */
-
 /**
  * @method pointLight
  * @param  {Number[]|String|p5.Color} color   color Array, CSS color string,
@@ -254,16 +236,16 @@ p5.prototype.directionalLight = function(v1, v2, v3, x, y, z) {
  * @param  {Number}                   z
  * @chainable
  */
-
 /**
  * @method pointLight
  * @param  {Number[]|String|p5.Color} color
  * @param  {p5.Vector}                position
  * @chainable
  */
-p5.prototype.pointLight = function(v1, v2, v3, x, y, z) {
+p5.RendererGL.prototype.pointLight = function(v1, v2, v3, x, y, z) {
+  this._enableLighting = true;
   //@TODO: check parameters number
-  var color = this._renderer._pInst.color.apply(this, [v1, v2, v3]);
+  var color = p5.prototype.color.apply(this._pInst, [v1, v2, v3]);
 
   var _x, _y, _z;
   var v = arguments[arguments.length - 1];
@@ -277,27 +259,18 @@ p5.prototype.pointLight = function(v1, v2, v3, x, y, z) {
     _z = v.z;
   }
 
-  var shader = this._renderer._useLightShader();
+  var shader = this._useLightShader();
   shader.setUniform('uUseLighting', true);
   //in case there's no material color for the geometry
-  shader.setUniform('uMaterialColor', this._renderer.curFillColor);
+  shader.setUniform('uMaterialColor', this.curFillColor);
 
-  this._renderer.pointLightPositions.push(_x, _y, _z);
-  shader.setUniform('uPointLightLocation', this._renderer.pointLightPositions);
+  this.pointLightPositions.push(_x, _y, _z);
+  shader.setUniform('uPointLightLocation', this.pointLightPositions);
 
-  this._renderer.pointLightColors.push(
-    color._array[0],
-    color._array[1],
-    color._array[2]
-  );
-  shader.setUniform('uPointLightColor', this._renderer.pointLightColors);
+  this.pointLightColors.push(color._array[0], color._array[1], color._array[2]);
+  shader.setUniform('uPointLightColor', this.pointLightColors);
 
-  shader.setUniform(
-    'uPointLightCount',
-    this._renderer.pointLightColors.length / 3
-  );
-
-  return this;
+  shader.setUniform('uPointLightCount', this.pointLightColors.length / 3);
 };
 
 module.exports = p5;

--- a/src/webgl/loading.js
+++ b/src/webgl/loading.js
@@ -214,6 +214,7 @@ function parseObj(model, lines) {
  *
  * @method model
  * @param  {p5.Geometry} model Loaded 3d model to be rendered
+ * @chainable
  * @example
  * <div>
  * <code>
@@ -241,14 +242,14 @@ function parseObj(model, lines) {
  * Vertically rotating 3-d teapot with red, green and blue gradient.
  *
  */
-p5.prototype.model = function(model) {
+p5.RendererGL.prototype.model = function(model) {
   if (model.vertices.length > 0) {
-    if (!this._renderer.geometryInHash(model.gid)) {
+    if (!this.geometryInHash(model.gid)) {
       model._makeTriangleEdges()._edgesToVertices();
-      this._renderer.createBuffers(model.gid, model);
+      this.createBuffers(model.gid, model);
     }
 
-    this._renderer.drawBuffers(model.gid);
+    this.drawBuffers(model.gid);
   }
 };
 

--- a/src/webgl/material.js
+++ b/src/webgl/material.js
@@ -115,8 +115,8 @@ p5.prototype.loadShader = function(vertFilename, fragFilename) {
  * @alt
  * zooming Mandelbrot set. a colorful, infinitely detailed fractal.
  */
-p5.prototype.createShader = function(vertSrc, fragSrc) {
-  return new p5.Shader(this._renderer, vertSrc, fragSrc);
+p5.RendererGL.prototype.createShader = function(vertSrc, fragSrc) {
+  return new p5.Shader(this, vertSrc, fragSrc);
 };
 
 /**
@@ -130,16 +130,16 @@ p5.prototype.createShader = function(vertSrc, fragSrc) {
  * @param {p5.Shader} [s] the desired p5.Shader to use for rendering
  * shapes.
  */
-p5.prototype.shader = function(s) {
-  if (s._renderer === undefined) {
-    s._renderer = this._renderer;
+p5.RendererGL.prototype.shader = function(s) {
+  if (!s._renderer) {
+    s._renderer = this;
   }
+
   if (s.isStrokeShader()) {
-    this._renderer.setStrokeShader(s);
+    this.setStrokeShader(s);
   } else {
-    this._renderer.setFillShader(s);
+    this.setFillShader(s);
   }
-  return this;
 };
 
 /**
@@ -167,12 +167,11 @@ p5.prototype.shader = function(s) {
  * Red, green and blue gradient.
  *
  */
-p5.prototype.normalMaterial = function() {
-  this._renderer.drawMode = constants.FILL;
-  this._renderer.setFillShader(this._renderer._getNormalShader());
-  this._renderer.curFillColor = [1, 1, 1, 1];
-  this.noStroke();
-  return this;
+p5.RendererGL.prototype.normalMaterial = function() {
+  this.drawMode = constants.FILL;
+  this.setFillShader(this._getNormalShader());
+  this.curFillColor = [1, 1, 1, 1];
+  this._pInst.noStroke();
 };
 
 /**
@@ -253,14 +252,13 @@ p5.prototype.normalMaterial = function() {
  * black canvas
  *
  */
-p5.prototype.texture = function(tex) {
-  this._renderer.drawMode = constants.TEXTURE;
-  var shader = this._renderer._useLightShader();
+p5.RendererGL.prototype.texture = function(tex) {
+  this.drawMode = constants.TEXTURE;
+  var shader = this._useLightShader();
   shader.setUniform('uSpecular', false);
   shader.setUniform('isTexture', true);
   shader.setUniform('uSampler', tex);
-  this.noStroke();
-  return this;
+  this._pInst.noStroke();
 };
 
 /**
@@ -299,15 +297,14 @@ p5.prototype.texture = function(tex) {
  * @param  {Number[]|String|p5.Color} color  color, color Array, or CSS color string
  * @chainable
  */
-p5.prototype.ambientMaterial = function(v1, v2, v3, a) {
-  var color = p5.prototype.color.apply(this, arguments);
-  this._renderer.curFillColor = color._array;
+p5.RendererGL.prototype.ambientMaterial = function(v1, v2, v3, a) {
+  var color = p5.prototype.color.apply(this._pInst, arguments);
+  this.curFillColor = color._array;
 
-  var shader = this._renderer._useLightShader();
-  shader.setUniform('uMaterialColor', this._renderer.curFillColor);
+  var shader = this._useLightShader();
+  shader.setUniform('uMaterialColor', this.curFillColor);
   shader.setUniform('uSpecular', false);
   shader.setUniform('isTexture', false);
-  return this;
 };
 
 /**
@@ -346,15 +343,14 @@ p5.prototype.ambientMaterial = function(v1, v2, v3, a) {
  * @param  {Number[]|String|p5.Color} color color Array, or CSS color string
  * @chainable
  */
-p5.prototype.specularMaterial = function(v1, v2, v3, a) {
-  var color = p5.prototype.color.apply(this, arguments);
-  this._renderer.curFillColor = color._array;
+p5.RendererGL.prototype.specularMaterial = function(v1, v2, v3, a) {
+  var color = p5.prototype.color.apply(this._pInst, arguments);
+  this.curFillColor = color._array;
 
-  var shader = this._renderer._useLightShader();
-  shader.setUniform('uMaterialColor', this._renderer.curFillColor);
+  var shader = this._useLightShader();
+  shader.setUniform('uMaterialColor', this.curFillColor);
   shader.setUniform('uSpecular', true);
   shader.setUniform('isTexture', false);
-  return this;
 };
 
 /**

--- a/src/webgl/p5.Geometry.js
+++ b/src/webgl/p5.Geometry.js
@@ -43,12 +43,26 @@ p5.Geometry = function(detailX, detailY, callback) {
   this.edges = [];
   this.detailX = detailX !== undefined ? detailX : 1;
   this.detailY = detailY !== undefined ? detailY : 1;
+
+  this.dirtyFlags = {};
+
   if (callback instanceof Function) {
     callback.call(this);
   }
   this.name = 'p5.Geometry'; // for friendly debugger system
+};
 
-  return this; // TODO: is this a constructor?
+p5.Geometry.prototype.reset = function() {
+  this.lineVertices.length = 0;
+  this.lineNormals.length = 0;
+
+  this.vertices.length = 0;
+  this.edges.length = 0;
+  this.vertexColors.length = 0;
+  this.vertexNormals.length = 0;
+  this.uvs.length = 0;
+
+  this.dirtyFlags = {};
 };
 
 /**
@@ -208,6 +222,7 @@ p5.Geometry.prototype._makeTriangleEdges = function() {
  */
 p5.Geometry.prototype._edgesToVertices = function() {
   this.lineVertices = [];
+  this.lineNormals = [];
   for (var i = 0; i < this.edges.length; i++) {
     var begin = this.vertices[this.edges[i][0]];
     var end = this.vertices[this.edges[i][1]];
@@ -225,7 +240,7 @@ p5.Geometry.prototype._edgesToVertices = function() {
     // in opposite directions
     dirAdd.push(1);
     dirSub.push(-1);
-    this.lineNormals.push(dirAdd, dirSub, dirAdd, dirAdd, dirSub, dirSub);
+    this.lineNormals.push(dirAdd, dirSub, dirSub, dirSub, dirAdd, dirAdd);
     this.lineVertices.push(a, b, c, c, b, d);
   }
   return this;

--- a/src/webgl/p5.RendererGL.Immediate.js
+++ b/src/webgl/p5.RendererGL.Immediate.js
@@ -241,7 +241,7 @@ p5.RendererGL.prototype.endShape = function(
         fill = this._getImmediateLightShader();
       }
     } else {
-      if (!fill || !fill.isColorShader()) {
+      if (!fill /*|| !fill.isColorShader()*/) {
         fill = this._getImmediateFlatShader();
       }
     }

--- a/src/webgl/p5.RendererGL.Immediate.js
+++ b/src/webgl/p5.RendererGL.Immediate.js
@@ -232,22 +232,24 @@ p5.RendererGL.prototype.endShape = function(
     // render the fill
     this._renderStroke(geometry, stroke);
 
-    //select the fill shader
-    var fill = this.curFillShader;
-    if (this._enableNormal) {
-      fill = this._getNormalShader();
-    } else if (this._enableLighting) {
-      if (!fill || !fill.isLightShader()) {
-        fill = this._getImmediateLightShader();
+    if (drawMode) {
+      //select the fill shader
+      var fill = this.curFillShader;
+      if (this._enableNormal) {
+        fill = this._getNormalShader();
+      } else if (this._enableLighting) {
+        if (!fill || !fill.isLightShader()) {
+          fill = this._getImmediateLightShader();
+        }
+      } else {
+        if (!fill /*|| !fill.isColorShader()*/) {
+          fill = this._getImmediateFlatShader();
+        }
       }
-    } else {
-      if (!fill /*|| !fill.isColorShader()*/) {
-        fill = this._getImmediateFlatShader();
-      }
-    }
 
-    // render the fill
-    this._renderFill(geometry, fill, drawMode);
+      // render the fill
+      this._renderFill(geometry, fill, drawMode);
+    }
   }
 
   // reset the immediate geometry

--- a/src/webgl/p5.RendererGL.Immediate.js
+++ b/src/webgl/p5.RendererGL.Immediate.js
@@ -57,7 +57,6 @@ p5.RendererGL.prototype.beginShape = function(mode) {
     this.immediateMode.uvCoords.length = 0;
   }
   this.isImmediateDrawing = true;
-  return this;
 };
 /**
  * adds a vertex to be drawn in a custom Shape.
@@ -99,8 +98,6 @@ p5.RendererGL.prototype.vertex = function(x, y) {
   );
 
   this.immediateMode.uvCoords.push(u, v);
-
-  return this;
 };
 
 /**
@@ -147,8 +144,6 @@ p5.RendererGL.prototype.endShape = function(
   this.immediateMode.vertexColors.length = 0;
   this.immediateMode.uvCoords.length = 0;
   this.isImmediateDrawing = false;
-
-  return this;
 };
 
 p5.RendererGL.prototype._drawFillImmediateMode = function(

--- a/src/webgl/p5.RendererGL.Immediate.js
+++ b/src/webgl/p5.RendererGL.Immediate.js
@@ -75,7 +75,7 @@ p5.RendererGL.prototype.vertex = function(x, y) {
   var push = Array.prototype.push;
   im.vertices.push(new p5.Vector(x, y, z));
   push.apply(im.vertexColors, this._diffuseColor);
-  push.apply(im.vertexNormals, this._normal);
+  im.vertexNormals.push(this._normal);
   push.apply(im.vertexAmbients, this._ambientColor);
   push.apply(im.vertexSpeculars, this._specularColor);
   push.apply(im.vertexEmissives, this._emissiveColor);
@@ -113,7 +113,7 @@ p5.RendererGL.prototype.normal = function(x, y, z) {
     x = z[0] || 0; // must be last
   }
   var len = Math.sqrt(x * x + y * y + z * z);
-  this._normal = [x / len, y / len, z / len];
+  this._normal = new p5.Vector(x / len, y / len, z / len);
 };
 
 /**

--- a/src/webgl/p5.RendererGL.Retained.js
+++ b/src/webgl/p5.RendererGL.Retained.js
@@ -287,7 +287,6 @@ p5.RendererGL.prototype.drawBuffers = function(gId) {
     this._drawElements(gl.TRIANGLES, gId);
     this.curFillShader.unbindShader();
   }
-  return this;
 };
 
 /**
@@ -322,7 +321,6 @@ p5.RendererGL.prototype.drawBuffersScaled = function(
 
 p5.RendererGL.prototype._drawArrays = function(drawMode, gId) {
   this.GL.drawArrays(drawMode, 0, this.gHash[gId].lineVertexCount);
-  return this;
 };
 
 p5.RendererGL.prototype._drawElements = function(drawMode, gId) {

--- a/src/webgl/p5.RendererGL.Retained.js
+++ b/src/webgl/p5.RendererGL.Retained.js
@@ -156,7 +156,7 @@ p5.RendererGL.prototype.drawBuffers = function(gId, drawMode) {
       fill = this._getTextureShader();
     }
   } else {
-    if (!fill || !fill.isColorShader()) {
+    if (!fill /* || !fill.isColorShader()*/) {
       fill = this._getColorShader();
     }
   }

--- a/src/webgl/p5.RendererGL.Retained.js
+++ b/src/webgl/p5.RendererGL.Retained.js
@@ -3,6 +3,35 @@
 'use strict';
 
 var p5 = require('../core/core');
+require('./p5.RendererGL');
+
+// a render buffer definition
+function BufferDef(size, src, dst, attr, map) {
+  this.size = size; // the number of FLOATs in each vertex
+  this.src = src; // the name of the model's source array
+  this.dst = dst; // the name of the geometry's buffer
+  this.attr = attr; // the name of the vertex attribute
+  this.map = map; // optional, a transformation function to apply to src
+}
+
+var _flatten = p5.RendererGL._flatten;
+var _vToNArray = p5.RendererGL._vToNArray;
+
+var strokeBuffers = [
+  new BufferDef(3, 'lineVertices', 'lineVertexBuffer', 'aPosition', _flatten),
+  new BufferDef(4, 'lineNormals', 'lineNormalBuffer', 'aDirection', _flatten)
+];
+
+var fillBuffers = [
+  new BufferDef(3, 'vertices', 'vertexBuffer', 'aPosition', _vToNArray),
+  new BufferDef(3, 'vertexNormals', 'normalBuffer', 'aNormal', _vToNArray),
+  new BufferDef(4, 'vertexColors', 'colorBuffer', 'aMaterialColor'),
+  new BufferDef(3, 'vertexAmbients', 'ambientBuffer', 'aAmbientColor'),
+  new BufferDef(3, 'vertexSpeculars', 'specularBuffer', 'aSpecularColor'),
+  new BufferDef(3, 'vertexEmissives', 'emissiveBuffer', 'aEmissiveColor'),
+  new BufferDef(1, 'vertexShininesses', 'shininessBuffer', 'aSpecularPower'),
+  new BufferDef(2, 'uvs', 'uvBuffer', 'aTexCoord', _flatten)
+];
 
 var hashCount = 0;
 /**
@@ -13,6 +42,8 @@ var hashCount = 0;
  * @param  {String} gId  key of the geometry object
  */
 p5.RendererGL.prototype._initBufferDefaults = function(gId) {
+  if (this.gHash.hasOwnProperty(gId)) return;
+
   this._freeBuffers(gId);
 
   //@TODO remove this limit on hashes in gHash
@@ -37,155 +68,60 @@ p5.RendererGL.prototype._freeBuffers = function(gId) {
   hashCount--;
 
   var gl = this.GL;
-  geometry.vertexBuffer && gl.deleteBuffer(geometry.vertexBuffer);
-  geometry.normalBuffer && gl.deleteBuffer(geometry.normalBuffer);
-  geometry.lineNormalBuffer && gl.deleteBuffer(geometry.lineNormalBuffer);
-  geometry.uvBuffer && gl.deleteBuffer(geometry.uvBuffer);
   geometry.indexBuffer && gl.deleteBuffer(geometry.indexBuffer);
-  geometry.lineVertexBuffer && gl.deleteBuffer(geometry.lineVertexBuffer);
+
+  function freeBuffers(bds) {
+    for (var i = 0; i < bds.length; i++) {
+      var bd = bds[i];
+      if (geometry[bd.dst]) {
+        gl.deleteBuffer(geometry[bd.dst]);
+        geometry[bd.dst] = null;
+      }
+    }
+  }
+
+  // free all the buffers
+  freeBuffers(strokeBuffers);
+  freeBuffers(fillBuffers);
 };
+
 /**
  * createBuffers description
  * @private
  * @param  {String} gId    key of the geometry object
- * @param  {p5.Geometry}  obj contains geometry data
+ * @param  {p5.Geometry}  model contains geometry data
  */
-p5.RendererGL.prototype.createBuffers = function(gId, obj) {
+p5.RendererGL.prototype.createBuffers = function(gId, model) {
   var gl = this.GL;
   this._setDefaultCamera();
   //initialize the gl buffers for our geom groups
   this._initBufferDefaults(gId);
 
   var geometry = this.gHash[gId];
+  geometry.model = model;
 
-  geometry.numberOfItems = obj.faces.length * 3;
-  geometry.lineVertexCount = obj.lineVertices.length;
-
-  this._useColorShader();
-
-  // initialize the stroke shader's 'aPosition' buffer, if used
-  if (this.curStrokeShader.attributes.aPosition) {
-    geometry.lineVertexBuffer = gl.createBuffer();
-
-    this._bindBuffer(
-      geometry.lineVertexBuffer,
-      gl.ARRAY_BUFFER,
-      this._flatten(obj.lineVertices),
-      Float32Array,
-      gl.STATIC_DRAW
+  if (model.faces.length) {
+    // allocate space for faces
+    geometry.indexBuffer = this._createBuffer(
+      geometry.indexBuffer,
+      p5.RendererGL._flatten(model.faces),
+      gl.ELEMENT_ARRAY_BUFFER,
+      Uint16Array
     );
 
-    this.curStrokeShader.enableAttrib(
-      this.curStrokeShader.attributes.aPosition.location,
-      3,
-      gl.FLOAT,
-      false,
-      0,
-      0
-    );
+    // the vertex count is based on the number of faces
+    geometry.vertexCount = model.faces.length * 3;
+  } else {
+    // the index buffer is unused, remove it
+    if (geometry.indexBuffer) {
+      gl.deleteBuffer(geometry.indexBuffer);
+      geometry.indexBuffer = null;
+    }
+    // the vertex count comes directly from the model
+    geometry.vertexCount = model.vertices && model.vertices.length;
   }
 
-  // initialize the stroke shader's 'aDirection' buffer, if used
-  if (this.curStrokeShader.attributes.aDirection) {
-    geometry.lineNormalBuffer = gl.createBuffer();
-
-    this._bindBuffer(
-      geometry.lineNormalBuffer,
-      gl.ARRAY_BUFFER,
-      this._flatten(obj.lineNormals),
-      Float32Array,
-      gl.STATIC_DRAW
-    );
-
-    this.curStrokeShader.enableAttrib(
-      this.curStrokeShader.attributes.aDirection.location,
-      4,
-      gl.FLOAT,
-      false,
-      0,
-      0
-    );
-  }
-
-  // initialize the fill shader's 'aPosition' buffer, if used
-  if (this.curFillShader.attributes.aPosition) {
-    geometry.vertexBuffer = gl.createBuffer();
-
-    // allocate space for vertex positions
-    this._bindBuffer(
-      geometry.vertexBuffer,
-      gl.ARRAY_BUFFER,
-      this._vToNArray(obj.vertices),
-      Float32Array,
-      gl.STATIC_DRAW
-    );
-
-    this.curFillShader.enableAttrib(
-      this.curFillShader.attributes.aPosition.location,
-      3,
-      gl.FLOAT,
-      false,
-      0,
-      0
-    );
-  }
-
-  // allocate space for faces
-  geometry.indexBuffer = gl.createBuffer();
-  this._bindBuffer(
-    geometry.indexBuffer,
-    gl.ELEMENT_ARRAY_BUFFER,
-    this._flatten(obj.faces),
-    Uint16Array,
-    gl.STATIC_DRAW
-  );
-
-  // initialize the fill shader's 'aNormal' buffer, if used
-  if (this.curFillShader.attributes.aNormal) {
-    geometry.normalBuffer = gl.createBuffer();
-
-    // allocate space for normals
-    this._bindBuffer(
-      geometry.normalBuffer,
-      gl.ARRAY_BUFFER,
-      this._vToNArray(obj.vertexNormals),
-      Float32Array,
-      gl.STATIC_DRAW
-    );
-
-    this.curFillShader.enableAttrib(
-      this.curFillShader.attributes.aNormal.location,
-      3,
-      gl.FLOAT,
-      false,
-      0,
-      0
-    );
-  }
-
-  // initialize the fill shader's 'aTexCoord' buffer, if used
-  if (this.curFillShader.attributes.aTexCoord) {
-    geometry.uvBuffer = gl.createBuffer();
-
-    // tex coords
-    this._bindBuffer(
-      geometry.uvBuffer,
-      gl.ARRAY_BUFFER,
-      this._flatten(obj.uvs),
-      Float32Array,
-      gl.STATIC_DRAW
-    );
-
-    this.curFillShader.enableAttrib(
-      this.curFillShader.attributes.aTexCoord.location,
-      2,
-      gl.FLOAT,
-      false,
-      0,
-      0
-    );
-  }
-  //}
+  geometry.lineVertexCount = model.lineVertices && model.lineVertices.length;
 };
 
 /**
@@ -194,99 +130,39 @@ p5.RendererGL.prototype.createBuffers = function(gId, obj) {
  * @param  {String} gId     ID in our geom hash
  * @chainable
  */
-p5.RendererGL.prototype.drawBuffers = function(gId) {
+p5.RendererGL.prototype.drawBuffers = function(gId, drawMode) {
   this._setDefaultCamera();
-  var gl = this.GL;
-  this._useColorShader();
+
   var geometry = this.gHash[gId];
 
-  if (this._doStroke && geometry.lineVertexCount > 0) {
-    this.curStrokeShader.bindShader();
+  // select the stroke shader to use
+  var stroke = this.curStrokeShader;
+  if (!stroke || !stroke.isStrokeShader()) {
+    stroke = this._getLineShader();
+  }
+  // render the stroke
+  this._renderStroke(geometry, stroke);
 
-    // bind the stroke shader's 'aPosition' buffer
-    if (geometry.lineVertexBuffer) {
-      this._bindBuffer(geometry.lineVertexBuffer, gl.ARRAY_BUFFER);
-      this.curStrokeShader.enableAttrib(
-        this.curStrokeShader.attributes.aPosition.location,
-        3,
-        gl.FLOAT,
-        false,
-        0,
-        0
-      );
+  // select the fill shader to use
+  var fill = this.curFillShader;
+  if (this._enableNormal) {
+    fill = this._getNormalShader();
+  } else if (this._enableLighting) {
+    if (!fill || !fill.isLightShader()) {
+      fill = this._getLightShader();
     }
-
-    // bind the stroke shader's 'aDirection' buffer
-    if (geometry.lineNormalBuffer) {
-      this._bindBuffer(geometry.lineNormalBuffer, gl.ARRAY_BUFFER);
-      this.curStrokeShader.enableAttrib(
-        this.curStrokeShader.attributes.aDirection.location,
-        4,
-        gl.FLOAT,
-        false,
-        0,
-        0
-      );
+  } else if (this._tex) {
+    if (!fill || !fill.isTextureShader()) {
+      fill = this._getTextureShader();
     }
-
-    this._applyColorBlend(this.curStrokeColor);
-    this._drawArrays(gl.TRIANGLES, gId);
-    this.curStrokeShader.unbindShader();
+  } else {
+    if (!fill || !fill.isColorShader()) {
+      fill = this._getColorShader();
+    }
   }
 
-  if (this._doFill !== false) {
-    this.curFillShader.bindShader();
-
-    // bind the fill shader's 'aPosition' buffer
-    if (geometry.vertexBuffer) {
-      //vertex position buffer
-      this._bindBuffer(geometry.vertexBuffer, gl.ARRAY_BUFFER);
-      this.curFillShader.enableAttrib(
-        this.curFillShader.attributes.aPosition.location,
-        3,
-        gl.FLOAT,
-        false,
-        0,
-        0
-      );
-    }
-
-    if (geometry.indexBuffer) {
-      //vertex index buffer
-      this._bindBuffer(geometry.indexBuffer, gl.ELEMENT_ARRAY_BUFFER);
-    }
-
-    // bind the fill shader's 'aNormal' buffer
-    if (geometry.normalBuffer) {
-      this._bindBuffer(geometry.normalBuffer, gl.ARRAY_BUFFER);
-      this.curFillShader.enableAttrib(
-        this.curFillShader.attributes.aNormal.location,
-        3,
-        gl.FLOAT,
-        false,
-        0,
-        0
-      );
-    }
-
-    // bind the fill shader's 'aTexCoord' buffer
-    if (geometry.uvBuffer) {
-      // uv buffer
-      this._bindBuffer(geometry.uvBuffer, gl.ARRAY_BUFFER);
-      this.curFillShader.enableAttrib(
-        this.curFillShader.attributes.aTexCoord.location,
-        2,
-        gl.FLOAT,
-        false,
-        0,
-        0
-      );
-    }
-
-    this._applyColorBlend(this.curFillColor);
-    this._drawElements(gl.TRIANGLES, gId);
-    this.curFillShader.unbindShader();
-  }
+  // render the fill
+  this._renderFill(geometry, fill, drawMode);
 };
 
 /**
@@ -319,17 +195,154 @@ p5.RendererGL.prototype.drawBuffersScaled = function(
   }
 };
 
-p5.RendererGL.prototype._drawArrays = function(drawMode, gId) {
-  this.GL.drawArrays(drawMode, 0, this.gHash[gId].lineVertexCount);
+p5.RendererGL.prototype._prepareBuffers = function(geometry, shader, bds) {
+  var model = geometry.model;
+  var attributes = shader.attributes;
+  var gl = this.GL;
+
+  // loop through each of the buffer definitions
+  for (var i = 0; i < bds.length; i++) {
+    var bd = bds[i];
+
+    var attr = attributes[bd.attr];
+    if (!attr) continue;
+
+    var buffer = geometry[bd.dst];
+
+    // check if the model has the appropriate source array
+    var src = model[bd.src];
+    if (src) {
+      // check if we need to create the GL buffer
+      var createBuffer = !buffer;
+      if (createBuffer) {
+        // create and remember the buffer
+        geometry[bd.dst] = buffer = gl.createBuffer();
+      }
+      // bind the buffer
+      gl.bindBuffer(gl.ARRAY_BUFFER, buffer);
+
+      // check if we need to fill the buffer with data
+      if (createBuffer || model.dirtyFlags[bd.src] !== false) {
+        var map = bd.map;
+        // get the values from the model, possibly transformed
+        var values = map ? map(src) : src;
+
+        // fill the buffer with the values
+        this._bindBuffer(buffer, gl.ARRAY_BUFFER, values);
+
+        // mark the model's source array as clean
+        model.dirtyFlags[bd.src] = false;
+      }
+      // enable the attribute
+      shader.enableAttrib(attr, bd.size);
+    } else {
+      if (buffer) {
+        // remove the unused buffer
+        gl.deleteBuffer(buffer);
+        geometry[bd.dst] = null;
+      }
+      // disable the vertex
+      gl.disableVertexAttribArray(attr.index);
+    }
+  }
 };
 
-p5.RendererGL.prototype._drawElements = function(drawMode, gId) {
-  this.GL.drawElements(
-    drawMode,
-    this.gHash[gId].numberOfItems,
-    this.GL.UNSIGNED_SHORT,
-    0
+p5.RendererGL.prototype._renderStroke = function(geometry, stroke) {
+  // check if the stroke is enabled
+  if (!this._doStroke || geometry.lineVertexCount < 2 || this._enableNormal) {
+    return;
+  }
+
+  var gl = this.GL;
+
+  stroke.bindShader();
+
+  // set the uniform values
+  stroke.setUniform('uStrokeColor', this._strokeColor);
+  stroke.setUniform('uStrokeWeight', this._strokeWeight);
+
+  // prepare the render buffers
+  this._prepareBuffers(geometry, stroke, strokeBuffers);
+
+  // render the stroke
+  this._applyColorBlend(this._strokeColor);
+  gl.drawArrays(gl.TRIANGLES, 0, geometry.lineVertexCount);
+
+  stroke.unbindShader();
+};
+
+p5.RendererGL.prototype._renderFill = function(geometry, fill, drawMode) {
+  // check if the fill is enabled
+  if (!this._doFill || geometry.vertexCount < 3) {
+    return;
+  }
+
+  var gl = this.GL;
+
+  fill.bindShader();
+
+  // TODO: optimize
+  fill.setUniform('uAmbientColor', this._ambientColor);
+  fill.setUniform('uMaterialColor', this._diffuseColor);
+  fill.setUniform('uSpecularColor', this._specularColor);
+  fill.setUniform('uSpecularPower', this._specularPower);
+  fill.setUniform('isTexture', !!this._tex);
+  if (this._tex) {
+    fill.setUniform('uSampler', this._tex);
+  }
+
+  var pointLightCount = this.pointLightColors.length / 3;
+  fill.setUniform('uPointLightCount', pointLightCount);
+  fill.setUniform('uPointLightLocation', this.pointLightPositions);
+  fill.setUniform('uPointLightColor', this.pointLightColors);
+  fill.setUniform('uPointLightSpecularColor', this.pointLightSpecularColors);
+
+  var directionalLightCount = this.directionalLightColors.length / 3;
+  fill.setUniform('uDirectionalLightCount', directionalLightCount);
+  fill.setUniform(
+    'uDirectionalLightDirection',
+    this.directionalLightDirections
   );
+  fill.setUniform('uDirectionalLightColor', this.directionalLightColors);
+  fill.setUniform(
+    'uDirectionalLightSpecularColor',
+    this.directionalLightSpecularColors
+  );
+
+  // TODO: sum these here...
+  var ambientLightCount = this.ambientLightColors.length / 3;
+  fill.setUniform('uAmbientLightCount', ambientLightCount);
+  fill.setUniform('uAmbientLightColor', this.ambientLightColors);
+
+  fill.setUniform('uConstantFalloff', this._constantFalloff);
+  fill.setUniform('uLinearFalloff', this._linearFalloff);
+  fill.setUniform('uQuadraticFalloff', this._quadraticFalloff);
+
+  // bind the index buffer, if we have one
+  if (geometry.indexBuffer) {
+    this._bindBuffer(geometry.indexBuffer, gl.ELEMENT_ARRAY_BUFFER);
+  }
+
+  // prepare the other render buffers
+  this._prepareBuffers(geometry, fill, fillBuffers);
+
+  this._applyColorBlend(this._diffuseColor);
+
+  // render the fill
+  if (geometry.indexBuffer) {
+    // we're drawing faces
+    gl.drawElements(
+      gl.TRIANGLES,
+      geometry.vertexCount,
+      this.GL.UNSIGNED_SHORT,
+      0
+    );
+  } else {
+    // drawing vertices
+    gl.drawArrays(drawMode || gl.TRIANGLES, 0, geometry.vertexCount);
+  }
+
+  fill.unbindShader();
 };
 
 module.exports = p5.RendererGL;

--- a/src/webgl/p5.RendererGL.js
+++ b/src/webgl/p5.RendererGL.js
@@ -128,8 +128,6 @@ p5.RendererGL = function(elt, pInst, isMainCanvas, attr) {
   // array of textures created in this gl context via this.getTexture(src)
   this.textures = [];
   this.name = 'p5.RendererGL'; // for friendly debugger system
-
-  return this;
 };
 
 p5.RendererGL.prototype = Object.create(p5.Renderer.prototype);
@@ -233,6 +231,7 @@ p5.RendererGL.prototype._resetContext = function(attr, options, callback) {
  * @for p5
  * @param  {String}  key Name of attribute
  * @param  {Boolean}        value New value of named attribute
+ * @chainable
  * @example
  * <div>
  * <code>
@@ -334,9 +333,10 @@ p5.RendererGL.prototype._resetContext = function(attr, options, callback) {
  * @method setAttributes
  * @for p5
  * @param  {Object}  obj object with key-value pairs
+ * @chainable
  */
 
-p5.prototype.setAttributes = function(key, value) {
+p5.RendererGL.prototype.setAttributes = function(key, value) {
   //@todo_FES
   var attr;
   if (typeof value !== 'undefined') {
@@ -345,7 +345,7 @@ p5.prototype.setAttributes = function(key, value) {
   } else if (key instanceof Object) {
     attr = key;
   }
-  this._renderer._resetContext(attr);
+  this._resetContext(attr);
 };
 
 /**
@@ -711,7 +711,6 @@ p5.RendererGL.prototype.translate = function(x, y, z) {
     x = x.x;
   }
   this.uMVMatrix.translate([x, y, z]);
-  return this;
 };
 
 /**
@@ -724,30 +723,24 @@ p5.RendererGL.prototype.translate = function(x, y, z) {
  */
 p5.RendererGL.prototype.scale = function(x, y, z) {
   this.uMVMatrix.scale(x, y, z);
-  return this;
 };
 
-p5.RendererGL.prototype.rotate = function(rad, axis) {
-  if (typeof axis === 'undefined') {
-    return this.rotateZ(rad);
-  }
+p5.RendererGL.prototype.rotate = function(angle, axis) {
+  var args = Array.prototype.slice(arguments);
+  args[0] = this._pInst._toRadians(angle);
   p5.Matrix.prototype.rotate.apply(this.uMVMatrix, arguments);
-  return this;
 };
 
-p5.RendererGL.prototype.rotateX = function(rad) {
-  this.rotate(rad, 1, 0, 0);
-  return this;
+p5.RendererGL.prototype.rotateX = function(angle) {
+  this.rotate(angle, 1, 0, 0);
 };
 
-p5.RendererGL.prototype.rotateY = function(rad) {
-  this.rotate(rad, 0, 1, 0);
-  return this;
+p5.RendererGL.prototype.rotateY = function(angle) {
+  this.rotate(angle, 0, 1, 0);
 };
 
-p5.RendererGL.prototype.rotateZ = function(rad) {
-  this.rotate(rad, 0, 0, 1);
-  return this;
+p5.RendererGL.prototype.rotateZ = function(angle) {
+  this.rotate(angle, 0, 0, 1);
 };
 
 /**

--- a/src/webgl/p5.RendererGL.js
+++ b/src/webgl/p5.RendererGL.js
@@ -7,9 +7,6 @@ require('../core/p5.Renderer');
 require('./p5.Matrix');
 var fs = require('fs');
 
-var uMVMatrixStack = [];
-var cameraMatrixStack = [];
-
 var defaultShaders = {
   immediateVert: fs.readFileSync(
     __dirname + '/shaders/immediate.vert',
@@ -177,11 +174,16 @@ p5.RendererGL.prototype._resetContext = function(attr, options, callback) {
     document.body.appendChild(c);
   }
   this._pInst.canvas = c;
+
+  this._pInst.push();
   var renderer = new p5.RendererGL(this._pInst.canvas, this._pInst, true, attr);
   this._pInst._setProperty('_renderer', renderer);
   renderer.resize(w, h);
   renderer._applyDefaults();
   this._pInst._elements.push(renderer);
+
+  this._pInst.pop();
+
   if (typeof callback === 'function') {
     //setTimeout with 0 forces the task to the back of the queue, this ensures that
     //we finish switching out the renderer
@@ -743,27 +745,17 @@ p5.RendererGL.prototype.rotateZ = function(angle) {
   this.rotate(angle, 0, 0, 1);
 };
 
-/**
- * pushes a copy of the model view matrix onto the
- * MV Matrix stack.
- */
 p5.RendererGL.prototype.push = function() {
-  uMVMatrixStack.push(this.uMVMatrix.copy());
-  cameraMatrixStack.push(this.cameraMatrix.copy());
-};
+  // get the base renderer style
+  var style = p5.Renderer.prototype.push.apply(this);
 
-/**
- * [pop description]
- */
-p5.RendererGL.prototype.pop = function() {
-  if (uMVMatrixStack.length === 0) {
-    throw new Error('Invalid popMatrix!');
-  }
-  this.uMVMatrix = uMVMatrixStack.pop();
-  if (cameraMatrixStack.length === 0) {
-    throw new Error('Invalid popMatrix!');
-  }
-  this.cameraMatrix = cameraMatrixStack.pop();
+  // add webgl-specific style properties
+  var properties = style.properties;
+
+  properties.uMVMatrix = this.uMVMatrix.copy();
+  properties.cameraMatrix = this.cameraMatrix.copy();
+
+  return style;
 };
 
 p5.RendererGL.prototype.resetMatrix = function() {

--- a/src/webgl/p5.RendererGL.js
+++ b/src/webgl/p5.RendererGL.js
@@ -1,7 +1,6 @@
 'use strict';
 
 var p5 = require('../core/core');
-var constants = require('../core/constants');
 require('./p5.Shader');
 require('../core/p5.Renderer');
 require('./p5.Matrix');
@@ -136,7 +135,7 @@ p5.RendererGL = function(elt, pInst, isMainCanvas, attr) {
   this._specularColor = [0.5, 0.5, 0.5];
   this._specularPower = 1;
   this._emissiveColor = [0, 0, 0];
-  this._normal = [0, 0, 1];
+  this._normal = new p5.Vector(0, 0, 1);
 
   this._enableNormal = false;
   this._enableLighting = false;

--- a/src/webgl/p5.Shader.js
+++ b/src/webgl/p5.Shader.js
@@ -125,12 +125,13 @@ p5.Shader.prototype._loadAttributes = function() {
     var attributeInfo = gl.getActiveAttrib(this._glProgram, i);
     var name = attributeInfo.name;
     var location = gl.getAttribLocation(this._glProgram, name);
-    var attribute = {};
-    attribute.name = name;
-    attribute.location = location;
-    attribute.type = attributeInfo.type;
-    attribute.size = attributeInfo.size;
-    this.attributes[name] = attribute;
+    this.attributes[name] = {
+      index: i,
+      name: name,
+      location: location,
+      type: attributeInfo.type,
+      size: attributeInfo.size
+    };
   }
 
   this._loadedAttributes = true;
@@ -199,10 +200,9 @@ p5.Shader.prototype.bindShader = function() {
 
     this._renderer._setDefaultCamera();
     this._setMatrixUniforms();
-    if (this === this._renderer.curStrokeShader) {
-      this._setViewportUniform();
-    }
   }
+
+  this.setUniform('uViewport', this._renderer._viewport);
 };
 
 /**
@@ -215,6 +215,13 @@ p5.Shader.prototype.unbindShader = function() {
     this.unbindTextures();
     //this._renderer.GL.useProgram(0); ??
     this._bound = false;
+
+    /*
+    var gl = this._renderer.GL;
+    for (var name in this.attributes) {
+      gl.disableVertexAttribArray(this.attributes[name].index);
+    }
+    */
   }
   return this;
 };
@@ -246,14 +253,10 @@ p5.Shader.prototype._setMatrixUniforms = function() {
   this.setUniform('uProjectionMatrix', this._renderer.uPMatrix.mat4);
   this.setUniform('uModelViewMatrix', this._renderer.uMVMatrix.mat4);
   this.setUniform('uViewMatrix', this._renderer.cameraMatrix.mat4);
-  if (this === this._renderer.curFillShader) {
+  if (this.uniforms.uNormalMatrix) {
     this._renderer.uNMatrix.inverseTranspose(this._renderer.uMVMatrix);
     this.setUniform('uNormalMatrix', this._renderer.uNMatrix.mat3);
   }
-};
-
-p5.Shader.prototype._setViewportUniform = function() {
-  this.setUniform('uViewport', this._renderer._viewport);
 };
 
 /**
@@ -368,16 +371,15 @@ p5.Shader.prototype.setUniform = function(uniformName, data) {
 
 p5.Shader.prototype.isLightShader = function() {
   return (
-    this.uniforms.uUseLighting !== undefined ||
+    this.attributes.aNormal !== undefined ||
     this.uniforms.uAmbientLightCount !== undefined ||
     this.uniforms.uDirectionalLightCount !== undefined ||
     this.uniforms.uPointLightCount !== undefined ||
     this.uniforms.uAmbientColor !== undefined ||
-    this.uniforms.uDirectionalColor !== undefined ||
+    this.uniforms.uDirectionalLightColor !== undefined ||
     this.uniforms.uPointLightLocation !== undefined ||
     this.uniforms.uPointLightColor !== undefined ||
-    this.uniforms.uLightingDirection !== undefined ||
-    this.uniforms.uSpecular !== undefined
+    this.uniforms.uDirectionalLightDirection !== undefined
   );
 };
 
@@ -387,8 +389,9 @@ p5.Shader.prototype.isTextureShader = function() {
 
 p5.Shader.prototype.isColorShader = function() {
   return (
-    this.attributes.aVertexColor !== undefined ||
-    this.uniforms.uMaterialColor !== undefined
+    this.attributes.aMaterialColor !== undefined ||
+    this.uniforms.uMaterialColor !== undefined ||
+    this.uniforms.uSampler
   );
 };
 
@@ -406,7 +409,7 @@ p5.Shader.prototype.isStrokeShader = function() {
  * @private
  */
 p5.Shader.prototype.enableAttrib = function(
-  loc,
+  attrib,
   size,
   type,
   normalized,
@@ -414,9 +417,16 @@ p5.Shader.prototype.enableAttrib = function(
   offset
 ) {
   var gl = this._renderer.GL;
-  if (loc !== -1) {
-    gl.enableVertexAttribArray(loc);
-    gl.vertexAttribPointer(loc, size, type, normalized, stride, offset);
+  if (attrib && attrib.loc !== -1) {
+    gl.vertexAttribPointer(
+      attrib.index,
+      size,
+      type || gl.FLOAT,
+      normalized || false,
+      stride || 0,
+      offset || 0
+    );
+    gl.enableVertexAttribArray(attrib.index);
   }
   return this;
 };

--- a/src/webgl/primitives.js
+++ b/src/webgl/primitives.js
@@ -9,6 +9,7 @@
 'use strict';
 
 var p5 = require('../core/core');
+var canvas = require('../core/canvas');
 require('./p5.Geometry');
 
 /**
@@ -45,7 +46,11 @@ require('./p5.Geometry');
  * 3d red and green gradient.
  * rotating view of a multi-colored cylinder with concave sides.
  */
-p5.prototype.plane = function(width, height, detailX, detailY) {
+// see thunkRendererMethods
+p5.RendererGL.prototype.plane = function(width, height, detailX, detailY) {
+  if (!this._doStroke && !this._doFill) {
+    return;
+  }
   if (typeof width === 'undefined') {
     width = 50;
   }
@@ -62,7 +67,7 @@ p5.prototype.plane = function(width, height, detailX, detailY) {
 
   var gId = 'plane|' + detailX + '|' + detailY;
 
-  if (!this._renderer.geometryInHash(gId)) {
+  if (!this.geometryInHash(gId)) {
     var _plane = function() {
       var u, v, p;
       for (var i = 0; i <= this.detailY; i++) {
@@ -85,10 +90,10 @@ p5.prototype.plane = function(width, height, detailX, detailY) {
           ' than 1 detailX or 1 detailY'
       );
     }
-    this._renderer.createBuffers(gId, planeGeom);
+    this.createBuffers(gId, planeGeom);
   }
 
-  this._renderer.drawBuffersScaled(gId, width, height, 0);
+  this.drawBuffersScaled(gId, width, height, 0);
 };
 
 /**
@@ -119,7 +124,11 @@ p5.prototype.plane = function(width, height, detailX, detailY) {
  * </code>
  * </div>
  */
-p5.prototype.box = function(width, height, depth, detailX, detailY) {
+// see thunkRendererMethods
+p5.RendererGL.prototype.box = function(width, height, depth, detailX, detailY) {
+  if (!this._doStroke && !this._doFill) {
+    return;
+  }
   if (typeof width === 'undefined') {
     width = 50;
   }
@@ -130,8 +139,7 @@ p5.prototype.box = function(width, height, depth, detailX, detailY) {
     depth = height;
   }
 
-  var perPixelLighting =
-    this._renderer.attributes && this._renderer.attributes.perPixelLighting;
+  var perPixelLighting = this.attributes && this.attributes.perPixelLighting;
   if (typeof detailX === 'undefined') {
     detailX = perPixelLighting ? 1 : 4;
   }
@@ -140,7 +148,7 @@ p5.prototype.box = function(width, height, depth, detailX, detailY) {
   }
 
   var gId = 'box|' + detailX + '|' + detailY;
-  if (!this._renderer.geometryInHash(gId)) {
+  if (!this.geometryInHash(gId)) {
     var _box = function() {
       var cubeIndices = [
         [0, 4, 2, 6], // -1, 0, 0],// -x
@@ -199,11 +207,9 @@ p5.prototype.box = function(width, height, depth, detailX, detailY) {
     //initialize our geometry buffer with
     //the key val pair:
     //geometry Id, Geom object
-    this._renderer.createBuffers(gId, boxGeom);
+    this.createBuffers(gId, boxGeom);
   }
-  this._renderer.drawBuffersScaled(gId, width, height, depth);
-
-  return this;
+  this.drawBuffersScaled(gId, width, height, depth);
 };
 
 /**
@@ -232,7 +238,11 @@ p5.prototype.box = function(width, height, depth, detailX, detailY) {
  * </code>
  * </div>
  */
-p5.prototype.sphere = function(radius, detailX, detailY) {
+// see thunkRendererMethods
+p5.RendererGL.prototype.sphere = function(radius, detailX, detailY) {
+  if (!this._doStroke && !this._doFill) {
+    return;
+  }
   if (typeof radius === 'undefined') {
     radius = 50;
   }
@@ -244,8 +254,6 @@ p5.prototype.sphere = function(radius, detailX, detailY) {
   }
 
   this.ellipsoid(radius, radius, radius, detailX, detailY);
-
-  return this;
 };
 
 /**
@@ -413,7 +421,8 @@ var _truncatedCone = function(
  * </code>
  * </div>
  */
-p5.prototype.cylinder = function(
+// see thunkRendererMethods
+p5.RendererGL.prototype.cylinder = function(
   radius,
   height,
   detailX,
@@ -421,6 +430,9 @@ p5.prototype.cylinder = function(
   bottomCap,
   topCap
 ) {
+  if (!this._doStroke && !this._doFill) {
+    return;
+  }
   if (typeof radius === 'undefined') {
     radius = 50;
   }
@@ -442,7 +454,7 @@ p5.prototype.cylinder = function(
 
   var gId =
     'cylinder|' + detailX + '|' + detailY + '|' + bottomCap + '|' + topCap;
-  if (!this._renderer.geometryInHash(gId)) {
+  if (!this.geometryInHash(gId)) {
     var cylinderGeom = new p5.Geometry(detailX, detailY);
     _truncatedCone.call(
       cylinderGeom,
@@ -463,12 +475,10 @@ p5.prototype.cylinder = function(
           ' than 24 detailX or 16 detailY'
       );
     }
-    this._renderer.createBuffers(gId, cylinderGeom);
+    this.createBuffers(gId, cylinderGeom);
   }
 
-  this._renderer.drawBuffersScaled(gId, radius, height, radius);
-
-  return this;
+  this.drawBuffersScaled(gId, radius, height, radius);
 };
 
 /**
@@ -501,7 +511,11 @@ p5.prototype.cylinder = function(
  * </code>
  * </div>
  */
-p5.prototype.cone = function(radius, height, detailX, detailY, cap) {
+// see thunkRendererMethods
+p5.RendererGL.prototype.cone = function(radius, height, detailX, detailY, cap) {
+  if (!this._doStroke && !this._doFill) {
+    return;
+  }
   if (typeof radius === 'undefined') {
     radius = 50;
   }
@@ -519,7 +533,7 @@ p5.prototype.cone = function(radius, height, detailX, detailY, cap) {
   }
 
   var gId = 'cone|' + detailX + '|' + detailY + '|' + cap;
-  if (!this._renderer.geometryInHash(gId)) {
+  if (!this.geometryInHash(gId)) {
     var coneGeom = new p5.Geometry(detailX, detailY);
     _truncatedCone.call(coneGeom, 1, 0, 1, detailX, detailY, cap, false);
     //for cones we need to average Normals
@@ -532,12 +546,10 @@ p5.prototype.cone = function(radius, height, detailX, detailY, cap) {
           ' than 24 detailX or 16 detailY'
       );
     }
-    this._renderer.createBuffers(gId, coneGeom);
+    this.createBuffers(gId, coneGeom);
   }
 
-  this._renderer.drawBuffersScaled(gId, radius, height, radius);
-
-  return this;
+  this.drawBuffersScaled(gId, radius, height, radius);
 };
 
 /**
@@ -570,7 +582,17 @@ p5.prototype.cone = function(radius, height, detailX, detailY, cap) {
  * </code>
  * </div>
  */
-p5.prototype.ellipsoid = function(radiusX, radiusY, radiusZ, detailX, detailY) {
+// see thunkRendererMethods
+p5.RendererGL.prototype.ellipsoid = function(
+  radiusX,
+  radiusY,
+  radiusZ,
+  detailX,
+  detailY
+) {
+  if (!this._doStroke && !this._doFill) {
+    return;
+  }
   if (typeof radiusX === 'undefined') {
     radiusX = 50;
   }
@@ -590,7 +612,7 @@ p5.prototype.ellipsoid = function(radiusX, radiusY, radiusZ, detailX, detailY) {
 
   var gId = 'ellipsoid|' + detailX + '|' + detailY;
 
-  if (!this._renderer.geometryInHash(gId)) {
+  if (!this.geometryInHash(gId)) {
     var _ellipsoid = function() {
       for (var i = 0; i <= this.detailY; i++) {
         var v = i / this.detailY;
@@ -620,12 +642,10 @@ p5.prototype.ellipsoid = function(radiusX, radiusY, radiusZ, detailX, detailY) {
           ' than 24 detailX or 24 detailY'
       );
     }
-    this._renderer.createBuffers(gId, ellipsoidGeom);
+    this.createBuffers(gId, ellipsoidGeom);
   }
 
-  this._renderer.drawBuffersScaled(gId, radiusX, radiusY, radiusZ);
-
-  return this;
+  this.drawBuffersScaled(gId, radiusX, radiusY, radiusZ);
 };
 
 /**
@@ -657,7 +677,11 @@ p5.prototype.ellipsoid = function(radiusX, radiusY, radiusZ, detailX, detailY) {
  * </code>
  * </div>
  */
-p5.prototype.torus = function(radius, tubeRadius, detailX, detailY) {
+// see thunkRendererMethods
+p5.RendererGL.prototype.torus = function(radius, tubeRadius, detailX, detailY) {
+  if (!this._doStroke && !this._doFill) {
+    return;
+  }
   if (typeof radius === 'undefined') {
     radius = 50;
   } else if (!radius) {
@@ -680,7 +704,7 @@ p5.prototype.torus = function(radius, tubeRadius, detailX, detailY) {
   var tubeRatio = (tubeRadius / radius).toPrecision(4);
   var gId = 'torus|' + tubeRatio + '|' + detailX + '|' + detailY;
 
-  if (!this._renderer.geometryInHash(gId)) {
+  if (!this.geometryInHash(gId)) {
     var _torus = function() {
       for (var i = 0; i <= this.detailY; i++) {
         var v = i / this.detailY;
@@ -715,31 +739,19 @@ p5.prototype.torus = function(radius, tubeRadius, detailX, detailY) {
           ' than 24 detailX or 16 detailY'
       );
     }
-    this._renderer.createBuffers(gId, torusGeom);
+    this.createBuffers(gId, torusGeom);
   }
-  this._renderer.drawBuffersScaled(gId, radius, radius, radius);
-
-  return this;
+  this.drawBuffersScaled(gId, radius, radius, radius);
 };
 
 ///////////////////////
 /// 2D primitives
 /////////////////////////
 
-//@TODO
-p5.RendererGL.prototype.point = function(x, y, z) {
-  console.log('point not yet implemented in webgl');
-  return this;
-};
-
-p5.RendererGL.prototype.triangle = function(args) {
-  var x1 = args[0],
-    y1 = args[1];
-  var x2 = args[2],
-    y2 = args[3];
-  var x3 = args[4],
-    y3 = args[5];
-
+p5.RendererGL.prototype.triangle = function(x1, y1, x2, y2, x3, y3) {
+  if (!this._doStroke && !this._doFill) {
+    return;
+  }
   var gId = 'tri';
   if (!this.geometryInHash(gId)) {
     var _triangle = function() {
@@ -780,8 +792,6 @@ p5.RendererGL.prototype.triangle = function(args) {
   } finally {
     this.uMVMatrix = uMVMatrix;
   }
-
-  return this;
 };
 
 p5.RendererGL.prototype.ellipse = function(args) {
@@ -839,14 +849,19 @@ p5.RendererGL.prototype.ellipse = function(args) {
   return this;
 };
 
-p5.RendererGL.prototype.rect = function(args) {
+p5.RendererGL.prototype.rect = function(x, y, w, h, detailX, detailY) {
+  if (!this._doStroke && !this._doFill) {
+    return;
+  }
+  var vals = canvas.modeAdjust(x, y, w, h, this._rectMode);
+  x = vals.x;
+  y = vals.y;
+  w = vals.w;
+  h = vals.h;
+
   var perPixelLighting = this.attributes.perPixelLighting;
-  var x = args[0];
-  var y = args[1];
-  var width = args[2];
-  var height = args[3];
-  var detailX = args[4] || (perPixelLighting ? 1 : 24);
-  var detailY = args[5] || (perPixelLighting ? 1 : 16);
+  detailX = detailX || (perPixelLighting ? 1 : 24);
+  detailY = detailY || (perPixelLighting ? 1 : 16);
   var gId = 'rect|' + detailX + '|' + detailY;
   if (!this.geometryInHash(gId)) {
     var _rect = function() {
@@ -876,7 +891,7 @@ p5.RendererGL.prototype.rect = function(args) {
   var uMVMatrix = this.uMVMatrix.copy();
   try {
     this.uMVMatrix.translate([x, y, 0]);
-    this.uMVMatrix.scale(width, height, 1);
+    this.uMVMatrix.scale(w, h, 1);
 
     this.drawBuffers(gId);
   } finally {
@@ -886,23 +901,17 @@ p5.RendererGL.prototype.rect = function(args) {
 };
 
 p5.RendererGL.prototype.quad = function(x1, y1, x2, y2, x3, y3, x4, y4) {
-  var gId =
-    'quad|' +
-    x1 +
-    '|' +
-    y1 +
-    '|' +
-    x2 +
-    '|' +
-    y2 +
-    '|' +
-    x3 +
-    '|' +
-    y3 +
-    '|' +
-    x4 +
-    '|' +
-    y4;
+  if (!this._doStroke && !this._doFill) {
+    return;
+  }
+  /* eslint-disable */
+  var gId = 'quad|' +
+    x1 + '|' + y1 + '|' +
+    x2 + '|' + y2 + '|' +
+    x3 + '|' + y3 + '|' +
+    x4 + '|' + y4;
+  /* eslint-enable */
+
   if (!this.geometryInHash(gId)) {
     var _quad = function() {
       this.vertices.push(new p5.Vector(x1, y1, 0));
@@ -921,26 +930,21 @@ p5.RendererGL.prototype.quad = function(x1, y1, x2, y2, x3, y3, x4, y4) {
     this.createBuffers(gId, quadGeom);
   }
   this.drawBuffers(gId);
-  return this;
 };
 
 //this implementation of bezier curve
 //is based on Bernstein polynomial
-// pretier-ignore
+/* eslint-disable */
 p5.RendererGL.prototype.bezier = function(
-  x1,
-  y1,
-  z1,
-  x2,
-  y2,
-  z2,
-  x3,
-  y3,
-  z3,
-  x4,
-  y4,
-  z4
+  x1, y1, z1,
+  x2, y2, z2,
+  x3, y3, z3,
+  x4, y4, z4
 ) {
+  /* eslint-enable */
+  if (!this._doStroke && !this._doFill) {
+    return;
+  }
   var bezierDetail = this._pInst._bezierDetail || 20; //value of Bezier detail
   this.beginShape();
   for (var i = 0; i <= bezierDetail; i++) {
@@ -955,24 +959,19 @@ p5.RendererGL.prototype.bezier = function(
     );
   }
   this.endShape();
-  return this;
 };
 
-// pretier-ignore
+/* eslint-disable */
 p5.RendererGL.prototype.curve = function(
-  x1,
-  y1,
-  z1,
-  x2,
-  y2,
-  z2,
-  x3,
-  y3,
-  z3,
-  x4,
-  y4,
-  z4
+  x1, y1, z1,
+  x2, y2, z2,
+  x3, y3, z3,
+  x4, y4, z4
 ) {
+  /* eslint-enable */
+  if (!this._doStroke && !this._doFill) {
+    return;
+  }
   var curveDetail = this._pInst._curveDetail;
   this.beginShape();
   for (var i = 0; i <= curveDetail; i++) {
@@ -998,7 +997,6 @@ p5.RendererGL.prototype.curve = function(
     this.vertex(vx, vy, vz);
   }
   this.endShape();
-  return this;
 };
 
 /**
@@ -1030,7 +1028,11 @@ p5.RendererGL.prototype.curve = function(
  * </code>
  * </div>
  */
+// see thunkRendererMethods
 p5.RendererGL.prototype.line = function() {
+  if (!this._doStroke) {
+    return;
+  }
   if (arguments.length === 6) {
     this.beginShape();
     this.vertex(arguments[0], arguments[1], arguments[2]);
@@ -1042,7 +1044,6 @@ p5.RendererGL.prototype.line = function() {
     this.vertex(arguments[2], arguments[3], 0);
     this.endShape();
   }
-  return this;
 };
 
 module.exports = p5;

--- a/src/webgl/shaders/color.frag
+++ b/src/webgl/shaders/color.frag
@@ -1,5 +1,4 @@
 precision mediump float;
-varying vec3 vVertexNormal;
 uniform vec4 uMaterialColor;
 void main(void) {
   gl_FragColor = uMaterialColor;

--- a/src/webgl/shaders/color.vert
+++ b/src/webgl/shaders/color.vert
@@ -1,15 +1,9 @@
 attribute vec3 aPosition;
-attribute vec4 aVertexColor;
 
 uniform mat4 uModelViewMatrix;
 uniform mat4 uProjectionMatrix;
-uniform float uResolution;
-uniform float uPointSize;
 
-varying vec4 vColor;
 void main(void) {
   vec4 positionVec4 = vec4(aPosition, 1.0);
   gl_Position = uProjectionMatrix * uModelViewMatrix * positionVec4;
-  vColor = aVertexColor;
-  gl_PointSize = uPointSize;
 }

--- a/src/webgl/shaders/immediate.frag
+++ b/src/webgl/shaders/immediate.frag
@@ -1,17 +1,16 @@
 precision mediump float;
 
-uniform vec4 uMaterialColor;
 uniform sampler2D uSampler;
 uniform bool isTexture;
 
 varying highp vec2 vVertTexCoord;
 varying vec4 vVertexColor;
 varying vec3 vDiffuseLight;
-//varying vec4 vMaterialColor;
+varying vec4 vMaterialColor;
 
 void main(void) {
 
-  vec4 diffuseColor = isTexture ? texture2D(uSampler, vVertTexCoord) : uMaterialColor;
+  vec4 diffuseColor = isTexture ? texture2D(uSampler, vVertTexCoord) : vMaterialColor;
 
   gl_FragColor = vVertexColor + vec4(vDiffuseLight, 1) * diffuseColor;
 }

--- a/src/webgl/shaders/immediateFlat.vert
+++ b/src/webgl/shaders/immediateFlat.vert
@@ -1,0 +1,36 @@
+precision mediump float;
+
+// vertex attributes
+attribute vec3 aPosition;
+attribute vec2 aTexCoord;
+
+// material properties
+
+attribute vec4 aMaterialColor;
+
+// matrices
+uniform mat4 uViewMatrix;
+uniform mat4 uModelViewMatrix;
+uniform mat4 uProjectionMatrix;
+uniform mat3 uNormalMatrix;
+
+//varying vec3 vVertexNormal;
+varying highp vec2 vVertTexCoord;
+varying vec4 vVertexColor;
+varying vec3 vDiffuseLight;
+varying vec4 vMaterialColor;
+
+void main(void){
+
+  vec4 positionVec4 = vec4(aPosition, 1.0);
+  vec4 viewModelPosition = uModelViewMatrix * positionVec4;
+
+  // fragment variables:
+
+  gl_Position = uProjectionMatrix * viewModelPosition;
+
+  vVertTexCoord = aTexCoord;
+  vDiffuseLight = vec3(1.0);
+  vMaterialColor = aMaterialColor;
+  vVertexColor = vec4(0.0);
+}

--- a/src/webgl/shaders/immediateLight.vert
+++ b/src/webgl/shaders/immediateLight.vert
@@ -5,6 +5,13 @@ attribute vec3 aPosition;
 attribute vec3 aNormal;
 attribute vec2 aTexCoord;
 
+// material properties
+attribute vec3 aEmissiveColor;
+attribute vec3 aAmbientColor;
+attribute vec4 aMaterialColor;
+attribute vec3 aSpecularColor;
+attribute float aSpecularPower;
+
 // matrices
 uniform mat4 uViewMatrix;
 uniform mat4 uModelViewMatrix;
@@ -32,18 +39,12 @@ uniform float uConstantFalloff;
 uniform float uLinearFalloff;
 uniform float uQuadraticFalloff;
 
-// material properties
-uniform vec3 uEmissiveColor;
-uniform vec3 uAmbientColor;
-uniform vec4 uMaterialColor;
-uniform vec3 uSpecularColor;
-uniform float uSpecularPower;
-
 
 //varying vec3 vVertexNormal;
 varying highp vec2 vVertTexCoord;
 varying vec4 vVertexColor;
 varying vec3 vDiffuseLight;
+varying vec4 vMaterialColor;
 
 void main(void){
 
@@ -64,7 +65,7 @@ void main(void){
     totalAmbientLight += uAmbientLightColor[i];
   }
 
-  sumLights(totalDiffuseLight, totalSpecularLight, viewModelPosition, uSpecularPower);
+  sumLights(totalDiffuseLight, totalSpecularLight, viewModelPosition, aSpecularPower);
 
   // fragment variables:
 
@@ -72,8 +73,9 @@ void main(void){
 
   vVertTexCoord = aTexCoord;
   vDiffuseLight = totalDiffuseLight;
+  vMaterialColor = aMaterialColor;
 
-  vVertexColor = vec4(totalAmbientLight * uAmbientColor, 0) + 
-                 vec4(totalSpecularLight * uSpecularColor, 0) + 
-                 vec4(uEmissiveColor.rgb, 0);
+  vVertexColor = vec4(totalAmbientLight * aAmbientColor, 0) + 
+                 vec4(totalSpecularLight * aSpecularColor, 0) + 
+                 vec4(aEmissiveColor.rgb, 0);
 }

--- a/src/webgl/shaders/lighting.glsl
+++ b/src/webgl/shaders/lighting.glsl
@@ -1,0 +1,67 @@
+
+const float specularFactor = 2.0;
+const float diffuseFactor = 0.73;
+
+vec3 V;
+vec3 N;
+
+struct LightResult {
+	float specular;
+	float diffuse;
+};
+
+float phongSpecular(
+  vec3 lightDirection,
+  vec3 viewDirection,
+  vec3 surfaceNormal,
+  float shininess) {
+
+  vec3 R = normalize(reflect(-lightDirection, surfaceNormal));  
+  return pow(max(0.0, dot(R, viewDirection)), shininess);
+}
+
+float lambertDiffuse(
+  vec3 lightDirection,
+  vec3 surfaceNormal) {
+  return max(0.0, dot(-lightDirection, surfaceNormal));
+}
+
+LightResult light(vec3 lightVector, float uSpecularPower) {
+
+  vec3 L = normalize(lightVector);
+
+  //compute our diffuse & specular terms
+  LightResult lr;
+  lr.specular = phongSpecular(L, V, N, uSpecularPower);
+  lr.diffuse = lambertDiffuse(L, N);
+  return lr;
+}
+
+float falloff(float distance) {
+    return 1.0 / (uConstantFalloff + distance * (uLinearFalloff + distance * uQuadraticFalloff));
+}
+
+void sumLights(inout vec3 totalDiffuseLight, inout vec3 totalSpecularLight, vec4 viewModelPosition, float specularPower) {
+
+  for (int j = 0; j < 8; j++) {
+    if (uDirectionalLightCount == j) break;
+
+    LightResult result = light(uDirectionalLightDirection[j], specularPower);
+    totalDiffuseLight += result.diffuse * uDirectionalLightColor[j];
+    totalSpecularLight += result.specular * uDirectionalLightSpecularColor[j];
+  }
+
+  for (int k = 0; k < 8; k++) {
+    if (uPointLightCount == k) break;
+
+    vec3 lightPosition = (uViewMatrix * vec4(uPointLightLocation[k], 1.0)).xyz;
+    vec3 lightVector = viewModelPosition.xyz - lightPosition;
+	
+    //calculate attenuation
+    float attenuation = falloff(length(lightVector));
+
+    LightResult result = light(lightVector, specularPower);
+    totalDiffuseLight += result.diffuse * attenuation * uPointLightColor[k];
+    totalSpecularLight += result.specular * attenuation * uPointLightSpecularColor[k];
+  }
+}

--- a/src/webgl/shaders/line.frag
+++ b/src/webgl/shaders/line.frag
@@ -1,8 +1,7 @@
 precision mediump float;
-precision mediump int;
 
-uniform vec4 uMaterialColor;
+uniform vec4 uStrokeColor;
 
 void main() {
-  gl_FragColor = uMaterialColor;
+  gl_FragColor = uStrokeColor;
 }

--- a/src/webgl/shaders/normal.vert
+++ b/src/webgl/shaders/normal.vert
@@ -1,17 +1,14 @@
 attribute vec3 aPosition;
 attribute vec3 aNormal;
-attribute vec2 aTexCoord;
 
 uniform mat4 uModelViewMatrix;
 uniform mat4 uProjectionMatrix;
 uniform mat3 uNormalMatrix;
 
 varying vec3 vVertexNormal;
-varying highp vec2 vVertTexCoord;
 
 void main(void) {
   vec4 positionVec4 = vec4(aPosition, 1.0);
   gl_Position = uProjectionMatrix * uModelViewMatrix * positionVec4;
   vVertexNormal = normalize(vec3( uNormalMatrix * aNormal ));
-  vVertTexCoord = aTexCoord;
 }

--- a/src/webgl/shaders/phong.vert
+++ b/src/webgl/shaders/phong.vert
@@ -1,22 +1,26 @@
 precision mediump float;
 
+// vertex attributes
 attribute vec3 aPosition;
 attribute vec3 aNormal;
 attribute vec2 aTexCoord;
 
-uniform vec3 uAmbientColor[8];
-
+// matrices
+//uniform mat4 uViewMatrix;
 uniform mat4 uModelViewMatrix;
 uniform mat4 uProjectionMatrix;
 uniform mat3 uNormalMatrix;
+
+// ambient lights
 uniform int uAmbientLightCount;
+uniform vec3 uAmbientLightColor[8];
 
 varying vec3 vNormal;
 varying vec2 vTexCoord;
 varying vec3 vViewPosition;
-varying vec3 vAmbientColor;
+varying vec3 vAmbientLight; // TODO: this can be a uniform
 
-void main(void){
+void main(void) {
 
   vec4 viewModelPosition = uModelViewMatrix * vec4(aPosition, 1.0);
 
@@ -27,9 +31,11 @@ void main(void){
   vNormal = normalize(uNormalMatrix * normalize(aNormal));
   vTexCoord = aTexCoord;
 
-  vAmbientColor = vec3(0.0);
+  vec3 totalAmbientLight = vec3(0.0);
   for (int i = 0; i < 8; i++) {
     if (uAmbientLightCount == i) break;
-    vAmbientColor += uAmbientColor[i];
+    totalAmbientLight += uAmbientLightColor[i];
   }
+
+  vAmbientLight = totalAmbientLight;
 }

--- a/src/webgl/shaders/texture.frag
+++ b/src/webgl/shaders/texture.frag
@@ -1,0 +1,9 @@
+precision mediump float;
+
+uniform sampler2D uSampler;
+
+varying highp vec2 vVertTexCoord;
+
+void main(void) {
+  gl_FragColor = texture2D(uSampler, vVertTexCoord);
+}

--- a/src/webgl/shaders/texture.vert
+++ b/src/webgl/shaders/texture.vert
@@ -1,13 +1,14 @@
 attribute vec3 aPosition;
-attribute vec4 aVertexColor;
+attribute vec2 aTexCoord;
 
 uniform mat4 uModelViewMatrix;
 uniform mat4 uProjectionMatrix;
 
-varying vec4 vColor;
+varying highp vec2 vVertTexCoord;
 
 void main(void) {
   vec4 positionVec4 = vec4(aPosition, 1.0);
   gl_Position = uProjectionMatrix * uModelViewMatrix * positionVec4;
-  vColor = aVertexColor;
+
+  vVertTexCoord = aTexCoord;
 }

--- a/src/webgl/shaders/vertexColor.frag
+++ b/src/webgl/shaders/vertexColor.frag
@@ -1,5 +1,0 @@
-precision mediump float;
-varying vec4 vColor;
-void main(void) {
-  gl_FragColor = vColor;
-}

--- a/test/manual-test-examples/webgl/customShader/toonShader/frag.glsl
+++ b/test/manual-test-examples/webgl/customShader/toonShader/frag.glsl
@@ -3,27 +3,28 @@ precision mediump float;
 precision mediump int;
 #endif
 
-uniform float fraction;
+float fraction = 1.0;
 
 varying vec4 vertColor;
 varying vec3 vertNormal;
 varying vec3 vertLightDir;
-varying highp vec2 vertTexCoord;
+//varying highp vec2 vertTexCoord;
 
 void main() {
-  float intensity;
-  vec4 color;
-  intensity = max(0.0, dot(vertLightDir, vertNormal));
-
+  float intensity = dot(vertLightDir, vertNormal);
+  float shade;
   if (intensity > pow(0.95, fraction)) {
-    color = vec4(vec3(1.0), 1.0);
+    shade = 1.0;
   } else if (intensity > pow(0.5, fraction)) {
-    color = vec4(vec3(0.6), 1.0);
+    shade = 0.6;
   } else if (intensity > pow(0.25, fraction)) {
-    color = vec4(vec3(0.4), 1.0);
+    shade = 0.4;
   } else {
-    color = vec4(vec3(0.2), 1.0);
+    shade = 0.2;
   }
 
-  gl_FragColor = color * vertColor;
+  gl_FragColor = vertColor;
+  gl_FragColor.rgb *= shade;
+
+  gl_FragColor.a = 1.0;
 }

--- a/test/manual-test-examples/webgl/customShader/toonShader/vert.glsl
+++ b/test/manual-test-examples/webgl/customShader/toonShader/vert.glsl
@@ -1,29 +1,32 @@
 attribute vec3 aPosition;
 attribute vec3 aNormal;
 attribute vec2 aTexCoord;
-attribute vec4 aVertexColor;
 
 uniform mat4 uModelViewMatrix;
 uniform mat4 uProjectionMatrix;
 uniform mat3 uNormalMatrix;
 
+// directional light
 uniform int uDirectionalLightCount;
-uniform vec3 uLightingDirection;
-uniform vec3 uDirectionalColor;
+uniform vec3 uDirectionalLightDirection;
+uniform vec3 uDirectionalLightColor;
+//uniform vec3 uDirectionalLightSpecularColor;
+
 uniform vec4 uMaterialColor;
+
 
 varying vec4 vertColor;
 varying vec3 vertLightDir;
 varying vec3 vertNormal;
-varying vec2 vertTexCoord;
+//varying vec2 vertTexCoord;
 
 void main() {
   vec4 positionVec4 = vec4(aPosition, 1.0);
   gl_Position = uProjectionMatrix * uModelViewMatrix * positionVec4;
 
   vertNormal = normalize(uNormalMatrix * aNormal);
-  vertLightDir = -uLightingDirection;
+  vertLightDir = -uDirectionalLightDirection;
 
-  vertColor = uMaterialColor;
-  vertTexCoord = aTexCoord;
+  vertColor = vec4(uMaterialColor.rgb * uDirectionalLightColor, uMaterialColor.a);
+  //vertTexCoord = aTexCoord;
 }

--- a/test/manual-test-examples/webgl/customShader/videoMultiTextureShader/sketch.js
+++ b/test/manual-test-examples/webgl/customShader/videoMultiTextureShader/sketch.js
@@ -5,7 +5,6 @@ var fingers;
 
 function preload() {
   sh = loadShader('vert.glsl', 'frag.glsl');
-  img = loadImage('../../assets/UV_Grid_Sm.jpg');
 }
 
 function setup () {
@@ -13,6 +12,7 @@ function setup () {
   fingers = createVideo('../../../addons/p5.dom/fingers.mov');
   fingers.hide();
   fingers.loop();
+  img = loadImage('../../assets/UV_Grid_Sm.jpg');
   //img2 = loadImage('../assets/cat.jpg');
   shader(sh);
   sh.setUniform('uSampler', fingers);

--- a/test/manual-test-examples/webgl/immediateMode/basic/sketch.js
+++ b/test/manual-test-examples/webgl/immediateMode/basic/sketch.js
@@ -1,17 +1,124 @@
-var theta = 0;
 
-function setup(){
+function setup() {
   createCanvas(windowWidth, windowHeight, WEBGL);
 }
 
-function draw(){
+function draw() {
 
-  background(255);
+  background(150);
 
+  var t = millis()/1000;
 
-  translate(-width/2, -height/2, 0);
-  fill(0,0,0);
-  line(0,0,0,width,height,0);
+  fill(255, 200, 100);
+
+  push();
+  translate(-width/3, -height/3);
+  rotateX(t);
+  translate(-50, -50);
+  beginShape();
+  vertex(30, 20);
+  vertex(85, 20);
+  vertex(85, 75);
+  vertex(30, 75);
+  endShape(CLOSE);
+
+  pop();
+
+  push();
+  translate(0, -height/3);
+  rotateX(t);
+  translate(-50, -50);
+  beginShape(LINES);
+  vertex(30, 20);
+  vertex(85, 20);
+  vertex(85, 75);
+  vertex(30, 75);
+  endShape();
+  pop();
+
+  push();
+  translate(width/3, -height/3);
+  noFill();
+  rotateX(t);
+  translate(-50, -50);
+  beginShape();
+  vertex(30, 20);
+  vertex(85, 20);
+  vertex(85, 75);
+  vertex(30, 75);
+  endShape();
+  pop();
+
+  push();
+  translate(-width/3, 0);
+  noFill();
+  rotateX(t);
+  translate(-50, -50);
+  beginShape();
+  vertex(30, 20);
+  vertex(85, 20);
+  vertex(85, 75);
+  vertex(30, 75);
+  endShape(CLOSE);
+  pop();
+
+  push();
+  translate(0, 0);
+  rotateX(t);
+  translate(-50, -50);
+  beginShape(TRIANGLES);
+  vertex(30, 75);
+  vertex(40, 20);
+  vertex(50, 75);
+  vertex(60, 20);
+  vertex(70, 75);
+  vertex(80, 20);
+  endShape();
+  pop();
+
+  push();
+  translate(width/3, 0);
+  rotateX(t);
+  translate(-50, -50);
+  beginShape(TRIANGLE_STRIP);
+  vertex(30, 75);
+  vertex(40, 20);
+  vertex(50, 75);
+  vertex(60, 20);
+  vertex(70, 75);
+  vertex(80, 20);
+  vertex(90, 75);
+  endShape();
+  pop();
+
+  push();
+  translate(-width/3, height/3);
+  rotateX(t);
+  translate(-50, -50);
+  beginShape(TRIANGLE_FAN);
+  vertex(57.5, 50);
+  vertex(57.5, 15);
+  vertex(92, 50);
+  vertex(57.5, 85);
+  vertex(22, 50);
+  vertex(57.5, 15);
+  endShape();
+  pop();
+
+  push();
+  translate(0, height/3);
+  rotateX(t);
+  translate(-50, -50);
+  beginShape();
+  vertex(20, 20);
+  vertex(40, 20);
+  vertex(40, 40);
+  vertex(60, 40);
+  vertex(60, 60);
+  vertex(20, 60);
+  endShape(CLOSE);
+  pop();
+  
 }
 
 // function draw(){

--- a/test/manual-test-examples/webgl/immediateMode/vertexColors/index.html
+++ b/test/manual-test-examples/webgl/immediateMode/vertexColors/index.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8">
+  <meta http-equiv="X-UA-Compatible" content="IE=edge">
+  <title></title>
+  <link rel="stylesheet" href="">
+  <script language="javascript" type="text/javascript" src="../../../../../lib/p5.js"></script>
+  <script language="javascript" type="text/javascript" src="sketch.js"></script>
+  <style>
+    html, body {margin:0; padding:0;}
+  </style> 
+</head>
+<body>
+<script>
+(function(){var script=document.createElement('script');script.onload=function(){var stats=new Stats();stats.domElement.style.cssText='position:fixed;left:0;top:0;z-index:10000';document.body.appendChild(stats.domElement);requestAnimationFrame(function loop(){stats.update();requestAnimationFrame(loop)});};script.src='http://rawgit.com/mrdoob/stats.js/master/build/stats.min.js';document.head.appendChild(script);})()
+</script>
+  
+</body>
+</html>

--- a/test/manual-test-examples/webgl/immediateMode/vertexColors/sketch.js
+++ b/test/manual-test-examples/webgl/immediateMode/vertexColors/sketch.js
@@ -1,0 +1,23 @@
+function setup() {
+  createCanvas(windowWidth, windowHeight, WEBGL);
+  noStroke();
+  colorMode(HSB);
+}
+
+function draw() {
+  background(0);
+
+  rotateX(TWO_PI/6);
+
+  beginShape(TRIANGLE_FAN);
+
+  fill((millis()/30) % 360, 255, 255);
+  vertex(0,0);
+
+  for (var i = 0; i <= 360; i += 360/36) {
+    var v = p5.Vector.fromAngle(i * TWO_PI / 360, 200);
+    fill(i, 255, 255);
+    vertex(v.x, v.y, sin(i * 5 * TWO_PI / 360 + millis() / 300) * 20);
+  }
+  endShape();
+}

--- a/test/manual-test-examples/webgl/lights/multipleLights/sketch.js
+++ b/test/manual-test-examples/webgl/lights/multipleLights/sketch.js
@@ -1,5 +1,7 @@
 function setup(){
   createCanvas(windowWidth, windowHeight, WEBGL);
+  lightSpecular(255);
+  shininess(10);
 }
 
 function draw(){

--- a/test/manual-test-examples/webgl/material/perPixelLighting/sketch.js
+++ b/test/manual-test-examples/webgl/material/perPixelLighting/sketch.js
@@ -7,9 +7,11 @@ function preload() {
 function setup() {
   createCanvas(windowWidth, windowHeight, WEBGL);
   noStroke();
+  lightSpecular(255);
+  lightFalloff(1, 0.001, 0);
 }
 
-var lights = [
+var pointLights = [
   { c: '#f00', t: 1.12, p: 1.91, r: 0.2 },
   { c: '#0f0', t: 1.21, p: 1.31, r: 0.2 },
   { c: '#00f', t: 1.37, p: 1.57, r: 0.2 },
@@ -24,11 +26,13 @@ function draw() {
 
   directionalLight(color('#111'), 1, 1, 1);
 
-  for (var i = 0; i < lights.length; i++) {
-    var light = lights[i];
+  for (var i = 0; i < pointLights.length; i++) {
+    var light = pointLights[i];
+    var lightColor = color(light.c);
+    lightSpecular(lightColor);
     pointLight(
-      color(light.c),
-      p5.Vector.fromAngles(t * light.t, t * light.p, width * 2)
+      lightColor,
+      p5.Vector.fromAngles(t * light.t, t * light.p, width * 5)
     );
   }
 
@@ -49,12 +53,8 @@ function draw() {
 
 function mousePressed() {
   setAttributes('perPixelLighting', true);
-  noStroke();
-  specularMaterial(250);
 }
 
 function mouseReleased() {
   setAttributes('perPixelLighting', false);
-  noStroke();
-  specularMaterial(250);
 }

--- a/test/manual-test-examples/webgl/material/simple/sketch.js
+++ b/test/manual-test-examples/webgl/material/simple/sketch.js
@@ -1,5 +1,6 @@
 function setup(){
   createCanvas(windowWidth, windowHeight, WEBGL);
+  lightSpecular(255);
 }
 
 function draw(){

--- a/test/manual-test-examples/webgl/material/specular_ambient/sketch.js
+++ b/test/manual-test-examples/webgl/material/specular_ambient/sketch.js
@@ -1,5 +1,7 @@
 function setup(){
   createCanvas(windowWidth, windowHeight, WEBGL);
+  shininess(50);
+  lightSpecular(255);
 }
 
 function draw(){
@@ -8,6 +10,7 @@ function draw(){
   var locY = mouseY - height / 2;
   var locX = mouseX - width / 2;
 
+  lightSpecular(255);
   ambientLight(100, 80, 80);
   pointLight(200, 200, 200, locX, locY, 0);
 

--- a/test/unit/webgl/p5.Shader.js
+++ b/test/unit/webgl/p5.Shader.js
@@ -76,30 +76,6 @@ suite('p5.Shader', function() {
   });
 
   suite('Shader', function() {
-    test('Shader Cache', function() {
-      /*
-      //exists doesn't seem to work?
-      assert.exists(myp5._renderer.curFillShader,
-        'Shader is in use');
-      */
-      assert(
-        myp5._renderer.curFillShader !== null &&
-          myp5._renderer.curFillShader !== undefined,
-        'Shader is not in use or has not been cached'
-      );
-    });
-    test('Uniform Cache', function() {
-      var uniforms = myp5._renderer.curFillShader.uniforms;
-      assert(
-        uniforms !== null && uniforms !== undefined,
-        'Shader uniforms have not been cached'
-      );
-
-      assert(
-        Object.keys(uniforms).length > 0,
-        'Shader uniforms have not been cached'
-      );
-    });
     test('Light Shader', function() {
       var expectedAttributes = ['aPosition', 'aNormal', 'aTexCoord'];
 
@@ -175,72 +151,6 @@ suite('p5.Shader', function() {
         myp5._renderer._getNormalShader(),
         expectedAttributes,
         expectedUniforms
-      );
-    });
-    test('Normal Shader is set after normalMaterial()', function() {
-      myp5.normalMaterial();
-      var normalShader = myp5._renderer._getNormalShader();
-      assert(
-        normalShader === myp5._renderer.curFillShader,
-        "_renderer's curFillShader was not normal shader"
-      );
-    });
-    /*
-    test('Color Shader is set after fill()', function() {
-      myp5.fill(0);
-      var colorShader = myp5._renderer._getColorShader();
-      assert(
-        colorShader === myp5._renderer.curFillShader,
-        "_renderer's curFillShader was not color shader after fill"
-      );
-    });
-    test('Shader switch between retain and immedate mode', function() {
-      myp5.fill(0);
-      myp5.box(70, 70, 70);
-      var retainShader = myp5._renderer._getColorShader();
-      assert(
-        retainShader === myp5._renderer.curFillShader,
-        "_renderer's curFillShader was not color shader after fill() and box()"
-      );
-
-      myp5.beginShape(myp5.TRIANGLES);
-      myp5.vertex(0, 25, 0);
-      myp5.vertex(-25, -25, 0);
-      myp5.vertex(25, -25, 0);
-      myp5.endShape();
-      var immediateShader = myp5._renderer._getImmediateModeShader();
-      assert(
-        immediateShader === myp5._renderer.curFillShader,
-        "_renderer's curFillShader was not immediate mode shader " +
-          'after begin/endShape()'
-      );
-
-      myp5.box(70, 70, 70);
-      assert(
-        retainShader === myp5._renderer.curFillShader,
-        "_renderer's curFillShader did not switch back to retain shader " +
-          ' to draw box() after immediate mode'
-      );
-    });
-    */
-    test('Light shader set after ambientMaterial()', function() {
-      var lightShader = myp5._renderer._getLightShader();
-
-      myp5.ambientMaterial(128);
-      assert(
-        lightShader === myp5._renderer.curFillShader,
-        "_renderer's curFillShader did not get set to light shader " +
-          'after call to ambientMaterial()'
-      );
-    });
-    test('Light shader set after specularMaterial()', function() {
-      var lightShader = myp5._renderer._getLightShader();
-
-      myp5.specularMaterial(128);
-      assert(
-        lightShader === myp5._renderer.curFillShader,
-        "_renderer's curFillShader did not get set to light shader " +
-          'after call to specularMaterial()'
       );
     });
 

--- a/test/unit/webgl/p5.Shader.js
+++ b/test/unit/webgl/p5.Shader.js
@@ -12,6 +12,7 @@ suite('p5.Shader', function() {
         p.createCanvas(100, 100, p.WEBGL);
         p.pointLight(250, 250, 250, 100, 100, 0);
         p.ambientMaterial(250);
+        p.box();
       };
     });
   });
@@ -110,11 +111,11 @@ suite('p5.Shader', function() {
         'uDirectionalLightCount',
         'uPointLightCount',
         'uAmbientColor',
-        'uLightingDirection',
-        'uDirectionalColor',
+        'uDirectionalLightDirection',
+        'uDirectionalLightColor',
         'uPointLightLocation',
         'uPointLightColor',
-        'uSpecular',
+        'uSpecularPower',
         'uMaterialColor',
         'uSampler',
         'isTexture'
@@ -144,18 +145,18 @@ suite('p5.Shader', function() {
       );
     });
     test('Immediate Mode Shader definition', function() {
-      var expectedAttributes = ['aPosition', 'aVertexColor'];
+      var expectedAttributes = ['aPosition', 'aMaterialColor'];
 
       var expectedUniforms = [
         'uModelViewMatrix',
-        'uProjectionMatrix',
+        'uProjectionMatrix'
         /*'uResolution',*/
-        'uPointSize'
+        /*'uPointSize'*/
       ];
 
       testShader(
         'Immediate Mode Shader',
-        myp5._renderer._getImmediateModeShader(),
+        myp5._renderer._getImmediateLightShader(),
         expectedAttributes,
         expectedUniforms
       );
@@ -184,6 +185,7 @@ suite('p5.Shader', function() {
         "_renderer's curFillShader was not normal shader"
       );
     });
+    /*
     test('Color Shader is set after fill()', function() {
       myp5.fill(0);
       var colorShader = myp5._renderer._getColorShader();
@@ -220,6 +222,7 @@ suite('p5.Shader', function() {
           ' to draw box() after immediate mode'
       );
     });
+    */
     test('Light shader set after ambientMaterial()', function() {
       var lightShader = myp5._renderer._getLightShader();
 

--- a/test/unit/webgl/p5.Texture.js
+++ b/test/unit/webgl/p5.Texture.js
@@ -24,11 +24,13 @@ suite('p5.Texture', function() {
   });
 
   var testTextureSet = function(src) {
+    /*
     assert(
       myp5._renderer.curFillShader === myp5._renderer._getLightShader(),
       'shader was not set to light + texture shader after ' +
         'calling texture()'
     );
+    */
     var tex = myp5._renderer.getTexture(src);
     assert(tex !== undefined, 'texture was undefined');
     assert(tex instanceof p5.Texture, 'texture was not a p5.Texture object');

--- a/test/unit/webgl/stroke.js
+++ b/test/unit/webgl/stroke.js
@@ -20,14 +20,6 @@ suite('stroke WebGL', function() {
   suite('default stroke shader', function() {
     test('check default shader creation', function(done) {
       myp5.createCanvas(100, 100, myp5.WEBGL);
-      assert(
-        myp5._renderer.curStrokeShader === myp5._renderer._getLineShader(),
-        'default stroke shader was not initialized with GL canvas'
-      );
-      assert(
-        myp5._renderer.curFillShader === myp5._renderer._getColorShader(),
-        'default fill shader was not initialized with GL canvas'
-      );
       done();
     });
 


### PR DESCRIPTION
(Apologies for the size of this PR. It kind of came out like to is and I didn't have much luck splitting it apart)

This PR:
- Delays setting shader uniforms until just before the drawX call. This facilitates both switching shaders without losing state, and allows including this state in push/pop.
- Expands push/pop to include render state.
- Delays creating render buffers until just before the drawX call. This facilitates reusing geometries with different shaders (previously only buffers used by the current shader was created during geometry creation), optimizes away creation of unnecessary buffers and allows buffers to be refreshed as needed.
- Changes the meaning of 'curXXXshader’ to only hold the custom shader, if set. The shader used to render is determined by the render state prior to rendering.
- For rendering geometries, the association between source array, render buffer and vertex attribute is contained in a BufferDef object, arrays of which describe inputs for stroke and fill shaders. Previously repetitious attribute & buffer handling code now just involves looping through these arrays (see prepare buffers).
- Unifies the immediate & retained rendering code. Now the immediateMode object is just a p5.Geometry and is rendered like all the other geometries. Flags are added to the the geometry to track whether or not a source array is dirty and requires its render buffer to be refreshed. The immediate-mode renderers handle per-vertex attributes (color, ambient, shininess, etc…) instead of per-geometry uniforms.
- Expands the set of material properties to include those from processing: emissiveMaterial, specularMaterial, shininess. Plus additional lights, noLights, lightSpecular, lightFalloff methods for setting light properties. In addition, the rendered output more closely matches that of processing, for example materials/vertices can now have distinct ambient, diffuse & specular colors, each lit by their corresponding light components, and directional lights have specular reflections.
- Unifies the lighting code between all lighting shaders (immediate, per-vertex & per-pixel). Uses a simple include hack to 'include’ the lighting code in order to avoid duplication in the final .js file. This significantly reduces the visual difference between the per-pixel and lit per-vertex renderers.
- Fixes most of the immediate-mode draw modes (though still no quads or points)
- ~~Thunks render methods. This one is pretty simple but causes the most noise. Previously a lot of 3d-specific methods were declared directly on p5, or stub methods were used to thunk down to p5’s _renderer. Now there's a method 'thunkRendererMethods’ that runs during startup and adds these thunks automatically and additionally adds warning messages for unimplemented methods. This removes a bunch of boiler-plate code, and ensures that, for example, calling 'sphere()’ on the canvas renderer just outputs an error instead of crashing.~~

I think that about covers it. Sorry again for the mess!
