### PR TITLE
fix vertex 3d overload

### DIFF
--- a/src/core/vertex.js
+++ b/src/core/vertex.js
@@ -733,9 +733,10 @@ p5.prototype.quadraticVertex = function(cx, cy, x3, y3) {
  * @method vertex
  * @param  {Number} x
  * @param  {Number} y
- * @param  {Number} [z] z-coordinate of the vertex
+ * @param  {Number} z   z-coordinate of the vertex
  * @param  {Number} [u] the vertex's texture u-coordinate
  * @param  {Number} [v] the vertex's texture v-coordinate
+ * @chainable
  */
 p5.prototype.vertex = function(x, y, moveTo, u, v) {
   if (this._renderer.isP3D) {


### PR DESCRIPTION
closes #2886 

fix `vertex` 3d overload:
- make it `@chainable`
- enforce `z` parameter (to disambiguate it from the 2d overload)
