### PR TITLE
Add YUIDoc for constants

### DIFF
--- a/docs/yuidoc-p5-theme-src/scripts/tpl/library.html
+++ b/docs/yuidoc-p5-theme-src/scripts/tpl/library.html
@@ -11,7 +11,9 @@
     <div class="column_<%=col%>">
   <% } %>
   <% if (group.name !== module.name && group.name !== 'p5') { %>
-    <a href="<%=group.hash%>" <% if (group.module !== module.name) { %>class="core"<% } %>><h4 class="group-name <% if (t == 0) { %> first<%}%>"><%=group.name%></h4></a>
+    <% if (group.hash) { %> <a href="<%=group.hash%>" <% if (group.module !== module.name) { %>class="core"<% } %>><% } %>  
+    <h4 class="group-name <% if (t == 0) { %> first<%}%>"><%=group.name%></h4>
+    <% if (group.hash) { %> </a> <% } %>
   <% } %>
   <% _.each(group.items.filter(function(item) {return item.access !== 'private'}), function(item) { %>
     <a href="<%=item.hash%>" <% if (item.module !== module.name) { %>class="core"<% } %>><%=item.name%><% if (item.itemtype === 'method') { %>()<%}%></a><br>

--- a/docs/yuidoc-p5-theme-src/scripts/views/libraryView.js
+++ b/docs/yuidoc-p5-theme-src/scripts/views/libraryView.js
@@ -1,109 +1,108 @@
-define([
-  'App',
-  // Templates
-  'text!tpl/library.html'
-], function (App, libraryTpl) {
+define(
+  [
+    'App',
+    // Templates
+    'text!tpl/library.html'
+  ],
+  function(App, libraryTpl) {
+    var libraryView = Backbone.View.extend({
+      el: '#list',
+      events: {},
+      /**
+       * Init.
+       */
+      init: function() {
+        this.libraryTpl = _.template(libraryTpl);
 
-  var libraryView = Backbone.View.extend({
-    el: '#list',
-    events: {},
-    /**
-     * Init.
-     */
-    init: function () {
-      this.libraryTpl = _.template(libraryTpl);
+        return this;
+      },
+      /**
+       * Render the list.
+       */
+      render: function(m, listCollection) {
+        if (m && listCollection) {
+          var self = this;
 
-      return this;
-    },
-    /**
-     * Render the list.
-     */
-    render: function (m, listCollection) {
-      if (m && listCollection) {
-        var self = this;
+          // Render items and group them by module
+          // module === group
+          this.groups = {};
+          _.each(m.items, function(item, i) {
+            var module = item.module || '_';
+            var group = item.class || '_';
+            var hash = App.router.getHash(item);
 
-        // Render items and group them by module
-        // module === group
-        this.groups = {};
-        _.each(m.items, function (item, i) {
-          var module = item.module || '_';
-          var group = item.class || '_';
-          var hash = App.router.getHash(item);
+            var ind = hash.lastIndexOf('/');
+            hash = hash.substring(0, ind);
 
-          var ind = hash.lastIndexOf('/');
-          hash = hash.substring(0, ind);
+            // Create a group list
+            if (!self.groups[group]) {
+              self.groups[group] = {
+                name: group.replace('_', '&nbsp;'),
+                module: module,
+                hash: hash,
+                items: []
+              };
+            }
 
-          // Create a group list
-          if (!self.groups[group]) {
-            self.groups[group] = {
-              name: group.replace('_', '&nbsp;'),
-              module: module,
-              hash: hash,
-              items: []
-            };
-          }
+            self.groups[group].items.push(item);
+          });
 
+          // Sort groups by name A-Z
+          self.groups = _.sortBy(self.groups, this.sortByName);
 
-          self.groups[group].items.push(item);
-        });
+          // Put the <li> items html into the list <ul>
+          var libraryHtml = self.libraryTpl({
+            title: self.capitalizeFirst(listCollection),
+            module: m.module,
+            totalItems: m.items.length,
+            groups: self.groups
+          });
 
-        // Sort groups by name A-Z
-        self.groups = _.sortBy(self.groups, this.sortByName);
+          // Render the view
+          this.$el.html(libraryHtml);
+        }
 
-        // Put the <li> items html into the list <ul>
-        var libraryHtml = self.libraryTpl({
-          'title': self.capitalizeFirst(listCollection),
-          'module': m.module,
-          'totalItems': m.items.length,
-          'groups': self.groups
-        });
+        return this;
+      },
+      /**
+       * Show a list of items.
+       * @param {array} items Array of item objects.
+       * @returns {object} This view.
+       */
+      show: function(listGroup) {
+        if (App[listGroup]) {
+          this.render(App[listGroup], listGroup);
+        }
+        App.pageView.hideContentViews();
 
-        // Render the view
-        this.$el.html(libraryHtml);
+        this.$el.show();
+
+        return this;
+      },
+      /**
+       * Helper method to capitalize the first letter of a string
+       * @param {string} str
+       * @returns {string} Returns the string.
+       */
+      capitalizeFirst: function(str) {
+        return str.substr(0, 1).toUpperCase() + str.substr(1);
+      },
+      /**
+       * Sort function (for the Array.prototype.sort() native method): from A to Z.
+       * @param {string} a
+       * @param {string} b
+       * @returns {Array} Returns an array with elements sorted from A to Z.
+       */
+      sortAZ: function(a, b) {
+        return a.innerHTML.toLowerCase() > b.innerHTML.toLowerCase() ? 1 : -1;
+      },
+
+      sortByName: function(a, b) {
+        if (a.name === 'p5') return -1;
+        else return 0;
       }
+    });
 
-      return this;
-    },
-    /**
-     * Show a list of items.
-     * @param {array} items Array of item objects.
-     * @returns {object} This view.
-     */
-    show: function (listGroup) {
-      if (App[listGroup]) {
-        this.render(App[listGroup], listGroup);
-      }
-      App.pageView.hideContentViews();
-
-      this.$el.show();
-
-      return this;
-    },
-    /**
-     * Helper method to capitalize the first letter of a string
-     * @param {string} str
-     * @returns {string} Returns the string.
-     */
-    capitalizeFirst: function (str) {
-      return str.substr(0, 1).toUpperCase() + str.substr(1);
-    },
-    /**
-     * Sort function (for the Array.prototype.sort() native method): from A to Z.
-     * @param {string} a
-     * @param {string} b
-     * @returns {Array} Returns an array with elements sorted from A to Z.
-     */
-    sortAZ: function (a, b) {
-      return a.innerHTML.toLowerCase() > b.innerHTML.toLowerCase() ? 1 : -1;
-    },
-
-    sortByName: function (a, b) {
-      if (a.name === 'p5') return -1;
-      else return 0;
-    }
-
-  });
-
-  return libraryView;
-
-});
+    return libraryView;
+  }
+);

--- a/docs/yuidoc-p5-theme-src/scripts/views/libraryView.js
+++ b/docs/yuidoc-p5-theme-src/scripts/views/libraryView.js
@@ -28,20 +28,40 @@ define(
           this.groups = {};
           _.each(m.items, function(item, i) {
             var module = item.module || '_';
-            var group = item.class || '_';
-            var hash = App.router.getHash(item);
+            var group;
+            // Override default group with a selected category
+            // TODO: Overwriting with the first category might not be the best choice
+            // We might also want to have links for categories
+            if (item.category && item.category[0]) {
+              group = item.category[0];
+              // Populate item.hash
+              App.router.getHash(item);
 
-            var ind = hash.lastIndexOf('/');
-            hash = hash.substring(0, ind);
+              // Create a group list without link hash
+              if (!self.groups[group]) {
+                self.groups[group] = {
+                  name: group.replace('_', '&nbsp;'),
+                  module: module,
+                  hash: undefined,
+                  items: []
+                };
+              }
+            } else {
+              group = item.class || '_';
+              var hash = App.router.getHash(item);
 
-            // Create a group list
-            if (!self.groups[group]) {
-              self.groups[group] = {
-                name: group.replace('_', '&nbsp;'),
-                module: module,
-                hash: hash,
-                items: []
-              };
+              var ind = hash.lastIndexOf('/');
+              hash = hash.substring(0, ind);
+
+              // Create a group list
+              if (!self.groups[group]) {
+                self.groups[group] = {
+                  name: group.replace('_', '&nbsp;'),
+                  module: module,
+                  hash: hash,
+                  items: []
+                };
+              }
             }
 
             self.groups[group].items.push(item);

--- a/lib/addons/p5.dom.js
+++ b/lib/addons/p5.dom.js
@@ -1023,11 +1023,13 @@
   /**
    * @property {String} VIDEO
    * @final
+   * @category Constants
    */
   p5.prototype.VIDEO = 'video';
   /**
    * @property {String} AUDIO
    * @final
+   * @category Constants
    */
   p5.prototype.AUDIO = 'audio';
 

--- a/lib/addons/p5.dom.js
+++ b/lib/addons/p5.dom.js
@@ -1020,7 +1020,15 @@
 
   /** CAMERA STUFF **/
 
+  /**
+   * @property {String} VIDEO
+   * @final
+   */
   p5.prototype.VIDEO = 'video';
+  /**
+   * @property {String} AUDIO
+   * @final
+   */
   p5.prototype.AUDIO = 'audio';
 
   // from: https://developer.mozilla.org/en-US/docs/Web/API/MediaDevices/getUserMedia

--- a/src/core/constants.js
+++ b/src/core/constants.js
@@ -22,11 +22,35 @@ module.exports = {
   WEBGL: 'webgl',
 
   // ENVIRONMENT
+  /**
+   * @property {String} ARROW
+   * @final
+   */
   ARROW: 'default',
+  /**
+   * @property {String} CROSS
+   * @final
+   */
   CROSS: 'crosshair',
+  /**
+   * @property {String} HAND
+   * @final
+   */
   HAND: 'pointer',
+  /**
+   * @property {String} MOVE
+   * @final
+   */
   MOVE: 'move',
+  /**
+   * @property {String} TEXT
+   * @final
+   */
   TEXT: 'text',
+  /**
+   * @property {String} WAIT
+   * @final
+   */
   WAIT: 'wait',
 
   // TRIGONOMETRY
@@ -323,6 +347,10 @@ module.exports = {
   HSL: 'hsl',
 
   // DOM EXTENSION
+  /**
+   * @property {String} AUTO
+   * @final
+   */
   AUTO: 'auto',
 
   // INPUT


### PR DESCRIPTION
These constants are referenced in other documentation.
They therefore need to be documented to generate TypeScript types.

Is there a reason for some constants (not named _CONSTANT) not to have YUIDoc?