### PR TITLE
added X/Y sensitivity to orbitControl

### DIFF
--- a/src/webgl/interaction.js
+++ b/src/webgl/interaction.js
@@ -14,7 +14,6 @@ var p5 = require('../core/core');
  * @param  {Number} [sensitivityX]        sensitivity to mouse movement along X axis
  * @param  {Number} [sensitivityY]        sensitivity to mouse movement along Y axis
  * @chainable
- *
  * @example
  * <div>
  * <code>

--- a/src/webgl/interaction.js
+++ b/src/webgl/interaction.js
@@ -7,8 +7,12 @@ var p5 = require('../core/core');
  * away from the center of the canvas in the X or Y direction, the sketch is
  * rotated about the Y or X axis respectively. Note that this rotation only
  * affects objects drawn after orbitControl() has been called in the draw() loop.
+ * To reverse movement in either axis, enter a negative number for sensitivity.
+ * Calling this function without arguments is equivalent to calling orbitControl(1,1).
  * @method orbitControl
  * @for p5
+ * @param  {Number} [sensitivityX]        sensitivity to mouse movement along X axis
+ * @param  {Number} [sensitivityY]        sensitivity to mouse movement along Y axis
  * @chainable
  *
  * @example
@@ -32,12 +36,24 @@ var p5 = require('../core/core');
  */
 //@TODO: implement full orbit controls including
 //pan, zoom, quaternion rotation, etc.
-p5.prototype.orbitControl = function() {
+p5.prototype.orbitControl = function(sensitivityX, sensitivityY) {
   this._assert3d('orbitControl');
   p5._validateParameters('orbitControl', arguments);
+
+  if (typeof sensitivityX === 'undefined') {
+    sensitivityX = 1;
+  }
+  if (typeof sensitivityY === 'undefined') {
+    sensitivityY = sensitivityX;
+  }
+
   if (this.mouseIsPressed) {
-    this.rotateY((this.mouseX - this.width / 2) / (this.width / 2));
-    this.rotateX((this.mouseY - this.height / 2) / (this.width / 2));
+    this.rotateY(
+      sensitivityX * (this.mouseX - this.width / 2) / (this.width / 2)
+    );
+    this.rotateX(
+      -sensitivityY * (this.mouseY - this.height / 2) / (this.width / 2)
+    );
   }
   return this;
 };


### PR DESCRIPTION
Fixes #2962.

Adds X and Y sensitivity parameters to `orbitControl()`, allowing user to adjust how much rotation happens per mouse movement.  This also allows user to invert axis of rotation by entering a negative value.  This also changes default behavior to a non-inverted y-axis (pulling the mouse down makes the camera look down).

I ended up using `width/2` as the default scale factor for movement, to avoid having to hardcode this value.  Sensitivity values passed in as arguments adjust based on this default scaling.   The `angleMode(DEGREES)` bug I mentioned [here](https://github.com/processing/p5.js/issues/2962#issuecomment-393933498) is not unique to orbitControl() and the issue is here: #2965.  

