### PR TITLE
fix travis build random build failures

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,3 +10,4 @@ before_script:
   - sed -i 's/options.logLevel/"verbose"/g' node_modules/mocha-chrome/lib/instance.js
 script: npm run grunt
 sudo: false
+services: docker


### PR DESCRIPTION
this causes travis to build on GCE instead of in a docker instance, which I believe is what's responsible for the random build errors.

i have run a bunch of test builds on travis and haven't seen a single error. not conclusive, but this will probably work.