### PR TITLE
Use proper module group for color conversion

### DIFF
--- a/src/color/color_conversion.js
+++ b/src/color/color_conversion.js
@@ -1,5 +1,5 @@
 /**
- * @module Conversion
+ * @module Color
  * @submodule Color Conversion
  * @for p5
  * @requires core
@@ -10,8 +10,9 @@
 /**
  * Conversions adapted from <http://www.easyrgb.com/en/math.php>.
  *
- * In these functions, hue is always in the range [0,1); all other components
- * are in the range [0,1]. 'Brightness' and 'value' are used interchangeably.
+ * In these functions, hue is always in the range [0, 1], just like all other
+ * components are in the range [0, 1]. 'Brightness' and 'value' are used
+ * interchangeably.
  */
 
 var p5 = require('../core/core');


### PR DESCRIPTION
There's currently a dead entry in the reference TOC because of this.

![image](https://user-images.githubusercontent.com/1662740/39855608-e25e9bf4-542c-11e8-9ac3-f206fe69e69f.png)
