### PR TITLE
OrbitControl Update

### DIFF
--- a/src/webgl/camera.js
+++ b/src/webgl/camera.js
@@ -81,6 +81,10 @@ p5.RendererGL.prototype.camera = function(
   this.cameraY = eyeY;
   this.cameraZ = eyeZ;
 
+  this.cameraCenterX = centerX;
+  this.cameraCenterY = centerY;
+  this.cameraCenterZ = centerZ;
+
   // calculate camera Z vector
   var z0 = eyeX - centerX;
   var z1 = eyeY - centerY;

--- a/src/webgl/interaction.js
+++ b/src/webgl/interaction.js
@@ -49,8 +49,9 @@ p5.prototype.orbitControl = function(sensitivityX, sensitivityY) {
   }
 
   if (this.mouseIsPressed) {
-    var deltaTheta = 0.02 * sensitivityX * (this.mouseX - this.pmouseX);
-    var deltaPhi = 0.02 * sensitivityY * (this.mouseY - this.pmouseY);
+    var scaleFactor = this.height < this.width ? this.height : this.width;
+    var deltaTheta = sensitivityX * (this.mouseX - this.pmouseX) / scaleFactor;
+    var deltaPhi = sensitivityY * (this.mouseY - this.pmouseY) / scaleFactor;
 
     // camera position
     var camX = this._renderer.cameraX;

--- a/src/webgl/interaction.js
+++ b/src/webgl/interaction.js
@@ -49,7 +49,7 @@ p5.prototype.orbitControl = function(sensitivityX, sensitivityY) {
 
   if (this.mouseIsPressed) {
     var deltaTheta = 0.1 * sensitivityX * (this.mouseX - this.pmouseX);
-    var deltaPhi = -0.1 * sensitivityY * (this.mouseY - this.pmouseY);
+    var deltaPhi = 0.1 * sensitivityY * (this.mouseY - this.pmouseY);
 
     // camera position
     var camX = this._renderer.cameraX;

--- a/src/webgl/interaction.js
+++ b/src/webgl/interaction.js
@@ -49,8 +49,8 @@ p5.prototype.orbitControl = function(sensitivityX, sensitivityY) {
   }
 
   if (this.mouseIsPressed) {
-    var deltaTheta = 0.1 * sensitivityX * (this.mouseX - this.pmouseX);
-    var deltaPhi = 0.1 * sensitivityY * (this.mouseY - this.pmouseY);
+    var deltaTheta = 0.02 * sensitivityX * (this.mouseX - this.pmouseX);
+    var deltaPhi = 0.02 * sensitivityY * (this.mouseY - this.pmouseY);
 
     // camera position
     var camX = this._renderer.cameraX;

--- a/src/webgl/interaction.js
+++ b/src/webgl/interaction.js
@@ -35,7 +35,8 @@ var p5 = require('../core/core');
  */
 //@TODO: implement full orbit controls including
 //pan, zoom, quaternion rotation, etc.
-// implementation based on three.js 'orbitControls'
+// implementation based on three.js 'orbitControls':
+// https://github.com/mrdoob/three.js/blob/dev/examples/js/controls/OrbitControls.js
 p5.prototype.orbitControl = function(sensitivityX, sensitivityY) {
   this._assert3d('orbitControl');
   p5._validateParameters('orbitControl', arguments);
@@ -67,7 +68,7 @@ p5.prototype.orbitControl = function(sensitivityX, sensitivityY) {
 
     // get spherical coorinates for current camera position about origin
     var camRadius = Math.sqrt(diffX * diffX + diffY * diffY + diffZ * diffZ);
-    // from three.js...
+    // from https://github.com/mrdoob/three.js/blob/dev/src/math/Spherical.js#L72-L73
     var camTheta = Math.atan2(diffX, diffZ); // equatorial angle
     var camPhi = Math.acos(Math.max(-1, Math.min(1, diffY / camRadius))); // polar angle
 
@@ -82,12 +83,12 @@ p5.prototype.orbitControl = function(sensitivityX, sensitivityY) {
       camPhi = 0.001;
     }
 
-    // turn back into Cartesian coordinates
-    var sinPhiRadius = Math.sin(camPhi) * camRadius;
+    // from https://github.com/mrdoob/three.js/blob/dev/src/math/Vector3.js#L628-L632
+    // var sinPhiRadius = Math.sin(camPhi) * camRadius;
 
-    var _x = sinPhiRadius * Math.sin(camTheta);
+    var _x = Math.sin(camPhi) * camRadius * Math.sin(camTheta);
     var _y = Math.cos(camPhi) * camRadius;
-    var _z = sinPhiRadius * Math.cos(camTheta);
+    var _z = Math.sin(camPhi) * camRadius * Math.cos(camTheta);
 
     this.camera(
       _x + centerX,

--- a/src/webgl/interaction.js
+++ b/src/webgl/interaction.js
@@ -50,7 +50,7 @@ p5.prototype.orbitControl = function(sensitivityX, sensitivityY) {
 
   if (this.mouseIsPressed) {
     var scaleFactor = this.height < this.width ? this.height : this.width;
-    var deltaTheta = sensitivityX * (this.mouseX - this.pmouseX) / scaleFactor;
+    var deltaTheta = -sensitivityX * (this.mouseX - this.pmouseX) / scaleFactor;
     var deltaPhi = sensitivityY * (this.mouseY - this.pmouseY) / scaleFactor;
 
     // camera position

--- a/src/webgl/interaction.js
+++ b/src/webgl/interaction.js
@@ -47,11 +47,28 @@ p5.prototype.orbitControl = function(sensitivityX, sensitivityY) {
   }
 
   if (this.mouseIsPressed) {
-    this.rotateY(
-      sensitivityX * (this.mouseX - this.width / 2) / (this.width / 2)
-    );
-    this.rotateX(
-      -sensitivityY * (this.mouseY - this.height / 2) / (this.width / 2)
+    var yAxisRotation = sensitivityX * (this.mouseX - this.pmouseX);
+    var xAxisRotation = -1 * sensitivityY * (this.mouseY - this.pmouseY);
+
+    var camMatrix = p5.Matrix.identity();
+
+    p5.Matrix.prototype.rotate.apply(camMatrix, [xAxisRotation, 1, 0, 0]);
+    p5.Matrix.prototype.rotate.apply(camMatrix, [yAxisRotation, 0, 1, 0]);
+
+    p5.Matrix.prototype.translate.apply(camMatrix, [
+      [this._renderer.cameraX, this._renderer.cameraY, this._renderer.cameraZ]
+    ]);
+
+    this.camera(
+      camMatrix.mat4[12],
+      camMatrix.mat4[13],
+      camMatrix.mat4[14],
+      0,
+      0,
+      0,
+      0,
+      1,
+      0
     );
   }
   return this;

--- a/src/webgl/interaction.js
+++ b/src/webgl/interaction.js
@@ -48,6 +48,14 @@ p5.prototype.orbitControl = function(sensitivityX, sensitivityY) {
   }
 
   if (this.mouseIsPressed) {
+    // avoid 'jumping' between mousedrag events
+    var distSq =
+      Math.pow(this.pmouseX - this.mouseX, 2) +
+      Math.pow(this.pmouseY - this.mouseY, 2);
+    if (distSq >= 200) {
+      return;
+    }
+
     var deltaTheta = 0.1 * sensitivityX * (this.mouseX - this.pmouseX);
     var deltaPhi = 0.1 * sensitivityY * (this.mouseY - this.pmouseY);
 
@@ -58,14 +66,15 @@ p5.prototype.orbitControl = function(sensitivityX, sensitivityY) {
 
     // get spherical coorinates for current camera position about origin
     var camRadius = Math.sqrt(camX * camX + camY * camY + camZ * camZ);
-    var camTheta = Math.atan2(camX, camZ); // equator angle around y-up axis
+    // from three.js...
+    var camTheta = Math.atan2(camX, camZ); // equatorial angle
     var camPhi = Math.acos(Math.max(-1, Math.min(1, camY / camRadius))); // polar angle
 
     // add mouse movements
     camTheta += deltaTheta;
     camPhi += deltaPhi;
 
-    // prevent move over the apex
+    // prevent rotation over the zenith / under bottom
     if (camPhi > Math.PI) {
       camPhi = Math.PI;
     } else if (camPhi <= 0) {

--- a/src/webgl/interaction.js
+++ b/src/webgl/interaction.js
@@ -56,11 +56,20 @@ p5.prototype.orbitControl = function(sensitivityX, sensitivityY) {
     var camY = this._renderer.cameraY;
     var camZ = this._renderer.cameraZ;
 
+    // center coordinates
+    var centerX = this._renderer.cameraCenterX;
+    var centerY = this._renderer.cameraCenterY;
+    var centerZ = this._renderer.cameraCenterZ;
+
+    var diffX = camX - centerX;
+    var diffY = camY - centerY;
+    var diffZ = camZ - centerZ;
+
     // get spherical coorinates for current camera position about origin
-    var camRadius = Math.sqrt(camX * camX + camY * camY + camZ * camZ);
+    var camRadius = Math.sqrt(diffX * diffX + diffY * diffY + diffZ * diffZ);
     // from three.js...
-    var camTheta = Math.atan2(camX, camZ); // equatorial angle
-    var camPhi = Math.acos(Math.max(-1, Math.min(1, camY / camRadius))); // polar angle
+    var camTheta = Math.atan2(diffX, diffZ); // equatorial angle
+    var camPhi = Math.acos(Math.max(-1, Math.min(1, diffY / camRadius))); // polar angle
 
     // add mouse movements
     camTheta += deltaTheta;
@@ -80,7 +89,17 @@ p5.prototype.orbitControl = function(sensitivityX, sensitivityY) {
     var _y = Math.cos(camPhi) * camRadius;
     var _z = sinPhiRadius * Math.cos(camTheta);
 
-    this.camera(_x, _y, _z, 0, 0, 0, 0, 1, 0);
+    this.camera(
+      _x + centerX,
+      _y + centerY,
+      _z + centerZ,
+      centerX,
+      centerY,
+      centerZ,
+      0,
+      1,
+      0
+    );
   }
   return this;
 };

--- a/src/webgl/interaction.js
+++ b/src/webgl/interaction.js
@@ -48,14 +48,6 @@ p5.prototype.orbitControl = function(sensitivityX, sensitivityY) {
   }
 
   if (this.mouseIsPressed) {
-    // avoid 'jumping' between mousedrag events
-    var distSq =
-      Math.pow(this.pmouseX - this.mouseX, 2) +
-      Math.pow(this.pmouseY - this.mouseY, 2);
-    if (distSq >= 200) {
-      return;
-    }
-
     var deltaTheta = 0.1 * sensitivityX * (this.mouseX - this.pmouseX);
     var deltaPhi = 0.1 * sensitivityY * (this.mouseY - this.pmouseY);
 

--- a/src/webgl/p5.RendererGL.js
+++ b/src/webgl/p5.RendererGL.js
@@ -91,6 +91,9 @@ p5.RendererGL = function(elt, pInst, isMainCanvas, attr) {
   this.cameraX = this.defaultCameraX;
   this.cameraY = this.defaultCameraY;
   this.cameraZ = this.defaultCameraZ;
+  this.cameraCenterX = this.defaultCameraCenterX;
+  this.cameraCenterY = this.defaultCameraCenterY;
+  this.cameraCenterZ = this.defaultCameraCenterZ;
   this.cameraNear = this.defaultCameraNear;
   this.cameraFar = this.defaultCameraFar;
   this.cameraMatrix = new p5.Matrix();
@@ -359,6 +362,9 @@ p5.RendererGL.prototype._computeCameraDefaultSettings = function() {
   this.defaultCameraY = 0;
   this.defaultCameraZ =
     this.height / 2.0 / Math.tan(this.defaultCameraFOV / 2.0);
+  this.defaultCameraCenterX = 0;
+  this.defaultCameraCenterY = 0;
+  this.defaultCameraCenterZ = 0;
   this.defaultCameraNear = this.defaultCameraZ * 0.1;
   this.defaultCameraFar = this.defaultCameraZ * 10;
 };
@@ -373,6 +379,9 @@ p5.RendererGL.prototype._setDefaultCamera = function() {
     this.cameraX = this.defaultCameraX;
     this.cameraY = this.defaultCameraY;
     this.cameraZ = this.defaultCameraZ;
+    this.cameraCenterX = this.defaultCameraCenterX;
+    this.cameraCenterY = this.defaultCameraCenterY;
+    this.cameraCenterZ = this.defaultCameraCenterZ;
     this.cameraNear = this.defaultCameraNear;
     this.cameraFar = this.defaultCameraFar;
 

--- a/test/manual-test-examples/webgl/interaction/index.html
+++ b/test/manual-test-examples/webgl/interaction/index.html
@@ -13,7 +13,7 @@
 
 <body>
   <header>
-    <p>Press mouse to toggle the world</p>
+    <p>Press and drag mouse to rotate view.</p>
   </header>
 </body>
 

--- a/test/manual-test-examples/webgl/interaction/sketch.js
+++ b/test/manual-test-examples/webgl/interaction/sketch.js
@@ -1,5 +1,8 @@
 function setup() {
   createCanvas(windowWidth, windowHeight, WEBGL);
+
+  // controls should work whether or not camera center is set to (0,0,0)
+  // camera(0, 0, 500, 300, 0, 0, 0, 1, 0);
 }
 
 function draw() {

--- a/test/manual-test-examples/webgl/interaction/sketch.js
+++ b/test/manual-test-examples/webgl/interaction/sketch.js
@@ -9,18 +9,21 @@ function draw() {
   orbitControl();
 
   normalMaterial();
-  translate(0, 0, -1000);
-  for (var i = 0; i <= 20; i++) {
-    for (var j = 0; j <= 20; j++) {
+
+  let scale = 200;
+  for (let px = -5; px < 5; px++) {
+    for (let pz = -5; pz < 5; pz++) {
       push();
-      var a = j / 20 * PI;
-      var b = i / 20 * PI;
-      translate(
-        sin(2 * a) * radius * sin(b),
-        cos(b) * radius / 2,
-        cos(2 * a) * radius * sin(b)
-      );
-      cone();
+      rotateX(PI);
+      translate(px * scale, 0, pz * scale);
+      if (px > 0) {
+        fill(255, 0, 0);
+      }
+      if (px == 0 && pz == 0) {
+        cone(50, 100);
+      } else {
+        cone(20, 50);
+      }
       pop();
     }
   }


### PR DESCRIPTION
Fixes #2497.

Adds persistence to `orbitControl()` and maintains y-axis up orientation. 

This change does the following:
- uses spherical coordinates to establish current camera position w/r/t center of sketch, adjust that position based on mouse movement and convert back to cartesian coordinates,
- makes adjustment persistent by applying those coordinates to rendererGL's `camera()` function which changes cameraMatrix,
- adds `cameraCenterX/Y/Z` properties to rendererGL to allow orbitControl about a center not at the origin.