### PR TITLE
fix: use postinstall for CI

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "lint:fix": "grunt lint-fix",
     "contributors:add": "all-contributors add",
     "contributors:generate": "all-contributors generate",
-    "prepare": "patch-package",
+    "postinstall": "patch-package",
     "generate": "all-contributors generate",
     "precommit": "lint-staged"
   },


### PR DESCRIPTION
Running `npm ci` or `yarn` throws an error because `patch-package` can not be found. Migrating from `prepare` to `postinstall` solves this.