### PR TITLE
add check for navigator.mediaDevices.getUserMedia in createCapture

### DIFF
--- a/lib/addons/p5.dom.js
+++ b/lib/addons/p5.dom.js
@@ -1118,7 +1118,7 @@
         cb = arguments[i];
       }
     }
-    if (navigator.getUserMedia) {
+    if (navigator.getUserMedia || navigator.mediaDevices.getUserMedia) {
       var elt = document.createElement('video');
 
       if (!constraints) {

--- a/lib/addons/p5.dom.js
+++ b/lib/addons/p5.dom.js
@@ -1118,7 +1118,7 @@
         cb = arguments[i];
       }
     }
-    if (navigator.getUserMedia || navigator.mediaDevices.getUserMedia) {
+    if (navigator.mediaDevices && navigator.mediaDevices.getUserMedia) {
       var elt = document.createElement('video');
 
       if (!constraints) {


### PR DESCRIPTION
On firefox 60, `navigator.getUserMedia` returns undefined. I added an additional check for `navigator.mediaDevices.getUserMedia` so that createCapture() didn't error out.

Looks like firefox is deprecating [getUserMedia](https://developer.mozilla.org/en-US/docs/Web/API/Navigator/getUserMedia) in favor of [mediaDevices](https://developer.mozilla.org/en-US/docs/Web/API/MediaDevices/getUserMedia)