### PR TITLE
fix(typescript): export declared p5 class to make it available

### DIFF
--- a/tasks/typescript/generate-typescript-annotations.js
+++ b/tasks/typescript/generate-typescript-annotations.js
@@ -469,6 +469,8 @@ function mod(yuidocs, localFileame, globalFilename, sourcePath) {
 
     emit = createEmitter(localFileame);
 
+    emit('export = p5;');
+
     emit('declare class p5 {');
     emit.indent();
 


### PR DESCRIPTION
This change will make the typescript typings of p5 available to the TS compiler.
It wasn't exported before and made the compiler even fail with the message

```
File 'some-project/node_modules/p5/lib/p5.d.ts' is not a module.
```

A monkey patch of the mentioned file with the following addition in the header fixed it.
```
// 👇This is missing
export = p5;

declare class p5 {
```

I don't see any side effects of this change so I prepared this PR.
Thanks a lot for P5 ✌️