### PR TITLE
Fix p5 Effect class extension reference urls

### DIFF
--- a/lib/addons/p5.sound.js
+++ b/lib/addons/p5.sound.js
@@ -7973,11 +7973,11 @@ effect = function () {
   * common and useful for current and future effects.
   *
   *
-  * This class is extended by <a href="reference/#/p5.Distortion">p5.Distortion</a>,
-  * <a href="reference/#/p5.Compressor">p5.Compressor</a>,
-  * <a href="reference/#/p5.Delay">p5.Delay</a>,
-  * <a href="reference/#/p5.Filter">p5.Filter</a>,
-  * <a href="reference/#/p5.Reverb">p5.Reverb</a>.
+  * This class is extended by <a href="#/p5.Distortion">p5.Distortion</a>,
+  * <a href="#/p5.Compressor">p5.Compressor</a>,
+  * <a href="#/p5.Delay">p5.Delay</a>,
+  * <a href="#/p5.Filter">p5.Filter</a>,
+  * <a href="#/p5.Reverb">p5.Reverb</a>.
   *
   * @class  p5.Effect
   * @constructor


### PR DESCRIPTION
This PR updates the links in the p5.Effect documentation to not 404. More specifically, the five links included in:
`This class is extended by p5.Distortion, p5.Compressor, p5.Delay, p5.Filter, p5.Reverb.`