### PR TITLE
remove unnecessary line

### DIFF
--- a/src/core/p5.Renderer.js
+++ b/src/core/p5.Renderer.js
@@ -24,7 +24,6 @@ var constants = require('../core/constants');
 p5.Renderer = function(elt, pInst, isMainCanvas) {
   p5.Element.call(this, elt, pInst);
   this.canvas = elt;
-  this._pInst = pInst;
   if (isMainCanvas) {
     this._isMainCanvas = true;
     // for pixel method sharing with pimage


### PR DESCRIPTION
`this._pInst` is set in the `p5.Element` constructor.