### PR TITLE
Stop webGL rect() stroke on diagonal / internal faces

### DIFF
--- a/src/webgl/primitives.js
+++ b/src/webgl/primitives.js
@@ -949,6 +949,15 @@ p5.RendererGL.prototype.rect = function(args) {
           this.uvs.push(u, v);
         }
       }
+      // using stroke indices to avoid stroke over face(s) of rectangle
+      if (detailX > 0 && detailY > 0) {
+        this.strokeIndices = [
+          [0, detailX],
+          [detailX, (detailX + 1) * (detailY + 1) - 1],
+          [(detailX + 1) * (detailY + 1) - 1, (detailX + 1) * detailY],
+          [(detailX + 1) * detailY, 0]
+        ];
+      }
     };
     var rectGeom = new p5.Geometry(detailX, detailY, _rect);
     rectGeom

--- a/test/manual-test-examples/webgl/rectStroke/index.html
+++ b/test/manual-test-examples/webgl/rectStroke/index.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<html>
+
+<head>
+  <meta charset="utf-8">
+  <meta http-equiv="X-UA-Compatible" content="IE=edge">
+  <title>Rect Stroke Test</title>
+  <link rel="stylesheet" href="../../styles.css">
+  <script language="javascript" type="text/javascript" src="../../../../lib/p5.js"></script>
+  <script language="javascript" type="text/javascript" src="sketch.js"></script>
+  <script src="../stats.js"></script>
+</head>
+
+<body>
+  <header>
+    <p>You should see a stroke around the rectangle, but not across the faces of the rectangle.</p>
+  </header>
+</body>
+
+</html>

--- a/test/manual-test-examples/webgl/rectStroke/sketch.js
+++ b/test/manual-test-examples/webgl/rectStroke/sketch.js
@@ -1,0 +1,19 @@
+/**
+ * WebGL rect() stroke test - you should see a border stroke, but no internal
+ * face or diagonal stroke
+ */
+
+function setup() {
+  createCanvas(500, 500, WEBGL);
+}
+
+function draw() {
+  background(200);
+  push();
+  stroke(0);
+  strokeWeight(3);
+  rectMode(CENTER);
+  fill(255);
+  rect(0, 0, 200, 200, 12, 12);
+  pop();
+}


### PR DESCRIPTION
Fixes #2943.

This stops rendererGL from drawing stroke across the diagonal and internal faces of rectangles by explicitly calculating the strokeIndices.   I added a check for detailX and detailY values at or below zero to avoid throwing an error in such cases.  Instead, no rectangle will show up on screen (matching current behavior).