### PR TITLE
webgl: add support for ivec2, ivec3, ivec4 uniforms

### DIFF
--- a/src/webgl/p5.Shader.js
+++ b/src/webgl/p5.Shader.js
@@ -341,6 +341,27 @@ p5.Shader.prototype.setUniform = function(uniformName, data) {
         gl.uniform4f(location, data[0], data[1], data[2], data[3]);
       }
       break;
+    case gl.INT_VEC2:
+      if (uniform.size > 1) {
+        data.length && gl.uniform2iv(location, data);
+      } else {
+        gl.uniform2i(location, data[0], data[1]);
+      }
+      break;
+    case gl.INT_VEC3:
+      if (uniform.size > 1) {
+        data.length && gl.uniform3iv(location, data);
+      } else {
+        gl.uniform3i(location, data[0], data[1], data[2]);
+      }
+      break;
+    case gl.INT_VEC4:
+      if (uniform.size > 1) {
+        data.length && gl.uniform4iv(location, data);
+      } else {
+        gl.uniform4i(location, data[0], data[1], data[2], data[3]);
+      }
+      break;
     case gl.SAMPLER_2D:
       gl.activeTexture(gl.TEXTURE0 + uniform.samplerIndex);
       uniform.texture = this._renderer.getTexture(data);


### PR DESCRIPTION
closes #3070 

adds support for integer vector uniforms.