### PR TITLE
Webgl curves implementation

### DIFF
--- a/package.json
+++ b/package.json
@@ -90,6 +90,7 @@
     "karma-firefox-launcher": "^1.0.1",
     "karma-ie-launcher": "^1.0.0",
     "karma-safari-launcher": "^1.0.0",
+    "libtess": "^1.2.2",
     "lint-staged": "^4.3.0",
     "marked": "^0.3.9",
     "opentype.js": "^0.7.3",

--- a/src/core/vertex.js
+++ b/src/core/vertex.js
@@ -284,8 +284,8 @@ p5.prototype.beginShape = function(kind) {
  * @method bezierVertex
  * @param  {Number} x2 x-coordinate for the first control point
  * @param  {Number} y2 y-coordinate for the first control point
- * @param  {Number} x3 x-coordinate for the first control point
- * @param  {Number} y3 y-coordinate for the first control point
+ * @param  {Number} x3 x-coordinate for the second control point
+ * @param  {Number} y3 y-coordinate for the second control point
  * @param  {Number} x4 x-coordinate for the anchor point
  * @param  {Number} y4 y-coordinate for the anchor point
  * @chainable
@@ -327,6 +327,41 @@ p5.prototype.beginShape = function(kind) {
  * @param  {Number} y4
  * @param  {Number} [z4] z-coordinate for the anchor point (for WebGL mode)
  * @chainable
+ * @example
+ * <div>
+ * <code>
+ * function setup() {
+ *   createCanvas(100, 100, WEBGL);
+ *   setAttributes('antialias', true);
+ * }
+ * function draw() {
+ *   orbitControl();
+ *   background(50);
+ *   strokeWeight(4);
+ *   stroke(255);
+ *   point(-25, 30);
+ *   point(25, 30);
+ *   point(25, -30);
+ *   point(-25, -30);
+ *
+ *   strokeWeight(1);
+ *   noFill();
+ *
+ *   beginShape();
+ *   vertex(-25, 30);
+ *   bezierVertex(25, 30, 25, -30, -25, -30);
+ *   endShape();
+ *
+ *   beginShape();
+ *   vertex(-25, 30, 20);
+ *   bezierVertex(25, 30, 20, 25, -30, 20, -25, -30, 20);
+ *   endShape();
+ * }
+ * </code>
+ * </div>
+ *
+ * @alt
+ * crescent shape in middle of canvas with another crescent shape on positive z-axis.
  */
 
 p5.prototype.bezierVertex = function() {

--- a/src/core/vertex.js
+++ b/src/core/vertex.js
@@ -269,60 +269,42 @@ p5.prototype.beginShape = function(kind) {
 
 /**
  * Specifies vertex coordinates for Bezier curves. Each call to
- * <a href="#/p5/bezierVertex">bezierVertex()</a> defines the position of two control points and
+ * bezierVertex() defines the position of two control points and
  * one anchor point of a Bezier curve, adding a new segment to a
- * line or shape.
+ * line or shape. For WebGL mode bezierVertex() can be used in 2D
+ * as well as 3D mode. 2D mode expects 6 parameters, while 3D mode
+ * expects 9 parameters (including z coordinates).
  * <br><br>
- * The first time <a href="#/p5/bezierVertex">bezierVertex()</a> is used within a
- * <a href="#/p5/beginShape">beginShape()</a> call, it must be prefaced with a call to <a href="#/p5/vertex">vertex()</a>
- * to set the first anchor point. This function must be used between
- * <a href="#/p5/beginShape">beginShape()</a> and <a href="#/p5/endShape">endShape()</a> and only when there is no MODE
- * parameter specified to <a href="#/p5/beginShape">beginShape()</a>.
+ * The first time bezierVertex() is used within a beginShape() call,
+ * it must be prefaced with a call to vertex() to set the first anchor
+ * point. This function must be used between beginShape() and endShape()
+ * and only when there is no MODE or POINTS parameter specified to
+ * beginShape().
  *
  * @method bezierVertex
  * @param  {Number} x2 x-coordinate for the first control point
  * @param  {Number} y2 y-coordinate for the first control point
- * @param  {Number} x3 x-coordinate for the second control point
- * @param  {Number} y3 y-coordinate for the second control point
+ * @param  {Number} x3 x-coordinate for the first control point
+ * @param  {Number} y3 y-coordinate for the first control point
  * @param  {Number} x4 x-coordinate for the anchor point
  * @param  {Number} y4 y-coordinate for the anchor point
  * @chainable
  * @example
  * <div>
  * <code>
- * strokeWeight(5);
- * point(30, 20);
- * point(80, 20);
- * point(80, 75);
- * point(30, 75);
- *
- * strokeWeight(1);
  * noFill();
  * beginShape();
  * vertex(30, 20);
- * bezierVertex(80, 20, 80, 75, 30, 75);
+ * bezierVertex(80, 0, 80, 75, 30, 75);
  * endShape();
  * </code>
  * </div>
  *
  * <div>
  * <code>
- * strokeWeight(5);
- * point(30, 20);
- * point(80, 20);
- * point(80, 75);
- * point(30, 75);
- *
- * stroke(244, 122, 158);
- * point(50, 80);
- * point(60, 25);
- * point(30, 20);
- *
- * stroke(0);
- * strokeWeight(1);
  * beginShape();
  * vertex(30, 20);
- * bezierVertex(80, 20, 80, 75, 30, 75);
+ * bezierVertex(80, 0, 80, 75, 30, 75);
  * bezierVertex(50, 80, 60, 25, 30, 20);
  * endShape();
  * </code>
@@ -331,23 +313,41 @@ p5.prototype.beginShape = function(kind) {
  * @alt
  * crescent-shaped line in middle of canvas. Points facing left.
  * white crescent shape in middle of canvas. Points facing left.
- *
+/**
+
+/**
+ * @method bezierVertex
+ * @param  {Number} x2
+ * @param  {Number} y2
+ * @param  {Number} [z2] z-coordinate for the first control point (for WebGL mode)
+ * @param  {Number} x3
+ * @param  {Number} y3
+ * @param  {Number} [z3] z-coordinate for the second control point (for WebGL mode)
+ * @param  {Number} x4
+ * @param  {Number} y4
+ * @param  {Number} [z4] z-coordinate for the anchor point (for WebGL mode)
+ * @chainable
  */
-p5.prototype.bezierVertex = function(x2, y2, x3, y3, x4, y4) {
+
+p5.prototype.bezierVertex = function() {
   p5._validateParameters('bezierVertex', arguments);
-  if (vertices.length === 0) {
-    throw new Error('vertex() must be used once before calling bezierVertex()');
+  if (this._renderer.isP3D) {
+    this._renderer.bezierVertex.apply(this._renderer, arguments);
   } else {
-    isBezier = true;
-    var vert = [];
-    for (var i = 0; i < arguments.length; i++) {
-      vert[i] = arguments[i];
-    }
-    vert.isVert = false;
-    if (isContour) {
-      contourVertices.push(vert);
+    if (vertices.length === 0) {
+      throw 'vertex() must be used once before calling bezierVertex()';
     } else {
-      vertices.push(vert);
+      isBezier = true;
+      var vert = [];
+      for (var i = 0; i < arguments.length; i++) {
+        vert[i] = arguments[i];
+      }
+      vert.isVert = false;
+      if (isContour) {
+        contourVertices.push(vert);
+      } else {
+        vertices.push(vert);
+      }
     }
   }
   return this;
@@ -355,15 +355,17 @@ p5.prototype.bezierVertex = function(x2, y2, x3, y3, x4, y4) {
 
 /**
  * Specifies vertex coordinates for curves. This function may only
- * be used between <a href="#/p5/beginShape">beginShape()</a> and <a href="#/p5/endShape">endShape()</a> and only when there
- * is no MODE parameter specified to <a href="#/p5/beginShape">beginShape()</a>.
+ * be used between beginShape() and endShape() and only when there
+ * is no MODE parameter specified to beginShape().
+ * For WebGL mode curveVertex() can be used in 2D as well as 3D mode.
+ * 2D mode expects 2 parameters, while 3D mode expects 3 parameters.
  * <br><br>
- * The first and last points in a series of <a href="#/p5/curveVertex">curveVertex()</a> lines will be used to
+ * The first and last points in a series of curveVertex() lines will be used to
  * guide the beginning and end of a the curve. A minimum of four
  * points is required to draw a tiny curve between the second and
- * third points. Adding a fifth point with <a href="#/p5/curveVertex">curveVertex()</a> will draw
+ * third points. Adding a fifth point with curveVertex() will draw
  * the curve between the second, third, and fourth points. The
- * <a href="#/p5/curveVertex">curveVertex()</a> function is an implementation of Catmull-Rom
+ * curveVertex() function is an implementation of Catmull-Rom
  * splines.
  *
  * @method curveVertex
@@ -395,12 +397,69 @@ p5.prototype.bezierVertex = function(x2, y2, x3, y3, x4, y4) {
  *
  * @alt
  * Upside-down u-shape line, mid canvas. left point extends beyond canvas view.
+ */
+/**
+ * @method curveVertex
+ * @param {Number} x
+ * @param {Number} y
+ * @param {Number} [z] z-coordinate of the vertex (for WebGL mode)
+ * @chainable
+ * @example
+ * <div>
+ * <code>
+ * function setup() {
+ *   createCanvas(100, 100, WEBGL);
+ *   setAttributes('antialias', true);
+ * }
+ * function draw() {
+ *   orbitControl();
+ *   background(50);
+ *   strokeWeight(4);
+ *   stroke(255);
+ *
+ *   point(-25, 25);
+ *   point(-25, 25);
+ *   point(-25, -25);
+ *   point(25, -25);
+ *   point(25, 25);
+ *   point(25, 25);
+ *
+ *   strokeWeight(1);
+ *   noFill();
+ *
+ *   beginShape();
+ *   curveVertex(-25, 25);
+ *   curveVertex(-25, 25);
+ *   curveVertex(-25, -25);
+ *   curveVertex(25, -25);
+ *   curveVertex(25, 25);
+ *   curveVertex(25, 25);
+ *   endShape();
+ *
+ *   beginShape();
+ *   curveVertex(-25, 25, 20);
+ *   curveVertex(-25, 25, 20);
+ *   curveVertex(-25, -25, 20);
+ *   curveVertex(25, -25, 20);
+ *   curveVertex(25, 25, 20);
+ *   curveVertex(25, 25, 20);
+ *   endShape();
+ * }
+ * </code>
+ * </div>
+ *
+ * @alt
+ * Upside-down u-shape line, mid canvas with the same shape in positive z-axis.
  *
  */
 p5.prototype.curveVertex = function(x, y) {
   p5._validateParameters('curveVertex', arguments);
-  isCurve = true;
-  this.vertex(x, y);
+  if (this._renderer.isP3D) {
+    this._renderer.curveVertex.apply(this._renderer, arguments);
+  } else {
+    isCurve = true;
+    this.vertex(x, y);
+  }
   return this;
 };
 
@@ -552,12 +611,17 @@ p5.prototype.endShape = function(mode) {
 
 /**
  * Specifies vertex coordinates for quadratic Bezier curves. Each call to
- * <a href="#/p5/quadraticVertex">quadraticVertex()</a> defines the position of one control points and one
+ * quadraticVertex() defines the position of one control points and one
  * anchor point of a Bezier curve, adding a new segment to a line or shape.
- * The first time <a href="#/p5/quadraticVertex">quadraticVertex()</a> is used within a <a href="#/p5/beginShape">beginShape()</a> call, it
- * must be prefaced with a call to <a href="#/p5/vertex">vertex()</a> to set the first anchor point.
- * This function must be used between <a href="#/p5/beginShape">beginShape()</a> and <a href="#/p5/endShape">endShape()</a> and only
- * when there is no MODE parameter specified to <a href="#/p5/beginShape">beginShape()</a>.
+ * The first time quadraticVertex() is used within a beginShape() call, it
+ * must be prefaced with a call to vertex() to set the first anchor point.
+ * For WebGL mode quadraticVertex() can be used in 2D as well as 3D mode.
+ * 2D mode expects 4 parameters, while 3D mode expects 6 parameters
+ * (including z coordinates).
+ * <br><br>
+ * This function must be used between beginShape() and endShape()
+ * and only when there is no MODE or POINTS parameter specified to
+ * beginShape().
  *
  * @method quadraticVertex
  * @param  {Number} cx x-coordinate for the control point
@@ -607,39 +671,94 @@ p5.prototype.endShape = function(mode) {
  * @alt
  * arched-shaped black line with 4 pixel thick stroke weight.
  * backwards s-shaped black line with 4 pixel thick stroke weight.
+ */
+/**
+ * @method quadraticVertex
+ * @param  {Number} cx
+ * @param  {Number} cy
+ * @param  {Number} [cz] z-coordinate for the control point (for WebGL mode)
+ * @param  {Number} x3
+ * @param  {Number} y3
+ * @param  {Number} [z3] z-coordinate for the anchor point (for WebGL mode)
+ * @chainable
+ * @example
+ * <div>
+ * <code>
+ * function setup() {
+ *   createCanvas(100, 100, WEBGL);
+ *   setAttributes('antialias', true);
+ * }
+ * function draw() {
+ *   orbitControl();
+ *   background(50);
+ *   strokeWeight(4);
+ *   stroke(255);
  *
+ *   point(-35, -35);
+ *   point(35, -35);
+ *   point(0, 0);
+ *   point(-35, 35);
+ *   point(35, 35);
+ *   point(35, 10);
+ *
+ *   strokeWeight(1);
+ *   noFill();
+ *
+ *   beginShape();
+ *   vertex(-35, -35);
+ *   quadraticVertex(35, -35, 0, 0);
+ *   quadraticVertex(-35, 35, 35, 35);
+ *   vertex(35, 10);
+ *   endShape();
+ *
+ *   beginShape();
+ *   vertex(-35, -35, 20);
+ *   quadraticVertex(35, -35, 20, 0, 0, 20);
+ *   quadraticVertex(-35, 35, 20, 35, 35, 20);
+ *   vertex(35, 10, 20);
+ *   endShape();
+ * }
+ * </code>
+ * </div>
+ *
+ * @alt
+ * backwards s-shaped black line with the same s-shaped line in postive z-axis.
  */
 p5.prototype.quadraticVertex = function(cx, cy, x3, y3) {
   p5._validateParameters('quadraticVertex', arguments);
-  //if we're drawing a contour, put the points into an
-  // array for inside drawing
-  if (this._contourInited) {
-    var pt = {};
-    pt.x = cx;
-    pt.y = cy;
-    pt.x3 = x3;
-    pt.y3 = y3;
-    pt.type = constants.QUADRATIC;
-    this._contourVertices.push(pt);
-
-    return this;
-  }
-  if (vertices.length > 0) {
-    isQuadratic = true;
-    var vert = [];
-    for (var i = 0; i < arguments.length; i++) {
-      vert[i] = arguments[i];
-    }
-    vert.isVert = false;
-    if (isContour) {
-      contourVertices.push(vert);
-    } else {
-      vertices.push(vert);
-    }
+  if (this._renderer.isP3D) {
+    this._renderer.quadraticVertex.apply(this._renderer, arguments);
   } else {
-    throw new Error(
-      'vertex() must be used once before calling quadraticVertex()'
-    );
+    //if we're drawing a contour, put the points into an
+    // array for inside drawing
+    if (this._contourInited) {
+      var pt = {};
+      pt.x = cx;
+      pt.y = cy;
+      pt.x3 = x3;
+      pt.y3 = y3;
+      pt.type = constants.QUADRATIC;
+      this._contourVertices.push(pt);
+
+      return this;
+    }
+    if (vertices.length > 0) {
+      isQuadratic = true;
+      var vert = [];
+      for (var i = 0; i < arguments.length; i++) {
+        vert[i] = arguments[i];
+      }
+      vert.isVert = false;
+      if (isContour) {
+        contourVertices.push(vert);
+      } else {
+        vertices.push(vert);
+      }
+    } else {
+      throw new Error(
+        'vertex() must be used once before calling quadraticVertex()'
+      );
+    }
   }
   return this;
 };

--- a/src/core/vertex.js
+++ b/src/core/vertex.js
@@ -313,8 +313,7 @@ p5.prototype.beginShape = function(kind) {
  * @alt
  * crescent-shaped line in middle of canvas. Points facing left.
  * white crescent shape in middle of canvas. Points facing left.
-/**
-
+ */
 /**
  * @method bezierVertex
  * @param  {Number} x2
@@ -487,13 +486,13 @@ p5.prototype.bezierVertex = function() {
  * Upside-down u-shape line, mid canvas with the same shape in positive z-axis.
  *
  */
-p5.prototype.curveVertex = function(x, y) {
+p5.prototype.curveVertex = function() {
   p5._validateParameters('curveVertex', arguments);
   if (this._renderer.isP3D) {
     this._renderer.curveVertex.apply(this._renderer, arguments);
   } else {
     isCurve = true;
-    this.vertex(x, y);
+    this.vertex(arguments[0], arguments[1]);
   }
   return this;
 };
@@ -759,7 +758,7 @@ p5.prototype.endShape = function(mode) {
  * @alt
  * backwards s-shaped black line with the same s-shaped line in postive z-axis.
  */
-p5.prototype.quadraticVertex = function(cx, cy, x3, y3) {
+p5.prototype.quadraticVertex = function() {
   p5._validateParameters('quadraticVertex', arguments);
   if (this._renderer.isP3D) {
     this._renderer.quadraticVertex.apply(this._renderer, arguments);
@@ -768,10 +767,10 @@ p5.prototype.quadraticVertex = function(cx, cy, x3, y3) {
     // array for inside drawing
     if (this._contourInited) {
       var pt = {};
-      pt.x = cx;
-      pt.y = cy;
-      pt.x3 = x3;
-      pt.y3 = y3;
+      pt.x = arguments[0];
+      pt.y = arguments[1];
+      pt.x3 = arguments[2];
+      pt.y3 = arguments[3];
       pt.type = constants.QUADRATIC;
       this._contourVertices.push(pt);
 

--- a/src/webgl/p5.RendererGL.Immediate.js
+++ b/src/webgl/p5.RendererGL.Immediate.js
@@ -190,7 +190,6 @@ p5.RendererGL.prototype.endShape = function(
   this.immediateMode.vertexColors.length = 0;
   this.immediateMode.uvCoords.length = 0;
   this.isImmediateDrawing = false;
-  this.isImmediateDrawing = false;
   this.isBezier = false;
   this.isQuadratic = false;
   this.isCurve = false;

--- a/src/webgl/p5.RendererGL.Immediate.js
+++ b/src/webgl/p5.RendererGL.Immediate.js
@@ -49,6 +49,11 @@ p5.RendererGL.prototype.beginShape = function(mode) {
     this.immediateMode.lineVertexBuffer = this.GL.createBuffer();
     this.immediateMode.lineNormalBuffer = this.GL.createBuffer();
     this.immediateMode.pointVertexBuffer = this.GL.createBuffer();
+    this.immediateMode._bezierVertex = [];
+    this.immediateMode._quadraticVertex = [];
+    this.immediateMode._curveVertex_x = [];
+    this.immediateMode._curveVertex_y = [];
+    this.immediateMode._curveVertex_z = [];
   } else {
     this.immediateMode.vertices.length = 0;
     this.immediateMode.edges.length = 0;
@@ -101,6 +106,14 @@ p5.RendererGL.prototype.vertex = function(x, y) {
 
   this.immediateMode.uvCoords.push(u, v);
 
+  this.immediateMode._bezierVertex[0] = x;
+  this.immediateMode._bezierVertex[1] = y;
+  this.immediateMode._bezierVertex[2] = z;
+
+  this.immediateMode._quadraticVertex[0] = x;
+  this.immediateMode._quadraticVertex[1] = y;
+  this.immediateMode._quadraticVertex[2] = z;
+
   return this;
 };
 
@@ -124,7 +137,7 @@ p5.RendererGL.prototype.endShape = function(
       this.immediateMode.pointVertexBuffer
     );
     this.curPointShader.unbindShader();
-  } else {
+  } else if (this.immediateMode.vertices.length > 1) {
     this._useImmediateModeShader();
 
     if (this._doStroke && this.drawMode !== constants.TEXTURE) {
@@ -141,17 +154,35 @@ p5.RendererGL.prototype.endShape = function(
       p5.Geometry.prototype._edgesToVertices.call(this.immediateMode);
       this._drawStrokeImmediateMode();
     }
-  }
 
-  if (this._doFill) {
-    this._drawFillImmediateMode(
-      mode,
-      isCurve,
-      isBezier,
-      isQuadratic,
-      isContour,
-      shapeKind
-    );
+    if (this._doFill) {
+      if (this.isBezier || this.isQuadratic || this.isCurve) {
+        var contours = [
+          new Float32Array(this._vToNArray(this.immediateMode.vertices))
+        ];
+        var polyTriangles = this._triangulate(contours);
+        this.immediateMode.vertices = [];
+        for (
+          var j = 0, polyTriLength = polyTriangles.length;
+          j < polyTriLength;
+          j = j + 3
+        ) {
+          this.vertex(
+            polyTriangles[j],
+            polyTriangles[j + 1],
+            polyTriangles[j + 2]
+          );
+        }
+      }
+      this._drawFillImmediateMode(
+        mode,
+        isCurve,
+        isBezier,
+        isQuadratic,
+        isContour,
+        shapeKind
+      );
+    }
   }
   //clear out our vertexPositions & colors arrays
   //after rendering
@@ -159,6 +190,16 @@ p5.RendererGL.prototype.endShape = function(
   this.immediateMode.vertexColors.length = 0;
   this.immediateMode.uvCoords.length = 0;
   this.isImmediateDrawing = false;
+  this.isImmediateDrawing = false;
+  this.isBezier = false;
+  this.isQuadratic = false;
+  this.isCurve = false;
+  this.immediateMode._bezierVertex.length = 0;
+  this.immediateMode._quadraticVertex.length = 0;
+
+  this.immediateMode._curveVertex_x.length = 0;
+  this.immediateMode._curveVertex_y.length = 0;
+  this.immediateMode._curveVertex_z.length = 0;
 
   return this;
 };
@@ -248,7 +289,10 @@ p5.RendererGL.prototype._drawFillImmediateMode = function(
       case constants.LINE_STRIP:
       case constants.LINES:
       case constants.TRIANGLES:
-        this.immediateMode.shapeMode = constants.TRIANGLE_FAN;
+        this.immediateMode.shapeMode =
+          this.isBezier || this.isQuadratic || this.isCurve
+            ? constants.TRIANGLES
+            : constants.TRIANGLE_FAN;
         break;
     }
   } else {

--- a/src/webgl/p5.RendererGL.js
+++ b/src/webgl/p5.RendererGL.js
@@ -2,6 +2,7 @@
 
 var p5 = require('../core/core');
 var constants = require('../core/constants');
+var libtess = require('libtess');
 require('./p5.Shader');
 require('../core/p5.Renderer');
 require('./p5.Matrix');
@@ -134,6 +135,14 @@ p5.RendererGL = function(elt, pInst, isMainCanvas, attr) {
   this.stroke(0, 0, 0);
   // array of textures created in this gl context via this.getTexture(src)
   this.textures = [];
+
+  this._curveTightness = 6;
+
+  // lookUpTable for coefficients needed to be calculated for bezierVertex, same are used for curveVertex
+  this._lookUpTableBezier = [];
+  // lookUpTable for coefficients needed to be calculated for quadraticVertex
+  this._lookUpTableQuadratic = [];
+
   return this;
 };
 
@@ -1111,6 +1120,95 @@ p5.prototype._assert3d = function(name) {
         ' and WebGL, see  https://p5js.org/examples/form-3d-primitives.html' +
         ' for more information.'
     );
+};
+
+// Initializing GLU Tesselator
+var tessy = (function initTesselator() {
+  // function called for each vertex of tesselator output
+  function vertexCallback(data, polyVertArray) {
+    polyVertArray[polyVertArray.length] = data[0];
+    polyVertArray[polyVertArray.length] = data[1];
+    polyVertArray[polyVertArray.length] = data[2];
+  }
+  function begincallback(type) {
+    if (type !== libtess.primitiveType.GL_TRIANGLES) {
+      console.log('expected TRIANGLES but got type: ' + type);
+    }
+  }
+  function errorcallback(errno) {
+    console.log('error callback');
+    console.log('error number: ' + errno);
+  }
+  // callback for when segments intersect and must be split
+  function combinecallback(coords, data, weight) {
+    return [coords[0], coords[1], coords[2]];
+  }
+  function edgeCallback(flag) {
+    // don't really care about the flag, but need no-strip/no-fan behavior
+  }
+
+  var tessy = new libtess.GluTesselator();
+  tessy.gluTessCallback(libtess.gluEnum.GLU_TESS_VERTEX_DATA, vertexCallback);
+  tessy.gluTessCallback(libtess.gluEnum.GLU_TESS_BEGIN, begincallback);
+  tessy.gluTessCallback(libtess.gluEnum.GLU_TESS_ERROR, errorcallback);
+  tessy.gluTessCallback(libtess.gluEnum.GLU_TESS_COMBINE, combinecallback);
+  tessy.gluTessCallback(libtess.gluEnum.GLU_TESS_EDGE_FLAG, edgeCallback);
+
+  return tessy;
+})();
+
+p5.RendererGL.prototype._triangulate = function(contours) {
+  // libtess will take 3d verts and flatten to a plane for tesselation
+  // since only doing 2d tesselation here, provide z=1 normal to skip
+  // iterating over verts only to get the same answer.
+  // comment out to test normal-generation code
+  tessy.gluTessNormal(0, 0, 1);
+
+  var triangleVerts = [];
+  tessy.gluTessBeginPolygon(triangleVerts);
+
+  for (var i = 0; i < contours.length; i++) {
+    tessy.gluTessBeginContour();
+    var contour = contours[i];
+    for (var j = 0; j < contour.length; j += 3) {
+      var coords = [contour[j], contour[j + 1], contour[j + 2]];
+      tessy.gluTessVertex(coords, coords);
+    }
+    tessy.gluTessEndContour();
+  }
+
+  // finish polygon
+  tessy.gluTessEndPolygon();
+
+  return triangleVerts;
+};
+
+// function to calculate BezierVertex Coefficients
+p5.RendererGL.prototype._bezierCoefficients = function(t) {
+  var t2 = t * t;
+  var t3 = t2 * t;
+  var mt = 1 - t;
+  var mt2 = mt * mt;
+  var mt3 = mt2 * mt;
+  return [mt3, 3 * mt2 * t, 3 * mt * t2, t3];
+};
+
+// function to calculate QuadraticVertex Coefficients
+p5.RendererGL.prototype._quadraticCoefficients = function(t) {
+  var t2 = t * t;
+  var mt = 1 - t;
+  var mt2 = mt * mt;
+  return [mt2, 2 * mt * t, t2];
+};
+
+// function to convert Bezier coordinates to Catmull Rom Splines
+p5.RendererGL.prototype.Bezier2Catmull = function(w) {
+  var p1 = w[1];
+  var p2 = w[1] + (w[2] - w[0]) / this._curveTightness;
+  var p3 = w[2] - (w[3] - w[1]) / this._curveTightness;
+  var p4 = w[2];
+  var p = [p1, p2, p3, p4];
+  return p;
 };
 
 module.exports = p5.RendererGL;

--- a/src/webgl/primitives.js
+++ b/src/webgl/primitives.js
@@ -1203,4 +1203,323 @@ p5.RendererGL.prototype.line = function() {
   return this;
 };
 
+p5.RendererGL.prototype.bezierVertex = function() {
+  if (this.immediateMode._bezierVertex.length === 0) {
+    throw 'vertex() must be used once before calling bezierVertex()';
+  } else {
+    var w_x = [];
+    var w_y = [];
+    var w_z = [];
+    var t, _x, _y, _z, i;
+
+    t = parseFloat(0.0);
+
+    if (
+      this._lookUpTableBezier.length === 0 ||
+      this._lookUpTableBezier[this._lookUpTableBezier.length - 1] !==
+        this._pInst._curveDetail
+    ) {
+      this._lookUpTableBezier = [];
+      var step = 1 / this._pInst._curveDetail;
+      var start = 0;
+      var end = 1;
+      var j = 0;
+      while (start < 1) {
+        t = parseFloat(start.toFixed(6));
+        this._lookUpTableBezier[j] = this._bezierCoefficients(t);
+        if (end.toFixed(6) === step.toFixed(6)) {
+          t = parseFloat(end.toFixed(6)) + parseFloat(start.toFixed(6));
+          ++j;
+          this._lookUpTableBezier[j] = this._bezierCoefficients(t);
+          break;
+        }
+        start += step;
+        end -= step;
+        ++j;
+      }
+
+      this._lookUpTableBezier.push(this._pInst._curveDetail);
+    }
+
+    var LUTLength = this._lookUpTableBezier.length;
+
+    if (arguments.length === 6) {
+      this.isBezier = true;
+
+      w_x = [
+        this.immediateMode._bezierVertex[0],
+        arguments[0],
+        arguments[2],
+        arguments[4]
+      ];
+      w_y = [
+        this.immediateMode._bezierVertex[1],
+        arguments[1],
+        arguments[3],
+        arguments[5]
+      ];
+
+      for (i = 0; i < LUTLength - 1; i++) {
+        _x =
+          w_x[0] * this._lookUpTableBezier[i][0] +
+          w_x[1] * this._lookUpTableBezier[i][1] +
+          w_x[2] * this._lookUpTableBezier[i][2] +
+          w_x[3] * this._lookUpTableBezier[i][3];
+        _y =
+          w_y[0] * this._lookUpTableBezier[i][0] +
+          w_y[1] * this._lookUpTableBezier[i][1] +
+          w_y[2] * this._lookUpTableBezier[i][2] +
+          w_y[3] * this._lookUpTableBezier[i][3];
+        this.vertex(_x, _y);
+      }
+      this.immediateMode._bezierVertex[0] = arguments[4];
+      this.immediateMode._bezierVertex[1] = arguments[5];
+    } else if (arguments.length === 9) {
+      this.isBezier = true;
+
+      w_x = [
+        this.immediateMode._bezierVertex[0],
+        arguments[0],
+        arguments[3],
+        arguments[6]
+      ];
+      w_y = [
+        this.immediateMode._bezierVertex[1],
+        arguments[1],
+        arguments[4],
+        arguments[7]
+      ];
+      w_z = [
+        this.immediateMode._bezierVertex[2],
+        arguments[2],
+        arguments[5],
+        arguments[8]
+      ];
+      for (i = 0; i < LUTLength - 1; i++) {
+        _x =
+          w_x[0] * this._lookUpTableBezier[i][0] +
+          w_x[1] * this._lookUpTableBezier[i][1] +
+          w_x[2] * this._lookUpTableBezier[i][2] +
+          w_x[3] * this._lookUpTableBezier[i][3];
+        _y =
+          w_y[0] * this._lookUpTableBezier[i][0] +
+          w_y[1] * this._lookUpTableBezier[i][1] +
+          w_y[2] * this._lookUpTableBezier[i][2] +
+          w_y[3] * this._lookUpTableBezier[i][3];
+        _z =
+          w_z[0] * this._lookUpTableBezier[i][0] +
+          w_z[1] * this._lookUpTableBezier[i][1] +
+          w_z[2] * this._lookUpTableBezier[i][2] +
+          w_z[3] * this._lookUpTableBezier[i][3];
+        this.vertex(_x, _y, _z);
+      }
+      this.immediateMode._bezierVertex[0] = arguments[6];
+      this.immediateMode._bezierVertex[1] = arguments[7];
+      this.immediateMode._bezierVertex[2] = arguments[8];
+    }
+  }
+};
+
+p5.RendererGL.prototype.quadraticVertex = function() {
+  if (this.immediateMode._quadraticVertex.length === 0) {
+    throw 'vertex() must be used once before calling quadraticVertex()';
+  } else {
+    var w_x = [];
+    var w_y = [];
+    var w_z = [];
+    var t, _x, _y, _z, i;
+
+    t = parseFloat(0.0);
+
+    if (
+      this._lookUpTableQuadratic.length === 0 ||
+      this._lookUpTableQuadratic[this._lookUpTableQuadratic.length - 1] !==
+        this._pInst._curveDetail
+    ) {
+      this._lookUpTableQuadratic = [];
+      var step = 1 / this._pInst._curveDetail;
+      var start = 0;
+      var end = 1;
+      var j = 0;
+      while (start < 1) {
+        t = parseFloat(start.toFixed(6));
+        this._lookUpTableQuadratic[j] = this._quadraticCoefficients(t);
+        if (end.toFixed(6) === step.toFixed(6)) {
+          t = parseFloat(end.toFixed(6)) + parseFloat(start.toFixed(6));
+          ++j;
+          this._lookUpTableQuadratic[j] = this._quadraticCoefficients(t);
+          break;
+        }
+        start += step;
+        end -= step;
+        ++j;
+      }
+
+      this._lookUpTableQuadratic.push(this._pInst._curveDetail);
+    }
+
+    var LUTLength = this._lookUpTableQuadratic.length;
+
+    if (arguments.length === 4) {
+      this.isQuadratic = true;
+
+      w_x = [
+        this.immediateMode._quadraticVertex[0],
+        arguments[0],
+        arguments[2]
+      ];
+      w_y = [
+        this.immediateMode._quadraticVertex[1],
+        arguments[1],
+        arguments[3]
+      ];
+
+      for (i = 0; i < LUTLength - 1; i++) {
+        _x =
+          w_x[0] * this._lookUpTableQuadratic[i][0] +
+          w_x[1] * this._lookUpTableQuadratic[i][1] +
+          w_x[2] * this._lookUpTableQuadratic[i][2];
+        _y =
+          w_y[0] * this._lookUpTableQuadratic[i][0] +
+          w_y[1] * this._lookUpTableQuadratic[i][1] +
+          w_y[2] * this._lookUpTableQuadratic[i][2];
+        this.vertex(_x, _y);
+      }
+
+      this.immediateMode._quadraticVertex[0] = arguments[2];
+      this.immediateMode._quadraticVertex[1] = arguments[3];
+    } else if (arguments.length === 6) {
+      this.isQuadratic = true;
+
+      w_x = [
+        this.immediateMode._quadraticVertex[0],
+        arguments[0],
+        arguments[3]
+      ];
+      w_y = [
+        this.immediateMode._quadraticVertex[1],
+        arguments[1],
+        arguments[4]
+      ];
+      w_z = [
+        this.immediateMode._quadraticVertex[2],
+        arguments[2],
+        arguments[5]
+      ];
+
+      for (i = 0; i < LUTLength - 1; i++) {
+        _x =
+          w_x[0] * this._lookUpTableQuadratic[i][0] +
+          w_x[1] * this._lookUpTableQuadratic[i][1] +
+          w_x[2] * this._lookUpTableQuadratic[i][2];
+        _y =
+          w_y[0] * this._lookUpTableQuadratic[i][0] +
+          w_y[1] * this._lookUpTableQuadratic[i][1] +
+          w_y[2] * this._lookUpTableQuadratic[i][2];
+        _z =
+          w_z[0] * this._lookUpTableQuadratic[i][0] +
+          w_z[1] * this._lookUpTableQuadratic[i][1] +
+          w_z[2] * this._lookUpTableQuadratic[i][2];
+        this.vertex(_x, _y, _z);
+      }
+
+      this.immediateMode._quadraticVertex[0] = arguments[3];
+      this.immediateMode._quadraticVertex[1] = arguments[4];
+      this.immediateMode._quadraticVertex[2] = arguments[5];
+    }
+  }
+};
+
+p5.RendererGL.prototype.curveVertex = function() {
+  var w_x = [];
+  var w_y = [];
+  var w_z = [];
+  var t, _x, _y, _z, i;
+  t = parseFloat(0.0);
+
+  if (
+    this._lookUpTableBezier.length === 0 ||
+    this._lookUpTableBezier[this._lookUpTableBezier.length - 1] !==
+      this._pInst._curveDetail
+  ) {
+    this._lookUpTableBezier = [];
+    var step = 1 / this._pInst._curveDetail;
+    var start = 0;
+    var end = 1;
+    var j = 0;
+    while (start < 1) {
+      t = parseFloat(start.toFixed(6));
+      this._lookUpTableBezier[j] = this._bezierCoefficients(t);
+      if (end.toFixed(6) === step.toFixed(6)) {
+        t = parseFloat(end.toFixed(6)) + parseFloat(start.toFixed(6));
+        ++j;
+        this._lookUpTableBezier[j] = this._bezierCoefficients(t);
+        break;
+      }
+      start += step;
+      end -= step;
+      ++j;
+    }
+    this._lookUpTableBezier.push(this._pInst._curveDetail);
+  }
+
+  var LUTLength = this._lookUpTableBezier.length;
+
+  if (arguments.length === 2) {
+    this.immediateMode._curveVertex_x.push(arguments[0]);
+    this.immediateMode._curveVertex_y.push(arguments[1]);
+    if (this.immediateMode._curveVertex_x.length === 4) {
+      this.isCurve = true;
+      w_x = this.Bezier2Catmull(this.immediateMode._curveVertex_x);
+      w_y = this.Bezier2Catmull(this.immediateMode._curveVertex_y);
+      for (i = 0; i < LUTLength - 1; i++) {
+        _x =
+          w_x[0] * this._lookUpTableBezier[i][0] +
+          w_x[1] * this._lookUpTableBezier[i][1] +
+          w_x[2] * this._lookUpTableBezier[i][2] +
+          w_x[3] * this._lookUpTableBezier[i][3];
+        _y =
+          w_y[0] * this._lookUpTableBezier[i][0] +
+          w_y[1] * this._lookUpTableBezier[i][1] +
+          w_y[2] * this._lookUpTableBezier[i][2] +
+          w_y[3] * this._lookUpTableBezier[i][3];
+        this.vertex(_x, _y);
+      }
+      this.immediateMode._curveVertex_x.shift(1);
+      this.immediateMode._curveVertex_y.shift(1);
+    }
+  } else if (arguments.length === 3) {
+    this.immediateMode._curveVertex_x.push(arguments[0]);
+    this.immediateMode._curveVertex_y.push(arguments[1]);
+    this.immediateMode._curveVertex_z.push(arguments[2]);
+    if (this.immediateMode._curveVertex_x.length === 4) {
+      this.isCurve = true;
+      w_x = this.Bezier2Catmull(this.immediateMode._curveVertex_x);
+      w_y = this.Bezier2Catmull(this.immediateMode._curveVertex_y);
+      w_z = this.Bezier2Catmull(this.immediateMode._curveVertex_z);
+      for (i = 0; i < LUTLength - 1; i++) {
+        _x =
+          w_x[0] * this._lookUpTableBezier[i][0] +
+          w_x[1] * this._lookUpTableBezier[i][1] +
+          w_x[2] * this._lookUpTableBezier[i][2] +
+          w_x[3] * this._lookUpTableBezier[i][3];
+        _y =
+          w_y[0] * this._lookUpTableBezier[i][0] +
+          w_y[1] * this._lookUpTableBezier[i][1] +
+          w_y[2] * this._lookUpTableBezier[i][2] +
+          w_y[3] * this._lookUpTableBezier[i][3];
+        _z =
+          w_z[0] * this._lookUpTableBezier[i][0] +
+          w_z[1] * this._lookUpTableBezier[i][1] +
+          w_z[2] * this._lookUpTableBezier[i][2] +
+          w_z[3] * this._lookUpTableBezier[i][3];
+        this.vertex(_x, _y, _z);
+      }
+      this.immediateMode._curveVertex_x.shift(1);
+      this.immediateMode._curveVertex_y.shift(1);
+      this.immediateMode._curveVertex_z.shift(1);
+    }
+  }
+};
+
 module.exports = p5;

--- a/test/manual-test-examples/webgl/curves/index.html
+++ b/test/manual-test-examples/webgl/curves/index.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html>
+
+<head>
+  <meta charset="utf-8">
+  <meta http-equiv="X-UA-Compatible" content="IE=edge">
+  <title></title>
+  <link rel="stylesheet" href="../../styles.css">
+  <script language="javascript" type="text/javascript" src="../../../../lib/p5.js"></script>
+  <script language="javascript" type="text/javascript" src="sketch.js"></script>
+  <script src="../stats.js"></script>
+</head>
+
+<body>
+</body>
+
+</html>

--- a/test/manual-test-examples/webgl/curves/sketch.js
+++ b/test/manual-test-examples/webgl/curves/sketch.js
@@ -1,0 +1,56 @@
+var angle = 0;
+
+function setup() {
+  createCanvas(800, 600, WEBGL);
+}
+
+function draw()
+{
+    background(220);
+    strokeWeight(2);
+
+    rotateY(angle);
+    stroke(255, 235, 59);
+    fill(121, 85, 72);
+    ellipse(0, -120, 50, 50);
+    fill(255, 111, 0);
+
+    push();
+    translate(0, -120, 0);
+    for (var i = 0; i < 20; i++) {
+        var _x = 30 * Math.cos(radians(i));
+        var _y = 30 * Math.sin(radians(i));
+        beginShape();
+        vertex(_x, _y,0);
+        bezierVertex(-50, -250, -20, 120, -200, -10, _x, _y, 0);
+        rotateZ(1);
+        endShape();
+    }
+    pop();
+
+    fill(62, 39, 35);
+    stroke(0, 0, 0);
+
+    beginShape();
+    vertex(0, -40, -5);
+    quadraticVertex(0, 300, -5, 100, 280, -5);
+    quadraticVertex(0, 250, -5, 0, -40, -5);
+    endShape();
+
+    fill(0,77,64);
+
+    beginShape();
+    curveVertex(10, 150, -4);
+    curveVertex(10, 150, -4);
+    curveVertex(60, 80, -4);
+    curveVertex(140, 100, -4);
+    curveVertex(200, 100, -4);
+    curveVertex(200, 110, -4);
+    curveVertex(160, 140, -4);
+    curveVertex(80, 160, -4);
+    curveVertex(10, 150, -4);
+    curveVertex(10, 150, -4);
+    endShape();
+
+    angle += 0.01;
+}


### PR DESCRIPTION
Implements bezierVertex(), quadraticVertex(), curveVertex() for WebGL mode. Uses [libtess](https://github.com/brendankenny/libtess.js/) to triangulate filled curves. Maintains a look up table to store coefficients required to draw curves. This helps in speeding up things (the coefficients aren't needed to be calculated the next time a specific curve is used). However, the coefficients are calculated again if the curveDetail() is changed.
Closes #2185, #2186, #2187.