### PR TITLE
Try to use event.key for reading character from keydown and keyup events

### DIFF
--- a/src/events/keyboard.js
+++ b/src/events/keyboard.js
@@ -182,11 +182,10 @@ p5.prototype._onkeydown = function(e) {
   this._setProperty('keyIsPressed', true);
   this._setProperty('keyCode', e.which);
   downKeys[e.which] = true;
-  var key = String.fromCharCode(e.which);
-  if (!key) {
-    key = e.which;
-  }
-  this._setProperty('key', key);
+  this._setProperty(
+    'key',
+    event.key || String.fromCharCode(e.which) || e.which
+  );
   var keyPressed = this.keyPressed || window.keyPressed;
   if (typeof keyPressed === 'function' && !e.charCode) {
     var executeDefault = keyPressed(e);
@@ -237,11 +236,10 @@ p5.prototype._onkeyup = function(e) {
 
   this._setProperty('_lastKeyCodeTyped', null);
 
-  var key = String.fromCharCode(e.which);
-  if (!key) {
-    key = e.which;
-  }
-  this._setProperty('key', key);
+  this._setProperty(
+    'key',
+    event.key || String.fromCharCode(e.which) || e.which
+  );
   this._setProperty('keyCode', e.which);
   if (typeof keyReleased === 'function') {
     var executeDefault = keyReleased(e);


### PR DESCRIPTION
This would improve the situation for #2893 

`KeyboardEvent.key` seems too have [ok support](https://caniuse.com/#feat=keyboardevent-key) and its output is probably much closer to what a user would expect.

I might be missing something here though.