### PR TITLE
travis: test on node 8 and 10

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 language: node_js
 node_js:
-  - "8.9"
+  - "8"
+  - "10"
 addons:
   chrome: stable
 install: npm install


### PR DESCRIPTION
I think now it's pretty much the norm to test on the two main node.js branches like this, which are currently 8.x and 10.x.