### PR TITLE
Remove redundant calls in p5.Shader.js

### DIFF
--- a/src/webgl/p5.Shader.js
+++ b/src/webgl/p5.Shader.js
@@ -191,7 +191,7 @@ p5.Shader.prototype.bindShader = function() {
     this.useProgram();
     this._bound = true;
     this.bindTextures();
-    
+
     this._renderer._setDefaultCamera();
     this._setMatrixUniforms();
     if (this === this._renderer.curStrokeShader) {

--- a/src/webgl/p5.Shader.js
+++ b/src/webgl/p5.Shader.js
@@ -34,8 +34,6 @@ p5.Shader = function(renderer, vertSrc, fragSrc) {
   this.uniforms = {};
   this._bound = false;
   this.samplers = [];
-
-  return this;
 };
 
 /**
@@ -193,10 +191,7 @@ p5.Shader.prototype.bindShader = function() {
     this.useProgram();
     this._bound = true;
     this.bindTextures();
-
-    this._loadAttributes();
-    this._loadUniforms();
-
+    
     this._renderer._setDefaultCamera();
     this._setMatrixUniforms();
     if (this === this._renderer.curStrokeShader) {


### PR DESCRIPTION
Calls to [`_loadAttributes()`](/processing/p5.js/blob/29fdfa36b8204ea1301270bb577d461377f282ea/src/webgl/p5.Shader.js#L197-L198) and [`_loadUniforms()`](/processing/p5.js/blob/29fdfa36b8204ea1301270bb577d461377f282ea/src/webgl/p5.Shader.js#L197-L198) inside `bindShader()` are deemed redundant as they would have been called by `init()`. Note that `getProgramParameter()`, `getActiveAttrib()`, `getAttribLocation()`, `getActiveUniform()` and  `getUniformLocation()` can hinder performance as they need to interrupt the GPU in order to query the WebGL states concerned, so we want to make sure they are not called for no reason. Also removed is the [return statement](https://github.com/processing/p5.js/blob/29fdfa36b8204ea1301270bb577d461377f282ea/src/webgl/p5.Shader.js#L38) in the constructor, which serves no real purpose.