### PR TITLE
Fixed a bug in saveCanvas

### DIFF
--- a/src/image/image.js
+++ b/src/image/image.js
@@ -148,8 +148,8 @@ p5.prototype.saveCanvas = function(cnv, filename, extension) {
   if (cnv instanceof p5.Element) {
     cnv = cnv.elt;
   } else if (!(cnv instanceof HTMLCanvasElement)) {
-    filename = cnv;
     extension = filename;
+    filename = cnv;
     cnv = this._curElement && this._curElement.elt;
   }
 


### PR DESCRIPTION
Fixed issue #2638 
- File was downloaded as "filename.filename"
- Fixed filename and extension assignment when canvas is absent from parameters