### PR TITLE
add smooth and noSmooth to WebGL

### DIFF
--- a/src/core/attributes.js
+++ b/src/core/attributes.js
@@ -82,10 +82,10 @@ p5.prototype.ellipseMode = function(m) {
 
 /**
  * Draws all geometry with jagged (aliased) edges. Note that <a href="#/p5/smooth">smooth()</a> is
- * active by default in 2D rendering, so it is necessary to call <a href="#/p5/noSmooth">noSmooth()</a> to disable
- * smoothing of geometry, images, and fonts. In 3D Rendering, <a href="#/p5/noSmooth">noSmooth()</a> is enabled
+ * active by default in 2D mode, so it is necessary to call <a href="#/p5/noSmooth">noSmooth()</a> to disable
+ * smoothing of geometry, images, and fonts. In 3D mode, <a href="#/p5/noSmooth">noSmooth()</a> is enabled
  * by default, so it is necessary to call <a href="#/p5/smooth">smooth()</a> if you would like
- * smooth (antialiased) edge on your geometry.
+ * smooth (antialiased) edges on your geometry.
  *
  * @method noSmooth
  * @chainable
@@ -182,10 +182,10 @@ p5.prototype.rectMode = function(m) {
 /**
  * Draws all geometry with smooth (anti-aliased) edges. <a href="#/p5/smooth">smooth()</a> will also
  * improve image quality of resized images. Note that <a href="#/p5/smooth">smooth()</a> is active by
- * default in 2D rendering; <a href="#/p5/noSmooth">noSmooth()</a> can be used to disable smoothing of geometry,
- * images, and fonts. In 3D Rendering, <a href="#/p5/noSmooth">noSmooth()</a> is enabled
+ * default in 2D mode; <a href="#/p5/noSmooth">noSmooth()</a> can be used to disable smoothing of geometry,
+ * images, and fonts. In 3D mode, <a href="#/p5/noSmooth">noSmooth()</a> is enabled
  * by default, so it is necessary to call <a href="#/p5/smooth">smooth()</a> if you would like
- * smooth (antialiased) edge on your geometry.
+ * smooth (antialiased) edges on your geometry.
  *
  * @method smooth
  * @chainable

--- a/src/core/attributes.js
+++ b/src/core/attributes.js
@@ -82,8 +82,10 @@ p5.prototype.ellipseMode = function(m) {
 
 /**
  * Draws all geometry with jagged (aliased) edges. Note that <a href="#/p5/smooth">smooth()</a> is
- * active by default, so it is necessary to call <a href="#/p5/noSmooth">noSmooth()</a> to disable
- * smoothing of geometry, images, and fonts.
+ * active by default in 2D rendering, so it is necessary to call <a href="#/p5/noSmooth">noSmooth()</a> to disable
+ * smoothing of geometry, images, and fonts. In 3D Rendering, <a href="#/p5/noSmooth">noSmooth()</a> is enabled
+ * by default, so it is necessary to call <a href="#/p5/smooth">smooth()</a> if you would like
+ * smooth (antialiased) edge on your geometry.
  *
  * @method noSmooth
  * @chainable
@@ -180,8 +182,10 @@ p5.prototype.rectMode = function(m) {
 /**
  * Draws all geometry with smooth (anti-aliased) edges. <a href="#/p5/smooth">smooth()</a> will also
  * improve image quality of resized images. Note that <a href="#/p5/smooth">smooth()</a> is active by
- * default; <a href="#/p5/noSmooth">noSmooth()</a> can be used to disable smoothing of geometry,
- * images, and fonts.
+ * default in 2D rendering; <a href="#/p5/noSmooth">noSmooth()</a> can be used to disable smoothing of geometry,
+ * images, and fonts. In 3D Rendering, <a href="#/p5/noSmooth">noSmooth()</a> is enabled
+ * by default, so it is necessary to call <a href="#/p5/smooth">smooth()</a> if you would like
+ * smooth (antialiased) edge on your geometry.
  *
  * @method smooth
  * @chainable

--- a/src/webgl/p5.RendererGL.js
+++ b/src/webgl/p5.RendererGL.js
@@ -984,72 +984,13 @@ p5.RendererGL.prototype._bindBuffer = function(
 //////////////////////////
 //// SMOOTHING
 /////////////////////////
-/**
- * Sets antialiasing to true if it is not already.
- * This is similar to using setAttributes('antialias', true);
- * @method smooth
- * @for p5
- * @class p5.RendererGL
- * @example
- * <div>
- * <code>
- * function setup() {
- *   createCanvas(100, 100, WEBGL);
- *   smooth();
- * }
- *
- * function draw() {
- *   background(255);
- *   push();
- *   rotateZ(frameCount * 0.02);
- *   rotateX(frameCount * 0.02);
- *   rotateY(frameCount * 0.02);
- *   fill(50);
- *   box(50);
- *   pop();
- * }
- * </code>
- * </div>
- *
- *
- * @alt a rotating cube with smoother edges
- */
+
 p5.RendererGL.prototype.smooth = function() {
   if (this.attributes.antialias === false) {
     this._pInst.setAttributes('antialias', true);
   }
 };
 
-/**
- * Sets antialiasing to false if it is not already.
- * This is similar to using setAttributes('antialias', false);
- * @method noSmooth
- * @class p5.RendererGL
- * @for p5
- * @example
- * <div>
- * <code>
- * function setup() {
- *   createCanvas(100, 100, WEBGL);
- *   noSmooth();
- * }
- *
- * function draw() {
- *   background(255);
- *   push();
- *   rotateZ(frameCount * 0.02);
- *   rotateX(frameCount * 0.02);
- *   rotateY(frameCount * 0.02);
- *   fill(50);
- *   box(50);
- *   pop();
- * }
- * </code>
- * </div>
- *
- *
- * @alt a rotating cube with jagged edges
- */
 p5.RendererGL.prototype.noSmooth = function() {
   if (this.attributes.antialias === true) {
     this._pInst.setAttributes('antialias', false);

--- a/src/webgl/p5.RendererGL.js
+++ b/src/webgl/p5.RendererGL.js
@@ -984,15 +984,76 @@ p5.RendererGL.prototype._bindBuffer = function(
 //////////////////////////
 //// SMOOTHING
 /////////////////////////
-// @TODO:
+/**
+ * Sets antialiasing to true if it is not already.
+ * This is similar to using setAttributes('antialias', true);
+ * @method smooth
+ * @for p5
+ * @class p5.RendererGL
+ * @example
+ * <div>
+ * <code>
+ * function setup() {
+ *   createCanvas(100, 100, WEBGL);
+ *   smooth();
+ * }
+ *
+ * function draw() {
+ *   background(255);
+ *   push();
+ *   rotateZ(frameCount * 0.02);
+ *   rotateX(frameCount * 0.02);
+ *   rotateY(frameCount * 0.02);
+ *   fill(50);
+ *   box(50);
+ *   pop();
+ * }
+ * </code>
+ * </div>
+ *
+ *
+ * @alt a rotating cube with smoother edges
+ */
 p5.RendererGL.prototype.smooth = function() {
-  //@TODO finish implementation
-  console.log('smoothing not yet implemented in webgl');
+  if (this.attributes.antialias === false) {
+    this._pInst.setAttributes('antialias', true);
+  }
 };
 
+/**
+ * Sets antialiasing to false if it is not already.
+ * This is similar to using setAttributes('antialias', false);
+ * @method noSmooth
+ * @class p5.RendererGL
+ * @for p5
+ * @example
+ * <div>
+ * <code>
+ * function setup() {
+ *   createCanvas(100, 100, WEBGL);
+ *   noSmooth();
+ * }
+ *
+ * function draw() {
+ *   background(255);
+ *   push();
+ *   rotateZ(frameCount * 0.02);
+ *   rotateX(frameCount * 0.02);
+ *   rotateY(frameCount * 0.02);
+ *   fill(50);
+ *   box(50);
+ *   pop();
+ * }
+ * </code>
+ * </div>
+ *
+ *
+ * @alt a rotating cube with jagged edges
+ */
 p5.RendererGL.prototype.noSmooth = function() {
-  //@TODO finish implementation
-  console.log('smoothing not yet implemented in webgl');
+  if (this.attributes.antialias === true) {
+    this._pInst.setAttributes('antialias', false);
+  }
 };
 
 ///////////////////////////////


### PR DESCRIPTION
Adding smooth and noSmooth function to GL Renderer. Check to see if the
context has antialias attribute set correctly, updates if not.

closes #2528 