### PR TITLE
fix #2847 by setting the playsinline attribute

### DIFF
--- a/lib/addons/p5.dom.js
+++ b/lib/addons/p5.dom.js
@@ -1138,6 +1138,8 @@
     }
     if (navigator.mediaDevices && navigator.mediaDevices.getUserMedia) {
       var elt = document.createElement('video');
+      // required to work in iOS 11 & up:
+      elt.setAttribute('playsinline', '');
 
       if (!constraints) {
         constraints = { video: useVideo, audio: useAudio };


### PR DESCRIPTION
resolves video capture for Safari on iOS 11 — with thanks to @kylemcdonald!