### PR TITLE
Change model() example

### DIFF
--- a/src/webgl/loading.js
+++ b/src/webgl/loading.js
@@ -249,11 +249,11 @@ function parseObj(model, lines) {
  * @example
  * <div>
  * <code>
- * //draw a spinning teapot
- * var teapot;
+ * //draw a spinning octahedron
+ * var octahedron;
  *
  * function preload() {
- *   teapot = loadModel('assets/teapot.obj');
+ *   octahedron = loadModel('assets/octahedron.obj');
  * }
  *
  * function setup() {
@@ -264,13 +264,13 @@ function parseObj(model, lines) {
  *   background(200);
  *   rotateX(frameCount * 0.01);
  *   rotateY(frameCount * 0.01);
- *   model(teapot);
+ *   model(octahedron);
  * }
  * </code>
  * </div>
  *
  * @alt
- * Vertically rotating 3-d teapot with red, green and blue gradient.
+ * Vertically rotating 3-d octahedron.
  *
  */
 p5.prototype.model = function(model) {


### PR DESCRIPTION
The current `model()` example has the same error the previous `loadModel()` example had. This PR fixes that issue by using the octahedron example instead.