### PR TITLE
Enable switching of UI language in reference

### DIFF
--- a/docs/yuidoc-p5-theme/layouts/main.handlebars
+++ b/docs/yuidoc-p5-theme/layouts/main.handlebars
@@ -207,6 +207,21 @@
           timeout = setTimeout(updateLanguage, 500);
         });
       }
+
+      var pathFragments = window.location.pathname.split('/').filter(function(v) { return v });
+      var currentLangPrefix = pathFragments.shift();
+      $('[data-lang]')
+        .on('click', function() {
+          var location = window.location.pathname;
+          var newPrefix = $(this).data('lang');
+          if (newPrefix === 'en') {
+            newPrefix = 'docs'; // english is using `/docs/:parameters`
+          }
+          window.location = '/' +
+            [newPrefix].concat(pathFragments).join('/') +
+            '/' +
+            (window.location.hash || '');
+        });
     });
 
     $(window).bind('hashchange', function() {


### PR DESCRIPTION
The buttons for changing the UI language currently do not work in the reference section.

This PR "kind of works" (:tm:) but it's not necessarily pretty.

I wonder if it would make sense to spend some time on looking into how to improve the entire localization setup for the reference as it's certainly something that helps the project become more accessible. I would be happy to look into that topic and work on it in the next week(s), but it's probably out of scope for the "documentation jam", so I wanted to discuss this beforehand.

Let me know what you think and we can maybe create an issue to track this.