### PR TITLE
remove bogus parameter from `p5.Geometry` constructor

### DIFF
--- a/src/webgl/p5.Geometry.js
+++ b/src/webgl/p5.Geometry.js
@@ -7,8 +7,6 @@ var p5 = require('../core/core');
  * p5 Geometry class
  * @class p5.Geometry
  * @constructor
- * @param  {function | Object} vertData callback function or Object
- *                     containing routine(s) for vertex data generation
  * @param  {Integer} [detailX] number of vertices on horizontal surface
  * @param  {Integer} [detailY] number of vertices on horizontal surface
  * @param {function} [callback] function to call upon object instantiation.


### PR DESCRIPTION
remove bogus parameter from `p5.Geometry` constructor