### PR TITLE
fix scaling of `plane` geometry

### DIFF
--- a/src/webgl/primitives.js
+++ b/src/webgl/primitives.js
@@ -90,7 +90,7 @@ p5.prototype.plane = function(width, height, detailX, detailY) {
     this._renderer.createBuffers(gId, planeGeom);
   }
 
-  this._renderer.drawBuffersScaled(gId, width, height, 0);
+  this._renderer.drawBuffersScaled(gId, width, height, 1);
 };
 
 /**


### PR DESCRIPTION
closes #2863 

fix scaling of `plane` geometry. This causes the plane's normals not to have zero-length, and allows the plane to be lit.