### PR TITLE
fix textLeading return value

### DIFF
--- a/src/core/p5.Renderer.js
+++ b/src/core/p5.Renderer.js
@@ -129,7 +129,7 @@ p5.Renderer.prototype.resize = function(w, h) {
 p5.Renderer.prototype.textLeading = function(l) {
   if (typeof l === 'number') {
     this._setProperty('_textLeading', l);
-    return this;
+    return this._pInst;
   }
 
   return this._textLeading;


### PR DESCRIPTION
closes #2884 

fix `textLeading`'s return when called in its chainable form.