### PR TITLE
Disallow es6 in library/sample code

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -135,6 +135,11 @@ module.exports = function(grunt) {
         }
       },
       source: {
+        options: {
+          parserOptions: {
+            ecmaVersion: 5
+          }
+        },
         src: ['src/**/*.js', 'lib/addons/p5.dom.js']
       },
       test: {
@@ -159,6 +164,9 @@ module.exports = function(grunt) {
 
     'eslint-samples': {
       options: {
+        parserOptions: {
+          ecmaVersion: 5
+        },
         configFile: '.eslintrc',
         format: 'unix'
       },

--- a/src/io/p5.Table.js
+++ b/src/io/p5.Table.js
@@ -428,7 +428,7 @@ p5.Table.prototype.findRows = function(value, column) {
  *
  * function setup() {
  *   //Search using specified regex on a given column, return TableRow object
- *   const mammal = table.matchRow(new RegExp('ant'), 1);
+ *   var mammal = table.matchRow(new RegExp('ant'), 1);
  *   print(mammal.getString(1));
  *   //Output "Panthera pardus"
  * }


### PR DESCRIPTION
closes #2825 

changes the linter settings to disallow ES6-isms for now.