### PR TITLE
updated preload() reference documentation

### DIFF
--- a/src/core/core.js
+++ b/src/core/core.js
@@ -51,7 +51,10 @@ var p5 = function(sketch, node, sync) {
    * asynchronous loading of external files in a blocking way. If a preload 
    * function is defined, setup() will wait until any load calls within have
    * finished. Nothing besides load calls (loadImage, loadJSON, loadFont,
-   * loadStrings, etc.) should be inside preload function.<br><br>
+   * loadStrings, etc.) should be inside preload function. If asynchronous
+   * loading is prederred, the load methods can instead be called in setup()
+   * or anywhere else with the use of a callback parameter.
+   * <br><br>
    * By default the text "loading..." will be displayed. To make your own
    * loading page, include an HTML element with id "p5_loading" in your
    * page. More information <a href="http://bit.ly/2kQ6Nio">here</a>.

--- a/src/core/core.js
+++ b/src/core/core.js
@@ -52,7 +52,7 @@ var p5 = function(sketch, node, sync) {
    * function is defined, setup() will wait until any load calls within have
    * finished. Nothing besides load calls (loadImage, loadJSON, loadFont,
    * loadStrings, etc.) should be inside preload function. If asynchronous
-   * loading is prederred, the load methods can instead be called in setup()
+   * loading is preferred, the load methods can instead be called in setup()
    * or anywhere else with the use of a callback parameter.
    * <br><br>
    * By default the text "loading..." will be displayed. To make your own

--- a/src/core/core.js
+++ b/src/core/core.js
@@ -48,10 +48,10 @@ var p5 = function(sketch, node, sync) {
 
   /**
    * Called directly before setup(), the preload() function is used to handle
-   * asynchronous loading of external files. If a preload function is
-   * defined, setup() will wait until any load calls within have finished.
-   * Nothing besides load calls should be inside preload (loadImage,
-   * loadJSON, loadFont, loadStrings, etc).<br><br>
+   * asynchronous loading of external files in a blocking way. If a preload 
+   * function is defined, setup() will wait until any load calls within have
+   * finished. Nothing besides load calls (loadImage, loadJSON, loadFont,
+   * loadStrings, etc.) should be inside preload function.<br><br>
    * By default the text "loading..." will be displayed. To make your own
    * loading page, include an HTML element with id "p5_loading" in your
    * page. More information <a href="http://bit.ly/2kQ6Nio">here</a>.


### PR DESCRIPTION
updated preload() reference documentation to contain explanation of its blocking nature and usage.
let me know if there is more that you want to add - i think the original already contained a lot of useful information already.