### PR TITLE
Finer grain copying of docs files to website

### DIFF
--- a/tasks/release/release-docs.js
+++ b/tasks/release/release-docs.js
@@ -38,7 +38,7 @@ module.exports = function(grunt) {
           console.log('Copying new docs ...');
           return new Promise(function(resolve, reject) {
             exec(
-              'cp -r docs/reference/ p5-website/src/templates/pages/reference/',
+              'cp -r docs/reference/{data.json,data.min.json,assets} p5-website/src/templates/pages/reference/',
               function(err, stdout, stderr) {
                 if (err) {
                   reject(err);


### PR DESCRIPTION
Works in conjucntion with https://github.com/processing/p5.js-website/pull/291

Simply cleans up the copying step of the `release-docs` task. Any future update for the docs can simple run `grunt release-docs` and any relevant files should be updated automatically.