### PR TITLE
Rework asynchronous loading test to remove logs

### DIFF
--- a/test/unit/core/core.js
+++ b/test/unit/core/core.js
@@ -171,22 +171,17 @@ suite('Core', function() {
 
     test('works when p5.js is loaded asynchronously', function() {
       return new Promise(function(resolve, reject) {
-        createP5Iframe();
+        createP5Iframe(`
+          <script>
+            window.onload = function() {
+              var script = document.createElement('script');
+              script.setAttribute('src', '${P5_SCRIPT_URL}');
 
-        iframe.contentWindow.addEventListener(
-          'load',
-          function() {
-            var win = iframe.contentWindow;
+              document.body.appendChild(script);
+            }
+          </script>`);
 
-            win.setup = resolve;
-
-            var script = win.document.createElement('script');
-            script.setAttribute('src', P5_SCRIPT_URL);
-
-            win.document.body.appendChild(script);
-          },
-          false
-        );
+        iframe.contentWindow.setup = resolve;
       });
     });
 


### PR DESCRIPTION
Fixes #3093

Many thanks to @Zalastax for basically solving it, so I have added them as a co-author. The issue is likely due to some cross frame issues with the way attaching handlers works (interestingly the code they came up with was working fine in an actual browser for me). I re-coded the test in a way more similar to the other tests and it appears to work. 