### PR TITLE
Improve construction of cylinder and cone primitives and geometry validation

### DIFF
--- a/src/webgl/p5.Geometry.js
+++ b/src/webgl/p5.Geometry.js
@@ -83,7 +83,9 @@ p5.Geometry.prototype._getFaceNormal = function(faceId) {
   var ln = p5.Vector.mag(n);
   var sinAlpha = ln / (p5.Vector.mag(ab) * p5.Vector.mag(ac));
   if (sinAlpha === 0 || isNaN(sinAlpha)) {
-    return new p5.Vector(0, 0, 0);
+    throw new Error(
+      'Degenerate geometry: This face either has a colinear sides or a repeated vertex.'
+    );
   }
   return n.mult(Math.asin(sinAlpha) / ln);
 };

--- a/src/webgl/p5.Geometry.js
+++ b/src/webgl/p5.Geometry.js
@@ -83,9 +83,11 @@ p5.Geometry.prototype._getFaceNormal = function(faceId) {
   var ln = p5.Vector.mag(n);
   var sinAlpha = ln / (p5.Vector.mag(ab) * p5.Vector.mag(ac));
   if (sinAlpha === 0 || isNaN(sinAlpha)) {
-    throw new Error(
-      'Degenerate geometry: This face either has colinear sides or a repeated vertex.'
+    console.warn(
+      'p5.Geometry.prototype._getFaceNormal:',
+      'face has colinear sides or a repeated vertex'
     );
+    return n;
   }
   return n.mult(Math.asin(sinAlpha) / ln);
 };

--- a/src/webgl/p5.Geometry.js
+++ b/src/webgl/p5.Geometry.js
@@ -82,6 +82,9 @@ p5.Geometry.prototype._getFaceNormal = function(faceId) {
   var n = p5.Vector.cross(ab, ac);
   var ln = p5.Vector.mag(n);
   var sinAlpha = ln / (p5.Vector.mag(ab) * p5.Vector.mag(ac));
+  if (sinAlpha === 0 || isNaN(sinAlpha)) {
+    return new p5.Vector(0, 0, 0);
+  }
   return n.mult(Math.asin(sinAlpha) / ln);
 };
 /**

--- a/src/webgl/p5.Geometry.js
+++ b/src/webgl/p5.Geometry.js
@@ -84,7 +84,7 @@ p5.Geometry.prototype._getFaceNormal = function(faceId) {
   var sinAlpha = ln / (p5.Vector.mag(ab) * p5.Vector.mag(ac));
   if (sinAlpha === 0 || isNaN(sinAlpha)) {
     throw new Error(
-      'Degenerate geometry: This face either has a colinear sides or a repeated vertex.'
+      'Degenerate geometry: This face either has colinear sides or a repeated vertex.'
     );
   }
   return n.mult(Math.asin(sinAlpha) / ln);

--- a/src/webgl/primitives.js
+++ b/src/webgl/primitives.js
@@ -442,7 +442,8 @@ p5.prototype.cylinder = function(
     bottomCap = true;
   }
 
-  var gId = 'cylinder|' + detailX + '|' + detailY;
+  var gId =
+    'cylinder|' + detailX + '|' + detailY + '|' + bottomCap + '|' + topCap;
   if (!this._renderer.geometryInHash(gId)) {
     var cylinderGeom = new p5.Geometry(detailX, detailY);
     _truncatedCone.call(
@@ -520,7 +521,8 @@ p5.prototype.cone = function(radius, height, detailX, detailY, cap) {
     cap = true;
   }
 
-  var gId = 'cone|' + radius + '|' + height + '|' + detailX + '|' + detailY;
+  var gId =
+    'cone|' + radius + '|' + height + '|' + detailX + '|' + detailY + '|' + cap;
   if (!this._renderer.geometryInHash(gId)) {
     var coneGeom = new p5.Geometry(detailX, detailY);
     _truncatedCone.call(

--- a/src/webgl/primitives.js
+++ b/src/webgl/primitives.js
@@ -525,16 +525,7 @@ p5.prototype.cone = function(radius, height, detailX, detailY, cap) {
     'cone|' + radius + '|' + height + '|' + detailX + '|' + detailY + '|' + cap;
   if (!this._renderer.geometryInHash(gId)) {
     var coneGeom = new p5.Geometry(detailX, detailY);
-    _truncatedCone.call(
-      coneGeom,
-      radius,
-      0,
-      height,
-      detailX,
-      detailY,
-      cap,
-      false
-    );
+    _truncatedCone.call(coneGeom, 1, 0, 1, detailX, detailY, cap, false);
     //for cones we need to average Normals
     coneGeom.computeNormals();
     if (detailX <= 24 && detailY <= 16) {
@@ -549,7 +540,7 @@ p5.prototype.cone = function(radius, height, detailX, detailY, cap) {
     this._renderer.createBuffers(gId, coneGeom);
   }
 
-  this._renderer.drawBuffers(gId);
+  this._renderer.drawBuffersScaled(gId, radius, height, radius);
 
   return this;
 };

--- a/src/webgl/primitives.js
+++ b/src/webgl/primitives.js
@@ -346,7 +346,7 @@ var _truncatedCone = function(
  *                               default is 24
  * @param  {Integer} [detailY]   number of segments in y-dimension,
  *                               the more segments the smoother geometry
- *                               default is 16
+ *                               default is 1
  * @param  {Boolean} [topCap]    whether to draw the top of the cylinder
  * @param  {Boolean} [bottomCap] whether to draw the top bottom of the cylinder
  * @chainable
@@ -378,7 +378,7 @@ p5.prototype.cylinder = function(radius, height, detailX, detailY, topCap, botto
     detailX = 24;
   }
   if (typeof detailY === 'undefined') {
-    detailY = 16;
+    detailY = 1;
   }
   if (typeof topCap === 'undefined') {
     topCap = true;
@@ -419,7 +419,7 @@ p5.prototype.cylinder = function(radius, height, detailX, detailY, topCap, botto
  *                                    default is 24
  * @param  {Integer} [detailY]        number of segments,
  *                                    the more segments the smoother geometry
- *                                    default is 16
+ *                                    default is 1
  * @param  {Boolean} [cap]            whether to draw the base of the cone
  * @chainable
  * @example
@@ -450,7 +450,7 @@ p5.prototype.cone = function(radius, height, detailX, detailY, cap) {
     detailX = 24;
   }
   if (typeof detailY === 'undefined') {
-    detailY = 16;
+    detailY = 1;
   }
   if (typeof cap === 'undefined') {
     cap = true;

--- a/src/webgl/primitives.js
+++ b/src/webgl/primitives.js
@@ -353,7 +353,7 @@ var _truncatedCone = function(
  * @example
  * <div>
  * <code>
- * //draw a spinning cylinder with radius 200 and height 200
+ * //draw a spinning cylinder with radius 20 and height 50
  * function setup() {
  *   createCanvas(100, 100, WEBGL);
  * }
@@ -425,7 +425,7 @@ p5.prototype.cylinder = function(radius, height, detailX, detailY, topCap, botto
  * @example
  * <div>
  * <code>
- * //draw a spinning cone with radius 200 and height 200
+ * //draw a spinning cone with radius 40 and height 70
  * function setup() {
  *   createCanvas(100, 100, WEBGL);
  * }

--- a/src/webgl/primitives.js
+++ b/src/webgl/primitives.js
@@ -338,15 +338,17 @@ var _truncatedCone = function(
 
 /**
  * Draw a cylinder with given radius and height
- * @method  cylinder
- * @param  {Number} [radius]   radius of the surface
- * @param  {Number} [height]   height of the cylinder
- * @param  {Integer} [detailX] number of segments,
- *                             the more segments the smoother geometry
- *                             default is 24
- * @param {Integer} [detailY]  number of segments in y-dimension,
- *                             the more segments the smoother geometry
- *                             default is 16
+ * @method cylinder
+ * @param  {Number}  [radius]    radius of the surface
+ * @param  {Number}  [height]    height of the cylinder
+ * @param  {Integer} [detailX]   number of segments,
+ *                               the more segments the smoother geometry
+ *                               default is 24
+ * @param  {Integer} [detailY]   number of segments in y-dimension,
+ *                               the more segments the smoother geometry
+ *                               default is 16
+ * @param  {Boolean} [topCap]    whether to draw the top of the cylinder
+ * @param  {Boolean} [bottomCap] whether to draw the top bottom of the cylinder
  * @chainable
  * @example
  * <div>
@@ -365,7 +367,7 @@ var _truncatedCone = function(
  * </code>
  * </div>
  */
-p5.prototype.cylinder = function(radius, height, detailX, detailY) {
+p5.prototype.cylinder = function(radius, height, detailX, detailY, topCap, bottomCap) {
   if (typeof radius === 'undefined') {
     radius = 50;
   }
@@ -378,11 +380,17 @@ p5.prototype.cylinder = function(radius, height, detailX, detailY) {
   if (typeof detailY === 'undefined') {
     detailY = 16;
   }
+  if (typeof topCap === 'undefined') {
+    topCap = true;
+  }
+  if (typeof bottomCap === 'undefined') {
+    bottomCap = true;
+  }
 
   var gId = 'cylinder|' + detailX + '|' + detailY;
   if (!this._renderer.geometryInHash(gId)) {
     var cylinderGeom = new p5.Geometry(detailX, detailY);
-    _truncatedCone.call(cylinderGeom, 1, 1, 1, detailX, detailY, true, true);
+    _truncatedCone.call(cylinderGeom, 1, 1, 1, detailX, detailY, topCap, bottomCap);
     cylinderGeom.computeNormals();
     if (detailX <= 24 && detailY <= 16) {
       cylinderGeom._makeTriangleEdges();
@@ -412,6 +420,7 @@ p5.prototype.cylinder = function(radius, height, detailX, detailY) {
  * @param  {Integer} [detailY]        number of segments,
  *                                    the more segments the smoother geometry
  *                                    default is 16
+ * @param  {Boolean} [cap]            whether to draw the base of the cone
  * @chainable
  * @example
  * <div>
@@ -430,7 +439,7 @@ p5.prototype.cylinder = function(radius, height, detailX, detailY) {
  * </code>
  * </div>
  */
-p5.prototype.cone = function(radius, height, detailX, detailY) {
+p5.prototype.cone = function(radius, height, detailX, detailY, cap) {
   if (typeof radius === 'undefined') {
     radius = 50;
   }
@@ -443,20 +452,14 @@ p5.prototype.cone = function(radius, height, detailX, detailY) {
   if (typeof detailY === 'undefined') {
     detailY = 16;
   }
+  if (typeof cap === 'undefined') {
+    cap = true;
+  }
 
   var gId = 'cone|' + radius + '|' + height + '|' + detailX + '|' + detailY;
   if (!this._renderer.geometryInHash(gId)) {
     var coneGeom = new p5.Geometry(detailX, detailY);
-    _truncatedCone.call(
-      coneGeom,
-      radius,
-      0, //top radius 0
-      height,
-      detailX,
-      detailY,
-      true,
-      true
-    );
+    _truncatedCone.call(coneGeom, radius, 0, height, detailX, detailY, cap, false);
     //for cones we need to average Normals
     coneGeom.computeNormals();
     if (detailX <= 24 && detailY <= 16) {

--- a/src/webgl/primitives.js
+++ b/src/webgl/primitives.js
@@ -521,8 +521,7 @@ p5.prototype.cone = function(radius, height, detailX, detailY, cap) {
     cap = true;
   }
 
-  var gId =
-    'cone|' + radius + '|' + height + '|' + detailX + '|' + detailY + '|' + cap;
+  var gId = 'cone|' + detailX + '|' + detailY + '|' + cap;
   if (!this._renderer.geometryInHash(gId)) {
     var coneGeom = new p5.Geometry(detailX, detailY);
     _truncatedCone.call(coneGeom, 1, 0, 1, detailX, detailY, cap, false);


### PR DESCRIPTION
This resolves the issue of spurious warnings in p5.Geometry._getFaceNormal as described in #2594. Closes #2594 