### PR TITLE
fix loadShader preload, add example

### DIFF
--- a/docs/yuidoc-p5-theme/assets/swirl.frag
+++ b/docs/yuidoc-p5-theme/assets/swirl.frag
@@ -1,0 +1,18 @@
+precision highp float;
+varying vec2 vPos;
+uniform float time;
+
+float r;
+
+float Q(float a, float b, float c, float d, float e) {
+  float v = 0.5 + 0.5 * sin(time * a + atan(vPos.y, vPos.x) * b + sin(log(r * c) * d * sin(time * e)));
+  return v*v*v;
+}
+void main() {
+  r = length(vPos);
+
+  gl_FragColor.a = 1.0;
+  gl_FragColor.r = Q(1.000, 5.0, 0.54, 5.00, 0.2471);
+  gl_FragColor.g = Q(1.123, 3.0, 0.59, 4.97, 0.2871);
+  gl_FragColor.b = Q(1.722, 4.0, 0.57, 5.13, 0.2371);
+}

--- a/docs/yuidoc-p5-theme/assets/swirl.vert
+++ b/docs/yuidoc-p5-theme/assets/swirl.vert
@@ -1,0 +1,16 @@
+precision highp float;
+
+attribute vec2 aTexCoord;
+attribute vec3 aPosition;
+
+uniform mat4 uModelViewMatrix;
+uniform mat4 uProjectionMatrix;
+
+varying vec2 vPos;
+
+void main(void) {
+  vec4 positionVec4 = vec4(aPosition, 1.0);
+  gl_Position = uProjectionMatrix * uModelViewMatrix * positionVec4;
+
+  vPos = aTexCoord * 2.0 - 1.0;
+}

--- a/src/webgl/material.js
+++ b/src/webgl/material.js
@@ -27,6 +27,29 @@ require('./p5.Texture');
  * source code
  * @return {p5.Shader} a shader object created from the provided
  * vertex and fragment shader files.
+ *
+ * @example
+ * <div modernizr='webgl'><code>
+ * var swirl;
+ * function preload() {
+ *   swirl = loadShader('assets/swirl.vert', 'assets/swirl.frag');
+ * }
+ * function setup() {
+ *   createCanvas(100, 100, WEBGL);
+ *   shader(swirl);
+ * }
+ * function draw() {
+ *   background(200);
+ *   var time = millis();
+ *   swirl.setUniform('time', time / 1000);
+ *   rotateX(time / 5234);
+ *   rotateZ(time / 3217);
+ *   box(60);
+ * }
+ * </code></div>
+ *
+ * @alt
+ * a spinning cube with an animated swirly texture
  */
 p5.prototype.loadShader = function(vertFilename, fragFilename) {
   var loadedShader = new p5.Shader();
@@ -38,15 +61,15 @@ p5.prototype.loadShader = function(vertFilename, fragFilename) {
   this.loadStrings(fragFilename, function(result) {
     loadedShader._fragSrc = result.join('\n');
     loadedFrag = true;
-    if (!loadedVert) {
-      self._incrementPreload();
+    if (loadedVert) {
+      self._decrementPreload();
     }
   });
   this.loadStrings(vertFilename, function(result) {
     loadedShader._vertSrc = result.join('\n');
     loadedVert = true;
-    if (!loadedFrag) {
-      self._incrementPreload();
+    if (loadedFrag) {
+      self._decrementPreload();
     }
   });
 


### PR DESCRIPTION
this PR fixes the `loadShader()` function's preload callback refcounting and adds an example for that method.