### PR TITLE
p5.XML implementation rework and httpPost support for p5.XML

### DIFF
--- a/src/io/files.js
+++ b/src/io/files.js
@@ -667,7 +667,7 @@ function makeObject(row, headers) {
  *
  */
 p5.prototype.loadXML = function() {
-  var ret = {};
+  var ret = new p5.XML();
   var callback, errorCallback;
 
   for (var i = 1; i < arguments.length; i++) {
@@ -1093,6 +1093,9 @@ p5.prototype.httpDo = function() {
           for (var attr in a) {
             jsonpOptions[attr] = a[attr];
           }
+        } else if (a instanceof p5.XML) {
+          data = a.serialize();
+          contentType = 'application/xml';
         } else {
           data = JSON.stringify(a);
           contentType = 'application/json';

--- a/src/io/files.js
+++ b/src/io/files.js
@@ -600,29 +600,6 @@ function makeObject(row, headers) {
   return ret;
 }
 
-function parseXML(two) {
-  var one = new p5.XML();
-  var children = two.childNodes;
-  if (children && children.length) {
-    for (var i = 0; i < children.length; i++) {
-      var node = parseXML(children[i]);
-      one.addChild(node);
-    }
-    one.setName(two.nodeName);
-    one._setCont(two.textContent);
-    one._setAttributes(two);
-    for (var j = 0; j < one.children.length; j++) {
-      one.children[j].parent = one;
-    }
-    return one;
-  } else {
-    one.setName(two.nodeName);
-    one._setCont(two.textContent);
-    one._setAttributes(two);
-    return one;
-  }
-}
-
 /**
  * Reads the contents of a file and creates an XML object with its values.
  * If the name of the file is used as the parameter, as in the above example,
@@ -1177,7 +1154,7 @@ p5.prototype.httpDo = function() {
           return res.text().then(function(text) {
             var parser = new DOMParser();
             var xml = parser.parseFromString(text, 'text/xml');
-            return parseXML(xml.documentElement);
+            return new p5.XML(xml.documentElement);
           });
         default:
           return res.text();

--- a/src/io/p5.XML.js
+++ b/src/io/p5.XML.js
@@ -836,4 +836,35 @@ p5.XML.prototype.setContent = function(content) {
   }
 };
 
+/**
+ * Serializes the element into a string. This function is useful for preparing
+ * the content to be sent over a http request or saved to file.
+ *
+ * @method serialize
+ * @return {String} Serialized string of the element
+ * @example
+ * <div class='norender'><code>
+ * var xml;
+ *
+ * function preload() {
+ *   xml = loadXML('assets/mammals.xml');
+ * }
+ *
+ * function setup() {
+ *   print(xml.serialize());
+ * }
+ *
+ * // Sketch prints:
+ * // <mammals>
+ * //   <animal id="0" species="Capra hircus">Goat</animal>
+ * //   <animal id="1" species="Panthera pardus">Leopard</animal>
+ * //   <animal id="2" species="Equus zebra">Zebra</animal>
+ * // </mammals>
+ * </code></div>
+ */
+p5.XML.prototype.serialize = function() {
+  var xmlSerializer = new XMLSerializer();
+  return xmlSerializer.serializeToString(this.DOM);
+};
+
 module.exports = p5;


### PR DESCRIPTION
Closes  #3170 

Also as part of #3189 the implementation now completely mirrors original public API implementation so there is no breaking change.

A few differences from original implementation: `setAttribute` will not check for attribute existence before setting it; and object will now only have the `DOM` property while all the functions are just querying the DOM property.

Passing a p5.XML object to httpPost to be sent to the server will also serialize the XML and set content type as `application/xml`. The return object from `loadXML` wasn't an instance of p5.XML but it has been fixed so that it does return an instance of p5.XML.

