### PR TITLE
per-renderer push/pop

### DIFF
--- a/src/core/p5.Renderer.js
+++ b/src/core/p5.Renderer.js
@@ -60,6 +60,46 @@ p5.Renderer = function(elt, pInst, isMainCanvas) {
 
 p5.Renderer.prototype = Object.create(p5.Element.prototype);
 
+p5.Renderer.prototype.push = function() {
+  return {
+    properties: {
+      _doStroke: this._doStroke,
+      _strokeSet: this._strokeSet,
+      _doFill: this._doFill,
+      _fillSet: this._fillSet,
+      _tint: this._tint,
+      _imageMode: this._imageMode,
+      _rectMode: this._rectMode,
+      _ellipseMode: this._ellipseMode,
+      _textFont: this._textFont,
+      _textLeading: this._textLeading,
+      _textSize: this._textSize,
+      _textStyle: this._textStyle
+    }
+  };
+};
+
+function assign(to, firstSource) {
+  for (var i = 1; i < arguments.length; i++) {
+    var nextSource = arguments[i];
+    if (nextSource === undefined || nextSource === null) {
+      continue;
+    }
+
+    for (var nextKey in nextSource)
+      if (nextSource.hasOwnProperty(nextKey)) {
+        to[nextKey] = nextSource[nextKey];
+      }
+  }
+  return to;
+}
+
+p5.Renderer.prototype.pop = function(style) {
+  if (style.properties) {
+    assign(this, style.properties);
+  }
+};
+
 /**
  * Resize our canvas element.
  */

--- a/src/core/p5.Renderer.js
+++ b/src/core/p5.Renderer.js
@@ -82,7 +82,7 @@ p5.Renderer.prototype.push = function() {
 };
 
 // this is implementation of Object.assign() which is unavailable in
-// IE11 and android browsers.
+// IE11 and (non-Chrome) Android browsers.
 // The assign() method is used to copy the values of all enumerable
 // own properties from one or more source objects to a target object.
 // It will return the target object.

--- a/src/core/p5.Renderer.js
+++ b/src/core/p5.Renderer.js
@@ -60,6 +60,8 @@ p5.Renderer = function(elt, pInst, isMainCanvas) {
 
 p5.Renderer.prototype = Object.create(p5.Element.prototype);
 
+// the renderer should return a 'style' object that it wishes to
+// store on the push stack.
 p5.Renderer.prototype.push = function() {
   return {
     properties: {
@@ -98,6 +100,9 @@ function assign(to, firstSource) {
   return to;
 }
 
+// a pop() operation is in progress
+// the renderer is passed the 'style' object that it returned
+// from its push() method.
 p5.Renderer.prototype.pop = function(style) {
   if (style.properties) {
     // copy the style properties back into the renderer

--- a/src/core/p5.Renderer.js
+++ b/src/core/p5.Renderer.js
@@ -81,7 +81,8 @@ p5.Renderer.prototype.push = function() {
   };
 };
 
-// this is implementation of Object.assign()
+// this is implementation of Object.assign() which is unavailable in
+// IE11 and android browsers.
 // The assign() method is used to copy the values of all enumerable
 // own properties from one or more source objects to a target object.
 // It will return the target object.

--- a/src/core/p5.Renderer.js
+++ b/src/core/p5.Renderer.js
@@ -79,6 +79,10 @@ p5.Renderer.prototype.push = function() {
   };
 };
 
+// this is implementation of Object.assign()
+// The assign() method is used to copy the values of all enumerable
+// own properties from one or more source objects to a target object.
+// It will return the target object.
 function assign(to, firstSource) {
   for (var i = 1; i < arguments.length; i++) {
     var nextSource = arguments[i];
@@ -96,6 +100,7 @@ function assign(to, firstSource) {
 
 p5.Renderer.prototype.pop = function(style) {
   if (style.properties) {
+    // copy the style properties back into the renderer
     assign(this, style.properties);
   }
 };

--- a/src/core/p5.Renderer2D.js
+++ b/src/core/p5.Renderer2D.js
@@ -1366,13 +1366,18 @@ p5.Renderer2D.prototype._applyTextProperties = function() {
 
 p5.Renderer2D.prototype.push = function() {
   this.drawingContext.save();
+
+  // get the base renderer style
+  return p5.Renderer.prototype.push.apply(this);
 };
 
-p5.Renderer2D.prototype.pop = function() {
+p5.Renderer2D.prototype.pop = function(style) {
   this.drawingContext.restore();
   // Re-cache the fill / stroke state
   this._cachedFillStyle = this.drawingContext.fillStyle;
   this._cachedStrokeStyle = this.drawingContext.strokeStyle;
+
+  p5.Renderer.prototype.pop.call(this, style);
 };
 
 module.exports = p5.Renderer2D;

--- a/src/core/p5.Renderer2D.js
+++ b/src/core/p5.Renderer2D.js
@@ -1364,6 +1364,11 @@ p5.Renderer2D.prototype._applyTextProperties = function() {
 // STRUCTURE
 //////////////////////////////////////////////
 
+// a push() operation is in progress.
+// the renderer should return a 'style' object that it wishes to
+// store on the push stack.
+// derived renderers should call the base class' push() method
+// to fetch the base style object.
 p5.Renderer2D.prototype.push = function() {
   this.drawingContext.save();
 
@@ -1371,6 +1376,11 @@ p5.Renderer2D.prototype.push = function() {
   return p5.Renderer.prototype.push.apply(this);
 };
 
+// a pop() operation is in progress
+// the renderer is passed the 'style' object that it returned
+// from its push() method.
+// derived renderers should pass this object to their base
+// class' pop method
 p5.Renderer2D.prototype.pop = function(style) {
   this.drawingContext.restore();
   // Re-cache the fill / stroke state

--- a/src/core/structure.js
+++ b/src/core/structure.js
@@ -186,25 +186,11 @@ function assign(dest, varArgs) {
  *
  */
 p5.prototype.push = function() {
-  this._renderer.push();
   this._styles.push({
     props: {
       _colorMode: this._colorMode
     },
-    renderer: {
-      _doStroke: this._renderer._doStroke,
-      _strokeSet: this._renderer._strokeSet,
-      _doFill: this._renderer._doFill,
-      _fillSet: this._renderer._fillSet,
-      _tint: this._renderer._tint,
-      _imageMode: this._renderer._imageMode,
-      _rectMode: this._renderer._rectMode,
-      _ellipseMode: this._renderer._ellipseMode,
-      _textFont: this._renderer._textFont,
-      _textLeading: this._renderer._textLeading,
-      _textSize: this._renderer._textSize,
-      _textStyle: this._renderer._textStyle
-    }
+    renderer: this._renderer.push()
   });
 };
 
@@ -265,10 +251,13 @@ p5.prototype.push = function() {
  *
  */
 p5.prototype.pop = function() {
-  this._renderer.pop();
-  var lastS = this._styles.pop();
-  assign(this._renderer, lastS.renderer);
-  assign(this, lastS.props);
+  var style = this._styles.pop();
+  if (style) {
+    this._renderer.pop(style.renderer);
+    assign(this, style.props);
+  } else {
+    console.warn('pop() was called without matching push()');
+  }
 };
 
 p5.prototype.pushStyle = function() {

--- a/src/webgl/p5.RendererGL.js
+++ b/src/webgl/p5.RendererGL.js
@@ -177,14 +177,11 @@ p5.RendererGL.prototype._resetContext = function(attr, options, callback) {
   }
   this._pInst.canvas = c;
 
-  this._pInst.push();
   var renderer = new p5.RendererGL(this._pInst.canvas, this._pInst, true, attr);
   this._pInst._setProperty('_renderer', renderer);
   renderer.resize(w, h);
   renderer._applyDefaults();
   this._pInst._elements.push(renderer);
-
-  this._pInst.pop();
 
   if (typeof callback === 'function') {
     //setTimeout with 0 forces the task to the back of the queue, this ensures that
@@ -347,7 +344,9 @@ p5.prototype.setAttributes = function(key, value) {
   } else if (key instanceof Object) {
     attr = key;
   }
+  this.push();
   this._renderer._resetContext(attr);
+  this.pop();
 };
 
 /**


### PR DESCRIPTION
this moves the handling of pushing & poping renderer-common and per-renderer  style properties out of the p5 class and into the renderer classes themselves. this makes it easier to expand the set of renderer-specific properties stored in the pushed style (for example, the webgl camera & matrix properties are now stored as part of this style object instead of on their own stacks).