### PR TITLE
Webgl text

### DIFF
--- a/developer_docs/webgl_mode_architecture.md
+++ b/developer_docs/webgl_mode_architecture.md
@@ -31,7 +31,7 @@ The p5.Shader class provides access to the uniforms and attributes of a GL progr
 There are four default shaders, as documented in the Shader section.
 
 ### p5.Texture
-The p5.Texture object manages GL state for a texture based on a `p5.Image`, `p5.MediaElement`, or `p5.Element`. In the future, this object could also be constructed for a piece of text to render in WEBGL mode.
+The p5.Texture object manages GL state for a texture based on a `p5.Image`, `p5.MediaElement`, `p5.Element`, or `ImageData`.
 
 * Internally handles processing image data based on type, so that the p5.Renderer implementation doesn’t have to make special exceptions in its own methods when handling textures
 * Updates conditionally every frame by making a best guess at whether or not image data has changed. Tries not to upload the texture if no change has been made, to help performance.
@@ -49,21 +49,22 @@ All attributes for drawing with Immediate Mode are stored in an object in the re
 ## Geometry: Retain and Immediate Mode
 Retained geometry is used for 3D primitives, while immediate mode is used for shapes created with begin/endShape.
 
-|Functions with retained geometry| Functions with immediate mode geometry | 2D functions not yet implemented|
-|--------------------------------|----------------------------------------|---------------------------------|
-|plane()                         | bezier()                               | text()                          |
-|box()                           | curve()                                |                                 |
-|sphere()                        | line()                                 |                                 |
-|cylinder()                      | beginShape()                           |                                 |
-|cone()                          | vertex()                               |                                 |
-|ellipsoid()                     | endShape()                             |                                 |
-|torus()                         | point()                                |                                 |
-|triangle()                      | curveVertex()                          |                                 |
-|arc()                           | bezierVertex()                         |                                 |
-|point()                         | quadraticVertex()                      |                                 |
+|Functions with retained geometry| Functions with immediate mode geometry |
+|--------------------------------|----------------------------------------|
+|plane()                         | bezier()                               |
+|box()                           | curve()                                |
+|sphere()                        | line()                                 |
+|cylinder()                      | beginShape()                           |
+|cone()                          | vertex()                               |
+|ellipsoid()                     | endShape()                             |
+|torus()                         | point()                                |
+|triangle()                      | curveVertex()                          |
+|arc()                           | bezierVertex()                         |
+|point()                         | quadraticVertex()                      |
 |ellipse()                       |
 |rect()                          |
 |quad()                          |
+|text()                          |
 
 
 

--- a/src/app.js
+++ b/src/app.js
@@ -81,6 +81,7 @@ require('./webgl/p5.RendererGL');
 require('./webgl/p5.RendererGL.Retained');
 require('./webgl/p5.Shader');
 require('./webgl/p5.Texture');
+require('./webgl/text');
 
 require('./core/init');
 

