### PR TITLE
fixes #2797 by removing window.performance.now shim

### DIFF
--- a/src/core/shim.js
+++ b/src/core/shim.js
@@ -15,22 +15,6 @@ window.requestAnimationFrame = (function() {
   );
 })();
 
-// use window.performance() to get max fast and accurate time in milliseconds
-window.performance = window.performance || {};
-window.performance.now = (function() {
-  var load_date = Date.now();
-  return (
-    window.performance.now ||
-    window.performance.mozNow ||
-    window.performance.msNow ||
-    window.performance.oNow ||
-    window.performance.webkitNow ||
-    function() {
-      return Date.now() - load_date;
-    }
-  );
-})();
-
 /**
  * shim for Uint8ClampedArray.slice
  * (allows arrayCopy to work with pixels[])


### PR DESCRIPTION
the shim for window.performance.now was introduced in 2014
to resolve some timing issues. at the time, it wasn't available
in all browsers, but now it's available in everything except
Opera Mini, so it seems safe to remove this shim.