### PR TITLE
tidy up manual test html

### DIFF
--- a/test/manual-test-examples/addons/p5.dom/audioEltSpotify/index.html
+++ b/test/manual-test-examples/addons/p5.dom/audioEltSpotify/index.html
@@ -1,10 +1,7 @@
 <head>
   <script language="javascript" type="text/javascript" src="../../../../../lib/p5.js"></script>
   <script language="javascript" type="text/javascript" src="../../../../../lib/addons/p5.dom.js"></script>
-  <script language="javascript" type="text/javascript" src="sketch.js"></script>        
-  <style>
-  </style>
-
+  <script language="javascript" type="text/javascript" src="sketch.js"></script>
 </head>
 
 <body>

--- a/test/manual-test-examples/empty-example/index.html
+++ b/test/manual-test-examples/empty-example/index.html
@@ -1,13 +1,24 @@
+<!DOCTYPE html>
+<html>
 
 <head>
+  <meta charset="utf-8">
+  <meta http-equiv="X-UA-Compatible" content="IE=edge">
+  <title></title>
+  <link rel="stylesheet" href="../styles.css">
+
   <script language="javascript" src="../../../lib/p5.js"></script>
   <!-- uncomment lines below to include extra p5 libraries -->
   <!--<script language="javascript" src="../addons/p5.dom.js"></script>-->
   <!--<script language="javascript" src="../addons/p5.sound.js"></script>-->
-  <script language="javascript" src="sketch.js"></script>
-  <!-- this line removes any default padding and style. you might only need one of these values set. -->
-  <style> body {padding: 0; margin: 0;} </style>
+  <script language="javascript" type="text/javascript" src="sketch.js"></script>
+  <!-- webgl stats: <script src="../stats.js"></script> -->
 </head>
 
 <body>
+  <header>
+    <p>Empty Example</p>
+  </header>
 </body>
+
+</html>

--- a/test/manual-test-examples/empty-example/sketch.js
+++ b/test/manual-test-examples/empty-example/sketch.js
@@ -1,8 +1,9 @@
 function setup() {
   // put setup code here
-  createCanvas(600, 400);
+  createCanvas(windowWidth, windowHeight);
 }
 
 function draw() {
   // put drawing code here
+  background(0);
 }

--- a/test/manual-test-examples/p5.Font/opentype/index.html
+++ b/test/manual-test-examples/p5.Font/opentype/index.html
@@ -1,10 +1,12 @@
 <html>
+
 <head>
+  <link rel="stylesheet" href="../../styles.css">
   <script language="javascript" type="text/javascript" src="../../../../lib/p5.js"></script>
   <script language="javascript" type="text/javascript" src="sketch.js"></script>
-  <style> body {padding: 0; margin: 0;}</style>
 </head>
 
 <body>
 </body>
+
 </html>

--- a/test/manual-test-examples/styles.css
+++ b/test/manual-test-examples/styles.css
@@ -1,0 +1,15 @@
+html, body {margin:0; padding:0;}
+
+header {
+  width: 100%;
+  position: absolute;
+  color: black;
+  background-color: rgba(240, 240, 240, 0.75);
+  font-family: Arial, Helvetica, sans-serif;
+  font-size: 105%;
+}
+
+header p {
+  width: 100%;
+  text-align: center;
+}

--- a/test/manual-test-examples/webgl/camera/box/index.html
+++ b/test/manual-test-examples/webgl/camera/box/index.html
@@ -1,21 +1,20 @@
 <!DOCTYPE html>
 <html>
+
 <head>
   <meta charset="utf-8">
   <meta http-equiv="X-UA-Compatible" content="IE=edge">
   <title></title>
-  <link rel="stylesheet" href="">
+  <link rel="stylesheet" href="../../../styles.css">
   <script language="javascript" type="text/javascript" src="../../../../../lib/p5.js"></script>
   <script language="javascript" type="text/javascript" src="sketch.js"></script>
-  <style>
-    html, body {margin:0; padding:0;}
-  </style> 
+  <script src="../../stats.js"></script>
 </head>
+
 <body>
-<p style="position: absolute; width:300px; left:50%; margin-left: -150px; color:white; text-align: center;">Perspective camera</p>
-<script>
-(function(){var script=document.createElement('script');script.onload=function(){var stats=new Stats();stats.domElement.style.cssText='position:fixed;left:0;top:0;z-index:10000';document.body.appendChild(stats.domElement);requestAnimationFrame(function loop(){stats.update();requestAnimationFrame(loop)});};script.src='http://rawgit.com/mrdoob/stats.js/master/build/stats.min.js';document.head.appendChild(script);})()
-</script>
-  
+  <header>
+    <p>Perspective camera</p>
+  </header>
 </body>
+
 </html>

--- a/test/manual-test-examples/webgl/camera/ortho/index.html
+++ b/test/manual-test-examples/webgl/camera/ortho/index.html
@@ -1,21 +1,20 @@
 <!DOCTYPE html>
 <html>
+
 <head>
   <meta charset="utf-8">
   <meta http-equiv="X-UA-Compatible" content="IE=edge">
   <title></title>
-  <link rel="stylesheet" href="">
+  <link rel="stylesheet" href="../../../styles.css">
   <script language="javascript" type="text/javascript" src="../../../../../lib/p5.js"></script>
   <script language="javascript" type="text/javascript" src="sketch.js"></script>
-  <style>
-    html, body {margin:0; padding:0;}
-  </style> 
+  <script src="../../stats.js"></script>
 </head>
+
 <body>
-<p style="position: absolute; width:300px; left:50%; margin-left: -150px; color:white; text-align: center;">Orthographic camera</p>
-<script>
-(function(){var script=document.createElement('script');script.onload=function(){var stats=new Stats();stats.domElement.style.cssText='position:fixed;left:0;top:0;z-index:10000';document.body.appendChild(stats.domElement);requestAnimationFrame(function loop(){stats.update();requestAnimationFrame(loop)});};script.src='http://rawgit.com/mrdoob/stats.js/master/build/stats.min.js';document.head.appendChild(script);})()
-</script>
-  
+  <header>
+    <p>Orthographic camera</p>
+  </header>
 </body>
+
 </html>

--- a/test/manual-test-examples/webgl/camera/perspective/index.html
+++ b/test/manual-test-examples/webgl/camera/perspective/index.html
@@ -1,21 +1,20 @@
 <!DOCTYPE html>
 <html>
