### PR TITLE
Enable local development of non-english reference docs

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -352,6 +352,7 @@ module.exports = function(grunt) {
           middleware: function(connect, options, middlewares) {
             middlewares.unshift(
               require('connect-modrewrite')([
+                '^/(es|zh-Hans)/(.*) /docs/$2 [L]',
                 '^/assets/js/p5(\\.min)?\\.js(.*) /lib/p5$1.js$2 [L]',
                 '^/assets/js/p5\\.(dom|sound)(\\.min)?\\.js(.*) /lib/addons/p5.$1$2.js$3 [L]'
               ]),


### PR DESCRIPTION
Right now localized origins like `/es/reference/#group-DOM` 404 in development. We can rewrite them to serve the docs content as all localization is happening on the client.