### PR TITLE
fix yui task

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -215,7 +215,13 @@ module.exports = function(grunt) {
           'src/**/*.frag',
           'src/**/*.vert'
         ],
-        tasks: ['browserify', 'yuidoc:prod', 'minjson', 'uglify'],
+        tasks: [
+          'browserify',
+          'browserify:min',
+          'yuidoc:prod',
+          'minjson',
+          'uglify'
+        ],
         options: {
           livereload: true
         }


### PR DESCRIPTION
when running `grunt docs:dev`, the watch task doesn't rebuild the minified library so the 'test-minified' unit test always runs with stale code. this just add the `browserify:min` task to the `watch:yui` task, so the minified library gets built.