### PR TITLE
Modified documentation for global `get()` function

### DIFF
--- a/src/image/pixels.js
+++ b/src/image/pixels.js
@@ -441,6 +441,9 @@ p5.prototype.filter = function(operation, value) {
  * <br><br>
  * See the reference for <a href="#/p5/pixels">pixels[]</a> for more information.
  *
+ * If you want to extract an array of colors or a subimage from an p5.Image object,
+ * take a look at <a href="#/p5.Image/get">p5.Image.get</a>
+ *
  * @method get
  * @param  {Number}         [x] x-coordinate of the pixel
  * @param  {Number}         [y] y-coordinate of the pixel


### PR DESCRIPTION
I've added a link to `p5.Image.get()` in the documentation for the global `get()` function, because some people (including me) might get confused and think that you cannot use get to extract
a subimage from a `p5.Image`.

The fact that you can call `copy(image, x, y, ...)` but you can't do the same with `get()` makes it a bit more confusing.