### PR TITLE
fix bezierDetail/curveDetail examples

### DIFF
--- a/src/core/curves.js
+++ b/src/core/curves.js
@@ -100,14 +100,28 @@ p5.prototype.bezier = function() {
  * @example
  * <div>
  * <code>
- * background(204);
- * bezierDetail(50);
- * bezier(85, 20, 10, 10, 90, 90, 15, 80);
+ * function setup() {
+ *   createCanvas(100, 100, WEBGL);
+ *   noFill();
+ * }
+ *
+ * function draw() {
+ *   background(200);
+ *
+ *   // a triangle-wave function
+ *   bezierDetail(2 + abs(15 - floor(millis() / 150) % 30));
+ *
+ *   // prettier-ignore
+ *   bezier(-40, -40, 0,
+ *           90, -40, 0,
+ *          -90,  40, 0,
+ *           40,  40, 0);
+ * }
  * </code>
  * </div>
  *
  * @alt
- * stretched black s-shape with 7 5x5 ellipses and orange lines along the shape.
+ * stretched black s-shape with varying bezier detail
  *
  */
 p5.prototype.bezierDetail = function(d) {
@@ -352,14 +366,26 @@ p5.prototype.curve = function() {
  * @example
  * <div>
  * <code>
- * background(204);
- * curveDetail(20);
- * curve(5, 26, 5, 26, 73, 24, 73, 61);
+ * function setup() {
+ *   createCanvas(100, 100, WEBGL);
+ * }
+ * function draw() {
+ *   background(200);
+ *
+ *   // a triangle-wave function
+ *   curveDetail(2 + abs(15 - floor(millis() / 150) % 30));
+ *
+ *   // prettier-ignore
+ *   curve( 250, 600, 0,
+ *          -30,  40, 0,
+ *           30,  30, 0,
+ *         -250, 600, 0);
+ * }
  * </code>
  * </div>
  *
  * @alt
- * white arch shape in top-mid canvas.
+ * white arch shape with varying levels of curve detail.
  *
  */
 p5.prototype.curveDetail = function(d) {

--- a/src/core/curves.js
+++ b/src/core/curves.js
@@ -98,7 +98,7 @@ p5.prototype.bezier = function() {
  * @param {Number} detail resolution of the curves
  * @chainable
  * @example
- * <div>
+ * <div modernizr='webgl'>
  * <code>
  * function setup() {
  *   createCanvas(100, 100, WEBGL);
@@ -364,7 +364,7 @@ p5.prototype.curve = function() {
  * @param {Number} resolution of the curves
  * @chainable
  * @example
- * <div>
+ * <div modernizr='webgl'>
  * <code>
  * function setup() {
  *   createCanvas(100, 100, WEBGL);

--- a/src/core/curves.js
+++ b/src/core/curves.js
@@ -103,13 +103,12 @@ p5.prototype.bezier = function() {
  * function setup() {
  *   createCanvas(100, 100, WEBGL);
  *   noFill();
+ *
+ *   bezierDetail(5);
  * }
  *
  * function draw() {
  *   background(200);
- *
- *   // a triangle-wave function
- *   bezierDetail(2 + abs(15 - floor(millis() / 150) % 30));
  *
  *   // prettier-ignore
  *   bezier(-40, -40, 0,
@@ -121,7 +120,7 @@ p5.prototype.bezier = function() {
  * </div>
  *
  * @alt
- * stretched black s-shape with varying bezier detail
+ * stretched black s-shape with a low level of bezier detail
  *
  */
 p5.prototype.bezierDetail = function(d) {
@@ -368,12 +367,11 @@ p5.prototype.curve = function() {
  * <code>
  * function setup() {
  *   createCanvas(100, 100, WEBGL);
+ *
+ *   curveDetail(5);
  * }
  * function draw() {
  *   background(200);
- *
- *   // a triangle-wave function
- *   curveDetail(2 + abs(15 - floor(millis() / 150) % 30));
  *
  *   // prettier-ignore
  *   curve( 250, 600, 0,
@@ -385,7 +383,7 @@ p5.prototype.curve = function() {
  * </div>
  *
  * @alt
- * white arch shape with varying levels of curve detail.
+ * white arch shape with a low level of curve detail.
  *
  */
 p5.prototype.curveDetail = function(d) {


### PR DESCRIPTION
this fixes the `bezierDetail` & `curveDetail` reference examples so they actually make use of those properties, and updates them to clearly illustrate the effect of changing the properties.

fixes #2691 (kinda)