### PR TITLE
avoid attachListener when disabling default drag/drop behavior

### DIFF
--- a/src/core/p5.Element.js
+++ b/src/core/p5.Element.js
@@ -1001,26 +1001,22 @@ p5.Element.prototype.drop = function(callback, fxn) {
 
   // Is the file stuff supported?
   if (window.File && window.FileReader && window.FileList && window.Blob) {
-    // If you want to be able to drop you've got to turn off
-    // a lot of default behavior
-    attachListener(
-      'dragover',
-      function(evt) {
-        evt.stopPropagation();
-        evt.preventDefault();
-      },
-      this
-    );
+    if (!this._dragDisabled) {
+      this._dragDisabled = true;
 
-    // If this is a drag area we need to turn off the default behavior
-    attachListener(
-      'dragleave',
-      function(evt) {
-        evt.stopPropagation();
+      var preventDefault = function(evt) {
+        //evt.stopPropagation();
         evt.preventDefault();
-      },
-      this
-    );
+      };
+
+      // If you want to be able to drop you've got to turn off
+      // a lot of default behavior.
+      // avoid `attachListener` here, since it overrides other handlers.
+      this.elt.addEventListener('dragover', preventDefault);
+
+      // If this is a drag area we need to turn off the default behavior
+      this.elt.addEventListener('dragleave', preventDefault);
+    }
 
     // Attach the second argument as a callback that receives the raw drop event
     if (typeof fxn !== 'undefined') {
@@ -1031,7 +1027,7 @@ p5.Element.prototype.drop = function(callback, fxn) {
     attachListener(
       'drop',
       function(evt) {
-        evt.stopPropagation();
+        //evt.stopPropagation();
         evt.preventDefault();
 
         // A FileList

--- a/src/core/p5.Element.js
+++ b/src/core/p5.Element.js
@@ -1005,7 +1005,6 @@ p5.Element.prototype.drop = function(callback, fxn) {
       this._dragDisabled = true;
 
       var preventDefault = function(evt) {
-        //evt.stopPropagation();
         evt.preventDefault();
       };
 
@@ -1027,7 +1026,6 @@ p5.Element.prototype.drop = function(callback, fxn) {
     attachListener(
       'drop',
       function(evt) {
-        //evt.stopPropagation();
         evt.preventDefault();
 
         // A FileList


### PR DESCRIPTION
closes #3208

this PR does two things (in `p5.Element.prototype.drop()`):
- removes the calls to `stopPropagation()` in the 3 event handlers.
- avoids using `attachListener` when disabling the `dragover` and `dragleave` default behavior since these events may already have been set by the user and `attachListener` will un-register those event handlers.