### PR TITLE
Stalling `npm install` workaround

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ node_js:
   - "10"
 addons:
   chrome: stable
-install: npm install
+install: for i in {1..3}; do travis_wait 5 npm install && break; rm -rf node_modules; done
 before_script:
   - sed -i 's/'"'"'--disable-gpu'"'"',//g' node_modules/mocha-chrome/lib/instance.js
   - sed -i 's/options.logLevel/"verbose"/g' node_modules/mocha-chrome/lib/instance.js


### PR DESCRIPTION
Suggestions from Travis CI to make your builds more stable.

Retry npm install up to 3 times and prevent it from stalling using the travis_wait utility function.