### PR TITLE
fix validating parameter-less methods

### DIFF
--- a/src/core/error_helpers.js
+++ b/src/core/error_helpers.js
@@ -169,7 +169,7 @@ if (typeof IS_MINIFIED !== 'undefined') {
         overloads.push(queryResult[0].overloads[i].params);
       }
     } else {
-      overloads.push(queryResult[0].params);
+      overloads.push(queryResult[0].params || []);
     }
 
     var mapConstants = {};


### PR DESCRIPTION
prevents a crash when calling `_validateParameters` for methods with no parameters or overloads.