### PR TITLE
thunk renderer methods

### DIFF
--- a/src/core/2d_primitives.js
+++ b/src/core/2d_primitives.js
@@ -233,15 +233,7 @@ p5.prototype.ellipse = function(x, y, w, h, detailX, detailY) {
  * @param  {Number} z2 the z-coordinate of the second point
  * @chainable
  */
-p5.prototype.line = function() {
-  p5._validateParameters('line', arguments);
-
-  if (this._renderer._doStroke) {
-    this._renderer.line.apply(this._renderer, arguments);
-  }
-
-  return this;
-};
+// see thunkRendererMethods
 
 /**
  * Draws a point, a coordinate in space at the dimension of one pixel.
@@ -268,15 +260,7 @@ p5.prototype.line = function() {
  *4 points centered in the middle-right of the canvas.
  *
  */
-p5.prototype.point = function() {
-  p5._validateParameters('point', arguments);
-
-  if (this._renderer._doStroke) {
-    this._renderer.point.apply(this._renderer, arguments);
-  }
-
-  return this;
-};
+// see thunkRendererMethods
 
 /**
  * Draw a quad. A quad is a quadrilateral, a four sided polygon. It is
@@ -322,15 +306,7 @@ p5.prototype.point = function() {
  * @param {Number} z4
  * @chainable
  */
-p5.prototype.quad = function() {
-  p5._validateParameters('quad', arguments);
-
-  if (this._renderer._doStroke || this._renderer._doFill) {
-    this._renderer.quad.apply(this._renderer, arguments);
-  }
-
-  return this;
-};
+// see thunkRendererMethods
 
 /**
  * Draws a rectangle to the screen. A rectangle is a four-sided shape with
@@ -392,16 +368,7 @@ p5.prototype.quad = function() {
  * @param  {Integer} [detailY] number of segments in the y-direction
  * @chainable
  */
-p5.prototype.rect = function(x, y, w, h, detailX, detailY) {
-  p5._validateParameters('rect', arguments);
-
-  if (this._renderer._doStroke || this._renderer._doFill) {
-    var vals = canvas.modeAdjust(x, y, w, h, this._renderer._rectMode);
-    this._renderer.rect([vals.x, vals.y, vals.w, vals.h, detailX, detailY]);
-  }
-
-  return this;
-};
+// see thunkRendererMethods
 
 /**
  * A triangle is a plane created by connecting three points. The first two
@@ -427,14 +394,6 @@ p5.prototype.rect = function(x, y, w, h, detailX, detailY) {
  * white triangle with black outline in mid-right of canvas.
  *
  */
-p5.prototype.triangle = function() {
-  p5._validateParameters('triangle', arguments);
-
-  if (this._renderer._doStroke || this._renderer._doFill) {
-    this._renderer.triangle(arguments);
-  }
-
-  return this;
-};
+// see thunkRendererMethods
 
 module.exports = p5;

--- a/src/core/attributes.js
+++ b/src/core/attributes.js
@@ -103,10 +103,6 @@ p5.prototype.ellipseMode = function(m) {
  * 2 pixelated 36x36 white ellipses to left & right of center, black background
  *
  */
-p5.prototype.noSmooth = function() {
-  this._renderer.noSmooth();
-  return this;
-};
 
 /**
  * Modifies the location from which rectangles are drawn by changing the way
@@ -201,10 +197,7 @@ p5.prototype.rectMode = function(m) {
  * 2 pixelated 36x36 white ellipses one left one right of center. On black.
  *
  */
-p5.prototype.smooth = function() {
-  this._renderer.smooth();
-  return this;
-};
+// see thunkRendererMethods
 
 /**
  * Sets the style for rendering line endings. These ends are either squared,
@@ -231,17 +224,7 @@ p5.prototype.smooth = function() {
  * 3 lines. Top line: rounded ends, mid: squared, bottom:longer squared ends.
  *
  */
-p5.prototype.strokeCap = function(cap) {
-  p5._validateParameters('strokeCap', arguments);
-  if (
-    cap === constants.ROUND ||
-    cap === constants.SQUARE ||
-    cap === constants.PROJECT
-  ) {
-    this._renderer.strokeCap(cap);
-  }
-  return this;
-};
+// see thunkRendererMethods
 
 /**
  * Sets the style of the joints which connect line segments. These joints
@@ -298,17 +281,7 @@ p5.prototype.strokeCap = function(cap) {
  * Right-facing arrowhead shape with rounded tip in center of canvas.
  *
  */
-p5.prototype.strokeJoin = function(join) {
-  p5._validateParameters('strokeJoin', arguments);
-  if (
-    join === constants.ROUND ||
-    join === constants.BEVEL ||
-    join === constants.MITER
-  ) {
-    this._renderer.strokeJoin(join);
-  }
-  return this;
-};
+// see thunkRendererMethods
 
 /**
  * Sets the width of the stroke used for lines, points, and the border
@@ -333,10 +306,6 @@ p5.prototype.strokeJoin = function(join) {
  * 3 horizontal black lines. Top line: thin, mid: medium, bottom:thick.
  *
  */
-p5.prototype.strokeWeight = function(w) {
-  p5._validateParameters('strokeWeight', arguments);
-  this._renderer.strokeWeight(w);
-  return this;
-};
+// see thunkRendererMethods
 
 module.exports = p5;

--- a/src/core/curves.js
+++ b/src/core/curves.js
@@ -79,15 +79,7 @@ require('./error_helpers');
  * @param  {Number} z4 z-coordinate for the second anchor point
  * @chainable
  */
-p5.prototype.bezier = function() {
-  p5._validateParameters('bezier', arguments);
-
-  if (this._renderer._doStroke || this._renderer._doFill) {
-    this._renderer.bezier.apply(this._renderer, arguments);
-  }
-
-  return this;
-};
+// see thunkRendererMethods
 
 /**
  * Sets the resolution at which Beziers display.
@@ -331,15 +323,7 @@ p5.prototype.bezierTangent = function(a, b, c, d, t) {
  * @param  {Number} z4 z-coordinate for the ending control point
  * @chainable
  */
-p5.prototype.curve = function() {
-  p5._validateParameters('curve', arguments);
-
-  if (this._renderer._doStroke) {
-    this._renderer.curve.apply(this._renderer, arguments);
-  }
-
-  return this;
-};
+// see thunkRendererMethods
 
 /**
  * Sets the resolution at which curves display.

--- a/src/core/error_helpers.js
+++ b/src/core/error_helpers.js
@@ -160,15 +160,24 @@ if (typeof IS_MINIFIED !== 'undefined') {
   // lookupParamDoc() for querying data.json
   var lookupParamDoc = function(func) {
     var queryResult = arrDoc.classitems.filter(function(x) {
-      return x.name === func;
+      return x.name === func && x.class === 'p5';
     });
+    if (!queryResult.length) {
+      queryResult = arrDoc.classitems.filter(function(x) {
+        return x.name === func;
+      });
+    }
+    if (!queryResult.length) {
+      return null;
+    }
+
     // different JSON structure for funct with multi-format
     var overloads = [];
     if (queryResult[0].hasOwnProperty('overloads')) {
       for (var i = 0; i < queryResult[0].overloads.length; i++) {
         overloads.push(queryResult[0].overloads[i].params);
       }
-    } else {
+    } else if (queryResult[0].params) {
       overloads.push(queryResult[0].params);
     }
 
@@ -424,7 +433,14 @@ if (typeof IS_MINIFIED !== 'undefined') {
       return; // skip FES
     }
 
-    var docs = docCache[func] || (docCache[func] = lookupParamDoc(func));
+    var docs = docCache[func];
+    if (typeof docs === 'undefined') {
+      docs = docCache[func] = lookupParamDoc(func);
+    }
+    if (docs === null) {
+      return;
+    }
+
     var errorArray = [];
     var minErrCount = 999999;
     var overloads = docs.overloads;

--- a/src/core/init.js
+++ b/src/core/init.js
@@ -2,6 +2,79 @@
 
 var p5 = require('../core/core');
 
+(function thunkRendererMethods() {
+  // prettier-ignore
+  var rendererMethods = [
+    // attributes.js
+    'noSmooth', 'smooth', 'strokeCap', 'strokeJoin', 'strokeWeight',
+    // 2d_primitives.js
+    'line', 'point', 'quad', 'rect', 'triangle',
+    // curves.js
+    'bezier', 'curve',
+    // vertex.js
+    'normal', 'vertex', 'bezierVertex', 'beginShape',
+    // pixels.js
+    'copy', 'loadPixels', 'get', 'set', 'updatePixels',
+    // transform.js
+    'applyMatrix', 'resetMatrix', 'rotate', 'rotateX', 'rotateY', 'rotateZ',
+    'translate', 'shearX', 'shearY',
+    // typography/attributes.js
+    'textAlign', 'textLeading', 'textSize', 'textStyle', 'textWidth',
+    'textAscent', 'textDescent' /*"_updateTextMetrics", */,
+    // typography/loading_displaying.js
+    'text',
+    // webgl/p5.RendererGL.js 
+    'setAttributes',
+    // webgl/lights.js 
+    'lights', 'noLights', 'lightSpecular', 'lightFalloff', 'ambientLight',
+    'directionalLight', 'pointLight',
+    // webgl/camera.js 
+    'perspective', 'camera', 'ortho',
+    // webgl/loading.js 
+    'model',
+    // webgl/material.js 
+    'shader', 'normalMaterial', 'texture', 'ambient', 'ambientMaterial',
+    'specular', 'specularMaterial', 'shininess', 'resetShader',
+    'createShader',
+    // webgl/primitives.js 
+    'plane', 'box', 'sphere', 'cylinder', 'cone', 'ellipsoid', 'torus',
+    // webgl/interaction.js
+    'orbitControl'
+  ];
+  var rendererPrototype = p5.Renderer.prototype;
+  for (var im = 0; im < rendererMethods.length; im++) {
+    var m = rendererMethods[im];
+
+    if (typeof IS_MINIFIED === 'undefined' && p5.prototype[m]) {
+      console.warn('p5.' + m + '() already defined!');
+    }
+
+    // create the proxy in p5 that calls into the _renderer
+    p5.prototype[m] = (function(m) {
+      return function() {
+        // validate the parameters
+        p5._validateParameters(m, arguments);
+
+        // thunk through to the underlying renderer method
+        var ret = this._renderer[m].apply(this._renderer, arguments);
+
+        // if the renderer returned 'undefined', method is chainable
+        if (typeof ret === 'undefined') ret = this;
+        return ret;
+      };
+    })(m);
+
+    // add an unimplemented warning in the base class
+    if (!rendererPrototype.hasOwnProperty(m)) {
+      rendererPrototype[m] = (function(m) {
+        return function() {
+          console.warn(m + '() is not supported in this rendering mode.');
+        };
+      })(m);
+    }
+  }
+})();
+
 /**
  * _globalInit
  *

--- a/src/core/p5.Renderer2D.js
+++ b/src/core/p5.Renderer2D.js
@@ -375,6 +375,12 @@ p5.Renderer2D.prototype.set = function(x, y, imgOrCol) {
 };
 
 p5.Renderer2D.prototype.updatePixels = function(x, y, w, h) {
+  if (this._pInst && this._pInst.pixels.length === 0) {
+    // graceful fail - if loadPixels() or set() has not been called, pixel
+    // array will be empty, ignore call to updatePixels()
+    return;
+  }
+
   var pd = this._pixelDensity || this._pInst._pixelDensity;
   if (
     x === undefined &&
@@ -534,13 +540,13 @@ p5.Renderer2D.prototype.ellipse = function(args) {
 };
 
 p5.Renderer2D.prototype.line = function(x1, y1, x2, y2) {
-  var ctx = this.drawingContext;
   if (!this._doStroke) {
     return this;
   } else if (this._getStroke() === styleEmpty) {
     return this;
   }
   // Translate the line by (0.5, 0.5) to draw it crisp
+  var ctx = this.drawingContext;
   if (ctx.lineWidth % 2 === 1) {
     ctx.translate(0.5, 0.5);
   }
@@ -555,12 +561,12 @@ p5.Renderer2D.prototype.line = function(x1, y1, x2, y2) {
 };
 
 p5.Renderer2D.prototype.point = function(x, y) {
-  var ctx = this.drawingContext;
   if (!this._doStroke) {
     return this;
   } else if (this._getStroke() === styleEmpty) {
     return this;
   }
+  var ctx = this.drawingContext;
   var s = this._getStroke();
   var f = this._getFill();
   x = Math.round(x);
@@ -578,7 +584,6 @@ p5.Renderer2D.prototype.point = function(x, y) {
 };
 
 p5.Renderer2D.prototype.quad = function(x1, y1, x2, y2, x3, y3, x4, y4) {
-  var ctx = this.drawingContext;
   var doFill = this._doFill,
     doStroke = this._doStroke;
   if (doFill && !doStroke) {
@@ -590,6 +595,7 @@ p5.Renderer2D.prototype.quad = function(x1, y1, x2, y2, x3, y3, x4, y4) {
       return this;
     }
   }
+  var ctx = this.drawingContext;
   ctx.beginPath();
   ctx.moveTo(x1, y1);
   ctx.lineTo(x2, y2);
@@ -605,15 +611,13 @@ p5.Renderer2D.prototype.quad = function(x1, y1, x2, y2, x3, y3, x4, y4) {
   return this;
 };
 
-p5.Renderer2D.prototype.rect = function(args) {
-  var x = args[0],
-    y = args[1],
-    w = args[2],
-    h = args[3],
-    tl = args[4],
-    tr = args[5],
-    br = args[6],
-    bl = args[7];
+p5.Renderer2D.prototype.rect = function(x, y, w, h, tl, tr, br, bl) {
+  var vals = canvas.modeAdjust(x, y, w, h, this._rectMode);
+  x = vals[0];
+  y = vals[1];
+  w = vals[2];
+  h = vals[3];
+
   var ctx = this.drawingContext;
   var doFill = this._doFill,
     doStroke = this._doStroke;
@@ -698,16 +702,9 @@ p5.Renderer2D.prototype.rect = function(args) {
   return this;
 };
 
-p5.Renderer2D.prototype.triangle = function(args) {
-  var ctx = this.drawingContext;
+p5.Renderer2D.prototype.triangle = function(x1, y1, x2, y2, x3, y3) {
   var doFill = this._doFill,
     doStroke = this._doStroke;
-  var x1 = args[0],
-    y1 = args[1];
-  var x2 = args[2],
-    y2 = args[3];
-  var x3 = args[4],
-    y3 = args[5];
   if (doFill && !doStroke) {
     if (this._getFill() === styleEmpty) {
       return this;
@@ -717,6 +714,7 @@ p5.Renderer2D.prototype.triangle = function(args) {
       return this;
     }
   }
+  var ctx = this.drawingContext;
   ctx.beginPath();
   ctx.moveTo(x1, y1);
   ctx.lineTo(x2, y2);
@@ -1070,21 +1068,25 @@ p5.Renderer2D.prototype._setStroke = function(strokeStyle) {
 // SHAPE | Curves
 //////////////////////////////////////////////
 p5.Renderer2D.prototype.bezier = function(x1, y1, x2, y2, x3, y3, x4, y4) {
+  if (!this._doStroke && !this._doFill) {
+    return;
+  }
   this._pInst.beginShape();
   this._pInst.vertex(x1, y1);
   this._pInst.bezierVertex(x2, y2, x3, y3, x4, y4);
   this._pInst.endShape();
-  return this;
 };
 
 p5.Renderer2D.prototype.curve = function(x1, y1, x2, y2, x3, y3, x4, y4) {
+  if (!this._doStroke && !this._doFill) {
+    return;
+  }
   this._pInst.beginShape();
   this._pInst.curveVertex(x1, y1);
   this._pInst.curveVertex(x2, y2);
   this._pInst.curveVertex(x3, y3);
   this._pInst.curveVertex(x4, y4);
   this._pInst.endShape();
-  return this;
 };
 
 //////////////////////////////////////////////
@@ -1119,6 +1121,9 @@ p5.Renderer2D.prototype.resetMatrix = function() {
 };
 
 p5.Renderer2D.prototype.rotate = function(r) {
+  if (this._pInst._angleMode === constants.DEGREES) {
+    r = this._pInst.radians(r);
+  }
   this.drawingContext.rotate(r);
 };
 
@@ -1128,19 +1133,11 @@ p5.Renderer2D.prototype.scale = function(x, y) {
 };
 
 p5.Renderer2D.prototype.shearX = function(angle) {
-  if (this._pInst._angleMode === constants.DEGREES) {
-    // undoing here, because it gets redone in tan()
-    angle = this._pInst.degrees(angle);
-  }
   this.drawingContext.transform(1, 0, this._pInst.tan(angle), 1, 0, 0);
   return this;
 };
 
 p5.Renderer2D.prototype.shearY = function(angle) {
-  if (this._pInst._angleMode === constants.DEGREES) {
-    // undoing here, because it gets redone in tan()
-    angle = this._pInst.degrees(angle);
-  }
   this.drawingContext.transform(1, this._pInst.tan(angle), 0, 1, 0, 0);
   return this;
 };
@@ -1310,6 +1307,9 @@ p5.Renderer2D.prototype._renderText = function(p, line, x, y, maxY) {
 };
 
 p5.Renderer2D.prototype.textWidth = function(s) {
+  if (s.length === 0) {
+    return 0;
+  }
   if (this._isOpenType()) {
     return this._textFont._textWidth(s, this._textSize);
   }

--- a/src/core/p5.Renderer2D.js
+++ b/src/core/p5.Renderer2D.js
@@ -613,10 +613,10 @@ p5.Renderer2D.prototype.quad = function(x1, y1, x2, y2, x3, y3, x4, y4) {
 
 p5.Renderer2D.prototype.rect = function(x, y, w, h, tl, tr, br, bl) {
   var vals = canvas.modeAdjust(x, y, w, h, this._rectMode);
-  x = vals[0];
-  y = vals[1];
-  w = vals[2];
-  h = vals[3];
+  x = vals.x;
+  y = vals.y;
+  w = vals.w;
+  h = vals.h;
 
   var ctx = this.drawingContext;
   var doFill = this._doFill,

--- a/src/core/transform.js
+++ b/src/core/transform.js
@@ -9,7 +9,6 @@
 'use strict';
 
 var p5 = require('./core');
-var constants = require('./constants');
 
 /**
  * Multiplies the current matrix by the one specified through the parameters.
@@ -116,10 +115,7 @@ var constants = require('./constants');
  * A rectangle shearing
  *
  */
