### PR TITLE
document `addRow`'s return type

### DIFF
--- a/src/io/p5.Table.js
+++ b/src/io/p5.Table.js
@@ -64,6 +64,7 @@ p5.Table = function(rows) {
  *
  *  @method  addRow
  *  @param   {p5.TableRow} [row] row to be added to the table
+ *  @return  {p5.TableRow} the row that was added
  *
  * @example
  * <div class="norender">


### PR DESCRIPTION
closes #2888 

add `@return` attribute for `p5.Table.prototype.addRow()`