### PR TITLE
add type column to doc parameters table

### DIFF
--- a/docs/yuidoc-p5-theme-src/scripts/tpl/item.html
+++ b/docs/yuidoc-p5-theme-src/scripts/tpl/item.html
@@ -138,20 +138,24 @@
     <tr>
     <td>
     <% var p = item.params[i] %>
-    <% if (p.optional) { %>
-      <code class="language-javascript"><%=p.name%></code>
-    <% } else { %>
-      <code class="language-javascript"><%=p.name%></code>
-    <% } %> 
+    <code class="language-javascript"><%=p.name%></code>
     <%if (p.optdefault) { %>=<%=p.optdefault%><% } %>
     </td>
     <td>
-    <% if (p.type) { %>
-      <span class="param-type label label-info"><%=p.type%></span>: <%=p.description%></span> 
-    <% } %>
+    <% if (p.type) {
+      var types = p.type.split('|');
+      for (var it = 0; it < types.length; it ++) {
+        var type = types[it].trim();
+        if (!type) continue;
+        %>
+        <code class="language-javascript"><%=type%></code>
+    <% } } %>
     <% if (p.multiple) {%>
       <span class="flag multiple" title="This argument may occur one or more times.">multiple</span>
     <% } %>
+    </td>
+    <td width="100%">
+      <span class="param-description"><%=p.description%></span>
     </td>
     </tr>
   <% } %>

--- a/docs/yuidoc-p5-theme/assets/reference.css
+++ b/docs/yuidoc-p5-theme/assets/reference.css
@@ -22,6 +22,24 @@
   font-size: inherit;
 }
 
+#reference .params table tr:nth-child(even) {
+  background-color: rgba(69,142,209,.08);
+}
+
+#reference .params table td {
+  padding: 0.4em;
+}
+
+#reference .params table :not(pre)>code[class*=language-] {
+  padding: 0 .3em .05em .3em;
+  display: inline-block;
+  margin-bottom: 2px;
+}
+
+#reference .params .param-type {
+
+}
+
 #reference .param-optional {
   color: #AFAFAF;
 }


### PR DESCRIPTION
this PR adds a column to the 'parameters' table in the reference docs. it separates the type(s) from the description and makes both easier to read. adds a zebra stripe to the table.


eg:
![image](https://user-images.githubusercontent.com/1088194/35250243-7254230c-ff8a-11e7-945c-8e8f0b0d9065.png)
