### PR TITLE
unlink touch events from mouse events in p5.Element

### DIFF
--- a/src/core/p5.Element.js
+++ b/src/core/p5.Element.js
@@ -187,8 +187,10 @@ p5.Element.prototype.class = function(c) {
 
 /**
  * The .<a href="#/p5.Element/mousePressed">mousePressed()</a> function is called once after every time a
- * mouse button is pressed over the element. This can be used to
- * attach element specific event listeners.
+ * mouse button is pressed over the element.
+ * Some mobile browsers may also trigger this event on a touch screen,
+ * if the user performs a quick tap.
+ * This can be used to attach element specific event listeners.
  *
  * @method mousePressed
  * @param  {Function|Boolean} fxn function to be fired when mouse is
@@ -231,7 +233,6 @@ p5.Element.prototype.class = function(c) {
  */
 p5.Element.prototype.mousePressed = function(fxn) {
   adjustListener('mousedown', fxn, this);
-  adjustListener('touchstart', fxn, this);
   return this;
 };
 
@@ -352,8 +353,10 @@ p5.Element.prototype.mouseWheel = function(fxn) {
 
 /**
  * The .<a href="#/p5.Element/mouseReleased">mouseReleased()</a> function is called once after every time a
- * mouse button is released over the element. This can be used to
- * attach element specific event listeners.
+ * mouse button is released over the element.
+ * Some mobile browsers may also trigger this event on a touch screen,
+ * if the user performs a quick tap.
+ * This can be used to attach element specific event listeners.
  *
  * @method mouseReleased
  * @param  {Function|Boolean} fxn function to be fired when mouse is
@@ -399,14 +402,15 @@ p5.Element.prototype.mouseWheel = function(fxn) {
  */
 p5.Element.prototype.mouseReleased = function(fxn) {
   adjustListener('mouseup', fxn, this);
-  adjustListener('touchend', fxn, this);
   return this;
 };
 
 /**
  * The .<a href="#/p5.Element/mouseClicked">mouseClicked()</a> function is called once after a mouse button is
- * pressed and released over the element. This can be used to
- * attach element specific event listeners.
+ * pressed and released over the element.
+ * Some mobile browsers may also trigger this event on a touch screen,
+ * if the user performs a quick tap.
+ * This can be used to attach element specific event listeners.
  *
  * @method mouseClicked
  * @param  {Function|Boolean} fxn function to be fired when mouse is
@@ -512,7 +516,6 @@ p5.Element.prototype.mouseClicked = function(fxn) {
  */
 p5.Element.prototype.mouseMoved = function(fxn) {
   adjustListener('mousemove', fxn, this);
-  adjustListener('touchmove', fxn, this);
   return this;
 };
 
@@ -748,7 +751,6 @@ p5.Element.prototype.mouseOut = function(fxn) {
  */
 p5.Element.prototype.touchStarted = function(fxn) {
   adjustListener('touchstart', fxn, this);
-  adjustListener('mousedown', fxn, this);
   return this;
 };
 
@@ -789,7 +791,6 @@ p5.Element.prototype.touchStarted = function(fxn) {
  */
 p5.Element.prototype.touchMoved = function(fxn) {
   adjustListener('touchmove', fxn, this);
-  adjustListener('mousemove', fxn, this);
   return this;
 };
 
@@ -839,7 +840,6 @@ p5.Element.prototype.touchMoved = function(fxn) {
  */
 p5.Element.prototype.touchEnded = function(fxn) {
   adjustListener('touchend', fxn, this);
-  adjustListener('mouseup', fxn, this);
   return this;
 };
 


### PR DESCRIPTION
fixes a bug (#1875) where touchEnded fires twice on tapped buttons & other
p5.Elements.

a mobile-browser quick-tap event generates a mouseup event
automatically--so having p5.Element.touchEnded generate events
for both touchended and mouseup can result in a double-firing
of the event.

I've attempted to update the documentation here, but have only
been able to test with Chrome for Android--that's why the language
in the documentation is a little non-committal.

as a precaution, I've unlinked all of the events for p5.Element.
however, for the general/global touchEnded etc. this isn't
necessary because p5 already takes precaution to make sure both
mouse/touch are not called.