### PR TITLE
add validation for non-p5 classes

### DIFF
--- a/lib/addons/p5.dom.js
+++ b/lib/addons/p5.dom.js
@@ -1211,6 +1211,7 @@
    * </code></div>
    */
   p5.Element.prototype.addClass = function(c) {
+    p5._validateParameters('p5.Element.addClass', arguments);
     if (this.elt.className) {
       // PEND don't add class more than once
       //var regex = new RegExp('[^a-zA-Z\d:]?'+c+'[^a-zA-Z\d:]?');
@@ -1249,6 +1250,7 @@
    * </code></div>
    */
   p5.Element.prototype.removeClass = function(c) {
+    p5._validateParameters('p5.Element.removeClass', arguments);
     var regex = new RegExp('(?:^|\\s)' + c + '(?!\\S)');
     this.elt.className = this.elt.className.replace(regex, '');
     this.elt.className = this.elt.className.replace(/^\s+|\s+$/g, ''); //prettify (optional)
@@ -1288,6 +1290,7 @@
    * @chainable
    */
   p5.Element.prototype.child = function(c) {
+    p5._validateParameters('p5.Element.child', arguments);
     if (typeof c === 'undefined') {
       return this.elt.childNodes;
     }
@@ -1323,6 +1326,7 @@
    * </code></div>
    */
   p5.Element.prototype.center = function(align) {
+    p5._validateParameters('p5.Element.center', arguments);
     var style = this.elt.style.display;
     var hidden = this.elt.style.display === 'none';
     var parentHidden = this.parent().style.display === 'none';
@@ -1385,6 +1389,7 @@
    * @chainable
    */
   p5.Element.prototype.html = function() {
+    p5._validateParameters('p5.Element.html', arguments);
     if (arguments.length === 0) {
       return this.elt.innerHTML;
     } else if (arguments[1]) {
@@ -1422,6 +1427,7 @@
    * @chainable
    */
   p5.Element.prototype.position = function() {
+    p5._validateParameters('p5.Element.position', arguments);
     if (arguments.length === 0) {
       return { x: this.elt.offsetLeft, y: this.elt.offsetTop };
     } else {
@@ -1541,6 +1547,7 @@
    * @chainable
    */
   p5.Element.prototype.style = function(prop, val) {
+    p5._validateParameters('p5.Element.style', arguments);
     var self = this;
 
     if (val instanceof p5.Color) {
@@ -1613,6 +1620,7 @@
    * @chainable
    */
   p5.Element.prototype.attribute = function(attr, value) {
+    p5._validateParameters('p5.Element.attribute', arguments);
     //handling for checkboxes and radios to ensure options get
     //attributes not divs
     if (
@@ -1667,6 +1675,7 @@
    * </code></div>
    */
   p5.Element.prototype.removeAttribute = function(attr) {
+    p5._validateParameters('p5.Element.removeAttribute', arguments);
     if (
       this.elt.firstChild != null &&
       (this.elt.firstChild.type === 'checkbox' ||
@@ -1716,6 +1725,7 @@
    * @chainable
    */
   p5.Element.prototype.value = function() {
+    p5._validateParameters('p5.Element.value', arguments);
     if (arguments.length > 0) {
       this.elt.value = arguments[0];
       return this;
@@ -1740,6 +1750,7 @@
    * </code></div>
    */
   p5.Element.prototype.show = function() {
+    p5._validateParameters('p5.Element.show', arguments);
     this.elt.style.display = 'block';
     return this;
   };
@@ -1756,6 +1767,7 @@
    * </code></div>
    */
   p5.Element.prototype.hide = function() {
+    p5._validateParameters('p5.Element.hide', arguments);
     this.elt.style.display = 'none';
     return this;
   };
@@ -1781,6 +1793,7 @@
    * @chainable
    */
   p5.Element.prototype.size = function(w, h) {
+    p5._validateParameters('p5.Element.size', arguments);
     if (arguments.length === 0) {
       return { width: this.elt.offsetWidth, height: this.elt.offsetHeight };
     } else {
@@ -1848,6 +1861,7 @@
    * </code></div>
    */
   p5.Element.prototype.remove = function() {
+    p5._validateParameters('p5.Element.remove', arguments);
     // deregister events
     for (var ev in this._events) {
       this.elt.removeEventListener(ev, this._events[ev]);
@@ -1989,6 +2003,7 @@
    * </code></div>
    */
   p5.MediaElement.prototype.play = function() {
+    p5._validateParameters('p5.MediaElement.play', arguments);
     if (this.elt.currentTime === this.elt.duration) {
       this.elt.currentTime = 0;
     }
@@ -2062,6 +2077,7 @@
    * </code></div>
    */
   p5.MediaElement.prototype.stop = function() {
+    p5._validateParameters('p5.MediaElement.stop', arguments);
     this.elt.pause();
     this.elt.currentTime = 0;
     return this;
@@ -2125,6 +2141,7 @@
    * </code></div>
    */
   p5.MediaElement.prototype.pause = function() {
+    p5._validateParameters('p5.MediaElement.pause', arguments);
     this.elt.pause();
     return this;
   };
@@ -2181,6 +2198,7 @@
    * </code></div>
    */
   p5.MediaElement.prototype.loop = function() {
+    p5._validateParameters('p5.MediaElement.loop', arguments);
     this.elt.setAttribute('loop', true);
     this.play();
     return this;
@@ -2233,6 +2251,7 @@
    *
    */
   p5.MediaElement.prototype.noLoop = function() {
+    p5._validateParameters('p5.MediaElement.noLoop', arguments);
     this.elt.setAttribute('loop', false);
     return this;
   };
@@ -2245,6 +2264,7 @@
    * @chainable
    */
   p5.MediaElement.prototype.autoplay = function(val) {
+    p5._validateParameters('p5.MediaElement.autoplay', arguments);
     this.elt.setAttribute('autoplay', val);
     return this;
   };
@@ -2328,6 +2348,7 @@
    * @chainable
    */
   p5.MediaElement.prototype.volume = function(val) {
+    p5._validateParameters('p5.MediaElement.volume', arguments);
     if (typeof val === 'undefined') {
       return this.elt.volume;
     } else {
@@ -2412,6 +2433,7 @@
    * @chainable
    */
   p5.MediaElement.prototype.speed = function(val) {
+    p5._validateParameters('p5.MediaElement.speed', arguments);
     if (typeof val === 'undefined') {
       return this.elt.playbackRate;
     } else {
@@ -2470,6 +2492,7 @@
    * @chainable
    */
   p5.MediaElement.prototype.time = function(val) {
+    p5._validateParameters('p5.MediaElement.time', arguments);
     if (typeof val === 'undefined') {
       return this.elt.currentTime;
     } else {
@@ -2507,6 +2530,7 @@
    * </code></div>
    */
   p5.MediaElement.prototype.duration = function() {
+    p5._validateParameters('p5.MediaElement.duration', arguments);
     return this.elt.duration;
   };
   p5.MediaElement.prototype.pixels = [];
@@ -2623,6 +2647,7 @@
    * </code></div>
    */
   p5.MediaElement.prototype.onended = function(callback) {
+    p5._validateParameters('p5.MediaElement.onended', arguments);
     this._onended = callback;
     return this;
   };
@@ -2642,6 +2667,7 @@
    * or an object from the p5.sound library
    */
   p5.MediaElement.prototype.connect = function(obj) {
+    p5._validateParameters('p5.MediaElement.connect', arguments);
     var audioContext, masterOutput;
 
     // if p5.sound exists, same audio context
@@ -2686,6 +2712,7 @@
    * @method  disconnect
    */
   p5.MediaElement.prototype.disconnect = function() {
+    p5._validateParameters('p5.MediaElement.disconnect', arguments);
     if (this.audioSourceNode) {
       this.audioSourceNode.disconnect();
     } else {
@@ -2721,6 +2748,7 @@
    * </code></div>
    */
   p5.MediaElement.prototype.showControls = function() {
+    p5._validateParameters('p5.MediaElement.showControls', arguments);
     // must set style for the element to show on the page
     this.elt.style['text-align'] = 'inherit';
     this.elt.controls = true;
@@ -2752,6 +2780,7 @@
    * </code></div>
    */
   p5.MediaElement.prototype.hideControls = function() {
+    p5._validateParameters('p5.MediaElement.hideControls', arguments);
     this.elt.controls = false;
   };
 
@@ -2816,6 +2845,7 @@
    * </code></div>
    */
   p5.MediaElement.prototype.addCue = function(time, callback, val) {
+    p5._validateParameters('p5.MediaElement.addCue', arguments);
     var id = this._cueIDCounter++;
 
     var cue = new Cue(callback, time, id, val);
@@ -2858,6 +2888,7 @@
    * </code></div>
    */
   p5.MediaElement.prototype.removeCue = function(id) {
+    p5._validateParameters('p5.MediaElement.removeCue', arguments);
     for (var i = 0; i < this._cues.length; i++) {
       if (this._cues[i].id === id) {
         console.log(id);
@@ -2905,6 +2936,7 @@
    * </code></div>
    */
   p5.MediaElement.prototype.clearCues = function() {
+    p5._validateParameters('p5.MediaElement.clearCues', arguments);
     this._cues = [];
     this.elt.ontimeupdate = null;
   };

--- a/src/color/p5.Color.js
+++ b/src/color/p5.Color.js
@@ -84,6 +84,8 @@ p5.Color = function(pInst, vals) {
  * canvas with text representation of color
  */
 p5.Color.prototype.toString = function(format) {
+  p5._validateParameters('p5.Color.toString', arguments);
+
   if (!this.hsba) this.hsba = color_conversion._rgbaToHSBA(this._array);
   if (!this.hsla) this.hsla = color_conversion._rgbaToHSLA(this._array);
 
@@ -268,6 +270,7 @@ p5.Color.prototype.toString = function(format) {
  * canvas with gradually changing background color
  */
 p5.Color.prototype.setRed = function(new_red) {
+  p5._validateParameters('p5.Color.setRed', arguments);
   this._array[0] = new_red / this.maxes[constants.RGB][0];
   this._calculateLevels();
 };
@@ -295,6 +298,7 @@ p5.Color.prototype.setRed = function(new_red) {
  * canvas with gradually changing background color
  **/
 p5.Color.prototype.setGreen = function(new_green) {
+  p5._validateParameters('p5.Color.setGreen', arguments);
   this._array[1] = new_green / this.maxes[constants.RGB][1];
   this._calculateLevels();
 };
@@ -322,6 +326,7 @@ p5.Color.prototype.setGreen = function(new_green) {
  * canvas with gradually changing background color
  **/
 p5.Color.prototype.setBlue = function(new_blue) {
+  p5._validateParameters('p5.Color.setBlue', arguments);
   this._array[2] = new_blue / this.maxes[constants.RGB][2];
   this._calculateLevels();
 };
@@ -359,6 +364,7 @@ p5.Color.prototype.setBlue = function(new_blue) {
  * circle behind a square with gradually changing opacity
  **/
 p5.Color.prototype.setAlpha = function(new_alpha) {
+  p5._validateParameters('p5.Color.setAlpha', arguments);
   this._array[3] = new_alpha / this.maxes[this.mode][3];
   this._calculateLevels();
 };

--- a/src/core/p5.Element.js
+++ b/src/core/p5.Element.js
@@ -97,6 +97,7 @@ p5.Element = function(elt, pInst) {
  *
  */
 p5.Element.prototype.parent = function(p) {
+  p5._validateParameters('p5.Element.parent', arguments);
   if (typeof p === 'undefined') {
     return this.elt.parentNode;
   }
@@ -140,6 +141,7 @@ p5.Element.prototype.parent = function(p) {
  * @return {String} the id of the element
  */
 p5.Element.prototype.id = function(id) {
+  p5._validateParameters('p5.Element.id', arguments);
   if (typeof id === 'undefined') {
     return this.elt.id;
   }
@@ -177,6 +179,7 @@ p5.Element.prototype.id = function(id) {
  * @return {String} the class of the element
  */
 p5.Element.prototype.class = function(c) {
+  p5._validateParameters('p5.Element.class', arguments);
   if (typeof c === 'undefined') {
     return this.elt.className;
   }
@@ -230,6 +233,7 @@ p5.Element.prototype.class = function(c) {
  *
  */
 p5.Element.prototype.mousePressed = function(fxn) {
+  p5._validateParameters('p5.Element.mousePressed', arguments);
   adjustListener('mousedown', fxn, this);
   adjustListener('touchstart', fxn, this);
   return this;
@@ -280,6 +284,7 @@ p5.Element.prototype.mousePressed = function(fxn) {
  *
  */
 p5.Element.prototype.doubleClicked = function(fxn) {
+  p5._validateParameters('p5.Element.doubleClicked', arguments);
   adjustListener('dblclick', fxn, this);
   return this;
 };
@@ -346,6 +351,7 @@ p5.Element.prototype.doubleClicked = function(fxn) {
  *
  */
 p5.Element.prototype.mouseWheel = function(fxn) {
+  p5._validateParameters('p5.Element.mouseWheel', arguments);
   adjustListener('wheel', fxn, this);
   return this;
 };
@@ -398,6 +404,7 @@ p5.Element.prototype.mouseWheel = function(fxn) {
  *
  */
 p5.Element.prototype.mouseReleased = function(fxn) {
+  p5._validateParameters('p5.Element.mouseReleased', arguments);
   adjustListener('mouseup', fxn, this);
   adjustListener('touchend', fxn, this);
   return this;
@@ -453,6 +460,7 @@ p5.Element.prototype.mouseReleased = function(fxn) {
  *
  */
 p5.Element.prototype.mouseClicked = function(fxn) {
+  p5._validateParameters('p5.Element.mouseClicked', arguments);
   adjustListener('click', fxn, this);
   return this;
 };
@@ -511,6 +519,7 @@ p5.Element.prototype.mouseClicked = function(fxn) {
  *
  */
 p5.Element.prototype.mouseMoved = function(fxn) {
+  p5._validateParameters('p5.Element.mouseMoved', arguments);
   adjustListener('mousemove', fxn, this);
   adjustListener('touchmove', fxn, this);
   return this;
@@ -555,6 +564,7 @@ p5.Element.prototype.mouseMoved = function(fxn) {
  *
  */
 p5.Element.prototype.mouseOver = function(fxn) {
+  p5._validateParameters('p5.Element.mouseOver', arguments);
   adjustListener('mouseover', fxn, this);
   return this;
 };
@@ -622,6 +632,7 @@ p5.Element.prototype.mouseOver = function(fxn) {
  *
  */
 p5.Element.prototype.changed = function(fxn) {
+  p5._validateParameters('p5.Element.changed', arguments);
   adjustListener('change', fxn, this);
   return this;
 };
@@ -657,6 +668,7 @@ p5.Element.prototype.changed = function(fxn) {
  *
  */
 p5.Element.prototype.input = function(fxn) {
+  p5._validateParameters('p5.Element.input', arguments);
   adjustListener('input', fxn, this);
   return this;
 };
@@ -699,6 +711,7 @@ p5.Element.prototype.input = function(fxn) {
  *
  */
 p5.Element.prototype.mouseOut = function(fxn) {
+  p5._validateParameters('p5.Element.mouseOut', arguments);
   adjustListener('mouseout', fxn, this);
   return this;
 };
@@ -747,6 +760,7 @@ p5.Element.prototype.mouseOut = function(fxn) {
  *
  */
 p5.Element.prototype.touchStarted = function(fxn) {
+  p5._validateParameters('p5.Element.touchStarted', arguments);
   adjustListener('touchstart', fxn, this);
   adjustListener('mousedown', fxn, this);
   return this;
@@ -788,6 +802,7 @@ p5.Element.prototype.touchStarted = function(fxn) {
  *
  */
 p5.Element.prototype.touchMoved = function(fxn) {
+  p5._validateParameters('p5.Element.touchMoved', arguments);
   adjustListener('touchmove', fxn, this);
   adjustListener('mousemove', fxn, this);
   return this;
@@ -838,6 +853,7 @@ p5.Element.prototype.touchMoved = function(fxn) {
  *
  */
 p5.Element.prototype.touchEnded = function(fxn) {
+  p5._validateParameters('p5.Element.touchEnded', arguments);
   adjustListener('touchend', fxn, this);
   adjustListener('mouseup', fxn, this);
   return this;
@@ -877,6 +893,7 @@ p5.Element.prototype.touchEnded = function(fxn) {
  * nothing displayed
  */
 p5.Element.prototype.dragOver = function(fxn) {
+  p5._validateParameters('p5.Element.dragOver', arguments);
   adjustListener('dragover', fxn, this);
   return this;
 };
@@ -915,6 +932,7 @@ p5.Element.prototype.dragOver = function(fxn) {
  * nothing displayed
  */
 p5.Element.prototype.dragLeave = function(fxn) {
+  p5._validateParameters('p5.Element.dragLeave', arguments);
   adjustListener('dragleave', fxn, this);
   return this;
 };
@@ -952,6 +970,7 @@ p5.Element.prototype.dragLeave = function(fxn) {
  *
  */
 p5.Element.prototype.drop = function(callback, fxn) {
+  p5._validateParameters('p5.Element.drop', arguments);
   // Make a file loader callback and trigger user's callback
   function makeLoader(theFile) {
     // Making a p5.File object

--- a/src/core/p5.Graphics.js
+++ b/src/core/p5.Graphics.js
@@ -118,6 +118,7 @@ p5.Graphics.prototype = Object.create(p5.Element.prototype);
  *
  */
 p5.Graphics.prototype.remove = function() {
+  p5._validateParameters('p5.Graphics.remove', arguments);
   if (this.elt.parentNode) {
     this.elt.parentNode.removeChild(this.elt);
   }

--- a/src/data/p5.TypedDict.js
+++ b/src/data/p5.TypedDict.js
@@ -119,6 +119,7 @@ p5.TypedDict = function(key, value) {
  *
  */
 p5.TypedDict.prototype.size = function() {
+  p5._validateParameters('p5.TypedDict.size', arguments);
   return Object.keys(this.data).length;
 };
 
@@ -142,6 +143,7 @@ p5.TypedDict.prototype.size = function() {
  */
 
 p5.TypedDict.prototype.hasKey = function(key) {
+  p5._validateParameters('p5.TypedDict.hasKey', arguments);
   return this.data.hasOwnProperty(key);
 };
 
@@ -165,6 +167,7 @@ p5.TypedDict.prototype.hasKey = function(key) {
  */
 
 p5.TypedDict.prototype.get = function(key) {
+  p5._validateParameters('p5.TypedDict.get', arguments);
   if (this.data.hasOwnProperty(key)) {
     return this.data[key];
   } else {
@@ -193,6 +196,7 @@ p5.TypedDict.prototype.get = function(key) {
  */
 
 p5.TypedDict.prototype.set = function(key, value) {
+  p5._validateParameters('p5.TypedDict.set', arguments);
   if (this._validate(value)) {
     this.data[key] = value;
   } else {
@@ -235,6 +239,7 @@ p5.TypedDict.prototype._addObj = function(obj) {
  */
 
 p5.TypedDict.prototype.create = function(key, value) {
+  p5._validateParameters('p5.TypedDict.create', arguments);
   if (key instanceof Object && typeof value === 'undefined') {
     this._addObj(key);
   } else if (typeof key !== 'undefined') {
@@ -265,6 +270,7 @@ p5.TypedDict.prototype.create = function(key, value) {
  */
 
 p5.TypedDict.prototype.clear = function() {
+  p5._validateParameters('p5.TypedDict.clear', arguments);
   this.data = {};
 };
 
@@ -291,6 +297,7 @@ p5.TypedDict.prototype.clear = function() {
  */
 
 p5.TypedDict.prototype.remove = function(key) {
+  p5._validateParameters('p5.TypedDict.remove', arguments);
   if (this.data.hasOwnProperty(key)) {
     delete this.data[key];
   } else {
@@ -317,6 +324,7 @@ p5.TypedDict.prototype.remove = function(key) {
  */
 
 p5.TypedDict.prototype.print = function() {
+  p5._validateParameters('p5.TypedDict.print', arguments);
   for (var item in this.data) {
     console.log('key:' + item + ' value:' + this.data[item]);
   }
@@ -344,6 +352,7 @@ p5.TypedDict.prototype.print = function() {
  */
 
 p5.TypedDict.prototype.saveTable = function(filename) {
+  p5._validateParameters('p5.TypedDict.saveTable', arguments);
   var output = '';
 
   for (var key in this.data) {
@@ -452,6 +461,7 @@ p5.NumberDict.prototype._validate = function(value) {
  */
 
 p5.NumberDict.prototype.add = function(key, amount) {
+  p5._validateParameters('p5.NumberDict.add', arguments);
   if (this.data.hasOwnProperty(key)) {
     this.data[key] += amount;
   } else {
@@ -504,6 +514,7 @@ p5.NumberDict.prototype.sub = function(key, amount) {
  */
 
 p5.NumberDict.prototype.mult = function(key, amount) {
+  p5._validateParameters('p5.NumberDict.mult', arguments);
   if (this.data.hasOwnProperty(key)) {
     this.data[key] *= amount;
   } else {
@@ -532,6 +543,7 @@ p5.NumberDict.prototype.mult = function(key, amount) {
  */
 
 p5.NumberDict.prototype.div = function(key, amount) {
+  p5._validateParameters('p5.NumberDict.div', arguments);
   if (this.data.hasOwnProperty(key)) {
     this.data[key] /= amount;
   } else {
@@ -582,6 +594,7 @@ p5.NumberDict.prototype._valueTest = function(flip) {
  */
 
 p5.NumberDict.prototype.minValue = function() {
+  p5._validateParameters('p5.NumberDict.minValue', arguments);
   return this._valueTest(1);
 };
 
@@ -603,6 +616,7 @@ p5.NumberDict.prototype.minValue = function() {
  */
 
 p5.NumberDict.prototype.maxValue = function() {
+  p5._validateParameters('p5.NumberDict.maxValue', arguments);
   return this._valueTest(-1);
 };
 
@@ -647,6 +661,7 @@ p5.NumberDict.prototype._keyTest = function(flip) {
  */
 
 p5.NumberDict.prototype.minKey = function() {
+  p5._validateParameters('p5.NumberDict.minKey', arguments);
   return this._keyTest(1);
 };
 
@@ -668,6 +683,7 @@ p5.NumberDict.prototype.minKey = function() {
  */
 
 p5.NumberDict.prototype.maxKey = function() {
+  p5._validateParameters('p5.NumberDict.maxKey', arguments);
   return this._keyTest(-1);
 };
 

--- a/src/image/p5.Image.js
+++ b/src/image/p5.Image.js
@@ -259,6 +259,7 @@ p5.Image.prototype._setProperty = function(prop, value) {
  *
  */
 p5.Image.prototype.loadPixels = function() {
+  p5._validateParameters('p5.Image.loadPixels', arguments);
   p5.Renderer2D.prototype.loadPixels.call(this);
   this.setModified(true);
 };
@@ -307,6 +308,7 @@ p5.Image.prototype.loadPixels = function() {
  * @method updatePixels
  */
 p5.Image.prototype.updatePixels = function(x, y, w, h) {
+  p5._validateParameters('p5.Image.updatePixels', arguments);
   p5.Renderer2D.prototype.updatePixels.call(this, x, y, w, h);
   this.setModified(true);
 };
@@ -425,6 +427,7 @@ p5.Image.prototype.set = function(x, y, imgOrCol) {
  *
  */
 p5.Image.prototype.resize = function(width, height) {
+  p5._validateParameters('p5.Image.resize', arguments);
   // Copy contents to a temporary canvas, resize the original
   // and then copy back.
   //
@@ -531,6 +534,7 @@ p5.Image.prototype.resize = function(width, height) {
  * @param  {Integer} dh
  */
 p5.Image.prototype.copy = function() {
+  p5._validateParameters('p5.Image.copy', arguments);
   var srcImage, sx, sy, sw, sh, dx, dy, dw, dh;
   if (arguments.length === 9) {
     srcImage = arguments[0];
@@ -593,6 +597,7 @@ p5.Image.prototype.copy = function() {
 //       moment this method does not match native processings original
 //       functionality exactly.
 p5.Image.prototype.mask = function(p5Image) {
+  p5._validateParameters('p5.Image.mask', arguments);
   if (p5Image === undefined) {
     p5Image = this;
   }
@@ -653,6 +658,7 @@ p5.Image.prototype.mask = function(p5Image) {
  *
  */
 p5.Image.prototype.filter = function(operation, value) {
+  p5._validateParameters('p5.Image.filter', arguments);
   Filters.apply(this.canvas, Filters[operation.toLowerCase()], value);
   this.setModified(true);
 };

--- a/src/io/p5.Table.js
+++ b/src/io/p5.Table.js
@@ -105,6 +105,7 @@ p5.Table = function(rows) {
  *
  */
 p5.Table.prototype.addRow = function(row) {
+  p5._validateParameters('p5.Table.addRow', arguments);
   // make sure it is a valid TableRow
   var r = row || new p5.TableRow();
 
@@ -159,6 +160,7 @@ p5.Table.prototype.addRow = function(row) {
  *
  */
 p5.Table.prototype.removeRow = function(id) {
+  p5._validateParameters('p5.Table.removeRow', arguments);
   this.rows[id].table = null; // remove reference to table
   var chunk = this.rows.splice(id + 1, this.rows.length);
   this.rows.pop();
@@ -208,6 +210,7 @@ p5.Table.prototype.removeRow = function(id) {
  *
  */
 p5.Table.prototype.getRow = function(r) {
+  p5._validateParameters('p5.Table.getRow', arguments);
   return this.rows[r];
 };
 
@@ -257,6 +260,7 @@ p5.Table.prototype.getRow = function(r) {
  *
  */
 p5.Table.prototype.getRows = function() {
+  p5._validateParameters('p5.Table.getRows', arguments);
   return this.rows;
 };
 
@@ -306,6 +310,7 @@ p5.Table.prototype.getRows = function() {
  *
  */
 p5.Table.prototype.findRow = function(value, column) {
+  p5._validateParameters('p5.Table.findRow', arguments);
   // try the Object
   if (typeof column === 'string') {
     for (var i = 0; i < this.rows.length; i++) {
@@ -376,6 +381,7 @@ p5.Table.prototype.findRow = function(value, column) {
  *
  */
 p5.Table.prototype.findRows = function(value, column) {
+  p5._validateParameters('p5.Table.findRows', arguments);
   var ret = [];
   if (typeof column === 'string') {
     for (var i = 0; i < this.rows.length; i++) {
@@ -437,6 +443,7 @@ p5.Table.prototype.findRows = function(value, column) {
  *
  */
 p5.Table.prototype.matchRow = function(regexp, column) {
+  p5._validateParameters('p5.Table.matchRow', arguments);
   if (typeof column === 'number') {
     for (var j = 0; j < this.rows.length; j++) {
       if (this.rows[j].arr[column].match(regexp)) {
@@ -503,6 +510,7 @@ p5.Table.prototype.matchRow = function(regexp, column) {
  * </div>
  */
 p5.Table.prototype.matchRows = function(regexp, column) {
+  p5._validateParameters('p5.Table.matchRows', arguments);
   var ret = [];
   if (typeof column === 'number') {
     for (var j = 0; j < this.rows.length; j++) {
@@ -560,6 +568,7 @@ p5.Table.prototype.matchRows = function(regexp, column) {
  *
  */
 p5.Table.prototype.getColumn = function(value) {
+  p5._validateParameters('p5.Table.getColumn', arguments);
   var ret = [];
   if (typeof value === 'string') {
     for (var i = 0; i < this.rows.length; i++) {
@@ -611,6 +620,7 @@ p5.Table.prototype.getColumn = function(value) {
  *
  */
 p5.Table.prototype.clearRows = function() {
+  p5._validateParameters('p5.Table.clearRows', arguments);
   delete this.rows;
   this.rows = [];
 };
@@ -662,6 +672,7 @@ p5.Table.prototype.clearRows = function() {
  *
  */
 p5.Table.prototype.addColumn = function(title) {
+  p5._validateParameters('p5.Table.addColumn', arguments);
   var t = title || null;
   this.columns.push(t);
 };
@@ -699,6 +710,7 @@ p5.Table.prototype.addColumn = function(title) {
  * </div>
  */
 p5.Table.prototype.getColumnCount = function() {
+  p5._validateParameters('p5.Table.getColumnCount', arguments);
   return this.columns.length;
 };
 
@@ -735,6 +747,7 @@ p5.Table.prototype.getColumnCount = function() {
  * </div>
  */
 p5.Table.prototype.getRowCount = function() {
+  p5._validateParameters('p5.Table.getRowCount', arguments);
   return this.rows.length;
 };
 
@@ -776,6 +789,7 @@ p5.Table.prototype.getRowCount = function() {
  * </code></div>
  */
 p5.Table.prototype.removeTokens = function(chars, column) {
+  p5._validateParameters('p5.Table.removeTokens', arguments);
   var escape = function(s) {
     return s.replace(/[-/\\^$*+?.()|[\]{}]/g, '\\$&');
   };
@@ -847,6 +861,7 @@ p5.Table.prototype.removeTokens = function(chars, column) {
  * </code></div>
  */
 p5.Table.prototype.trim = function(column) {
+  p5._validateParameters('p5.Table.trim', arguments);
   var regex = new RegExp(' ', 'g');
 
   if (typeof column === 'undefined') {
@@ -917,6 +932,7 @@ p5.Table.prototype.trim = function(column) {
  *
  */
 p5.Table.prototype.removeColumn = function(c) {
+  p5._validateParameters('p5.Table.removeColumn', arguments);
   var cString;
   var cNumber;
   if (typeof c === 'string') {
@@ -989,6 +1005,7 @@ p5.Table.prototype.removeColumn = function(c) {
  *
  */
 p5.Table.prototype.set = function(row, column, value) {
+  p5._validateParameters('p5.Table.set', arguments);
   this.rows[row].set(column, value);
 };
 
@@ -1035,6 +1052,7 @@ p5.Table.prototype.set = function(row, column, value) {
  * no image displayed
  */
 p5.Table.prototype.setNum = function(row, column, value) {
+  p5._validateParameters('p5.Table.setNum', arguments);
   this.rows[row].setNum(column, value);
 };
 
@@ -1080,6 +1098,7 @@ p5.Table.prototype.setNum = function(row, column, value) {
  * no image displayed
  */
 p5.Table.prototype.setString = function(row, column, value) {
+  p5._validateParameters('p5.Table.setString', arguments);
   this.rows[row].setString(column, value);
 };
 
@@ -1127,6 +1146,7 @@ p5.Table.prototype.setString = function(row, column, value) {
  *
  */
 p5.Table.prototype.get = function(row, column) {
+  p5._validateParameters('p5.Table.get', arguments);
   return this.rows[row].get(column);
 };
 
@@ -1172,6 +1192,7 @@ p5.Table.prototype.get = function(row, column) {
  *
  */
 p5.Table.prototype.getNum = function(row, column) {
+  p5._validateParameters('p5.Table.getNum', arguments);
   return this.rows[row].getNum(column);
 };
 
@@ -1225,6 +1246,7 @@ p5.Table.prototype.getNum = function(row, column) {
  */
 
 p5.Table.prototype.getString = function(row, column) {
+  p5._validateParameters('p5.Table.getString', arguments);
   return this.rows[row].getString(column);
 };
 
@@ -1271,6 +1293,7 @@ p5.Table.prototype.getString = function(row, column) {
  *
  */
 p5.Table.prototype.getObject = function(headerColumn) {
+  p5._validateParameters('p5.Table.getObject', arguments);
   var tableObject = {};
   var obj, cPos, index;
 
@@ -1333,6 +1356,7 @@ p5.Table.prototype.getObject = function(headerColumn) {
  *
  */
 p5.Table.prototype.getArray = function() {
+  p5._validateParameters('p5.Table.getArray', arguments);
   var tableArray = [];
   for (var i = 0; i < this.rows.length; i++) {
     tableArray.push(this.rows[i].arr);

--- a/src/io/p5.TableRow.js
+++ b/src/io/p5.TableRow.js
@@ -80,6 +80,7 @@ p5.TableRow = function(str, separator) {
  * no image displayed
  */
 p5.TableRow.prototype.set = function(column, value) {
+  p5._validateParameters('p5.TableRow.set', arguments);
   // if typeof column is string, use .obj
   if (typeof column === 'string') {
     var cPos = this.table.columns.indexOf(column); // index of columnID
@@ -143,6 +144,7 @@ p5.TableRow.prototype.set = function(column, value) {
  * no image displayed
  */
 p5.TableRow.prototype.setNum = function(column, value) {
+  p5._validateParameters('p5.TableRow.setNum', arguments);
   var floatVal = parseFloat(value);
   this.set(column, floatVal);
 };
@@ -188,6 +190,7 @@ p5.TableRow.prototype.setNum = function(column, value) {
  * no image displayed
  */
 p5.TableRow.prototype.setString = function(column, value) {
+  p5._validateParameters('p5.TableRow.setString', arguments);
   var stringVal = value.toString();
   this.set(column, stringVal);
 };
@@ -233,6 +236,7 @@ p5.TableRow.prototype.setString = function(column, value) {
  * no image displayed
  */
 p5.TableRow.prototype.get = function(column) {
+  p5._validateParameters('p5.TableRow.get', arguments);
   if (typeof column === 'string') {
     return this.obj[column];
   } else {
@@ -283,6 +287,7 @@ p5.TableRow.prototype.get = function(column) {
  * no image displayed
  */
 p5.TableRow.prototype.getNum = function(column) {
+  p5._validateParameters('p5.TableRow.getNum', arguments);
   var ret;
   if (typeof column === 'string') {
     ret = parseFloat(this.obj[column]);
@@ -340,6 +345,7 @@ p5.TableRow.prototype.getNum = function(column) {
  * no image displayed
  */
 p5.TableRow.prototype.getString = function(column) {
+  p5._validateParameters('p5.TableRow.getString', arguments);
   if (typeof column === 'string') {
     return this.obj[column].toString();
   } else {

--- a/src/io/p5.XML.js
+++ b/src/io/p5.XML.js
@@ -96,6 +96,7 @@ p5.XML = function() {
  * </code></div>
  */
 p5.XML.prototype.getParent = function() {
+  p5._validateParameters('p5.XML.getParent', arguments);
   return this.parent;
 };
 
@@ -131,6 +132,7 @@ p5.XML.prototype.getParent = function() {
  * </code></div>
  */
 p5.XML.prototype.getName = function() {
+  p5._validateParameters('p5.XML.getName', arguments);
   return this.name;
 };
 
@@ -169,6 +171,7 @@ p5.XML.prototype.getName = function() {
  * </code></div>
  */
 p5.XML.prototype.setName = function(name) {
+  p5._validateParameters('p5.XML.setName', arguments);
   this.name = name;
 };
 
@@ -205,6 +208,7 @@ p5.XML.prototype.setName = function(name) {
  * </code></div>
  */
 p5.XML.prototype.hasChildren = function() {
+  p5._validateParameters('p5.XML.hasChildren', arguments);
   return this.children.length > 0;
 };
 
@@ -242,6 +246,7 @@ p5.XML.prototype.hasChildren = function() {
  * </code></div>
  */
 p5.XML.prototype.listChildren = function() {
+  p5._validateParameters('p5.XML.listChildren', arguments);
   return this.children.map(function(c) {
     return c.name;
   });
@@ -288,6 +293,7 @@ p5.XML.prototype.listChildren = function() {
  * </code></div>
  */
 p5.XML.prototype.getChildren = function(param) {
+  p5._validateParameters('p5.XML.getChildren', arguments);
   if (param) {
     return this.children.filter(function(c) {
       return c.name === param;
@@ -348,6 +354,7 @@ p5.XML.prototype.getChildren = function(param) {
  * </code></div>
  */
 p5.XML.prototype.getChild = function(param) {
+  p5._validateParameters('p5.XML.getChild', arguments);
   if (typeof param === 'string') {
     for (var i = 0; i < this.children.length; i++) {
       var child = this.children[i];
@@ -402,6 +409,7 @@ p5.XML.prototype.getChild = function(param) {
  * </code></div>
  */
 p5.XML.prototype.addChild = function(node) {
+  p5._validateParameters('p5.XML.addChild', arguments);
   if (node instanceof p5.XML) {
     this.children.push(node);
   } else {
@@ -465,6 +473,7 @@ p5.XML.prototype.addChild = function(node) {
  * </code></div>
  */
 p5.XML.prototype.removeChild = function(param) {
+  p5._validateParameters('p5.XML.removeChild', arguments);
   var ind = -1;
   if (typeof param === 'string') {
     for (var i = 0; i < this.children.length; i++) {
@@ -514,6 +523,7 @@ p5.XML.prototype.removeChild = function(param) {
  * </code></div>
  */
 p5.XML.prototype.getAttributeCount = function() {
+  p5._validateParameters('p5.XML.getAttributeCount', arguments);
   return Object.keys(this.attributes).length;
 };
 
@@ -551,6 +561,7 @@ p5.XML.prototype.getAttributeCount = function() {
  * </code></div>
  */
 p5.XML.prototype.listAttributes = function() {
+  p5._validateParameters('p5.XML.listAttributes', arguments);
   return Object.keys(this.attributes);
 };
 
@@ -590,6 +601,7 @@ p5.XML.prototype.listAttributes = function() {
  * </code></div>
  */
 p5.XML.prototype.hasAttribute = function(name) {
+  p5._validateParameters('p5.XML.hasAttribute', arguments);
   return this.attributes[name] ? true : false;
 };
 
@@ -631,6 +643,7 @@ p5.XML.prototype.hasAttribute = function(name) {
  * </code></div>
  */
 p5.XML.prototype.getNum = function(name, defaultValue) {
+  p5._validateParameters('p5.XML.getNum', arguments);
   return Number(this.attributes[name]) || defaultValue || 0;
 };
 
@@ -672,6 +685,7 @@ p5.XML.prototype.getNum = function(name, defaultValue) {
  * </code></div>
  */
 p5.XML.prototype.getString = function(name, defaultValue) {
+  p5._validateParameters('p5.XML.getString', arguments);
   return String(this.attributes[name]) || defaultValue || null;
 };
 
@@ -713,6 +727,7 @@ p5.XML.prototype.getString = function(name, defaultValue) {
  * </code></div>
  */
 p5.XML.prototype.setAttribute = function(name, value) {
+  p5._validateParameters('p5.XML.setAttribute', arguments);
   if (this.attributes[name]) {
     this.attributes[name] = value;
   }
@@ -753,6 +768,7 @@ p5.XML.prototype.setAttribute = function(name, value) {
  * </code></div>
  */
 p5.XML.prototype.getContent = function(defaultValue) {
+  p5._validateParameters('p5.XML.getContent', arguments);
   return this.content || defaultValue || null;
 };
 
@@ -792,6 +808,7 @@ p5.XML.prototype.getContent = function(defaultValue) {
  * </code></div>
  */
 p5.XML.prototype.setContent = function(content) {
+  p5._validateParameters('p5.XML.setContent', arguments);
   if (!this.children.length) {
     this.content = content;
   }

--- a/src/typography/p5.Font.js
+++ b/src/typography/p5.Font.js
@@ -83,6 +83,7 @@ p5.Font.prototype.list = function() {
  *
  */
 p5.Font.prototype.textBounds = function(str, x, y, fontSize, options) {
+  p5._validateParameters('p5.Font.textBounds', arguments);
   x = x !== undefined ? x : 0;
   y = y !== undefined ? y : 0;
   fontSize = fontSize || this.parent._renderer._textSize;
@@ -215,6 +216,7 @@ p5.Font.prototype.textBounds = function(str, x, y, fontSize, options) {
  *
  */
 p5.Font.prototype.textToPoints = function(txt, x, y, fontSize, options) {
+  p5._validateParameters('p5.Font.textToPoints', arguments);
   var xoff = 0,
     result = [],
     glyphs = this._getGlyphs(txt);

--- a/src/webgl/p5.Geometry.js
+++ b/src/webgl/p5.Geometry.js
@@ -52,6 +52,7 @@ p5.Geometry = function(detailX, detailY, callback) {
  * @chainable
  */
 p5.Geometry.prototype.computeFaces = function() {
+  p5._validateParameters('p5.Geometry.computeFaces', arguments);
   this.faces.length = 0;
   var sliceCount = this.detailX + 1;
   var a, b, c, d;
@@ -96,6 +97,7 @@ p5.Geometry.prototype._getFaceNormal = function(faceId) {
  * @chainable
  */
 p5.Geometry.prototype.computeNormals = function() {
+  p5._validateParameters('p5.Geometry.computeNormals', arguments);
   var vertexNormals = this.vertexNormals;
   var vertices = this.vertices;
   var faces = this.faces;
@@ -135,6 +137,7 @@ p5.Geometry.prototype.computeNormals = function() {
  * @chainable
  */
 p5.Geometry.prototype.averageNormals = function() {
+  p5._validateParameters('p5.Geometry.averageNormals', arguments);
   for (var i = 0; i <= this.detailY; i++) {
     var offset = this.detailX + 1;
     var temp = p5.Vector.add(
@@ -155,6 +158,7 @@ p5.Geometry.prototype.averageNormals = function() {
  * @chainable
  */
 p5.Geometry.prototype.averagePoleNormals = function() {
+  p5._validateParameters('p5.Geometry.averagePoleNormals', arguments);
   //average the north pole
   var sum = new p5.Vector(0, 0, 0);
   for (var i = 0; i < this.detailX; i++) {
@@ -248,6 +252,7 @@ p5.Geometry.prototype._edgesToVertices = function() {
  * @chainable
  */
 p5.Geometry.prototype.normalize = function() {
+  p5._validateParameters('p5.Geometry.normalize', arguments);
   if (this.vertices.length > 0) {
     // Find the corners of our bounding box
     var maxPosition = this.vertices[0].copy();

--- a/src/webgl/p5.Shader.js
+++ b/src/webgl/p5.Shader.js
@@ -281,6 +281,7 @@ p5.Shader.prototype.useProgram = function() {
  * matrix, or texture / sampler reference)
  */
 p5.Shader.prototype.setUniform = function(uniformName, data) {
+  p5._validateParameters('p5.Shader.setUniform', arguments);
   //@todo update all current gl.uniformXX calls
 
   var uniform = this.uniforms[uniformName];


### PR DESCRIPTION
re: #2848 

adds parameter validation to exposed methods of the following classes:
- `p5.Element`, `p5.MediaElement`
- `p5.Color`
- `p5.Graphics`, `p5.Image`
- `p5.TypedDict`, `p5.NumberDict`
- `p5.Table`, `p5.TableRow`
- `p5.XML`
- `p5.Font`
- `p5.Shader`