### PR TITLE
fix rotation in DEGREES mode

### DIFF
--- a/src/webgl/p5.Matrix.js
+++ b/src/webgl/p5.Matrix.js
@@ -511,7 +511,6 @@ p5.Matrix.prototype.scale = function(x, y, z) {
  * inspired by Toji's gl-matrix lib, mat4 rotation
  */
 p5.Matrix.prototype.rotate = function(a, x, y, z) {
-
   if (x instanceof p5.Vector) {
     // x is a vector, extract the components from it.
     y = x.y;

--- a/src/webgl/p5.Matrix.js
+++ b/src/webgl/p5.Matrix.js
@@ -511,7 +511,6 @@ p5.Matrix.prototype.scale = function(x, y, z) {
  * inspired by Toji's gl-matrix lib, mat4 rotation
  */
 p5.Matrix.prototype.rotate = function(a, x, y, z) {
-  var _a = this.p5 ? this.p5._toRadians(a) : a;
 
   if (x instanceof p5.Vector) {
     // x is a vector, extract the components from it.
@@ -544,8 +543,8 @@ p5.Matrix.prototype.rotate = function(a, x, y, z) {
   var a23 = this.mat4[11];
 
   //sin,cos, and tan of respective angle
-  var sA = Math.sin(_a);
-  var cA = Math.cos(_a);
+  var sA = Math.sin(a);
+  var cA = Math.cos(a);
   var tA = 1 - cA;
   // Construct the elements of the rotation matrix
   var b00 = x * x * tA + cA;


### PR DESCRIPTION
the (private) matrix methods are _only_ passed radians by p5, regardless of the `angleMode`. this PR fixes the double-conversion that occurs when using `DEGREES` mode.