### PR TITLE
add 'npm run dev' script, docs

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -362,6 +362,9 @@ module.exports = function(grunt) {
     open: {
       yui: {
         path: 'http://127.0.0.1:9001/docs/reference/'
+      },
+      dev: {
+        path: 'http://127.0.0.1:9001/test/'
       }
     },
     'saucelabs-mocha': {

--- a/developer_docs/README.md
+++ b/developer_docs/README.md
@@ -78,7 +78,7 @@ $ grunt
 Sometimes it is useful to run the tests in the browser instead of on the command line. To do this, first start the [connect](https://github.com/gruntjs/grunt-contrib-connect) server:
 
 ```
-$ npm run grunt connect -keepalive
+$ npm run dev
 ```
 
 With the server running, you should be able to open `test/test.html` in a browser.
@@ -108,7 +108,7 @@ A complete guide to unit testing is beyond the scope of the p5.js documentation,
    $ npm run grunt
    ```
    
-   If you're continuously changing files in the library, you may want to run `npm run grunt watch:quick` to automatically rebuild the library for you whenever any of its source files change without you having to first type the command manually.
+   If you're continuously changing files in the library, you may want to run `npm run dev` to automatically rebuild the library for you whenever any of its source files change without you having to first type the command manually.
 
 6. Make some changes to the codebase and [commit](https://help.github.com/articles/github-glossary/#commit) them with Git.
 

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "scripts": {
     "grunt": "grunt",
     "build": "grunt build",
+    "dev": "grunt browserify connect open:dev watch:quick",
     "docs": "grunt yui",
     "docs:dev": "grunt yui:dev",
     "test": "grunt",


### PR DESCRIPTION
this just adds a `dev` script to `package.json` that's an alias for `grunt browserify connect open:dev watch:quick` - i got bored of tying it all the time...