### PR TITLE
Unlink touch/mouse events firing to fix #1875

### DIFF
--- a/src/core/p5.Element.js
+++ b/src/core/p5.Element.js
@@ -231,7 +231,6 @@ p5.Element.prototype.class = function(c) {
  */
 p5.Element.prototype.mousePressed = function(fxn) {
   adjustListener('mousedown', fxn, this);
-  adjustListener('touchstart', fxn, this);
   return this;
 };
 
@@ -399,7 +398,6 @@ p5.Element.prototype.mouseWheel = function(fxn) {
  */
 p5.Element.prototype.mouseReleased = function(fxn) {
   adjustListener('mouseup', fxn, this);
-  adjustListener('touchend', fxn, this);
   return this;
 };
 
@@ -512,7 +510,6 @@ p5.Element.prototype.mouseClicked = function(fxn) {
  */
 p5.Element.prototype.mouseMoved = function(fxn) {
   adjustListener('mousemove', fxn, this);
-  adjustListener('touchmove', fxn, this);
   return this;
 };
 
@@ -748,7 +745,6 @@ p5.Element.prototype.mouseOut = function(fxn) {
  */
 p5.Element.prototype.touchStarted = function(fxn) {
   adjustListener('touchstart', fxn, this);
-  adjustListener('mousedown', fxn, this);
   return this;
 };
 
@@ -789,7 +785,6 @@ p5.Element.prototype.touchStarted = function(fxn) {
  */
 p5.Element.prototype.touchMoved = function(fxn) {
   adjustListener('touchmove', fxn, this);
-  adjustListener('mousemove', fxn, this);
   return this;
 };
 
@@ -839,7 +834,6 @@ p5.Element.prototype.touchMoved = function(fxn) {
  */
 p5.Element.prototype.touchEnded = function(fxn) {
   adjustListener('touchend', fxn, this);
-  adjustListener('mouseup', fxn, this);
   return this;
 };
 

--- a/src/events/mouse.js
+++ b/src/events/mouse.js
@@ -288,7 +288,7 @@ p5.prototype.pwinMouseX = 0;
 p5.prototype.pwinMouseY = 0;
 
 /**
- * Processing automatically tracks if the mouse button is pressed and which
+ * p5 automatically tracks if the mouse button is pressed and which
  * button is pressed. The value of the system variable mouseButton is either
  * LEFT, RIGHT, or CENTER depending on which button was pressed last.
  * Warning: different browsers may track mouseButton differently.
@@ -328,7 +328,8 @@ p5.prototype.mouseButton = 0;
 
 /**
  * The boolean system variable mouseIsPressed is true if the mouse is pressed
- * and false if not.
+ * and false if not. On mobile or tablet devices with touch-screens,
+ * mouseIsPressed will also be true if the user is touching the screen.
  *
  * @property {Boolean} mouseIsPressed
  * @readOnly
@@ -461,8 +462,8 @@ p5.prototype._setMouseButton = function(e) {
 
 /**
  * The <a href="#/p5/mouseDragged">mouseDragged()</a> function is called once every time the mouse moves and
- * a mouse button is pressed. If no <a href="#/p5/mouseDragged">mouseDragged()</a> function is defined, the
- * <a href="#/p5/touchMoved">touchMoved()</a> function will be called instead if it is defined.<br><br>
+ * a mouse button is pressed. On touch screen devices, <a href="#/p5/mouseDragged">mouseDragged()</a> is
+ * only called if no <a href="#/p5/touchMoved">touchMoved()</a> function is defined.<br><br>
  * Browsers may have different default
  * behaviors attached to various mouse events. To prevent any default
  * behavior for this event, add "return false" to the end of the method.
@@ -520,11 +521,6 @@ p5.prototype._onmousemove = function(e) {
       if (executeDefault === false) {
         e.preventDefault();
       }
-    } else if (typeof context.touchMoved === 'function') {
-      executeDefault = context.touchMoved(e);
-      if (executeDefault === false) {
-        e.preventDefault();
-      }
     }
   }
 };
@@ -532,9 +528,9 @@ p5.prototype._onmousemove = function(e) {
 /**
  * The <a href="#/p5/mousePressed">mousePressed()</a> function is called once after every time a mouse button
  * is pressed. The mouseButton variable (see the related reference entry)
- * can be used to determine which button has been pressed. If no
- * <a href="#/p5/mousePressed">mousePressed()</a> function is defined, the <a href="#/p5/touchStarted">touchStarted()</a> function will be
- * called instead if it is defined.<br><br>
+ * can be used to determine which button has been pressed.
+ * On touch screen devices, <a href="#/p5/mousePressed">mousePressed()</a> is
+ * only called if no <a href="#/p5/touchStarted">touchStarted()</a> function is defined.<br><br>
  * Browsers may have different default
  * behaviors attached to various mouse events. To prevent any default
  * behavior for this event, add "return false" to the end of the method.
@@ -587,18 +583,13 @@ p5.prototype._onmousedown = function(e) {
     if (executeDefault === false) {
       e.preventDefault();
     }
-  } else if (typeof context.touchStarted === 'function') {
-    executeDefault = context.touchStarted(e);
-    if (executeDefault === false) {
-      e.preventDefault();
-    }
   }
 };
 
 /**
  * The <a href="#/p5/mouseReleased">mouseReleased()</a> function is called every time a mouse button is
- * released. If no <a href="#/p5/mouseReleased">mouseReleased()</a> function is defined, the <a href="#/p5/touchEnded">touchEnded()</a>
- * function will be called instead if it is defined.<br><br>
+ * released. On touch screen devices, <a href="#/p5/mouseReleased">mouseReleased()</a> is
+ * only called if no <a href="#/p5/touchEnded">touchEnded()</a> function is defined.<br><br>
  * Browsers may have different default
  * behaviors attached to various mouse events. To prevent any default
  * behavior for this event, add "return false" to the end of the method.
@@ -651,11 +642,6 @@ p5.prototype._onmouseup = function(e) {
     if (executeDefault === false) {
       e.preventDefault();
     }
-  } else if (typeof context.touchEnded === 'function') {
-    executeDefault = context.touchEnded(e);
-    if (executeDefault === false) {
-      e.preventDefault();
-    }
   }
 };
 
@@ -667,7 +653,9 @@ p5.prototype._ondragover = p5.prototype._onmousemove;
  * pressed and then released.<br><br>
  * Browsers handle clicks differently, so this function is only guaranteed to be
  * run when the left mouse button is clicked. To handle other mouse buttons
- * being pressed or released, see <a href="#/p5/mousePressed">mousePressed()</a> or <a href="#/p5/mouseReleased">mouseReleased()</a>.<br><br>
+ * being pressed or released, see <a href="#/p5/mousePressed">mousePressed()</a> or <a href="#/p5/mouseReleased">mouseReleased()</a>.
+ * On touch screen devices, <a href="#/p5/mouseClicked">mouseClicked()</a> may not be called
+ * at all.<br><br>
  * Browsers may have different default
  * behaviors attached to various mouse events. To prevent any default
  * behavior for this event, add "return false" to the end of the method.


### PR DESCRIPTION
- core/mouse.js: removes touch events from firing in mouse.js events
- core/touch.js: removes mouse events from firing in touch.js events
- core/p5.Element.js: removes touch events from firing in mouse
  functions and mouse events from firing in touch-related functions

to alleviate double-firing of mouse & touch events when working
with p5.dom elements. now, library users should favor using
mouse events for p5.Elements instead of touch (modern mobile
devices will link these automatically -- but using the mouse
events ensures they will happen on a desktop machine for testing,
too). the exception is if the user would like to track touch
movement on a mobile or tablet device: then touchMoved should be
used.

touch events will no longer fire on desktop browsers, unless
using dev tools to simulate mobile devices.

relevant documentation for mouse and touch events is updated
to more accurately describe the new behavior.

the p5.Element case is a little strange because there is no passing of touchMoved to mouseDragged, because there is no mouseDragged in p5.Element (see #1967). moreover, whether or not a mouse event is triggered by touch seems a little inconsistent. I can make a mouseMoved event appear if I long-tap (contact with no movement) on the device, but only a single mouseMoved. a quick tap can trigger 4 different mouse events if they are all registered: mouseMoved, mousePressed, mouseReleased, and mouseClicked if all are registered. I feel like this information is valuable but couldn't figure out how to attach it to the p5.Element events; I am open to suggestions on this!