### PR TITLE
Add support for a Promise being returned from httpDo, httpGet and httpPost

### DIFF
--- a/src/io/files.js
+++ b/src/io/files.js
@@ -769,6 +769,9 @@ p5.prototype.loadBytes = function(file, callback, errorCallback) {
  * @param  {function}      [errorCallback] function to be executed if
  *                                    there is an error, response is passed
  *                                    in as first argument
+ * @return {Promise} A promise that resolves with the data when the operation
+ *                   completes successfully or rejects with the error after
+ *                   one occurs.
  * @example
  * <div class='norender'><code>
  * // Examples use USGS Earthquake API:
@@ -808,19 +811,21 @@ p5.prototype.loadBytes = function(file, callback, errorCallback) {
  * @param  {Object|Boolean} data
  * @param  {function}      [callback]
  * @param  {function}      [errorCallback]
+ * @return {Promise}
  */
 /**
  * @method httpGet
  * @param  {String}        path
  * @param  {function}      callback
  * @param  {function}      [errorCallback]
+ * @return {Promise}
  */
 p5.prototype.httpGet = function() {
   p5._validateParameters('httpGet', arguments);
 
   var args = Array.prototype.slice.call(arguments);
   args.splice(1, 0, 'GET');
-  p5.prototype.httpDo.apply(this, args);
+  return p5.prototype.httpDo.apply(this, args);
 };
 
 /**
@@ -839,6 +844,9 @@ p5.prototype.httpGet = function() {
  * @param  {function}      [errorCallback] function to be executed if
  *                                    there is an error, response is passed
  *                                    in as first argument
+ * @return {Promise} A promise that resolves with the data when the operation
+ *                   completes successfully or rejects with the error after
+ *                   one occurs.
  *
  * @example
  * <div>
@@ -908,19 +916,21 @@ p5.prototype.httpGet = function() {
  * @param  {Object|Boolean} data
  * @param  {function}      [callback]
  * @param  {function}      [errorCallback]
+ * @return {Promise}
  */
 /**
  * @method httpPost
  * @param  {String}        path
  * @param  {function}      callback
  * @param  {function}      [errorCallback]
+ * @return {Promise}
  */
 p5.prototype.httpPost = function() {
   p5._validateParameters('httpPost', arguments);
 
   var args = Array.prototype.slice.call(arguments);
   args.splice(1, 0, 'POST');
-  p5.prototype.httpDo.apply(this, args);
+  return p5.prototype.httpDo.apply(this, args);
 };
 
 /**
@@ -942,7 +952,9 @@ p5.prototype.httpPost = function() {
  * @param  {function}      [errorCallback] function to be executed if
  *                                    there is an error, response is passed
  *                                    in as first argument
- *
+ * @return {Promise} A promise that resolves with the data when the operation
+ *                   completes successfully or rejects with the error after
+ *                   one occurs.
  *
  * @example
  * <div>
@@ -999,6 +1011,7 @@ p5.prototype.httpPost = function() {
  * <a href="https://developer.mozilla.org/en/docs/Web/API/Fetch_API">reference</a>
  * @param  {function}      [callback]
  * @param  {function}      [errorCallback]
+ * @return {Promise}
  */
 p5.prototype.httpDo = function() {
   var type;
@@ -1091,35 +1104,41 @@ p5.prototype.httpDo = function() {
     }
   }
 
-  (type === 'jsonp' ? fetchJsonp(path, jsonpOptions) : fetch(request))
-    .then(function(res) {
-      if (!res.ok) {
-        var err = new Error(res.body);
-        err.status = res.status;
-        err.ok = false;
-        throw err;
-      }
+  var promise;
+  if (type === 'jsonp') {
+    promise = fetchJsonp(path, jsonpOptions);
+  } else {
+    promise = fetch(request);
+  }
+  promise = promise.then(function(res) {
+    if (!res.ok) {
+      var err = new Error(res.body);
+      err.status = res.status;
+      err.ok = false;
+      throw err;
+    }
 
-      switch (type) {
-        case 'json':
-        case 'jsonp':
-          return res.json();
-        case 'binary':
-          return res.blob();
-        case 'arrayBuffer':
-          return res.arrayBuffer();
-        case 'xml':
-          return res.text().then(function(text) {
-            var parser = new DOMParser();
-            var xml = parser.parseFromString(text, 'text/xml');
-            return parseXML(xml.documentElement);
-          });
-        default:
-          return res.text();
-      }
-    })
-    .then(callback || function() {})
-    .catch(errorCallback || console.error);
+    switch (type) {
+      case 'json':
+      case 'jsonp':
+        return res.json();
+      case 'binary':
+        return res.blob();
+      case 'arrayBuffer':
+        return res.arrayBuffer();
+      case 'xml':
+        return res.text().then(function(text) {
+          var parser = new DOMParser();
+          var xml = parser.parseFromString(text, 'text/xml');
+          return parseXML(xml.documentElement);
+        });
+      default:
+        return res.text();
+    }
+  });
+  promise.then(callback || function() {});
+  promise.catch(errorCallback || console.error);
+  return promise;
 };
 
 /**

--- a/test/unit/io/files_input.js
+++ b/test/unit/io/files_input.js
@@ -75,6 +75,30 @@ suite('Files', function() {
         assert.equal(err.status, 404, 'Error status is 404');
       });
     });
+
+    test('should return a promise', function() {
+      var promise = myp5.httpDo('unit/assets/sentences.txt');
+      assert.instanceOf(promise, Promise);
+      return promise.then(function(data) {
+        assert.ok(data);
+        assert.isString(data);
+      });
+    });
+
+    test('should return a promise that rejects on error', function() {
+      return new Promise(function(resolve, reject) {
+        var promise = myp5.httpDo('404file');
+        assert.instanceOf(promise, Promise);
+        promise.then(function(data) {
+          reject(new Error('promise resolved.'));
+        });
+        resolve(
+          promise.catch(function(error) {
+            assert.instanceOf(error, Error);
+          })
+        );
+      });
+    });
   });
 
   // tests while preload is true without callbacks


### PR DESCRIPTION
Forwards the Promise from the underlying fetch so that it is exposed to users of the http APIs.

- Note that I have specified Promise as the return type, but this is showing a warning about typescript definitions. I do not know enough about these to fix this warning, however, so these need to be fixed by someone who knows that area of code.