+
 <head>
   <meta charset="utf-8">
   <meta http-equiv="X-UA-Compatible" content="IE=edge">
   <title></title>
-  <link rel="stylesheet" href="">
+  <link rel="stylesheet" href="../../../styles.css">
   <script language="javascript" type="text/javascript" src="../../../../../lib/p5.js"></script>
   <script language="javascript" type="text/javascript" src="sketch.js"></script>
-  <style>
-    html, body {margin:0; padding:0;}
-  </style> 
+  <script src="../../stats.js"></script>
 </head>
+
 <body>
-<p style="position: absolute; width:300px; left:50%; margin-left: -150px; color:white; text-align: center;">Perspective camera</p>
-<script>
-(function(){var script=document.createElement('script');script.onload=function(){var stats=new Stats();stats.domElement.style.cssText='position:fixed;left:0;top:0;z-index:10000';document.body.appendChild(stats.domElement);requestAnimationFrame(function loop(){stats.update();requestAnimationFrame(loop)});};script.src='http://rawgit.com/mrdoob/stats.js/master/build/stats.min.js';document.head.appendChild(script);})()
-</script>
-  
+  <header>
+    <p>Perspective camera</p>
+  </header>
 </body>
+
 </html>

--- a/test/manual-test-examples/webgl/customShader/toonShader/index.html
+++ b/test/manual-test-examples/webgl/customShader/toonShader/index.html
@@ -1,22 +1,21 @@
 <!DOCTYPE html>
 <html>
+
 <head>
   <meta charset="utf-8">
   <meta http-equiv="X-UA-Compatible" content="IE=edge">
   <title></title>
-  <link rel="stylesheet" href="">
+  <link rel="stylesheet" href="../../../styles.css">
   <script language="javascript" type="text/javascript" src="../../../../../lib/p5.js"></script>
   <script language="javascript" type="text/javascript" src="../../../../../lib/addons/p5.dom.js"></script>
   <script language="javascript" type="text/javascript" src="sketch.js"></script>
-  <style>
-    html, body {margin:0; padding:0;}
-  </style>
+  <script src="../../stats.js"></script>
 </head>
-<body>
-<p style="position: absolute; width:300px; left:50%; margin-left: -150px; text-align: center; color:white;">move mouse to move light source</p>
-<script>
-(function(){var script=document.createElement('script');script.onload=function(){var stats=new Stats();stats.domElement.style.cssText='position:fixed;left:0;top:0;z-index:10000';document.body.appendChild(stats.domElement);requestAnimationFrame(function loop(){stats.update();requestAnimationFrame(loop)});};script.src='http://rawgit.com/mrdoob/stats.js/master/build/stats.min.js';document.head.appendChild(script);})()
-</script>
 
+<body>
+  <header>
+    <p>move mouse to move light source</p>
+  </header>
 </body>
+
 </html>

--- a/test/manual-test-examples/webgl/customShader/videoMultiTextureShader/index.html
+++ b/test/manual-test-examples/webgl/customShader/videoMultiTextureShader/index.html
@@ -1,22 +1,20 @@
 <!DOCTYPE html>
 <html>
+
 <head>
   <meta charset="utf-8">
   <meta http-equiv="X-UA-Compatible" content="IE=edge">
   <title></title>
-  <link rel="stylesheet" href="">
+  <link rel="stylesheet" href="../../../styles.css">
   <script language="javascript" type="text/javascript" src="../../../../../lib/p5.js"></script>
   <script language="javascript" type="text/javascript" src="../../../../../lib/addons/p5.dom.js"></script>
   <script language="javascript" type="text/javascript" src="sketch.js"></script>
-  <style>
-    html, body {margin:0; padding:0;}
-  </style>
 </head>
-<body>
-<p style="position: absolute; width:300px; left:50%; margin-left: -150px; text-align: center; color:black;">press any key to toggle video play/pause</p>
-<script>
-(function(){var script=document.createElement('script');script.onload=function(){var stats=new Stats();stats.domElement.style.cssText='position:fixed;left:0;top:0;z-index:10000';document.body.appendChild(stats.domElement);requestAnimationFrame(function loop(){stats.update();requestAnimationFrame(loop)});};script.src='http://rawgit.com/mrdoob/stats.js/master/build/stats.min.js';document.head.appendChild(script);})()
-</script>
 
+<body>
+  <header>
+    <p>press any key to toggle video play/pause</p>
+  </header>
 </body>
+
 </html>

--- a/test/manual-test-examples/webgl/defaultFillAndStroke/index.html
+++ b/test/manual-test-examples/webgl/defaultFillAndStroke/index.html
@@ -1,22 +1,22 @@
 <!DOCTYPE html>
 <html>
+
 <head>
   <meta charset="utf-8">
   <meta http-equiv="X-UA-Compatible" content="IE=edge">
   <title></title>
-  <link rel="stylesheet" href="">
+  <link rel="stylesheet" href="../../styles.css">
   <script language="javascript" type="text/javascript" src="../../../../lib/p5.js"></script>
   <script language="javascript" type="text/javascript" src="sketch.js"></script>
-  <style>
-    html, body {margin:0; padding:0;}
-  </style>
+  <script src="../stats.js"></script>
 </head>
+
 <body>
-<p style="width:1000px; margin:10px auto; text-align: center; color:black;">Drag mouse to toggle the world</p>
-<p style="width:1000px; margin:10px auto; text-align: center; color:black;">(3d primitives and 2d primitives can be used together)</p>
-<script>
-(function(){var script=document.createElement('script');script.onload=function(){var stats=new Stats();stats.domElement.style.cssText='position:fixed;left:0;top:0;z-index:10000';document.body.appendChild(stats.domElement);requestAnimationFrame(function loop(){stats.update();requestAnimationFrame(loop)});};script.src='http://rawgit.com/mrdoob/stats.js/master/build/stats.min.js';document.head.appendChild(script);})()
-</script>
+  <header>
+    <p>Drag mouse to toggle the world</p>
+    <p>(3d primitives and 2d primitives can be used together)</p>
+  </header>
 
 </body>
+
 </html>

--- a/test/manual-test-examples/webgl/geometry/index.html
+++ b/test/manual-test-examples/webgl/geometry/index.html
@@ -4,18 +4,14 @@
   <meta charset="utf-8">
   <meta http-equiv="X-UA-Compatible" content="IE=edge">
   <title></title>
