### PR TITLE
Added clipping plane value checks to perspective.

### DIFF
--- a/src/webgl/camera.js
+++ b/src/webgl/camera.js
@@ -221,6 +221,21 @@ p5.RendererGL.prototype.perspective = function(fovy, aspect, near, far) {
     far = this.defaultCameraFar;
   }
 
+  if (near <= 0.0001) {
+    near = 0.01;
+    console.log(
+      'Avoid perspective near plane values close to or below 0. ' +
+        'Setting value to 0.01.'
+    );
+  }
+
+  if (far < near) {
+    console.log(
+      'Perspective far plane value is less than near plane value. ' +
+        'Nothing will be shown.'
+    );
+  }
+
   this.cameraFOV = this._pInst._toRadians(fovy);
   this.cameraAspect = aspect;
   this.cameraNear = near;
@@ -309,9 +324,9 @@ p5.RendererGL.prototype.ortho = function(left, right, bottom, top, near, far) {
   this.uPMatrix = p5.Matrix.identity();
 
   // prettier-ignore
-  this.uPMatrix.set(  x,  0,  0,  0, 
-                      0, -y,  0,  0, 
-                      0,  0,  z,  0, 
+  this.uPMatrix.set(  x,  0,  0,  0,
+                      0, -y,  0,  0,
+                      0,  0,  z,  0,
                      tx, ty, tz,  1);
 
   this._curCamera = 'custom';


### PR DESCRIPTION
Fixes #2936.

Adds two checks to perspective() arguments: 

1. Checks whether near plane is at or below 0.0001.  If so, resets this value to 0.01 and logs a warning to console. This value (0.0001) seems to be about where strange artifacts become very noticeable.  See below screenshot of perspective near plane set to 0.00011:

![screen shot 2018-05-23 at 7 07 16 pm](https://user-images.githubusercontent.com/6486359/40455931-032ed214-5ebd-11e8-8aa7-30db964c48be.png)

2. Checks whether far plane value is less than near plane and logs a warning to the console.

Is there any reason these checks should happen elsewhere in the function (after this.cameraNear and this.cameraFar are set, for instance)?