### PR TITLE
fix creation of temporary image

### DIFF
--- a/lib/addons/p5.dom.js
+++ b/lib/addons/p5.dom.js
@@ -2692,10 +2692,10 @@
       }
 
       return p5.Renderer2D.prototype.get.call(this, x, y, w, h);
-    } else if (typeof x === 'undefined') {
+    } else if (typeof w === 'undefined' || typeof h === 'undefined') {
       return new p5.Image(1, 1);
     } else if (w > 1) {
-      return new p5.Image(x, y, w, h);
+      return new p5.Image(w, h);
     } else {
       return [0, 0, 0, 255];
     }


### PR DESCRIPTION
closes #3051
- fix parameters passed to `p5.Image` constructor
- improve check for valid `w`/`h` parameters