-  <link rel="stylesheet" href="">
+  <link rel="stylesheet" href="../../styles.css">
   <script language="javascript" type="text/javascript" src="../../../../lib/p5.js"></script>
   <script language="javascript" type="text/javascript" src="sketch.js"></script>
-  <style>
-    html, body {margin:0; padding:0;}
-  </style>
 </head>
 <body>
-<p style="width:1000px; margin:10px auto; text-align: center; color:black;">Move mouse to spin geometries</p>
-<script>
-(function(){var script=document.createElement('script');script.onload=function(){var stats=new Stats();stats.domElement.style.cssText='position:fixed;left:0;top:0;z-index:10000';document.body.appendChild(stats.domElement);requestAnimationFrame(function loop(){stats.update();requestAnimationFrame(loop)});};script.src='http://rawgit.com/mrdoob/stats.js/master/build/stats.min.js';document.head.appendChild(script);})()
-</script>
-
+  <header>
+    <p>Drag mouse to toggle the world</p>
+    <p>Move mouse to spin geometries</p>
+  </header>
 </body>
 </html>

--- a/test/manual-test-examples/webgl/immediateMode/basic/index.html
+++ b/test/manual-test-examples/webgl/immediateMode/basic/index.html
@@ -1,21 +1,22 @@
 <!DOCTYPE html>
 <html>
+
 <head>
   <meta charset="utf-8">
   <meta http-equiv="X-UA-Compatible" content="IE=edge">
   <title></title>
-  <link rel="stylesheet" href="">
+  <link rel="stylesheet" href="../../../styles.css">
   <script language="javascript" type="text/javascript" src="../../../../../lib/p5.js"></script>
   <script language="javascript" type="text/javascript" src="sketch.js"></script>
-  <style>
-    html, body {margin:0; padding:0;}
-  </style> 
+  <script src="../../stats.js"></script>
 </head>
+
 <body>
-<p style="position: absolute; width:300px; left:50%; margin-left: -150px; text-align: center; color:black;">Drag mouse to toggle the world</p>
-<script>
-(function(){var script=document.createElement('script');script.onload=function(){var stats=new Stats();stats.domElement.style.cssText='position:fixed;left:0;top:0;z-index:10000';document.body.appendChild(stats.domElement);requestAnimationFrame(function loop(){stats.update();requestAnimationFrame(loop)});};script.src='http://rawgit.com/mrdoob/stats.js/master/build/stats.min.js';document.head.appendChild(script);})()
-</script>
-  
+  <header>
+    <p>Drag mouse to toggle the world</p>
+    <p>Drag mouse to toggle the world</p>
+  </header>
+
 </body>
+
 </html>

--- a/test/manual-test-examples/webgl/immediateMode/mixTextureAndFill/index.html
+++ b/test/manual-test-examples/webgl/immediateMode/mixTextureAndFill/index.html
@@ -1,21 +1,20 @@
 <!DOCTYPE html>
 <html>
+
 <head>
   <meta charset="utf-8">
   <meta http-equiv="X-UA-Compatible" content="IE=edge">
   <title></title>
-  <link rel="stylesheet" href="">
+  <link rel="stylesheet" href="../../../styles.css">
   <script language="javascript" type="text/javascript" src="../../../../../lib/p5.js"></script>
   <script language="javascript" type="text/javascript" src="sketch.js"></script>
-  <style>
-    html, body {margin:0; padding:0;}
-  </style> 
+  <script src="../../stats.js"></script>
 </head>
+
 <body>
-<p style="position: absolute; width:300px; left:50%; margin-left: -150px; text-align: center; color:black;">400 triangles (200 quads), interleaving texture and fill</p>
-<script>
-(function(){var script=document.createElement('script');script.onload=function(){var stats=new Stats();stats.domElement.style.cssText='position:fixed;left:0;top:0;z-index:10000';document.body.appendChild(stats.domElement);requestAnimationFrame(function loop(){stats.update();requestAnimationFrame(loop)});};script.src='http://rawgit.com/mrdoob/stats.js/master/build/stats.min.js';document.head.appendChild(script);})()
-</script>
-  
+  <header>
+    <p>400 triangles (200 quads), interleaving texture and fill</p>
+  </header>
 </body>
+
 </html>

--- a/test/manual-test-examples/webgl/immediateMode/performance/index.html
+++ b/test/manual-test-examples/webgl/immediateMode/performance/index.html
@@ -1,21 +1,20 @@
 <!DOCTYPE html>
 <html>
+
 <head>
   <meta charset="utf-8">
   <meta http-equiv="X-UA-Compatible" content="IE=edge">
   <title></title>
-  <link rel="stylesheet" href="">
+  <link rel="stylesheet" href="../../../styles.css">
   <script language="javascript" type="text/javascript" src="../../../../../lib/p5.js"></script>
   <script language="javascript" type="text/javascript" src="sketch.js"></script>
-  <style>
-    html, body {margin:0; padding:0;}
-  </style> 
+  <script src="../../stats.js"></script>
 </head>
+
 <body>
-<p style="position: absolute; width:300px; left:50%; margin-left: -150px; text-align: center; color:black;">1000 triangles in a for-loop in immediate mode via beginShape(TRIANGLES)</p>
-<script>
-(function(){var script=document.createElement('script');script.onload=function(){var stats=new Stats();stats.domElement.style.cssText='position:fixed;left:0;top:0;z-index:10000';document.body.appendChild(stats.domElement);requestAnimationFrame(function loop(){stats.update();requestAnimationFrame(loop)});};script.src='http://rawgit.com/mrdoob/stats.js/master/build/stats.min.js';document.head.appendChild(script);})()
-</script>
-  
+  <header>
+    <p>1000 triangles in a for-loop in immediate mode via beginShape(TRIANGLES)</p>
+  </header>
 </body>
+
 </html>

--- a/test/manual-test-examples/webgl/immediateMode/texture/index.html
+++ b/test/manual-test-examples/webgl/immediateMode/texture/index.html
@@ -1,21 +1,17 @@
 <!DOCTYPE html>
 <html>
+
 <head>
   <meta charset="utf-8">
   <meta http-equiv="X-UA-Compatible" content="IE=edge">
   <title></title>
