### PR TITLE
documentation

### DIFF
--- a/src/README.md
+++ b/src/README.md
@@ -4,6 +4,8 @@ The p5.js source code is organized into subdirectories which are roughly concept
 
 The `src/core` directory is the primary exception to this. It contains most of the internal logic of p5.js — the code which orchestrates everything else. It is possible to create optimized minimalist [custom builds](/developer_docs/custom_p5_build.md) of the p5.js library which only include specific desired modules. In such a custom build, the contents of the core directory would be the only hard requirement, and everything else would be optional.
 
+[JSDoc](http://usejsdoc.org/) [module](http://usejsdoc.org/tags-module.html) annotations are used throughout the codebase, but they primarily organize the public-facing [p5 reference manual](https://p5js.org/reference/), which is built automatically from the source code. These annotations structure the *expressive and creative API* of p5, and consequently they might not always align exactly with the *source code structure*.
+
 The `app.js` file is simply an index of all the other modules which exports the p5 constructor function.
 
 # APIs
@@ -12,6 +14,6 @@ p5.js seeks to create a toolkit for working with the web technologies that are m
 
 Public APIs which are exposed to users of the p5.js should use short, clear, declarative function names. If the name of a public API function is longer than one or two words, it may be worth carefully considering whether the API should be restructured.
 
-Internal APIs which are not exposed to the user but are used for coordination within the library should generally as constructor functions which can be exported across module boundaries. Those constructors are often attached to the `p5` constructor as a form of namespacing, but otherwise do not meaningfully act as methods that reference the host object. In cases where a `p5` object is needed inside a constructor, an instance will be passed as a creation argument.
+Internal APIs which are not exposed to the user but are used for coordination within the library should generally as constructor functions which can be exported across module boundaries. Those constructors are often attached to the `p5` constructor as a form of namespacing, but otherwise do not meaningfully act as methods that reference the host object. In cases where a `p5` object is needed inside a constructor, an instance will be explicitly passed as an input argument.
 
 The above are guidelines, and in practice there may be occasional exceptions.

--- a/src/README.md
+++ b/src/README.md
@@ -12,7 +12,7 @@ The `app.js` file is simply an index of all the other modules which exports the 
 
 p5.js seeks to create a toolkit for working with the web technologies that are most valuable for building art projects. For both expressive and pedagogical reasons, p5.js values (but does not necessarily always achieve lol!) clarity in its APIs.
 
-Public APIs which are exposed to users of the p5.js should use short, clear, declarative function names. If the name of a public API function is longer than one or two words, it may be worth carefully considering whether the API should be restructured.
+Public APIs which are exposed to users of the p5.js library during the course of working on sketches and projects should use short, clear, declarative function names. If the name of a public API function is longer than one or two words, it may be worth carefully considering whether the API should be restructured into something more creative, expressive, or intuitive.
 
 Internal APIs which are not exposed to the user but are used for coordination within the library should generally as constructor functions which can be exported across module boundaries. Those constructors are often attached to the `p5` constructor as a form of namespacing, but otherwise do not meaningfully act as methods that reference the host object. In cases where a `p5` object is needed inside a constructor, an instance will be explicitly passed as an input argument.
 

--- a/src/README.md
+++ b/src/README.md
@@ -1,5 +1,17 @@
+# Organization
+
 The p5.js source code is organized into subdirectories which are roughly conceptually equivalent to third-party addons, except that these "addons" are actually just shipped as part of the p5.js library because the functionality they provide is so useful and central to p5's goal of building art projects for the web.
 
 The `src/core` directory is the primary exception to this. It contains most of the internal logic of p5.js — the code which orchestrates everything else. It is possible to create optimized minimalist [custom builds](/developer_docs/custom_p5_build.md) of the p5.js library which only include specific desired modules. In such a custom build, the contents of the core directory would be the only hard requirement, and everything else would be optional.
 
 The `app.js` file is simply an index of all the other modules which exports the p5 constructor function.
+
+# APIs
+
+p5.js seeks to create a toolkit for working with the web technologies that are most valuable for building art projects. For both expressive and pedagogical reasons, p5.js values (but does not necessarily always achieve lol!) clarity in its APIs.
+
+Public APIs which are exposed to users of the p5.js should use short, clear, declarative function names. If the name of a public API function is longer than one or two words, it may be worth carefully considering whether the API should be restructured.
+
+Internal APIs which are not exposed to the user but are used for coordination within the library should generally as constructor functions which can be exported across module boundaries. Those constructors are often attached to the `p5` constructor as a form of namespacing, but otherwise do not meaningfully act as methods that reference the host object. In cases where a `p5` object is needed inside a constructor, an instance will be passed as a creation argument.
+
+The above are guidelines, and in practice there may be occasional exceptions.

--- a/src/core/README.md
+++ b/src/core/README.md
@@ -32,7 +32,7 @@ The `environment.js` module detects and semantically reassigns various features 
 
 Sometimes p5.js needs to use new browser APIs or other features which haven't yet been completely standardized; for example, a feature that still uses [vendor prefixes](https://developer.mozilla.org/en-US/docs/Glossary/Vendor_Prefix). In any such cases where it is necessary to handle multiple versions of the same functionality, the `shim.js` module juggles the available variants and assigns the results of that evaluation to a standardized property on the `p5` object. The rest of the p5.js library can then use that functionality without needing to constantly reconsider the specific browser implementation details.
 
-# [p5.Element.js](./p5.Element.js)
+## [p5.Element.js](./p5.Element.js)
 
 Although p5.js is a general toolkit for all sorts of interactive art projects, in practice many p5.js sketches focus on rendering two dimensional graphics into a `<canvas>` element. The `p5.Element.js` module is a wrapper around the browser's DOM API which is focused on the `<canvas>` element and also handles user input events like clicks and mouse movements. Conceptually, p5.js considers the sketch to be *the entire web page*, but for historical reasons, manipulation of non-`canvas` DOM elements is handled by the [p5.dom add-on](https://p5js.org/reference/#/libraries/p5.dom). It's useful to separate `<canvas>` from the more general DOM because so many p5.js projects focus on `<canvas>` and this enables smaller [custom builds](https://github.com/processing/p5.js/blob/master/developer_docs/custom_p5_build.md). 
 
@@ -60,22 +60,22 @@ The `p5.Graphics` module is a lightweight wrapper around renderers which is used
 
 *lines, shapes, and visual styles*
 
-# [attributes.js](./attributes.js)
+## [attributes.js](./attributes.js)
 
 Attributes are an important part of the general API for the web, but the `attributes.js` module defines and handles miscellaneous *graphical* attributes that can be consider a set of active parameters for the current drawing style. Think of this as a grab bag of all the remaining drawing parameters that were not moved out into separate dedicated modules as with [color](../color/) and [typography](../typography/).
 
-# [2d_primitives.js](./2d_primitives.js)
+## [2d_primitives.js](./2d_primitives.js)
 
 The `2d_primitives.js` module provides helper functions for drawing common shapes. The resulting drawing commands are sent to the currently active [renderer](./rendering.js).
 
-# [transform.js](./transform.js)
+## [transform.js](./transform.js)
 
 The `transform.js` module implements logic for scaling, rotation, and matrix transformations.
 
-# [vertex.js](./vertex.js)
+## [vertex.js](./vertex.js)
 
 The `vertex.js` module handles points and coordinates for drawing curves and shapes.
 
-# [curves.js](./curves.js)
+## [curves.js](./curves.js)
 
 The `curves.js` module draws curves based on a set of vertices.

--- a/src/core/README.md
+++ b/src/core/README.md
@@ -1,6 +1,6 @@
 # Application
 
-internal structure and logic
+*internal structure and logic*
 
 ## [init.js](./init.js)
 
@@ -22,7 +22,7 @@ The `constants.js` module provides various default values mostly related to math
 
 # Browser
 
-utilizing and abstracting web technologies
+*utilizing and abstracting web technologies*
 
 ## [environment.js](./environment.js)
 
@@ -38,7 +38,7 @@ Although p5.js is a general toolkit for all sorts of interactive art projects, i
 
 # Rendering
 
-project output options
+*project output options*
 
 ## [rendering.js](./rendering.js)
 
@@ -58,7 +58,7 @@ The `p5.Graphics` module is a lightweight wrapper around renderers which is used
 
 # Drawing
 
-lines, shapes, and visual styles
+*lines, shapes, and visual styles*
 
 # [attributes.js](./attributes.js)
 

--- a/src/core/README.md
+++ b/src/core/README.md
@@ -66,7 +66,7 @@ Attributes are an important part of the general API for the web, but the `attrib
 
 # [2d_primitives.js](./2d_primitives.js)
 
-The `2d_primitives.js` module provides helper functions for drawing common shapes. The resulting drawing commands are sent to the currently active [renderer](./renderer.js).
+The `2d_primitives.js` module provides helper functions for drawing common shapes. The resulting drawing commands are sent to the currently active [renderer](./rendering.js).
 
 # [transform.js](./transform.js)
 

--- a/src/core/README.md
+++ b/src/core/README.md
@@ -1,33 +1,81 @@
-# [init.js](./init.js)
+# Application
+
+internal structure and logic
+
+## [init.js](./init.js)
 
 The `init.js` module initializes a new `p5` object in either global mode, instance mode, or unit testing mode. Broadly speaking, this module should only contain logic that needs to execute *before startup*, such as testing the environment in which the code is running in order to make decisions about how it should load.
 
-# [core.js](./core.js)
+## [core.js](./core.js)
 
 The sole job of the `core.js` module is to create and then export the constructor function for creating a new `p5` object. This constructor function is also called `p5`, and doesn't use the typical JavaScript convention of capitalizing constructor functions. The constructor handles a number of mechanical startup concerns, including assigning functions and properties from elsewhere in the source code to the newly created `p5` object as either public or private methods and properties.
 
 Aside from the exported constructor function, the most important thing in this module is the set of functions that define the loop used by nearly every p5.js project: `preload()`, `setup()`, `draw()`, `remove()`, and so on. These functions are both available on the `p5` object as methods, and also assigned to variables in the global space for syntactic simplicity, because calling a function named `draw()` is more creatively expressive than namespacing the same functionality with an object as with `mySketch.draw()` or similar. The `friendlyBindGlobal` function standardizes the process by which the necessary global variables can be created, notably including logging [friendly error messages](https://github.com/processing/p5.js/wiki/Friendly-Error-System) when conflicts are detected, but it is not exported from the module's internal scope.
 
-# [structure.js](./structure.js)
+## [structure.js](./structure.js)
 
 The `structure.js` module is best thought of as a collection of ways to make *modifications* to the typical *loop structure* of p5's `draw()` function. The functions in this module allow you to add and extract individual renders from the loop, draw the loop one frame at a time, pause and resume the loop, and so on.
 
-# [constants.js](./constants.js)
+## [constants.js](./constants.js)
 
 The `constants.js` module provides various default values mostly related to math and web standards using clear semantic names to increase syntax clarity when they are used in other algorithms. These values are attached to the `p5` object prototype as properties by the constructor function so they can be more easily accessed by other parts of the p5.js library or by user code.
 
-# [environment.js](./environment.js)
+# Browser
+
+utilizing and abstracting web technologies
+
+## [environment.js](./environment.js)
 
 The `environment.js` module detects and semantically reassigns various features of the code execution environment that are arguably beyond the control of the p5.js library, such as device properties, window dimensions, and the URL bar. In general, this module should only contain code that exposes mechanics of the web that usually would not be considered part of the p5.js "sketch." This module is conceptually similar to `init.js` in that it tests the environment in which the p5.js code is executing, but one major difference is that broadly speaking the code in `environment.js` does *not* need to run solely at initialization as with `init.js`, and can be invoked whenever necessary.
 
-# [shim.js](./shim.js)
+## [shim.js](./shim.js)
 
 Sometimes p5.js needs to use new browser APIs or other features which haven't yet been completely standardized; for example, a feature that still uses [vendor prefixes](https://developer.mozilla.org/en-US/docs/Glossary/Vendor_Prefix). In any such cases where it is necessary to handle multiple versions of the same functionality, the `shim.js` module juggles the available variants and assigns the results of that evaluation to a standardized property on the `p5` object. The rest of the p5.js library can then use that functionality without needing to constantly reconsider the specific browser implementation details.
 
-# [rendering.js](./rendering.js)
+# [p5.Element.js](./p5.Element.js)
 
-The `rendering.js` module defines graphical output options. In the overwhelming majority of cases, a p5.js sketch will be output to a `<canvas>` tag on the current web page, but it is also possible to do "headless" output using `nocanvas` mode or "render" to a graphics buffer that is computed but never actually appears on the screen.
+Although p5.js is a general toolkit for all sorts of interactive art projects, in practice many p5.js sketches focus on rendering two dimensional graphics into a `<canvas>` element. The `p5.Element.js` module is a wrapper around the browser's DOM API which is focused on the `<canvas>` element and also handles user input events like clicks and mouse movements. Conceptually, p5.js considers the sketch to be *the entire web page*, but for historical reasons, manipulation of non-`canvas` DOM elements is handled by the [p5.dom add-on](https://p5js.org/reference/#/libraries/p5.dom). It's useful to separate `<canvas>` from the more general DOM because so many p5.js projects focus on `<canvas>` and this enables smaller [custom builds](https://github.com/processing/p5.js/blob/master/developer_docs/custom_p5_build.md). 
+
+# Rendering
+
+project output options
+
+## [rendering.js](./rendering.js)
+
+The `rendering.js` module presents the user-facing API for p5's various graphical output options. In the overwhelming majority of cases, a p5.js sketch will be output to a `<canvas>` tag on the current web page, but it is also possible to do "headless" output using `nocanvas` mode or "render" to a graphics buffer that is computed but never actually appears on the screen.
+
+## [p5.Renderer.js](./p5.Renderer.js)
+
+The `p5.Renderer.js` module provides a common base definition for a p5 project output mode that can then be extended as with [p5.Renderer2D](./p5.Renderer2D.js). For three dimensional output, see the [webgl module](../webgl/). Each `p5` object instance typically has a `Renderer` attached as a property.
+
+## [p5.Renderer2D.js](./p5.Renderer2D.js)
+
+The `p5.Renderer2D.js` module extends the generic `p5.Renderer` definition and optimizes it for two dimensional images.
+
+## [p5.Graphics.js](./p5.Graphics.js)
+
+The `p5.Graphics` module is a lightweight wrapper around renderers which is used to create output graphics in memory without ever actually drawing them on the screen.
+
+# Drawing
+
+lines, shapes, and visual styles
+
+# [attributes.js](./attributes.js)
+
+Attributes are an important part of the general API for the web, but the `attributes.js` module defines and handles miscellaneous *graphical* attributes that can be consider a set of active parameters for the current drawing style. Think of this as a grab bag of all the remaining drawing parameters that were not moved out into separate dedicated modules as with [color](../color/) and [typography](../typography/).
 
 # [2d_primitives.js](./2d_primitives.js)
 
 The `2d_primitives.js` module provides helper functions for drawing common shapes. The resulting drawing commands are sent to the currently active [renderer](./renderer.js).
+
+# [transform.js](./transform.js)
+
+The `transform.js` module implements logic for scaling, rotation, and matrix transformations.
+
+# [vertex.js](./vertex.js)
+
+The `vertex.js` module handles points and coordinates for drawing curves and shapes.
+
+# [curves.js](./curves.js)
+
+The `curves.js` module draws curves based on a set of vertices.


### PR DESCRIPTION
- explain additional modules in `src/core`
- add structure to `src/core/README.md`
- document some of the informal naming conventions in `src/README.md`