### PR TITLE
Changed createCapture() documentation and example

### DIFF
--- a/lib/addons/p5.dom.js
+++ b/lib/addons/p5.dom.js
@@ -1046,8 +1046,10 @@
   }
 
   /**
-   * <p>Creates a new &lt;video&gt; element that contains the audio/video feed
-   * from a webcam. This can be drawn onto the canvas using video().</p>
+   * <p>Creates a new HTML5 &lt;video&gt; element that contains the audio/video
+   * feed from a webcam. The element is separate from the canvas and is
+   * displayed by default. The element can be hidden using .hide(). The feed
+   * can be drawn onto the canvas using image().</p>
    * <p>More specific properties of the feed can be passing in a Constraints object.
    * See the
    * <a href='http://w3c.github.io/mediacapture-main/getusermedia.html#media-track-constraints'> W3C
@@ -1070,8 +1072,8 @@
    * var capture;
    *
    * function setup() {
-   *   createCanvas(480, 120);
-   *   capture = createCapture(VIDEO);
+   *   createCanvas(480, 480);
+   *   capture = createCapture(VIDEO).hide();
    * }
    *
    * function draw() {

--- a/lib/addons/p5.dom.js
+++ b/lib/addons/p5.dom.js
@@ -1073,7 +1073,8 @@
    *
    * function setup() {
    *   createCanvas(480, 480);
-   *   capture = createCapture(VIDEO).hide();
+   *   capture = createCapture(VIDEO);
+   *   capture.hide();
    * }
    *
    * function draw() {


### PR DESCRIPTION
The docs for createCapture() referenced the non-existent method video(). Corrected the description and updated the example.