--- a/src/core/p5.Renderer.js
+++ b/src/core/p5.Renderer.js
@@ -45,7 +45,7 @@ p5.Renderer = function(elt, pInst, isMainCanvas) {
   this._textAscent = null;
   this._textDescent = null;
   this._textAlign = constants.LEFT;
-  this._textBaseline = constants.BOTTOM;
+  this._textBaseline = constants.BASELINE;
 
   this._rectMode = constants.CORNER;
   this._ellipseMode = constants.CENTER;

--- a/src/core/p5.Renderer.js
+++ b/src/core/p5.Renderer.js
@@ -233,6 +233,7 @@ p5.Renderer.prototype.text = function(str, x, y, maxWidth, maxHeight) {
         break;
     }
 
+    var baselineHacked = false;
     if (typeof maxHeight !== 'undefined') {
       switch (this._textBaseline) {
         case constants.BOTTOM:
@@ -240,6 +241,10 @@ p5.Renderer.prototype.text = function(str, x, y, maxWidth, maxHeight) {
           break;
         case constants.CENTER:
           y += (maxHeight - totalHeight) / 2;
+          break;
+        case constants.BASELINE:
+          baselineHacked = true;
+          this._textBaseline = constants.TOP;
           break;
       }
 
@@ -264,6 +269,10 @@ p5.Renderer.prototype.text = function(str, x, y, maxWidth, maxHeight) {
 
       this._renderText(p, line, x, y, finalMaxHeight);
       y += p.textLeading();
+
+      if (baselineHacked) {
+        this._textBaseline = constants.BASELINE;
+      }
     }
   } else {
     // Offset to account for vertically centering multiple lines of text - no

--- a/src/core/p5.Renderer.js
+++ b/src/core/p5.Renderer.js
@@ -44,6 +44,8 @@ p5.Renderer = function(elt, pInst, isMainCanvas) {
   this._textStyle = constants.NORMAL;
   this._textAscent = null;
   this._textDescent = null;
+  this._textAlign = constants.LEFT;
+  this._textBaseline = constants.BOTTOM;
 
   this._rectMode = constants.CORNER;
   this._ellipseMode = constants.CENTER;
@@ -75,6 +77,8 @@ p5.Renderer.prototype.push = function() {
       _textFont: this._textFont,
       _textLeading: this._textLeading,
       _textSize: this._textSize,
+      _textAlign: this._textAlign,
+      _textBaseline: this._textBaseline,
       _textStyle: this._textStyle
     }
   };
@@ -153,6 +157,132 @@ p5.Renderer.prototype.textDescent = function() {
     this._updateTextMetrics();
   }
   return this._textDescent;
+};
+
+p5.Renderer.prototype.textAlign = function(h, v) {
+  if (typeof h !== 'undefined') {
+    this._setProperty('_textAlign', h);
+
+    if (typeof v !== 'undefined') {
+      this._setProperty('_textBaseline', v);
+    }
+
+    return this._applyTextProperties();
+  } else {
+    return {
+      horizontal: this._textAlign,
+      vertical: this._textBaseline
+    };
+  }
+};
+
+p5.Renderer.prototype.text = function(str, x, y, maxWidth, maxHeight) {
+  var p = this._pInst,
+    cars,
+    n,
+    ii,
+    jj,
+    line,
+    testLine,
+    testWidth,
+    words,
+    totalHeight,
+    finalMaxHeight = Number.MAX_VALUE;
+
+  if (!(this._doFill || this._doStroke)) {
+    return;
+  }
+
+  if (typeof str === 'undefined') {
+    return;
+  } else if (typeof str !== 'string') {
+    str = str.toString();
+  }
+
+  str = str.replace(/(\t)/g, '  ');
+  cars = str.split('\n');
+
+  if (typeof maxWidth !== 'undefined') {
+    totalHeight = 0;
+    for (ii = 0; ii < cars.length; ii++) {
+      line = '';
+      words = cars[ii].split(' ');
+      for (n = 0; n < words.length; n++) {
+        testLine = line + words[n] + ' ';
+        testWidth = this.textWidth(testLine);
+        if (testWidth > maxWidth) {
+          line = words[n] + ' ';
+          totalHeight += p.textLeading();
+        } else {
+          line = testLine;
+        }
+      }
+    }
+
+    if (this._rectMode === constants.CENTER) {
+      x -= maxWidth / 2;
+      y -= maxHeight / 2;
+    }
+
+    switch (this._textAlign) {
+      case constants.CENTER:
+        x += maxWidth / 2;
+        break;
+      case constants.RIGHT:
+        x += maxWidth;
+        break;
+    }
+
+    if (typeof maxHeight !== 'undefined') {
+      switch (this._textBaseline) {
+        case constants.BOTTOM:
+          y += maxHeight - totalHeight;
+          break;
+        case constants.CENTER:
+          y += (maxHeight - totalHeight) / 2;
+          break;
+      }
+
+      // remember the max-allowed y-position for any line (fix to #928)
+      finalMaxHeight = y + maxHeight - p.textAscent();
+    }
+
+    for (ii = 0; ii < cars.length; ii++) {
+      line = '';
+      words = cars[ii].split(' ');
+      for (n = 0; n < words.length; n++) {
+        testLine = line + words[n] + ' ';
+        testWidth = this.textWidth(testLine);
+        if (testWidth > maxWidth && line.length > 0) {
+          this._renderText(p, line, x, y, finalMaxHeight);
+          line = words[n] + ' ';
+          y += p.textLeading();
+        } else {
+          line = testLine;
+        }
+      }
+
+      this._renderText(p, line, x, y, finalMaxHeight);
+      y += p.textLeading();
+    }
+  } else {
+    // Offset to account for vertically centering multiple lines of text - no
+    // need to adjust anything for vertical align top or baseline
+    var offset = 0,
+      vAlign = p.textAlign().vertical;
+    if (vAlign === constants.CENTER) {
+      offset = (cars.length - 1) * p.textLeading() / 2;
+    } else if (vAlign === constants.BOTTOM) {
+      offset = (cars.length - 1) * p.textLeading();
+    }
+
+    for (jj = 0; jj < cars.length; jj++) {
+      this._renderText(p, cars[jj], x, y - offset, finalMaxHeight);
+      y += p.textLeading();
+    }
+  }
+
+  return p;
 };
 
 p5.Renderer.prototype._applyDefaults = function() {

--- a/src/core/p5.Renderer2D.js
+++ b/src/core/p5.Renderer2D.js
@@ -1168,119 +1168,20 @@ p5.Renderer2D.prototype.translate = function(x, y) {
 //////////////////////////////////////////////
 
 p5.Renderer2D.prototype.text = function(str, x, y, maxWidth, maxHeight) {
-  var p = this._pInst,
-    cars,
-    n,
-    ii,
-    jj,
-    line,
-    testLine,
-    testWidth,
-    words,
-    totalHeight,
-    baselineHacked,
-    finalMaxHeight = Number.MAX_VALUE;
+  var baselineHacked;
 
   // baselineHacked: (HACK)
   // A temporary fix to conform to Processing's implementation
   // of BASELINE vertical alignment in a bounding box
 
-  if (!(this._doFill || this._doStroke)) {
-    return;
-  }
-
-  if (typeof str === 'undefined') {
-    return;
-  } else if (typeof str !== 'string') {
-    str = str.toString();
-  }
-
-  str = str.replace(/(\t)/g, '  ');
-  cars = str.split('\n');
-
-  if (typeof maxWidth !== 'undefined') {
-    totalHeight = 0;
-    for (ii = 0; ii < cars.length; ii++) {
-      line = '';
-      words = cars[ii].split(' ');
-      for (n = 0; n < words.length; n++) {
-        testLine = line + words[n] + ' ';
-        testWidth = this.textWidth(testLine);
-        if (testWidth > maxWidth) {
-          line = words[n] + ' ';
-          totalHeight += p.textLeading();
-        } else {
-          line = testLine;
-        }
-      }
-    }
-
-    if (this._rectMode === constants.CENTER) {
-      x -= maxWidth / 2;
-      y -= maxHeight / 2;
-    }
-
-    switch (this.drawingContext.textAlign) {
-      case constants.CENTER:
-        x += maxWidth / 2;
-        break;
-      case constants.RIGHT:
-        x += maxWidth;
-        break;
-    }
-
-    if (typeof maxHeight !== 'undefined') {
-      switch (this.drawingContext.textBaseline) {
-        case constants.BOTTOM:
-          y += maxHeight - totalHeight;
-          break;
-        case constants._CTX_MIDDLE: // CENTER?
-          y += (maxHeight - totalHeight) / 2;
-          break;
-        case constants.BASELINE:
-          baselineHacked = true;
-          this.drawingContext.textBaseline = constants.TOP;
-          break;
-      }
-
-      // remember the max-allowed y-position for any line (fix to #928)
-      finalMaxHeight = y + maxHeight - p.textAscent();
-    }
-
-    for (ii = 0; ii < cars.length; ii++) {
-      line = '';
-      words = cars[ii].split(' ');
-      for (n = 0; n < words.length; n++) {
-        testLine = line + words[n] + ' ';
-        testWidth = this.textWidth(testLine);
-        if (testWidth > maxWidth && line.length > 0) {
-          this._renderText(p, line, x, y, finalMaxHeight);
-          line = words[n] + ' ';
-          y += p.textLeading();
-        } else {
-          line = testLine;
-        }
-      }
-
-      this._renderText(p, line, x, y, finalMaxHeight);
-      y += p.textLeading();
-    }
-  } else {
-    // Offset to account for vertically centering multiple lines of text - no
-    // need to adjust anything for vertical align top or baseline
-    var offset = 0,
-      vAlign = p.textAlign().vertical;
-    if (vAlign === constants.CENTER) {
-      offset = (cars.length - 1) * p.textLeading() / 2;
-    } else if (vAlign === constants.BOTTOM) {
-      offset = (cars.length - 1) * p.textLeading();
-    }
-
-    for (jj = 0; jj < cars.length; jj++) {
-      this._renderText(p, cars[jj], x, y - offset, finalMaxHeight);
-      y += p.textLeading();
+  if (typeof maxWidth !== 'undefined' && typeof maxHeight !== 'undefined') {
+    if (this.drawingContext.textBaseline === constants.BASELINE) {
+      baselineHacked = true;
+      this.drawingContext.textBaseline = constants.TOP;
     }
   }
+
+  var p = p5.Renderer.prototype.text.apply(this, arguments);
 
   if (baselineHacked) {
     this.drawingContext.textBaseline = constants.BASELINE;
@@ -1332,44 +1233,6 @@ p5.Renderer2D.prototype.textWidth = function(s) {
   return this.drawingContext.measureText(s).width;
 };
 
-p5.Renderer2D.prototype.textAlign = function(h, v) {
-  if (typeof h !== 'undefined') {
-    if (
-      h === constants.LEFT ||
-      h === constants.RIGHT ||
-      h === constants.CENTER
-    ) {
-      this.drawingContext.textAlign = h;
-    }
-
-    if (
-      v === constants.TOP ||
-      v === constants.BOTTOM ||
-      v === constants.CENTER ||
-      v === constants.BASELINE
-    ) {
-      if (v === constants.CENTER) {
-        this.drawingContext.textBaseline = constants._CTX_MIDDLE;
-      } else {
-        this.drawingContext.textBaseline = v;
-      }
-    }
-
-    return this._pInst;
-  } else {
-    var valign = this.drawingContext.textBaseline;
-
-    if (valign === constants._CTX_MIDDLE) {
-      valign = constants.CENTER;
-    }
-
-    return {
-      horizontal: this.drawingContext.textAlign,
-      vertical: valign
-    };
-  }
-};
-
 p5.Renderer2D.prototype._applyTextProperties = function() {
   var font,
     p = this._pInst;
@@ -1390,6 +1253,13 @@ p5.Renderer2D.prototype._applyTextProperties = function() {
     (this._textSize || 12) +
     'px ' +
     (font || 'sans-serif');
+
+  this.drawingContext.textAlign = this._textAlign;
+  if (this._textBaseline === constants.CENTER) {
+    this.drawingContext.textBaseline = constants._CTX_MIDDLE;
+  } else {
+    this.drawingContext.textBaseline = this._textBaseline;
+  }
 
   return p;
 };

--- a/src/math/p5.Vector.js
+++ b/src/math/p5.Vector.js
@@ -1749,16 +1749,4 @@ p5.Vector.mag = function mag(vecT) {
   return Math.sqrt(magSq);
 };
 
-p5.Vector.prototype.plus = function(v) {
-  return p5.Vector.add(this, v);
-};
-
-p5.Vector.prototype.minus = function(v) {
-  return p5.Vector.sub(this, v);
-};
-
-p5.Vector.prototype.times = function(v) {
-  return p5.Vector.mult(this, v);
-};
-
 module.exports = p5.Vector;

--- a/src/math/p5.Vector.js
+++ b/src/math/p5.Vector.js
@@ -1749,4 +1749,16 @@ p5.Vector.mag = function mag(vecT) {
   return Math.sqrt(magSq);
 };
 
+p5.Vector.prototype.plus = function(v) {
+  return p5.Vector.add(this, v);
+};
+
+p5.Vector.prototype.minus = function(v) {
+  return p5.Vector.sub(this, v);
+};
+
+p5.Vector.prototype.times = function(v) {
+  return p5.Vector.mult(this, v);
+};
+
 module.exports = p5.Vector;

--- a/src/typography/loading_displaying.js
+++ b/src/typography/loading_displaying.js
@@ -158,6 +158,10 @@ p5.prototype.loadFont = function(path, onSuccess, onError) {
  * does not fit completely within the rectangle specified will not be drawn
  * to the screen. If x2 and y2 are not specified, the baseline alignment is the
  * default, which means that the text will be drawn upwards from x and y.
+ * <br><br>
+ * <b>WEBGL</b>: Only opentype/truetype fonts are supported. You must load a font using the
+ * <a href="#/p5/loadFont">loadFont()</a> method (see the example above).
+ * <a href="#/p5/stroke">stroke()</a> currently has no effect in webgl mode.
  *
  * @method text
  * @param {String|Object|Array|Number|Boolean} str the alphanumeric
@@ -225,6 +229,8 @@ p5.prototype.text = function(str, x, y, maxWidth, maxHeight) {
 
 /**
  * Sets the current font that will be drawn with the <a href="#/p5/text">text()</a> function.
+ * <br><br>
+ * <b>WEBGL</b>: Only fonts loaded via <a href="#/p5/loadFont">loadFont()</a> are supported.
  *
  * @method textFont
  * @return {Object} the current font

--- a/src/typography/loading_displaying.js
+++ b/src/typography/loading_displaying.js
@@ -188,9 +188,32 @@ p5.prototype.loadFont = function(path, onSuccess, onError) {
  * </code>
  * </div>
  *
+ * <div modernizr='webgl'>
+ * <code>
+ * var avenir;
+ * function preload() {
+ *   avenir = loadFont('assets/Avenir.otf');
+ * }
+ * function setup() {
+ *   createCanvas(100, 100, WEBGL);
+ *   textFont(avenir);
+ *   textSize(width / 3);
+ *   textAlign(CENTER, CENTER);
+ * }
+ * function draw() {
+ *   background(0);
+ *   var time = millis();
+ *   rotateX(time / 1000);
+ *   rotateZ(time / 1234);
+ *   text('p5.js', 0, 0);
+ * }
+ * </code>
+ * </div>
+ *
  * @alt
  *'word' displayed 3 times going from black, blue to translucent blue
  * The quick brown fox jumped over the lazy dog.
+ * the text 'p5.js' spinning in 3d
  *
  */
 p5.prototype.text = function(str, x, y, maxWidth, maxHeight) {

--- a/src/typography/p5.Font.js
+++ b/src/typography/p5.Font.js
@@ -466,7 +466,7 @@ p5.Font.prototype._handleAlignment = function(renderer, line, x, y, textWidth) {
     case constants.CENTER:
       y += this._textAscent(fontSize) / 2;
       break;
-    case constants.BASELINE:
+    case constants.BOTTOM:
       y -= this._textDescent(fontSize);
       break;
   }

--- a/src/typography/p5.Font.js
+++ b/src/typography/p5.Font.js
@@ -466,7 +466,7 @@ p5.Font.prototype._handleAlignment = function(renderer, line, x, y, textWidth) {
     case constants.CENTER:
       y += this._textAscent(fontSize) / 2;
       break;
-    case constants.BOTTOM:
+    case constants.BASELINE:
       y -= this._textDescent(fontSize);
       break;
   }

--- a/src/typography/p5.Font.js
+++ b/src/typography/p5.Font.js
@@ -469,7 +469,7 @@ p5.Font.prototype._handleAlignment = function(renderer, line, x, y, textWidth) {
     case constants.BOTTOM:
       y -= this._textDescent(fontSize);
       break;
-  }  
+  }
 
   return { x: x, y: y };
 };

--- a/src/webgl/p5.RendererGL.Retained.js
+++ b/src/webgl/p5.RendererGL.Retained.js
@@ -185,6 +185,7 @@ p5.RendererGL.prototype.createBuffers = function(gId, obj) {
     );
   }
   //}
+  return geometry;
 };
 
 /**

--- a/src/webgl/p5.RendererGL.js
+++ b/src/webgl/p5.RendererGL.js
@@ -32,6 +32,8 @@ var defaultShaders = {
   ),
   phongVert: fs.readFileSync(__dirname + '/shaders/phong.vert', 'utf-8'),
   phongFrag: fs.readFileSync(__dirname + '/shaders/phong.frag', 'utf-8'),
+  fontVert: fs.readFileSync(__dirname + '/shaders/font.vert', 'utf-8'),
+  fontFrag: fs.readFileSync(__dirname + '/shaders/font.frag', 'utf-8'),
   lineVert: fs.readFileSync(__dirname + '/shaders/line.vert', 'utf-8'),
   lineFrag: fs.readFileSync(__dirname + '/shaders/line.frag', 'utf-8'),
   pointVert: fs.readFileSync(__dirname + '/shaders/point.vert', 'utf-8'),
@@ -139,6 +141,7 @@ p5.RendererGL = function(elt, pInst, isMainCanvas, attr) {
 
   this._tessy = this._initTessy();
 
+  this.fontInfos = {};
   return this;
 };
 
@@ -761,13 +764,6 @@ p5.RendererGL.prototype.resetMatrix = function() {
   return this;
 };
 
-// Text/Typography
-// @TODO:
-p5.RendererGL.prototype._applyTextProperties = function() {
-  //@TODO finish implementation
-  console.error('text commands not yet implemented in webgl');
-};
-
 //////////////////////////////////////////////
 // SHADER
 //////////////////////////////////////////////
@@ -959,6 +955,17 @@ p5.RendererGL.prototype._getLineShader = function() {
   return this._defaultLineShader;
 };
 
+p5.RendererGL.prototype._getFontShader = function() {
+  if (!this._defaultFontShader) {
+    this._defaultFontShader = new p5.Shader(
+      this,
+      defaultShaders.fontVert,
+      defaultShaders.fontFrag
+    );
+  }
+  return this._defaultFontShader;
+};
+
 p5.RendererGL.prototype._getEmptyTexture = function() {
   if (!this._emptyTexture) {
     // a plain white texture RGBA, full alpha, single pixel.
@@ -970,16 +977,14 @@ p5.RendererGL.prototype._getEmptyTexture = function() {
 };
 
 p5.RendererGL.prototype.getTexture = function(img) {
-  var checkSource = function(element) {
-    return element.src === img;
-  };
-  //this.drawMode = constants.TEXTURE;
-  var tex = this.textures.find(checkSource);
-  if (!tex) {
-    tex = new p5.Texture(this, img);
-    this.textures.push(tex);
+  var textures = this.textures;
+  for (var it = 0; it < textures.length; ++it) {
+    var texture = textures[it];
+    if (texture.src === img) return texture;
   }
 
+  var tex = new p5.Texture(this, img);
+  this.textures.push(tex);
   return tex;
 };
 

--- a/src/webgl/p5.RendererGL.js
+++ b/src/webgl/p5.RendererGL.js
@@ -957,6 +957,7 @@ p5.RendererGL.prototype._getLineShader = function() {
 
 p5.RendererGL.prototype._getFontShader = function() {
   if (!this._defaultFontShader) {
+    this.GL.getExtension('OES_standard_derivatives');
     this._defaultFontShader = new p5.Shader(
       this,
       defaultShaders.fontVert,

--- a/src/webgl/p5.Shader.js
+++ b/src/webgl/p5.Shader.js
@@ -231,6 +231,16 @@ p5.Shader.prototype.bindTextures = function() {
   }
 };
 
+p5.Shader.prototype.updateTextures = function() {
+  for (var i = 0; i < this.samplers.length; i++) {
+    var uniform = this.samplers[i];
+    var tex = uniform.texture;
+    if (tex) {
+      tex.update();
+    }
+  }
+};
+
 p5.Shader.prototype.unbindTextures = function() {
   // TODO: migrate stuff from material.js here
   // - OR - have material.js define this function

--- a/src/webgl/shaders/font.frag
+++ b/src/webgl/shaders/font.frag
@@ -1,0 +1,199 @@
+precision mediump float;
+
+#if 0
+	#define int float
+	#define ivec2 vec2
+	#define INT(x) float(x)
+
+	int ifloor(float v) { return floor(v); }
+	ivec2 ifloor(vec2 v) { return floor(v); }
+
+#else
+	precision mediump int;
+	#define INT(x) x
+
+	int ifloor(float v) { return int(v); }
+	int ifloor(int v) { return v; }
+	ivec2 ifloor(vec2 v) { return ivec2(v); }
+
+#endif
+
+uniform sampler2D uSamplerStrokes;
+uniform sampler2D uSamplerRowStrokes;
+uniform sampler2D uSamplerRows;
+uniform sampler2D uSamplerColStrokes;
+uniform sampler2D uSamplerCols;
+
+uniform ivec2 uStrokeImageSize;
+uniform ivec2 uCellsImageSize;
+uniform ivec2 uGridImageSize;
+
+uniform ivec2 uGridOffset;
+uniform ivec2 uGridSize;
+uniform vec4 uMaterialColor;
+
+uniform vec4 uGlyphRect;
+uniform float uFontSize;
+
+uniform vec2 uPpmScale;
+
+varying vec2 vTexCoord;
+varying float w;
+
+int round(float v) { return ifloor(v + 0.5); }
+ivec2 round(vec2 v) { return ifloor(v + 0.5); }
+float saturate(float v) { return clamp(v, 0.0, 1.0); }
+vec2 saturate(vec2 v) { return clamp(v, 0.0, 1.0); }
+
+int mul(float v1, int v2) {
+  return ifloor(v1 * float(v2));
+}
+
+ivec2 mul(vec2 v1, ivec2 v2) {
+  return ifloor(v1 * vec2(v2) + 0.5);
+}
+
+int getInt16(vec2 v) {
+  ivec2 iv = round(v * 255.0);
+  return iv.x * INT(128) + iv.y;
+}
+
+vec2 ppm;
+vec2 cov = vec2(0.0);
+vec2 wgt = vec2(0.0);
+
+const int N = INT(250);
+
+vec4 getTexel(sampler2D sampler, int pos, ivec2 size) {
+  int width = size.x;
+  int y = ifloor(pos / width);
+  int x = pos - y * width;
+
+  return texture2D(sampler, (vec2(x, y) + 0.5) / vec2(size));
+}
+
+void coverageX(vec2 p0, vec2 p1, vec2 p2) {
+
+  vec2 a = p0 - p1 * 2.0 + p2;
+  vec2 b = p0 - p1;
+  vec2 c = p0 - vTexCoord;
+
+  vec2 surd = sqrt(max(vec2(0.0), b * b - a * c));
+  vec2 t1 = ((b - surd) / a).yx;
+  vec2 t2 = ((b + surd) / a).yx;
+
+  if (abs(a.y) < 0.001)
+    t1.x = t2.x = c.y / (2.0 * b.y);
+
+  if (abs(a.x) < 0.001)
+    t1.y = t2.y = c.x / (2.0 * b.x);
+
+  vec2 C1 = ((a * t1 - b * 2.0) * t1 + c) * ppm;
+  vec2 C2 = ((a * t2 - b * 2.0) * t2 + c) * ppm;
+
+  bool y0 = p0.y > vTexCoord.y;
+  bool y1 = p1.y > vTexCoord.y;
+  bool y2 = p2.y > vTexCoord.y;
+
+  if (y1 ? !y2 : y0) {
+    cov.x += saturate(C1.x + 0.5);
+    wgt.x = max(wgt.x, saturate(1.0 - abs(C1.x) * 2.0));
+  }
+
+  if (y1 ? !y0 : y2) {
+    cov.x -= saturate(C2.x + 0.5);
+    wgt.x = max(wgt.x, saturate(1.0 - abs(C2.x) * 2.0));
+  }
+}
+
+
+void coverageY(vec2 p0, vec2 p1, vec2 p2) {
+
+  vec2 a = p0 - p1 * 2.0 + p2;
+  vec2 b = p0 - p1;
+  vec2 c = p0 - vTexCoord;
+
+  vec2 surd = sqrt(max(vec2(0.0), b * b - a * c));
+  vec2 t1 = ((b - surd) / a).yx;
+  vec2 t2 = ((b + surd) / a).yx;
+
+  if (abs(a.y) < 0.001)
+    t1.x = t2.x = c.y / (2.0 * b.y);
+
+  if (abs(a.x) < 0.001)
+    t1.y = t2.y = c.x / (2.0 * b.x);
+
+  vec2 C1 = ((a * t1 - b * 2.0) * t1 + c) * ppm;
+  vec2 C2 = ((a * t2 - b * 2.0) * t2 + c) * ppm;
+
+  bool x0 = p0.x > vTexCoord.x;
+  bool x1 = p1.x > vTexCoord.x;
+  bool x2 = p2.x > vTexCoord.x;
+
+  if (x1 ? !x2 : x0) {
+    cov.y -= saturate(C1.y + 0.5);
+    wgt.y = max(wgt.y, saturate(1.0 - abs(C1.y) * 2.0));
+  }
+
+  if (x1 ? !x0 : x2) {
+    cov.y += saturate(C2.y + 0.5);
+    wgt.y = max(wgt.y, saturate(1.0 - abs(C2.y) * 2.0));
+  }
+}
+
+void main() {
+
+  ppm = 200.0 * uFontSize * uGlyphRect.zw / (w * w);
+
+  ivec2 gridCoord = ifloor(vTexCoord * vec2(uGridSize));
+
+  {
+    int rowIndex = gridCoord.y + uGridOffset.y;
+    vec4 rowInfo = getTexel(uSamplerRows, rowIndex, uGridImageSize);
+    int rowStrokeIndex = getInt16(rowInfo.xy);
+    int rowStrokeCount = getInt16(rowInfo.zw);
+
+    for (int iRowStroke = INT(0); iRowStroke < N; iRowStroke++) {
+      if (iRowStroke >= rowStrokeCount)
+        break;
+
+      vec4 strokeIndices = getTexel(uSamplerRowStrokes, rowStrokeIndex++, uCellsImageSize);
+
+      int strokePos = getInt16(strokeIndices.xy);
+      vec4 stroke0 = getTexel(uSamplerStrokes, strokePos + INT(0), uStrokeImageSize);
+      vec4 stroke1 = getTexel(uSamplerStrokes, strokePos + INT(1), uStrokeImageSize);
+      coverageX(stroke0.xy, stroke0.zw, stroke1.xy);
+    }
+  }
+
+  {
+    int colIndex = gridCoord.x + uGridOffset.x;
+    vec4 colInfo = getTexel(uSamplerCols, colIndex, uGridImageSize);
+    int colStrokeIndex = getInt16(colInfo.xy);
+    int colStrokeCount = getInt16(colInfo.zw);
+    
+    for (int iColStroke = INT(0); iColStroke < N; iColStroke++) {
+      if (iColStroke >= colStrokeCount)
+        break;
+
+      vec4 strokeIndices = getTexel(uSamplerColStrokes, colStrokeIndex++, uCellsImageSize);
+
+      int strokePos = getInt16(strokeIndices.xy);
+      vec4 stroke0 = getTexel(uSamplerStrokes, strokePos + INT(0), uStrokeImageSize);
+      vec4 stroke1 = getTexel(uSamplerStrokes, strokePos + INT(1), uStrokeImageSize);
+      coverageY(stroke0.xy, stroke0.zw, stroke1.xy);
+    }
+  }
+
+  float v = saturate(max(abs(cov.x * wgt.x + cov.y * wgt.y) / max(wgt.x + wgt.y, 0.0001220703125), min(abs(cov.x), abs(cov.y))));
+
+  //gl_FragColor.rg = (v * .8 + .2) * (vec2(gridCoord) * .8 + .2) / vec2(uGridSize);
+  gl_FragColor = uMaterialColor;
+  gl_FragColor.a *= v;
+
+  /*
+  gl_FragColor.a = 1.0;
+  gl_FragColor.b = fract(w/1000.0);
+  gl_FragColor.rgb = vec3(1.0);
+  */
+}

--- a/src/webgl/shaders/font.frag
+++ b/src/webgl/shaders/font.frag
@@ -1,3 +1,4 @@
+#extension GL_OES_standard_derivatives : enable
 precision mediump float;
 
 #if 0
@@ -31,9 +32,6 @@ uniform ivec2 uGridImageSize;
 uniform ivec2 uGridOffset;
 uniform ivec2 uGridSize;
 uniform vec4 uMaterialColor;
-
-uniform vec4 uGlyphRect;
-uniform float uFontSize;
 
 uniform vec2 uPpmScale;
 
@@ -143,7 +141,7 @@ void coverageY(vec2 p0, vec2 p1, vec2 p2) {
 
 void main() {
 
-  ppm = 200.0 * uFontSize * uGlyphRect.zw / (w * w);
+  ppm = 1.0 / fwidth(vTexCoord);
 
   ivec2 gridCoord = ifloor(vTexCoord * vec2(uGridSize));
 
@@ -186,14 +184,6 @@ void main() {
   }
 
   float v = saturate(max(abs(cov.x * wgt.x + cov.y * wgt.y) / max(wgt.x + wgt.y, 0.0001220703125), min(abs(cov.x), abs(cov.y))));
-
-  //gl_FragColor.rg = (v * .8 + .2) * (vec2(gridCoord) * .8 + .2) / vec2(uGridSize);
   gl_FragColor = uMaterialColor;
   gl_FragColor.a *= v;
-
-  /*
-  gl_FragColor.a = 1.0;
-  gl_FragColor.b = fract(w/1000.0);
-  gl_FragColor.rgb = vec3(1.0);
-  */
 }

--- a/src/webgl/shaders/font.frag
+++ b/src/webgl/shaders/font.frag
@@ -2,6 +2,7 @@
 precision mediump float;
 
 #if 0
+  // simulate integer math using floats
 	#define int float
 	#define ivec2 vec2
 	#define INT(x) float(x)
@@ -10,6 +11,7 @@ precision mediump float;
 	ivec2 ifloor(vec2 v) { return floor(v); }
 
 #else
+  // use native integer math
 	precision mediump int;
 	#define INT(x) x
 
@@ -33,11 +35,9 @@ uniform ivec2 uGridOffset;
 uniform ivec2 uGridSize;
 uniform vec4 uMaterialColor;
 
-uniform vec2 uPpmScale;
-
 varying vec2 vTexCoord;
-varying float w;
 
+// some helper functions
 int round(float v) { return ifloor(v + 0.5); }
 ivec2 round(vec2 v) { return ifloor(v + 0.5); }
 float saturate(float v) { return clamp(v, 0.0, 1.0); }
@@ -51,103 +51,117 @@ ivec2 mul(vec2 v1, ivec2 v2) {
   return ifloor(v1 * vec2(v2) + 0.5);
 }
 
+// unpack a 16-bit integer from a float vec2
 int getInt16(vec2 v) {
   ivec2 iv = round(v * 255.0);
   return iv.x * INT(128) + iv.y;
 }
 
-vec2 ppm;
-vec2 cov = vec2(0.0);
-vec2 wgt = vec2(0.0);
+vec2 pixelScale;
+vec2 coverage = vec2(0.0);
+vec2 weight = vec2(0.5);
+const float minDistance = 1.0/8192.0;
+const float hardness = 1.05; // amount of antialias
 
+// the maximum number of curves in a glyph
 const int N = INT(250);
 
+// retrieves an indexed pixel from a sampler
 vec4 getTexel(sampler2D sampler, int pos, ivec2 size) {
   int width = size.x;
   int y = ifloor(pos / width);
-  int x = pos - y * width;
+  int x = pos - y * width;  // pos % width
 
   return texture2D(sampler, (vec2(x, y) + 0.5) / vec2(size));
 }
 
-void coverageX(vec2 p0, vec2 p1, vec2 p2) {
+void calulateCrossings(vec2 p0, vec2 p1, vec2 p2, out vec2 C1, out vec2 C2) {
 
+  // get the coefficients of the quadratic in t
   vec2 a = p0 - p1 * 2.0 + p2;
   vec2 b = p0 - p1;
   vec2 c = p0 - vTexCoord;
 
+  // found out which values of 't' it crosses the axes
   vec2 surd = sqrt(max(vec2(0.0), b * b - a * c));
   vec2 t1 = ((b - surd) / a).yx;
   vec2 t2 = ((b + surd) / a).yx;
 
+  // approximate straight lines to avoid rounding errors
   if (abs(a.y) < 0.001)
     t1.x = t2.x = c.y / (2.0 * b.y);
 
   if (abs(a.x) < 0.001)
     t1.y = t2.y = c.x / (2.0 * b.x);
 
-  vec2 C1 = ((a * t1 - b * 2.0) * t1 + c) * ppm;
-  vec2 C2 = ((a * t2 - b * 2.0) * t2 + c) * ppm;
+  // plug into quadratic formula to find the corrdinates of the crossings
+  C1 = ((a * t1 - b * 2.0) * t1 + c) * pixelScale;
+  C2 = ((a * t2 - b * 2.0) * t2 + c) * pixelScale;
+}
 
+void coverageX(vec2 p0, vec2 p1, vec2 p2) {
+
+  vec2 C1, C2;
+  calulateCrossings(p0, p1, p2, C1, C2);
+
+  // determine on which side of the x-axis the points lie
   bool y0 = p0.y > vTexCoord.y;
   bool y1 = p1.y > vTexCoord.y;
   bool y2 = p2.y > vTexCoord.y;
 
+  // could web be under the curve (after t1)?
   if (y1 ? !y2 : y0) {
-    cov.x += saturate(C1.x + 0.5);
-    wgt.x = max(wgt.x, saturate(1.0 - abs(C1.x) * 2.0));
+    // add the coverage for t1
+    coverage.x += saturate(C1.x + 0.5);
+    // calculate the anti-aliasing for t1
+    weight.x = min(weight.x, abs(C1.x));
   }
 
+  // are we outside the curve (after t2)?
   if (y1 ? !y0 : y2) {
-    cov.x -= saturate(C2.x + 0.5);
-    wgt.x = max(wgt.x, saturate(1.0 - abs(C2.x) * 2.0));
+    // subtract the coverage for t2
+    coverage.x -= saturate(C2.x + 0.5);
+    // calculate the anti-aliasing for t2
+    weight.x = min(weight.x, abs(C2.x));
   }
 }
 
-
+// this is essentially the same as coverageX, but with the axes swapped
 void coverageY(vec2 p0, vec2 p1, vec2 p2) {
 
-  vec2 a = p0 - p1 * 2.0 + p2;
-  vec2 b = p0 - p1;
-  vec2 c = p0 - vTexCoord;
-
-  vec2 surd = sqrt(max(vec2(0.0), b * b - a * c));
-  vec2 t1 = ((b - surd) / a).yx;
-  vec2 t2 = ((b + surd) / a).yx;
-
-  if (abs(a.y) < 0.001)
-    t1.x = t2.x = c.y / (2.0 * b.y);
-
-  if (abs(a.x) < 0.001)
-    t1.y = t2.y = c.x / (2.0 * b.x);
-
-  vec2 C1 = ((a * t1 - b * 2.0) * t1 + c) * ppm;
-  vec2 C2 = ((a * t2 - b * 2.0) * t2 + c) * ppm;
+  vec2 C1, C2;
+  calulateCrossings(p0, p1, p2, C1, C2);
 
   bool x0 = p0.x > vTexCoord.x;
   bool x1 = p1.x > vTexCoord.x;
   bool x2 = p2.x > vTexCoord.x;
 
   if (x1 ? !x2 : x0) {
-    cov.y -= saturate(C1.y + 0.5);
-    wgt.y = max(wgt.y, saturate(1.0 - abs(C1.y) * 2.0));
+    coverage.y -= saturate(C1.y + 0.5);
+    weight.y = min(weight.y, abs(C1.y));
   }
 
   if (x1 ? !x0 : x2) {
-    cov.y += saturate(C2.y + 0.5);
-    wgt.y = max(wgt.y, saturate(1.0 - abs(C2.y) * 2.0));
+    coverage.y += saturate(C2.y + 0.5);
+    weight.y = min(weight.y, abs(C2.y));
   }
 }
 
 void main() {
 
-  ppm = 1.0 / fwidth(vTexCoord);
+  // calculate the pixel scale based on screen-coordinates
+  pixelScale = hardness / fwidth(vTexCoord);
 
+  // which grid cell is this pixel in?
   ivec2 gridCoord = ifloor(vTexCoord * vec2(uGridSize));
 
+  // intersect curves in this row
   {
+    // the index into the row info bitmap
     int rowIndex = gridCoord.y + uGridOffset.y;
+    // fetch the info texel
     vec4 rowInfo = getTexel(uSamplerRows, rowIndex, uGridImageSize);
+    // unpack the rowInfo
     int rowStrokeIndex = getInt16(rowInfo.xy);
     int rowStrokeCount = getInt16(rowInfo.zw);
 
@@ -155,15 +169,24 @@ void main() {
       if (iRowStroke >= rowStrokeCount)
         break;
 
+      // each stroke is made up of 3 points: the start and control point
+      // and the start of the next curve.
+      // fetch the indices of this pair of strokes:
       vec4 strokeIndices = getTexel(uSamplerRowStrokes, rowStrokeIndex++, uCellsImageSize);
 
+      // unpack the stroke index
       int strokePos = getInt16(strokeIndices.xy);
+
+      // fetch the two strokes
       vec4 stroke0 = getTexel(uSamplerStrokes, strokePos + INT(0), uStrokeImageSize);
       vec4 stroke1 = getTexel(uSamplerStrokes, strokePos + INT(1), uStrokeImageSize);
+
+      // calculate the coverage
       coverageX(stroke0.xy, stroke0.zw, stroke1.xy);
     }
   }
 
+  // intersect curves in this column
   {
     int colIndex = gridCoord.x + uGridOffset.x;
     vec4 colInfo = getTexel(uSamplerCols, colIndex, uGridImageSize);
@@ -183,7 +206,10 @@ void main() {
     }
   }
 
-  float v = saturate(max(abs(cov.x * wgt.x + cov.y * wgt.y) / max(wgt.x + wgt.y, 0.0001220703125), min(abs(cov.x), abs(cov.y))));
+  weight = saturate(1.0 - weight * 2.0);
+  float distance = max(weight.x + weight.y, minDistance); // manhattan approx.
+  float antialias = abs(dot(coverage, weight) / distance);
+  float cover = min(abs(coverage.x), abs(coverage.y));
   gl_FragColor = uMaterialColor;
-  gl_FragColor.a *= v;
+  gl_FragColor.a *= saturate(max(antialias, cover));
 }

--- a/src/webgl/shaders/font.vert
+++ b/src/webgl/shaders/font.vert
@@ -1,0 +1,22 @@
+precision mediump float;
+
+attribute vec3 aPosition;
+attribute vec2 aTexCoord;
+uniform mat4 uModelViewMatrix;
+uniform mat4 uProjectionMatrix;
+
+uniform vec4 uGlyphRect;
+uniform float uGlyphOffset;
+
+varying vec2 vTexCoord;
+varying float w;
+
+void main() {
+  vec4 positionVec4 = vec4(aPosition, 1.0);
+  positionVec4.xy *= uGlyphRect.zw - uGlyphRect.xy;
+  positionVec4.xy += uGlyphRect.xy;
+  positionVec4.x += uGlyphOffset;
+  gl_Position = uProjectionMatrix * uModelViewMatrix * positionVec4;
+  vTexCoord = aTexCoord;
+  w = gl_Position.w;
+}

--- a/src/webgl/shaders/font.vert
+++ b/src/webgl/shaders/font.vert
@@ -13,9 +13,16 @@ varying float w;
 
 void main() {
   vec4 positionVec4 = vec4(aPosition, 1.0);
+
+  // scale by the size of the glyph's rectangle
   positionVec4.xy *= uGlyphRect.zw - uGlyphRect.xy;
+
+  // move to the corner of the glyph
   positionVec4.xy += uGlyphRect.xy;
+
+  // move to the letter's line offset
   positionVec4.x += uGlyphOffset;
+  
   gl_Position = uProjectionMatrix * uModelViewMatrix * positionVec4;
   vTexCoord = aTexCoord;
   w = gl_Position.w;

--- a/src/webgl/text.js
+++ b/src/webgl/text.js
@@ -282,10 +282,10 @@ var FontInfo = function(font) {
        */
       this.quadError = function() {
         return (
-          this.p1
-            .minus(this.p0)
-            .minus(this.c1.minus(this.c0).times(3))
-            .mag() / 2
+          p5.Vector.sub(
+            p5.Vector.sub(this.p1, this.p0),
+            p5.Vector.mult(p5.Vector.sub(this.c1, this.c0), 3)
+          ).mag() / 2
         );
       };
 
@@ -320,12 +320,12 @@ var FontInfo = function(font) {
        * this cubic is (potentially) altered and returned in the list.
        */
       this.splitInflections = function() {
-        var a = this.c0.minus(this.p0);
-        var b = this.c1.minus(this.c0).minus(a);
-        var c = this.p1
-          .minus(this.c1)
-          .minus(a)
-          .minus(b.times(2));
+        var a = p5.Vector.sub(this.c0, this.p0);
+        var b = p5.Vector.sub(p5.Vector.sub(this.c1, this.c0), a);
+        var c = p5.Vector.sub(
+          p5.Vector.sub(p5.Vector.sub(this.p1, this.c1), a),
+          p5.Vector.mult(b, 2)
+        );
 
         var cubics = [];
 

--- a/src/webgl/text.js
+++ b/src/webgl/text.js
@@ -1,0 +1,347 @@
+'use strict';
+
+var p5 = require('../core/main');
+var constants = require('../core/constants');
+require('./p5.Shader');
+require('./p5.RendererGL');
+
+// Text/Typography
+// @TODO:
+p5.RendererGL.prototype._applyTextProperties = function() {
+  //@TODO finish implementation
+  //console.error('text commands not yet implemented in webgl');
+};
+
+p5.RendererGL.prototype.textWidth = function(s) {
+  if (this._isOpenType()) {
+    return this._textFont._textWidth(s, this._textSize);
+  }
+
+  return 0; // TODO: error
+};
+
+// rendering constants
+var charGridWidth = 9;
+var charGridHeight = charGridWidth;
+var strokeImageWidth = 64;
+var strokeImageHeight = 64;
+var cellImageWidth = 64;
+var cellImageHeight = 64;
+var gridImageWidth = 64;
+var gridImageHeight = 64;
+
+function setPixel(imageInfo, r, g, b, a) {
+  var imageData = imageInfo.imageData;
+  var pixels = imageData.data;
+  var index = imageInfo.index++ * 4;
+  pixels[index++] = r;
+  pixels[index++] = g;
+  pixels[index++] = b;
+  pixels[index++] = a;
+}
+
+function ImageInfos(width, height) {
+  this.width = width;
+  this.height = height;
+  this.infos = [];
+
+  this.findImage = function(space) {
+    var imageSize = this.width * this.height;
+    if (space > imageSize)
+      throw new Error('font is too complex to render in 3D');
+
+    var imageInfo, imageData;
+    for (var ii = this.infos.length - 1; ii >= 0; --ii) {
+      var imageInfoTest = this.infos[ii];
+      if (imageInfoTest.index + space < imageSize) {
+        imageInfo = imageInfoTest;
+        imageData = imageInfoTest.imageData;
+        break;
+      }
+    }
+
+    if (!imageInfo) {
+      imageData = new ImageData(this.width, this.height);
+      imageInfo = { index: 0, imageData: imageData };
+      this.infos.push(imageInfo);
+    }
+
+    var index = imageInfo.index;
+    imageInfo.index += space;
+    imageData._dirty = true;
+    return { imageData: imageData, index: index };
+  };
+}
+
+var FontInfo = function(font) {
+  this.font = font;
+  this.strokeImageInfos = new ImageInfos(strokeImageWidth, strokeImageHeight);
+  this.colDimImageInfos = new ImageInfos(gridImageWidth, gridImageHeight);
+  this.rowDimImageInfos = new ImageInfos(gridImageWidth, gridImageHeight);
+  this.colCellImageInfos = new ImageInfos(cellImageWidth, cellImageHeight);
+  this.rowCellImageInfos = new ImageInfos(cellImageWidth, cellImageHeight);
+  this.glyphInfos = {};
+
+  this.getGlyphInfo = function(glyph) {
+    var gi = this.glyphInfos[glyph.index];
+    if (gi) return gi;
+
+    var bb = glyph.getBoundingBox();
+    var xMin = bb.x1;
+    var yMin = bb.y1;
+    var gWidth = bb.x2 - xMin;
+    var gHeight = bb.y2 - yMin;
+    if (gWidth === 0 || gHeight === 0) {
+      return (this.glyphInfos[glyph.index] = {});
+    }
+
+    var i;
+    var strokes = [];
+    var rows = [];
+    var cols = [];
+    for (i = charGridWidth - 1; i >= 0; --i) cols.push([]);
+    for (i = charGridHeight - 1; i >= 0; --i) rows.push([]);
+
+    function push(xs, ys, v) {
+      var index = strokes.length;
+      strokes.push(v);
+
+      function minMax(rg, min, max) {
+        for (var i = rg.length; i-- > 0; ) {
+          var v = rg[i];
+          if (min > v) min = v;
+          if (max < v) max = v;
+        }
+        return { min: min, max: max };
+      }
+
+      var mmX = minMax(xs, 1, 0);
+      var ixMin = Math.max(Math.floor(mmX.min * charGridWidth), 0);
+      var ixMax = Math.min(Math.ceil(mmX.max * charGridWidth), charGridWidth);
+      for (var iCol = ixMin; iCol < ixMax; ++iCol) cols[iCol].push(index);
+
+      var mmY = minMax(ys, 1, 0);
+      var iyMin = Math.max(Math.floor(mmY.min * charGridHeight), 0);
+      var iyMax = Math.min(Math.ceil(mmY.max * charGridHeight), charGridHeight);
+      for (var iRow = iyMin; iRow < iyMax; ++iRow) rows[iRow].push(index);
+    }
+
+    function clamp(v, min, max) {
+      if (v < min) return min;
+      if (v > max) return max;
+      return v;
+    }
+    function byte(v) {
+      return clamp(255 * v, 0, 255);
+    }
+
+    var x0, y0, cx, cy;
+    var cmds = glyph.path.commands;
+    for (var iCmd = 0; iCmd < cmds.length; ++iCmd) {
+      var cmd = cmds[iCmd];
+      var x1 = (cmd.x - xMin) / gWidth;
+      var y1 = (cmd.y - yMin) / gHeight;
+
+      if (Math.abs(x1 - x0) < 0.00001 && Math.abs(y1 - y0) < 0.00001) continue;
+
+      switch (cmd.type) {
+        case 'M':
+          break;
+        case 'L':
+          cx = (x0 + x1) / 2;
+          cy = (y0 + y1) / 2;
+          push([x0, x1], [y0, y1], { x: x0, y: y0, cx: cx, cy: cy });
+          break;
+        case 'Q':
+          cx = (cmd.x1 - xMin) / gWidth;
+          cy = (cmd.y1 - yMin) / gHeight;
+          push([x0, x1, cx], [y0, y1, cy], { x: x0, y: y0, cx: cx, cy: cy });
+          break;
+        case 'Z':
+          strokes.push({ x: x0, y: y0 });
+          break;
+        case 'C':
+          throw new Error('cubics are not yet supported');
+        default:
+          throw new Error('unknown command type: ' + cmd.type);
+      }
+      x0 = x1;
+      y0 = y1;
+    }
+
+    var strokeCount = strokes.length;
+    var strokeImageInfo = this.strokeImageInfos.findImage(strokeCount);
+    var strokeOffset = strokeImageInfo.index;
+
+    // fill the stroke image
+    for (var il = 0; il < strokeCount; ++il) {
+      var s = strokes[il];
+      setPixel(strokeImageInfo, byte(s.x), byte(s.y), byte(s.cx), byte(s.cy));
+    }
+
+    function layout(dim, dimImageInfos, cellImageInfos) {
+      var dimLength = dim.length;
+      var dimImageInfo = dimImageInfos.findImage(dimLength);
+      var dimOffset = dimImageInfo.index;
+      var totalStrokes = 0;
+      for (var id = 0; id < dimLength; ++id) {
+        totalStrokes += dim[id].length;
+      }
+
+      var cellImageInfo = cellImageInfos.findImage(totalStrokes);
+      for (var i = 0; i < dimLength; ++i) {
+        var strokeIndices = dim[i];
+        var strokeCount = strokeIndices.length;
+        var cellLineIndex = cellImageInfo.index;
+
+        setPixel(
+          dimImageInfo,
+          cellLineIndex >> 7,
+          cellLineIndex & 0x7f,
+          strokeCount >> 7,
+          strokeCount & 0x7f
+        );
+
+        for (var iil = 0; iil < strokeCount; ++iil) {
+          var strokeIndex = strokeIndices[iil] + strokeOffset;
+          setPixel(cellImageInfo, strokeIndex >> 7, strokeIndex & 0x7f, 0, 0);
+        }
+      }
+
+      return {
+        cellImageInfo: cellImageInfo,
+        dimOffset: dimOffset,
+        dimImageInfo: dimImageInfo
+      };
+    }
+
+    gi = this.glyphInfos[glyph.index] = {
+      glyph: glyph,
+      uGlyphRect: [glyph.xMin, -glyph.yMin, glyph.xMax, -glyph.yMax],
+      strokeImageInfo: strokeImageInfo,
+      strokes: strokes,
+      colInfo: layout(cols, this.colDimImageInfos, this.colCellImageInfos),
+      rowInfo: layout(rows, this.rowDimImageInfos, this.rowCellImageInfos)
+    };
+    gi.uGridOffset = [gi.colInfo.dimOffset, gi.rowInfo.dimOffset];
+    return gi;
+  };
+};
+
+p5.RendererGL.prototype._renderText = function(p, line, x, y, maxY) {
+  if (y >= maxY || !this._doFill) {
+    return; // don't render lines beyond our maxY position
+  }
+
+  if (!this._isOpenType()) {
+    console.log('WEBGL: only opentype fonts are supported');
+    return p;
+  }
+
+  p.push(); // fix to #803
+
+  var curFillShader = this.curFillShader;
+  var doStroke = this._doStroke;
+  var drawMode = this.drawMode;
+
+  this.curFillShader = null;
+  this._doStroke = false;
+  this.drawMode = constants.TEXTURE;
+
+  var font = this._textFont.font;
+  var glyphs = font.stringToGlyphs(line);
+  var fontInfo = this._textFont._fontInfo;
+  if (!fontInfo) {
+    fontInfo = this._textFont._fontInfo = new FontInfo(font);
+  }
+
+  var pos = this._textFont._handleAlignment(this, line, x, y);
+  var fontSize = this._textSize;
+  var scale = fontSize / font.unitsPerEm;
+
+  this.translate(pos.x, pos.y, 0);
+  this.scale(scale, scale, 1);
+
+  var gl = this.GL;
+  var initializeShader = !this._defaultFontShader;
+  var sh = this.setFillShader(this._getFontShader());
+  if (initializeShader) {
+    sh.setUniform('uGridImageSize', [gridImageWidth, gridImageHeight]);
+    sh.setUniform('uCellsImageSize', [cellImageWidth, cellImageHeight]);
+    sh.setUniform('uStrokeImageSize', [strokeImageWidth, strokeImageHeight]);
+    sh.setUniform('uGridSize', [charGridWidth, charGridHeight]);
+  }
+  this._applyColorBlend(this.curFillColor);
+
+  var g = this.gHash['glyph'];
+  if (!g) {
+    var geom = (this._textGeom = new p5.Geometry(1, 1, function() {
+      for (var i = 0; i <= 1; i++) {
+        for (var j = 0; j <= 1; j++) {
+          this.vertices.push(new p5.Vector(j, i, 0));
+          this.uvs.push(j, i);
+        }
+      }
+    }));
+    geom.computeFaces().computeNormals();
+    g = this.createBuffers('glyph', geom);
+  }
+
+  this._bindBuffer(g.vertexBuffer, gl.ARRAY_BUFFER);
+  sh.enableAttrib(sh.attributes.aPosition.location, 3, gl.FLOAT, false, 0, 0);
+  this._bindBuffer(g.indexBuffer, gl.ELEMENT_ARRAY_BUFFER);
+  this._bindBuffer(g.uvBuffer, gl.ARRAY_BUFFER);
+  sh.enableAttrib(sh.attributes.aTexCoord.location, 2, gl.FLOAT, false, 0, 0);
+
+  sh.setUniform('uMaterialColor', this.curFillColor);
+  sh.setUniform('uFontSize', fontSize);
+
+  try {
+    var dx = 0;
+    var glyphPrev = null;
+    var shaderBound = false;
+    for (var ig = 0; ig < glyphs.length; ++ig) {
+      var glyph = glyphs[ig];
+      if (glyphPrev) {
+        var kerning = font.getKerningValue(glyphPrev, glyph);
+        dx += kerning;
+      }
+
+      var gi = fontInfo.getGlyphInfo(glyph);
+      if (gi.uGlyphRect) {
+        var rowInfo = gi.rowInfo,
+          colInfo = gi.colInfo;
+        sh.setUniform('uSamplerStrokes', gi.strokeImageInfo.imageData);
+        sh.setUniform('uSamplerRowStrokes', rowInfo.cellImageInfo.imageData);
+        sh.setUniform('uSamplerRows', rowInfo.dimImageInfo.imageData);
+        sh.setUniform('uSamplerColStrokes', colInfo.cellImageInfo.imageData);
+        sh.setUniform('uSamplerCols', colInfo.dimImageInfo.imageData);
+        sh.setUniform('uGridOffset', gi.uGridOffset);
+        sh.setUniform('uGlyphRect', gi.uGlyphRect);
+        sh.setUniform('uGlyphOffset', dx);
+
+        if (!shaderBound) {
+          shaderBound = true;
+          sh.bindShader();
+        } else {
+          sh.bindTextures();
+        }
+
+        gl.drawElements(gl.TRIANGLES, 6, this.GL.UNSIGNED_SHORT, 0);
+      }
+      dx += glyph.advanceWidth;
+      glyphPrev = glyph;
+    }
+  } finally {
+    sh.unbindShader();
+
+    this.curFillShader = curFillShader;
+    this._doStroke = doStroke;
+    this.drawMode = drawMode;
+
+    p.pop();
+  }
+
+  this._pInst._pixelsDirty = true;
+  return p;
+};

--- a/src/webgl/text.js
+++ b/src/webgl/text.js
@@ -442,7 +442,6 @@ p5.RendererGL.prototype._renderText = function(p, line, x, y, maxY) {
   sh.enableAttrib(sh.attributes.aTexCoord.location, 2, gl.FLOAT, false, 0, 0);
 
   sh.setUniform('uMaterialColor', this.curFillColor);
-  sh.setUniform('uFontSize', fontSize);
 
   try {
     var dx = 0;

--- a/src/webgl/text.js
+++ b/src/webgl/text.js
@@ -71,8 +71,29 @@ function ImageInfos(width, height) {
     }
 
     if (!imageInfo) {
-      // create a new image
-      imageData = new ImageData(this.width, this.height);
+      try {
+        // create a new image
+        imageData = new ImageData(this.width, this.height);
+      } catch (err) {
+        // for browsers that don't support ImageData constructors (ie IE11)
+        // create an ImageData using the old method
+        var canvas = document.getElementsByTagName('canvas')[0];
+        var created = !canvas;
+        if (!canvas) {
+          // create a temporary canvas
+          canvas = document.createElement('canvas');
+          canvas.style.display = 'none';
+          document.body.appendChild(canvas);
+        }
+        var ctx = canvas.getContext('2d');
+        if (ctx) {
+          imageData = ctx.createImageData(this.width, this.height);
+        }
+        if (created) {
+          // distroy the temporary canvas, if necessary
+          document.body.removeChild(canvas);
+        }
+      }
       imageInfo = { index: 0, imageData: imageData };
       this.infos.push(imageInfo);
     }

--- a/test/manual-test-examples/webgl/text/chinese/index.html
+++ b/test/manual-test-examples/webgl/text/chinese/index.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html>
+
+<head>
+  <meta charset="utf-8">
+  <meta http-equiv="X-UA-Compatible" content="IE=edge">
+  <title></title>
+  <link rel="stylesheet" href="../../../styles.css">
+  <script language="javascript" type="text/javascript" src="../../../../../lib/p5.js"></script>
+  <script language="javascript" type="text/javascript" src="../../../../../lib/addons/p5.dom.js"></script>
+  <script language="javascript" type="text/javascript" src="sketch.js"></script>
+  <script src="../../stats.js"></script>
+</head>
+
+<body>
+</body>
+
+</html>

--- a/test/manual-test-examples/webgl/text/chinese/sketch.js
+++ b/test/manual-test-examples/webgl/text/chinese/sketch.js
@@ -1,0 +1,69 @@
+var font;
+
+function preload() {
+  font = loadFont('https://fonts.gstatic.com/ea/notosanstc/v1/NotoSansTC-Regular.otf');
+}
+
+var chars = [];
+
+function setup() {
+  createCanvas(windowWidth, windowHeight, WEBGL);
+  textSize(3000);
+  textAlign(CENTER, CENTER);
+  fill(255);
+
+  textFont(font);
+  textSize(100);
+
+  var glyphs = font.font.glyphs.glyphs;
+  for (var pn of Object.getOwnPropertyNames(glyphs)) {
+    var glyph = glyphs[pn];
+    var char = glyph.unicode;
+    if (char) {
+      chars.push(String.fromCodePoint(char));
+    }
+  }
+}
+
+var ich = 0;
+var lines = [];
+
+function addLine() {
+  var line = "";
+  while (textWidth(line + chars[ich]) < width) {
+    line += chars[ich++];
+    if (ich > chars.length) {
+      ich -= chars.length;
+    }
+  }
+  lines.push(line);
+}
+var txt;
+var yoff = 0;
+var timeLast = 0;
+
+function draw() {
+  background(0);
+
+  var leading = textLeading();
+
+  var timeNow = millis() / 5;
+  yoff += timeNow - timeLast;
+  timeLast = timeNow;
+
+  while(yoff > leading) {
+    yoff -= leading;
+    lines.shift();
+  }
+
+  while((lines.length - 1) * leading < height) {
+    addLine();
+    txt = null;
+  }
+
+  if (!txt) {
+    txt = lines.join('\n');
+  }
+
+  text(txt, 0, -yoff);
+}

--- a/test/manual-test-examples/webgl/text/chinese/sketch.js
+++ b/test/manual-test-examples/webgl/text/chinese/sketch.js
@@ -1,7 +1,9 @@
 var font;
 
 function preload() {
-  font = loadFont('https://fonts.gstatic.com/ea/notosanstc/v1/NotoSansTC-Regular.otf');
+  font = loadFont(
+    'https://fonts.gstatic.com/ea/notosanstc/v1/NotoSansTC-Regular.otf'
+  );
 }
 
 var chars = [];
@@ -16,11 +18,12 @@ function setup() {
   textSize(100);
 
   var glyphs = font.font.glyphs.glyphs;
-  for (var pn of Object.getOwnPropertyNames(glyphs)) {
-    var glyph = glyphs[pn];
+  var glyphNames = Object.getOwnPropertyNames(glyphs);
+  for (var ipn = 0; ipn < glyphNames.length; ipn++) {
+    var glyph = glyphs[glyphNames[ipn]];
     var char = glyph.unicode;
     if (char) {
-      chars.push(String.fromCodePoint(char));
+      chars.push(String.fromCharCode(char));
     }
   }
 }
@@ -29,7 +32,7 @@ var ich = 0;
 var lines = [];
 
 function addLine() {
-  var line = "";
+  var line = '';
   while (textWidth(line + chars[ich]) < width) {
     line += chars[ich++];
     if (ich > chars.length) {
@@ -51,12 +54,12 @@ function draw() {
   yoff += timeNow - timeLast;
   timeLast = timeNow;
 
-  while(yoff > leading) {
+  while (yoff > leading) {
     yoff -= leading;
     lines.shift();
   }
 
-  while((lines.length - 1) * leading < height) {
+  while ((lines.length - 1) * leading < height) {
     addLine();
     txt = null;
   }

--- a/test/manual-test-examples/webgl/text/multiple/index.html
+++ b/test/manual-test-examples/webgl/text/multiple/index.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html>
+
+<head>
+  <meta charset="utf-8">
+  <meta http-equiv="X-UA-Compatible" content="IE=edge">
+  <title></title>
+  <link rel="stylesheet" href="../../../styles.css">
+  <script language="javascript" type="text/javascript" src="../../../../../lib/p5.js"></script>
+  <script language="javascript" type="text/javascript" src="sketch.js"></script>
+  <script src="../../stats.js"></script>
+</head>
+
+<body>
+</body>
+
+</html>

--- a/test/manual-test-examples/webgl/text/multiple/sketch.js
+++ b/test/manual-test-examples/webgl/text/multiple/sketch.js
@@ -1,0 +1,46 @@
+var font;
+var txtWidth;
+
+function preload() {
+  font = loadFont(
+    'https://fonts.gstatic.com/s/newscycle/v14/CSR54z1Qlv-GDxkbKVQ_dFsvWNRevA.ttf'
+  );
+}
+
+function setup() {
+  createCanvas(windowWidth, windowHeight, WEBGL);
+  textFont(font);
+  textSize(40);
+  textAlign(CENTER, CENTER);
+  fill(255);
+  colorMode(HSB);
+}
+
+function windowResized() {
+  resizeCanvas(windowWidth, windowHeight);
+}
+
+var P1 = 11;
+var P2 = 2;
+var txt = 'p5.js  ';
+var N = Math.floor(400);
+
+function draw() {
+  background(0);
+  rotateY(millis() / 3000);
+  rotateX(1);
+  for (var i = 0; i < N; i++) {
+    var n = 2 * PI * P1 * P2 * i / N - millis() / 300;
+
+    fill(i * 400 / N, 255, 255);
+
+    push();
+    rotateY(n / P1);
+    translate(0, 0, 200);
+    rotateX(n / P2);
+    translate(0, 0, 100);
+    rotateZ(-PI / 3);
+    text(txt.charAt(i % txt.length), 0, 0);
+    pop();
+  }
+}

--- a/test/manual-test-examples/webgl/text/simple/index.html
+++ b/test/manual-test-examples/webgl/text/simple/index.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html>
+
+<head>
+  <meta charset="utf-8">
+  <meta http-equiv="X-UA-Compatible" content="IE=edge">
+  <title></title>
+  <link rel="stylesheet" href="../../../styles.css">
+  <script language="javascript" type="text/javascript" src="../../../../../lib/p5.js"></script>
+  <script language="javascript" type="text/javascript" src="../../../../../lib/addons/p5.dom.js"></script>
+  <script language="javascript" type="text/javascript" src="sketch.js"></script>
+  <script src="../../stats.js"></script>
+</head>
+
+<body>
+</body>
+
+</html>

--- a/test/manual-test-examples/webgl/text/simple/sketch.js
+++ b/test/manual-test-examples/webgl/text/simple/sketch.js
@@ -1,0 +1,55 @@
+var txt;
+var lines = [
+  '               Episode IV',
+  '            A NEW HOPE',
+  'It is a period of civil war.',
+  'Rebel spaceships, striking',
+  'from a hidden base, have won',
+  'their first victory against',
+  'the evil Galactic Empire.',
+  '',
+  'During the battle, Rebel',
+  'spies managed to steal secret',
+  "plans to the Empire's",
+  'ultimate weapon, the DEATH',
+  'STAR, an armored space',
+  'station with enough power to',
+  'destroy an entire planet.',
+  '',
+  "Pursued by the Empire's",
+  'sinister agents, Princess',
+  'Leia races home aboard her',
+  'starship, custodian of the',
+  'stolen plans that can save',
+  'her people and restore',
+  'freedom to the galaxy.....'
+];
+
+var font;
+var txtWidth;
+
+function preload() {
+  font = loadFont('../../../p5.Font/Helvetica.ttf');
+}
+
+function setup() {
+  createCanvas(windowWidth, windowHeight, WEBGL);
+  textFont(font);
+  textSize(width * 0.04);
+  textAlign(LEFT, TOP);
+  fill(238, 213, 75);
+
+  txt = join(lines, '\n');
+
+  txtWidth = 0;
+  for (var i = 0; i < lines.length; i++) {
+    txtWidth = max(txtWidth, textWidth(lines[i]));
+  }
+}
+
+function draw() {
+  background(0);
+
+  rotateX(5 * PI / 16);
+  text(txt, -txtWidth / 2, height / 2 - millis() / 30);
+}


### PR DESCRIPTION
closes #2183

implements `text()` for the webgl renderer. most of the code is in src/webgl/text.js, however some other changes were required:

- moving most of the `p5.Renderer2D.prototype.text()` and `textAlign()` code into shared methods in `p5.Renderer`, this necessitated:
- changing the `textAlign` and `textBaseline` properties so they are backed directly by variables in the renderer instead of being calculated based on canvas properties. this also simplifies the logic for those properties.
- changes to `push`/`pop`, `_applyTextProperties` methods to accommodate the above.
- changes to various `p5.Font` methods to make them renderer-independent.
- optimization in `p5.RendererGL.prototype.getTexture` which gets called a _ton_.
- add support for creating `p5.Texture` from an `ImageData` object.
- a new private `p5.Shader.prototype.updateTextures()` method that ensures all dirty textures are sent to the GPU.