### PR TITLE
docs: fix `orbitControl` entry location

### DIFF
--- a/src/webgl/interaction.js
+++ b/src/webgl/interaction.js
@@ -1,3 +1,9 @@
+/**
+ * @module Lights, Camera
+ * @submodule Camera
+ * @for p5
+ * @requires core
+ */
 'use strict';
 
 var p5 = require('../core/core');


### PR DESCRIPTION
moves the `orbitControl()` reference entry to the 'Camera' section. previously it didn't belong to _any_ section.