### PR TITLE
Instance mode calls global

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -2,16 +2,13 @@
   "env": {
     "node": true,
     "browser": true,
-    "mocha": true,
     "amd": true,
     "es6": true
   },
   "globals": {
-    "p5": true,
-    "assert": true,
-    "expect": true,
-    "sinon": true
+    "p5": true
   },
+  "root": true,
   "extends": ["eslint:recommended", "prettier"],
   "plugins": ["prettier"],
   "parserOptions": {

--- a/src/core/main.js
+++ b/src/core/main.js
@@ -48,7 +48,7 @@ var p5 = function(sketch, node, sync) {
 
   /**
    * Called directly before <a href="#/p5/setup">setup()</a>, the <a href="#/p5/preload">preload()</a> function is used to handle
-   * asynchronous loading of external files in a blocking way. If a preload 
+   * asynchronous loading of external files in a blocking way. If a preload
    * function is defined, <a href="#/p5/setup">setup()</a> will wait until any load calls within have
    * finished. Nothing besides load calls (<a href="#/p5/loadImage">loadImage</a>, <a href="#/p5/loadJSON">loadJSON</a>, <a href="#/p5/loadFont">loadFont</a>,
    * <a href="#/p5/loadStrings">loadStrings</a>, etc.) should be inside the preload function. If asynchronous
@@ -238,7 +238,8 @@ var p5 = function(sketch, node, sync) {
       }
     }
 
-    var userPreload = this.preload || window.preload; // look for "preload"
+    var context = this._isGlobal ? window : this;
+    var userPreload = context.preload;
     if (userPreload) {
       // Setup loading screen
       // Set loading screen into dom if not present
@@ -252,11 +253,11 @@ var p5 = function(sketch, node, sync) {
         var node = this._userNode || document.body;
         node.appendChild(loadingScreen);
       }
-      // var methods = this._preloadMethods;
-      for (var method in this._preloadMethods) {
+      var methods = this._preloadMethods;
+      for (var method in methods) {
         // default to p5 if no object defined
-        this._preloadMethods[method] = this._preloadMethods[method] || p5;
-        var obj = this._preloadMethods[method];
+        methods[method] = methods[method] || p5;
+        var obj = methods[method];
         //it's p5, check if it's global or instance
         if (obj === p5.prototype || obj === p5) {
           if (this._isGlobal) {

--- a/src/core/structure.js
+++ b/src/core/structure.js
@@ -313,25 +313,25 @@ p5.prototype.redraw = function(n) {
     numberOfRedraws = 1;
   }
 
-  var userSetup = this.setup || window.setup;
-  var userDraw = this.draw || window.draw;
+  var context = this._isGlobal ? window : this;
+  var userSetup = context.setup;
+  var userDraw = context.draw;
   if (typeof userDraw === 'function') {
     if (typeof userSetup === 'undefined') {
-      this.scale(this._pixelDensity, this._pixelDensity);
+      context.scale(context._pixelDensity, context._pixelDensity);
     }
-    var self = this;
     var callMethod = function(f) {
-      f.call(self);
+      f.call(context);
     };
     for (var idxRedraw = 0; idxRedraw < numberOfRedraws; idxRedraw++) {
-      this.resetMatrix();
-      if (this._renderer.isP3D) {
-        this._renderer._update();
+      context.resetMatrix();
+      if (context._renderer.isP3D) {
+        context._renderer._update();
       }
-      this._setProperty('frameCount', this.frameCount + 1);
-      this._registeredMethods.pre.forEach(callMethod);
+      context._setProperty('frameCount', context.frameCount + 1);
+      context._registeredMethods.pre.forEach(callMethod);
       userDraw();
-      this._registeredMethods.post.forEach(callMethod);
+      context._registeredMethods.post.forEach(callMethod);
     }
   }
 };

--- a/test/.eslintrc
+++ b/test/.eslintrc
@@ -7,6 +7,9 @@
     "sinon": false,
     "expect": false,
     "promisedSketch": true,
-    "testSketchWithPromise": true
+    "testSketchWithPromise": true,
+    "createP5Iframe": true,
+    "P5_SCRIPT_URL": true,
+    "P5_SCRIPT_TAG": true
   }
 }

--- a/test/.eslintrc
+++ b/test/.eslintrc
@@ -1,0 +1,12 @@
+{
+  "env": {
+    "mocha": true
+  },
+  "globals": {
+    "assert": false,
+    "sinon": false,
+    "expect": false,
+    "promisedSketch": true,
+    "testSketchWithPromise": true
+  }
+}

--- a/test/js/p5_helpers.js
+++ b/test/js/p5_helpers.js
@@ -10,7 +10,7 @@ function promisedSketch(sketch_fn) {
     myInstance.remove();
   });
   return promise;
-};
+}
 
 function testSketchWithPromise(name, sketch_fn) {
   var test_fn = function() {
@@ -20,4 +20,27 @@ function testSketchWithPromise(name, sketch_fn) {
     return sketch_fn.toString();
   };
   return test(name, test_fn);
-};
+}
+
+var P5_SCRIPT_URL = '../../lib/p5.js';
+var P5_SCRIPT_TAG = '<script src="' + P5_SCRIPT_URL + '"></script>';
+
+function createP5Iframe(html) {
+  html = html || P5_SCRIPT_TAG;
+
+  var elt = document.createElement('iframe');
+
+  document.body.appendChild(elt);
+  elt.setAttribute('style', 'visibility: hidden');
+
+  elt.contentDocument.open();
+  elt.contentDocument.write(html);
+  elt.contentDocument.close();
+
+  return {
+    elt: elt,
+    teardown: function() {
+      elt.parentNode.removeChild(elt);
+    }
+  };
+}

--- a/test/unit/core/core.js
+++ b/test/unit/core/core.js
@@ -127,34 +127,19 @@ suite('Core', function() {
   });
 
   suite('new p5() / global mode', function() {
-    var P5_SCRIPT_URL = '../../lib/p5.js';
-    var P5_SCRIPT_TAG = '<script src="' + P5_SCRIPT_URL + '"></script>';
     var iframe;
-
-    function createP5Iframe(html) {
-      html = html || P5_SCRIPT_TAG;
-
-      iframe = document.createElement('iframe');
-
-      document.body.appendChild(iframe);
-      iframe.setAttribute('style', 'visibility: hidden');
-
-      iframe.contentDocument.open();
-      iframe.contentDocument.write(html);
-      iframe.contentDocument.close();
-    }
 
     teardown(function() {
       if (iframe) {
-        iframe.parentNode.removeChild(iframe);
+        iframe.teardown();
         iframe = null;
       }
     });
 
     test('is triggered when "setup" is in window', function() {
       return new Promise(function(resolve, reject) {
-        createP5Iframe();
-        iframe.contentWindow.setup = function() {
+        iframe = createP5Iframe();
+        iframe.elt.contentWindow.setup = function() {
           resolve();
         };
       });
@@ -162,8 +147,8 @@ suite('Core', function() {
 
     test('is triggered when "draw" is in window', function() {
       return new Promise(function(resolve, reject) {
-        createP5Iframe();
-        iframe.contentWindow.draw = function() {
+        iframe = createP5Iframe();
+        iframe.elt.contentWindow.draw = function() {
           resolve();
         };
       });
@@ -171,7 +156,7 @@ suite('Core', function() {
 
     test('works when p5.js is loaded asynchronously', function() {
       return new Promise(function(resolve, reject) {
-        createP5Iframe(`
+        iframe = createP5Iframe(`
           <script>
             window.onload = function() {
               var script = document.createElement('script');
@@ -181,13 +166,13 @@ suite('Core', function() {
             }
           </script>`);
 
-        iframe.contentWindow.setup = resolve;
+        iframe.elt.contentWindow.setup = resolve;
       });
     });
 
     test('works on-demand', function() {
       return new Promise(function(resolve, reject) {
-        createP5Iframe(
+        iframe = createP5Iframe(
           [
             P5_SCRIPT_TAG,
             '<script>',
@@ -199,9 +184,9 @@ suite('Core', function() {
             '</script>'
           ].join('\n')
         );
-        iframe.contentWindow.onDoneLoading = resolve;
+        iframe.elt.contentWindow.onDoneLoading = resolve;
       }).then(function() {
-        var win = iframe.contentWindow;
+        var win = iframe.elt.contentWindow;
         assert.equal(typeof win.myURL, 'string');
         assert.strictEqual(win.setupCalled, true);
         assert.strictEqual(win.originalP5Instance, win.p5.instance);

--- a/test/unit/core/structure.js
+++ b/test/unit/core/structure.js
@@ -258,7 +258,16 @@ suite('Structure', function() {
     });
   });
 
-  suite('p5.prototype.redraw', function() {
+  suite.only('p5.prototype.redraw', function() {
+    var iframe;
+
+    teardown(function() {
+      if (iframe) {
+        iframe.teardown();
+        iframe = null;
+      }
+    });
+
     test('resets the rendering matrix between frames', function() {
       return new Promise(function(resolve, reject) {
         myp5.draw = function() {
@@ -272,6 +281,34 @@ suite('Structure', function() {
         };
         myp5.redraw(10);
         resolve();
+      });
+    });
+
+    test('instance redraw is independent of window', function() {
+      // callback for p5 instance mode.
+      // It does not call noLoop so redraw will be called many times.
+      // Redraw is not supposed to call window.draw even though no draw is defined in cb
+      function cb(s) {
+        s.setup = function() {
+          setTimeout(window.afterSetup, 1000);
+        };
+      }
+      return new Promise(function(resolve) {
+        iframe = createP5Iframe(
+          [
+            P5_SCRIPT_TAG,
+            '<script>',
+            'globalDraws = 0;',
+            'function setup() { noLoop(); }',
+            'function draw() { window.globalDraws++; }',
+            'new p5(' + cb.toString() + ');',
+            '</script>'
+          ].join('\n')
+        );
+        iframe.elt.contentWindow.afterSetup = resolve;
+      }).then(function() {
+        var win = iframe.elt.contentWindow;
+        assert.strictEqual(win.globalDraws, 1);
       });
     });
   });


### PR DESCRIPTION
The first two commits clean up JSHint / ESLint files.
`createP5Iframe` is needed in the tests I've added so I made it accessible for all tests in the third commit.
The fourth commit tests the problem described in #2999 and the last commit make the tests green again.