### PR TITLE
Improve the camera example code

### DIFF
--- a/src/webgl/camera.js
+++ b/src/webgl/camera.js
@@ -35,15 +35,16 @@ var p5 = require('../core/core');
  *   createCanvas(100, 100, WEBGL);
  * }
  * function draw() {
+ *   background(204);
  *   //move the camera away from the plane by a sin wave
- *   camera(0, 0, sin(frameCount * 0.01) * 100, 0, 0, 0, 0, 1, 0);
- *   plane(120, 120);
+ *   camera(0, 0, 20 + sin(frameCount * 0.01) * 10, 0, 0, 0, 0, 1, 0);
+ *   plane(10, 10);
  * }
  * </code>
  * </div>
  *
  * @alt
- * blue square shrinks in size grows to fill canvas. disappears then loops.
+ * White square repeatedly grows to fill canvas and then shrinks.
  *
  */
 p5.prototype.camera = function() {


### PR DESCRIPTION
Improves the example code for the `camera()` function as shown on the reference page as described in issue #2828

The previous example drew a plane that completely filled the canvas, so even though the camera was moving back and forth, this wasn’t visible. All you could see was white. This change:
1. Draws the plane smaller (10x10)
2. Moves the camera less (20 +- 10) so the plane always stays visible
3. Sets the background colour to 204 so the plane is more visible.
4. Adjust the alt text to be more accurate.