-  <link rel="stylesheet" href="">
+  <link rel="stylesheet" href="../../../styles.css">
   <script language="javascript" type="text/javascript" src="../../../../../lib/p5.js"></script>
   <script language="javascript" type="text/javascript" src="sketch.js"></script>
-  <style>
-    html, body {margin:0; padding:0;}
-  </style> 
+  <script src="../../stats.js"></script>
 </head>
+
 <body>
-<p style="position: absolute; width:300px; left:50%; margin-left: -150px; text-align: center; color:black;"></p>
-<script>
-(function(){var script=document.createElement('script');script.onload=function(){var stats=new Stats();stats.domElement.style.cssText='position:fixed;left:0;top:0;z-index:10000';document.body.appendChild(stats.domElement);requestAnimationFrame(function loop(){stats.update();requestAnimationFrame(loop)});};script.src='http://rawgit.com/mrdoob/stats.js/master/build/stats.min.js';document.head.appendChild(script);})()
-</script>
-  
 </body>
+
 </html>

--- a/test/manual-test-examples/webgl/immediateMode/vertexArgs/index.html
+++ b/test/manual-test-examples/webgl/immediateMode/vertexArgs/index.html
@@ -1,21 +1,20 @@
 <!DOCTYPE html>
 <html>
+
 <head>
   <meta charset="utf-8">
   <meta http-equiv="X-UA-Compatible" content="IE=edge">
   <title></title>
-  <link rel="stylesheet" href="">
+  <link rel="stylesheet" href="../../../styles.css">
   <script language="javascript" type="text/javascript" src="../../../../../lib/p5.js"></script>
   <script language="javascript" type="text/javascript" src="sketch.js"></script>
-  <style>
-    html, body {margin:0; padding:0;}
-  </style> 
+  <script src="../../stats.js"></script>
 </head>
+
 <body>
-<p style="position: absolute; width:300px; left:50%; margin-left: -150px; text-align: center; color:black;">left to right: vertex(x,y), vertex(x,y,z), vertex(x,y,u,v), vertex(x,y,z,u,v)</p>
-<script>
-(function(){var script=document.createElement('script');script.onload=function(){var stats=new Stats();stats.domElement.style.cssText='position:fixed;left:0;top:0;z-index:10000';document.body.appendChild(stats.domElement);requestAnimationFrame(function loop(){stats.update();requestAnimationFrame(loop)});};script.src='http://rawgit.com/mrdoob/stats.js/master/build/stats.min.js';document.head.appendChild(script);})()
-</script>
-  
+  <header>
+    <p>left to right: vertex(x,y), vertex(x,y,z), vertex(x,y,u,v), vertex(x,y,z,u,v)</p>
+  </header>
 </body>
+
 </html>

--- a/test/manual-test-examples/webgl/interaction/index.html
+++ b/test/manual-test-examples/webgl/interaction/index.html
@@ -1,21 +1,20 @@
 <!DOCTYPE html>
 <html>
+
 <head>
   <meta charset="utf-8">
   <meta http-equiv="X-UA-Compatible" content="IE=edge">
   <title></title>
-  <link rel="stylesheet" href="">
+  <link rel="stylesheet" href="../../styles.css">
   <script language="javascript" type="text/javascript" src="../../../../lib/p5.js"></script>
   <script language="javascript" type="text/javascript" src="sketch.js"></script>
-  <style>
-    html, body {margin:0; padding:0;}
-  </style>
+  <script src="../stats.js"></script>
 </head>
-<body>
-<p style="position: absolute; width:300px; left:50%; margin-left: -150px; color:black; text-align: center;">Press mouse to toggle the world</p>
-<script>
-(function(){var script=document.createElement('script');script.onload=function(){var stats=new Stats();stats.domElement.style.cssText='position:fixed;left:0;top:0;z-index:10000';document.body.appendChild(stats.domElement);requestAnimationFrame(function loop(){stats.update();requestAnimationFrame(loop)});};script.src='http://rawgit.com/mrdoob/stats.js/master/build/stats.min.js';document.head.appendChild(script);})()
-</script>
 
+<body>
+  <header>
+    <p>Press mouse to toggle the world</p>
+  </header>
 </body>
+
 </html>

--- a/test/manual-test-examples/webgl/lights/ambientLight/index.html
+++ b/test/manual-test-examples/webgl/lights/ambientLight/index.html
@@ -1,20 +1,17 @@
 <!DOCTYPE html>
 <html>
+
 <head>
   <meta charset="utf-8">
   <meta http-equiv="X-UA-Compatible" content="IE=edge">
   <title></title>
-  <link rel="stylesheet" href="">
+  <link rel="stylesheet" href="../../../styles.css">
   <script language="javascript" type="text/javascript" src="../../../../../lib/p5.js"></script>
   <script language="javascript" type="text/javascript" src="sketch.js"></script>
-  <style>
-    html, body {margin:0; padding:0;}
-  </style> 
+  <script src="../../stats.js"></script>
 </head>
+
 <body>
-<script>
-(function(){var script=document.createElement('script');script.onload=function(){var stats=new Stats();stats.domElement.style.cssText='position:fixed;left:0;top:0;z-index:10000';document.body.appendChild(stats.domElement);requestAnimationFrame(function loop(){stats.update();requestAnimationFrame(loop)});};script.src='http://rawgit.com/mrdoob/stats.js/master/build/stats.min.js';document.head.appendChild(script);})()
-</script>
-  
 </body>
+
 </html>

--- a/test/manual-test-examples/webgl/lights/directionalLight/index.html
+++ b/test/manual-test-examples/webgl/lights/directionalLight/index.html
@@ -1,21 +1,20 @@
 <!DOCTYPE html>
 <html>
+
 <head>
   <meta charset="utf-8">
   <meta http-equiv="X-UA-Compatible" content="IE=edge">
   <title></title>
-  <link rel="stylesheet" href="">
+  <link rel="stylesheet" href="../../../styles.css">
   <script language="javascript" type="text/javascript" src="../../../../../lib/p5.js"></script>
   <script language="javascript" type="text/javascript" src="sketch.js"></script>
-  <style>
-    html, body {margin:0; padding:0;}
-  </style> 
+  <script src="../../stats.js"></script>
 </head>
+
 <body>
