### PR TITLE
parseXML in instance mode fix

### DIFF
--- a/src/io/files.js
+++ b/src/io/files.js
@@ -559,13 +559,12 @@ function makeObject(row, headers) {
   return ret;
 }
 
-/*global parseXML */
-p5.prototype.parseXML = function(two) {
+p5.prototype.parseXML = function (two) {
   var one = new p5.XML();
   var i;
   if (two.children.length) {
-    for (i = 0; i < two.children.length; i++) {
-      var node = parseXML(two.children[i]);
+    for ( i = 0; i < two.children.length; i++ ) {
+      var node = this.parseXML(two.children[i]);
       one.addChild(node);
     }
     one.setName(two.nodeName);
@@ -1018,7 +1017,8 @@ p5.prototype.httpDo = function() {
           throw err;
         }
       });
-  } else {
+  }else{
+    var self = this;
     fetch(request)
       .then(function(res) {
         if (res.ok) {
@@ -1035,7 +1035,7 @@ p5.prototype.httpDo = function() {
         if (type === 'xml') {
           var parser = new DOMParser();
           resp = parser.parseFromString(resp, 'text/xml');
-          resp = parseXML(resp.documentElement);
+          resp = self.parseXML(resp.documentElement);
         }
         callback(resp);
       })

--- a/src/io/files.js
+++ b/src/io/files.js
@@ -559,12 +559,12 @@ function makeObject(row, headers) {
   return ret;
 }
 
-p5.prototype.parseXML = function(two) {
+function parseXML(two) {
   var one = new p5.XML();
   var i;
   if (two.children.length) {
     for (i = 0; i < two.children.length; i++) {
-      var node = this.parseXML(two.children[i]);
+      var node = parseXML(two.children[i]);
       one.addChild(node);
     }
     one.setName(two.nodeName);
@@ -580,7 +580,7 @@ p5.prototype.parseXML = function(two) {
     one._setAttributes(two);
     return one;
   }
-};
+}
 
 /**
  * Reads the contents of a file and creates an XML object with its values.
@@ -1018,7 +1018,6 @@ p5.prototype.httpDo = function() {
         }
       });
   } else {
-    var self = this;
     fetch(request)
       .then(function(res) {
         if (res.ok) {
@@ -1035,7 +1034,7 @@ p5.prototype.httpDo = function() {
         if (type === 'xml') {
           var parser = new DOMParser();
           resp = parser.parseFromString(resp, 'text/xml');
-          resp = self.parseXML(resp.documentElement);
+          resp = parseXML(resp.documentElement);
         }
         callback(resp);
       })

--- a/src/io/files.js
+++ b/src/io/files.js
@@ -559,11 +559,11 @@ function makeObject(row, headers) {
   return ret;
 }
 
-p5.prototype.parseXML = function (two) {
+p5.prototype.parseXML = function(two) {
   var one = new p5.XML();
   var i;
   if (two.children.length) {
-    for ( i = 0; i < two.children.length; i++ ) {
+    for (i = 0; i < two.children.length; i++) {
       var node = this.parseXML(two.children[i]);
       one.addChild(node);
     }
@@ -1017,7 +1017,7 @@ p5.prototype.httpDo = function() {
           throw err;
         }
       });
-  }else{
+  } else {
     var self = this;
     fetch(request)
       .then(function(res) {


### PR DESCRIPTION
Closes #2388 

This PR implements solution 2 from #2388 which makes parseXML a local private function within `io/files.js`.