### PR TITLE
add missing createImg overload

### DIFF
--- a/lib/addons/p5.dom.js
+++ b/lib/addons/p5.dom.js
@@ -321,6 +321,12 @@
    * createImg('http://p5js.org/img/asterisk-01.png');
    * </code></div>
    */
+  /**
+   * @method createImg
+   * @param  {String} src
+   * @param  {Function} successCallback
+   * @return {Object|p5.Element}
+   */
   p5.prototype.createImg = function() {
     p5._validateParameters('createImg', arguments);
     var elt = document.createElement('img');


### PR DESCRIPTION
this adds the missing `createImg(src,successCallback)` overload.