-  <p style="position: absolute; width:300px; left:50%; margin-left: -150px; color:white; text-align: center;">Move mouse to change light position</p>
-<script>
-(function(){var script=document.createElement('script');script.onload=function(){var stats=new Stats();stats.domElement.style.cssText='position:fixed;left:0;top:0;z-index:10000';document.body.appendChild(stats.domElement);requestAnimationFrame(function loop(){stats.update();requestAnimationFrame(loop)});};script.src='http://rawgit.com/mrdoob/stats.js/master/build/stats.min.js';document.head.appendChild(script);})()
-</script>
-  
+  <header>
+    <p>Move mouse to change light position</p>
+  </header>
 </body>
+
 </html>

--- a/test/manual-test-examples/webgl/lights/multipleLights/index.html
+++ b/test/manual-test-examples/webgl/lights/multipleLights/index.html
@@ -1,21 +1,20 @@
 <!DOCTYPE html>
 <html>
+
 <head>
   <meta charset="utf-8">
   <meta http-equiv="X-UA-Compatible" content="IE=edge">
   <title></title>
-  <link rel="stylesheet" href="">
+  <link rel="stylesheet" href="../../../styles.css">
   <script language="javascript" type="text/javascript" src="../../../../../lib/p5.js"></script>
   <script language="javascript" type="text/javascript" src="sketch.js"></script>
-  <style>
-    html, body {margin:0; padding:0;}
-  </style> 
+  <script src="../../stats.js"></script>
 </head>
+
 <body>
-  <p style="position: absolute; width:300px; left:50%; margin-left: -150px; color:white; text-align: center;">Move mouse to change light position</p>
-<script>
-(function(){var script=document.createElement('script');script.onload=function(){var stats=new Stats();stats.domElement.style.cssText='position:fixed;left:0;top:0;z-index:10000';document.body.appendChild(stats.domElement);requestAnimationFrame(function loop(){stats.update();requestAnimationFrame(loop)});};script.src='http://rawgit.com/mrdoob/stats.js/master/build/stats.min.js';document.head.appendChild(script);})()
-</script>
-  
+  <header>
+    <p>Move mouse to change light position</p>
+  </header>
 </body>
+
 </html>

--- a/test/manual-test-examples/webgl/lights/pointLight/index.html
+++ b/test/manual-test-examples/webgl/lights/pointLight/index.html
@@ -1,21 +1,20 @@
 <!DOCTYPE html>
 <html>
+
 <head>
   <meta charset="utf-8">
   <meta http-equiv="X-UA-Compatible" content="IE=edge">
   <title></title>
-  <link rel="stylesheet" href="">
+  <link rel="stylesheet" href="../../../styles.css">
   <script language="javascript" type="text/javascript" src="../../../../../lib/p5.js"></script>
   <script language="javascript" type="text/javascript" src="sketch.js"></script>
-  <style>
-    html, body {margin:0; padding:0;}
-  </style> 
+  <script src="../../stats.js"></script>
 </head>
+
 <body>
-  <p style="position: absolute; width:300px; left:50%; margin-left: -150px; color:white; text-align: center;">Move mouse to change light position</p>
-<script>
-(function(){var script=document.createElement('script');script.onload=function(){var stats=new Stats();stats.domElement.style.cssText='position:fixed;left:0;top:0;z-index:10000';document.body.appendChild(stats.domElement);requestAnimationFrame(function loop(){stats.update();requestAnimationFrame(loop)});};script.src='http://rawgit.com/mrdoob/stats.js/master/build/stats.min.js';document.head.appendChild(script);})()
-</script>
-  
+  <header>
+    <p>Move mouse to change light position</p>
+  </header>
 </body>
+
 </html>

--- a/test/manual-test-examples/webgl/material/edgestroke/index.html
+++ b/test/manual-test-examples/webgl/material/edgestroke/index.html
@@ -1,20 +1,18 @@
 <!DOCTYPE html>
 <html>
+
 <head>
   <meta charset="utf-8">
   <meta http-equiv="X-UA-Compatible" content="IE=edge">
   <title></title>
-  <link rel="stylesheet" href="">
+  <link rel="stylesheet" href="../../../styles.css">
   <script language="javascript" type="text/javascript" src="../../../../../lib/p5.js"></script>
-  <style>
-    html, body {margin:0; padding:0;}
-  </style>
+  <!--<script src="../../stats.js"></script>-->
 </head>
+
 <body>
-<!-- <canvas width = "570" height = "570" id = "my_Canvas"></canvas> -->
-<script language="javascript" type="text/javascript" src="sketch.js"></script>
-<!-- <script>
-(function(){var script=document.createElement('script');script.onload=function(){var stats=new Stats();stats.domElement.style.cssText='position:fixed;left:0;top:800;z-index:10000';document.body.appendChild(stats.domElement);requestAnimationFrame(function loop(){stats.update();requestAnimationFrame(loop)});};script.src='http://rawgit.com/mrdoob/stats.js/master/build/stats.min.js';document.head.appendChild(script);})()
-</script> -->
+  <!-- <canvas width = "570" height = "570" id = "my_Canvas"></canvas> -->
+  <script language="javascript" type="text/javascript" src="sketch.js"></script>
 </body>
+
 </html>

--- a/test/manual-test-examples/webgl/material/perPixelLighting/index.html
+++ b/test/manual-test-examples/webgl/material/perPixelLighting/index.html
@@ -1,21 +1,20 @@
 <!DOCTYPE html>
 <html>
+
 <head>
   <meta charset="utf-8">
   <meta http-equiv="X-UA-Compatible" content="IE=edge">
   <title></title>
-  <link rel="stylesheet" href="">
+  <link rel="stylesheet" href="../../../styles.css">
   <script language="javascript" type="text/javascript" src="../../../../../lib/p5.js"></script>
   <script language="javascript" type="text/javascript" src="sketch.js"></script>
-  <style>
-    html, body {margin:0; padding:0;}
-  </style> 
+  <script src="../../stats.js"></script>
 </head>
+
 <body>
-  <p style="position: absolute; width:300px; left:50%; margin-left: -150px; color:white; text-align: center;">Press mouse to enable per-pixel-lighting</p>
-<script>
-(function(){var script=document.createElement('script');script.onload=function(){var stats=new Stats();stats.domElement.style.cssText='position:fixed;left:0;top:0;z-index:10000';document.body.appendChild(stats.domElement);requestAnimationFrame(function loop(){stats.update();requestAnimationFrame(loop)});};script.src='http://rawgit.com/mrdoob/stats.js/master/build/stats.min.js';document.head.appendChild(script);})()
-</script>
-  
+  <header>
+    <p>Press mouse to enable per-pixel-lighting</p>
+  </header>
 </body>
