### PR TITLE
update gl pipeline to set shader uniforms at render time

### DIFF
--- a/src/webgl/light.js
+++ b/src/webgl/light.js
@@ -73,27 +73,13 @@ p5.prototype.ambientLight = function(v1, v2, v3, a) {
   p5._validateParameters('ambientLight', arguments);
   var color = this.color.apply(this, arguments);
 
-  var shader = this._renderer._useLightShader();
-
-  //@todo this is a bit icky. array uniforms have
-  //to be multiples of the type 3(rgb) in this case.
-  //a preallocated Float32Array(24) that we copy into
-  //would be better
-  shader.setUniform('uUseLighting', true);
-  //in case there's no material color for the geometry
-  shader.setUniform('uMaterialColor', this._renderer.curFillColor);
-
   this._renderer.ambientLightColors.push(
     color._array[0],
     color._array[1],
     color._array[2]
   );
-  shader.setUniform('uAmbientColor', this._renderer.ambientLightColors);
 
-  shader.setUniform(
-    'uAmbientLightCount',
-    this._renderer.ambientLightColors.length / 3
-  );
+  this._renderer._enableLighting = true;
 
   return this;
 };
@@ -161,9 +147,7 @@ p5.prototype.ambientLight = function(v1, v2, v3, a) {
 p5.prototype.directionalLight = function(v1, v2, v3, x, y, z) {
   this._assert3d('directionalLight');
   p5._validateParameters('directionalLight', arguments);
-  var shader = this._renderer._useLightShader();
 
-  //@TODO: check parameters number
   var color = this.color.apply(this, [v1, v2, v3]);
 
   var _x, _y, _z;
@@ -177,29 +161,18 @@ p5.prototype.directionalLight = function(v1, v2, v3, x, y, z) {
     _y = v.y;
     _z = v.z;
   }
-  shader.setUniform('uUseLighting', true);
-  //in case there's no material color for the geometry
-  shader.setUniform('uMaterialColor', this._renderer.curFillColor);
 
   // normalize direction
   var l = Math.sqrt(_x * _x + _y * _y + _z * _z);
   this._renderer.directionalLightDirections.push(_x / l, _y / l, _z / l);
-  shader.setUniform(
-    'uLightingDirection',
-    this._renderer.directionalLightDirections
-  );
 
   this._renderer.directionalLightColors.push(
     color._array[0],
     color._array[1],
     color._array[2]
   );
-  shader.setUniform('uDirectionalColor', this._renderer.directionalLightColors);
 
-  shader.setUniform(
-    'uDirectionalLightCount',
-    this._renderer.directionalLightColors.length / 3
-  );
+  this._renderer._enableLighting = true;
 
   return this;
 };
@@ -274,6 +247,7 @@ p5.prototype.directionalLight = function(v1, v2, v3, x, y, z) {
 p5.prototype.pointLight = function(v1, v2, v3, x, y, z) {
   this._assert3d('pointLight');
   p5._validateParameters('pointLight', arguments);
+
   //@TODO: check parameters number
   var color = this._renderer._pInst.color.apply(this, [v1, v2, v3]);
 
@@ -289,25 +263,14 @@ p5.prototype.pointLight = function(v1, v2, v3, x, y, z) {
     _z = v.z;
   }
 
-  var shader = this._renderer._useLightShader();
-  shader.setUniform('uUseLighting', true);
-  //in case there's no material color for the geometry
-  shader.setUniform('uMaterialColor', this._renderer.curFillColor);
-
   this._renderer.pointLightPositions.push(_x, _y, _z);
-  shader.setUniform('uPointLightLocation', this._renderer.pointLightPositions);
-
   this._renderer.pointLightColors.push(
     color._array[0],
     color._array[1],
     color._array[2]
   );
-  shader.setUniform('uPointLightColor', this._renderer.pointLightColors);
 
-  shader.setUniform(
-    'uPointLightCount',
-    this._renderer.pointLightColors.length / 3
-  );
+  this._renderer._enableLighting = true;
 
   return this;
 };

--- a/src/webgl/material.js
+++ b/src/webgl/material.js
@@ -162,14 +162,20 @@ p5.prototype.createShader = function(vertSrc, fragSrc) {
 p5.prototype.shader = function(s) {
   this._assert3d('shader');
   p5._validateParameters('shader', arguments);
+
   if (s._renderer === undefined) {
     s._renderer = this._renderer;
   }
+
   if (s.isStrokeShader()) {
-    this._renderer.setStrokeShader(s);
+    this._renderer.userStrokeShader = s;
   } else {
-    this._renderer.setFillShader(s);
+    this._renderer.userFillShader = s;
+    this._renderer._useNormalMaterial = false;
   }
+
+  s.init();
+
   return this;
 };
 
@@ -202,8 +208,10 @@ p5.prototype.normalMaterial = function() {
   this._assert3d('normalMaterial');
   p5._validateParameters('normalMaterial', arguments);
   this._renderer.drawMode = constants.FILL;
-  this._renderer.setFillShader(this._renderer._getNormalShader());
+  this._renderer._useSpecularMaterial = false;
+  this._renderer._useNormalMaterial = true;
   this._renderer.curFillColor = [1, 1, 1, 1];
+  this._renderer._setProperty('_doFill', true);
   this.noStroke();
   return this;
 };
@@ -289,12 +297,13 @@ p5.prototype.normalMaterial = function() {
 p5.prototype.texture = function(tex) {
   this._assert3d('texture');
   p5._validateParameters('texture', arguments);
+
   this._renderer.drawMode = constants.TEXTURE;
-  var shader = this._renderer._useLightShader();
-  shader.setUniform('uSpecular', false);
-  shader.setUniform('isTexture', true);
-  shader.setUniform('uSampler', tex);
-  this.noStroke();
+  this._renderer._useSpecularMaterial = false;
+  this._renderer._useNormalMaterial = false;
+  this._renderer._tex = tex;
+  this._renderer._setProperty('_doFill', true);
+
   return this;
 };
 
@@ -337,13 +346,14 @@ p5.prototype.texture = function(tex) {
 p5.prototype.ambientMaterial = function(v1, v2, v3, a) {
   this._assert3d('ambientMaterial');
   p5._validateParameters('ambientMaterial', arguments);
+
   var color = p5.prototype.color.apply(this, arguments);
   this._renderer.curFillColor = color._array;
+  this._renderer._useSpecularMaterial = false;
+  this._renderer._useNormalMaterial = false;
+  this._renderer._enableLighting = true;
+  this._renderer._tex = null;
 
-  var shader = this._renderer._useLightShader();
-  shader.setUniform('uMaterialColor', this._renderer.curFillColor);
-  shader.setUniform('uSpecular', false);
-  shader.setUniform('isTexture', false);
   return this;
 };
 
@@ -386,13 +396,14 @@ p5.prototype.ambientMaterial = function(v1, v2, v3, a) {
 p5.prototype.specularMaterial = function(v1, v2, v3, a) {
   this._assert3d('specularMaterial');
   p5._validateParameters('specularMaterial', arguments);
+
   var color = p5.prototype.color.apply(this, arguments);
   this._renderer.curFillColor = color._array;
+  this._renderer._useSpecularMaterial = true;
+  this._renderer._useNormalMaterial = false;
+  this._renderer._enableLighting = true;
+  this._renderer._tex = null;
 
-  var shader = this._renderer._useLightShader();
-  shader.setUniform('uMaterialColor', this._renderer.curFillColor);
-  shader.setUniform('uSpecular', true);
-  shader.setUniform('isTexture', false);
   return this;
 };
 

--- a/src/webgl/p5.RendererGL.Immediate.js
+++ b/src/webgl/p5.RendererGL.Immediate.js
@@ -115,8 +115,6 @@ p5.RendererGL.prototype.endShape = function(
   isContour,
   shapeKind
 ) {
-  this._useImmediateModeShader();
-
   if (this._doStroke && this.drawMode !== constants.TEXTURE) {
     for (var i = 0; i < this.immediateMode.vertices.length - 1; i++) {
       this.immediateMode.edges.push([i, i + 1]);
@@ -160,10 +158,11 @@ p5.RendererGL.prototype._drawFillImmediateMode = function(
   shapeKind
 ) {
   var gl = this.GL;
-  this.curFillShader.bindShader();
+  var shader = this._getImmediateFillShader();
+  this._setFillUniforms(shader);
 
   // initialize the fill shader's 'aPosition' buffer
-  if (this.curFillShader.attributes.aPosition) {
+  if (shader.attributes.aPosition) {
     //vertex position Attribute
     this._bindBuffer(
       this.immediateMode.vertexBuffer,
@@ -173,8 +172,8 @@ p5.RendererGL.prototype._drawFillImmediateMode = function(
       gl.DYNAMIC_DRAW
     );
 
-    this.curFillShader.enableAttrib(
-      this.curFillShader.attributes.aPosition.location,
+    shader.enableAttrib(
+      shader.attributes.aPosition.location,
       3,
       gl.FLOAT,
       false,
@@ -184,10 +183,7 @@ p5.RendererGL.prototype._drawFillImmediateMode = function(
   }
 
   // initialize the fill shader's 'aVertexColor' buffer
-  if (
-    this.drawMode === constants.FILL &&
-    this.curFillShader.attributes.aVertexColor
-  ) {
+  if (this.drawMode === constants.FILL && shader.attributes.aVertexColor) {
     this._bindBuffer(
       this.immediateMode.colorBuffer,
       gl.ARRAY_BUFFER,
@@ -196,8 +192,8 @@ p5.RendererGL.prototype._drawFillImmediateMode = function(
       gl.DYNAMIC_DRAW
     );
 
-    this.curFillShader.enableAttrib(
-      this.curFillShader.attributes.aVertexColor.location,
+    shader.enableAttrib(
+      shader.attributes.aVertexColor.location,
       4,
       gl.FLOAT,
       false,
@@ -207,10 +203,7 @@ p5.RendererGL.prototype._drawFillImmediateMode = function(
   }
 
   // initialize the fill shader's 'aTexCoord' buffer
-  if (
-    this.drawMode === constants.TEXTURE &&
-    this.curFillShader.attributes.aTexCoord
-  ) {
+  if (this.drawMode === constants.TEXTURE && shader.attributes.aTexCoord) {
     //texture coordinate Attribute
     this._bindBuffer(
       this.immediateMode.uvBuffer,
@@ -220,8 +213,8 @@ p5.RendererGL.prototype._drawFillImmediateMode = function(
       gl.DYNAMIC_DRAW
     );
 
-    this.curFillShader.enableAttrib(
-      this.curFillShader.attributes.aTexCoord.location,
+    shader.enableAttrib(
+      shader.attributes.aTexCoord.location,
       2,
       gl.FLOAT,
       false,
@@ -269,15 +262,16 @@ p5.RendererGL.prototype._drawFillImmediateMode = function(
     );
   }
   // todo / optimizations? leave bound until another shader is set?
-  this.curFillShader.unbindShader();
+  shader.unbindShader();
 };
 
 p5.RendererGL.prototype._drawStrokeImmediateMode = function() {
   var gl = this.GL;
-  this.curStrokeShader.bindShader();
+  var shader = this._getImmediateStrokeShader();
+  this._setStrokeUniforms(shader);
 
   // initialize the stroke shader's 'aPosition' buffer
-  if (this.curStrokeShader.attributes.aPosition) {
+  if (shader.attributes.aPosition) {
     this._bindBuffer(
       this.immediateMode.lineVertexBuffer,
       gl.ARRAY_BUFFER,
@@ -286,8 +280,8 @@ p5.RendererGL.prototype._drawStrokeImmediateMode = function() {
       gl.STATIC_DRAW
     );
 
-    this.curStrokeShader.enableAttrib(
-      this.curStrokeShader.attributes.aPosition.location,
+    shader.enableAttrib(
+      shader.attributes.aPosition.location,
       3,
       gl.FLOAT,
       false,
@@ -297,7 +291,7 @@ p5.RendererGL.prototype._drawStrokeImmediateMode = function() {
   }
 
   // initialize the stroke shader's 'aDirection' buffer
-  if (this.curStrokeShader.attributes.aDirection) {
+  if (shader.attributes.aDirection) {
     this._bindBuffer(
       this.immediateMode.lineNormalBuffer,
       gl.ARRAY_BUFFER,
@@ -305,8 +299,8 @@ p5.RendererGL.prototype._drawStrokeImmediateMode = function() {
       Float32Array,
       gl.STATIC_DRAW
     );
-    this.curStrokeShader.enableAttrib(
-      this.curStrokeShader.attributes.aDirection.location,
+    shader.enableAttrib(
+      shader.attributes.aDirection.location,
       4,
       gl.FLOAT,
       false,
@@ -319,7 +313,7 @@ p5.RendererGL.prototype._drawStrokeImmediateMode = function() {
   gl.drawArrays(gl.TRIANGLES, 0, this.immediateMode.lineVertices.length);
 
   // todo / optimizations? leave bound until another shader is set?
-  this.curStrokeShader.unbindShader();
+  shader.unbindShader();
 };
 
 module.exports = p5.RendererGL;

--- a/src/webgl/p5.RendererGL.Retained.js
+++ b/src/webgl/p5.RendererGL.Retained.js
@@ -61,10 +61,11 @@ p5.RendererGL.prototype.createBuffers = function(gId, obj) {
   geometry.numberOfItems = obj.faces.length * 3;
   geometry.lineVertexCount = obj.lineVertices.length;
 
-  this._useColorShader();
+  var strokeShader = this._getRetainedStrokeShader();
+  strokeShader.bindShader();
 
   // initialize the stroke shader's 'aPosition' buffer, if used
-  if (this.curStrokeShader.attributes.aPosition) {
+  if (strokeShader.attributes.aPosition) {
     geometry.lineVertexBuffer = gl.createBuffer();
 
     this._bindBuffer(
@@ -75,8 +76,8 @@ p5.RendererGL.prototype.createBuffers = function(gId, obj) {
       gl.STATIC_DRAW
     );
 
-    this.curStrokeShader.enableAttrib(
-      this.curStrokeShader.attributes.aPosition.location,
+    strokeShader.enableAttrib(
+      strokeShader.attributes.aPosition.location,
       3,
       gl.FLOAT,
       false,
@@ -86,7 +87,7 @@ p5.RendererGL.prototype.createBuffers = function(gId, obj) {
   }
 
   // initialize the stroke shader's 'aDirection' buffer, if used
-  if (this.curStrokeShader.attributes.aDirection) {
+  if (strokeShader.attributes.aDirection) {
     geometry.lineNormalBuffer = gl.createBuffer();
 
     this._bindBuffer(
@@ -97,8 +98,8 @@ p5.RendererGL.prototype.createBuffers = function(gId, obj) {
       gl.STATIC_DRAW
     );
 
-    this.curStrokeShader.enableAttrib(
-      this.curStrokeShader.attributes.aDirection.location,
+    strokeShader.enableAttrib(
+      strokeShader.attributes.aDirection.location,
       4,
       gl.FLOAT,
       false,
@@ -106,9 +107,13 @@ p5.RendererGL.prototype.createBuffers = function(gId, obj) {
       0
     );
   }
+  strokeShader.unbindShader();
+
+  var fillShader = this._getRetainedFillShader();
+  fillShader.bindShader();
 
   // initialize the fill shader's 'aPosition' buffer, if used
-  if (this.curFillShader.attributes.aPosition) {
+  if (fillShader.attributes.aPosition) {
     geometry.vertexBuffer = gl.createBuffer();
 
     // allocate space for vertex positions
@@ -120,8 +125,8 @@ p5.RendererGL.prototype.createBuffers = function(gId, obj) {
       gl.STATIC_DRAW
     );
 
-    this.curFillShader.enableAttrib(
-      this.curFillShader.attributes.aPosition.location,
+    fillShader.enableAttrib(
+      fillShader.attributes.aPosition.location,
       3,
       gl.FLOAT,
       false,
@@ -141,7 +146,7 @@ p5.RendererGL.prototype.createBuffers = function(gId, obj) {
   );
 
   // initialize the fill shader's 'aNormal' buffer, if used
-  if (this.curFillShader.attributes.aNormal) {
+  if (fillShader.attributes.aNormal) {
     geometry.normalBuffer = gl.createBuffer();
 
     // allocate space for normals
@@ -153,8 +158,8 @@ p5.RendererGL.prototype.createBuffers = function(gId, obj) {
       gl.STATIC_DRAW
     );
 
-    this.curFillShader.enableAttrib(
-      this.curFillShader.attributes.aNormal.location,
+    fillShader.enableAttrib(
+      fillShader.attributes.aNormal.location,
       3,
       gl.FLOAT,
       false,
@@ -164,7 +169,7 @@ p5.RendererGL.prototype.createBuffers = function(gId, obj) {
   }
 
   // initialize the fill shader's 'aTexCoord' buffer, if used
-  if (this.curFillShader.attributes.aTexCoord) {
+  if (fillShader.attributes.aTexCoord) {
     geometry.uvBuffer = gl.createBuffer();
 
     // tex coords
@@ -176,8 +181,8 @@ p5.RendererGL.prototype.createBuffers = function(gId, obj) {
       gl.STATIC_DRAW
     );
 
-    this.curFillShader.enableAttrib(
-      this.curFillShader.attributes.aTexCoord.location,
+    fillShader.enableAttrib(
+      fillShader.attributes.aTexCoord.location,
       2,
       gl.FLOAT,
       false,
@@ -185,7 +190,7 @@ p5.RendererGL.prototype.createBuffers = function(gId, obj) {
       0
     );
   }
-  //}
+  fillShader.unbindShader();
 };
 
 /**
@@ -197,17 +202,17 @@ p5.RendererGL.prototype.createBuffers = function(gId, obj) {
 p5.RendererGL.prototype.drawBuffers = function(gId) {
   this._setDefaultCamera();
   var gl = this.GL;
-  this._useColorShader();
   var geometry = this.gHash[gId];
 
   if (this._doStroke && geometry.lineVertexCount > 0) {
-    this.curStrokeShader.bindShader();
+    var strokeShader = this._getRetainedStrokeShader();
+    this._setStrokeUniforms(strokeShader);
 
     // bind the stroke shader's 'aPosition' buffer
     if (geometry.lineVertexBuffer) {
       this._bindBuffer(geometry.lineVertexBuffer, gl.ARRAY_BUFFER);
-      this.curStrokeShader.enableAttrib(
-        this.curStrokeShader.attributes.aPosition.location,
+      strokeShader.enableAttrib(
+        strokeShader.attributes.aPosition.location,
         3,
         gl.FLOAT,
         false,
@@ -219,8 +224,8 @@ p5.RendererGL.prototype.drawBuffers = function(gId) {
     // bind the stroke shader's 'aDirection' buffer
     if (geometry.lineNormalBuffer) {
       this._bindBuffer(geometry.lineNormalBuffer, gl.ARRAY_BUFFER);
-      this.curStrokeShader.enableAttrib(
-        this.curStrokeShader.attributes.aDirection.location,
+      strokeShader.enableAttrib(
+        strokeShader.attributes.aDirection.location,
         4,
         gl.FLOAT,
         false,
@@ -231,18 +236,19 @@ p5.RendererGL.prototype.drawBuffers = function(gId) {
 
     this._applyColorBlend(this.curStrokeColor);
     this._drawArrays(gl.TRIANGLES, gId);
-    this.curStrokeShader.unbindShader();
+    strokeShader.unbindShader();
   }
 
   if (this._doFill !== false) {
-    this.curFillShader.bindShader();
+    var fillShader = this._getRetainedFillShader();
+    this._setFillUniforms(fillShader);
 
     // bind the fill shader's 'aPosition' buffer
     if (geometry.vertexBuffer) {
       //vertex position buffer
       this._bindBuffer(geometry.vertexBuffer, gl.ARRAY_BUFFER);
-      this.curFillShader.enableAttrib(
-        this.curFillShader.attributes.aPosition.location,
+      fillShader.enableAttrib(
+        fillShader.attributes.aPosition.location,
         3,
         gl.FLOAT,
         false,
@@ -259,8 +265,8 @@ p5.RendererGL.prototype.drawBuffers = function(gId) {
     // bind the fill shader's 'aNormal' buffer
     if (geometry.normalBuffer) {
       this._bindBuffer(geometry.normalBuffer, gl.ARRAY_BUFFER);
-      this.curFillShader.enableAttrib(
-        this.curFillShader.attributes.aNormal.location,
+      fillShader.enableAttrib(
+        fillShader.attributes.aNormal.location,
         3,
         gl.FLOAT,
         false,
@@ -273,8 +279,8 @@ p5.RendererGL.prototype.drawBuffers = function(gId) {
     if (geometry.uvBuffer) {
       // uv buffer
       this._bindBuffer(geometry.uvBuffer, gl.ARRAY_BUFFER);
-      this.curFillShader.enableAttrib(
-        this.curFillShader.attributes.aTexCoord.location,
+      fillShader.enableAttrib(
+        fillShader.attributes.aTexCoord.location,
         2,
         gl.FLOAT,
         false,
@@ -285,7 +291,7 @@ p5.RendererGL.prototype.drawBuffers = function(gId) {
 
     this._applyColorBlend(this.curFillColor);
     this._drawElements(gl.TRIANGLES, gId);
-    this.curFillShader.unbindShader();
+    fillShader.unbindShader();
   }
   return this;
 };

--- a/src/webgl/p5.RendererGL.js
+++ b/src/webgl/p5.RendererGL.js
@@ -67,12 +67,20 @@ p5.RendererGL = function(elt, pInst, isMainCanvas, attr) {
 
   // lights
 
+  this._enableLighting = false;
+
   this.ambientLightColors = [];
   this.directionalLightDirections = [];
   this.directionalLightColors = [];
 
   this.pointLightPositions = [];
   this.pointLightColors = [];
+
+  this.curFillColor = [1, 1, 1, 1];
+  this.curStrokeColor = [0, 0, 0, 1];
+
+  this._useSpecularMaterial = false;
+  this._useNormalMaterial = false;
 
   /**
    * model view, projection, & normal
@@ -104,26 +112,21 @@ p5.RendererGL = function(elt, pInst, isMainCanvas, attr) {
   this._defaultNormalShader = undefined;
   this._defaultColorShader = undefined;
 
-  this.curFillShader = undefined;
-  this.curStrokeShader = undefined;
-
-  this._useColorShader();
-  this.setStrokeShader(this._getLineShader());
+  this.userFillShader = undefined;
+  this.userStrokeShader = undefined;
 
   //Imediate Mode
   //default drawing is done in Retained Mode
   this.isImmediateDrawing = false;
   this.immediateMode = {};
 
-  // note: must call fill() and stroke () AFTER
-  // default shader has been set.
-  this.fill(255, 255, 255, 255);
-  //this.stroke(0, 0, 0, 255);
   this.pointSize = 5.0; //default point size
-  this.strokeWeight(1);
-  this.stroke(0, 0, 0);
+  this.curStrokeWeight = 1;
+
   // array of textures created in this gl context via this.getTexture(src)
   this.textures = [];
+  this._tex = null;
+
   return this;
 };
 
@@ -412,6 +415,8 @@ p5.RendererGL.prototype._update = function() {
 
   this.pointLightPositions.length = 0;
   this.pointLightColors.length = 0;
+
+  this._enableLighting = false;
 };
 
 /**
@@ -473,14 +478,9 @@ p5.RendererGL.prototype.fill = function(v1, v2, v3, a) {
   //see material.js for more info on color blending in webgl
   var color = p5.prototype.color.apply(this._pInst, arguments);
   this.curFillColor = color._array;
-
-  if (this.isImmediateDrawing) {
-    this.setFillShader(this._getImmediateModeShader());
-  } else {
-    this.setFillShader(this._getColorShader());
-  }
   this.drawMode = constants.FILL;
-  this.curFillShader.setUniform('uMaterialColor', this.curFillColor);
+  this._useNormalMaterial = false;
+  this._tex = null;
 };
 
 /**
@@ -520,7 +520,6 @@ p5.RendererGL.prototype.stroke = function(r, g, b, a) {
   arguments[3] = 255;
   var color = p5.prototype.color.apply(this._pInst, arguments);
   this.curStrokeColor = color._array;
-  this.curStrokeShader.setUniform('uMaterialColor', this.curStrokeColor);
 };
 
 /**
@@ -567,7 +566,6 @@ p5.RendererGL.prototype.strokeWeight = function(w) {
   if (this.curStrokeWeight !== w) {
     this.pointSize = w;
     this.curStrokeWeight = w;
-    this.curStrokeShader.setUniform('uStrokeWeight', w);
   }
 };
 
@@ -764,6 +762,29 @@ p5.RendererGL.prototype.push = function() {
   properties.uMVMatrix = this.uMVMatrix.copy();
   properties.cameraMatrix = this.cameraMatrix.copy();
 
+  properties.ambientLightColors = this.ambientLightColors.slice();
+
+  properties.directionalLightDirections = this.directionalLightDirections.slice();
+  properties.directionalLightColors = this.directionalLightColors.slice();
+
+  properties.pointLightPositions = this.pointLightPositions.slice();
+  properties.pointLightColors = this.pointLightColors.slice();
+
+  properties.userFillShader = this.userFillShader;
+  properties.userStrokeShader = this.userStrokeShader;
+
+  properties.pointSize = this.pointSize;
+  properties.curStrokeWeight = this.curStrokeWeight;
+  properties.curStrokeColor = this.curStrokeColor;
+  properties.curFillColor = this.curFillColor;
+
+  properties._useSpecularMaterial = this._useSpecularMaterial;
+
+  properties._enableLighting = this._enableLighting;
+  properties._useNormalMaterial = this._useNormalMaterial;
+  properties._tex = this._tex;
+  properties.drawMode = this.drawMode;
+
   return style;
 };
 
@@ -784,49 +805,6 @@ p5.RendererGL.prototype._applyTextProperties = function() {
 //////////////////////////////////////////////
 
 /*
- * Initializes and uses the specified shader, then returns
- * that shader. Note: initialization and resetting the program
- * is only used if needed (say, if a new value is provided)
- * so it is safe to call this method with the same shader multiple
- * times without a signficant performance hit).
- *
- * @method setFillShader
- * @param {p5.Shader} [s] a p5.Shader object
- * @return {p5.Shader} the current, updated fill shader
- */
-p5.RendererGL.prototype.setFillShader = function(s) {
-  if (this.curFillShader !== s) {
-    // only do setup etc. if shader is actually new.
-    this.curFillShader = s;
-
-    // safe to do this multiple times;
-    // init() will bail early if has already been run.
-    this.curFillShader.init();
-    //this.curFillShader.useProgram();
-  }
-  // always return this.curFillShader, even if no change was made.
-  return this.curFillShader;
-};
-
-/*
- * @method setStrokeShader
- * @param {p5.Shader} [s] a p5.Shader object
- * @return {p5.Shader} the current, updated stroke shader
- */
-p5.RendererGL.prototype.setStrokeShader = function(s) {
-  if (this.curStrokeShader !== s) {
-    // only do setup etc. if shader is actually new.
-    this.curStrokeShader = s;
-    // safe to do this multiple times;
-    // init() will bail early if has already been run.
-    this.curStrokeShader.init();
-    //this.curStrokeShader.useProgram();
-  }
-  // always return this.curLineShader, even if no change was made.
-  return this.curStrokeShader;
-};
-
-/*
  * shaders are created and cached on a per-renderer basis,
  * on the grounds that each renderer will have its own gl context
  * and the shader must be valid in that context.
@@ -834,42 +812,64 @@ p5.RendererGL.prototype.setStrokeShader = function(s) {
  *
  */
 
-p5.RendererGL.prototype._useLightShader = function() {
-  if (!this.curFillShader || !this.curFillShader.isLightShader()) {
-    this.setFillShader(this._getLightShader());
+p5.RendererGL.prototype._getImmediateStrokeShader = function() {
+  // select the stroke shader to use
+  var stroke = this.userStrokeShader;
+  if (!stroke || !stroke.isStrokeShader()) {
+    return this._getLineShader();
   }
-  return this.curFillShader;
+  return stroke;
 };
 
-p5.RendererGL.prototype._useColorShader = function() {
-  // looking at the code within the glsl files, I'm not really
-  // sure why these are two different shaders. but, they are,
-  // and if we're drawing in retain mode but the shader is the
-  // immediate mode one, we need to switch.
+p5.RendererGL.prototype._getRetainedStrokeShader =
+  p5.RendererGL.prototype._getImmediateStrokeShader;
 
-  // TODO: what if curFillShader is _any_ other shader?
-  if (
-    !this.curFillShader ||
-    this.curFillShader === this._defaultImmediateModeShader
-  ) {
-    // there are different immediate mode and retain mode color shaders.
-    // if we're using the immediate mode one, we need to switch to
-    // one that works for retain mode.
-    this.setFillShader(this._getColorShader());
+/*
+ * selects which fill shader should be used based on renderer state,
+ * for use with begin/endShape and immediate vertex mode.
+ */
+p5.RendererGL.prototype._getImmediateFillShader = function() {
+  if (this._useNormalMaterial) {
+    return this._getNormalShader();
   }
-  return this.curFillShader;
+
+  var fill = this.userFillShader;
+  if (this._enableLighting) {
+    if (!fill || !fill.isLightShader()) {
+      return this._getLightShader();
+    }
+  } else if (this._tex) {
+    if (!fill || !fill.isTextureShader()) {
+      return this._getLightShader();
+    }
+  } else if (!fill /*|| !fill.isColorShader()*/) {
+    return this._getImmediateModeShader();
+  }
+  return fill;
 };
 
-p5.RendererGL.prototype._useImmediateModeShader = function() {
-  // TODO: what if curFillShader is _any_ other shader?
-  if (!this.curFillShader || this.curFillShader === this._defaultColorShader) {
-    // this is the fill/stroke shader for retain mode.
-    // must switch to immediate mode shader before drawing!
-    this.setFillShader(this._getImmediateModeShader());
-    // note that if we're using the texture shader...
-    // this shouldn't change. :)
+/*
+ * selects which fill shader should be used based on renderer state
+ * for retained mode.
+ */
+p5.RendererGL.prototype._getRetainedFillShader = function() {
+  if (this._useNormalMaterial) {
+    return this._getNormalShader();
   }
-  return this.curFillShader;
+
+  var fill = this.userFillShader;
+  if (this._enableLighting) {
+    if (!fill || !fill.isLightShader()) {
+      return this._getLightShader();
+    }
+  } else if (this._tex) {
+    if (!fill || !fill.isTextureShader()) {
+      return this._getLightShader();
+    }
+  } else if (!fill /* || !fill.isColorShader()*/) {
+    return this._getColorShader();
+  }
+  return fill;
 };
 
 p5.RendererGL.prototype._getLightShader = function() {
@@ -888,7 +888,7 @@ p5.RendererGL.prototype._getLightShader = function() {
       );
     }
   }
-  //this.drawMode = constants.FILL;
+
   return this._defaultLightShader;
 };
 
@@ -900,7 +900,7 @@ p5.RendererGL.prototype._getImmediateModeShader = function() {
       defaultShaders.vertexColorFrag
     );
   }
-  //this.drawMode = constants.FILL;
+
   return this._defaultImmediateModeShader;
 };
 
@@ -912,7 +912,7 @@ p5.RendererGL.prototype._getNormalShader = function() {
       defaultShaders.normalFrag
     );
   }
-  //this.drawMode = constants.FILL;
+
   return this._defaultNormalShader;
 };
 
@@ -924,7 +924,7 @@ p5.RendererGL.prototype._getColorShader = function() {
       defaultShaders.basicFrag
     );
   }
-  //this.drawMode = constants.FILL;
+
   return this._defaultColorShader;
 };
 
@@ -936,7 +936,7 @@ p5.RendererGL.prototype._getLineShader = function() {
       defaultShaders.lineFrag
     );
   }
-  //this.drawMode = constants.STROKE;
+
   return this._defaultLineShader;
 };
 
@@ -954,7 +954,7 @@ p5.RendererGL.prototype.getTexture = function(img) {
   var checkSource = function(element) {
     return element.src === img;
   };
-  //this.drawMode = constants.TEXTURE;
+
   var tex = this.textures.find(checkSource);
   if (!tex) {
     tex = new p5.Texture(this, img);
@@ -964,9 +964,47 @@ p5.RendererGL.prototype.getTexture = function(img) {
   return tex;
 };
 
-//Binds a buffer to the drawing context
-//when passed more than two arguments it also updates or initializes
-//the data associated with the buffer
+p5.RendererGL.prototype._setStrokeUniforms = function(strokeShader) {
+  strokeShader.bindShader();
+
+  // set the uniform values
+  strokeShader.setUniform('uMaterialColor', this.curStrokeColor);
+  strokeShader.setUniform('uStrokeWeight', this.curStrokeWeight);
+};
+
+p5.RendererGL.prototype._setFillUniforms = function(fillShader) {
+  fillShader.bindShader();
+
+  // TODO: optimize
+  fillShader.setUniform('uMaterialColor', this.curFillColor);
+  fillShader.setUniform('isTexture', !!this._tex);
+  if (this._tex) {
+    fillShader.setUniform('uSampler', this._tex);
+  }
+  fillShader.setUniform('uSpecular', this._useSpecularMaterial);
+
+  fillShader.setUniform('uUseLighting', this._enableLighting);
+
+  var pointLightCount = this.pointLightColors.length / 3;
+  fillShader.setUniform('uPointLightCount', pointLightCount);
+  fillShader.setUniform('uPointLightLocation', this.pointLightPositions);
+  fillShader.setUniform('uPointLightColor', this.pointLightColors);
+
+  var directionalLightCount = this.directionalLightColors.length / 3;
+  fillShader.setUniform('uDirectionalLightCount', directionalLightCount);
+  fillShader.setUniform('uLightingDirection', this.directionalLightDirections);
+  fillShader.setUniform('uDirectionalColor', this.directionalLightColors);
+
+  // TODO: sum these here...
+  var ambientLightCount = this.ambientLightColors.length / 3;
+  fillShader.setUniform('uAmbientLightCount', ambientLightCount);
+  fillShader.setUniform('uAmbientColor', this.ambientLightColors);
+};
+
+/* Binds a buffer to the drawing context
+ * when passed more than two arguments it also updates or initializes
+ * the data associated with the buffer
+ */
 p5.RendererGL.prototype._bindBuffer = function(
   buffer,
   target,

--- a/src/webgl/p5.Shader.js
+++ b/src/webgl/p5.Shader.js
@@ -194,9 +194,8 @@ p5.Shader.prototype.bindShader = function() {
 
     this._renderer._setDefaultCamera();
     this._setMatrixUniforms();
-    if (this === this._renderer.curStrokeShader) {
-      this._setViewportUniform();
-    }
+
+    this.setUniform('uViewport', this._renderer._viewport);
   }
 };
 
@@ -241,14 +240,10 @@ p5.Shader.prototype._setMatrixUniforms = function() {
   this.setUniform('uProjectionMatrix', this._renderer.uPMatrix.mat4);
   this.setUniform('uModelViewMatrix', this._renderer.uMVMatrix.mat4);
   this.setUniform('uViewMatrix', this._renderer.cameraMatrix.mat4);
-  if (this === this._renderer.curFillShader) {
+  if (this.uniforms.uNormalMatrix) {
     this._renderer.uNMatrix.inverseTranspose(this._renderer.uMVMatrix);
     this.setUniform('uNormalMatrix', this._renderer.uNMatrix.mat3);
   }
-};
-
-p5.Shader.prototype._setViewportUniform = function() {
-  this.setUniform('uViewport', this._renderer._viewport);
 };
 
 /**
@@ -280,17 +275,13 @@ p5.Shader.prototype.setUniform = function(uniformName, data) {
 
   var uniform = this.uniforms[uniformName];
   if (!uniform) {
-    //@todo warning?
     return;
   }
+
   var location = uniform.location;
 
   var gl = this._renderer.GL;
-  // todo: is this safe to do here?
-  // todo: store the values another way?
   this.useProgram();
-
-  // TODO BIND?
 
   switch (uniform.type) {
     case gl.BOOL:
@@ -363,6 +354,7 @@ p5.Shader.prototype.setUniform = function(uniformName, data) {
 
 p5.Shader.prototype.isLightShader = function() {
   return (
+    this.attributes.aNormal !== undefined ||
     this.uniforms.uUseLighting !== undefined ||
     this.uniforms.uAmbientLightCount !== undefined ||
     this.uniforms.uDirectionalLightCount !== undefined ||

--- a/test/manual-test-examples/webgl/camera/box/sketch.js
+++ b/test/manual-test-examples/webgl/camera/box/sketch.js
@@ -15,7 +15,7 @@ function draw() {
   cone(90);
   pop();
 
-  fill(255);
+  fill(0, 0, 255);
   rect(0, 0, width / 4, height / 4);
   fill(0, 255, 0);
   ellipse(width / 4, height / 4, width / 4, height / 4);
@@ -23,7 +23,7 @@ function draw() {
   push();
   translate(width / 4, height / 4);
   fill(0, 0, 255);
-  ellipse(0, 0, width / 4, height / 4);
+  ellipse(0, 0, width / 8, height / 8);
   pop();
 
   fill(255, 0, 0);

--- a/test/manual-test-examples/webgl/material/texture/sketch.js
+++ b/test/manual-test-examples/webgl/material/texture/sketch.js
@@ -24,7 +24,6 @@ function setup() {
 
 function draw() {
   background(255, 255, 255, 255);
-  translate(0, 0, 400);
   translate(-200, 0, 0);
   push();
   rotate(theta * mouseX * 0.001, [1, 1, 1]);
@@ -33,7 +32,7 @@ function draw() {
   // texture(vid);
   texture(img);
   // normalMaterial();
-  sphere(80);
+  sphere();
   pop();
   translate(150, 0, 0);
   push();

--- a/test/unit/webgl/p5.Shader.js
+++ b/test/unit/webgl/p5.Shader.js
@@ -52,22 +52,10 @@ suite('p5.Shader', function() {
     expectedAttributes,
     expectedUniforms
   ) {
-    myp5.shader(shaderObj);
-    var s = myp5._renderer.curFillShader;
-
-    assert(
-      s !== null && s === shaderObj,
-      shaderName + ' was returned from p5.RendererGL.shader'
-    );
-
-    assert(
-      myp5._renderer.curFillShader !== null &&
-        myp5._renderer.curFillShader === shaderObj,
-      shaderName + " was not set as renderer's curFillShader in shader()"
-    );
-
-    testAttributes(shaderName, s.attributes, expectedAttributes);
-    testUniforms(shaderName, s.uniforms, expectedUniforms);
+    shaderObj.bindShader();
+    testAttributes(shaderName, shaderObj.attributes, expectedAttributes);
+    testUniforms(shaderName, shaderObj.uniforms, expectedUniforms);
+    shaderObj.unbindShader();
   };
 
   teardown(function() {
@@ -75,30 +63,6 @@ suite('p5.Shader', function() {
   });
 
   suite('Shader', function() {
-    test('Shader Cache', function() {
-      /*
-      //exists doesn't seem to work?
-      assert.exists(myp5._renderer.curFillShader,
-        'Shader is in use');
-      */
-      assert(
-        myp5._renderer.curFillShader !== null &&
-          myp5._renderer.curFillShader !== undefined,
-        'Shader is not in use or has not been cached'
-      );
-    });
-    test('Uniform Cache', function() {
-      var uniforms = myp5._renderer.curFillShader.uniforms;
-      assert(
-        uniforms !== null && uniforms !== undefined,
-        'Shader uniforms have not been cached'
-      );
-
-      assert(
-        Object.keys(uniforms).length > 0,
-        'Shader uniforms have not been cached'
-      );
-    });
     test('Light Shader', function() {
       var expectedAttributes = ['aPosition', 'aNormal', 'aTexCoord'];
 
@@ -179,71 +143,68 @@ suite('p5.Shader', function() {
     test('Normal Shader is set after normalMaterial()', function() {
       myp5.normalMaterial();
       var normalShader = myp5._renderer._getNormalShader();
+      var selectedRetainedShader = myp5._renderer._getRetainedFillShader();
+      var selectedImmediateShader = myp5._renderer._getRetainedFillShader();
       assert(
-        normalShader === myp5._renderer.curFillShader,
-        "_renderer's curFillShader was not normal shader"
+        normalShader === selectedRetainedShader,
+        "_renderer's retain mode shader was not normal shader"
+      );
+      assert(
+        normalShader === selectedImmediateShader,
+        "_renderer's retain mode shader was not normal shader"
       );
     });
     test('Color Shader is set after fill()', function() {
       myp5.fill(0);
-      var colorShader = myp5._renderer._getColorShader();
+      var retainedColorShader = myp5._renderer._getColorShader();
+      var immediateColorShader = myp5._renderer._getImmediateModeShader();
+      var selectedRetainedShader = myp5._renderer._getRetainedFillShader();
+      var selectedImmediateShader = myp5._renderer._getImmediateFillShader();
       assert(
-        colorShader === myp5._renderer.curFillShader,
-        "_renderer's curFillShader was not color shader after fill"
+        retainedColorShader === selectedRetainedShader,
+        "_renderer's retain mode shader was not color shader after fill"
       );
-    });
-    test('Shader switch between retain and immedate mode', function() {
-      myp5.fill(0);
-      myp5.box(70, 70, 70);
-      var retainShader = myp5._renderer._getColorShader();
       assert(
-        retainShader === myp5._renderer.curFillShader,
-        "_renderer's curFillShader was not color shader after fill() and box()"
-      );
-
-      myp5.beginShape(myp5.TRIANGLES);
-      myp5.vertex(0, 25, 0);
-      myp5.vertex(-25, -25, 0);
-      myp5.vertex(25, -25, 0);
-      myp5.endShape();
-      var immediateShader = myp5._renderer._getImmediateModeShader();
-      assert(
-        immediateShader === myp5._renderer.curFillShader,
-        "_renderer's curFillShader was not immediate mode shader " +
-          'after begin/endShape()'
-      );
-
-      myp5.box(70, 70, 70);
-      assert(
-        retainShader === myp5._renderer.curFillShader,
-        "_renderer's curFillShader did not switch back to retain shader " +
-          ' to draw box() after immediate mode'
+        immediateColorShader === selectedImmediateShader,
+        "_renderer's retain mode shader was not color shader after fill"
       );
     });
     test('Light shader set after ambientMaterial()', function() {
       var lightShader = myp5._renderer._getLightShader();
-
       myp5.ambientMaterial(128);
+      var selectedRetainedShader = myp5._renderer._getRetainedFillShader();
+      var selectedImmediateShader = myp5._renderer._getImmediateFillShader();
       assert(
-        lightShader === myp5._renderer.curFillShader,
-        "_renderer's curFillShader did not get set to light shader " +
+        lightShader === selectedRetainedShader,
+        "_renderer's retain mode shader was not light shader " +
+          'after call to ambientMaterial()'
+      );
+      assert(
+        lightShader === selectedImmediateShader,
+        "_renderer's immediate mode shader was not light shader" +
           'after call to ambientMaterial()'
       );
     });
     test('Light shader set after specularMaterial()', function() {
       var lightShader = myp5._renderer._getLightShader();
-
       myp5.specularMaterial(128);
+      var selectedRetainedShader = myp5._renderer._getRetainedFillShader();
+      var selectedImmediateShader = myp5._renderer._getImmediateFillShader();
       assert(
-        lightShader === myp5._renderer.curFillShader,
-        "_renderer's curFillShader did not get set to light shader " +
+        lightShader === selectedRetainedShader,
+        "_renderer's retain mode shader was not light shader " +
+          'after call to specularMaterial()'
+      );
+      assert(
+        lightShader === selectedImmediateShader,
+        "_renderer's immediate mode shader was not light shader " +
           'after call to specularMaterial()'
       );
     });
 
     test('Able to setUniform empty arrays', function() {
       myp5.shader(myp5._renderer._getLightShader());
-      var s = myp5._renderer.curFillShader;
+      var s = myp5._renderer.userFillShader;
 
       s.setUniform('uMaterialColor', []);
       s.setUniform('uLightingDirection', []);

--- a/test/unit/webgl/p5.Texture.js
+++ b/test/unit/webgl/p5.Texture.js
@@ -15,6 +15,8 @@ suite('p5.Texture', function() {
         texImg1 = p.loadImage('unit/assets/nyan_cat.gif');
         texImg2 = p.loadImage('unit/assets/target.gif');
         p.texture(texImg1);
+        // texture object isn't created until it's used for something:
+        //p.box(70, 70, 70);
       };
     });
   });
@@ -24,11 +26,16 @@ suite('p5.Texture', function() {
   });
 
   var testTextureSet = function(src) {
-    assert(
-      myp5._renderer.curFillShader === myp5._renderer._getLightShader(),
-      'shader was not set to light + texture shader after ' +
-        'calling texture()'
-    );
+    test('Light shader set after texture()', function() {
+      var lightShader = myp5._renderer._getLightShader();
+      var selectedShader = myp5._renderer._getRetainedFillShader();
+      assert(
+        lightShader === selectedShader,
+        "_renderer's retain mode shader was not light shader " +
+          'after call to texture()'
+      );
+    });
+
     var tex = myp5._renderer.getTexture(src);
     assert(tex !== undefined, 'texture was undefined');
     assert(tex instanceof p5.Texture, 'texture was not a p5.Texture object');

--- a/test/unit/webgl/stroke.js
+++ b/test/unit/webgl/stroke.js
@@ -21,11 +21,13 @@ suite('stroke WebGL', function() {
     test('check default shader creation', function(done) {
       myp5.createCanvas(100, 100, myp5.WEBGL);
       assert(
-        myp5._renderer.curStrokeShader === myp5._renderer._getLineShader(),
+        myp5._renderer._getRetainedStrokeShader() ===
+          myp5._renderer._getLineShader(),
         'default stroke shader was not initialized with GL canvas'
       );
       assert(
-        myp5._renderer.curFillShader === myp5._renderer._getColorShader(),
+        myp5._renderer._getRetainedFillShader() ===
+          myp5._renderer._getColorShader(),
         'default fill shader was not initialized with GL canvas'
       );
       done();


### PR DESCRIPTION
p5.RendererGL is updated to hold more state so that shader uniforms
can be set later, when it's time to render a shape. then, a shader
does not have to be bound at all time to change state. this enables
things like full support for push/pop.

in particular, p5.RendererGL state is added for tracking:

- whether or not the normal shader is in use
- use of lighting (boolean)
- use of specular component (boolean)

the curFillShader and curStrokeShader objects are removed from
p5.RendererGL in favor of selecting a default shader at render time,
based on current gl state (lighting conditions, texture settings,
and fill/stroke). additionally, _userFillShader and _userStrokeShader
are introduced to indicate that a custom shader has been set by the
library user using a call to shader(). in this case, the user shader
takes priority over any default shaders. this enables the user to mix
and match calls to fill, stroke, lights, etc. to set uniforms in
their own shader.

adds p5.RendererGL._setFillUniforms and
p5.RendererGL._setStrokeUniforms to set all of the known default
uniforms for the shader, to be used just before shape render time.

unit tests are updated to reflect this new structure; still heavily
dependent on internal state but better than nothing.

Fixes #2370.
