### PR TITLE
Allow Promises from lifecycle functions

### DIFF
--- a/src/core/structure.js
+++ b/src/core/structure.js
@@ -263,6 +263,7 @@ p5.prototype.pop = function() {
  *
  * @method redraw
  * @param  {Integer} [n] Redraw for n-times. The default value is 1.
+ * @return {Promise} A promise that resolves once all redraws are finished.
  * @example
  * <div><code>
  * var x = 0;
@@ -308,6 +309,7 @@ p5.prototype.pop = function() {
  *
  */
 p5.prototype.redraw = function(n) {
+  var promise = Promise.resolve();
   var numberOfRedraws = parseInt(n);
   if (isNaN(numberOfRedraws) || numberOfRedraws < 1) {
     numberOfRedraws = 1;
@@ -324,16 +326,22 @@ p5.prototype.redraw = function(n) {
       f.call(self);
     };
     for (var idxRedraw = 0; idxRedraw < numberOfRedraws; idxRedraw++) {
-      this.resetMatrix();
-      if (this._renderer.isP3D) {
-        this._renderer._update();
-      }
-      this._setProperty('frameCount', this.frameCount + 1);
-      this._registeredMethods.pre.forEach(callMethod);
-      userDraw();
-      this._registeredMethods.post.forEach(callMethod);
+      promise = promise
+        .then(function() {
+          self.resetMatrix();
+          if (self._renderer.isP3D) {
+            self._renderer._update();
+          }
+          self._setProperty('frameCount', self.frameCount + 1);
+          self._registeredMethods.pre.forEach(callMethod);
+        })
+        .then(userDraw)
+        .then(function() {
+          self._registeredMethods.post.forEach(callMethod);
+        });
     }
   }
+  return promise;
 };
 
 module.exports = p5;

--- a/test/js/p5_helpers.js
+++ b/test/js/p5_helpers.js
@@ -1,0 +1,23 @@
+function promisedSketch(sketch_fn) {
+  var myInstance;
+  var promise = new Promise(function(resolve, reject) {
+    myInstance = new p5(function(sketch) {
+      return sketch_fn(sketch, resolve, reject);
+    });
+  });
+
+  promise.catch(function() {}).then(function() {
+    myInstance.remove();
+  });
+  return promise;
+};
+
+function testSketchWithPromise(name, sketch_fn) {
+  var test_fn = function() {
+    return promisedSketch(sketch_fn);
+  };
+  test_fn.toString = function() {
+    return sketch_fn.toString();
+  };
+  return test(name, test_fn);
+};

--- a/test/test-minified.html
+++ b/test/test-minified.html
@@ -23,6 +23,7 @@
   <script src="js/sinon.js" type="text/javascript" ></script>
   <script src="js/modernizr.js" type="text/javascript" ></script>
   <script src="js/chai_helpers.js" type="text/javascript" ></script>
+  <script src="js/p5_helpers.js" type="text/javascript" ></script>
 
   <!-- Include anything you want to test -->
   <script src="../lib/p5.min.js" type="text/javascript" ></script>

--- a/test/test.html
+++ b/test/test.html
@@ -22,6 +22,7 @@
   <script src="js/sinon.js" type="text/javascript" ></script>
   <script src="js/modernizr.js" type="text/javascript" ></script>
   <script src="js/chai_helpers.js" type="text/javascript" ></script>
+  <script src="js/p5_helpers.js" type="text/javascript" ></script>
 
   <!-- Include anything you want to test -->
   <script src="../lib/p5.js" type="text/javascript" ></script>

--- a/test/unit/core/core.js
+++ b/test/unit/core/core.js
@@ -18,59 +18,119 @@ suite('Core', function() {
     // readyState is "loading" and we can verify that the code is doing the
     // right thing during page load.
 
-    var myp5 = new p5(function() {}, null, true);
-    var isDrawingContextDefined = myp5.drawingContext !== undefined;
+    var isPreloadCalled = false;
+    var myp5 = new p5(
+      function(s) {
+        s.preload = function() {
+          isPreloadCalled = true;
+        };
+      },
+      null,
+      true
+    );
+    var preloadedHere = isPreloadCalled;
+    teardown(function() {
+      myp5.remove();
+    });
 
-    test('should define drawContext synchronously', function() {
-      assert.ok(isDrawingContextDefined);
+    test('should start preload immediately', function() {
+      assert.ok(preloadedHere);
     });
   });
 
   suite('new p5(sketch, null, false)', function() {
-    var myp5 = new p5(function() {}, null, false);
-    var isDrawingContextDefined = myp5.drawingContext !== undefined;
+    var isPreloadCalled = false;
+    var myp5 = new p5(
+      function(s) {
+        s.preload = function() {
+          isPreloadCalled = true;
+        };
+      },
+      null,
+      false
+    );
+    var preloadedHere = isPreloadCalled;
+    teardown(function() {
+      myp5.remove();
+    });
 
-    test('should define drawContext asynchronously', function() {
-      assert.equal(isDrawingContextDefined, false);
-      assert.isDefined(myp5.drawingContext);
+    test('should start preload asynchronously', function() {
+      assert.isFalse(preloadedHere);
+      assert.isTrue(isPreloadCalled);
     });
   });
 
   suite('new p5(sketch, node, true)', function() {
-    var myp5 = new p5(function() {}, node, true);
-    var isDrawingContextDefined = myp5.drawingContext !== undefined;
+    var isPreloadCalled = false;
+    var myp5 = new p5(
+      function(s) {
+        s.preload = function() {
+          isPreloadCalled = true;
+        };
+      },
+      node,
+      true
+    );
+    var preloadedHere = isPreloadCalled;
+    teardown(function() {
+      myp5.remove();
+    });
 
-    test('should define drawContext synchronously', function() {
-      assert.ok(isDrawingContextDefined);
+    test('should start preload synchronously', function() {
+      assert.isTrue(preloadedHere);
     });
   });
 
   suite('new p5(sketch, node)', function() {
-    var myp5 = new p5(function() {}, node);
-    var isDrawingContextDefined = myp5.drawingContext !== undefined;
+    var isPreloadCalled = false;
+    var myp5 = new p5(function(s) {
+      s.preload = function() {
+        isPreloadCalled = true;
+      };
+    }, node);
+    var preloadedHere = isPreloadCalled;
+    teardown(function() {
+      myp5.remove();
+    });
 
-    test('should define drawContext asynchronously', function() {
-      assert.equal(isDrawingContextDefined, false);
-      assert.isDefined(myp5.drawingContext);
+    test('should start preload asynchronously', function() {
+      assert.isFalse(preloadedHere);
+      assert.isTrue(isPreloadCalled);
     });
   });
 
   suite('new p5(sketch, true)', function() {
-    var myp5 = new p5(function() {}, true);
-    var isDrawingContextDefined = myp5.drawingContext !== undefined;
+    var isPreloadCalled = false;
+    var myp5 = new p5(function(s) {
+      s.preload = function() {
+        isPreloadCalled = true;
+      };
+    }, true);
+    var preloadedHere = isPreloadCalled;
+    teardown(function() {
+      myp5.remove();
+    });
 
-    test('should define drawContext synchronously', function() {
-      assert.ok(isDrawingContextDefined);
+    test('should start preload synchronously', function() {
+      assert.isTrue(preloadedHere);
     });
   });
 
   suite('new p5(sketch)', function() {
-    var myp5 = new p5(function() {});
-    var isDrawingContextDefined = myp5.drawingContext !== undefined;
+    var isPreloadCalled = false;
+    var myp5 = new p5(function(s) {
+      s.preload = function() {
+        isPreloadCalled = true;
+      };
+    });
+    var preloadedHere = isPreloadCalled;
+    teardown(function() {
+      myp5.remove();
+    });
 
-    test('should define drawContext asynchronously', function() {
-      assert.equal(isDrawingContextDefined, false);
-      assert.isDefined(myp5.drawingContext);
+    test('should start preload asynchronously', function() {
+      assert.isFalse(preloadedHere);
+      assert.isTrue(isPreloadCalled);
     });
   });
 

--- a/test/unit/core/promises.js
+++ b/test/unit/core/promises.js
@@ -1,0 +1,182 @@
+/* global testSketchWithPromise */
+/* This file tests the three user-implemented functions preload, setup and draw
+ * to ensure that a returned Promise will be respected by p5
+ */
+
+suite('Promises', function() {
+  suite('preload', function() {
+    testSketchWithPromise('ignores a non-Promise return', function(
+      sketch,
+      resolve,
+      reject
+    ) {
+      sketch.preload = function() {
+        return 4;
+      };
+
+      sketch.setup = resolve;
+      sketch.draw = function() {
+        reject(new Error('Draw was called before setup'));
+      };
+    });
+
+    testSketchWithPromise('loading stops when preload rejects', function(
+      sketch,
+      resolve,
+      reject
+    ) {
+      sketch.preload = function() {
+        setTimeout(resolve, 50);
+        return Promise.reject();
+      };
+
+      sketch.setup = function() {
+        reject(new Error('Setup was called'));
+      };
+      sketch.draw = function() {
+        reject(new Error('Draw was called before setup'));
+      };
+    });
+
+    testSketchWithPromise('setup runs when preload is fulfilled', function(
+      sketch,
+      resolve,
+      reject
+    ) {
+      var resolved = false;
+      sketch.preload = function() {
+        return new Promise(function(resolve, reject) {
+          setTimeout(function() {
+            resolved = true;
+            resolve();
+          }, 100);
+        });
+      };
+
+      sketch.setup = function() {
+        if (!resolved) {
+          reject(new Error('Setup was called before fulfilment'));
+        } else {
+          resolve();
+        }
+      };
+      sketch.draw = function() {
+        reject(new Error('Draw was called before setup'));
+      };
+    });
+  });
+
+  suite('setup', function() {
+    testSketchWithPromise('ignores a non-Promise return', function(
+      sketch,
+      resolve,
+      reject
+    ) {
+      sketch.setup = function() {
+        return 4;
+      };
+
+      sketch.draw = resolve;
+    });
+
+    testSketchWithPromise('loading stops when setup rejects', function(
+      sketch,
+      resolve,
+      reject
+    ) {
+      sketch.setup = function() {
+        setTimeout(resolve, 50);
+        return Promise.reject();
+      };
+
+      sketch.draw = function() {
+        reject(new Error('Draw was called'));
+      };
+    });
+
+    testSketchWithPromise('draw runs when setup is fulfilled', function(
+      sketch,
+      resolve,
+      reject
+    ) {
+      var resolved = false;
+      sketch.setup = function() {
+        return new Promise(function(resolve, reject) {
+          setTimeout(function() {
+            resolved = true;
+            resolve();
+          }, 100);
+        });
+      };
+
+      sketch.draw = function() {
+        if (!resolved) {
+          reject(new Error('Draw was called before fulfilment'));
+        } else {
+          resolve();
+        }
+      };
+    });
+  });
+
+  suite('draw', function() {
+    testSketchWithPromise('ignores a non-Promise return', function(
+      sketch,
+      resolve,
+      reject
+    ) {
+      var run = false;
+      sketch.draw = function() {
+        if (run) {
+          resolve();
+        } else {
+          run = true;
+        }
+        return 4;
+      };
+    });
+
+    testSketchWithPromise('stops looping after a rejection', function(
+      sketch,
+      resolve,
+      reject
+    ) {
+      var run = false;
+      sketch.draw = function() {
+        if (run) {
+          reject();
+        } else {
+          run = true;
+          setTimeout(resolve, 100);
+          return Promise.reject();
+        }
+      };
+    });
+
+    testSketchWithPromise('waits until previous draw is fulfilled', function(
+      sketch,
+      resolve,
+      reject
+    ) {
+      var run = false;
+      var resolved = false;
+      sketch.draw = function() {
+        if (run) {
+          if (resolved) {
+            resolve();
+          } else {
+            reject(new Error('Draw ran before previous draw fulfilled'));
+          }
+        } else {
+          run = true;
+          return new Promise(function(resolve, reject) {
+            setTimeout(function() {
+              resolved = true;
+              resolve();
+            }, 100);
+          });
+        }
+      };
+    });
+  });
+});

--- a/test/unit/core/structure.js
+++ b/test/unit/core/structure.js
@@ -270,8 +270,7 @@ suite('Structure', function() {
           }
           myp5.rotate(10);
         };
-        myp5.redraw(10);
-        resolve();
+        myp5.redraw(10).then(resolve);
       });
     });
   });

--- a/test/unit/spec.js
+++ b/test/unit/spec.js
@@ -8,6 +8,7 @@ var spec = {
     'element',
     'error_helpers',
     'graphics',
+    'promises',
     'renderer',
     'structure'
   ],


### PR DESCRIPTION
Permits a user to optionally return a Promise from `preload`, `setup` and/or `draw` and will use them to continue when appropriate.