+
 </html>

--- a/test/manual-test-examples/webgl/material/simple/index.html
+++ b/test/manual-test-examples/webgl/material/simple/index.html
@@ -1,20 +1,17 @@
 <!DOCTYPE html>
 <html>
+
 <head>
   <meta charset="utf-8">
   <meta http-equiv="X-UA-Compatible" content="IE=edge">
   <title></title>
-  <link rel="stylesheet" href="">
+  <link rel="stylesheet" href="../../../styles.css">
   <script language="javascript" type="text/javascript" src="../../../../../lib/p5.js"></script>
   <script language="javascript" type="text/javascript" src="sketch.js"></script>
-  <style>
-    html, body {margin:0; padding:0;}
-  </style> 
+  <script src="../../stats.js"></script>
 </head>
+
 <body>
-<script>
-(function(){var script=document.createElement('script');script.onload=function(){var stats=new Stats();stats.domElement.style.cssText='position:fixed;left:0;top:0;z-index:10000';document.body.appendChild(stats.domElement);requestAnimationFrame(function loop(){stats.update();requestAnimationFrame(loop)});};script.src='http://rawgit.com/mrdoob/stats.js/master/build/stats.min.js';document.head.appendChild(script);})()
-</script>
-  
 </body>
+
 </html>

--- a/test/manual-test-examples/webgl/material/specular_ambient/index.html
+++ b/test/manual-test-examples/webgl/material/specular_ambient/index.html
@@ -1,20 +1,17 @@
 <!DOCTYPE html>
 <html>
+
 <head>
   <meta charset="utf-8">
   <meta http-equiv="X-UA-Compatible" content="IE=edge">
   <title></title>
-  <link rel="stylesheet" href="">
+  <link rel="stylesheet" href="../../../styles.css">
   <script language="javascript" type="text/javascript" src="../../../../../lib/p5.js"></script>
   <script language="javascript" type="text/javascript" src="sketch.js"></script>
-  <style>
-    html, body {margin:0; padding:0;}
-  </style> 
+  <script src="../../stats.js"></script>
 </head>
+
 <body>
-<script>
-(function(){var script=document.createElement('script');script.onload=function(){var stats=new Stats();stats.domElement.style.cssText='position:fixed;left:0;top:0;z-index:10000';document.body.appendChild(stats.domElement);requestAnimationFrame(function loop(){stats.update();requestAnimationFrame(loop)});};script.src='http://rawgit.com/mrdoob/stats.js/master/build/stats.min.js';document.head.appendChild(script);})()
-</script>
-  
 </body>
+
 </html>

--- a/test/manual-test-examples/webgl/material/texture/index.html
+++ b/test/manual-test-examples/webgl/material/texture/index.html
@@ -1,20 +1,17 @@
 <!DOCTYPE html>
 <html>
+
 <head>
   <meta charset="utf-8">
   <meta http-equiv="X-UA-Compatible" content="IE=edge">
   <title></title>
-  <link rel="stylesheet" href="">
+  <link rel="stylesheet" href="../../../styles.css">
   <script language="javascript" type="text/javascript" src="../../../../../lib/p5.js"></script>
   <script language="javascript" type="text/javascript" src="sketch.js"></script>
-  <style>
-    html, body {margin:0; padding:0;}
-  </style> 
+  <script src="../../stats.js"></script>
 </head>
+
 <body>
-<script>
-(function(){var script=document.createElement('script');script.onload=function(){var stats=new Stats();stats.domElement.style.cssText='position:fixed;left:0;top:0;z-index:10000';document.body.appendChild(stats.domElement);requestAnimationFrame(function loop(){stats.update();requestAnimationFrame(loop)});};script.src='http://rawgit.com/mrdoob/stats.js/master/build/stats.min.js';document.head.appendChild(script);})()
-</script>
-  
 </body>
+
 </html>

--- a/test/manual-test-examples/webgl/material/wireframe/index.html
+++ b/test/manual-test-examples/webgl/material/wireframe/index.html
@@ -1,19 +1,17 @@
 <!DOCTYPE html>
 <html>
+
 <head>
   <meta charset="utf-8">
   <meta http-equiv="X-UA-Compatible" content="IE=edge">
   <title></title>
-  <link rel="stylesheet" href="">
+  <link rel="stylesheet" href="../../../styles.css">
   <script language="javascript" type="text/javascript" src="../../../../../lib/p5.js"></script>
   <script language="javascript" type="text/javascript" src="sketch.js"></script>
-  <style>
-    html, body {margin:0; padding:0;}
-  </style>
+  <script src="../../stats.js"></script>
 </head>
+
 <body>
-<script>
-(function(){var script=document.createElement('script');script.onload=function(){var stats=new Stats();stats.domElement.style.cssText='position:fixed;left:0;top:800;z-index:10000';document.body.appendChild(stats.domElement);requestAnimationFrame(function loop(){stats.update();requestAnimationFrame(loop)});};script.src='http://rawgit.com/mrdoob/stats.js/master/build/stats.min.js';document.head.appendChild(script);})()
-</script>
 </body>
+
 </html>

--- a/test/manual-test-examples/webgl/mixedMode/index.html
+++ b/test/manual-test-examples/webgl/mixedMode/index.html
@@ -1,22 +1,21 @@
 <!DOCTYPE html>
 <html>
+
 <head>
   <meta charset="utf-8">
   <meta http-equiv="X-UA-Compatible" content="IE=edge">
   <title></title>
-  <link rel="stylesheet" href="">
+  <link rel="stylesheet" href="../../styles.css">
   <script language="javascript" type="text/javascript" src="../../../../lib/p5.js"></script>
   <script language="javascript" type="text/javascript" src="sketch.js"></script>
-  <style>
-    html, body {margin:0; padding:0;}
-  </style>
+  <script src="../stats.js"></script>
 </head>
-<body>
-<p style="width:1000px; margin:10px auto; text-align: center; color:black;">Drag mouse to toggle the world</p>
-<p style="width:1000px; margin:10px auto; text-align: center; color:black;">(3d primitives and 2d primitives can be used together)</p>
-<script>
-(function(){var script=document.createElement('script');script.onload=function(){var stats=new Stats();stats.domElement.style.cssText='position:fixed;left:0;top:0;z-index:10000';document.body.appendChild(stats.domElement);requestAnimationFrame(function loop(){stats.update();requestAnimationFrame(loop)});};script.src='http://rawgit.com/mrdoob/stats.js/master/build/stats.min.js';document.head.appendChild(script);})()
-</script>
 
