### PR TITLE
Fix scaling issue when using Graphics on retina

### DIFF
--- a/src/core/p5.Renderer2D.js
+++ b/src/core/p5.Renderer2D.js
@@ -110,12 +110,16 @@ p5.Renderer2D.prototype.image = function(
     if (!cnv) {
       cnv = img.canvas || img.elt;
     }
+    var s = 1;
+    if (img.width && img.width > 0) {
+      s = cnv.width / img.width;
+    }
     this.drawingContext.drawImage(
       cnv,
-      sx,
-      sy,
-      sWidth,
-      sHeight,
+      s * sx,
+      s * sy,
+      s * sWidth,
+      s * sHeight,
       dx,
       dy,
       dWidth,

--- a/src/core/rendering.js
+++ b/src/core/rendering.js
@@ -152,6 +152,8 @@ p5.prototype.resizeCanvas = function(w, h, noRedraw) {
       }
     }
     this._renderer.resize(w, h);
+    this.width = w;
+    this.height = h;
     // reset canvas properties
     for (var savedKey in props) {
       try {

--- a/test/unit/core/graphics.js
+++ b/test/unit/core/graphics.js
@@ -120,7 +120,6 @@ suite('Graphics', function() {
       var graph = myp5.createGraphics(10, 17);
       graph.pixelDensity(1);
       graph.resizeCanvas(19, 16);
-      // this fails:
       assertValidGraphSizes(graph, 19, 16, 1);
     });
 
@@ -142,7 +141,6 @@ suite('Graphics', function() {
       var graph = myp5.createGraphics(10, 17);
       graph.pixelDensity(2);
       graph.resizeCanvas(19, 16);
-      // this fails:
       assertValidGraphSizes(graph, 19, 16, 2);
     });
 

--- a/test/unit/core/graphics.js
+++ b/test/unit/core/graphics.js
@@ -1,0 +1,163 @@
+suite('Graphics', function() {
+  var myp5;
+
+  setup(function(done) {
+    new p5(function(p) {
+      p.setup = function() {
+        myp5 = p;
+        done();
+      };
+    });
+  });
+
+  teardown(function() {
+    myp5.remove();
+  });
+
+  function assertValidGraphSizes(graph, w, h, density) {
+    assert.strictEqual(graph.pixelDensity(), density, 'invalid pixel density');
+    assert.strictEqual(graph.width, w, 'invalid width');
+    assert.strictEqual(graph.height, h, 'invalid height');
+  }
+
+  function assertValidCanvasSizes(canvas, w, h, density) {
+    assert.strictEqual(canvas.width, w * density, 'canvas.width');
+    assert.strictEqual(canvas.height, h * density, 'canvas.height');
+    var s = canvas.style; // for linting: otherwise line too long...
+    assert.strictEqual(s.width, '' + w + 'px', 'invalid canvas.style.width');
+    assert.strictEqual(s.height, '' + h + 'px', 'invalid canvas.style.height');
+  }
+
+  function assertValidPixels(graph, w, h, density) {
+    graph.loadPixels();
+    var real = graph.pixels.length;
+    var expected = w * density * h * density * 4;
+    assert.strictEqual(real, expected, 'invalid number of pixels');
+  }
+
+  suite('p5.prototype.createGraphics', function() {
+    test('it creates a graphics', function() {
+      var graph = myp5.createGraphics(10, 17);
+      assert.isObject(graph);
+    });
+  });
+
+  suite('p5.Graphics', function() {
+    test('it has necessary properties', function() {
+      var graph = myp5.createGraphics(10, 17);
+      assert.property(graph, 'width');
+      assert.property(graph, 'height');
+      assert.property(graph, 'canvas');
+      assert.property(graph, 'pixelDensity');
+      assert.property(graph, 'loadPixels');
+      assert.property(graph, 'pixels');
+    });
+
+    test('it has consistent sizes', function() {
+      var graph = myp5.createGraphics(10, 17);
+      graph.pixelDensity(1);
+      assertValidGraphSizes(graph, 10, 17, 1);
+    });
+
+    test('its canvas has consistent sizes', function() {
+      var graph = myp5.createGraphics(10, 17);
+      graph.pixelDensity(1);
+      assertValidCanvasSizes(graph.canvas, 10, 17, 1);
+    });
+
+    test('it has a valid pixels array', function() {
+      var graph = myp5.createGraphics(10, 17);
+      graph.pixelDensity(1);
+      assertValidPixels(graph, 10, 17, 1);
+    });
+  });
+
+  suite('p5.Graphics.pixelDensity', function() {
+    test('it can change density', function() {
+      var graph = myp5.createGraphics(10, 17);
+      graph.pixelDensity(1);
+      assert.strictEqual(graph.pixelDensity(), 1);
+      graph.pixelDensity(3);
+      assert.strictEqual(graph.pixelDensity(), 3);
+    });
+
+    test('it keeps valid sizes after change', function() {
+      var graph = myp5.createGraphics(10, 17);
+      graph.pixelDensity(1);
+      assertValidGraphSizes(graph, 10, 17, 1);
+      graph.pixelDensity(3);
+      assertValidGraphSizes(graph, 10, 17, 3);
+    });
+
+    test('its canvas keeps valid sizes after change', function() {
+      var graph = myp5.createGraphics(10, 17);
+      graph.pixelDensity(1);
+      assertValidCanvasSizes(graph.canvas, 10, 17, 1);
+      graph.pixelDensity(3);
+      assertValidCanvasSizes(graph.canvas, 10, 17, 3);
+    });
+
+    test('it keeps a valid pixel array after change', function() {
+      var graph = myp5.createGraphics(10, 17);
+      graph.pixelDensity(1);
+      assertValidPixels(graph, 10, 17, 1);
+
+      graph.pixelDensity(3);
+      assertValidPixels(graph, 10, 17, 3);
+    });
+  });
+
+  suite('p5.Graphics.resizeCanvas', function() {
+    test('it can call resizeCanvas', function() {
+      var graph = myp5.createGraphics(10, 17);
+      var resize = function() {
+        graph.resizeCanvas(19, 16);
+      };
+      assert.doesNotThrow(resize);
+    });
+
+    test('it resizes properly with pixelDensity 1', function() {
+      var graph = myp5.createGraphics(10, 17);
+      graph.pixelDensity(1);
+      graph.resizeCanvas(19, 16);
+      // this fails:
+      assertValidGraphSizes(graph, 19, 16, 1);
+    });
+
+    test('its canvas resizes properly with pixelDensity 1', function() {
+      var graph = myp5.createGraphics(10, 17);
+      graph.pixelDensity(1);
+      graph.resizeCanvas(19, 16);
+      assertValidCanvasSizes(graph.canvas, 19, 16, 1);
+    });
+
+    test('it resizes properly the pixels array with density 1', function() {
+      var graph = myp5.createGraphics(10, 17);
+      graph.pixelDensity(1);
+      graph.resizeCanvas(19, 16);
+      assertValidPixels(graph, 19, 16, 1);
+    });
+
+    test('it resizes properly with pixelDensity 2', function() {
+      var graph = myp5.createGraphics(10, 17);
+      graph.pixelDensity(2);
+      graph.resizeCanvas(19, 16);
+      // this fails:
+      assertValidGraphSizes(graph, 19, 16, 2);
+    });
+
+    test('its canvas resizes properly with pixelDensity 2', function() {
+      var graph = myp5.createGraphics(10, 17);
+      graph.pixelDensity(2);
+      graph.resizeCanvas(19, 16);
+      assertValidCanvasSizes(graph.canvas, 19, 16, 2);
+    });
+
+    test('it resizes properly the pixels array with density 2', function() {
+      var graph = myp5.createGraphics(10, 17);
+      graph.pixelDensity(2);
+      graph.resizeCanvas(19, 16);
+      assertValidPixels(graph, 19, 16, 2);
+    });
+  });
+});

--- a/test/unit/spec.js
+++ b/test/unit/spec.js
@@ -7,6 +7,7 @@ var spec = {
     'curves',
     'element',
     'error_helpers',
+    'graphics',
     'renderer',
     'structure'
   ],


### PR DESCRIPTION
Using `image(p5.Graphics)` on a screen with `pixelDensity()`
higher than 1 results in distorted results.

This commit fixes this issue by using the technique implemented
in [`_copyHelper()`](https://github.com/processing/p5.js/blob/master/src/core/p5.Renderer2D.js#L218). I am however not sure if this commit breaks anything
else as  the rendering tests are sparse and I am only discovering
the codebase.

I do not know how to add unit tests for this part of the code; I didn't write any.

Closes: #2077