### PR TITLE
Fix transparent textures

### DIFF
--- a/src/webgl/material.js
+++ b/src/webgl/material.js
@@ -254,13 +254,6 @@ p5.prototype.normalMaterial = function() {
  *
  */
 p5.prototype.texture = function(tex) {
-  this._renderer.GL.depthMask(true);
-  this._renderer.GL.enable(this._renderer.GL.BLEND);
-  this._renderer.GL.blendFunc(
-    this._renderer.GL.SRC_ALPHA,
-    this._renderer.GL.ONE_MINUS_SRC_ALPHA
-  );
-
   this._renderer.drawMode = constants.TEXTURE;
   var shader = this._renderer._useLightShader();
   shader.setUniform('uSpecular', false);
@@ -373,8 +366,10 @@ p5.prototype.specularMaterial = function(v1, v2, v3, a) {
  */
 p5.RendererGL.prototype._applyColorBlend = function(colors) {
   var gl = this.GL;
-  if (colors[colors.length - 1] < 1.0) {
-    gl.depthMask(false);
+
+  var isTexture = this.drawMode === constants.TEXTURE;
+  if (isTexture || colors[colors.length - 1] < 1.0) {
+    gl.depthMask(isTexture);
     gl.enable(gl.BLEND);
     gl.blendEquation(gl.FUNC_ADD);
     gl.blendFunc(gl.SRC_ALPHA, gl.ONE_MINUS_SRC_ALPHA);

--- a/test/manual-test-examples/webgl/texture/transparentTexture/index.html
+++ b/test/manual-test-examples/webgl/texture/transparentTexture/index.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8">
+  <meta http-equiv="X-UA-Compatible" content="IE=edge">
+  <title></title>
+  <link rel="stylesheet" href="">
+  <script language="javascript" type="text/javascript" src="../../../../../lib/p5.js"></script>
+  <script language="javascript" type="text/javascript" src="../../../../../lib/addons/p5.dom.js"></script>
+  <script language="javascript" type="text/javascript" src="sketch.js"></script>
+  <style>
+    html, body {margin:0; padding:0; background: blue;}
+  </style> 
+</head>
+<body>
+<p style="position: absolute; width:300px; left:50%; margin-left: -150px; text-align: center; color:black;"></p>
+</body>
+</html>

--- a/test/manual-test-examples/webgl/texture/transparentTexture/sketch.js
+++ b/test/manual-test-examples/webgl/texture/transparentTexture/sketch.js
@@ -1,0 +1,50 @@
+var im1;
+
+function setup() {
+  createCanvas(windowWidth, windowHeight, WEBGL);
+
+  im1 = createGraphics(400, 400);
+  im1.background(0, 0, 0, 0);
+  im1.strokeWeight(0.25);
+  im1.colorMode(HSB);
+  for (var i = 0; i < 10; i ++) {
+    drawLine(im1);
+  }
+}
+
+function drawLine(im) {
+  im.stroke((millis() / 40) % 255, 255, 255);
+  var w = im.width;
+  var h = im.height;
+  var x1 = random(0, w);
+  var y1 = random(0, h);
+
+  var x2 = random(-w/2, w*3/2);
+  var y2 = random(-h/2, h*3/2);
+
+  im.line(x1, y1, x2, y2);
+  if (x2 < 0) {
+    im.line(x1+w, y1, x2+w, y2);
+  } else if (x2 > w) {
+    im.line(x1-w, y1, x2-w, y2);
+  }
+
+  if (y2 < 0) {
+    im.line(x1, y1+h, x2, y2+h);
+  } else if (y2 > h) {
+    im.line(x1, y1-h, x2, y2-h);
+  }
+}
+
+function draw() {
+
+  drawLine(im1);
+
+  background(0, 0, 0);
+  fill(255, 255, 255);
+  texture(im1);
+
+  translate(0, 0, 100);
+  rotateY(millis()/1000);
+  torus(100, 50);
+}


### PR DESCRIPTION
this PR ensures that the gl blend state is set correctly when the `drawMode` is set to `TEXTURE`. closes #2608

i also added a manual test to rendering a (procedurally-generated) transparent texture. there is still a separate issue where some faces are not always rendered transparent (this is evident in the new test), but i have verified that this PR demonstrates the same behavior as 0.5.16.

