### PR TITLE
webgl assertions

### DIFF
--- a/src/core/transform.js
+++ b/src/core/transform.js
@@ -223,11 +223,8 @@ p5.prototype.rotate = function(angle, axis) {
  */
 p5.prototype.rotateX = function(angle) {
   p5._validateParameters('rotateX', arguments);
-  if (this._renderer.isP3D) {
-    this._renderer.rotateX(this._toRadians(angle));
-  } else {
-    throw 'not supported in p2d. Please use webgl mode';
-  }
+  this._assert3d();
+  this._renderer.rotateX(this._toRadians(angle));
   return this;
 };
 
@@ -256,11 +253,8 @@ p5.prototype.rotateX = function(angle) {
  */
 p5.prototype.rotateY = function(angle) {
   p5._validateParameters('rotateY', arguments);
-  if (this._renderer.isP3D) {
-    this._renderer.rotateY(this._toRadians(angle));
-  } else {
-    throw 'not supported in p2d. Please use webgl mode';
-  }
+  this._assert3d();
+  this._renderer.rotateY(this._toRadians(angle));
   return this;
 };
 
@@ -289,11 +283,8 @@ p5.prototype.rotateY = function(angle) {
  */
 p5.prototype.rotateZ = function(angle) {
   p5._validateParameters('rotateZ', arguments);
-  if (this._renderer.isP3D) {
-    this._renderer.rotateZ(this._toRadians(angle));
-  } else {
-    throw 'not supported in p2d. Please use webgl mode';
-  }
+  this._assert3d();
+  this._renderer.rotateZ(this._toRadians(angle));
   return this;
 };
 

--- a/src/core/transform.js
+++ b/src/core/transform.js
@@ -223,7 +223,7 @@ p5.prototype.rotate = function(angle, axis) {
  */
 p5.prototype.rotateX = function(angle) {
   p5._validateParameters('rotateX', arguments);
-  this._assert3d();
+  this._assert3d('rotateX');
   this._renderer.rotateX(this._toRadians(angle));
   return this;
 };
@@ -253,7 +253,7 @@ p5.prototype.rotateX = function(angle) {
  */
 p5.prototype.rotateY = function(angle) {
   p5._validateParameters('rotateY', arguments);
-  this._assert3d();
+  this._assert3d('rotateY');
   this._renderer.rotateY(this._toRadians(angle));
   return this;
 };
@@ -283,7 +283,7 @@ p5.prototype.rotateY = function(angle) {
  */
 p5.prototype.rotateZ = function(angle) {
   p5._validateParameters('rotateZ', arguments);
-  this._assert3d();
+  this._assert3d('rotateZ');
   this._renderer.rotateZ(this._toRadians(angle));
   return this;
 };

--- a/src/webgl/camera.js
+++ b/src/webgl/camera.js
@@ -47,6 +47,7 @@ var p5 = require('../core/core');
  *
  */
 p5.prototype.camera = function() {
+  this._assert3d();
   this._renderer.camera.apply(this._renderer, arguments);
   return this;
 };
@@ -199,6 +200,7 @@ p5.RendererGL.prototype.camera = function(
  *
  */
 p5.prototype.perspective = function() {
+  this._assert3d();
   this._renderer.perspective.apply(this._renderer, arguments);
   return this;
 };
@@ -276,6 +278,7 @@ p5.RendererGL.prototype.perspective = function(fovy, aspect, near, far) {
  *
  */
 p5.prototype.ortho = function() {
+  this._assert3d();
   this._renderer.ortho.apply(this._renderer, arguments);
   return this;
 };

--- a/src/webgl/camera.js
+++ b/src/webgl/camera.js
@@ -47,7 +47,7 @@ var p5 = require('../core/core');
  *
  */
 p5.prototype.camera = function() {
-  this._assert3d();
+  this._assert3d('camera');
   this._renderer.camera.apply(this._renderer, arguments);
   return this;
 };
@@ -200,7 +200,7 @@ p5.RendererGL.prototype.camera = function(
  *
  */
 p5.prototype.perspective = function() {
-  this._assert3d();
+  this._assert3d('perspective');
   this._renderer.perspective.apply(this._renderer, arguments);
   return this;
 };
@@ -278,7 +278,7 @@ p5.RendererGL.prototype.perspective = function(fovy, aspect, near, far) {
  *
  */
 p5.prototype.ortho = function() {
-  this._assert3d();
+  this._assert3d('ortho');
   this._renderer.ortho.apply(this._renderer, arguments);
   return this;
 };

--- a/src/webgl/interaction.js
+++ b/src/webgl/interaction.js
@@ -29,7 +29,7 @@ var p5 = require('../core/core');
 //@TODO: implement full orbit controls including
 //pan, zoom, quaternion rotation, etc.
 p5.prototype.orbitControl = function() {
-  this._assert3d();
+  this._assert3d('orbitControl');
   if (this.mouseIsPressed) {
     this.rotateY((this.mouseX - this.width / 2) / (this.width / 2));
     this.rotateX((this.mouseY - this.height / 2) / (this.width / 2));

--- a/src/webgl/interaction.js
+++ b/src/webgl/interaction.js
@@ -29,6 +29,7 @@ var p5 = require('../core/core');
 //@TODO: implement full orbit controls including
 //pan, zoom, quaternion rotation, etc.
 p5.prototype.orbitControl = function() {
+  this._assert3d();
   if (this.mouseIsPressed) {
     this.rotateY((this.mouseX - this.width / 2) / (this.width / 2));
     this.rotateX((this.mouseY - this.height / 2) / (this.width / 2));

--- a/src/webgl/light.js
+++ b/src/webgl/light.js
@@ -63,7 +63,7 @@ var p5 = require('../core/core');
  * @chainable
  */
 p5.prototype.ambientLight = function(v1, v2, v3, a) {
-  this._assert3d();
+  this._assert3d('ambientLight');
   var color = this.color.apply(this, arguments);
 
   var shader = this._renderer._useLightShader();
@@ -152,7 +152,7 @@ p5.prototype.ambientLight = function(v1, v2, v3, a) {
  * @chainable
  */
 p5.prototype.directionalLight = function(v1, v2, v3, x, y, z) {
-  this._assert3d();
+  this._assert3d('directionalLight');
   var shader = this._renderer._useLightShader();
 
   //@TODO: check parameters number
@@ -264,7 +264,7 @@ p5.prototype.directionalLight = function(v1, v2, v3, x, y, z) {
  * @chainable
  */
 p5.prototype.pointLight = function(v1, v2, v3, x, y, z) {
-  this._assert3d();
+  this._assert3d('pointLight');
   //@TODO: check parameters number
   var color = this._renderer._pInst.color.apply(this, [v1, v2, v3]);
 

--- a/src/webgl/light.js
+++ b/src/webgl/light.js
@@ -63,6 +63,7 @@ var p5 = require('../core/core');
  * @chainable
  */
 p5.prototype.ambientLight = function(v1, v2, v3, a) {
+  this._assert3d();
   var color = this.color.apply(this, arguments);
 
   var shader = this._renderer._useLightShader();
@@ -151,6 +152,7 @@ p5.prototype.ambientLight = function(v1, v2, v3, a) {
  * @chainable
  */
 p5.prototype.directionalLight = function(v1, v2, v3, x, y, z) {
+  this._assert3d();
   var shader = this._renderer._useLightShader();
 
   //@TODO: check parameters number
@@ -262,6 +264,7 @@ p5.prototype.directionalLight = function(v1, v2, v3, x, y, z) {
  * @chainable
  */
 p5.prototype.pointLight = function(v1, v2, v3, x, y, z) {
+  this._assert3d();
   //@TODO: check parameters number
   var color = this._renderer._pInst.color.apply(this, [v1, v2, v3]);
 

--- a/src/webgl/loading.js
+++ b/src/webgl/loading.js
@@ -242,7 +242,7 @@ function parseObj(model, lines) {
  *
  */
 p5.prototype.model = function(model) {
-  this._assert3d();
+  this._assert3d('model');
   if (model.vertices.length > 0) {
     if (!this._renderer.geometryInHash(model.gid)) {
       model._makeTriangleEdges()._edgesToVertices();

--- a/src/webgl/loading.js
+++ b/src/webgl/loading.js
@@ -242,6 +242,7 @@ function parseObj(model, lines) {
  *
  */
 p5.prototype.model = function(model) {
+  this._assert3d();
   if (model.vertices.length > 0) {
     if (!this._renderer.geometryInHash(model.gid)) {
       model._makeTriangleEdges()._edgesToVertices();

--- a/src/webgl/material.js
+++ b/src/webgl/material.js
@@ -29,7 +29,6 @@ require('./p5.Texture');
  * vertex and fragment shader files.
  */
 p5.prototype.loadShader = function(vertFilename, fragFilename) {
-  this._assert3d('loadShader');
   var loadedShader = new p5.Shader();
 
   var self = this;

--- a/src/webgl/material.js
+++ b/src/webgl/material.js
@@ -29,6 +29,7 @@ require('./p5.Texture');
  * vertex and fragment shader files.
  */
 p5.prototype.loadShader = function(vertFilename, fragFilename) {
+  this._assert3d();
   var loadedShader = new p5.Shader();
 
   var self = this;
@@ -116,6 +117,7 @@ p5.prototype.loadShader = function(vertFilename, fragFilename) {
  * zooming Mandelbrot set. a colorful, infinitely detailed fractal.
  */
 p5.prototype.createShader = function(vertSrc, fragSrc) {
+  this._assert3d();
   return new p5.Shader(this._renderer, vertSrc, fragSrc);
 };
 
@@ -131,6 +133,7 @@ p5.prototype.createShader = function(vertSrc, fragSrc) {
  * shapes.
  */
 p5.prototype.shader = function(s) {
+  this._assert3d();
   if (s._renderer === undefined) {
     s._renderer = this._renderer;
   }
@@ -168,6 +171,7 @@ p5.prototype.shader = function(s) {
  *
  */
 p5.prototype.normalMaterial = function() {
+  this._assert3d();
   this._renderer.drawMode = constants.FILL;
   this._renderer.setFillShader(this._renderer._getNormalShader());
   this._renderer.curFillColor = [1, 1, 1, 1];
@@ -254,6 +258,7 @@ p5.prototype.normalMaterial = function() {
  *
  */
 p5.prototype.texture = function(tex) {
+  this._assert3d();
   this._renderer.drawMode = constants.TEXTURE;
   var shader = this._renderer._useLightShader();
   shader.setUniform('uSpecular', false);
@@ -300,6 +305,7 @@ p5.prototype.texture = function(tex) {
  * @chainable
  */
 p5.prototype.ambientMaterial = function(v1, v2, v3, a) {
+  this._assert3d();
   var color = p5.prototype.color.apply(this, arguments);
   this._renderer.curFillColor = color._array;
 
@@ -347,6 +353,7 @@ p5.prototype.ambientMaterial = function(v1, v2, v3, a) {
  * @chainable
  */
 p5.prototype.specularMaterial = function(v1, v2, v3, a) {
+  this._assert3d();
   var color = p5.prototype.color.apply(this, arguments);
   this._renderer.curFillColor = color._array;
 

--- a/src/webgl/material.js
+++ b/src/webgl/material.js
@@ -29,7 +29,7 @@ require('./p5.Texture');
  * vertex and fragment shader files.
  */
 p5.prototype.loadShader = function(vertFilename, fragFilename) {
-  this._assert3d();
+  this._assert3d('loadShader');
   var loadedShader = new p5.Shader();
 
   var self = this;
@@ -117,7 +117,7 @@ p5.prototype.loadShader = function(vertFilename, fragFilename) {
  * zooming Mandelbrot set. a colorful, infinitely detailed fractal.
  */
 p5.prototype.createShader = function(vertSrc, fragSrc) {
-  this._assert3d();
+  this._assert3d('createShader');
   return new p5.Shader(this._renderer, vertSrc, fragSrc);
 };
 
@@ -133,7 +133,7 @@ p5.prototype.createShader = function(vertSrc, fragSrc) {
  * shapes.
  */
 p5.prototype.shader = function(s) {
-  this._assert3d();
+  this._assert3d('shader');
   if (s._renderer === undefined) {
     s._renderer = this._renderer;
   }
@@ -171,7 +171,7 @@ p5.prototype.shader = function(s) {
  *
  */
 p5.prototype.normalMaterial = function() {
-  this._assert3d();
+  this._assert3d('normalMaterial');
   this._renderer.drawMode = constants.FILL;
   this._renderer.setFillShader(this._renderer._getNormalShader());
   this._renderer.curFillColor = [1, 1, 1, 1];
@@ -258,7 +258,7 @@ p5.prototype.normalMaterial = function() {
  *
  */
 p5.prototype.texture = function(tex) {
-  this._assert3d();
+  this._assert3d('texture');
   this._renderer.drawMode = constants.TEXTURE;
   var shader = this._renderer._useLightShader();
   shader.setUniform('uSpecular', false);
@@ -305,7 +305,7 @@ p5.prototype.texture = function(tex) {
  * @chainable
  */
 p5.prototype.ambientMaterial = function(v1, v2, v3, a) {
-  this._assert3d();
+  this._assert3d('ambientMaterial');
   var color = p5.prototype.color.apply(this, arguments);
   this._renderer.curFillColor = color._array;
 
@@ -353,7 +353,7 @@ p5.prototype.ambientMaterial = function(v1, v2, v3, a) {
  * @chainable
  */
 p5.prototype.specularMaterial = function(v1, v2, v3, a) {
-  this._assert3d();
+  this._assert3d('specularMaterial');
   var color = p5.prototype.color.apply(this, arguments);
   this._renderer.curFillColor = color._array;
 

--- a/src/webgl/p5.RendererGL.js
+++ b/src/webgl/p5.RendererGL.js
@@ -336,6 +336,7 @@ p5.RendererGL.prototype._resetContext = function(attr, options, callback) {
  */
 
 p5.prototype.setAttributes = function(key, value) {
+  this._assert3d();
   //@todo_FES
   var attr;
   if (typeof value !== 'undefined') {
@@ -1046,6 +1047,14 @@ p5.RendererGL.prototype._vToNArray = function(arr) {
       return [item.x, item.y, item.z];
     })
   );
+};
+
+/**
+ * ensures that p5 is using a 3d renderer. throws an error if not.
+ */
+p5.prototype._assert3d = function() {
+  if (!this._renderer.isP3D)
+    throw 'Not supported in P2D mode. Please use webgl mode';
 };
 
 module.exports = p5.RendererGL;

--- a/src/webgl/p5.RendererGL.js
+++ b/src/webgl/p5.RendererGL.js
@@ -336,7 +336,7 @@ p5.RendererGL.prototype._resetContext = function(attr, options, callback) {
  */
 
 p5.prototype.setAttributes = function(key, value) {
-  this._assert3d();
+  this._assert3d('setAttributes');
   //@todo_FES
   var attr;
   if (typeof value !== 'undefined') {
@@ -1052,9 +1052,14 @@ p5.RendererGL.prototype._vToNArray = function(arr) {
 /**
  * ensures that p5 is using a 3d renderer. throws an error if not.
  */
-p5.prototype._assert3d = function() {
+p5.prototype._assert3d = function(name) {
   if (!this._renderer.isP3D)
-    throw 'Not supported in P2D mode. Please use webgl mode';
+    throw new Error(
+      name +
+        "() is only supported in WEBGL mode. If you'd like to use 3D graphics" +
+        ' and WebGL, see  https://p5js.org/examples/form-3d-primitives.html' +
+        ' for more information.'
+    );
 };
 
 module.exports = p5.RendererGL;

--- a/src/webgl/primitives.js
+++ b/src/webgl/primitives.js
@@ -46,7 +46,7 @@ require('./p5.Geometry');
  * rotating view of a multi-colored cylinder with concave sides.
  */
 p5.prototype.plane = function(width, height, detailX, detailY) {
-  this._assert3d();
+  this._assert3d('plane');
   if (typeof width === 'undefined') {
     width = 50;
   }
@@ -121,7 +121,7 @@ p5.prototype.plane = function(width, height, detailX, detailY) {
  * </div>
  */
 p5.prototype.box = function(width, height, depth, detailX, detailY) {
-  this._assert3d();
+  this._assert3d('box');
   if (typeof width === 'undefined') {
     width = 50;
   }
@@ -235,7 +235,7 @@ p5.prototype.box = function(width, height, depth, detailX, detailY) {
  * </div>
  */
 p5.prototype.sphere = function(radius, detailX, detailY) {
-  this._assert3d();
+  this._assert3d('sphere');
   if (typeof radius === 'undefined') {
     radius = 50;
   }
@@ -424,7 +424,7 @@ p5.prototype.cylinder = function(
   bottomCap,
   topCap
 ) {
-  this._assert3d();
+  this._assert3d('cylinder');
   if (typeof radius === 'undefined') {
     radius = 50;
   }
@@ -506,7 +506,7 @@ p5.prototype.cylinder = function(
  * </div>
  */
 p5.prototype.cone = function(radius, height, detailX, detailY, cap) {
-  this._assert3d();
+  this._assert3d('cone');
   if (typeof radius === 'undefined') {
     radius = 50;
   }
@@ -576,7 +576,7 @@ p5.prototype.cone = function(radius, height, detailX, detailY, cap) {
  * </div>
  */
 p5.prototype.ellipsoid = function(radiusX, radiusY, radiusZ, detailX, detailY) {
-  this._assert3d();
+  this._assert3d('ellipsoid');
   if (typeof radiusX === 'undefined') {
     radiusX = 50;
   }
@@ -664,7 +664,7 @@ p5.prototype.ellipsoid = function(radiusX, radiusY, radiusZ, detailX, detailY) {
  * </div>
  */
 p5.prototype.torus = function(radius, tubeRadius, detailX, detailY) {
-  this._assert3d();
+  this._assert3d('torus');
   if (typeof radius === 'undefined') {
     radius = 50;
   } else if (!radius) {

--- a/src/webgl/primitives.js
+++ b/src/webgl/primitives.js
@@ -46,6 +46,7 @@ require('./p5.Geometry');
  * rotating view of a multi-colored cylinder with concave sides.
  */
 p5.prototype.plane = function(width, height, detailX, detailY) {
+  this._assert3d();
   if (typeof width === 'undefined') {
     width = 50;
   }
@@ -120,6 +121,7 @@ p5.prototype.plane = function(width, height, detailX, detailY) {
  * </div>
  */
 p5.prototype.box = function(width, height, depth, detailX, detailY) {
+  this._assert3d();
   if (typeof width === 'undefined') {
     width = 50;
   }
@@ -233,6 +235,7 @@ p5.prototype.box = function(width, height, depth, detailX, detailY) {
  * </div>
  */
 p5.prototype.sphere = function(radius, detailX, detailY) {
+  this._assert3d();
   if (typeof radius === 'undefined') {
     radius = 50;
   }
@@ -421,6 +424,7 @@ p5.prototype.cylinder = function(
   bottomCap,
   topCap
 ) {
+  this._assert3d();
   if (typeof radius === 'undefined') {
     radius = 50;
   }
@@ -502,6 +506,7 @@ p5.prototype.cylinder = function(
  * </div>
  */
 p5.prototype.cone = function(radius, height, detailX, detailY, cap) {
+  this._assert3d();
   if (typeof radius === 'undefined') {
     radius = 50;
   }
@@ -571,6 +576,7 @@ p5.prototype.cone = function(radius, height, detailX, detailY, cap) {
  * </div>
  */
 p5.prototype.ellipsoid = function(radiusX, radiusY, radiusZ, detailX, detailY) {
+  this._assert3d();
   if (typeof radiusX === 'undefined') {
     radiusX = 50;
   }
@@ -658,6 +664,7 @@ p5.prototype.ellipsoid = function(radiusX, radiusY, radiusZ, detailX, detailY) {
  * </div>
  */
 p5.prototype.torus = function(radius, tubeRadius, detailX, detailY) {
+  this._assert3d();
   if (typeof radius === 'undefined') {
     radius = 50;
   } else if (!radius) {

--- a/test/manual-test-examples/webgl/customGeometry/sketch.js
+++ b/test/manual-test-examples/webgl/customGeometry/sketch.js
@@ -24,7 +24,6 @@ function setup() {
 }
 
 function draw() {
-
   var tt = millis();
 
   background(0);
@@ -48,7 +47,11 @@ function draw() {
 
   for (var y = 0; y <= geometry.detailY; y++) {
     for (var x = 0; x <= geometry.detailX; x++) {
-      var v = noise(3 * x / geometry.detailX, 3 * y / geometry.detailY, tt / 10000);
+      var v = noise(
+        3 * x / geometry.detailX,
+        3 * y / geometry.detailY,
+        tt / 10000
+      );
       v = map(v, 0, 1, -0.5, 1);
       if (v < 0) v = 0;
       v = v * v * v;
@@ -63,6 +66,6 @@ function draw() {
   pointLight(150, 150, 150, moonPos);
 
   geometry.computeFaces().computeNormals();
-  renderer.createBuffers("!", geometry);
-  renderer.drawBuffersScaled("!", 1000, 1000, 1);
+  renderer.createBuffers('!', geometry);
+  renderer.drawBuffersScaled('!', 1000, 1000, 1);
 }

--- a/test/unit/core/renderer.js
+++ b/test/unit/core/renderer.js
@@ -89,4 +89,27 @@ suite('Renderer', function() {
       drawX();
     });
   });
+
+  suite('webgl assertions', function() {
+    test('box() should throw an Error', function() {
+      expect(function() {
+        myp5.box(100);
+      }).to.throw(Error);
+    });
+    test('sphere() should throw an Error', function() {
+      expect(function() {
+        myp5.sphere(100);
+      }).to.throw(Error);
+    });
+    test('rotateX() should throw an Error', function() {
+      expect(function() {
+        myp5.rotateX(100);
+      }).to.throw(Error);
+    });
+    test('normalMaterial() should throw an Error', function() {
+      expect(function() {
+        myp5.normalMaterial(100);
+      }).to.throw(Error);
+    });
+  });
 });

--- a/test/unit/core/renderer.js
+++ b/test/unit/core/renderer.js
@@ -90,26 +90,37 @@ suite('Renderer', function() {
     });
   });
 
+  // prettier-ignore
+  var webglMethods = [
+    'rotateX', 'rotateY', 'rotateZ',
+    'camera', 'perspective', 'ortho', 'orbitControl',
+    'ambientLight', 'directionalLight', 'pointLight',
+    'model',
+    'createShader', 'shader',
+    'normalMaterial', 'texture', 'ambientMaterial', 'specularMaterial',
+    'setAttributes',
+    'plane', 'box', 'sphere', 'cylinder', 'cone', 'ellipsoid', 'torus',
+  ];
+
   suite('webgl assertions', function() {
-    test('box() should throw an Error', function() {
-      expect(function() {
-        myp5.box(100);
-      }).to.throw(Error);
-    });
-    test('sphere() should throw an Error', function() {
-      expect(function() {
-        myp5.sphere(100);
-      }).to.throw(Error);
-    });
-    test('rotateX() should throw an Error', function() {
-      expect(function() {
-        myp5.rotateX(100);
-      }).to.throw(Error);
-    });
-    test('normalMaterial() should throw an Error', function() {
-      expect(function() {
-        myp5.normalMaterial(100);
-      }).to.throw(Error);
-    });
+    for (var i = 0; i < webglMethods.length; i++) {
+      var webglMethod = webglMethods[i];
+      test(
+        webglMethod + '() should throw a WEBGL assertion Error',
+        (function(webglMethod) {
+          return function() {
+            var validateParamters = myp5.validateParameters;
+            myp5.validateParameters = false;
+            try {
+              expect(function() {
+                myp5[webglMethod].call(myp5);
+              }).to.throw(Error, /is only supported in WEBGL mode/);
+            } finally {
+              myp5.validateParameters = validateParamters;
+            }
+          };
+        })(webglMethod)
+      );
+    }
   });
 });


### PR DESCRIPTION
if you call method of `p5.prototype` that are webgl-only when you are not using the webgl renderer, you get undefined behavior - often crashes.

this PR adds assertions to all such webgl-only p5.prototype methods.