### PR TITLE
Ensure errors are always thrown in the same fashion

### DIFF
--- a/src/core/structure.js
+++ b/src/core/structure.js
@@ -10,7 +10,7 @@
 var p5 = require('./core');
 
 p5.prototype.exit = function() {
-  throw 'exit() not implemented, see remove()';
+  throw new Error('exit() not implemented, see remove()');
 };
 /**
  * Stops p5.js from continuously executing the code within draw().
@@ -364,7 +364,7 @@ p5.prototype.redraw = function(n) {
 p5.prototype.size = function() {
   var s = 'size() is not a valid p5 function, to set the size of the ';
   s += 'drawing canvas, please use createCanvas() instead';
-  throw s;
+  throw new Error(s);
 };
 
 module.exports = p5;

--- a/src/core/vertex.js
+++ b/src/core/vertex.js
@@ -336,7 +336,7 @@ p5.prototype.beginShape = function(kind) {
 p5.prototype.bezierVertex = function(x2, y2, x3, y3, x4, y4) {
   p5._validateParameters('bezierVertex', arguments);
   if (vertices.length === 0) {
-    throw 'vertex() must be used once before calling bezierVertex()';
+    throw new Error('vertex() must be used once before calling bezierVertex()');
   } else {
     isBezier = true;
     var vert = [];
@@ -637,7 +637,9 @@ p5.prototype.quadraticVertex = function(cx, cy, x3, y3) {
       vertices.push(vert);
     }
   } else {
-    throw 'vertex() must be used once before calling quadraticVertex()';
+    throw new Error(
+      'vertex() must be used once before calling quadraticVertex()'
+    );
   }
   return this;
 };

--- a/src/data/p5.TypedDict.js
+++ b/src/data/p5.TypedDict.js
@@ -294,7 +294,7 @@ p5.TypedDict.prototype.remove = function(key) {
   if (this.data.hasOwnProperty(key)) {
     delete this.data[key];
   } else {
-    throw key + ' does not exist in this Dictionary';
+    throw new Error(key + ' does not exist in this Dictionary');
   }
 };
 
@@ -548,7 +548,9 @@ p5.NumberDict.prototype.div = function(key, amount) {
 
 p5.NumberDict.prototype._valueTest = function(flip) {
   if (Object.keys(this.data).length === 0) {
-    throw 'Unable to search for a minimum or maximum value on an empty NumberDict';
+    throw new Error(
+      'Unable to search for a minimum or maximum value on an empty NumberDict'
+    );
   } else if (Object.keys(this.data).length === 1) {
     return this.data[Object.keys(this.data)[0]];
   } else {
@@ -613,7 +615,7 @@ p5.NumberDict.prototype.maxValue = function() {
 
 p5.NumberDict.prototype._keyTest = function(flip) {
   if (Object.keys(this.data).length === 0) {
-    throw 'Unable to use minValue on an empty NumberDict';
+    throw new Error('Unable to use minValue on an empty NumberDict');
   } else if (Object.keys(this.data).length === 1) {
     return Object.keys(this.data)[0];
   } else {

--- a/src/io/files.js
+++ b/src/io/files.js
@@ -1093,7 +1093,12 @@ p5.prototype.httpDo = function() {
 
   (type === 'jsonp' ? fetchJsonp(path, jsonpOptions) : fetch(request))
     .then(function(res) {
-      if (!res.ok) throw res;
+      if (!res.ok) {
+        var err = new Error(res.body);
+        err.status = res.status;
+        err.ok = false;
+        throw err;
+      }
 
       switch (type) {
         case 'json':

--- a/src/io/p5.Table.js
+++ b/src/io/p5.Table.js
@@ -109,7 +109,7 @@ p5.Table.prototype.addRow = function(row) {
 
   if (typeof r.arr === 'undefined' || typeof r.obj === 'undefined') {
     //r = new p5.prototype.TableRow(r);
-    throw 'invalid TableRow: ' + r;
+    throw new Error('invalid TableRow: ' + r);
   }
   r.table = this;
   this.rows.push(r);
@@ -1282,7 +1282,9 @@ p5.Table.prototype.getObject = function(headerColumn) {
         index = obj[headerColumn];
         tableObject[index] = obj;
       } else {
-        throw 'This table has no column named "' + headerColumn + '"';
+        throw new Error(
+          'This table has no column named "' + headerColumn + '"'
+        );
       }
     } else {
       tableObject[i] = this.rows[i].obj;

--- a/src/io/p5.TableRow.js
+++ b/src/io/p5.TableRow.js
@@ -87,7 +87,7 @@ p5.TableRow.prototype.set = function(column, value) {
       this.obj[column] = value;
       this.arr[cPos] = value;
     } else {
-      throw 'This table has no column named "' + column + '"';
+      throw new Error('This table has no column named "' + column + '"');
     }
   } else {
     // if typeof column is number, use .arr
@@ -96,7 +96,9 @@ p5.TableRow.prototype.set = function(column, value) {
       var cTitle = this.table.columns[column];
       this.obj[cTitle] = value;
     } else {
-      throw 'Column #' + column + ' is out of the range of this table';
+      throw new Error(
+        'Column #' + column + ' is out of the range of this table'
+      );
     }
   }
 };

--- a/src/typography/loading_displaying.js
+++ b/src/typography/loading_displaying.js
@@ -254,7 +254,7 @@ p5.prototype.textFont = function(theFont, theSize) {
   p5._validateParameters('textFont', arguments);
   if (arguments.length) {
     if (!theFont) {
-      throw Error('null font passed to textFont');
+      throw new Error('null font passed to textFont');
     }
 
     this._renderer._setProperty('_textFont', theFont);

--- a/src/typography/p5.Font.js
+++ b/src/typography/p5.Font.js
@@ -37,7 +37,7 @@ p5.Font = function(p) {
 
 p5.Font.prototype.list = function() {
   // TODO
-  throw 'not yet implemented';
+  throw new Error('not yet implemented');
 };
 
 /**

--- a/src/webgl/p5.RendererGL.js
+++ b/src/webgl/p5.RendererGL.js
@@ -151,7 +151,7 @@ p5.RendererGL.prototype._initContext = function() {
       );
     }
   } catch (er) {
-    throw new Error(er);
+    throw er;
   }
 };
 

--- a/test/unit/io/files_input.js
+++ b/test/unit/io/files_input.js
@@ -71,7 +71,6 @@ suite('Files', function() {
           resolve
         );
       }).then(function(err) {
-        assert.instanceOf(err, Response, 'err is a Response');
         assert.isFalse(err.ok, 'err.ok is false');
         assert.equal(err.status, 404, 'Error status is 404');
       });
@@ -175,7 +174,6 @@ suite('Files', function() {
           resolve
         );
       }).then(function(err) {
-        assert.instanceOf(err, Response, 'err is a Response.');
         assert.isFalse(err.ok, 'err.ok is false');
         assert.equal(err.status, 404, 'Error status is 404');
       });
@@ -240,7 +238,6 @@ suite('Files', function() {
           resolve
         );
       }).then(function(err) {
-        assert.instanceOf(err, Response, 'err is an object');
         assert.isFalse(err.ok, 'err.ok is false');
         assert.equal(err.status, 404, 'Error status is 404');
       });


### PR DESCRIPTION
The way p5.js currently throws errors is not entirely consitent, which makes it harder for other libraries to interact with it.

This PR normalizes all throwing of errors to use the currently prevailing style of

```js
throw new Error('this is the error message');
```

which also [seems to be the most user friendly one](https://www.nczonline.net/blog/2009/03/10/the-art-of-throwing-javascript-errors-part-2/) as it will always print the message.