### PR TITLE
fix shader tests

### DIFF
--- a/test/unit/webgl/p5.Shader.js
+++ b/test/unit/webgl/p5.Shader.js
@@ -128,12 +128,11 @@ suite('p5.Shader', function() {
       );
     });
     test('Color Shader definition', function() {
-      var expectedAttributes = ['aPosition', 'aNormal', 'aTexCoord'];
+      var expectedAttributes = ['aPosition'];
 
       var expectedUniforms = [
         'uModelViewMatrix',
         'uProjectionMatrix',
-        'uNormalMatrix',
         'uMaterialColor'
       ];
 
@@ -162,7 +161,7 @@ suite('p5.Shader', function() {
       );
     });
     test('Normal Shader definition', function() {
-      var expectedAttributes = ['aPosition', 'aNormal', 'aTexCoord'];
+      var expectedAttributes = ['aPosition', 'aNormal'];
 
       var expectedUniforms = [
         'uModelViewMatrix',

--- a/test/unit/webgl/stroke.js
+++ b/test/unit/webgl/stroke.js
@@ -48,7 +48,7 @@ suite('stroke WebGL', function() {
         'stroke shader not active after stroke()'
       );
       assert.isTrue(
-        myp5._renderer._doFill,
+        !myp5._renderer._doFill,
         'fill shader still active after noFill()'
       );
       done();


### PR DESCRIPTION
this one fixes 3 failures in webgl test that only fail when run in the browser (webgl tests dont run in PhantomJS).

closes #2597

the shader uniforms/attributes need to be removed from the checks because they're not actually used in the shader and on some browsers they are optimized away, causing the checks to fail. this is basically the same bug as #2262, but now that the code has checks to prevent crashe on those browsers, (#2349) the webgl tests are now able to run better.

the `_doFill` change is because previously the webgl renderer didn't affect the `_doFill` property at all (it used `curFillShader.active` and other state) so this property wasn't actually changed. now that both renderers use the same flag and it _is_ updates in the `fill()` call the bug in the test is exposed.