### PR TITLE
Changed in release-docs grunt task

### DIFF
--- a/developer_docs/release_process.md
+++ b/developer_docs/release_process.md
@@ -5,6 +5,7 @@
 
 
 ## Requirements
+* Operating System: macOS, Linux or Unix. _(For Windows see at the end of this document)_
 * Logged in NPM CLI : Check if you are logged in by `npm whoami`
 * High Bandwidth : Lots of things to download/pull/push (~190 MB total I presume)
 * An environment variable named __GITHUB_TOKEN__ with the value of your Access Token : Make one by going [here](https://github.com/settings/tokens). Once you have it, in your shell, run `export GITHUB_TOKEN=<your token here>`.
@@ -30,8 +31,11 @@ A Grunt Task uses sub tasks to draft and cut a release end-to-end :
 * Upload the Library files and the ZIP file to the GitHub Release.
 
 ## Testing
-Now you can simply edit up a few config vars with your own creds to point the releases at them instead of processing. 
+Now you can simply edit up a few configuration variables with your own credentials to point the releases at them, instead of processing.
 
 In [tasks/release/release-p5.js](https://github.com/processing/p5.js/blob/master/tasks/release/release-p5.js),
-* Update L#60 till L#62 to mention your forks instead of this upstream.
-* Uncomment L#55 to set dry run as true for testing.
+* Update [Line #60](https://github.com/processing/p5.js/blob/master/tasks/release/release-p5.js#L60) till [Line #62](https://github.com/processing/p5.js/blob/master/tasks/release/release-p5.js#L62) to mention your forks instead of this upstream.
+* Uncomment [Line #55](https://github.com/processing/p5.js/blob/master/tasks/release/release-p5.js#L55) to set dry run as true for testing.
+
+## Note for Windows users
+The release process contains many shell commands that may not run or work expectedly on Windows environment. It is recommended to have linux/unix environment running, however you can use [Windows Subsystem for Linux](https://docs.microsoft.com/en-us/windows/wsl/install-win10) which works on Windows 10 Anniversary update onwards (only 64-bit). If you are on Lower version of Windows you can use [Cygwin](https://www.cygwin.com/) or use [Virtual Box](https://www.virtualbox.org/) (or any other preferred virtualization tool) to run Linux.

--- a/tasks/release/release-docs.js
+++ b/tasks/release/release-docs.js
@@ -35,10 +35,12 @@ module.exports = function(grunt) {
       })
         .then(function() {
           // Copy the new docs over
+          const src = 'docs/reference';
+          const dest = 'p5-website/src/templates/pages/reference/';
           console.log('Copying new docs ...');
           return new Promise(function(resolve, reject) {
             exec(
-              'cp -r docs/reference/{data.json,data.min.json,assets} p5-website/src/templates/pages/reference/',
+              `(cp ${src}/data.json ${dest}) && (cp ${src}/data.json ${dest}) && (cp -r ${src}/assets ${dest})`,
               function(err, stdout, stderr) {
                 if (err) {
                   reject(err);

--- a/tasks/release/release-docs.js
+++ b/tasks/release/release-docs.js
@@ -69,12 +69,14 @@ module.exports = function(grunt) {
                 if (stderr) {
                   reject(stderr);
                 }
-                console.log('Released Docs on Website!');
                 resolve();
-                done();
               }
             );
           });
+        })
+        .then(function() {
+          console.log('Released Docs on Website!');
+          done();
         })
         .catch(function(err) {
           throw new Error(err);

--- a/tasks/release/release-docs.js
+++ b/tasks/release/release-docs.js
@@ -40,7 +40,7 @@ module.exports = function(grunt) {
           console.log('Copying new docs ...');
           return new Promise(function(resolve, reject) {
             exec(
-              `(cp ${src}/data.json ${dest}) && (cp ${src}/data.json ${dest}) && (cp -r ${src}/assets ${dest})`,
+              `(cp ${src}/data.json ${src}/data.min.json ${dest}) && (cp -r ${src}/assets ${dest})`,
               function(err, stdout, stderr) {
                 if (err) {
                   reject(err);


### PR DESCRIPTION
1. In the task to copy files the error of `No such file or directory` happened everytime even the files were there (and the commands runs perfectly when done manually).
I couldn't find the exact reason for the errors. But now the given solution works. 
2. In the last promise chain even if the error occurs the `console.log('Released on Github')`.

_Error:_
![deepinscreenshot_select-area_20181122041052](https://user-images.githubusercontent.com/26515826/48873374-83556080-ee13-11e8-8041-4b06a6e8841e.png)

_Update:_ 
The reason for the error is due the default shell that node child_process api uses is `sh` shell and `sh` shell due to its less feature set is not supporting the copying multiple files using `{file1, file2, file3}` this format. Thus new grunt file changes will target every user either using macos or linux.