### PR TITLE
Fix error on set() reference page

### DIFF
--- a/lib/addons/p5.sound.js
+++ b/lib/addons/p5.sound.js
@@ -6048,7 +6048,7 @@ env = function () {
    *  var t2 = 0.3; // decay time in seconds
    *  var l2 = 0.1; // decay level  0.0 to 1.0
    *  var t3 = 0.2; // sustain time in seconds
-   *  var l3 = dL; // sustain level  0.0 to 1.0
+   *  var l3 = 0.2; // sustain level  0.0 to 1.0
    *  // release level defaults to zero
    *
    *  var env;


### PR DESCRIPTION
Resolves issue #2489, and the linked issue in processing/p5.js-website#155

`var l3 = dL` causes an Uncaught ReferenceError because dL is not defined. This causes the description text on the reference page to overlap with the example code: [https://p5js.org/reference/#/p5.Env/set.](https://p5js.org/reference/#/p5.Env/set)

The issue is fixed by replacing this value with a number. 

