### PR TITLE
remove unused `detailY` parameter from `ellipse` method

### DIFF
--- a/src/core/2d_primitives.js
+++ b/src/core/2d_primitives.js
@@ -162,10 +162,9 @@ p5.prototype.arc = function(x, y, w, h, start, stop, mode) {
  * @param  {Number} y
  * @param  {Number} w
  * @param  {Number} h
- * @param  {Integer} detailX number of segments in the x-direction
- * @param  {Integer} [detailY] number of segments in the y-direction
+ * @param  {Integer} detail number of radial sectors to draw
  */
-p5.prototype.ellipse = function(x, y, w, h, detailX, detailY) {
+p5.prototype.ellipse = function(x, y, w, h, detailX) {
   p5._validateParameters('ellipse', arguments);
 
   // p5 supports negative width and heights for rects
@@ -182,7 +181,7 @@ p5.prototype.ellipse = function(x, y, w, h, detailX, detailY) {
 
   if (this._renderer._doStroke || this._renderer._doFill) {
     var vals = canvas.modeAdjust(x, y, w, h, this._renderer._ellipseMode);
-    this._renderer.ellipse([vals.x, vals.y, vals.w, vals.h, detailX, detailY]);
+    this._renderer.ellipse([vals.x, vals.y, vals.w, vals.h, detailX]);
   }
 
   return this;


### PR DESCRIPTION
this parameter isn't used any more.

closes #2210 
