### PR TITLE
Parameter validation tests

### DIFF
--- a/lib/addons/p5.dom.js
+++ b/lib/addons/p5.dom.js
@@ -47,8 +47,9 @@
    *
    * @method select
    * @param  {String} name id, class, or tag name of element to search for
-   * @param  {String} [container] id, p5.Element, or HTML element to search within
-   * @return {Object|p5.Element|Null} p5.Element containing node found
+   * @param  {String|p5.Element|HTMLElement|null} [container] id, p5.Element, or
+   *                                             HTML element to search within
+   * @return {Object|p5.Element|null} p5.Element containing node found
    * @example
    * <div ><code class='norender'>
    * function setup() {

--- a/src/color/creating_reading.js
+++ b/src/color/creating_reading.js
@@ -292,7 +292,6 @@ p5.prototype.brightness = function(c) {
 /**
  * @method color
  * @param  {String}        value   a color string
- * @param  {Number}        [alpha]
  * @return {p5.Color}
  */
 /**

--- a/src/color/setting.js
+++ b/src/color/setting.js
@@ -469,6 +469,12 @@ p5.prototype.colorMode = function(mode, max1, max2, max3, maxA) {
 /**
  * @method fill
  * @param  {String}        value   a color string
+ * @chainable
+ */
+
+/**
+ * @method fill
+ * @param  {Number}        gray   a gray value
  * @param  {Number}        [alpha]
  * @chainable
  */
@@ -715,6 +721,12 @@ p5.prototype.noStroke = function() {
 /**
  * @method stroke
  * @param  {String}        value   a color string
+ * @chainable
+ */
+
+/**
+ * @method stroke
+ * @param  {Number}        gray   a gray value
  * @param  {Number}        [alpha]
  * @chainable
  */

--- a/src/core/error_helpers.js
+++ b/src/core/error_helpers.js
@@ -147,6 +147,7 @@ if (typeof IS_MINIFIED !== 'undefined') {
 
   var docCache = {};
   var builtinTypes = [
+    'null',
     'number',
     'string',
     'boolean',
@@ -159,26 +160,53 @@ if (typeof IS_MINIFIED !== 'undefined') {
   // validateParameters() helper functions:
   // lookupParamDoc() for querying data.json
   var lookupParamDoc = function(func) {
-    var queryResult = arrDoc.classitems.filter(function(x) {
-      return x.name === func;
-    });
+    // look for the docs in the `data.json` datastructure
+    var queryResult;
+    var classitems = arrDoc.classitems;
+    for (var ici = 0; ici < classitems.length; ici++) {
+      if (classitems[ici].name === func) {
+        queryResult = classitems[ici];
+        break;
+      }
+    }
+    // bail if we couldn't find it (should never happen)
+    if (!queryResult) throw new Error('missing docs for method ' + func);
+
     // different JSON structure for funct with multi-format
     var overloads = [];
-    if (queryResult[0].hasOwnProperty('overloads')) {
-      for (var i = 0; i < queryResult[0].overloads.length; i++) {
-        overloads.push(queryResult[0].overloads[i].params);
+    if (queryResult.hasOwnProperty('overloads')) {
+      // add all the overloads
+      for (var i = 0; i < queryResult.overloads.length; i++) {
+        overloads.push({ formats: queryResult.overloads[i].params });
       }
     } else {
-      overloads.push(queryResult[0].params);
+      // no overloads, just add the main method definition
+      overloads.push({ formats: queryResult.params || [] });
     }
 
+    // parse the parameter types for each overload
     var mapConstants = {};
     var maxParams = 0;
-    overloads.forEach(function(formats) {
+    overloads.forEach(function(overload) {
+      var formats = overload.formats;
+
+      // keep a record of the maximum number of arguments
+      // this method requires.
       if (maxParams < formats.length) {
         maxParams = formats.length;
       }
+
+      // calculate the minimum number of arguments
+      // this overload requires.
+      var minParams = formats.length;
+      while (minParams > 0 && formats[minParams - 1].optional) {
+        minParams--;
+      }
+      overload.minParams = minParams;
+
+      // loop through each parameter position, and parse its types
       formats.forEach(function(format) {
+        // split this parameter's types
         format.types = format.type.split('|').map(function ct(type) {
           // array
           if (type.substr(type.length - 2, 2) === '[]') {
@@ -269,67 +297,136 @@ if (typeof IS_MINIFIED !== 'undefined') {
 
   var testParamType = function(param, type) {
     var isArray = param instanceof Array;
+    var matches = true;
     if (type.array && isArray) {
       for (var i = 0; i < param.length; i++) {
-        if (!testParamType(param[i], type.array)) {
-          return false;
-        }
+        var error = testParamType(param[i], type.array);
+        if (error) return error / 2; // half error for elements
       }
-      return true;
     } else if (type.prototype) {
-      return param instanceof type.prototype;
+      matches = param instanceof type.prototype;
     } else if (type.builtin) {
       switch (type.builtin) {
         case 'number':
-          return typeof param === 'number' || (!!param && !isNaN(param));
+          matches =
+            typeof param === 'number' || (!!param && !isArray && !isNaN(param));
+          break;
         case 'integer':
-          return (
-            (typeof param === 'number' || (!!param && !isNaN(param))) &&
-            Number(param) === Math.floor(param)
-          );
+          matches =
+            (typeof param === 'number' ||
+              (!!param && !isArray && !isNaN(param))) &&
+            Number(param) === Math.floor(param);
+          break;
         case 'boolean':
         case 'any':
-          return true;
+          matches = true;
+          break;
         case 'array':
-          return isArray;
+          matches = isArray;
+          break;
         case 'string':
-          return typeof param === 'number' || typeof param === 'string';
+          matches = /*typeof param === 'number' ||*/ typeof param === 'string';
+          break;
         case 'constant':
-          return type.values.hasOwnProperty(param);
+          matches = type.values.hasOwnProperty(param);
+          break;
         case 'function':
-          return param instanceof Function;
+          matches = param instanceof Function;
+          break;
+        case 'null':
+          matches = param === null;
+          break;
       }
+    } else {
+      matches = typeof param === type.t;
     }
-
-    return typeof param === type.t;
+    return matches ? 0 : 1;
   };
 
   // testType() for non-object type parameter validation
-  // Returns true if PASS, false if FAIL
   var testParamTypes = function(param, types) {
-    for (var i = 0; i < types.length; i++) {
-      if (testParamType(param, types[i])) {
-        return true;
-      }
+    var minScore = 9999;
+    for (var i = 0; minScore > 0 && i < types.length; i++) {
+      var score = testParamType(param, types[i]);
+      if (minScore > score) minScore = score;
     }
-    return false;
+    return minScore;
   };
 
-  var testParamFormat = function(args, formats) {
+  // generate a score (higher is worse) for applying these args to
+  // this overload.
+  var scoreOverload = function(args, argCount, overload, minScore) {
+    var score = 0;
+    var formats = overload.formats;
+
+    // check for too few/many args
+    // the score is double number of extra/missing args
+    if (argCount < overload.minParams) {
+      score = (overload.minParams - argCount) * 2;
+    } else if (argCount > formats.length) {
+      score = (argCount - formats.length) * 2;
+    }
+
+    // loop through the formats, adding up the error score for each arg.
+    // quit early if the score gets higher than the previous best overload.
+    for (var p = 0; score <= minScore && p < formats.length; p++) {
+      var arg = args[p];
+      var format = formats[p];
+      if (arg == null) {
+        // handle non-optional and non-trailing undefined args
+        if (
+          !format.optional ||
+          (p < overload.minParams ? true : p < argCount)
+        ) {
+          score += 1;
+        }
+      } else {
+        score += testParamTypes(arg, format.types);
+      }
+    }
+    return score;
+  };
+
+  // gets a list of errors for this overload
+  var getOverloadErrors = function(args, argCount, overload) {
+    var formats = overload.formats;
+
+    // check for too few/many args
+    if (argCount < overload.minParams) {
+      return [
+        {
+          type: 'TOO_FEW_ARGUMENTS',
+          argCount: argCount,
+          minParams: overload.minParams
+        }
+      ];
+    } else if (argCount > formats.length) {
+      return [
+        {
+          type: 'TOO_MANY_ARGUMENTS',
+          argCount: argCount,
+          maxParams: formats.length
+        }
+      ];
+    }
+
     var errorArray = [];
     for (var p = 0; p < formats.length; p++) {
       var arg = args[p];
       var format = formats[p];
-      var argType = typeof arg;
-      if ('undefined' === argType || null === arg) {
-        if (format.optional !== true) {
+      if (arg == null) {
+        // handle non-optional and non-trailing undefined args
+        if (
+          !format.optional ||
+          (p < overload.minParams ? true : p < argCount)
+        ) {
           errorArray.push({
             type: 'EMPTY_VAR',
             position: p,
             format: format
           });
         }
-      } else if (!testParamTypes(arg, format.types)) {
+      } else if (testParamTypes(arg, format.types) > 0) {
         errorArray.push({
           type: 'WRONG_TYPE',
           position: p,
@@ -338,8 +435,24 @@ if (typeof IS_MINIFIED !== 'undefined') {
         });
       }
     }
+
     return errorArray;
   };
+
+  // a custom error type, used by the mocha
+  // tests when expecting validation errors
+  p5.ValidationError = (function(name) {
+    var err = function(message, func) {
+      this.message = message;
+      this.func = func;
+      if ('captureStackTrace' in Error) Error.captureStackTrace(this, err);
+      else this.stack = new Error().stack;
+    };
+    err.prototype = Object.create(Error.prototype);
+    err.prototype.name = name;
+    err.prototype.constructor = err;
+    return err;
+  })('ValidationError');
 
   // function for generating console.log() msg
   p5._friendlyParamError = function(errorObj, func) {
@@ -368,7 +481,10 @@ if (typeof IS_MINIFIED !== 'undefined') {
         break;
       case 'WRONG_TYPE':
         var arg = errorObj.arg;
-        var argType = arg instanceof Array ? 'array' : arg.name || typeof arg;
+        var argType =
+          arg instanceof Array
+            ? 'array'
+            : arg === null ? 'null' : arg.name || typeof arg;
         message =
           func +
           '() was expecting ' +
@@ -379,10 +495,18 @@ if (typeof IS_MINIFIED !== 'undefined') {
           argType +
           ' instead';
         break;
-      case 'WRONG_ARGUMENT_COUNT':
+      case 'TOO_FEW_ARGUMENTS':
         message =
           func +
-          '() was expecting ' +
+          '() was expecting at least ' +
+          errorObj.minParams +
+          ' arguments, but received only ' +
+          errorObj.argCount;
+        break;
+      case 'TOO_MANY_ARGUMENTS':
+        message =
+          func +
+          '() was expecting no more than ' +
           errorObj.maxParams +
           ' arguments, but received ' +
           errorObj.argCount;
@@ -390,6 +514,10 @@ if (typeof IS_MINIFIED !== 'undefined') {
     }
 
     if (message) {
+      if (p5._throwValidationErrors) {
+        throw new p5.ValidationError(message);
+      }
+
       try {
         var re = /Function\.validateParameters.*[\r\n].*[\r\n].*\(([^)]*)/;
         var location = re.exec(new Error().stack)[1];
@@ -424,33 +552,41 @@ if (typeof IS_MINIFIED !== 'undefined') {
       return; // skip FES
     }
 
+    // lookup the docs in the 'data.json' file
     var docs = docCache[func] || (docCache[func] = lookupParamDoc(func));
-    var errorArray = [];
-    var minErrCount = 999999;
     var overloads = docs.overloads;
+
+    // ignore any trailing `undefined` arguments
+    var argCount = args.length;
+    while (argCount > 0 && args[argCount - 1] == null) argCount--;
+
+    // find the overload with the best score
+    var minScore = 99999;
+    var minOverload;
     for (var i = 0; i < overloads.length; i++) {
-      var arrError = testParamFormat(args, overloads[i]);
-      // see if this is the format with min number of err
-      if (minErrCount > arrError.length) {
-        minErrCount = arrError.length;
-        errorArray = arrError;
-      }
-      if (arrError.length === 0) {
-        break; // no error
+      var score = scoreOverload(args, argCount, overloads[i], minScore);
+      if (score === 0) {
+        return; // done!
+      } else if (minScore > score) {
+        // this score is better that what we have so far...
+        minScore = score;
+        minOverload = i;
       }
     }
 
-    if (!errorArray.length && args.length > docs.maxParams) {
-      errorArray.push({
-        type: 'WRONG_ARGUMENT_COUNT',
-        argCount: args.length,
-        maxParams: docs.maxParams
-      });
-    }
+    // this should _always_ be true here...
+    if (minScore > 0) {
+      // get the errors for the best overload
+      var errorArray = getOverloadErrors(
+        args,
+        argCount,
+        overloads[minOverload]
+      );
 
-    // generate err msg
-    for (var n = 0; n < errorArray.length; n++) {
-      p5._friendlyParamError(errorArray[n], func);
+      // generate err msg
+      for (var n = 0; n < errorArray.length; n++) {
+        p5._friendlyParamError(errorArray[n], func);
+      }
     }
   };
 

--- a/src/core/transform.js
+++ b/src/core/transform.js
@@ -222,8 +222,8 @@ p5.prototype.rotate = function(angle, axis) {
  * 3d box rotating around the x axis.
  */
 p5.prototype.rotateX = function(angle) {
-  p5._validateParameters('rotateX', arguments);
   this._assert3d('rotateX');
+  p5._validateParameters('rotateX', arguments);
   this._renderer.rotateX(this._toRadians(angle));
   return this;
 };
@@ -252,8 +252,8 @@ p5.prototype.rotateX = function(angle) {
  * 3d box rotating around the y axis.
  */
 p5.prototype.rotateY = function(angle) {
-  p5._validateParameters('rotateY', arguments);
   this._assert3d('rotateY');
+  p5._validateParameters('rotateY', arguments);
   this._renderer.rotateY(this._toRadians(angle));
   return this;
 };
@@ -282,8 +282,8 @@ p5.prototype.rotateY = function(angle) {
  * 3d box rotating around the z axis.
  */
 p5.prototype.rotateZ = function(angle) {
-  p5._validateParameters('rotateZ', arguments);
   this._assert3d('rotateZ');
+  p5._validateParameters('rotateZ', arguments);
   this._renderer.rotateZ(this._toRadians(angle));
   return this;
 };

--- a/src/image/loading_displaying.js
+++ b/src/image/loading_displaying.js
@@ -369,6 +369,11 @@ p5.prototype.image = function(
 /**
  * @method tint
  * @param  {String}        value   a color string
+ */
+
+/**
+ * @method tint
+ * @param  {Number}        gray   a gray value
  * @param  {Number}        [alpha]
  */
 

--- a/src/typography/loading_displaying.js
+++ b/src/typography/loading_displaying.js
@@ -158,7 +158,8 @@ p5.prototype.loadFont = function(path, onSuccess, onError) {
  * to the screen.
  *
  * @method text
- * @param {String|Object|Array} str the alphanumeric symbols to be displayed
+ * @param {String|Object|Array|Number|Boolean} str the alphanumeric
+ *                                             symbols to be displayed
  * @param {Number} x   x-coordinate of text
  * @param {Number} y   y-coordinate of text
  * @param {Number} [x2]  by default, the width of the text box,

--- a/src/webgl/light.js
+++ b/src/webgl/light.js
@@ -46,6 +46,12 @@ var p5 = require('../core/core');
 /**
  * @method ambientLight
  * @param  {String}        value   a color string
+ * @chainable
+ */
+
+/**
+ * @method ambientLight
+ * @param  {Number}        gray   a gray value
  * @param  {Number}        [alpha]
  * @chainable
  */

--- a/src/webgl/light.js
+++ b/src/webgl/light.js
@@ -156,7 +156,12 @@ p5.prototype.directionalLight = function(v1, v2, v3, x, y, z) {
   var shader = this._renderer._useLightShader();
 
   //@TODO: check parameters number
-  var color = this.color.apply(this, [v1, v2, v3]);
+  var color;
+  if (v1 instanceof p5.Color) {
+    color = v1;
+  } else {
+    color = this.color(v1, v2, v3);
+  }
 
   var _x, _y, _z;
   var v = arguments[arguments.length - 1];
@@ -266,7 +271,12 @@ p5.prototype.directionalLight = function(v1, v2, v3, x, y, z) {
 p5.prototype.pointLight = function(v1, v2, v3, x, y, z) {
   this._assert3d('pointLight');
   //@TODO: check parameters number
-  var color = this._renderer._pInst.color.apply(this, [v1, v2, v3]);
+  var color;
+  if (v1 instanceof p5.Color) {
+    color = v1;
+  } else {
+    color = this.color(v1, v2, v3);
+  }
 
   var _x, _y, _z;
   var v = arguments[arguments.length - 1];

--- a/tasks/typescript/generate-typescript-annotations.js
+++ b/tasks/typescript/generate-typescript-annotations.js
@@ -55,7 +55,7 @@ function mod(yuidocs, localFileame, globalFilename, sourcePath) {
     String: 'string',
     Constant: 'any',
     undefined: 'undefined',
-    Null: 'null',
+    null: 'null',
     Array: 'any[]',
     Boolean: 'boolean',
     '*': 'any',

--- a/test/js/chai_helpers.js
+++ b/test/js/chai_helpers.js
@@ -8,3 +8,14 @@ assert.arrayApproximately = function(arr1, arr2, delta) {
     assert.approximately(arr1[i], arr2[i], delta);
   }
 }
+
+
+// a custom assertion for validation errors that correctly handles
+// minified p5 libraries.
+assert.validationError = function(fn) {
+  if (p5.ValidationError) {
+    assert.throws(fn, p5.ValidationError);
+  } else {
+    assert.doesNotThrow(fn, Error, 'got unwanted exception');
+  }
+};

--- a/test/test-reference.html
+++ b/test/test-reference.html
@@ -48,6 +48,8 @@
   </script>
 
   <script>
+  p5._throwValidationErrors = true;
+
   var TEST_FILENAME_FILTERS = [
     {regex: /webgl/, condition: Modernizr.webgl},
     {regex: /acceleration/, condition: Modernizr.webgl},
@@ -154,8 +156,6 @@
             test_context.timeout(MS_TIMEOUT);
             myp5Div = document.createElement('div');
             document.body.appendChild(myp5Div);
-
-            p5._throwValidationErrors = true;
 
             myp5 = new p5(createExampleSketch(exampleCode, function(p) {
               var drawCalled = false;

--- a/test/test-reference.html
+++ b/test/test-reference.html
@@ -155,6 +155,8 @@
             myp5Div = document.createElement('div');
             document.body.appendChild(myp5Div);
 
+            p5._throwValidationErrors = true;
+
             myp5 = new p5(createExampleSketch(exampleCode, function(p) {
               var drawCalled = false;
               var oldSetup = p.setup || function() {};

--- a/test/test.html
+++ b/test/test.html
@@ -32,15 +32,13 @@
 
   <!-- run mocha -->
   <script type="text/javascript" >
+    p5._throwValidationErrors = true;
+  
     // If tests run in a real browser
     // Can alternatively do a check on window.PHANTOMJS
     if (navigator.userAgent.indexOf('PhantomJS') < 0) {
       window.addEventListener('load', function() {
         var runner = mocha.run();
-
-        runner.on('test', function (test) {
-          p5._throwValidationErrors = true;
-        });
 
         // This exposes our test results to Sauce Labs. For more
         // details, see: https://github.com/axemclion/grunt-saucelabs.

--- a/test/test.html
+++ b/test/test.html
@@ -38,6 +38,10 @@
       window.addEventListener('load', function() {
         var runner = mocha.run();
 
+        runner.on('test', function (test) {
+          p5._throwValidationErrors = true;
+        });
+
         // This exposes our test results to Sauce Labs. For more
         // details, see: https://github.com/axemclion/grunt-saucelabs.
 

--- a/test/unit/color/creating_reading.js
+++ b/test/unit/color/creating_reading.js
@@ -47,14 +47,10 @@ suite('color/CreatingReading', function() {
       );
     });
     test('wrong param type at #0', function() {
-      assert.doesNotThrow(
-        function() {
-          c = 20;
-          val = myp5.alpha(c);
-        },
-        Error,
-        'got unwanted exception'
-      );
+      assert.validationError(function() {
+        c = 20;
+        val = myp5.alpha(c);
+      });
     });
   });
 
@@ -180,13 +176,9 @@ suite('color/CreatingReading', function() {
       assert.deepEqual(interB.levels, [72, 61, 139, 255]);
     });
     test('missing param #2', function() {
-      assert.doesNotThrow(
-        function() {
-          myp5.lerpColor(fromColor, toColor);
-        },
-        Error,
-        'got unwanted exception'
-      );
+      assert.validationError(function() {
+        myp5.lerpColor(fromColor, toColor);
+      });
     });
   });
   suite('p5.prototype.lerpColor with alpha', function() {

--- a/test/unit/color/p5.Color.js
+++ b/test/unit/color/p5.Color.js
@@ -78,6 +78,14 @@ suite('p5.Color', function() {
       c = myp5.color('#cat');
       assert.deepEqual(c.levels, [255, 255, 255, 255]);
     });
+
+    test('should not be able to pass css & alpha', function() {
+      // TODO: change this to expect p5.ValidationError when
+      // color() docs are fixed.
+      assert.throws(function() {
+        c = myp5.color('#fff', 100);
+      }, Error);
+    });
   });
 
   suite('p5.prototype.color("#rgba")', function() {

--- a/test/unit/core/2d_primitives.js
+++ b/test/unit/core/2d_primitives.js
@@ -29,22 +29,14 @@ suite('2D Primitives', function() {
       );
     });
     test('missing param #4, #5', function() {
-      assert.doesNotThrow(
-        function() {
-          myp5.arc(1, 1, 10.5, 10);
-        },
-        Error,
-        'got unwanted exception'
-      );
+      assert.validationError(function() {
+        myp5.arc(1, 1, 10.5, 10);
+      });
     });
     test('wrong param type at #0', function() {
-      assert.doesNotThrow(
-        function() {
-          myp5.arc('1', 1, 10.5, 10, 0, Math.PI, 'pie');
-        },
-        Error,
-        'got unwanted exception'
-      );
+      assert.validationError(function() {
+        myp5.arc('a', 1, 10.5, 10, 0, Math.PI, 'pie');
+      });
     });
   });
 
@@ -63,32 +55,20 @@ suite('2D Primitives', function() {
       );
     });
     test('missing param #2', function() {
-      assert.doesNotThrow(
-        function() {
-          myp5.ellipse(0, 0);
-        },
-        Error,
-        'got unwanted exception'
-      );
+      assert.validationError(function() {
+        myp5.ellipse(0, 0);
+      });
     });
     test('missing param #2', function() {
-      assert.doesNotThrow(
-        function() {
-          var size;
-          myp5.ellipse(0, 0, size);
-        },
-        Error,
-        'got unwanted exception'
-      );
+      assert.validationError(function() {
+        var size;
+        myp5.ellipse(0, 0, size);
+      });
     });
     test('wrong param type at #0', function() {
-      assert.doesNotThrow(
-        function() {
-          myp5.ellipse('0', 0, 100, 100);
-        },
-        Error,
-        'got unwanted exception'
-      );
+      assert.validationError(function() {
+        myp5.ellipse('a', 0, 100, 100);
+      });
     });
   });
 
@@ -116,33 +96,21 @@ suite('2D Primitives', function() {
       );
     });
     test('missing param #3', function() {
-      assert.doesNotThrow(
-        function() {
-          myp5.line(0, 0, Math.PI);
-        },
-        Error,
-        'got unwanted exception'
-      );
+      assert.validationError(function() {
+        myp5.line(0, 0, Math.PI);
+      });
     });
     test('missing param #4 ', function() {
       // this err case escapes
-      assert.doesNotThrow(
-        function() {
-          var x3;
-          myp5.line(0, 0, 100, 100, x3, Math.PI);
-        },
-        Error,
-        'got unwanted exception'
-      );
+      assert.validationError(function() {
+        var x3;
+        myp5.line(0, 0, 100, 100, x3, Math.PI);
+      });
     });
     test('wrong param type at #1', function() {
-      assert.doesNotThrow(
-        function() {
-          myp5.line(0, '0', 100, 100);
-        },
-        Error,
-        'got unwanted exception'
-      );
+      assert.validationError(function() {
+        myp5.line(0, 'a', 100, 100);
+      });
     });
   });
 
@@ -170,33 +138,23 @@ suite('2D Primitives', function() {
       );
     });
     test('missing param #1', function() {
-      assert.doesNotThrow(
-        function() {
-          myp5.point(0);
-        },
-        Error,
-        'got unwanted exception'
-      );
+      assert.validationError(function() {
+        myp5.point(0);
+      });
     });
+    /* this is not an error because 2d point exists.
     test('missing param #3', function() {
       // this err case escapes
-      assert.doesNotThrow(
-        function() {
-          var z;
-          myp5.point(0, Math.PI, z);
-        },
-        Error,
-        'got unwanted exception'
-      );
+      assert.validationError(function() {
+        var z;
+        myp5.point(0, Math.PI, z);
+      });
     });
+    */
     test('wrong param type at #1', function() {
-      assert.doesNotThrow(
-        function() {
-          myp5.point(Math.PI, '0');
-        },
-        Error,
-        'got unwanted exception'
-      );
+      assert.validationError(function() {
+        myp5.point(Math.PI, 'a');
+      });
     });
   });
 
@@ -215,22 +173,14 @@ suite('2D Primitives', function() {
       );
     });
     test('missing param #7', function() {
-      assert.doesNotThrow(
-        function() {
-          myp5.quad(Math.PI, 0, Math.PI, 5.1, 10, 5.1, 10);
-        },
-        Error,
-        'got unwanted exception'
-      );
+      assert.validationError(function() {
+        myp5.quad(Math.PI, 0, Math.PI, 5.1, 10, 5.1, 10);
+      });
     });
     test('wrong param type at #1', function() {
-      assert.doesNotThrow(
-        function() {
-          myp5.quad(Math.PI, '0', Math.PI, 5.1, 10, 5.1, 10, 0);
-        },
-        Error,
-        'got unwanted exception'
-      );
+      assert.validationError(function() {
+        myp5.quad(Math.PI, 'a', Math.PI, 5.1, 10, 5.1, 10, 0);
+      });
     });
   });
 
@@ -258,33 +208,21 @@ suite('2D Primitives', function() {
       );
     });
     test('missing param #3', function() {
-      assert.doesNotThrow(
-        function() {
-          myp5.rect(0, 0, Math.PI);
-        },
-        Error,
-        'got unwanted exception'
-      );
+      assert.validationError(function() {
+        myp5.rect(0, 0, Math.PI);
+      });
     });
     test('missing param #4', function() {
       // this err case escapes
-      assert.doesNotThrow(
-        function() {
-          var r1;
-          myp5.rect(0, 0, 100, 100, r1, Math.PI, 1, Math.PI);
-        },
-        Error,
-        'got unwanted exception'
-      );
+      assert.validationError(function() {
+        var r1;
+        myp5.rect(0, 0, 100, 100, r1, Math.PI, 1, Math.PI);
+      });
     });
     test('wrong param type at #1', function() {
-      assert.doesNotThrow(
-        function() {
-          myp5.rect(0, '0', 100, 100);
-        },
-        Error,
-        'got unwanted exception'
-      );
+      assert.validationError(function() {
+        myp5.rect(0, 'a', 100, 100);
+      });
     });
   });
 
@@ -303,22 +241,14 @@ suite('2D Primitives', function() {
       );
     });
     test('missing param #5', function() {
-      assert.doesNotThrow(
-        function() {
-          myp5.triangle(Math.PI, 0, Math.PI, 5.1, 10);
-        },
-        Error,
-        'got unwanted exception'
-      );
+      assert.validationError(function() {
+        myp5.triangle(Math.PI, 0, Math.PI, 5.1, 10);
+      });
     });
     test('wrong param type at #1', function() {
-      assert.doesNotThrow(
-        function() {
-          myp5.triangle(Math.PI, '0', Math.PI, 5.1, 10, 5.1);
-        },
-        Error,
-        'got unwanted exception'
-      );
+      assert.validationError(function() {
+        myp5.triangle(Math.PI, 'a', Math.PI, 5.1, 10, 5.1);
+      });
     });
   });
 });

--- a/test/unit/core/curves.js
+++ b/test/unit/core/curves.js
@@ -29,22 +29,14 @@ suite('Curves', function() {
       );
     });
     test('no friendly-err-msg. missing param #6, #7', function() {
-      assert.doesNotThrow(
-        function() {
-          myp5.bezier(85, 20, 10, 10, 90, 90);
-        },
-        Error,
-        'got unwanted exception'
-      );
+      assert.validationError(function() {
+        myp5.bezier(85, 20, 10, 10, 90, 90);
+      });
     });
     test('wrong param type at #0', function() {
-      assert.doesNotThrow(
-        function() {
-          myp5.bezier('85', 20, 10, 10, 90, 90, 15, 80);
-        },
-        Error,
-        'got unwanted exception'
-      );
+      assert.validationError(function() {
+        myp5.bezier('a', 20, 10, 10, 90, 90, 15, 80);
+      });
     });
   });
 
@@ -55,8 +47,9 @@ suite('Curves', function() {
       assert.typeOf(myp5.bezierPoint, 'function');
     });
     test('should return a number: missing param #0~4', function() {
-      result = myp5.bezierPoint();
-      assert.typeOf(result, 'number');
+      assert.validationError(function() {
+        result = myp5.bezierPoint();
+      });
     });
     test('should return the correct point on a Bezier Curve', function() {
       result = myp5.bezierPoint(85, 10, 90, 15, 0.5);
@@ -72,8 +65,9 @@ suite('Curves', function() {
       assert.typeOf(myp5.bezierTangent, 'function');
     });
     test('should return a number: missing param #0~4', function() {
-      result = myp5.bezierTangent();
-      assert.typeOf(result, 'number');
+      assert.validationError(function() {
+        result = myp5.bezierTangent();
+      });
     });
     test('should return the correct point on a Bezier Curve', function() {
       result = myp5.bezierTangent(95, 73, 73, 15, 0.5);
@@ -96,22 +90,14 @@ suite('Curves', function() {
       );
     });
     test('no friendly-err-msg. missing param #6, #7', function() {
-      assert.doesNotThrow(
-        function() {
-          myp5.curve(5, 26, 5, 26, 73, 24);
-        },
-        Error,
-        'got unwanted exception'
-      );
+      assert.validationError(function() {
+        myp5.curve(5, 26, 5, 26, 73, 24);
+      });
     });
     test('wrong param type at #0', function() {
-      assert.doesNotThrow(
-        function() {
-          myp5.curve('5', 26, 5, 26, 73, 24, 73, 61);
-        },
-        Error,
-        'got unwanted exception'
-      );
+      assert.validationError(function() {
+        myp5.curve('a', 26, 5, 26, 73, 24, 73, 61);
+      });
     });
   });
 
@@ -122,8 +108,9 @@ suite('Curves', function() {
       assert.typeOf(myp5.curvePoint, 'function');
     });
     test('should return a number: missing param #0~4', function() {
-      result = myp5.curvePoint();
-      assert.typeOf(result, 'number');
+      assert.validationError(function() {
+        result = myp5.curvePoint();
+      });
     });
     test('should return the correct point on a Catmull-Rom Curve', function() {
       result = myp5.curvePoint(5, 5, 73, 73, 0.5);
@@ -139,8 +126,9 @@ suite('Curves', function() {
       assert.typeOf(myp5.curveTangent, 'function');
     });
     test('should return a number: missing param #0~4', function() {
-      result = myp5.curveTangent();
-      assert.typeOf(result, 'number');
+      assert.validationError(function() {
+        result = myp5.curveTangent();
+      });
     });
     test('should return the correct point on a Catmull-Rom Curve', function() {
       result = myp5.curveTangent(95, 73, 73, 15, 0.5);

--- a/test/unit/core/error_helpers.js
+++ b/test/unit/core/error_helpers.js
@@ -26,22 +26,14 @@ suite('Error Helpers', function() {
       );
     });
     test('arc(): missing param #4, #5', function() {
-      assert.doesNotThrow(
-        function() {
-          p5._validateParameters('arc', [1, 1, 10.5, 10]);
-        },
-        Error,
-        'got unwanted exception'
-      );
+      assert.validationError(function() {
+        p5._validateParameters('arc', [1, 1, 10.5, 10]);
+      });
     });
     test('arc(): wrong param type at #0', function() {
-      assert.doesNotThrow(
-        function() {
-          p5._validateParameters('arc', ['1', 1, 10.5, 10, 0, Math.PI, 'pie']);
-        },
-        Error,
-        'got unwanted exception'
-      );
+      assert.validationError(function() {
+        p5._validateParameters('arc', ['a', 1, 10.5, 10, 0, Math.PI, 'pie']);
+      });
     });
   });
 
@@ -56,22 +48,14 @@ suite('Error Helpers', function() {
       );
     });
     test('rect(): missing param #3', function() {
-      assert.doesNotThrow(
-        function() {
-          p5._validateParameters('rect', [1, 1, 10.5]);
-        },
-        Error,
-        'got unwanted exception'
-      );
+      assert.validationError(function() {
+        p5._validateParameters('rect', [1, 1, 10.5]);
+      });
     });
     test('rect(): wrong param type at #0', function() {
-      assert.doesNotThrow(
-        function() {
-          p5._validateParameters('rect', ['1', 1, 10.5, 10, 0, Math.PI]);
-        },
-        Error,
-        'got unwanted exception'
-      );
+      assert.validationError(function() {
+        p5._validateParameters('rect', ['a', 1, 10.5, 10, 0, Math.PI]);
+      });
     });
   });
 

--- a/test/unit/core/error_helpers.js
+++ b/test/unit/core/error_helpers.js
@@ -30,6 +30,46 @@ suite('Error Helpers', function() {
         p5._validateParameters('arc', [1, 1, 10.5, 10]);
       });
     });
+    test('arc(): missing param #0', function() {
+      assert.validationError(function() {
+        p5._validateParameters('arc', [
+          undefined,
+          1,
+          10.5,
+          10,
+          0,
+          Math.PI,
+          'pie'
+        ]);
+      });
+    });
+    test('arc(): missing param #4', function() {
+      assert.validationError(function() {
+        p5._validateParameters('arc', [
+          1,
+          1,
+          10.5,
+          10,
+          undefined,
+          Math.PI,
+          'pie'
+        ]);
+      });
+    });
+    test('arc(): missing param #5', function() {
+      assert.validationError(function() {
+        p5._validateParameters('arc', [1, 1, 10.5, 10, 0, undefined, 'pie']);
+      });
+    });
+    test('arc(): missing param #6, no friendly-err-msg', function() {
+      assert.doesNotThrow(
+        function() {
+          p5._validateParameters('arc', [1, 1, 10.5, 10, 0, Math.PI]);
+        },
+        Error,
+        'got unwanted exception'
+      );
+    });
     test('arc(): wrong param type at #0', function() {
       assert.validationError(function() {
         p5._validateParameters('arc', ['a', 1, 10.5, 10, 0, Math.PI, 'pie']);

--- a/test/unit/core/error_helpers.js
+++ b/test/unit/core/error_helpers.js
@@ -143,6 +143,26 @@ suite('Error Helpers', function() {
         'got unwanted exception'
       );
     });
+    test('color(): optional parameter, incorrect type', function() {
+      assert.validationError(function() {
+        p5._validateParameters('color', [0, 0, 0, 'A']);
+      });
+    });
+    test('color(): extra parameter', function() {
+      assert.validationError(function() {
+        p5._validateParameters('color', [[0, 0, 0], 0]);
+      });
+    });
+    test('color(): incorrect element type', function() {
+      assert.validationError(function() {
+        p5._validateParameters('color', [['A', 'B', 'C']]);
+      });
+    });
+    test('color(): incorrect parameter count', function() {
+      assert.validationError(function() {
+        p5._validateParameters('color', ['A', 'A', 0, 0, 0, 0, 0, 0]);
+      });
+    });
   });
 
   suite('helpForMisusedAtTopLevelCode', function() {

--- a/test/unit/core/structure.js
+++ b/test/unit/core/structure.js
@@ -181,51 +181,51 @@ suite('Structure', function() {
     });
 
     test('leak no state after strokeCap()', function() {
-      myp5.strokeCap(p5.ROUND);
+      myp5.strokeCap(myp5.ROUND);
       assertCanPreserveRenderState(function() {
-        myp5.strokeCap(p5.SQUARE);
+        myp5.strokeCap(myp5.SQUARE);
       });
     });
 
     test('leak no state after strokeJoin()', function() {
-      myp5.strokeJoin(p5.BEVEL);
+      myp5.strokeJoin(myp5.BEVEL);
       assertCanPreserveRenderState(function() {
-        myp5.strokeJoin(p5.MITER);
+        myp5.strokeJoin(myp5.MITER);
       });
     });
 
     test('leak no state after imageMode()', function() {
-      myp5.imageMode(p5.CORNER);
+      myp5.imageMode(myp5.CORNER);
       assertCanPreserveRenderState(function() {
-        myp5.imageMode(p5.CENTER);
+        myp5.imageMode(myp5.CENTER);
       });
     });
 
     test('leak no state after rectMode()', function() {
-      myp5.rectMode(p5.CORNER);
+      myp5.rectMode(myp5.CORNER);
       assertCanPreserveRenderState(function() {
-        myp5.rectMode(p5.CENTER);
+        myp5.rectMode(myp5.CENTER);
       });
     });
 
     test('leak no state after ellipseMode()', function() {
-      myp5.ellipseMode(p5.CORNER);
+      myp5.ellipseMode(myp5.CORNER);
       assertCanPreserveRenderState(function() {
-        myp5.ellipseMode(p5.CENTER);
+        myp5.ellipseMode(myp5.CENTER);
       });
     });
 
     test('leak no state after colorMode()', function() {
-      myp5.colorMode(p5.HSB);
+      myp5.colorMode(myp5.HSB);
       assertCanPreserveRenderState(function() {
-        myp5.colorMode(p5.RGB);
+        myp5.colorMode(myp5.RGB);
       });
     });
 
     test('leak no state after textAlign()', function() {
-      myp5.textAlign(p5.RIGHT, p5.BOTTOM);
+      myp5.textAlign(myp5.RIGHT, myp5.BOTTOM);
       assertCanPreserveRenderState(function() {
-        myp5.textAlign(p5.CENTER, p5.CENTER);
+        myp5.textAlign(myp5.CENTER, myp5.CENTER);
       });
     });
 
@@ -237,9 +237,9 @@ suite('Structure', function() {
     });
 
     test('leak no state after textStyle()', function() {
-      myp5.textStyle(p5.ITALIC);
+      myp5.textStyle(myp5.ITALIC);
       assertCanPreserveRenderState(function() {
-        myp5.textStyle(p5.BOLD);
+        myp5.textStyle(myp5.BOLD);
       });
     });
 

--- a/test/unit/spec.js
+++ b/test/unit/spec.js
@@ -37,3 +37,15 @@ Object.keys(spec).map(function(folder) {
     document.write(string.join(''));
   });
 });
+
+p5._throwValidationErrors = true;
+
+// a custom assertion for validation errors that correctly handles
+// minified p5 libraries.
+assert.validationError = function(fn) {
+  if (p5.ValidationError) {
+    assert.throws(fn, p5.ValidationError);
+  } else {
+    assert.doesNotThrow(fn, Error, 'got unwanted exception');
+  }
+};

--- a/test/unit/spec.js
+++ b/test/unit/spec.js
@@ -37,15 +37,3 @@ Object.keys(spec).map(function(folder) {
     document.write(string.join(''));
   });
 });
-
-p5._throwValidationErrors = true;
-
-// a custom assertion for validation errors that correctly handles
-// minified p5 libraries.
-assert.validationError = function(fn) {
-  if (p5.ValidationError) {
-    assert.throws(fn, p5.ValidationError);
-  } else {
-    assert.doesNotThrow(fn, Error, 'got unwanted exception');
-  }
-};


### PR DESCRIPTION
this PR allows the mocha/precommit tests to catch validation errors in the examples, and bugs in the doc comments.

this stemmed from the spew of FES errors that occur during the test runs. the problem is that most of these are intentional FES errors in the tests that the tests weren't previously able to detect. the error messages would just get spewed to the output masking any _actual_ FES errors that were _not_ expected.

- allows parameter validation errors to trigger mocha test failures. the tests set a global flag which causes custom Errors to be throw when an FES error occurs. some of the tests _expect_ to catch these errors, and any that aren't expected cause the test run to fail.
- fixes some erroneous doc comment parameter definitions. in order to get the tests to actually pass now some of the previously masked, unexpected FES errors need to be fixed.
- fixes the parameterValidation handling of undefined/null parameters.
- uses a scoring mechanism to handle 'undefined' trailing parameters, improve error applicability and avoid extraneous error array allocation. 


the first three commits hold the bulk of the changes and can each be considered separately, but they do require each other (and the additional requested changes) in order to work correctly.
