### PR TITLE
Adding dashed lines

### DIFF
--- a/src/core/attributes.js
+++ b/src/core/attributes.js
@@ -311,6 +311,70 @@ p5.prototype.strokeJoin = function(join) {
 };
 
 /**
+ * Sets the line dash pattern used when drawing lines,
+ * using an array of values which specify alternating lengths of lines and gaps
+ * which describe the pattern.
+ * If the argument is omitted, the function just returns the current line dash setting.
+ *
+ * @method lineDash
+ * @param  {Number[]} [segments] An array of numbers which specify distances to alternately draw a line and a gap.
+ * If the number of elements in the array is odd, the elements of the array get copied and concatenated.
+ * For example, (5, 15, 25) will become (5, 15, 25, 5, 15, 25).
+ * If the array is empty, the line dash list is cleared and line strokes return to being solid.
+ * @return {Number[]} The current line dash setting.
+ * @example
+ * <div>
+ * <code>
+ * strokeWeight(2);
+ *
+ * // A simple pattern:
+ * // Stroke 5 pixels and leave 5 pixels of spacing
+ * lineDash([5]);
+ *
+ * line(10, 10, 10, 90);
+ *
+ * fill(255, 0, 0);
+ * rect(30, 20, 60, 60);
+ * </code>
+ * </div>
+ *
+ * <div>
+ * <code>
+ * strokeWeight(2);
+ * stroke(255, 0, 0);
+ *
+ * // A more complex pattern:
+ * // Stroke 10 pixels, leave 5 pixels of spacing, stroke 2 pixels, leave 5 pixels of spacing and repeat
+ * lineDash([10, 5, 2, 5]);
+ *
+ * ellipse(width / 2, height / 2, 80);
+ * </code>
+ * </div>
+ *
+ * <div>
+ * <code>
+ * stroke(255, 255, 0);
+ *
+ * lineDash([10]);
+ * line(10, height / 3, 90, height / 3);
+ *
+ * // Go back to solid lines
+ * lineDash([]);
+ * line(10, 2 / 3 * height, 90, 2 / 3 * height);
+ * </code>
+ * </div>
+ *
+ * @alt
+ * A dashed vertical line and a square with a dashed perimeter.
+ * A circle with a red, dashed outline.
+ * A dashed line on the top, a normal line on the bottom.
+ */
+p5.prototype.lineDash = function(segments) {
+  p5._validateParameters('lineDash', arguments);
+  return this._renderer.lineDash(segments);
+};
+
+/**
  * Sets the width of the stroke used for lines, points, and the border
  * around shapes. All widths are set in units of pixels.
  *

--- a/src/core/p5.Renderer2D.js
+++ b/src/core/p5.Renderer2D.js
@@ -1042,6 +1042,15 @@ p5.Renderer2D.prototype.strokeJoin = function(join) {
   return this;
 };
 
+p5.Renderer2D.prototype.lineDash = function(segments) {
+  if (typeof segments === 'undefined') {
+    return this.drawingContext.getLineDash();
+  }
+
+  this.drawingContext.setLineDash(segments);
+  return segments;
+};
+
 p5.Renderer2D.prototype.strokeWeight = function(w) {
   if (typeof w === 'undefined' || w === 0) {
     // hack because lineWidth 0 doesn't work


### PR DESCRIPTION
This pull request adds a `lineDash()` function to the p5 prototype which provides an easy way to draw dashed lines.
The implementation is based on the native `CanvasRenderingContext2D.getLineDash()` / `CanvasRenderingContext2D.setLineDash()` methods.

The changes include:
* `lineDash()` method definition in `p5.Renderer2D` class
* `lineDash()` method definition in `p5` class
* A description of the function based on [this MDN article](https://developer.mozilla.org/en-US/docs/Web/API/CanvasRenderingContext2D/setLineDash)
* A few examples for the p5 documentation page

As this is my first pull request to the p5 project, I had a few problems with the parameter validation system which I didn't manage to get to work, so I'm looking for some help on that. Furthermore, I have no idea how to write tests for the new functionality, so I'll need help on that as well.

There are a few things about the API which I'm not sure about that I'd leave to someone more experienced than me to decide:
* The `lineDash()` function accepts an array as its only argument for now, while we might consider to use rest parameters instead
* The `lineDash()` function always returns the current line dash settings, and is therefore not *chainable*
* The `lineDash()` function can be called with no parameters (it just returns the current settings)
* A `noLineDash()` function equivalent to calling `lineDash([])` might be a good addition, since it would probably make the API more clear
* There is no support for the function in WEBGL mode, and no "friendly debug log" is provided if it gets called in that context (which is the case also for other p5 functions such as `strokeCap()` and `strokeJoin()`)

Looking forward to receiving your suggestions.