### PR TITLE
Fixed Documentation for createCanvas()

### DIFF
--- a/src/core/rendering.js
+++ b/src/core/rendering.js
@@ -33,7 +33,7 @@ var defaultClass = 'p5Canvas';
  * @param  {Number} w width of the canvas
  * @param  {Number} h height of the canvas
  * @param  {Constant} [renderer] either P2D or WEBGL
- * @return {HTMLCanvasElement} canvas generated
+ * @return {p5.Renderer} object 
  * @example
  * <div>
  * <code>


### PR DESCRIPTION
Fix to the issue referenced in #2817 

Changed text to read:
@return {p5.Renderer} object 
for the createCanvas() function