### PR TITLE
Fix command line copy mistake

### DIFF
--- a/tasks/release/release-docs.js
+++ b/tasks/release/release-docs.js
@@ -38,7 +38,7 @@ module.exports = function(grunt) {
           console.log('Copying new docs ...');
           return new Promise(function(resolve, reject) {
             exec(
-              'cp -r docs/reference/**/* p5-website/src/templates/pages/reference/',
+              'cp -r docs/reference/ p5-website/src/templates/pages/reference/',
               function(err, stdout, stderr) {
                 if (err) {
                   reject(err);


### PR DESCRIPTION
Closes  #3190 

A mistake I made in https://github.com/processing/p5.js/commit/3c944907a1e4794d8bf46f5de7924eef49805d76 which cause the reference to not be copied over to the website repo. After merging this the release step for the documentation should be run to update the reference which by now should be 3 months out of date. 😨 