### PR TITLE
Closes #2678, added validateParamenters() to text()

### DIFF
--- a/src/typography/loading_displaying.js
+++ b/src/typography/loading_displaying.js
@@ -191,6 +191,7 @@ p5.prototype.loadFont = function(path, onSuccess, onError) {
  *
  */
 p5.prototype.text = function(str, x, y, maxWidth, maxHeight) {
+  p5._validateParameters('text', arguments);
   return !(this._renderer._doFill || this._renderer._doStroke)
     ? this
     : this._renderer.text.apply(this._renderer, arguments);


### PR DESCRIPTION
Now the text function calls validateParamenters() to print a friendy
error in case the arguments of the function are invalide (e.g., text is
undefined, wrong type, etc).