-p5.prototype.applyMatrix = function(a, b, c, d, e, f) {
-  this._renderer.applyMatrix(a, b, c, d, e, f);
-  return this;
-};
+// see thunkRendererMethods
 
 p5.prototype.popMatrix = function() {
   throw new Error('popMatrix() not used, see pop()');
@@ -154,10 +150,7 @@ p5.prototype.pushMatrix = function() {
  * A rotated retangle in the center with another at the top left corner
  *
  */
-p5.prototype.resetMatrix = function() {
-  this._renderer.resetMatrix();
-  return this;
-};
+// see thunkRendererMethods
 
 /**
  * Rotates a shape the amount specified by the angle parameter. This
@@ -193,17 +186,7 @@ p5.prototype.resetMatrix = function() {
  * white 52x52 rect with black outline at center rotated counter 45 degrees
  *
  */
-p5.prototype.rotate = function(angle, axis) {
-  p5._validateParameters('rotate', arguments);
-  var r;
-  if (this._angleMode === constants.DEGREES) {
-    r = this.radians(angle);
-  } else if (this._angleMode === constants.RADIANS) {
-    r = angle;
-  }
-  this._renderer.rotate(r, axis);
-  return this;
-};
+// see thunkRendererMethods
 
 /**
  * Rotates around X axis.
@@ -227,15 +210,7 @@ p5.prototype.rotate = function(angle, axis) {
  * @alt
  * 3d box rotating around the x axis.
  */
-p5.prototype.rotateX = function(rad) {
-  p5._validateParameters('rotateX', arguments);
-  if (this._renderer.isP3D) {
-    this._renderer.rotateX(rad);
-  } else {
-    throw 'not supported in p2d. Please use webgl mode';
-  }
-  return this;
-};
+// see thunkRendererMethods
 
 /**
  * Rotates around Y axis.
@@ -259,15 +234,7 @@ p5.prototype.rotateX = function(rad) {
  * @alt
  * 3d box rotating around the y axis.
  */
-p5.prototype.rotateY = function(rad) {
-  p5._validateParameters('rotateY', arguments);
-  if (this._renderer.isP3D) {
-    this._renderer.rotateY(rad);
-  } else {
-    throw 'not supported in p2d. Please use webgl mode';
-  }
-  return this;
-};
+// see thunkRendererMethods
 
 /**
  * Rotates around Z axis. Webgl mode only.
@@ -291,15 +258,7 @@ p5.prototype.rotateY = function(rad) {
  * @alt
  * 3d box rotating around the z axis.
  */
-p5.prototype.rotateZ = function(rad) {
-  p5._validateParameters('rotateZ', arguments);
-  if (this._renderer.isP3D) {
-    this._renderer.rotateZ(rad);
-  } else {
-    throw 'not supported in p2d. Please use webgl mode';
-  }
-  return this;
-};
+// see thunkRendererMethods
 
 /**
  * Increases or decreases the size of a shape by expanding and contracting
@@ -409,14 +368,7 @@ p5.prototype.scale = function(x, y, z) {
  * white irregular quadrilateral with black outline at top middle.
  *
  */
-p5.prototype.shearX = function(angle) {
-  p5._validateParameters('shearX', arguments);
-  if (this._angleMode === constants.DEGREES) {
-    angle = this.radians(angle);
-  }
-  this._renderer.shearX(angle);
-  return this;
-};
+// see thunkRendererMethods
 
 /**
  * Shears a shape around the y-axis the amount specified by the angle
@@ -451,14 +403,7 @@ p5.prototype.shearX = function(angle) {
  * white irregular quadrilateral with black outline at middle bottom.
  *
  */
-p5.prototype.shearY = function(angle) {
-  p5._validateParameters('shearY', arguments);
-  if (this._angleMode === constants.DEGREES) {
-    angle = this.radians(angle);
-  }
-  this._renderer.shearY(angle);
-  return this;
-};
+// see thunkRendererMethods
 
 /**
  * Specifies an amount to displace objects within the display window.
@@ -500,14 +445,6 @@ p5.prototype.shearY = function(angle) {
  * 3 white 55x55 rects with black outlines at top-l, center-r and bottom-r.
  *
  */
-p5.prototype.translate = function(x, y, z) {
-  p5._validateParameters('translate', arguments);
-  if (this._renderer.isP3D) {
-    this._renderer.translate(x, y, z);
-  } else {
-    this._renderer.translate(x, y);
-  }
-  return this;
-};
+// see thunkRendererMethods
 
 module.exports = p5;

--- a/src/core/vertex.js
+++ b/src/core/vertex.js
@@ -242,28 +242,24 @@ p5.prototype.beginContour = function() {
  * Thick white l-shape with black outline mid-top-left of canvas.
  *
  */
-p5.prototype.beginShape = function(kind) {
-  if (this._renderer.isP3D) {
-    this._renderer.beginShape.apply(this._renderer, arguments);
+// see thunkRendererMethods
+p5.Renderer2D.prototype.beginShape = function(kind) {
+  if (
+    kind === constants.POINTS ||
+    kind === constants.LINES ||
+    kind === constants.TRIANGLES ||
+    kind === constants.TRIANGLE_FAN ||
+    kind === constants.TRIANGLE_STRIP ||
+    kind === constants.QUADS ||
+    kind === constants.QUAD_STRIP
+  ) {
+    shapeKind = kind;
   } else {
-    if (
-      kind === constants.POINTS ||
-      kind === constants.LINES ||
-      kind === constants.TRIANGLES ||
-      kind === constants.TRIANGLE_FAN ||
-      kind === constants.TRIANGLE_STRIP ||
-      kind === constants.QUADS ||
-      kind === constants.QUAD_STRIP
-    ) {
-      shapeKind = kind;
-    } else {
-      shapeKind = null;
-    }
-
-    vertices = [];
-    contourVertices = [];
+    shapeKind = null;
   }
-  return this;
+
+  vertices = [];
+  contourVertices = [];
 };
 
 /**
@@ -312,8 +308,8 @@ p5.prototype.beginShape = function(kind) {
  * white crescent shape in middle of canvas. Points facing left.
  *
  */
-p5.prototype.bezierVertex = function(x2, y2, x3, y3, x4, y4) {
-  p5._validateParameters('bezierVertex', arguments);
+// see thunkRendererMethods
+p5.Renderer2D.prototype.bezierVertex = function(x2, y2, x3, y3, x4, y4) {
   if (vertices.length === 0) {
     throw 'vertex() must be used once before calling bezierVertex()';
   } else {
@@ -329,7 +325,6 @@ p5.prototype.bezierVertex = function(x2, y2, x3, y3, x4, y4) {
       vertices.push(vert);
     }
   }
-  return this;
 };
 
 /**
@@ -632,33 +627,29 @@ p5.prototype.quadraticVertex = function(cx, cy, x3, y3) {
  * @param  {Number} [u] the vertex's texture u-coordinate
  * @param  {Number} [v] the vertex's texture v-coordinate
  */
-p5.prototype.vertex = function(x, y, moveTo, u, v) {
-  if (this._renderer.isP3D) {
-    this._renderer.vertex.apply(this._renderer, arguments);
-  } else {
-    var vert = [];
-    vert.isVert = true;
-    vert[0] = x;
-    vert[1] = y;
-    vert[2] = 0;
-    vert[3] = 0;
-    vert[4] = 0;
-    vert[5] = this._renderer._getFill();
-    vert[6] = this._renderer._getStroke();
+// see thunkRendererMethods
+p5.Renderer2D.prototype.vertex = function(x, y, moveTo, u, v) {
+  var vert = [];
+  vert.isVert = true;
+  vert[0] = x;
+  vert[1] = y;
+  vert[2] = 0;
+  vert[3] = 0;
+  vert[4] = 0;
+  vert[5] = this._getFill();
+  vert[6] = this._getStroke();
 
-    if (moveTo) {
-      vert.moveTo = moveTo;
-    }
-    if (isContour) {
-      if (contourVertices.length === 0) {
-        vert.moveTo = true;
-      }
-      contourVertices.push(vert);
-    } else {
-      vertices.push(vert);
-    }
+  if (moveTo) {
+    vert.moveTo = moveTo;
   }
-  return this;
+  if (isContour) {
+    if (contourVertices.length === 0) {
+      vert.moveTo = true;
+    }
+    contourVertices.push(vert);
+  } else {
+    vertices.push(vert);
+  }
 };
 
 module.exports = p5;

--- a/src/image/loading_displaying.js
+++ b/src/image/loading_displaying.js
@@ -384,7 +384,7 @@ p5.prototype.image = function(
  */
 p5.prototype.tint = function() {
   p5._validateParameters('tint', arguments);
-  var c = this.color.apply(this, arguments);
+  var c = p5.prototype.color.apply(this, arguments);
   this._renderer._tint = c.levels;
 };
 

--- a/src/image/p5.Image.js
+++ b/src/image/p5.Image.js
@@ -369,8 +369,8 @@ p5.Image.prototype.get = function(x, y, w, h) {
  * @method set
  * @param {Number}              x x-coordinate of the pixel
  * @param {Number}              y y-coordinate of the pixel
- * @param {Number|Number[]|Object}   a grayscale value | pixel array |
- *                                a p5.Color | image to copy
+ * @param {Number|Number[]|p5.Color|p5.Image}   a grayscale value |
+ *                    pixel array | a p5.Color | image to copy
  * @example
  * <div>
  * <code>

--- a/src/image/pixels.js
+++ b/src/image/pixels.js
@@ -191,6 +191,7 @@ p5.prototype.blend = function() {
  * @param  {Integer} dy Y coordinate of the destination's upper left corner
  * @param  {Integer} dw destination image width
  * @param  {Integer} dh destination image height
+ * @chainable
  *
  * @example
  * <div><code>
@@ -226,11 +227,9 @@ p5.prototype.blend = function() {
  * @param  {Integer} dy
  * @param  {Integer} dw
  * @param  {Integer} dh
+ * @chainable
  */
-p5.prototype.copy = function() {
-  p5._validateParameters('copy', arguments);
-  p5.Renderer2D.prototype.copy.apply(this._renderer, arguments);
-};
+// see thunkRendererMethods
 
 /**
  * Applies a filter to the canvas.
@@ -482,9 +481,7 @@ p5.prototype.filter = function(operation, value) {
  * Image of the rocky mountains with 50x50 green rect in center of canvas
  *
  */
-p5.prototype.get = function(x, y, w, h) {
-  return this._renderer.get(x, y, w, h);
-};
+// see thunkRendererMethods
 
 /**
  * Loads the pixel data for the display window into the pixels[] array. This
@@ -493,6 +490,7 @@ p5.prototype.get = function(x, y, w, h) {
  * will occur.
  *
  * @method loadPixels
+ * @chainable
  * @example
  * <div>
  * <code>
@@ -518,9 +516,7 @@ p5.prototype.get = function(x, y, w, h) {
  * two images of the rocky mountains. one on top, one on bottom of canvas.
  *
  */
-p5.prototype.loadPixels = function() {
-  this._renderer.loadPixels();
-};
+// see thunkRendererMethods
 
 /**
  * <p>Changes the color of any pixel, or writes an image directly to the
@@ -546,8 +542,9 @@ p5.prototype.loadPixels = function() {
  * @method set
  * @param {Number}              x x-coordinate of the pixel
  * @param {Number}              y y-coordinate of the pixel
- * @param {Number|Number[]|Object} c insert a grayscale value | a pixel array |
- *                                a p5.Color object | a p5.Image to copy
+ * @param {Number|Number[]|p5.Color|p5.Image} c insert a grayscale value |
+ *                   a pixel array | a p5.Color object | a p5.Image to copy
+ * @chainable
  * @example
  * <div>
  * <code>
@@ -593,9 +590,8 @@ p5.prototype.loadPixels = function() {
  * square with orangey-brown gradient lightening at bottom right.
  * image of the rocky mountains. with lines like an 'x' through the center.
  */
-p5.prototype.set = function(x, y, imgOrCol) {
-  this._renderer.set(x, y, imgOrCol);
-};
+// see thunkRendererMethods
+
 /**
  * Updates the display window with the data in the pixels[] array.
  * Use in conjunction with loadPixels(). If you're only reading pixels from
@@ -634,13 +630,6 @@ p5.prototype.set = function(x, y, imgOrCol) {
  * @alt
  * two images of the rocky mountains. one on top, one on bottom of canvas.
  */
-p5.prototype.updatePixels = function(x, y, w, h) {
-  // graceful fail - if loadPixels() or set() has not been called, pixel
-  // array will be empty, ignore call to updatePixels()
-  if (this.pixels.length === 0) {
-    return;
-  }
-  this._renderer.updatePixels(x, y, w, h);
-};
+// see thunkRendererMethods
 
 module.exports = p5;

--- a/src/math/trigonometry.js
+++ b/src/math/trigonometry.js
@@ -313,9 +313,7 @@ p5.prototype.degrees = function(angle) {
  * </code>
  * </div>
  */
-p5.prototype.radians = function(angle) {
-  return polarGeometry.degreesToRadians(angle);
-};
+p5.prototype.radians = polarGeometry.degreesToRadians;
 
 /**
  * Sets the current mode of p5 to given mode. Default mode is RADIANS.

--- a/src/typography/attributes.js
+++ b/src/typography/attributes.js
@@ -52,9 +52,7 @@ var p5 = require('../core/core');
  * @method textAlign
  * @return {Object}
  */
-p5.prototype.textAlign = function(horizAlign, vertAlign) {
-  return this._renderer.textAlign.apply(this._renderer, arguments);
-};
+// see thunkRendererMethods
 
 /**
  * Sets/gets the spacing, in pixels, between lines of text. This
@@ -89,9 +87,7 @@ p5.prototype.textAlign = function(horizAlign, vertAlign) {
  * @method textLeading
  * @return {Number}
  */
-p5.prototype.textLeading = function(theLeading) {
-  return this._renderer.textLeading.apply(this._renderer, arguments);
-};
+// see thunkRendererMethods
 
 /**
  * Sets/gets the current font size. This size will be used in all subsequent
@@ -120,9 +116,7 @@ p5.prototype.textLeading = function(theLeading) {
  * @method textSize
  * @return {Number}
  */
-p5.prototype.textSize = function(theSize) {
-  return this._renderer.textSize.apply(this._renderer, arguments);
-};
+// see thunkRendererMethods
 
 /**
  * Sets/gets the style of the text for system fonts to NORMAL, ITALIC, or BOLD.
@@ -154,9 +148,7 @@ p5.prototype.textSize = function(theSize) {
  * @method textStyle
  * @return {String}
  */
-p5.prototype.textStyle = function(theStyle) {
-  return this._renderer.textStyle.apply(this._renderer, arguments);
-};
+// see thunkRendererMethods
 
 /**
  * Calculates and returns the width of any character or text string.
@@ -185,12 +177,7 @@ p5.prototype.textStyle = function(theStyle) {
  *Letter P and p5.js are displayed with vertical lines at end. P is wide
  *
  */
-p5.prototype.textWidth = function(theText) {
-  if (theText.length === 0) {
-    return 0;
-  }
-  return this._renderer.textWidth.apply(this._renderer, arguments);
-};
+// see thunkRendererMethods
 
 /**
  * Returns the ascent of the current font at its current size. The ascent
@@ -216,9 +203,7 @@ p5.prototype.textWidth = function(theText) {
  * </code>
  * </div>
  */
-p5.prototype.textAscent = function() {
-  return this._renderer.textAscent();
-};
+// see thunkRendererMethods
 
 /**
  * Returns the descent of the current font at its current size. The descent
@@ -244,9 +229,7 @@ p5.prototype.textAscent = function() {
  * </code>
  * </div>
  */
-p5.prototype.textDescent = function() {
-  return this._renderer.textDescent();
-};
+// see thunkRendererMethods
 
 /**
  * Helper function to measure ascent and descent.

--- a/src/typography/loading_displaying.js
+++ b/src/typography/loading_displaying.js
@@ -190,11 +190,7 @@ p5.prototype.loadFont = function(path, onSuccess, onError) {
  * The quick brown fox jumped over the lazy dog.
  *
  */
-p5.prototype.text = function(str, x, y, maxWidth, maxHeight) {
-  return !(this._renderer._doFill || this._renderer._doStroke)
-    ? this
-    : this._renderer.text.apply(this._renderer, arguments);
-};
+// see thunkRendererMethods
 
 /**
  * Sets the current font that will be drawn with the text() function.

--- a/src/webgl/camera.js
+++ b/src/webgl/camera.js
@@ -46,11 +46,7 @@ var p5 = require('../core/core');
  * blue square shrinks in size grows to fill canvas. disappears then loops.
  *
  */
-p5.prototype.camera = function() {
-  this._renderer.camera.apply(this._renderer, arguments);
-  return this;
-};
-
+// see thunkRendererMethods
 p5.RendererGL.prototype.camera = function(
   eyeX,
   eyeY,
@@ -153,7 +149,6 @@ p5.RendererGL.prototype.camera = function(
     this.cameraMatrix.mat4[14],
     this.cameraMatrix.mat4[15]
   );
-  return this;
 };
 
 /**
@@ -198,11 +193,7 @@ p5.RendererGL.prototype.camera = function(
  * colored 3d boxes toggleable with mouse position
  *
  */
-p5.prototype.perspective = function() {
-  this._renderer.perspective.apply(this._renderer, arguments);
-  return this;
-};
-
+// see thunkRendererMethods
 p5.RendererGL.prototype.perspective = function(fovy, aspect, near, far) {
   if (typeof fovy === 'undefined') {
     fovy = this.defaultCameraFOV;
@@ -275,11 +266,7 @@ p5.RendererGL.prototype.perspective = function(fovy, aspect, near, far) {
  * 3 3d boxes, reveal several more boxes on 3d plane when mouse used to toggle
  *
  */
-p5.prototype.ortho = function() {
-  this._renderer.ortho.apply(this._renderer, arguments);
-  return this;
-};
-
+// see thunkRendererMethods
 p5.RendererGL.prototype.ortho = function(left, right, bottom, top, near, far) {
   if (left === undefined) left = -this.width / 2;
   if (right === undefined) right = +this.width / 2;

--- a/src/webgl/interaction.js
+++ b/src/webgl/interaction.js
@@ -9,7 +9,7 @@ var p5 = require('../core/core');
  */
 //@TODO: implement full orbit controls including
 //pan, zoom, quaternion rotation, etc.
-p5.prototype.orbitControl = function() {
+p5.RendererGL.prototype.orbitControl = function() {
   if (this.mouseIsPressed) {
     this.rotateY((this.mouseX - this.width / 2) / (this.width / 2));
     this.rotateX((this.mouseY - this.height / 2) / (this.width / 2));

--- a/src/webgl/light.js
+++ b/src/webgl/light.js
@@ -42,30 +42,27 @@ var p5 = require('../core/core');
  * evenly distributed light across a sphere
  *
  */
-
 /**
  * @method ambientLight
- * @param  {String}        value   a color string
+ * @param  {String|Number}        value   a color string or grey value
  * @param  {Number}        [alpha]
  * @chainable
  */
-
 /**
  * @method ambientLight
  * @param  {Number[]}      values  an array containing the red,green,blue &
  *                                 and alpha components of the color
  * @chainable
  */
-
 /**
  * @method ambientLight
  * @param  {p5.Color}      color   the ambient light color
  * @chainable
  */
-p5.prototype.ambientLight = function(v1, v2, v3, a) {
-  var color = this.color.apply(this, arguments);
+p5.RendererGL.prototype.ambientLight = function(v1, v2, v3, a) {
+  var color = p5.prototype.color.apply(this._pInst, arguments);
 
-  var shader = this._renderer._useLightShader();
+  var shader = this._useLightShader();
 
   //@todo this is a bit icky. array uniforms have
   //to be multiples of the type 3(rgb) in this case.
@@ -73,21 +70,16 @@ p5.prototype.ambientLight = function(v1, v2, v3, a) {
   //would be better
   shader.setUniform('uUseLighting', true);
   //in case there's no material color for the geometry
-  shader.setUniform('uMaterialColor', this._renderer.curFillColor);
+  shader.setUniform('uMaterialColor', this.curFillColor);
 
-  this._renderer.ambientLightColors.push(
+  this.ambientLightColors.push(
     color._array[0],
     color._array[1],
     color._array[2]
   );
-  shader.setUniform('uAmbientColor', this._renderer.ambientLightColors);
+  shader.setUniform('uAmbientColor', this.ambientLightColors);
 
-  shader.setUniform(
-    'uAmbientLightCount',
-    this._renderer.ambientLightColors.length / 3
-  );
-
-  return this;
+  shader.setUniform('uAmbientLightCount', this.ambientLightColors.length / 3);
 };
 
 /**
@@ -122,7 +114,6 @@ p5.prototype.ambientLight = function(v1, v2, v3, a) {
  * light source on canvas changeable with mouse position
  *
  */
-
 /**
  * @method directionalLight
  * @param  {Number[]|String|p5.Color} color   color Array, CSS color string,
@@ -132,14 +123,12 @@ p5.prototype.ambientLight = function(v1, v2, v3, a) {
  * @param  {Number}                   z       z axis direction
  * @chainable
  */
-
 /**
  * @method directionalLight
  * @param  {Number[]|String|p5.Color} color
  * @param  {p5.Vector}                position
  * @chainable
  */
-
 /**
  * @method directionalLight
  * @param  {Number}    v1
@@ -150,11 +139,11 @@ p5.prototype.ambientLight = function(v1, v2, v3, a) {
  * @param  {Number}    z
  * @chainable
  */
-p5.prototype.directionalLight = function(v1, v2, v3, x, y, z) {
-  var shader = this._renderer._useLightShader();
+p5.RendererGL.prototype.directionalLight = function(v1, v2, v3, x, y, z) {
+  var shader = this._useLightShader();
 
   //@TODO: check parameters number
-  var color = this.color.apply(this, [v1, v2, v3]);
+  var color = p5.prototype.color.apply(this._pInst, [v1, v2, v3]);
 
   var _x, _y, _z;
   var v = arguments[arguments.length - 1];
@@ -169,29 +158,24 @@ p5.prototype.directionalLight = function(v1, v2, v3, x, y, z) {
   }
   shader.setUniform('uUseLighting', true);
   //in case there's no material color for the geometry
-  shader.setUniform('uMaterialColor', this._renderer.curFillColor);
+  shader.setUniform('uMaterialColor', this.curFillColor);
 
   // normalize direction
   var l = Math.sqrt(_x * _x + _y * _y + _z * _z);
-  this._renderer.directionalLightDirections.push(_x / l, _y / l, _z / l);
-  shader.setUniform(
-    'uLightingDirection',
-    this._renderer.directionalLightDirections
-  );
+  this.directionalLightDirections.push(_x / l, _y / l, _z / l);
+  shader.setUniform('uLightingDirection', this.directionalLightDirections);
 
-  this._renderer.directionalLightColors.push(
+  this.directionalLightColors.push(
     color._array[0],
     color._array[1],
     color._array[2]
   );
-  shader.setUniform('uDirectionalColor', this._renderer.directionalLightColors);
+  shader.setUniform('uDirectionalColor', this.directionalLightColors);
 
   shader.setUniform(
     'uDirectionalLightCount',
-    this._renderer.directionalLightColors.length / 3
+    this.directionalLightColors.length / 3
   );
-
-  return this;
 };
 
 /**
@@ -235,7 +219,6 @@ p5.prototype.directionalLight = function(v1, v2, v3, x, y, z) {
  * spot light on canvas changes position with mouse
  *
  */
-
 /**
  * @method pointLight
  * @param  {Number}    v1
@@ -244,7 +227,6 @@ p5.prototype.directionalLight = function(v1, v2, v3, x, y, z) {
  * @param  {p5.Vector} position the position of the light
  * @chainable
  */
-
 /**
  * @method pointLight
  * @param  {Number[]|String|p5.Color} color   color Array, CSS color string,
@@ -254,16 +236,16 @@ p5.prototype.directionalLight = function(v1, v2, v3, x, y, z) {
  * @param  {Number}                   z
  * @chainable
  */
-
 /**
  * @method pointLight
  * @param  {Number[]|String|p5.Color} color
  * @param  {p5.Vector}                position
  * @chainable
  */
-p5.prototype.pointLight = function(v1, v2, v3, x, y, z) {
+p5.RendererGL.prototype.pointLight = function(v1, v2, v3, x, y, z) {
+  this._enableLighting = true;
   //@TODO: check parameters number
-  var color = this._renderer._pInst.color.apply(this, [v1, v2, v3]);
+  var color = p5.prototype.color.apply(this._pInst, [v1, v2, v3]);
 
   var _x, _y, _z;
   var v = arguments[arguments.length - 1];
@@ -277,27 +259,18 @@ p5.prototype.pointLight = function(v1, v2, v3, x, y, z) {
     _z = v.z;
   }
 
-  var shader = this._renderer._useLightShader();
+  var shader = this._useLightShader();
   shader.setUniform('uUseLighting', true);
   //in case there's no material color for the geometry
-  shader.setUniform('uMaterialColor', this._renderer.curFillColor);
+  shader.setUniform('uMaterialColor', this.curFillColor);
 
-  this._renderer.pointLightPositions.push(_x, _y, _z);
-  shader.setUniform('uPointLightLocation', this._renderer.pointLightPositions);
+  this.pointLightPositions.push(_x, _y, _z);
+  shader.setUniform('uPointLightLocation', this.pointLightPositions);
 
-  this._renderer.pointLightColors.push(
-    color._array[0],
-    color._array[1],
-    color._array[2]
-  );
-  shader.setUniform('uPointLightColor', this._renderer.pointLightColors);
+  this.pointLightColors.push(color._array[0], color._array[1], color._array[2]);
+  shader.setUniform('uPointLightColor', this.pointLightColors);
 
-  shader.setUniform(
-    'uPointLightCount',
-    this._renderer.pointLightColors.length / 3
-  );
-
-  return this;
+  shader.setUniform('uPointLightCount', this.pointLightColors.length / 3);
 };
 
 module.exports = p5;

--- a/src/webgl/loading.js
+++ b/src/webgl/loading.js
@@ -214,6 +214,7 @@ function parseObj(model, lines) {
  *
  * @method model
  * @param  {p5.Geometry} model Loaded 3d model to be rendered
+ * @chainable
  * @example
  * <div>
  * <code>
@@ -241,15 +242,15 @@ function parseObj(model, lines) {
  * Vertically rotating 3-d teapot with red, green and blue gradient.
  *
  */
-p5.prototype.model = function(model) {
+p5.RendererGL.prototype.model = function(model) {
   if (model.vertices.length > 0) {
-    if (!this._renderer.geometryInHash(model.gid)) {
+    if (!this.geometryInHash(model.gid)) {
       model._makeTriangleEdges();
-      this._renderer._edgesToVertices(model);
-      this._renderer.createBuffers(model.gid, model);
+      this._edgesToVertices(model);
+      this.createBuffers(model.gid, model);
     }
 
-    this._renderer.drawBuffers(model.gid);
+    this.drawBuffers(model.gid);
   }
 };
 

--- a/src/webgl/material.js
+++ b/src/webgl/material.js
@@ -115,8 +115,8 @@ p5.prototype.loadShader = function(vertFilename, fragFilename) {
  * @alt
  * zooming Mandelbrot set. a colorful, infinitely detailed fractal.
  */
-p5.prototype.createShader = function(vertSrc, fragSrc) {
-  return new p5.Shader(this._renderer, vertSrc, fragSrc);
+p5.RendererGL.prototype.createShader = function(vertSrc, fragSrc) {
+  return new p5.Shader(this, vertSrc, fragSrc);
 };
 
 /**
@@ -130,16 +130,16 @@ p5.prototype.createShader = function(vertSrc, fragSrc) {
  * @param {p5.Shader} [s] the desired p5.Shader to use for rendering
  * shapes.
  */
-p5.prototype.shader = function(s) {
-  if (s._renderer === undefined) {
-    s._renderer = this._renderer;
+p5.RendererGL.prototype.shader = function(s) {
+  if (!s._renderer) {
+    s._renderer = this;
   }
+
   if (s.isStrokeShader()) {
-    this._renderer.setStrokeShader(s);
+    this.setStrokeShader(s);
   } else {
-    this._renderer.setFillShader(s);
+    this.setFillShader(s);
   }
-  return this;
 };
 
 /**
@@ -167,12 +167,11 @@ p5.prototype.shader = function(s) {
  * Red, green and blue gradient.
  *
  */
-p5.prototype.normalMaterial = function() {
-  this._renderer.drawMode = constants.FILL;
-  this._renderer.setFillShader(this._renderer._getNormalShader());
-  this._renderer.curFillColor = [1, 1, 1, 1];
-  this.noStroke();
-  return this;
+p5.RendererGL.prototype.normalMaterial = function() {
+  this.drawMode = constants.FILL;
+  this.setFillShader(this._getNormalShader());
+  this.curFillColor = [1, 1, 1, 1];
+  this._pInst.noStroke();
 };
 
 /**
@@ -253,21 +252,17 @@ p5.prototype.normalMaterial = function() {
  * black canvas
  *
  */
-p5.prototype.texture = function(tex) {
-  this._renderer.GL.depthMask(true);
-  this._renderer.GL.enable(this._renderer.GL.BLEND);
-  this._renderer.GL.blendFunc(
-    this._renderer.GL.SRC_ALPHA,
-    this._renderer.GL.ONE_MINUS_SRC_ALPHA
-  );
+p5.RendererGL.prototype.texture = function(tex) {
+  this.GL.depthMask(true);
+  this.GL.enable(this.GL.BLEND);
+  this.GL.blendFunc(this.GL.SRC_ALPHA, this.GL.ONE_MINUS_SRC_ALPHA);
 
-  this._renderer.drawMode = constants.TEXTURE;
-  var shader = this._renderer._useLightShader();
+  this.drawMode = constants.TEXTURE;
+  var shader = this._useLightShader();
   shader.setUniform('uSpecular', false);
   shader.setUniform('isTexture', true);
   shader.setUniform('uSampler', tex);
-  this.noStroke();
-  return this;
+  this._pInst.noStroke();
 };
 
 /**
@@ -306,15 +301,14 @@ p5.prototype.texture = function(tex) {
  * @param  {Number[]|String|p5.Color} color  color, color Array, or CSS color string
  * @chainable
  */
-p5.prototype.ambientMaterial = function(v1, v2, v3, a) {
-  var color = p5.prototype.color.apply(this, arguments);
-  this._renderer.curFillColor = color._array;
+p5.RendererGL.prototype.ambientMaterial = function(v1, v2, v3, a) {
+  var color = p5.prototype.color.apply(this._pInst, arguments);
+  this.curFillColor = color._array;
 
-  var shader = this._renderer._useLightShader();
-  shader.setUniform('uMaterialColor', this._renderer.curFillColor);
+  var shader = this._useLightShader();
+  shader.setUniform('uMaterialColor', this.curFillColor);
   shader.setUniform('uSpecular', false);
   shader.setUniform('isTexture', false);
-  return this;
 };
 
 /**
@@ -353,15 +347,14 @@ p5.prototype.ambientMaterial = function(v1, v2, v3, a) {
  * @param  {Number[]|String|p5.Color} color color Array, or CSS color string
  * @chainable
  */
-p5.prototype.specularMaterial = function(v1, v2, v3, a) {
-  var color = p5.prototype.color.apply(this, arguments);
-  this._renderer.curFillColor = color._array;
+p5.RendererGL.prototype.specularMaterial = function(v1, v2, v3, a) {
+  var color = p5.prototype.color.apply(this._pInst, arguments);
+  this.curFillColor = color._array;
 
-  var shader = this._renderer._useLightShader();
-  shader.setUniform('uMaterialColor', this._renderer.curFillColor);
+  var shader = this._useLightShader();
+  shader.setUniform('uMaterialColor', this.curFillColor);
   shader.setUniform('uSpecular', true);
   shader.setUniform('isTexture', false);
-  return this;
 };
 
 /**

--- a/src/webgl/p5.RendererGL.Immediate.js
+++ b/src/webgl/p5.RendererGL.Immediate.js
@@ -56,7 +56,6 @@ p5.RendererGL.prototype.beginShape = function(mode) {
     this.immediateMode.uvCoords.length = 0;
   }
   this.isImmediateDrawing = true;
-  return this;
 };
 /**
  * adds a vertex to be drawn in a custom Shape.
@@ -97,8 +96,6 @@ p5.RendererGL.prototype.vertex = function(x, y) {
   );
 
   this.immediateMode.uvCoords.push(u, v);
-
-  return this;
 };
 
 /**
@@ -145,8 +142,6 @@ p5.RendererGL.prototype.endShape = function(
   this.immediateMode.vertexColors.length = 0;
   this.immediateMode.uvCoords.length = 0;
   this.isImmediateDrawing = false;
-
-  return this;
 };
 
 p5.RendererGL.prototype._drawFillImmediateMode = function(

--- a/src/webgl/p5.RendererGL.Retained.js
+++ b/src/webgl/p5.RendererGL.Retained.js
@@ -287,7 +287,6 @@ p5.RendererGL.prototype.drawBuffers = function(gId) {
     this._drawElements(gl.TRIANGLES, gId);
     this.curFillShader.unbindShader();
   }
-  return this;
 };
 
 /**
@@ -322,7 +321,6 @@ p5.RendererGL.prototype.drawBuffersScaled = function(
 
 p5.RendererGL.prototype._drawArrays = function(drawMode, gId) {
   this.GL.drawArrays(drawMode, 0, this.gHash[gId].lineVertexCount);
-  return this;
 };
 
 p5.RendererGL.prototype._drawElements = function(drawMode, gId) {

--- a/src/webgl/p5.RendererGL.js
+++ b/src/webgl/p5.RendererGL.js
@@ -127,8 +127,6 @@ p5.RendererGL = function(elt, pInst, isMainCanvas, attr) {
   // array of textures created in this gl context via this.getTexture(src)
   this.textures = [];
   this.name = 'p5.RendererGL'; // for friendly debugger system
-
-  return this;
 };
 
 p5.RendererGL.prototype = Object.create(p5.Renderer.prototype);
@@ -232,6 +230,7 @@ p5.RendererGL.prototype._resetContext = function(attr, options, callback) {
  * @for p5
  * @param  {String}  key Name of attribute
  * @param  {Boolean}        value New value of named attribute
+ * @chainable
  * @example
  * <div>
  * <code>
@@ -333,9 +332,10 @@ p5.RendererGL.prototype._resetContext = function(attr, options, callback) {
  * @method setAttributes
  * @for p5
  * @param  {Object}  obj object with key-value pairs
+ * @chainable
  */
 
-p5.prototype.setAttributes = function(key, value) {
+p5.RendererGL.prototype.setAttributes = function(key, value) {
   //@todo_FES
   var attr;
   if (typeof value !== 'undefined') {
@@ -344,7 +344,7 @@ p5.prototype.setAttributes = function(key, value) {
   } else if (key instanceof Object) {
     attr = key;
   }
-  this._renderer._resetContext(attr);
+  this._resetContext(attr);
 };
 
 /**
@@ -709,7 +709,6 @@ p5.RendererGL.prototype.translate = function(x, y, z) {
     x = x.x;
   }
   this.uMVMatrix.translate([x, y, z]);
-  return this;
 };
 
 /**
@@ -722,7 +721,6 @@ p5.RendererGL.prototype.translate = function(x, y, z) {
  */
 p5.RendererGL.prototype.scale = function(x, y, z) {
   this.uMVMatrix.scale(x, y, z);
-  return this;
 };
 
 p5.RendererGL.prototype.rotate = function(rad, axis) {
@@ -730,22 +728,18 @@ p5.RendererGL.prototype.rotate = function(rad, axis) {
     return this.rotateZ(rad);
   }
   p5.Matrix.prototype.rotate.apply(this.uMVMatrix, arguments);
-  return this;
 };
 
 p5.RendererGL.prototype.rotateX = function(rad) {
   this.rotate(rad, 1, 0, 0);
-  return this;
 };
 
 p5.RendererGL.prototype.rotateY = function(rad) {
   this.rotate(rad, 0, 1, 0);
-  return this;
 };
 
 p5.RendererGL.prototype.rotateZ = function(rad) {
   this.rotate(rad, 0, 0, 1);
-  return this;
 };
 
 /**

--- a/src/webgl/primitives.js
+++ b/src/webgl/primitives.js
@@ -794,10 +794,10 @@ p5.RendererGL.prototype.rect = function(x, y, w, h, detailX, detailY) {
     return;
   }
   var vals = canvas.modeAdjust(x, y, w, h, this._rectMode);
-  x = vals[0];
-  y = vals[1];
-  w = vals[2];
-  h = vals[3];
+  x = vals.x;
+  y = vals.y;
+  w = vals.w;
+  h = vals.h;
 
   var perPixelLighting = this.attributes.perPixelLighting;
   detailX = detailX || (perPixelLighting ? 1 : 24);

--- a/src/webgl/primitives.js
+++ b/src/webgl/primitives.js
@@ -9,6 +9,7 @@
 'use strict';
 
 var p5 = require('../core/core');
+var canvas = require('../core/canvas');
 require('./p5.Geometry');
 /**
  * Draw a plane with given a width and height
@@ -44,7 +45,11 @@ require('./p5.Geometry');
  * 3d red and green gradient.
  * rotating view of a multi-colored cylinder with concave sides.
  */
-p5.prototype.plane = function(width, height, detailX, detailY) {
+// see thunkRendererMethods
+p5.RendererGL.prototype.plane = function(width, height, detailX, detailY) {
+  if (!this._doStroke && !this._doFill) {
+    return;
+  }
   if (typeof width === 'undefined') {
     width = 50;
   }
@@ -61,7 +66,7 @@ p5.prototype.plane = function(width, height, detailX, detailY) {
 
   var gId = 'plane|' + detailX + '|' + detailY;
 
-  if (!this._renderer.geometryInHash(gId)) {
+  if (!this.geometryInHash(gId)) {
     var _plane = function() {
       var u, v, p;
       for (var i = 0; i <= this.detailY; i++) {
@@ -78,17 +83,17 @@ p5.prototype.plane = function(width, height, detailX, detailY) {
     planeGeom.computeFaces().computeNormals();
     if (detailX <= 1 && detailY <= 1) {
       planeGeom._makeTriangleEdges();
-      this._renderer._edgesToVertices(planeGeom);
+      this._edgesToVertices(planeGeom);
     } else {
       console.log(
         'Cannot draw stroke on plane objects with more' +
           ' than 1 detailX or 1 detailY'
       );
     }
-    this._renderer.createBuffers(gId, planeGeom);
+    this.createBuffers(gId, planeGeom);
   }
 
-  this._renderer.drawBuffersScaled(gId, width, height, 0);
+  this.drawBuffersScaled(gId, width, height, 0);
 };
 
 /**
@@ -119,7 +124,11 @@ p5.prototype.plane = function(width, height, detailX, detailY) {
  * </code>
  * </div>
  */
-p5.prototype.box = function(width, height, depth, detailX, detailY) {
+// see thunkRendererMethods
+p5.RendererGL.prototype.box = function(width, height, depth, detailX, detailY) {
+  if (!this._doStroke && !this._doFill) {
+    return;
+  }
   if (typeof width === 'undefined') {
     width = 50;
   }
@@ -140,7 +149,7 @@ p5.prototype.box = function(width, height, depth, detailX, detailY) {
   }
 
   var gId = 'box|' + detailX + '|' + detailY;
-  if (!this._renderer.geometryInHash(gId)) {
+  if (!this.geometryInHash(gId)) {
     var _box = function() {
       var cubeIndices = [
         [0, 4, 2, 6], // -1, 0, 0],// -x
@@ -190,7 +199,7 @@ p5.prototype.box = function(width, height, depth, detailX, detailY) {
     boxGeom.computeNormals();
     if (detailX <= 4 && detailY <= 4) {
       boxGeom._makeTriangleEdges();
-      this._renderer._edgesToVertices(boxGeom);
+      this._edgesToVertices(boxGeom);
     } else {
       console.log(
         'Cannot draw stroke on box objects with more' +
@@ -200,11 +209,9 @@ p5.prototype.box = function(width, height, depth, detailX, detailY) {
     //initialize our geometry buffer with
     //the key val pair:
     //geometry Id, Geom object
-    this._renderer.createBuffers(gId, boxGeom);
+    this.createBuffers(gId, boxGeom);
   }
-  this._renderer.drawBuffersScaled(gId, width, height, depth);
-
-  return this;
+  this.drawBuffersScaled(gId, width, height, depth);
 };
 
 /**
@@ -233,7 +240,11 @@ p5.prototype.box = function(width, height, depth, detailX, detailY) {
  * </code>
  * </div>
  */
-p5.prototype.sphere = function(radius, detailX, detailY) {
+// see thunkRendererMethods
+p5.RendererGL.prototype.sphere = function(radius, detailX, detailY) {
+  if (!this._doStroke && !this._doFill) {
+    return;
+  }
   if (typeof radius === 'undefined') {
     radius = 50;
   }
@@ -245,8 +256,6 @@ p5.prototype.sphere = function(radius, detailX, detailY) {
   }
 
   this.ellipsoid(radius, radius, radius, detailX, detailY);
-
-  return this;
 };
 
 /**
@@ -364,7 +373,11 @@ var _truncatedCone = function(
  * </code>
  * </div>
  */
-p5.prototype.cylinder = function(radius, height, detailX, detailY) {
+// see thunkRendererMethods
+p5.RendererGL.prototype.cylinder = function(radius, height, detailX, detailY) {
+  if (!this._doStroke && !this._doFill) {
+    return;
+  }
   if (typeof radius === 'undefined') {
     radius = 50;
   }
@@ -379,25 +392,23 @@ p5.prototype.cylinder = function(radius, height, detailX, detailY) {
   }
 
   var gId = 'cylinder|' + detailX + '|' + detailY;
-  if (!this._renderer.geometryInHash(gId)) {
+  if (!this.geometryInHash(gId)) {
     var cylinderGeom = new p5.Geometry(detailX, detailY);
     _truncatedCone.call(cylinderGeom, 1, 1, 1, detailX, detailY, true, true);
     cylinderGeom.computeNormals();
     if (detailX <= 24 && detailY <= 16) {
       cylinderGeom._makeTriangleEdges();
-      this._renderer._edgesToVertices(cylinderGeom);
+      this._edgesToVertices(cylinderGeom);
     } else {
       console.log(
         'Cannot draw stroke on cylinder objects with more' +
           ' than 24 detailX or 16 detailY'
       );
     }
-    this._renderer.createBuffers(gId, cylinderGeom);
+    this.createBuffers(gId, cylinderGeom);
   }
 
-  this._renderer.drawBuffersScaled(gId, radius, height, radius);
-
-  return this;
+  this.drawBuffersScaled(gId, radius, height, radius);
 };
 
 /**
@@ -429,7 +440,11 @@ p5.prototype.cylinder = function(radius, height, detailX, detailY) {
  * </code>
  * </div>
  */
-p5.prototype.cone = function(radius, height, detailX, detailY) {
+// see thunkRendererMethods
+p5.RendererGL.prototype.cone = function(radius, height, detailX, detailY) {
+  if (!this._doStroke && !this._doFill) {
+    return;
+  }
   if (typeof radius === 'undefined') {
     radius = 50;
   }
@@ -444,7 +459,7 @@ p5.prototype.cone = function(radius, height, detailX, detailY) {
   }
 
   var gId = 'cone|' + radius + '|' + height + '|' + detailX + '|' + detailY;
-  if (!this._renderer.geometryInHash(gId)) {
+  if (!this.geometryInHash(gId)) {
     var coneGeom = new p5.Geometry(detailX, detailY);
     _truncatedCone.call(
       coneGeom,
@@ -460,19 +475,17 @@ p5.prototype.cone = function(radius, height, detailX, detailY) {
     coneGeom.computeNormals();
     if (detailX <= 24 && detailY <= 16) {
       coneGeom._makeTriangleEdges();
-      this._renderer._edgesToVertices(coneGeom);
+      this._edgesToVertices(coneGeom);
     } else {
       console.log(
         'Cannot draw stroke on cone objects with more' +
           ' than 24 detailX or 16 detailY'
       );
     }
-    this._renderer.createBuffers(gId, coneGeom);
+    this.createBuffers(gId, coneGeom);
   }
 
-  this._renderer.drawBuffers(gId);
-
-  return this;
+  this.drawBuffers(gId);
 };
 
 /**
@@ -505,7 +518,17 @@ p5.prototype.cone = function(radius, height, detailX, detailY) {
  * </code>
  * </div>
  */
-p5.prototype.ellipsoid = function(radiusX, radiusY, radiusZ, detailX, detailY) {
+// see thunkRendererMethods
+p5.RendererGL.prototype.ellipsoid = function(
+  radiusX,
+  radiusY,
+  radiusZ,
+  detailX,
+  detailY
+) {
+  if (!this._doStroke && !this._doFill) {
+    return;
+  }
   if (typeof radiusX === 'undefined') {
     radiusX = 50;
   }
@@ -525,7 +548,7 @@ p5.prototype.ellipsoid = function(radiusX, radiusY, radiusZ, detailX, detailY) {
 
   var gId = 'ellipsoid|' + detailX + '|' + detailY;
 
-  if (!this._renderer.geometryInHash(gId)) {
+  if (!this.geometryInHash(gId)) {
     var _ellipsoid = function() {
       for (var i = 0; i <= this.detailY; i++) {
         var v = i / this.detailY;
@@ -549,19 +572,17 @@ p5.prototype.ellipsoid = function(radiusX, radiusY, radiusZ, detailX, detailY) {
     ellipsoidGeom.computeFaces();
     if (detailX <= 24 && detailY <= 24) {
       ellipsoidGeom._makeTriangleEdges();
-      this._renderer._edgesToVertices(ellipsoidGeom);
+      this._edgesToVertices(ellipsoidGeom);
     } else {
       console.log(
         'Cannot draw stroke on ellipsoids with more' +
           ' than 24 detailX or 24 detailY'
       );
     }
-    this._renderer.createBuffers(gId, ellipsoidGeom);
+    this.createBuffers(gId, ellipsoidGeom);
   }
 
-  this._renderer.drawBuffersScaled(gId, radiusX, radiusY, radiusZ);
-
-  return this;
+  this.drawBuffersScaled(gId, radiusX, radiusY, radiusZ);
 };
 
 /**
@@ -593,7 +614,11 @@ p5.prototype.ellipsoid = function(radiusX, radiusY, radiusZ, detailX, detailY) {
  * </code>
  * </div>
  */
-p5.prototype.torus = function(radius, tubeRadius, detailX, detailY) {
+// see thunkRendererMethods
+p5.RendererGL.prototype.torus = function(radius, tubeRadius, detailX, detailY) {
+  if (!this._doStroke && !this._doFill) {
+    return;
+  }
   if (typeof radius === 'undefined') {
     radius = 50;
   } else if (!radius) {
@@ -616,7 +641,7 @@ p5.prototype.torus = function(radius, tubeRadius, detailX, detailY) {
   var tubeRatio = (tubeRadius / radius).toPrecision(4);
   var gId = 'torus|' + tubeRatio + '|' + detailX + '|' + detailY;
 
-  if (!this._renderer.geometryInHash(gId)) {
+  if (!this.geometryInHash(gId)) {
     var _torus = function() {
       for (var i = 0; i <= this.detailY; i++) {
         var v = i / this.detailY;
@@ -645,38 +670,26 @@ p5.prototype.torus = function(radius, tubeRadius, detailX, detailY) {
     torusGeom.computeFaces();
     if (detailX <= 24 && detailY <= 16) {
       torusGeom._makeTriangleEdges();
-      this._renderer._edgesToVertices(torusGeom);
+      this._edgesToVertices(torusGeom);
     } else {
       console.log(
         'Cannot draw strokes on torus object with more' +
           ' than 24 detailX or 16 detailY'
       );
     }
-    this._renderer.createBuffers(gId, torusGeom);
+    this.createBuffers(gId, torusGeom);
   }
-  this._renderer.drawBuffersScaled(gId, radius, radius, radius);
-
-  return this;
+  this.drawBuffersScaled(gId, radius, radius, radius);
 };
 
 ///////////////////////
 /// 2D primitives
 /////////////////////////
 
-//@TODO
-p5.RendererGL.prototype.point = function(x, y, z) {
-  console.log('point not yet implemented in webgl');
-  return this;
-};
-
-p5.RendererGL.prototype.triangle = function(args) {
-  var x1 = args[0],
-    y1 = args[1];
-  var x2 = args[2],
-    y2 = args[3];
-  var x3 = args[4],
-    y3 = args[5];
-
+p5.RendererGL.prototype.triangle = function(x1, y1, x2, y2, x3, y3) {
+  if (!this._doStroke && !this._doFill) {
+    return;
+  }
   var gId = 'tri';
   if (!this.geometryInHash(gId)) {
     var _triangle = function() {
@@ -718,8 +731,6 @@ p5.RendererGL.prototype.triangle = function(args) {
   } finally {
     this.uMVMatrix = uMVMatrix;
   }
-
-  return this;
 };
 
 p5.RendererGL.prototype.ellipse = function(args) {
@@ -778,14 +789,19 @@ p5.RendererGL.prototype.ellipse = function(args) {
   return this;
 };
 
-p5.RendererGL.prototype.rect = function(args) {
+p5.RendererGL.prototype.rect = function(x, y, w, h, detailX, detailY) {
+  if (!this._doStroke && !this._doFill) {
+    return;
+  }
+  var vals = canvas.modeAdjust(x, y, w, h, this._rectMode);
+  x = vals[0];
+  y = vals[1];
+  w = vals[2];
+  h = vals[3];
+
   var perPixelLighting = this.attributes.perPixelLighting;
-  var x = args[0];
-  var y = args[1];
-  var width = args[2];
-  var height = args[3];
-  var detailX = args[4] || (perPixelLighting ? 1 : 24);
-  var detailY = args[5] || (perPixelLighting ? 1 : 16);
+  detailX = detailX || (perPixelLighting ? 1 : 24);
+  detailY = detailY || (perPixelLighting ? 1 : 16);
   var gId = 'rect|' + detailX + '|' + detailY;
   if (!this.geometryInHash(gId)) {
     var _rect = function() {
@@ -815,7 +831,7 @@ p5.RendererGL.prototype.rect = function(args) {
   var uMVMatrix = this.uMVMatrix.copy();
   try {
     this.uMVMatrix.translate([x, y, 0]);
-    this.uMVMatrix.scale(width, height, 1);
+    this.uMVMatrix.scale(w, h, 1);
 
     this.drawBuffers(gId);
   } finally {
@@ -825,23 +841,17 @@ p5.RendererGL.prototype.rect = function(args) {
 };
 
 p5.RendererGL.prototype.quad = function(x1, y1, x2, y2, x3, y3, x4, y4) {
-  var gId =
-    'quad|' +
-    x1 +
-    '|' +
-    y1 +
-    '|' +
-    x2 +
-    '|' +
-    y2 +
-    '|' +
-    x3 +
-    '|' +
-    y3 +
-    '|' +
-    x4 +
-    '|' +
-    y4;
+  if (!this._doStroke && !this._doFill) {
+    return;
+  }
+  /* eslint-disable */
+  var gId = 'quad|' +
+    x1 + '|' + y1 + '|' +
+    x2 + '|' + y2 + '|' +
+    x3 + '|' + y3 + '|' +
+    x4 + '|' + y4;
+  /* eslint-enable */
+
   if (!this.geometryInHash(gId)) {
     var _quad = function() {
       this.vertices.push(new p5.Vector(x1, y1, 0));
@@ -858,26 +868,21 @@ p5.RendererGL.prototype.quad = function(x1, y1, x2, y2, x3, y3, x4, y4) {
     this.createBuffers(gId, quadGeom);
   }
   this.drawBuffers(gId);
-  return this;
 };
 
 //this implementation of bezier curve
 //is based on Bernstein polynomial
-// pretier-ignore
+/* eslint-disable */
 p5.RendererGL.prototype.bezier = function(
-  x1,
-  y1,
-  z1,
-  x2,
-  y2,
-  z2,
-  x3,
-  y3,
-  z3,
-  x4,
-  y4,
-  z4
+  x1, y1, z1,
+  x2, y2, z2,
+  x3, y3, z3,
+  x4, y4, z4
 ) {
+  /* eslint-enable */
+  if (!this._doStroke && !this._doFill) {
+    return;
+  }
   var bezierDetail = this._pInst._bezierDetail || 20; //value of Bezier detail
   this.beginShape();
   for (var i = 0; i <= bezierDetail; i++) {
@@ -892,24 +897,19 @@ p5.RendererGL.prototype.bezier = function(
     );
   }
   this.endShape();
-  return this;
 };
 
-// pretier-ignore
+/* eslint-disable */
 p5.RendererGL.prototype.curve = function(
-  x1,
-  y1,
-  z1,
-  x2,
-  y2,
-  z2,
-  x3,
-  y3,
-  z3,
-  x4,
-  y4,
-  z4
+  x1, y1, z1,
+  x2, y2, z2,
+  x3, y3, z3,
+  x4, y4, z4
 ) {
+  /* eslint-enable */
+  if (!this._doStroke && !this._doFill) {
+    return;
+  }
   var curveDetail = this._pInst._curveDetail;
   this.beginShape();
   for (var i = 0; i <= curveDetail; i++) {
@@ -935,7 +935,6 @@ p5.RendererGL.prototype.curve = function(
     this.vertex(vx, vy, vz);
   }
   this.endShape();
-  return this;
 };
 
 /**
@@ -967,7 +966,11 @@ p5.RendererGL.prototype.curve = function(
  * </code>
  * </div>
  */
+// see thunkRendererMethods
 p5.RendererGL.prototype.line = function() {
+  if (!this._doStroke) {
+    return;
+  }
   if (arguments.length === 6) {
     this.beginShape();
     this.vertex(arguments[0], arguments[1], arguments[2]);
@@ -979,7 +982,6 @@ p5.RendererGL.prototype.line = function() {
     this.vertex(arguments[2], arguments[3], 0);
     this.endShape();
   }
-  return this;
 };
 
 module.exports = p5;


### PR DESCRIPTION
(this is part of the 'Render pipeline changes' PR)

Previously a lot of 3d-specific methods were declared directly on p5, or stub methods were used to thunk down to p5’s _renderer. Now there's a method 'thunkRendererMethods’ that runs during startup and adds these thunks automatically and additionally adds warning messages for unimplemented methods. This removes a bunch of boiler-plate code, and ensures that, for example, calling 'sphere()’ on the canvas renderer just outputs an error instead of crashing.
