### PR TITLE
Texture filtering and wrapping

### DIFF
--- a/src/core/constants.js
+++ b/src/core/constants.js
@@ -20,6 +20,11 @@ module.exports = {
    * @final
    */
   WEBGL: 'webgl',
+  NEAREST: 'nearest',
+  LINEAR: 'linear',
+  REPEAT: 'repeat',
+  CLAMP: 'clamp',
+  MIRROR: 'mirror',
 
   // ENVIRONMENT
   ARROW: 'default',

--- a/src/core/constants.js
+++ b/src/core/constants.js
@@ -21,7 +21,6 @@ module.exports = {
    */
   WEBGL: 'webgl',
 
-
   // ENVIRONMENT
   ARROW: 'default',
   CROSS: 'crosshair',
@@ -499,7 +498,7 @@ module.exports = {
   IMMEDIATE: 'immediate',
 
   //WEBGL TEXTURE WRAP AND FILTERING
-  // LINEAR already exists above 
+  // LINEAR already exists above
   NEAREST: 'nearest',
   REPEAT: 'repeat',
   CLAMP: 'clamp',

--- a/src/core/constants.js
+++ b/src/core/constants.js
@@ -20,11 +20,7 @@ module.exports = {
    * @final
    */
   WEBGL: 'webgl',
-  NEAREST: 'nearest',
-  LINEAR: 'linear',
-  REPEAT: 'repeat',
-  CLAMP: 'clamp',
-  MIRROR: 'mirror',
+
 
   // ENVIRONMENT
   ARROW: 'default',
@@ -501,6 +497,13 @@ module.exports = {
   FILL: 'fill',
   TEXTURE: 'texture',
   IMMEDIATE: 'immediate',
+
+  //WEBGL TEXTURE WRAP AND FILTERING
+  // LINEAR already exists above 
+  NEAREST: 'nearest',
+  REPEAT: 'repeat',
+  CLAMP: 'clamp',
+  MIRROR: 'mirror',
 
   // DEVICE-ORIENTATION
   /**

--- a/src/webgl/p5.Texture.js
+++ b/src/webgl/p5.Texture.js
@@ -9,6 +9,7 @@
 'use strict';
 
 var p5 = require('../core/core');
+var constants = require('./constants');
 
 /**
  * Texture class for WEBGL Mode
@@ -250,6 +251,74 @@ p5.Texture.prototype.unbindTexture = function() {
   // unbind per above, disable texturing on glTarget
   var gl = this._renderer.GL;
   gl.bindTexture(this.glTarget, null);
+};
+
+/**
+ * Sets texture min / mag filters
+ * @method setTextureFilters
+ */
+p5.Texture.prototype.setTextureFilters = function(minFilter, magFilter) {
+  var gl = this._renderer.GL;
+
+  if (minFilter === constants.NEAREST) {
+    this.glMinFilter = gl.NEAREST;
+  } else if (minFilter === constants.LINEAR) {
+    this.glMinFilter = gl.LINEAR;
+  } else {
+    // falling back to default
+    this.glMinFilter = gl.LINEAR;
+  }
+
+  if (magFilter === constants.NEAREST) {
+    this.glMagFilter = gl.NEAREST;
+  } else if (magFilter === constants.LINEAR) {
+    this.glMagFilter = gl.LINEAR;
+  } else {
+    // falling back to default
+    this.glMagFilter = gl.LINEAR;
+  }
+
+  this.bindTexture();
+
+  gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MAG_FILTER, this.glMagFilter);
+  gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MIN_FILTER, this.glMinFilter);
+
+  this.unbindTexture();
+};
+
+/**
+ * Sets texture wrap
+ * @method setTextureWrap
+ */
+p5.Texture.prototype.setTextureWrap = function(wrapS, wrapT) {
+  var gl = this._renderer.GL;
+
+  if (wrapS === constants.CLAMP) {
+    this.glWrapS = gl.CLAMP_TO_EDGE;
+  } else if (wrapS === constants.REPEAT) {
+    this.glWrapS = gl.REPEAT;
+  } else if (wrapS === constants.MIRROR) {
+    this.glWrapS = gl.MIRRORED_REPEAT;
+  } else {
+    // falling back to default
+    this.glWrapS = gl.CLAMP_TO_EDGE;
+  }
+
+  if (wrapT === constants.CLAMP) {
+    this.glWrapT = gl.CLAMP_TO_EDGE;
+  } else if (wrapT === constants.REPEAT) {
+    this.glWrapT = gl.REPEAT;
+  } else if (wrapT === constants.MIRROR) {
+    this.glWrapT = gl.MIRRORED_REPEAT;
+  } else {
+    // falling back to default
+    this.glWrapT = gl.CLAMP_TO_EDGE;
+  }
+
+  this.bindTexture();
+  gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_WRAP_S, this.glWrapS);
+  gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_WRAP_T, this.glWrapT);
+  this.unbindTexture();
 };
 
 module.exports = p5.Texture;

--- a/test/unit/webgl/p5.Texture.js
+++ b/test/unit/webgl/p5.Texture.js
@@ -45,5 +45,35 @@ suite('p5.Texture', function() {
       // other image was made into a texture in setup, should still be there!
       //testTextureSet(texImg1);
     });
+    test('Set filter mode to linear', function() {
+      var tex = myp5._renderer.getTexture(texImg2);
+      tex.setInterpolation(myp5.LINEAR, myp5.LINEAR);
+      assert.deepEqual(tex.glMinFilter, myp5._renderer.GL.LINEAR);
+      assert.deepEqual(tex.glMagFilter, myp5._renderer.GL.LINEAR);
+    });
+    test('Set filter mode to nearest', function() {
+      var tex = myp5._renderer.getTexture(texImg2);
+      tex.setInterpolation(myp5.NEAREST, myp5.NEAREST);
+      assert.deepEqual(tex.glMinFilter, myp5._renderer.GL.NEAREST);
+      assert.deepEqual(tex.glMagFilter, myp5._renderer.GL.NEAREST);
+    });
+    test('Set wrap mode to clamp', function() {
+      var tex = myp5._renderer.getTexture(texImg2);
+      tex.setWrapMode(myp5.CLAMP, myp5.CLAMP);
+      assert.deepEqual(tex.glWrapS, myp5._renderer.GL.CLAMP_TO_EDGE);
+      assert.deepEqual(tex.glWrapT, myp5._renderer.GL.CLAMP_TO_EDGE);
+    });
+    test('Set wrap mode to repeat', function() {
+      var tex = myp5._renderer.getTexture(texImg2);
+      tex.setWrapMode(myp5.REPEAT, myp5.REPEAT);
+      assert.deepEqual(tex.glWrapS, myp5._renderer.GL.REPEAT);
+      assert.deepEqual(tex.glWrapT, myp5._renderer.GL.REPEAT);
+    });
+    test('Set wrap mode to mirror', function() {
+      var tex = myp5._renderer.getTexture(texImg2);
+      tex.setWrapMode(myp5.MIRROR, myp5.MIRROR);
+      assert.deepEqual(tex.glWrapS, myp5._renderer.GL.MIRRORED_REPEAT);
+      assert.deepEqual(tex.glWrapT, myp5._renderer.GL.MIRRORED_REPEAT);
+    });
   });
 });


### PR DESCRIPTION
I was wanting some more control over how textures were filtered and wrapped so I implemented these two functions on top of the Texture class. 

````
tex.setInterpolation( downscale, upscale);
// downscale & upscale can be constants NEAREST or LINEAR

tex.setWrapMode( wrapX, wrapY);
// wrapX and wrapY can be CLAMP, REPEAT, or MIRROR
// if the texture is not power of two it will fallback to clamp
````

WebGL2 does support non power of two texture for REPEAT and MIRROR but since there wasn't an obvious way to get at version information I just implemented it as a webGL1 function. I also left out mipmapping for now.

You can use them like so...
````
let canvas, img;
function preload(){
   img = loadImage('img.jpg');
}

function setup(){
  canvas = createCanvas(400,400,WEBGL);
  let tex = canvas.getTexture(img);
  tex.setTextureWrap(REPEAT, REPEAT);
  tex.setInterpolation(NEAREST, NEAREST);
}

````