### PR TITLE
Fix error in keyboard events

### DIFF
--- a/src/events/keyboard.js
+++ b/src/events/keyboard.js
@@ -182,10 +182,7 @@ p5.prototype._onkeydown = function(e) {
   this._setProperty('keyIsPressed', true);
   this._setProperty('keyCode', e.which);
   downKeys[e.which] = true;
-  this._setProperty(
-    'key',
-    event.key || String.fromCharCode(e.which) || e.which
-  );
+  this._setProperty('key', e.key || String.fromCharCode(e.which) || e.which);
   var keyPressed = this.keyPressed || window.keyPressed;
   if (typeof keyPressed === 'function' && !e.charCode) {
     var executeDefault = keyPressed(e);
@@ -236,10 +233,7 @@ p5.prototype._onkeyup = function(e) {
 
   this._setProperty('_lastKeyCodeTyped', null);
 
-  this._setProperty(
-    'key',
-    event.key || String.fromCharCode(e.which) || e.which
-  );
+  this._setProperty('key', e.key || String.fromCharCode(e.which) || e.which);
   this._setProperty('keyCode', e.which);
   if (typeof keyReleased === 'function') {
     var executeDefault = keyReleased(e);


### PR DESCRIPTION
Changes event to e, fixing a bug introduced from #2898 