### PR TITLE
fix return value of `plane`

### DIFF
--- a/src/webgl/primitives.js
+++ b/src/webgl/primitives.js
@@ -91,6 +91,7 @@ p5.prototype.plane = function(width, height, detailX, detailY) {
   }
 
   this._renderer.drawBuffersScaled(gId, width, height, 0);
+  return this;
 };
 
 /**


### PR DESCRIPTION
closes #2890 

fix `plane`'s return value (makes it actually chainable)