### PR TITLE
In scale doc, replace rotate example with basic scale example.

### DIFF
--- a/src/core/transform.js
+++ b/src/core/transform.js
@@ -314,9 +314,9 @@ p5.prototype.rotateZ = function(angle) {
  * @example
  * <div>
  * <code>
- * translate(width / 2, height / 2);
- * rotate(PI / 3.0);
- * rect(-26, -26, 52, 52);
+ * rect(30, 20, 50, 50);
+ * scale(0.5);
+ * rect(30, 20, 50, 50);
  * </code>
  * </div>
  *


### PR DESCRIPTION
The `scale()` documentation contains two code examples where one is a `rotate()` example.  Replaced it with the basic `scale()` example used on processing.org.