### PR TITLE
hide 'private' constructors in reference docs

### DIFF
--- a/docs/yuidoc-p5-theme-src/scripts/main.js
+++ b/docs/yuidoc-p5-theme-src/scripts/main.js
@@ -51,7 +51,7 @@ require([
 
     // Get classes
     _.each(classes, function(c, idx, array) {
-      if (c.is_constructor) {
+      if (!c.private) {
         App.classes.push(c);
       }
     });

--- a/docs/yuidoc-p5-theme-src/scripts/tpl/class.html
+++ b/docs/yuidoc-p5-theme-src/scripts/tpl/class.html
@@ -1,5 +1,5 @@
 
-<% if (is_constructor) { %>
+<% if (typeof constructor !== 'undefined') { %>
 <div class="constructor">
   <!--<h2>Constructor</h2>--> 
   <%=constructor%>

--- a/docs/yuidoc-p5-theme-src/scripts/tpl/item.html
+++ b/docs/yuidoc-p5-theme-src/scripts/tpl/item.html
@@ -57,6 +57,8 @@
 
 </div>
 
+<% if (isConstructor || !isClass) { %>
+
 <div>
   <h4><span id="reference-syntax">Syntax</span></h4>
   <p>
@@ -166,4 +168,6 @@
       <p class='returns'><span class="param-type label label-info"><%=item.return.type%></span>: <%= item.return.description %></p>
     <% } %>
 </div>
+<% } %>
+
 <% } %>

--- a/docs/yuidoc-p5-theme-src/scripts/tpl/search_suggestion.html
+++ b/docs/yuidoc-p5-theme-src/scripts/tpl/search_suggestion.html
@@ -13,7 +13,7 @@
     in <strong><%=className%></strong>
     <% } %>
 
-    <% if (is_constructor) { %>
+    <% if (typeof is_constructor !== 'undefined' && is_constructor) { %>
     <strong><span class="glyphicon glyphicon-star"></span> constructor</strong>
     <% } %>
   </span>

--- a/docs/yuidoc-p5-theme-src/scripts/views/itemView.js
+++ b/docs/yuidoc-p5-theme-src/scripts/views/itemView.js
@@ -74,13 +74,13 @@ define([
 
         // Set item contents
         if (isClass) {
-          if (isConstructor) {
-            var constructor = this.tpl({
-              item: cleanItem,
-              syntaxes: syntaxes
-            });
-            cleanItem.constructor = constructor;
-          }
+          var constructor = this.tpl({
+            item: cleanItem,
+            isClass: true,
+            isConstructor: isConstructor,
+            syntaxes: syntaxes
+          });
+          cleanItem.constructor = constructor;
 
           var contents = _.find(App.classes, function(c){ return c.name === cleanItem.name; });
           cleanItem.things = contents.items;
@@ -93,6 +93,8 @@ define([
 
           itemHtml = this.tpl({
             item: cleanItem,
+            isClass: false,
+            isConstructor: false,
             syntaxes: syntaxes
           });
         }

--- a/docs/yuidoc-p5-theme-src/scripts/views/searchView.js
+++ b/docs/yuidoc-p5-theme-src/scripts/views/searchView.js
@@ -104,7 +104,7 @@ define([
               'itemtype': item.itemtype,
               'name': item.name,
               'className': item.class,
-              'is_constructor': item.is_constructor,
+              'is_constructor': !!item.is_constructor,
               'final': item.final,
               'idx': i
             });

--- a/src/color/p5.Color.js
+++ b/src/color/p5.Color.js
@@ -28,7 +28,7 @@ var color_conversion = require('./color_conversion');
  * conversion that has already been performed.
  *
  * @class p5.Color
- * @constructor
+ * @ constructor
  */
 p5.Color = function(pInst, vals) {
   // Record color mode and maxes at time of construction.

--- a/src/color/p5.Color.js
+++ b/src/color/p5.Color.js
@@ -28,7 +28,6 @@ var color_conversion = require('./color_conversion');
  * conversion that has already been performed.
  *
  * @class p5.Color
- * @ constructor
  */
 p5.Color = function(pInst, vals) {
   // Record color mode and maxes at time of construction.

--- a/src/core/p5.Element.js
+++ b/src/core/p5.Element.js
@@ -19,7 +19,6 @@ var p5 = require('./core');
  * or in the p5.dom library, createDiv, createImg, createInput, etc.
  *
  * @class p5.Element
- * @ constructor
  * @param {String} elt DOM node that is wrapped
  * @param {p5} [pInst] pointer to p5 instance
  */

--- a/src/core/p5.Element.js
+++ b/src/core/p5.Element.js
@@ -19,7 +19,7 @@ var p5 = require('./core');
  * or in the p5.dom library, createDiv, createImg, createInput, etc.
  *
  * @class p5.Element
- * @constructor
+ * @ constructor
  * @param {String} elt DOM node that is wrapped
  * @param {p5} [pInst] pointer to p5 instance
  */

--- a/src/core/p5.Graphics.js
+++ b/src/core/p5.Graphics.js
@@ -17,7 +17,6 @@ var constants = require('./constants');
  * extensive, but mirror the normal drawing API for p5.
  *
  * @class p5.Graphics
- * @ constructor
  * @extends p5.Element
  * @param {Number} w            width
  * @param {Number} h            height

--- a/src/core/p5.Graphics.js
+++ b/src/core/p5.Graphics.js
@@ -17,7 +17,7 @@ var constants = require('./constants');
  * extensive, but mirror the normal drawing API for p5.
  *
  * @class p5.Graphics
- * @constructor
+ * @ constructor
  * @extends p5.Element
  * @param {Number} w            width
  * @param {Number} h            height

--- a/src/data/p5.TypedDict.js
+++ b/src/data/p5.TypedDict.js
@@ -69,7 +69,6 @@ p5.prototype.createNumberDict = function(key, value) {
  * typed Dictionary objects inherit from this
  *
  * @class p5.TypedDict
- * @ constructor
  *
  */
 
@@ -379,7 +378,6 @@ p5.TypedDict.prototype._validate = function(value) {
  *
  *
  * @class p5.StringDict
- * @ constructor
  * @extends p5.TypedDict
  *
  */
@@ -400,7 +398,6 @@ p5.StringDict.prototype._validate = function(value) {
  *
  *
  * @class p5.NumberDict
- * @ constructor
  * @extends p5.TypedDict
  *
  */

--- a/src/data/p5.TypedDict.js
+++ b/src/data/p5.TypedDict.js
@@ -69,7 +69,7 @@ p5.prototype.createNumberDict = function(key, value) {
  * typed Dictionary objects inherit from this
  *
  * @class p5.TypedDict
- * @constructor
+ * @ constructor
  *
  */
 
@@ -379,7 +379,7 @@ p5.TypedDict.prototype._validate = function(value) {
  *
  *
  * @class p5.StringDict
- * @constructor
+ * @ constructor
  * @extends p5.TypedDict
  *
  */
@@ -400,7 +400,7 @@ p5.StringDict.prototype._validate = function(value) {
  *
  *
  * @class p5.NumberDict
- * @constructor
+ * @ constructor
  * @extends p5.TypedDict
  *
  */

--- a/src/image/p5.Image.js
+++ b/src/image/p5.Image.js
@@ -83,7 +83,6 @@ var Filters = require('./filters');
  *
  *
  * @class p5.Image
- * @ constructor
  * @param {Number} width
  * @param {Number} height
  */

--- a/src/image/p5.Image.js
+++ b/src/image/p5.Image.js
@@ -83,7 +83,7 @@ var Filters = require('./filters');
  *
  *
  * @class p5.Image
- * @constructor
+ * @ constructor
  * @param {Number} width
  * @param {Number} height
  */

--- a/src/io/files.js
+++ b/src/io/files.js
@@ -1100,7 +1100,6 @@ p5.prototype.createWriter = function(name, extension) {
 
 /**
  *  @class p5.PrintWriter
- *  @ constructor
  *  @param  {String}     filename
  *  @param  {String}     [extension]
  */

--- a/src/io/files.js
+++ b/src/io/files.js
@@ -1100,7 +1100,7 @@ p5.prototype.createWriter = function(name, extension) {
 
 /**
  *  @class p5.PrintWriter
- *  @constructor
+ *  @ constructor
  *  @param  {String}     filename
  *  @param  {String}     [extension]
  */

--- a/src/math/p5.Vector.js
+++ b/src/math/p5.Vector.js
@@ -29,7 +29,6 @@ var constants = require('../core/constants');
  * "vector" math, which is made easy by the methods inside the p5.Vector class.
  *
  * @class p5.Vector
- * @ constructor
  * @param {Number} [x] x component of the vector
  * @param {Number} [y] y component of the vector
  * @param {Number} [z] z component of the vector

--- a/src/math/p5.Vector.js
+++ b/src/math/p5.Vector.js
@@ -29,7 +29,7 @@ var constants = require('../core/constants');
  * "vector" math, which is made easy by the methods inside the p5.Vector class.
  *
  * @class p5.Vector
- * @constructor
+ * @ constructor
  * @param {Number} [x] x component of the vector
  * @param {Number} [y] y component of the vector
  * @param {Number} [z] z component of the vector

--- a/src/typography/p5.Font.js
+++ b/src/typography/p5.Font.js
@@ -21,7 +21,7 @@ var constants = require('../core/constants');
 /**
  * Base class for font handling
  * @class p5.Font
- * @constructor
+ * @ constructor
  * @param {p5} [pInst] pointer to p5 instance
  */
 p5.Font = function(p) {

--- a/src/typography/p5.Font.js
+++ b/src/typography/p5.Font.js
@@ -21,7 +21,6 @@ var constants = require('../core/constants');
 /**
  * Base class for font handling
  * @class p5.Font
- * @ constructor
  * @param {p5} [pInst] pointer to p5 instance
  */
 p5.Font = function(p) {

--- a/src/webgl/p5.Shader.js
+++ b/src/webgl/p5.Shader.js
@@ -13,7 +13,7 @@ var p5 = require('../core/core');
 /**
  * Shader class for WEBGL Mode
  * @class p5.Shader
- * @constructor
+ * @ constructor
  * @param {p5.RendererGL} renderer an instance of p5.RendererGL that
  * will provide the GL context for this new p5.Shader
  * @param {String} vertSrc source code for the vertex shader (as a string)

--- a/src/webgl/p5.Shader.js
+++ b/src/webgl/p5.Shader.js
@@ -13,7 +13,6 @@ var p5 = require('../core/core');
 /**
  * Shader class for WEBGL Mode
  * @class p5.Shader
- * @ constructor
  * @param {p5.RendererGL} renderer an instance of p5.RendererGL that
  * will provide the GL context for this new p5.Shader
  * @param {String} vertSrc source code for the vertex shader (as a string)

--- a/src/webgl/p5.Texture.js
+++ b/src/webgl/p5.Texture.js
@@ -14,7 +14,7 @@ var p5 = require('../core/core');
  * Texture class for WEBGL Mode
  * @private
  * @class p5.Texture
- * @constructor
+ * @ constructor
  * @param {p5.RendererGL} renderer an instance of p5.RendererGL that
  * will provide the GL context for this new p5.Texture
  * @param {p5.Image|p5.Graphics|p5.Element|p5.MediaElement} [obj] the

--- a/src/webgl/p5.Texture.js
+++ b/src/webgl/p5.Texture.js
@@ -14,7 +14,6 @@ var p5 = require('../core/core');
  * Texture class for WEBGL Mode
  * @private
  * @class p5.Texture
- * @ constructor
  * @param {p5.RendererGL} renderer an instance of p5.RendererGL that
  * will provide the GL context for this new p5.Texture
  * @param {p5.Image|p5.Graphics|p5.Element|p5.MediaElement} [obj] the


### PR DESCRIPTION
closes #2601

this removes various constructors from the reference docs that shouldn't be visible to the user.