### PR TITLE
fixes #2539, quiets missing example output for WebGL

### DIFF
--- a/src/webgl/p5.RendererGL.Immediate.js
+++ b/src/webgl/p5.RendererGL.Immediate.js
@@ -22,6 +22,7 @@ var constants = require('../core/constants');
  * performance will likely drop as a result of too many calls to
  * beginShape() / endShape().  As a high performance alternative,
  * please use p5.js geometry primitives.
+ * @private
  * @method beginShape
  * @param  {Number} mode webgl primitives mode.  beginShape supports the
  *                       following modes:
@@ -60,6 +61,7 @@ p5.RendererGL.prototype.beginShape = function(mode) {
 };
 /**
  * adds a vertex to be drawn in a custom Shape.
+ * @private
  * @method vertex
  * @param  {Number} x x-coordinate of vertex
  * @param  {Number} y y-coordinate of vertex

--- a/src/webgl/p5.RendererGL.js
+++ b/src/webgl/p5.RendererGL.js
@@ -39,6 +39,7 @@ var defaultShaders = {
 
 /**
  * 3D graphics class
+ * @private
  * @class p5.RendererGL
  * @constructor
  * @extends p5.Renderer
@@ -585,7 +586,7 @@ p5.RendererGL.prototype.strokeWeight = function(w) {
  * as grabbing the data directly from pixels[]. The equivalent statement to
  * get(x, y) is using pixels[] with pixel density d
  *
- *
+ * @private
  * @method get
  * @param  {Number}               [x] x-coordinate of the pixel
  * @param  {Number}               [y] y-coordinate of the pixel
@@ -603,6 +604,7 @@ p5.RendererGL.prototype.get = function(x, y, w, h) {
  * Note that updatePixels() and set() do not work.
  * Any pixel manipulation must be done directly to the pixels[] array.
  *
+ * @private
  * @method loadPixels
  *
  */

--- a/src/webgl/p5.Texture.js
+++ b/src/webgl/p5.Texture.js
@@ -12,6 +12,7 @@ var p5 = require('../core/core');
 
 /**
  * Texture class for WEBGL Mode
+ * @private
  * @class p5.Texture
  * @constructor
  * @param {p5.RendererGL} renderer an instance of p5.RendererGL that


### PR DESCRIPTION
removes "missing example" warnings for WebGL methods that do not need
to be part of the public API, and the renderer itself (which wasn't generating
a page).

made RendererGL methods (and class) private, but also noticed that the regular p5.Renderer class isn't explicitly marked private and doesn't show up in the documentation. open to suggestions if this should have been handled another way!

ended up leaving p5.Geometry in for now, but can also remove and make private if that seems more appropriate.