### PR TITLE
fix Renderer2D's get when called from MediaElement

### DIFF
--- a/lib/addons/p5.dom.js
+++ b/lib/addons/p5.dom.js
@@ -2632,6 +2632,9 @@
     return this.elt.duration;
   };
   p5.MediaElement.prototype.pixels = [];
+  p5.MediaElement.prototype._ensureCanvas = function() {
+    if (!this.canvas) this.loadPixels();
+  };
   p5.MediaElement.prototype.loadPixels = function() {
     if (!this.canvas) {
       this.canvas = document.createElement('canvas');
@@ -2670,6 +2673,7 @@
   p5.MediaElement.prototype.updatePixels = function(x, y, w, h) {
     if (this.loadedmetadata) {
       // wait for metadata
+      this._ensureCanvas();
       p5.Renderer2D.prototype.updatePixels.call(this, x, y, w, h);
     }
     this.setModified(true);
@@ -2680,10 +2684,9 @@
       // wait for metadata
       var currentTime = this.elt.currentTime;
       if (this._pixelsTime !== currentTime) {
-        // if the video has changed time, then force an
-        // update to the pixels array.
-        this._pixelsDirty = true;
-        this._pixelsTime = currentTime;
+        this.loadPixels();
+      } else {
+        this._ensureCanvas();
       }
 
       return p5.Renderer2D.prototype.get.call(this, x, y, w, h);
@@ -2698,11 +2701,13 @@
   p5.MediaElement.prototype.set = function(x, y, imgOrCol) {
     if (this.loadedmetadata) {
       // wait for metadata
+      this._ensureCanvas();
       p5.Renderer2D.prototype.set.call(this, x, y, imgOrCol);
       this.setModified(true);
     }
   };
   p5.MediaElement.prototype.copy = function() {
+    this._ensureCanvas();
     p5.Renderer2D.prototype.copy.apply(this, arguments);
   };
   p5.MediaElement.prototype.mask = function() {


### PR DESCRIPTION
fixes #3153 

yet another confusion between `this.canvas` and `this.elt`

~~IMHO, since the Renderers (and `p5` itself) _are_ `instanceof p5.Element` we should remove those classes' `this.canvas` properties and change all the code to use the `p5.Element.elt` variable. having two variables (sometimes) that serve the same purpose requires code like this:~~
 https://github.com/processing/p5.js/blob/5a46133fdc3e8c42fda1c1888864cf499940d86d/src/core/p5.Renderer2D.js#L112
https://github.com/processing/p5.js/blob/5a46133fdc3e8c42fda1c1888864cf499940d86d/src/image/pixels.js#L408
https://github.com/processing/p5.js/blob/5a46133fdc3e8c42fda1c1888864cf499940d86d/src/webgl/p5.Texture.js#L60
