### PR TITLE
3d rendered bezier curve args get overwritten, fixes #3344

### DIFF
--- a/src/webgl/3d_primitives.js
+++ b/src/webgl/3d_primitives.js
@@ -7,7 +7,6 @@
  */
 
 'use strict';
-
 var p5 = require('../core/main');
 require('./p5.Geometry');
 var constants = require('../core/constants');
@@ -1081,15 +1080,14 @@ p5.RendererGL.prototype.bezier = function(
   z4
 ) {
   if (arguments.length === 8) {
-    x4 = x3;
     y4 = y3;
+    x4 = x3;
+    y3 = z2;
     x3 = y2;
-    y3 = x2;
-    x2 = z1;
     y2 = x2;
+    x2 = z1;
     z1 = z2 = z3 = z4 = 0;
   }
-
   var bezierDetail = this._pInst._bezierDetail || 20; //value of Bezier detail
   this.beginShape();
   for (var i = 0; i <= bezierDetail; i++) {


### PR DESCRIPTION
Reorder argument setting to bezier in 3d mode, so original arg values aren't overwritten.

In the code below:
https://github.com/processing/p5.js/blob/master/src/webgl/3d_primitives.js#L1088
`x2` should = `z1`, but assigning `y2 = x2` afterwards is basically assigning `y2 = z1`.

 Demoing the bug:

<img width="817" alt="screen shot 2018-11-26 at 10 12 09 am" src="https://user-images.githubusercontent.com/92090/49023036-4c10e780-f164-11e8-8fcb-9d1bfc75c1fc.png">

Having a bezier with all `z` coords set to `0` should result in the same curve as a bezier with no `z`;

Like this (with changes from this branch):
<img width="778" alt="screen shot 2018-11-26 at 10 09 13 am" src="https://user-images.githubusercontent.com/92090/49023135-7a8ec280-f164-11e8-8da2-9aa9437609cd.png">
