### PR TITLE
Fix AngleMode(DEGREES) in RendererGL Rotate()

### DIFF
--- a/src/webgl/p5.RendererGL.js
+++ b/src/webgl/p5.RendererGL.js
@@ -735,6 +735,7 @@ p5.RendererGL.prototype.rotate = function(rad, axis) {
   if (typeof axis === 'undefined') {
     return this.rotateZ(rad);
   }
+  arguments[0] = this._pInst._fromRadians(rad);
   p5.Matrix.prototype.rotate.apply(this.uMVMatrix, arguments);
   return this;
 };


### PR DESCRIPTION
Fixes #2965 issue where degree to radian conversion was happening twice in RendererGL rotate() function, resulting in less rotation than expected when angleMode was DEGREES.  

This current fix uses `fromRadians()` conversion to reverse one of the two conversions.  This means that when angleMode is  degrees, all angles passed to rotate are converted from degrees to radians in `p5.prototype.rotate/X/Y/Z`, radians to degrees in `p5.RendererGL.prototype.rotate`, and again back to radians in `p5.Matrix.prototype.rotate`.  I'm not sure if this is ideal, but it avoids changes to the 2D renderer API.  