### PR TITLE
Added some provision for testing Release script out

### DIFF
--- a/tasks/release/release-bower.js
+++ b/tasks/release/release-bower.js
@@ -12,13 +12,17 @@ module.exports = function(grunt) {
       var done = this.async();
       // Keep the version handy
       var version = require('../../package.json').version;
+      // Keep the release-party ready
+      var releaseParty = grunt.config.get('bowerReleaser');
       // Avoiding Callback Hell and using Promises
       new Promise(function(resolve, reject) {
         // Clone the repo. NEEDS TO BE QUIET. Took 3 hours to realise this.
         // Otherwise the stdout screws up
         console.log('Cloning the Release repo ...');
         exec(
-          'rm -rf bower-repo/ && git clone -q https://github.com/lmccart/p5.js-release.git bower-repo',
+          'rm -rf bower-repo/ && git clone -q https://github.com/' +
+            releaseParty +
+            '/p5.js-release.git bower-repo',
           function(err, stdout, stderr) {
             if (err) {
               reject(err);
@@ -67,6 +71,7 @@ module.exports = function(grunt) {
                 if (stderr) {
                   reject(stderr);
                 }
+                console.log('Released on Bower!');
                 resolve();
                 done();
               }
@@ -74,6 +79,7 @@ module.exports = function(grunt) {
           });
         })
         .catch(function(err) {
+          console.log('Failed to Release on Bower!');
           throw new Error(err);
         });
     }

--- a/tasks/release/release-docs.js
+++ b/tasks/release/release-docs.js
@@ -12,12 +12,16 @@ module.exports = function(grunt) {
       var done = this.async();
       // Keep the version handy
       var version = require('../../package.json').version;
+      // Keep the release-party ready
+      var releaseParty = grunt.config.get('docsReleaser');
       // Avoiding Callback Hell and using Promises
       new Promise(function(resolve, reject) {
         // Clone the website locally
         console.log('Cloning the website ...');
         exec(
-          'rm -rf p5-website/ && git clone -q https://github.com/sakshamsaxena/p5.js-website.git p5-website',
+          'rm -rf p5-website/ && git clone -q https://github.com/' +
+            releaseParty +
+            '/p5.js-website.git p5-website',
           function(err, stdout, stderr) {
             if (err) {
               reject(err);
@@ -64,6 +68,7 @@ module.exports = function(grunt) {
                 if (stderr) {
                   reject(stderr);
                 }
+                console.log('Released Docs on Website!');
                 resolve();
                 done();
               }

--- a/tasks/release/release-github.js
+++ b/tasks/release/release-github.js
@@ -9,6 +9,8 @@ module.exports = function(grunt) {
   ) {
     // Async Task
     var done = this.async();
+    // Keep the release-party ready
+    var releaseParty = grunt.config.get('githubReleaser');
 
     // Prepare the data
     var data = {
@@ -27,10 +29,12 @@ module.exports = function(grunt) {
     // Set up vars for requests
     var accessTokenParam = '?access_token=' + process.env.GITHUB_TOKEN;
     var createURL =
-      'https://api.github.com/repos/processing/p5.js/releases' +
+      'https://api.github.com/repos/' +
+      releaseParty +
+      '/p5.js/releases' +
       accessTokenParam;
     var uploadURL =
-      'https://uploads.github.com/repos/processing/p5.js/releases/';
+      'https://uploads.github.com/repos/' + releaseParty + '/p5.js/releases/';
     var ID = '';
     var count = 0;
 
@@ -93,6 +97,7 @@ module.exports = function(grunt) {
             count++;
             if (count === 7) {
               done();
+              console.log('Released on GitHub!\n All done!');
             }
           }
         )

--- a/tasks/release/release-p5.js
+++ b/tasks/release/release-p5.js
@@ -48,10 +48,18 @@ module.exports = function(grunt) {
     'Drafts and Publishes a fresh release of p5.js',
     function(args) {
       // 0. Setup Config
+
       // Default increment is patch (x.y.z+1)
       opts.releaseIt.options.increment = args;
+      // Uncomment to set dry run as true for testing
+      // opts.releaseIt.options['dry-run'] = true;
       grunt.config.set('release-it', opts.releaseIt);
       grunt.config.set('compress', opts.compress);
+      // Keeping URLs as config vars, so that anyone can change
+      // them to add their own, to test if release works or not.
+      grunt.config.set('bowerReleaser', 'lmccart');
+      grunt.config.set('docsReleaser', 'processing');
+      grunt.config.set('githubReleaser', 'processing');
 
       // 1. Test Suite
       grunt.task.run('test');


### PR DESCRIPTION
Now you can simply edit up a few config vars with your own creds to point the releases at them instead of processing. 

In tasks/release/release-p5.js
> Kept URLs as config vars, so that anyone can change them to add their own, to test if release works or not.
> Uncomment L#55 to set dry run as true for testing