### PR TITLE
fix _pixelsDirty

### DIFF
--- a/src/color/setting.js
+++ b/src/color/setting.js
@@ -179,6 +179,7 @@ p5.prototype.background = function() {
   } else {
     this._renderer.background.apply(this._renderer, arguments);
   }
+  this._pixelsDirty = true;
   return this;
 };
 
@@ -217,6 +218,7 @@ p5.prototype.background = function() {
 
 p5.prototype.clear = function() {
   this._renderer.clear();
+  this._pixelsDirty = true;
   return this;
 };
 

--- a/src/core/p5.Renderer2D.js
+++ b/src/core/p5.Renderer2D.js
@@ -60,8 +60,6 @@ p5.Renderer2D.prototype.background = function() {
     this._setFill(curFill);
   }
   this.drawingContext.restore();
-
-  this._pInst._pixelsDirty = true;
 };
 
 p5.Renderer2D.prototype.clear = function() {
@@ -69,8 +67,6 @@ p5.Renderer2D.prototype.clear = function() {
   this.resetMatrix();
   this.drawingContext.clearRect(0, 0, this.width, this.height);
   this.drawingContext.restore();
-
-  this._pInst._pixelsDirty = true;
 };
 
 p5.Renderer2D.prototype.fill = function() {
@@ -131,8 +127,6 @@ p5.Renderer2D.prototype.image = function(
       throw e;
     }
   }
-
-  this._pInst._pixelsDirty = true;
 };
 
 p5.Renderer2D.prototype._getTintedImageCanvas = function(img) {
@@ -209,6 +203,7 @@ p5.Renderer2D.prototype.copy = function() {
   }
   p5.Renderer2D._copyHelper(this, srcImage, sx, sy, sw, sh, dx, dy, dw, dh);
 
+  // this is done here because this method is re-used by Image etc.
   this._pInst._pixelsDirty = true;
 };
 
@@ -976,7 +971,6 @@ p5.Renderer2D.prototype.endShape = function(
     vertices.pop();
   }
 
-  this._pInst._pixelsDirty = true;
   return this;
 };
 //////////////////////////////////////////////
@@ -1091,8 +1085,7 @@ p5.Renderer2D.prototype._doFillStrokeClose = function() {
   if (this._doStroke) {
     this.drawingContext.stroke();
   }
-
-  this._pInst._pixelsDirty = true;
+  this.drawingContext.closePath();
 };
 
 //////////////////////////////////////////////
@@ -1200,7 +1193,6 @@ p5.Renderer2D.prototype._renderText = function(p, line, x, y, maxY) {
 
   p.pop();
 
-  this._pInst._pixelsDirty = true;
   return p;
 };
 

--- a/src/core/shape/2d_primitives.js
+++ b/src/core/shape/2d_primitives.js
@@ -142,6 +142,7 @@ p5.prototype.arc = function(x, y, w, h, start, stop, mode, detail) {
 
   var vals = canvas.modeAdjust(x, y, w, h, this._renderer._ellipseMode);
   this._renderer.arc(vals.x, vals.y, vals.w, vals.h, start, stop, mode, detail);
+  this._pixelsDirty = true;
 
   return this;
 };
@@ -202,6 +203,7 @@ p5.prototype.ellipse = function(x, y, w, h, detailX) {
 
   var vals = canvas.modeAdjust(x, y, w, h, this._renderer._ellipseMode);
   this._renderer.ellipse([vals.x, vals.y, vals.w, vals.h, detailX]);
+  this._pixelsDirty = true;
 
   return this;
 };
@@ -287,6 +289,7 @@ p5.prototype.line = function() {
 
   if (this._renderer._doStroke) {
     this._renderer.line.apply(this._renderer, arguments);
+    this._pixelsDirty = true;
   }
 
   return this;
@@ -322,6 +325,7 @@ p5.prototype.point = function() {
 
   if (this._renderer._doStroke) {
     this._renderer.point.apply(this._renderer, arguments);
+    this._pixelsDirty = true;
   }
 
   return this;
@@ -376,6 +380,7 @@ p5.prototype.quad = function() {
 
   if (this._renderer._doStroke || this._renderer._doFill) {
     this._renderer.quad.apply(this._renderer, arguments);
+    this._pixelsDirty = true;
   }
 
   return this;
@@ -459,6 +464,7 @@ p5.prototype.rect = function() {
       args[i] = arguments[i];
     }
     this._renderer.rect(args);
+    this._pixelsDirty = true;
   }
 
   return this;
@@ -550,6 +556,7 @@ p5.prototype.triangle = function() {
 
   if (this._renderer._doStroke || this._renderer._doFill) {
     this._renderer.triangle(arguments);
+    this._pixelsDirty = true;
   }
 
   return this;

--- a/src/core/shape/curves.js
+++ b/src/core/shape/curves.js
@@ -89,6 +89,7 @@ p5.prototype.bezier = function() {
   }
 
   this._renderer.bezier.apply(this._renderer, arguments);
+  this._pixelsDirty = true;
 
   return this;
 };
@@ -356,6 +357,7 @@ p5.prototype.curve = function() {
 
   if (this._renderer._doStroke) {
     this._renderer.curve.apply(this._renderer, arguments);
+    this._pixelsDirty = true;
   }
 
   return this;

--- a/src/core/shape/vertex.js
+++ b/src/core/shape/vertex.js
@@ -648,6 +648,7 @@ p5.prototype.endShape = function(mode) {
       vertices.pop();
     }
   }
+  this._pixelsDirty = true;
   return this;
 };
 

--- a/src/image/loading_displaying.js
+++ b/src/image/loading_displaying.js
@@ -293,6 +293,7 @@ p5.prototype.image = function(
 
   // tint the image if there is a tint
   this._renderer.image(img, _sx, _sy, _sw, _sh, vals.x, vals.y, vals.w, vals.h);
+  this._pixelsDirty = true;
 };
 
 /**

--- a/src/typography/loading_displaying.js
+++ b/src/typography/loading_displaying.js
@@ -222,9 +222,11 @@ p5.prototype.loadFont = function(path, onSuccess, onError) {
  */
 p5.prototype.text = function(str, x, y, maxWidth, maxHeight) {
   p5._validateParameters('text', arguments);
-  return !(this._renderer._doFill || this._renderer._doStroke)
-    ? this
-    : this._renderer.text.apply(this._renderer, arguments);
+  if (this._renderer._doFill || this._renderer._doStroke) {
+    this._renderer.text.apply(this._renderer, arguments);
+    this._pixelsDirty = true;
+  }
+  return this;
 };
 
 /**

--- a/src/webgl/text.js
+++ b/src/webgl/text.js
@@ -733,6 +733,5 @@ p5.RendererGL.prototype._renderText = function(p, line, x, y, maxY) {
     p.pop();
   }
 
-  this._pInst._pixelsDirty = true;
   return p;
 };


### PR DESCRIPTION
closes #3191 

this ensures that the `_pixelsDirty` flag is set after all drawing calls. some of the existing code has been moved out of Renderer2d and into the top-level p5 methods in order to reduce code duplication between renderers.