### PR TITLE
Optimize get/loadPixels

### DIFF
--- a/lib/addons/p5.dom.js
+++ b/lib/addons/p5.dom.js
@@ -1883,6 +1883,8 @@
     this._cues = [];
     this._pixelDensity = 1;
     this._modified = false;
+    this._pixelsDirty = true;
+    this._pixelsTime = -1; // the time at which we last updated 'pixels'
 
     /**
      * Path to the media element source.
@@ -2522,15 +2524,25 @@
         this.canvas.height = this.elt.height;
         this.width = this.canvas.width;
         this.height = this.canvas.height;
+        this._pixelsDirty = true;
       }
-      this.drawingContext.drawImage(
-        this.elt,
-        0,
-        0,
-        this.canvas.width,
-        this.canvas.height
-      );
-      p5.Renderer2D.prototype.loadPixels.call(this);
+
+      var currentTime = this.elt.currentTime;
+      if (this._pixelsDirty || this._pixelsTime !== currentTime) {
+        // only update the pixels array if it's dirty, or
+        // if the video time has changed.
+        this._pixelsTime = currentTime;
+        this._pixelsDirty = true;
+
+        this.drawingContext.drawImage(
+          this.elt,
+          0,
+          0,
+          this.canvas.width,
+          this.canvas.height
+        );
+        p5.Renderer2D.prototype.loadPixels.call(this);
+      }
     }
     this.setModified(true);
     return this;
@@ -2546,6 +2558,14 @@
   p5.MediaElement.prototype.get = function(x, y, w, h) {
     if (this.loadedmetadata) {
       // wait for metadata
+      var currentTime = this.elt.currentTime;
+      if (this._pixelsTime !== currentTime) {
+        // if the video has changed time, then force an
+        // update to the pixels array.
+        this._pixelsDirty = true;
+        this._pixelsTime = currentTime;
+      }
+
       return p5.Renderer2D.prototype.get.call(this, x, y, w, h);
     } else if (typeof x === 'undefined') {
       return new p5.Image(1, 1);

--- a/src/core/core.js
+++ b/src/core/core.js
@@ -579,6 +579,8 @@ p5.prototype._initializeInstanceVariables = function() {
     hsb: [360, 100, 100, 1],
     hsl: [360, 100, 100, 1]
   };
+
+  this._pixelsDirty = true;
 };
 
 // This is a pointer to our global mode p5 instance, if we're in

--- a/src/core/environment.js
+++ b/src/core/environment.js
@@ -526,8 +526,10 @@ p5.prototype.pixelDensity = function(val) {
   p5._validateParameters('pixelDensity', arguments);
   var returnValue;
   if (typeof val === 'number') {
-    this._pixelDensity = val;
-    this._pixelsDirty = false;
+    if (val !== this._pixelDensity) {
+      this._pixelDensity = val;
+      this._pixelsDirty = true;
+    }
     returnValue = this;
   } else {
     returnValue = this._pixelDensity;

--- a/src/core/environment.js
+++ b/src/core/environment.js
@@ -527,6 +527,7 @@ p5.prototype.pixelDensity = function(val) {
   var returnValue;
   if (typeof val === 'number') {
     this._pixelDensity = val;
+    this._pixelsDirty = false;
     returnValue = this;
   } else {
     returnValue = this._pixelDensity;

--- a/src/core/p5.Renderer2D.js
+++ b/src/core/p5.Renderer2D.js
@@ -61,6 +61,8 @@ p5.Renderer2D.prototype.background = function() {
     this._setFill(curFill);
   }
   this.drawingContext.restore();
+
+  this._pInst._pixelsDirty = true;
 };
 
 p5.Renderer2D.prototype.clear = function() {
@@ -68,6 +70,8 @@ p5.Renderer2D.prototype.clear = function() {
   this.resetMatrix();
   this.drawingContext.clearRect(0, 0, this.width, this.height);
   this.drawingContext.restore();
+
+  this._pInst._pixelsDirty = true;
 };
 
 p5.Renderer2D.prototype.fill = function() {
@@ -128,6 +132,8 @@ p5.Renderer2D.prototype.image = function(
       throw e;
     }
   }
+
+  this._pInst._pixelsDirty = true;
 };
 
 p5.Renderer2D.prototype._getTintedImageCanvas = function(img) {
@@ -203,6 +209,8 @@ p5.Renderer2D.prototype.copy = function() {
     throw new Error('Signature not supported');
   }
   p5.Renderer2D._copyHelper(this, srcImage, sx, sy, sw, sh, dx, dy, dw, dh);
+
+  this._pInst._pixelsDirty = true;
 };
 
 p5.Renderer2D._copyHelper = function(
@@ -233,29 +241,23 @@ p5.Renderer2D._copyHelper = function(
 };
 
 p5.Renderer2D.prototype.get = function(x, y, w, h) {
-  if (
-    x === undefined &&
-    y === undefined &&
-    w === undefined &&
-    h === undefined
-  ) {
-    x = 0;
-    y = 0;
-    w = this.width;
-    h = this.height;
-  } else if (w === undefined && h === undefined) {
-    w = 1;
-    h = 1;
+  if (typeof w === 'undefined' && typeof h === 'undefined') {
+    if (typeof x === 'undefined' && typeof y === 'undefined') {
+      x = y = 0;
+      w = this.width;
+      h = this.height;
+    } else {
+      w = h = 1;
+    }
   }
 
   // if the section does not overlap the canvas
-  if (x + w < 0 || y + h < 0 || x > this.width || y > this.height) {
+  if (x + w < 0 || y + h < 0 || x >= this.width || y >= this.height) {
+    // TODO: is this valid for w,h > 1 ?
     return [0, 0, 0, 255];
   }
 
   var ctx = this._pInst || this;
-  ctx.loadPixels();
-
   var pd = ctx._pixelDensity;
 
   // round down to get integer numbers
@@ -267,9 +269,20 @@ p5.Renderer2D.prototype.get = function(x, y, w, h) {
   var sx = x * pd;
   var sy = y * pd;
   if (w === 1 && h === 1 && !(this instanceof p5.RendererGL)) {
-    var imageData = this.drawingContext.getImageData(sx, sy, 1, 1).data;
-    //imageData = [0,0,0,0];
-    return [imageData[0], imageData[1], imageData[2], imageData[3]];
+    var imageData, index;
+    if (ctx._pixelsDirty) {
+      imageData = this.drawingContext.getImageData(sx, sy, 1, 1).data;
+      index = 0;
+    } else {
+      imageData = ctx.pixels;
+      index = (sx + sy * this.width * pd) * 4;
+    }
+    return [
+      imageData[index + 0],
+      imageData[index + 1],
+      imageData[index + 2],
+      imageData[index + 3]
+    ];
   } else {
     //auto constrain the width and height to
     //dimensions of the source image
@@ -289,6 +302,9 @@ p5.Renderer2D.prototype.get = function(x, y, w, h) {
 
 p5.Renderer2D.prototype.loadPixels = function() {
   var ctx = this._pInst || this; // if called by p5.Image
+  if (!ctx._pixelsDirty) return;
+  ctx._pixelsDirty = false;
+
   var pd = ctx._pixelDensity;
   var w = this.width * pd;
   var h = this.height * pd;
@@ -309,8 +325,8 @@ p5.Renderer2D.prototype.set = function(x, y, imgOrCol) {
     this.drawingContext.setTransform(1, 0, 0, 1, 0, 0);
     this.drawingContext.scale(ctx._pixelDensity, ctx._pixelDensity);
     this.drawingContext.drawImage(imgOrCol.canvas, x, y);
-    this.loadPixels.call(ctx);
     this.drawingContext.restore();
+    ctx._pixelsDirty = true;
   } else {
     var r = 0,
       g = 0,
@@ -320,7 +336,7 @@ p5.Renderer2D.prototype.set = function(x, y, imgOrCol) {
       4 *
       (y * ctx._pixelDensity * (this.width * ctx._pixelDensity) +
         x * ctx._pixelDensity);
-    if (!ctx.imageData) {
+    if (!ctx.imageData || ctx._pixelsDirty) {
       ctx.loadPixels.call(ctx);
     }
     if (typeof imgOrCol === 'number') {
@@ -386,6 +402,10 @@ p5.Renderer2D.prototype.updatePixels = function(x, y, w, h) {
   h *= pd;
 
   this.drawingContext.putImageData(ctx.imageData, x, y, 0, 0, w, h);
+
+  if (x !== 0 || y !== 0 || w !== this.width || h !== this.height) {
+    ctx._pixelsDirty = true;
+  }
 };
 
 //////////////////////////////////////////////
@@ -977,6 +997,8 @@ p5.Renderer2D.prototype.endShape = function(
   if (closeShape) {
     vertices.pop();
   }
+
+  this._pInst._pixelsDirty = true;
   return this;
 };
 //////////////////////////////////////////////
@@ -1090,6 +1112,8 @@ p5.Renderer2D.prototype._doFillStrokeClose = function() {
     this.drawingContext.stroke();
   }
   this.drawingContext.closePath();
+
+  this._pInst._pixelsDirty = true;
 };
 
 //////////////////////////////////////////////
@@ -1296,6 +1320,7 @@ p5.Renderer2D.prototype._renderText = function(p, line, x, y, maxY) {
 
   p.pop();
 
+  this._pInst._pixelsDirty = true;
   return p;
 };
 

--- a/src/image/p5.Image.js
+++ b/src/image/p5.Image.js
@@ -148,6 +148,7 @@ p5.Image = function(width, height) {
   this._pixelDensity = 1;
   //used for webgl texturing only
   this._modified = false;
+  this._pixelsDirty = true;
   /**
    * Array containing the values for all the pixels in the display window.
    * These values are numbers. This array is the size (include an appropriate
@@ -476,6 +477,7 @@ p5.Image.prototype.resize = function(width, height) {
   }
 
   this.setModified(true);
+  this._pixelsDirty = true;
 };
 
 /**
@@ -556,6 +558,7 @@ p5.Image.prototype.copy = function() {
     throw new Error('Signature not supported');
   }
   p5.Renderer2D._copyHelper(this, srcImage, sx, sy, sw, sh, dx, dy, dw, dh);
+  this._pixelsDirty = true;
 };
 
 /**

--- a/src/webgl/p5.RendererGL.Immediate.js
+++ b/src/webgl/p5.RendererGL.Immediate.js
@@ -267,6 +267,8 @@ p5.RendererGL.prototype._drawFillImmediateMode = function(
       0,
       this.immediateMode.vertices.length
     );
+
+    this._pInst._pixelsDirty = true;
   }
   // todo / optimizations? leave bound until another shader is set?
   this.curFillShader.unbindShader();
@@ -320,6 +322,8 @@ p5.RendererGL.prototype._drawStrokeImmediateMode = function() {
 
   // todo / optimizations? leave bound until another shader is set?
   this.curStrokeShader.unbindShader();
+
+  this._pInst._pixelsDirty = true;
 };
 
 module.exports = p5.RendererGL;

--- a/src/webgl/p5.RendererGL.Retained.js
+++ b/src/webgl/p5.RendererGL.Retained.js
@@ -322,6 +322,7 @@ p5.RendererGL.prototype.drawBuffersScaled = function(
 
 p5.RendererGL.prototype._drawArrays = function(drawMode, gId) {
   this.GL.drawArrays(drawMode, 0, this.gHash[gId].lineVertexCount);
+  this._pInst._pixelsDirty = true;
   return this;
 };
 
@@ -332,6 +333,7 @@ p5.RendererGL.prototype._drawElements = function(drawMode, gId) {
     this.GL.UNSIGNED_SHORT,
     0
   );
+  this._pInst._pixelsDirty = true;
 };
 
 module.exports = p5.RendererGL;

--- a/test/manual-test-examples/p5.Image/loadPixels.html
+++ b/test/manual-test-examples/p5.Image/loadPixels.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<html>
+
+<head>
+  <meta charset="utf-8">
+  <meta http-equiv="X-UA-Compatible" content="IE=edge">
+  <title></title>
+  <link rel="stylesheet" href="../styles.css">
+
+  <script language="javascript" src="../../../lib/p5.js"></script>
+  <script language="javascript" src="../../../lib/addons/p5.dom.js"></script>
+  <!-- uncomment lines below to include extra p5 libraries -->
+  <!--<script language="javascript" src="../addons/p5.dom.js"></script>-->
+  <!--<script language="javascript" src="../addons/p5.sound.js"></script>-->
+  <script language="javascript" type="text/javascript" src="loadPixels.js"></script>
+  <script src="../webgl/stats.js"></script>
+</head>
+
+<body>
+  <header>
+    <p>loadPixels Example</p>
+  </header>
+</body>
+
+</html>

--- a/test/manual-test-examples/p5.Image/loadPixels.js
+++ b/test/manual-test-examples/p5.Image/loadPixels.js
@@ -1,0 +1,32 @@
+p5.disableFriendlyErrors = true;
+
+var img;
+function preload() {
+  img = createVideo('../addons/p5.dom/fingers.mov');
+  img.loop();
+  img.hide();
+}
+
+function setup() {
+  // put setup code here
+  createCanvas(windowWidth, windowHeight);
+  background(0);
+  noStroke();
+  rectMode(CENTER);
+
+  translate((width - img.width) / 2, (height - img.height) / 2);
+}
+
+function draw() {
+  translate((width - img.width) / 2, (height - img.height) / 2);
+
+  img.loadPixels();
+
+  for (var i = 0; i < 3000; i++) {
+    var px = random(img.width);
+    var py = random(img.height);
+
+    fill(img.get(px, py));
+    ellipse(px, py, 3, 3);
+  }
+}


### PR DESCRIPTION
closes #2832 

this adds a `_pixelsDirty` flag to the p5 instance/Image/MediaElement that tracks if `loadPixels` needs to actually do anything. `get()` is updated to use `pixels[]` if it's not dirty. the upshot of this is that you can call `loadPixels()` once followed by many fast calls to `get()`. Existing behavior is preserved wrt. calling `get()` without `loadPixels()` (for large images on mobile browsers) and calling `get()` to retrieve sub-images.

adds a manual test example demonstrating calling `get()` on a video element. (running this on 0.6.1 will hang the browser).