### PR TITLE
Replicating PR #188 from p5.js-website repo - add reference topic to page title

### DIFF
--- a/docs/yuidoc-p5-theme-src/scripts/views/itemView.js
+++ b/docs/yuidoc-p5-theme-src/scripts/views/itemView.js
@@ -106,6 +106,15 @@ define([
 
         renderCode();
 
+        // Set the document title based on the item name.
+        // If it is a method, add parentheses to the name
+        if (item.itemtype === "method"){
+            App.pageView.appendToDocumentTitle(item.name + "()");
+        }
+        else {
+            App.pageView.appendToDocumentTitle(item.name);
+        }
+
         // Hook up alt-text for examples
         setTimeout(function() {
           var alts = $('.example-content')[0];

--- a/docs/yuidoc-p5-theme-src/scripts/views/pageView.js
+++ b/docs/yuidoc-p5-theme-src/scripts/views/pageView.js
@@ -9,6 +9,9 @@ define([
   'libraryView'
 ], function(App, searchView, listView, itemView, menuView, libraryView) {
 
+  // Store the original title parts so we can substitue different endings.
+  var _originalDocumentTitle = window.document.title;
+
   var pageView = Backbone.View.extend({
     el: 'body',
     /**
@@ -72,7 +75,19 @@ define([
       });
 
       return this;
-    }
+    },
+    /**
+     * Append the supplied name to the first part of original document title.
+     * If no name is supplied, the title will reset to the original one.
+     */
+    appendToDocumentTitle: function(name){
+      if(name){
+        let firstTitlePart = _originalDocumentTitle.split(" | ")[0];
+        window.document.title = [firstTitlePart, name].join(" | ");
+      } else {
+        window.document.title = _originalDocumentTitle;
+      }
+    }    
   });
 
   return pageView;


### PR DESCRIPTION
Use javascript to update the document title on reference pages to reflect the current topic being browsed. 

![image](https://user-images.githubusercontent.com/92529/38789769-d76f1102-417f-11e8-970a-6b30ec75373b.png)

This was originally submitted as a PR to the p5.js-website repo [PR 188](https://github.com/processing/p5.js-website/pull/188), but I realise that it would be better to submit it here, because these are the ultimate source of the reference page files.

The original pull request has more info, as does the original issue from the p5.js-website repo [issue 38](https://github.com/processing/p5.js-website/issues/38)