### PR TITLE
Fix 3d stroke

### DIFF
--- a/src/webgl/p5.RendererGL.js
+++ b/src/webgl/p5.RendererGL.js
@@ -123,7 +123,7 @@ p5.RendererGL = function(elt, pInst, isMainCanvas, attr) {
   this.fill(255, 255, 255, 255);
   //this.stroke(0, 0, 0, 255);
   this.pointSize = 5.0; //default point size
-  this.strokeWeight(2);
+  this.strokeWeight(1);
   this.stroke(0, 0, 0);
   // array of textures created in this gl context via this.getTexture(src)
   this.textures = [];

--- a/src/webgl/shaders/line.vert
+++ b/src/webgl/shaders/line.vert
@@ -23,7 +23,7 @@ uniform mat4 uProjectionMatrix;
 uniform float uStrokeWeight;
 
 uniform vec4 uViewport;
-vec3 scale = vec3(1.0);
+vec3 scale = vec3(0.9995);
 
 attribute vec4 aPosition;
 attribute vec4 aDirection;

--- a/src/webgl/shaders/line.vert
+++ b/src/webgl/shaders/line.vert
@@ -23,6 +23,10 @@ uniform mat4 uProjectionMatrix;
 uniform float uStrokeWeight;
 
 uniform vec4 uViewport;
+
+// using a scale <1 moves the lines towards the camera
+// in order to prevent popping effects due to half of
+// the line disappearing behind the geometry faces.
 vec3 scale = vec3(0.9995);
 
 attribute vec4 aPosition;


### PR DESCRIPTION

this fixes the webgl stroke popping & disappearing issues seen here:

https://codepen.io/Spongman/pen/JpLdao?editors=0010

it moves the strokes a tiny distance toward the camera, and halves the default stroke width (since previously half the stroke was usually hidden behind the face).

![pi](https://user-images.githubusercontent.com/1088194/38751929-6c74b6a4-3f0e-11e8-9573-123b073c3ce8.gif)
