### PR TITLE
Add initial support for other draw modes in beginShape().

### DIFF
--- a/src/webgl/p5.RendererGL.Immediate.js
+++ b/src/webgl/p5.RendererGL.Immediate.js
@@ -316,7 +316,11 @@ p5.RendererGL.prototype._drawStrokeImmediateMode = function() {
   }
 
   this._applyColorBlend(this.curStrokeColor);
-  gl.drawArrays(gl.TRIANGLES, 0, this.immediateMode.lineVertices.length);
+  gl.drawArrays(
+    this.immediateMode.shapeMode,
+    0,
+    this.immediateMode.lineVertices.length
+  );
 
   // todo / optimizations? leave bound until another shader is set?
   this.curStrokeShader.unbindShader();

--- a/src/webgl/p5.RendererGL.js
+++ b/src/webgl/p5.RendererGL.js
@@ -568,6 +568,12 @@ p5.RendererGL.prototype.strokeWeight = function(w) {
     this.pointSize = w;
     this.curStrokeWeight = w;
     this.curStrokeShader.setUniform('uStrokeWeight', w);
+    this.curStrokeShader.setUniform('uPointSize', w);
+    // TODO: Implement lineWidth as a vertex shader.
+    // As gl.lineWidth has a implementation defined minimum and maximum.
+    // and generally produces poor visual results.
+    // This is unlikely to change.
+    // this.drawingContext.lineWidth(w);
   }
 };
 

--- a/src/webgl/shaders/line.vert
+++ b/src/webgl/shaders/line.vert
@@ -21,6 +21,7 @@
 uniform mat4 uModelViewMatrix;
 uniform mat4 uProjectionMatrix;
 uniform float uStrokeWeight;
+uniform float uPointSize;
 
 uniform vec4 uViewport;
 vec3 scale = vec3(1.0);
@@ -84,6 +85,8 @@ void main() {
   vec2 noPerspScale = p.w / (0.5 * uViewport.zw);
 
   //gl_Position.xy = p.xy + offset.xy * mix(noPerspScale, perspScale, float(perspective > 0));
-  gl_Position.xy = p.xy + offset.xy * perspScale;
+  gl_Position.xy = p.xy + perspScale.xy;
   gl_Position.zw = p.zw;
+
+  gl_PointSize = uPointSize;
 }


### PR DESCRIPTION
Pass through shapeMode in _drawStrokeImmediateMode and update the immediate vertex and fragment shaders to support setting gl_PointSize as a uniform. Set new uniforms in RendererGL.strokeWeight. Stroke color and material shader can conflict (z-fight). The current line.vert shader attempts to render lines with thickness, but this can cause strange behavior if gl_PointSize is set so that is removed. Ideally this shader would nicely handle all point and line drawing options.

Definitely a WIP. An immediate mode vertex shader with a better implementation of the line options we want to support is ideal. For some examples see: https://mattdesl.svbtle.com/drawing-lines-is-hard

Fix #2662 