### PR TITLE
Line 20 (Tutorial) Typo Fix

### DIFF
--- a/lib/addons/p5.dom.js
+++ b/lib/addons/p5.dom.js
@@ -17,7 +17,7 @@
  * <a href='https://raw.githubusercontent.com/lmccart/p5.js/master/lib/addons/p5.dom.js'>
  * here</a>.</p>
  * <p>See <a href='https://github.com/processing/p5.js/wiki/Beyond-the-canvas'>tutorial: beyond the canvas</a>
- * for more info on how to use this libary.</a>
+ * for more info on how to use this library.</a>
  *
  * @module p5.dom
  * @submodule p5.dom


### PR DESCRIPTION
The word 'library' was misspelled (was 'libary')