### PR TITLE
Bugfix p5.DOM: provide pInst

### DIFF
--- a/lib/addons/p5.dom.js
+++ b/lib/addons/p5.dom.js
@@ -187,7 +187,7 @@
   p5.prototype._wrapElement = function(elt) {
     var children = Array.prototype.slice.call(elt.children);
     if (elt.tagName === 'INPUT' && elt.type === 'checkbox') {
-      var converted = new p5.Element(elt);
+      var converted = new p5.Element(elt, this);
       converted.checked = function() {
         if (arguments.length === 0) {
           return this.elt.checked;
@@ -200,18 +200,18 @@
       };
       return converted;
     } else if (elt.tagName === 'VIDEO' || elt.tagName === 'AUDIO') {
-      return new p5.MediaElement(elt);
+      return new p5.MediaElement(elt, this);
     } else if (elt.tagName === 'SELECT') {
-      return this.createSelect(new p5.Element(elt));
+      return this.createSelect(new p5.Element(elt, this));
     } else if (
       children.length > 0 &&
       children.every(function(c) {
         return c.tagName === 'INPUT' || c.tagName === 'LABEL';
       })
     ) {
-      return this.createRadio(new p5.Element(elt));
+      return this.createRadio(new p5.Element(elt, this));
     } else {
-      return new p5.Element(elt);
+      return new p5.Element(elt, this);
     }
   };
 
@@ -248,7 +248,9 @@
   function addElement(elt, pInst, media) {
     var node = pInst._userNode ? pInst._userNode : document.body;
     node.appendChild(elt);
-    var c = media ? new p5.MediaElement(elt) : new p5.Element(elt);
+    var c = media
+      ? new p5.MediaElement(elt, pInst)
+      : new p5.Element(elt, pInst);
     pInst._elements.push(c);
     return c;
   }
@@ -1934,7 +1936,7 @@
         this.width = this.elt.offsetWidth;
         this.height = this.elt.offsetHeight;
 
-        if (this._pInst) {
+        if (this._pInst && this._pInst._curElement) {
           // main canvas associated with p5 instance
           if (this._pInst._curElement.elt === this.elt) {
             this._pInst._setProperty('width', this.elt.offsetWidth);

--- a/test/unit/addons/p5.dom.js
+++ b/test/unit/addons/p5.dom.js
@@ -1,3 +1,4 @@
+/* global testSketchWithPromise */
 suite('DOM', function() {
   suite('p5.prototype.select', function() {
     var myp5;
@@ -62,6 +63,20 @@ suite('DOM', function() {
     test('should create an empty node when no html is provided', function() {
       const elem = myp5.createDiv();
       assert.strictEqual(elem.elt.innerHTML, '');
+    });
+  });
+
+  suite('p5.prototype.createButton', function() {
+    testSketchWithPromise('mousePressed works', function(
+      sketch,
+      resolve,
+      reject
+    ) {
+      sketch.setup = function() {
+        var elem = sketch.createButton('test');
+        elem.mousePressed(resolve);
+        elem.elt.dispatchEvent(new Event('mousedown'));
+      };
     });
   });
 });


### PR DESCRIPTION
Fixes #3141, adds regression test

Note that the problem is still visible for elements that weren't created by p5, but this needs a different fix - do we want to assume `new p5.Element()` should bind to the global script or should we check that `this._pInst` exists in the `mousedown` event wrapper? I might prefer promoting `p5._wrapElement` to `p5.wrapElement` and deprectaing explicit use of the `p5.Element` constructor

```html
<button id='test'>test</button>
<script>
function setup() {
  var elt = document.querySelector('#test');
  var elem = new p5.Element(elt);
  elem.mousePressed(function() {});
  elt.dispatchEvent(new Event('mousedown'));
}
</script>
```