### PR TITLE
patch grunt-mocha to fix 'test.titlePath' errors on test failure

### DIFF
--- a/package.json
+++ b/package.json
@@ -90,6 +90,8 @@
     "lint-staged": "^4.3.0",
     "marked": "^0.3.9",
     "opentype.js": "^0.7.3",
+    "patch-package": "^5.1.1",
+    "postinstall-prepare": "^1.0.1",
     "prettier": "^1.7.4",
     "request": "^2.81.0",
     "whatwg-fetch": "^2.0.3",

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "lint:fix": "grunt lint-fix",
     "add": "all-contributors add",
     "generate": "all-contributors generate",
+    "prepare": "patch-package",
     "precommit": "lint-staged"
   },
   "lint-staged": {

--- a/patches/grunt-mocha+1.0.4.patch
+++ b/patches/grunt-mocha+1.0.4.patch
@@ -1,0 +1,51 @@
+patch-package
+--- a/node_modules/grunt-mocha/phantomjs/bridge.js
++++ b/node_modules/grunt-mocha/phantomjs/bridge.js
+@@ -40,6 +40,7 @@
+ 
+       if (test) {
+         data.title = test.title;
++        data.titlePath = test.titlePath();
+         data.fullTitle = test.fullTitle();
+         data.state = test.state;
+         data.duration = test.duration;
+--- a/node_modules/grunt-mocha/tasks/mocha.js
++++ b/node_modules/grunt-mocha/tasks/mocha.js
+@@ -30,13 +30,15 @@ module.exports = function(grunt) {
+   var reporter;
+ 
+   // Growl is optional
+-  var growl;
++  var growl = function(){};
++  /*
+   try {
+     growl = require('growl');
+   } catch(e) {
+     growl = function(){};
+     grunt.verbose.write('Growl not found, \'npm install growl\' for Growl support');
+   }
++  */
+ 
+   // Get an asset file, local to the root of the project.
+   var asset = path.join.bind(null, __dirname, '..');
+@@ -48,7 +50,7 @@ module.exports = function(grunt) {
+ 
+     // Hook on Phantomjs Mocha reporter events.
+     phantomjs.on('mocha.*', function(test) {
+-      var name, fullTitle, slow, err;
++      var name, titlePath, fullTitle, slow, err;
+       var evt = this.event.replace('mocha.', '');
+ 
+       if (evt === 'end') {
+@@ -57,6 +59,11 @@ module.exports = function(grunt) {
+ 
+       // Expand test values (and façace the Mocha test object)
+       if (test) {
++        titlePath = test.titlePath;
++        test.titlePath = function() {
++          return titlePath;
++        };
++
+         fullTitle = test.fullTitle;
+         test.fullTitle = function() {
+           return fullTitle;


### PR DESCRIPTION
re: #2648, #2746, https://github.com/disqus/grunt-mocha/issues/6, https://github.com/disqus/grunt-mocha/pull/7, 

this PR patches the grunt-mocha package with fixes so that test failures will now display the actual failure information instead of some internal `test.titlePath is not a function` error.