+<body>
+  <header>
+    <p>Drag mouse to toggle the world</p>
+    <p>(3d primitives and 2d primitives can be used together)</p>
+  </header>
 </body>
+
 </html>

--- a/test/manual-test-examples/webgl/mobile/index.html
+++ b/test/manual-test-examples/webgl/mobile/index.html
@@ -1,20 +1,17 @@
 <!DOCTYPE html>
 <html>
+
 <head>
   <meta charset="utf-8">
   <meta http-equiv="X-UA-Compatible" content="IE=edge">
   <title></title>
-  <link rel="stylesheet" href="">
+  <link rel="stylesheet" href="../../styles.css">
   <script language="javascript" type="text/javascript" src="../../../../lib/p5.js"></script>
   <script language="javascript" type="text/javascript" src="sketch.js"></script>
-  <style>
-    html, body {margin:0; padding:0;}
-  </style>
+  <script src="../stats.js"></script>
 </head>
-<body>
-<script>
-(function(){var script=document.createElement('script');script.onload=function(){var stats=new Stats();stats.domElement.style.cssText='position:fixed;left:0;top:0;z-index:10000';document.body.appendChild(stats.domElement);requestAnimationFrame(function loop(){stats.update();requestAnimationFrame(loop)});};script.src='http://rawgit.com/mrdoob/stats.js/master/build/stats.min.js';document.head.appendChild(script);})()
-</script>
 
+<body>
 </body>
+
 </html>

--- a/test/manual-test-examples/webgl/origin/center_origin/index.html
+++ b/test/manual-test-examples/webgl/origin/center_origin/index.html
@@ -1,21 +1,20 @@
 <!DOCTYPE html>
 <html>
+
 <head>
   <meta charset="utf-8">
   <meta http-equiv="X-UA-Compatible" content="IE=edge">
   <title></title>
-  <link rel="stylesheet" href="">
+  <link rel="stylesheet" href="../../../styles.css">
   <script language="javascript" type="text/javascript" src="../../../../../lib/p5.js"></script>
   <script language="javascript" type="text/javascript" src="sketch.js"></script>
-  <style>
-    html, body {margin:0; padding:0;}
-  </style> 
+  <script src="../../stats.js"></script>
 </head>
+
 <body>
-<p style="position: absolute; width:400px; left:50%; margin-left: -200px; text-align: center; color:black;">[0, 0, 0] is in the center of the screen by default</p>
-<script>
-(function(){var script=document.createElement('script');script.onload=function(){var stats=new Stats();stats.domElement.style.cssText='position:fixed;left:0;top:0;z-index:10000';document.body.appendChild(stats.domElement);requestAnimationFrame(function loop(){stats.update();requestAnimationFrame(loop)});};script.src='http://rawgit.com/mrdoob/stats.js/master/build/stats.min.js';document.head.appendChild(script);})()
-</script>
-  
+  <header>
+    <p>[0, 0, 0] is in the center of the screen by default</p>
+  </header>
 </body>
+
 </html>

--- a/test/manual-test-examples/webgl/origin/topleft_origin/index.html
+++ b/test/manual-test-examples/webgl/origin/topleft_origin/index.html
@@ -1,21 +1,20 @@
 <!DOCTYPE html>
 <html>
+
 <head>
   <meta charset="utf-8">
   <meta http-equiv="X-UA-Compatible" content="IE=edge">
   <title></title>
-  <link rel="stylesheet" href="">
+  <link rel="stylesheet" href="../../../styles.css">
   <script language="javascript" type="text/javascript" src="../../../../../lib/p5.js"></script>
   <script language="javascript" type="text/javascript" src="sketch.js"></script>
-  <style>
-    html, body {margin:0; padding:0;}
-  </style> 
+  <script src="../../stats.js"></script>
 </head>
+
 <body>
-<p style="width:1000px; margin:10px auto; text-align: center; color:black;">[0, 0, 0] is in the top left corner now</p>
-<script>
-(function(){var script=document.createElement('script');script.onload=function(){var stats=new Stats();stats.domElement.style.cssText='position:fixed;left:0;top:0;z-index:10000';document.body.appendChild(stats.domElement);requestAnimationFrame(function loop(){stats.update();requestAnimationFrame(loop)});};script.src='http://rawgit.com/mrdoob/stats.js/master/build/stats.min.js';document.head.appendChild(script);})()
-</script>
-  
+  <header>
+    <p>[0, 0, 0] is in the top left corner now</p>
+  </header>
 </body>
+
 </html>

--- a/test/manual-test-examples/webgl/performance/index.html
+++ b/test/manual-test-examples/webgl/performance/index.html
@@ -1,21 +1,20 @@
 <!DOCTYPE html>
 <html>
+
 <head>
   <meta charset="utf-8">
   <meta http-equiv="X-UA-Compatible" content="IE=edge">
   <title></title>
-  <link rel="stylesheet" href="">
+  <link rel="stylesheet" href="../../styles.css">
   <script language="javascript" type="text/javascript" src="../../../../lib/p5.js"></script>
   <script language="javascript" type="text/javascript" src="sketch.js"></script>
-  <style>
-    html, body {margin:0; padding:0;}
-  </style>
+  <script src="../stats.js"></script>
 </head>
-<p style="position: absolute; width:300px; left:50%; text-align: center; margin-left: -150px; color:black;">1000 spheres, how's the speed?</p>
-<body>
-<script>
-(function(){var script=document.createElement('script');script.onload=function(){var stats=new Stats();stats.domElement.style.cssText='position:fixed;left:0;top:0;z-index:10000';document.body.appendChild(stats.domElement);requestAnimationFrame(function loop(){stats.update();requestAnimationFrame(loop)});};script.src='http://rawgit.com/mrdoob/stats.js/master/build/stats.min.js';document.head.appendChild(script);})()
-</script>
 
+<body>
+  <header>
+    <p>1000 spheres, how's the speed?</p>
+  </header>
 </body>
+
 </html>

--- a/test/manual-test-examples/webgl/pixels/index.html
+++ b/test/manual-test-examples/webgl/pixels/index.html
@@ -1,21 +1,20 @@
 <!DOCTYPE html>
 <html>
