### PR TITLE
Add missing return in order to make curveTightness chainable

### DIFF
--- a/src/core/curves.js
+++ b/src/core/curves.js
@@ -443,6 +443,7 @@ p5.prototype.curveDetail = function(d) {
 p5.prototype.curveTightness = function(t) {
   p5._validateParameters('curveTightness', arguments);
   this._renderer._curveTightness = t;
+  return this;
 };
 
 /**


### PR DESCRIPTION
`curveTightness` is documented as chainable (and probably should be chainable as `curveDetail` is too), but currently returns nothing.