### PR TITLE
fix typo

### DIFF
--- a/docs/yuidoc-p5-theme/layouts/main.handlebars
+++ b/docs/yuidoc-p5-theme/layouts/main.handlebars
@@ -24,7 +24,7 @@
     <script type="text/javascript" src="https://p5js.org/assets/js/scroll.js"></script>
     <script type="text/javascript" src="https://p5js.org/assets/js/init.js"></script>
     <link rel="shortcut icon" href="{{projectAssets}}/favicon.ico">
-    <link rel="icon" href="{{projectAssents}}/favicon.ico">
+    <link rel="icon" href="{{projectAssets}}/favicon.ico">
 
   </head>
 


### PR DESCRIPTION
delete extra 'n'

`<link rel="icon" href="{{projectAssents}}/favicon.ico">`
to 
`<link rel="icon" href="{{projectAssets}}/favicon.ico">`