### PR TITLE
add support for validating parameters of methods of non-p5 classes

### DIFF
--- a/lib/addons/p5.dom.js
+++ b/lib/addons/p5.dom.js
@@ -21,7 +21,7 @@
  *
  * @module p5.dom
  * @submodule p5.dom
- * @for p5.dom
+ * @for p5
  * @main
  */
 

--- a/src/core/error_helpers.js
+++ b/src/core/error_helpers.js
@@ -159,8 +159,11 @@ if (typeof IS_MINIFIED !== 'undefined') {
   // validateParameters() helper functions:
   // lookupParamDoc() for querying data.json
   var lookupParamDoc = function(func) {
+    var ichDot = func.lastIndexOf('.');
+    var funcName = func.substr(ichDot + 1);
+    var funcClass = func.substr(0, ichDot) || 'p5';
     var queryResult = arrDoc.classitems.filter(function(x) {
-      return x.name === func;
+      return x.name === funcName && x.class === funcClass;
     });
     // different JSON structure for funct with multi-format
     var overloads = [];


### PR DESCRIPTION
re: #2848

this makes it possible to specify the class name when validating parameters, eg: `p5._validateParameters('p5.Element.size', arguments);`

if no class name is specified, then `p5` is assumed.