### PR TITLE
Fixes arc stroke, removes arcModeAdjust

### DIFF
--- a/src/core/canvas.js
+++ b/src/core/canvas.js
@@ -17,17 +17,5 @@ module.exports = {
     } else if (mode === constants.CENTER) {
       return { x: a - c * 0.5, y: b - d * 0.5, w: c, h: d };
     }
-  },
-
-  arcModeAdjust: function(a, b, c, d, mode) {
-    if (mode === constants.CORNER) {
-      return { x: a + c * 0.5, y: b + d * 0.5, w: c, h: d };
-    } else if (mode === constants.CORNERS) {
-      return { x: a, y: b, w: c + a, h: d + b };
-    } else if (mode === constants.RADIUS) {
-      return { x: a, y: b, w: 2 * c, h: 2 * d };
-    } else if (mode === constants.CENTER) {
-      return { x: a, y: b, w: c, h: d };
-    }
   }
 };

--- a/src/core/p5.Renderer2D.js
+++ b/src/core/p5.Renderer2D.js
@@ -435,14 +435,14 @@ p5.Renderer2D.prototype._acuteArcToBezier = function _acuteArcToBezier(
 
   // Return rotated waypoints.
   return {
-    ax: Math.cos(start),
-    ay: Math.sin(start),
-    bx: lambda * cos_phi + mu * sin_phi,
-    by: lambda * sin_phi - mu * cos_phi,
-    cx: lambda * cos_phi - mu * sin_phi,
-    cy: lambda * sin_phi + mu * cos_phi,
-    dx: Math.cos(start + size),
-    dy: Math.sin(start + size)
+    ax: Math.cos(start).toFixed(7),
+    ay: Math.sin(start).toFixed(7),
+    bx: (lambda * cos_phi + mu * sin_phi).toFixed(7),
+    by: (lambda * sin_phi - mu * cos_phi).toFixed(7),
+    cx: (lambda * cos_phi - mu * sin_phi).toFixed(7),
+    cy: (lambda * sin_phi + mu * cos_phi).toFixed(7),
+    dx: Math.cos(start + size).toFixed(7),
+    dy: Math.sin(start + size).toFixed(7)
   };
 };
 


### PR DESCRIPTION
Fixes #2919 : 2D arc renders/flickers a rect on the screen. Also removes arcModeAdjust() as it is not being used with the new arc implementation in webgl-gsoc-2018.