### PR TITLE
Added info in docs of textBounds() #3251

### DIFF
--- a/src/typography/p5.Font.js
+++ b/src/typography/p5.Font.js
@@ -48,8 +48,11 @@ p5.Font.prototype.list = function() {
  * @param  {String} line     a line of text
  * @param  {Number} x        x-position
  * @param  {Number} y        y-position
- * @param  {Number} [fontSize] font size to use (optional)
+ * @param  {Number} [fontSize] font size to use (optional) Default is 12.
  * @param  {Object} [options] opentype options (optional)
+ *                            opentype fonts contains alignment and baseline options.
+ *                            Default is 'LEFT' and 'alphabetic'
+ *
  *
  * @return {Object}          a rectangle object with properties: x, y, w, h
  *


### PR DESCRIPTION
This commit covers 1. of the #3251.

The `textBounds(line, x, y, [fontSize], [options])` has two optional parameters `fontSize` and `options` . This commit includes the description of default value of `fontSize` i.e. 12 and `options` i.e. 'LEFT' for text alignment and 'alphabetic' for baseline.
