### PR TITLE
fix `npm run dev`

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "scripts": {
     "grunt": "grunt",
     "build": "grunt build",
-    "dev": "grunt browserify connect open:dev watch:quick",
+    "dev": "grunt browserify connect:yui watch:quick",
     "docs": "grunt yui",
     "docs:dev": "grunt yui:dev",
     "test": "grunt",


### PR DESCRIPTION
recent package removal (specifically `open`) broke the `npm run dev` command which depended on that package. this removes that dependency and fixes that command.