### PR TITLE
Fix overflowing example render in p5.Color#toString

### DIFF
--- a/src/color/p5.Color.js
+++ b/src/color/p5.Color.js
@@ -72,9 +72,10 @@ p5.Color = function(pInst, vals) {
  * }
  *
  * function draw() {
- *   text(myColor.toString(), 10, 10);
- *   text(myColor.toString('#rrggbb'), 10, 95);
- *   text(myColor.toString('rgba%'), 10, 180);
+ *   rotate(HALF_PI);
+ *   text(myColor.toString(), 0, -5);
+ *   text(myColor.toString('#rrggbb'), 0, -30);
+ *   text(myColor.toString('rgba%'), 0, -55);
  * }
  * </code>
  * </div>


### PR DESCRIPTION
The example at https://p5js.org/reference/#/p5.Color/toString currently renders the examples in a way where it collides with the source code:

![image](https://user-images.githubusercontent.com/1662740/39862406-045cbc6a-5444-11e8-82d3-f34aeab6cc2e.png)