+
 <head>
   <meta charset="utf-8">
   <meta http-equiv="X-UA-Compatible" content="IE=edge">
   <title></title>
-  <link rel="stylesheet" href="">
+  <link rel="stylesheet" href="../../styles.css">
   <script language="javascript" type="text/javascript" src="../../../../lib/p5.js"></script>
   <script language="javascript" type="text/javascript" src="sketch.js"></script>
-  <style>
-    html, body {margin:0; padding:0;}
-  </style> 
+  <script src="../stats.js"></script>
 </head>
+
 <body>
-<h2 style='margin-left:100px'>If you click the canvas, the box should get textured with an image of the canvas</h2>
-<script>
-(function(){var script=document.createElement('script');script.onload=function(){var stats=new Stats();stats.domElement.style.cssText='position:fixed;left:0;top:0;z-index:10000';document.body.appendChild(stats.domElement);requestAnimationFrame(function loop(){stats.update();requestAnimationFrame(loop)});};script.src='http://rawgit.com/mrdoob/stats.js/master/build/stats.min.js';document.head.appendChild(script);})()
-</script>
-  
+  <header>
+    <p>If you click the canvas, the box should get textured with an image of the canvas</p>
+  </header>
 </body>
+
 </html>

--- a/test/manual-test-examples/webgl/stats.js
+++ b/test/manual-test-examples/webgl/stats.js
@@ -1,0 +1,14 @@
+(function() {
+  var script = document.createElement('script');
+  script.onload = function() {
+    var stats = new Stats();
+    stats.domElement.style.cssText = 'position:fixed;left:0;top:0;z-index:10000';
+    document.body.appendChild(stats.domElement);
+    requestAnimationFrame(function loop() {
+      stats.update();
+      requestAnimationFrame(loop)
+    });
+  };
+  script.src = 'http://rawgit.com/mrdoob/stats.js/master/build/stats.min.js';
+  document.head.appendChild(script);
+})()

--- a/test/manual-test-examples/webgl/texture/multipleTextures/index.html
+++ b/test/manual-test-examples/webgl/texture/multipleTextures/index.html
@@ -1,22 +1,18 @@
 <!DOCTYPE html>
 <html>
+
 <head>
   <meta charset="utf-8">
   <meta http-equiv="X-UA-Compatible" content="IE=edge">
   <title></title>
-  <link rel="stylesheet" href="">
+  <link rel="stylesheet" href="../../../styles.css">
   <script language="javascript" type="text/javascript" src="../../../../../lib/p5.js"></script>
   <script language="javascript" type="text/javascript" src="../../../../../lib/addons/p5.dom.js"></script>
   <script language="javascript" type="text/javascript" src="sketch.js"></script>
-  <style>
-    html, body {margin:0; padding:0;}
-  </style> 
+  <script src="../../stats.js"></script>
 </head>
+
 <body>
-<p style="position: absolute; width:300px; left:50%; margin-left: -150px; text-align: center; color:black;"></p>
-<script>
-(function(){var script=document.createElement('script');script.onload=function(){var stats=new Stats();stats.domElement.style.cssText='position:fixed;left:0;top:0;z-index:10000';document.body.appendChild(stats.domElement);requestAnimationFrame(function loop(){stats.update();requestAnimationFrame(loop)});};script.src='http://rawgit.com/mrdoob/stats.js/master/build/stats.min.js';document.head.appendChild(script);})()
-</script>
-  
 </body>
+
 </html>

--- a/test/manual-test-examples/webgl/texture/transparentTexture/index.html
+++ b/test/manual-test-examples/webgl/texture/transparentTexture/index.html
@@ -1,18 +1,17 @@
 <!DOCTYPE html>
 <html>
+
 <head>
   <meta charset="utf-8">
   <meta http-equiv="X-UA-Compatible" content="IE=edge">
   <title></title>
-  <link rel="stylesheet" href="">
+  <link rel="stylesheet" href="../../../styles.css">
   <script language="javascript" type="text/javascript" src="../../../../../lib/p5.js"></script>
   <script language="javascript" type="text/javascript" src="../../../../../lib/addons/p5.dom.js"></script>
   <script language="javascript" type="text/javascript" src="sketch.js"></script>
-  <style>
-    html, body {margin:0; padding:0; background: blue;}
-  </style> 
 </head>
+
 <body>
-<p style="position: absolute; width:300px; left:50%; margin-left: -150px; text-align: center; color:black;"></p>
 </body>
+
 </html>

--- a/test/manual-test-examples/webgl/texture/videoTexture/index.html
+++ b/test/manual-test-examples/webgl/texture/videoTexture/index.html
@@ -1,22 +1,21 @@
 <!DOCTYPE html>
 <html>
+
 <head>
   <meta charset="utf-8">
   <meta http-equiv="X-UA-Compatible" content="IE=edge">
   <title></title>
-  <link rel="stylesheet" href="">
+  <link rel="stylesheet" href="../../../styles.css">
   <script language="javascript" type="text/javascript" src="../../../../../lib/p5.js"></script>
   <script language="javascript" type="text/javascript" src="../../../../../lib/addons/p5.dom.js"></script>
   <script language="javascript" type="text/javascript" src="sketch.js"></script>
-  <style>
-    html, body {margin:0; padding:0;}
-  </style>
+  <script src="../../stats.js"></script>
 </head>
-<body>
-<p style="position: absolute; width:300px; left:50%; margin-left: -150px; text-align: center; color:black;">press any key to toggle video play/pause</p>
-<script>
-(function(){var script=document.createElement('script');script.onload=function(){var stats=new Stats();stats.domElement.style.cssText='position:fixed;left:0;top:0;z-index:10000';document.body.appendChild(stats.domElement);requestAnimationFrame(function loop(){stats.update();requestAnimationFrame(loop)});};script.src='http://rawgit.com/mrdoob/stats.js/master/build/stats.min.js';document.head.appendChild(script);})()
-</script>
 
+<body>
+  <header>
+    <p>press any key to toggle video play/pause</p>
+  </header>
 </body>
+
 </html>


### PR DESCRIPTION
- adds common stylesheet for manual tests
- simplifies header formatting (mostly used by webgl tests)
- simplifies loading of webgl stats box

this will allow the manual test examples to take advantage of whatever fix is used for #2619.
