### PR TITLE
Preload bugs

### DIFF
--- a/src/core/core.js
+++ b/src/core/core.js
@@ -256,7 +256,10 @@ var p5 = function(sketch, node, sync) {
         var obj = this._preloadMethods[method];
         //it's p5, check if it's global or instance
         if (obj === p5.prototype || obj === p5) {
-          obj = this._isGlobal ? window : this;
+          if (this._isGlobal) {
+            window[method] = this._wrapPreload(this, method);
+          }
+          obj = this;
         }
         this._registeredPreloadMethods[method] = obj[method];
         obj[method] = this._wrapPreload(obj, method);

--- a/src/webgl/loading.js
+++ b/src/webgl/loading.js
@@ -81,6 +81,7 @@ p5.prototype.loadModel = function(path) {
 
   var model = new p5.Geometry();
   model.gid = path + '|' + normalize;
+  var self = this;
   this.loadStrings(
     path,
     function(strings) {
@@ -90,6 +91,7 @@ p5.prototype.loadModel = function(path) {
         model.normalize();
       }
 
+      self._decrementPreload();
       if (typeof successCallback === 'function') {
         successCallback(model);
       }


### PR DESCRIPTION
Attaches preload functions to the global instance as well as to window when creating a global object. Fixes `loadModel` preload. Fixes #2568. Incompatible with #2696 