### PR TITLE
bugfix: Set mousepress details prior to Element#mousePressed

### DIFF
--- a/src/core/p5.Element.js
+++ b/src/core/p5.Element.js
@@ -232,7 +232,12 @@ p5.Element.prototype.class = function(c) {
  *
  */
 p5.Element.prototype.mousePressed = function(fxn) {
-  adjustListener('mousedown', fxn, this);
+  var eventPrependedFxn = function(event) {
+    this._pInst._setProperty('mouseIsPressed', true);
+    this._pInst._setMouseButton(event);
+    return fxn();
+  };
+  adjustListener('mousedown', eventPrependedFxn, this);
   return this;
 };
 


### PR DESCRIPTION
This resolves the issue in #3087, in which the `mouseButton` variable reports the incorrect value in `mousePressed` functions attached to `p5.Element`s rather than to the global scope.

Looking forward to hearing your thoughts; this does not change functionality; tests still pass as they do on latest mater, and I don't believe this affects or requires changes to any of the existing examples.

**[EDIT]** I'd be happy to add some inline docs if anyone feels that it's unclear what's happening here.