### PR TITLE
Updated Image Reference Examples on p5js.org to ES6

### DIFF
--- a/src/image/image.js
+++ b/src/image/image.js
@@ -43,10 +43,10 @@ var p5 = require('../core/main');
  * @example
  * <div>
  * <code>
- * var img = createImage(66, 66);
+ * let img = createImage(66, 66);
  * img.loadPixels();
- * for (var i = 0; i < img.width; i++) {
- *   for (var j = 0; j < img.height; j++) {
+ * for (let i = 0; i < img.width; i++) {
+ *   for (let j = 0; j < img.height; j++) {
  *     img.set(i, j, color(0, 90, 102));
  *   }
  * }
@@ -57,10 +57,10 @@ var p5 = require('../core/main');
  *
  * <div>
  * <code>
- * var img = createImage(66, 66);
+ * let img = createImage(66, 66);
  * img.loadPixels();
- * for (var i = 0; i < img.width; i++) {
- *   for (var j = 0; j < img.height; j++) {
+ * for (let i = 0; i < img.width; i++) {
+ *   for (let j = 0; j < img.height; j++) {
  *     img.set(i, j, color(0, 90, 102, (i % img.width) * 2));
  *   }
  * }
@@ -72,12 +72,12 @@ var p5 = require('../core/main');
  *
  * <div>
  * <code>
- * var pink = color(255, 102, 204);
- * var img = createImage(66, 66);
+ * let pink = color(255, 102, 204);
+ * let img = createImage(66, 66);
  * img.loadPixels();
- * var d = pixelDensity();
- * var halfImage = 4 * (img.width * d) * (img.height / 2 * d);
- * for (var i = 0; i < halfImage; i += 4) {
+ * let d = pixelDensity();
+ * let halfImage = 4 * (img.width * d) * (img.height / 2 * d);
+ * for (let i = 0; i < halfImage; i += 4) {
  *   img.pixels[i] = red(pink);
  *   img.pixels[i + 1] = green(pink);
  *   img.pixels[i + 2] = blue(pink);
@@ -112,7 +112,7 @@ p5.prototype.createImage = function(width, height) {
  *  @example
  * <div class='norender notest'><code>
  * function setup() {
- *   var c = createCanvas(100, 100);
+ *   let c = createCanvas(100, 100);
  *   background(255, 0, 0);
  *   saveCanvas(c, 'myCanvas', 'jpg');
  * }
@@ -121,7 +121,7 @@ p5.prototype.createImage = function(width, height) {
  * // note that this example has the same result as above
  * // if no canvas is specified, defaults to main canvas
  * function setup() {
- *   var c = createCanvas(100, 100);
+ *   let c = createCanvas(100, 100);
  *   background(255, 0, 0);
  *   saveCanvas('myCanvas', 'jpg');
  *
@@ -225,7 +225,7 @@ p5.prototype.saveCanvas = function() {
  * }
  *
  * function mousePressed() {
- *   saveFrames('out', 'png', 1, 25, function(data) {
+ *   saveFrames('out', 'png', 1, 25, data => {
  *     print(data);
  *   });
  * }

--- a/src/image/loading_displaying.js
+++ b/src/image/loading_displaying.js
@@ -38,7 +38,7 @@ require('../core/error_helpers');
  * @example
  * <div>
  * <code>
- * var img;
+ * let img;
  * function preload() {
  *   img = loadImage('assets/laDefense.jpg');
  * }
@@ -51,7 +51,7 @@ require('../core/error_helpers');
  * <code>
  * function setup() {
  *   // here we use a callback to display the image after loading
- *   loadImage('assets/laDefense.jpg', function(img) {
+ *   loadImage('assets/laDefense.jpg', img => {
  *     image(img, 0, 0);
  *   });
  * }
@@ -148,7 +148,7 @@ function _sAssign(sVal, iVal) {
  * @example
  * <div>
  * <code>
- * var img;
+ * let img;
  * function preload() {
  *   img = loadImage('assets/laDefense.jpg');
  * }
@@ -161,7 +161,7 @@ function _sAssign(sVal, iVal) {
  * </div>
  * <div>
  * <code>
- * var img;
+ * let img;
  * function preload() {
  *   img = loadImage('assets/laDefense.jpg');
  * }
@@ -177,7 +177,7 @@ function _sAssign(sVal, iVal) {
  * <code>
  * function setup() {
  *   // Here, we use a callback to display the image after loading
- *   loadImage('assets/laDefense.jpg', function(img) {
+ *   loadImage('assets/laDefense.jpg', img => {
  *     image(img, 0, 0);
  *   });
  * }
@@ -185,7 +185,7 @@ function _sAssign(sVal, iVal) {
  * </div>
  * <div>
  * <code>
- * var img;
+ * let img;
  * function preload() {
  *   img = loadImage('assets/gradient.png');
  * }
@@ -319,7 +319,7 @@ p5.prototype.image = function(
  * @example
  * <div>
  * <code>
- * var img;
+ * let img;
  * function preload() {
  *   img = loadImage('assets/laDefense.jpg');
  * }
@@ -333,7 +333,7 @@ p5.prototype.image = function(
  *
  * <div>
  * <code>
- * var img;
+ * let img;
  * function preload() {
  *   img = loadImage('assets/laDefense.jpg');
  * }
@@ -347,7 +347,7 @@ p5.prototype.image = function(
  *
  * <div>
  * <code>
- * var img;
+ * let img;
  * function preload() {
  *   img = loadImage('assets/laDefense.jpg');
  * }
@@ -401,7 +401,7 @@ p5.prototype.tint = function() {
  * @example
  * <div>
  * <code>
- * var img;
+ * let img;
  * function preload() {
  *   img = loadImage('assets/bricks.jpg');
  * }
@@ -481,7 +481,7 @@ p5.prototype._getTintedImageCanvas = function(img) {
  *
  * <div>
  * <code>
- * var img;
+ * let img;
  * function preload() {
  *   img = loadImage('assets/bricks.jpg');
  * }
@@ -494,7 +494,7 @@ p5.prototype._getTintedImageCanvas = function(img) {
  *
  * <div>
  * <code>
- * var img;
+ * let img;
  * function preload() {
  *   img = loadImage('assets/bricks.jpg');
  * }
@@ -507,7 +507,7 @@ p5.prototype._getTintedImageCanvas = function(img) {
  *
  * <div>
  * <code>
- * var img;
+ * let img;
  * function preload() {
  *   img = loadImage('assets/bricks.jpg');
  * }

--- a/src/image/p5.Image.js
+++ b/src/image/p5.Image.js
@@ -38,28 +38,28 @@ var Filters = require('./filters');
  * @example
  * <div><code>
  * function setup() {
- *   var img = createImage(100, 100); // same as new p5.Image(100, 100);
+ *   let img = createImage(100, 100); // same as new p5.Image(100, 100);
  *   img.loadPixels();
  *   createCanvas(100, 100);
  *   background(0);
  *
  *   // helper for writing color to array
  *   function writeColor(image, x, y, red, green, blue, alpha) {
- *     var index = (x + y * width) * 4;
+ *     let index = (x + y * width) * 4;
  *     image.pixels[index] = red;
  *     image.pixels[index + 1] = green;
  *     image.pixels[index + 2] = blue;
  *     image.pixels[index + 3] = alpha;
  *   }
  *
- *   var x, y;
+ *   let x, y;
  *   // fill with random colors
  *   for (y = 0; y < img.height; y++) {
  *     for (x = 0; x < img.width; x++) {
- *       var red = random(255);
- *       var green = random(255);
- *       var blue = random(255);
- *       var alpha = 255;
+ *       let red = random(255);
+ *       let green = random(255);
+ *       let blue = random(255);
+ *       let alpha = 255;
  *       writeColor(img, x, y, red, green, blue, alpha);
  *     }
  *   }
@@ -93,7 +93,7 @@ p5.Image = function(width, height) {
    * @readOnly
    * @example
    * <div><code>
-   * var img;
+   * let img;
    * function preload() {
    *   img = loadImage('assets/rockies.jpg');
    * }
@@ -101,8 +101,8 @@ p5.Image = function(width, height) {
    * function setup() {
    *   createCanvas(100, 100);
    *   image(img, 0, 0);
-   *   for (var i = 0; i < img.width; i++) {
-   *     var c = img.get(i, img.height / 2);
+   *   for (let i = 0; i < img.width; i++) {
+   *     let c = img.get(i, img.height / 2);
    *     stroke(c);
    *     line(i, height / 2, i, height);
    *   }
@@ -120,7 +120,7 @@ p5.Image = function(width, height) {
    * @readOnly
    * @example
    * <div><code>
-   * var img;
+   * let img;
    * function preload() {
    *   img = loadImage('assets/rockies.jpg');
    * }
@@ -128,8 +128,8 @@ p5.Image = function(width, height) {
    * function setup() {
    *   createCanvas(100, 100);
    *   image(img, 0, 0);
-   *   for (var i = 0; i < img.height; i++) {
-   *     var c = img.get(img.width / 2, i);
+   *   for (let i = 0; i < img.height; i++) {
+   *     let c = img.get(img.width / 2, i);
    *     stroke(c);
    *     line(0, i, width / 2, i);
    *   }
@@ -164,15 +164,15 @@ p5.Image = function(width, height) {
    * values of the pixel at (1, 0). More generally, to set values for a pixel
    * at (x, y):
    * ```javascript
-   * var d = pixelDensity();
-   * for (var i = 0; i < d; i++) {
-   *   for (var j = 0; j < d; j++) {
+   * let d = pixelDensity();
+   * for (let i = 0; i < d; i++) {
+   *   for (let j = 0; j < d; j++) {
    *     // loop over
-   *     idx = 4 * ((y * d + j) * width * d + (x * d + i));
-   *     pixels[idx] = r;
-   *     pixels[idx+1] = g;
-   *     pixels[idx+2] = b;
-   *     pixels[idx+3] = a;
+   *     index = 4 * ((y * d + j) * width * d + (x * d + i));
+   *     pixels[index] = r;
+   *     pixels[index+1] = g;
+   *     pixels[index+2] = b;
+   *     pixels[index+3] = a;
    *   }
    * }
    * ```
@@ -184,10 +184,10 @@ p5.Image = function(width, height) {
    * @example
    * <div>
    * <code>
-   * var img = createImage(66, 66);
+   * let img = createImage(66, 66);
    * img.loadPixels();
-   * for (var i = 0; i < img.width; i++) {
-   *   for (var j = 0; j < img.height; j++) {
+   * for (let i = 0; i < img.width; i++) {
+   *   for (let j = 0; j < img.height; j++) {
    *     img.set(i, j, color(0, 90, 102));
    *   }
    * }
@@ -197,10 +197,10 @@ p5.Image = function(width, height) {
    * </div>
    * <div>
    * <code>
-   * var pink = color(255, 102, 204);
-   * var img = createImage(66, 66);
+   * let pink = color(255, 102, 204);
+   * let img = createImage(66, 66);
    * img.loadPixels();
-   * for (var i = 0; i < 4 * (width * height / 2); i += 4) {
+   * for (let i = 0; i < 4 * (width * height / 2); i += 4) {
    *   img.pixels[i] = red(pink);
    *   img.pixels[i + 1] = green(pink);
    *   img.pixels[i + 2] = blue(pink);
@@ -234,8 +234,8 @@ p5.Image.prototype._setProperty = function(prop, value) {
  * @method loadPixels
  * @example
  * <div><code>
- * var myImage;
- * var halfImage;
+ * let myImage;
+ * let halfImage;
  *
  * function preload() {
  *   myImage = loadImage('assets/rockies.jpg');
@@ -244,7 +244,7 @@ p5.Image.prototype._setProperty = function(prop, value) {
  * function setup() {
  *   myImage.loadPixels();
  *   halfImage = 4 * width * height / 2;
- *   for (var i = 0; i < halfImage; i++) {
+ *   for (let i = 0; i < halfImage; i++) {
  *     myImage.pixels[i + halfImage] = myImage.pixels[i];
  *   }
  *   myImage.updatePixels();
@@ -279,8 +279,8 @@ p5.Image.prototype.loadPixels = function() {
  *                              underlying canvas
  * @example
  * <div><code>
- * var myImage;
- * var halfImage;
+ * let myImage;
+ * let halfImage;
  *
  * function preload() {
  *   myImage = loadImage('assets/rockies.jpg');
@@ -289,7 +289,7 @@ p5.Image.prototype.loadPixels = function() {
  * function setup() {
  *   myImage.loadPixels();
  *   halfImage = 4 * width * height / 2;
- *   for (var i = 0; i < halfImage; i++) {
+ *   for (let i = 0; i < halfImage; i++) {
  *     myImage.pixels[i + halfImage] = myImage.pixels[i];
  *   }
  *   myImage.updatePixels();
@@ -331,8 +331,8 @@ p5.Image.prototype.updatePixels = function(x, y, w, h) {
  *                                    [R, G, B, A] or <a href="#/p5.Image">p5.Image</a>
  * @example
  * <div><code>
- * var myImage;
- * var c;
+ * let myImage;
+ * let c;
  *
  * function preload() {
  *   myImage = loadImage('assets/rockies.jpg');
@@ -373,10 +373,10 @@ p5.Image.prototype.get = function(x, y, w, h) {
  * @example
  * <div>
  * <code>
- * var img = createImage(66, 66);
+ * let img = createImage(66, 66);
  * img.loadPixels();
- * for (var i = 0; i < img.width; i++) {
- *   for (var j = 0; j < img.height; j++) {
+ * for (let i = 0; i < img.width; i++) {
+ *   for (let j = 0; j < img.height; j++) {
  *     img.set(i, j, color(0, 90, 102, (i % img.width) * 2));
  *   }
  * }
@@ -406,7 +406,7 @@ p5.Image.prototype.set = function(x, y, imgOrCol) {
  * @param {Number} height the resized image height
  * @example
  * <div><code>
- * var img;
+ * let img;
  *
  * function preload() {
  *   img = loadImage('assets/rockies.jpg');
@@ -499,10 +499,10 @@ p5.Image.prototype.resize = function(width, height) {
  * @param  {Integer} dh destination image height
  * @example
  * <div><code>
- * var photo;
- * var bricks;
- * var x;
- * var y;
+ * let photo;
+ * let bricks;
+ * let x;
+ * let y;
  *
  * function preload() {
  *   photo = loadImage('assets/rockies.jpg');
@@ -570,7 +570,7 @@ p5.Image.prototype.copy = function() {
  * @param {p5.Image} srcImage source image
  * @example
  * <div><code>
- * var photo, maskImage;
+ * let photo, maskImage;
  * function preload() {
  *   photo = loadImage('assets/rockies.jpg');
  *   maskImage = loadImage('assets/mask2.png');
@@ -636,8 +636,8 @@ p5.Image.prototype.mask = function(p5Image) {
  *                                to each filter, see above
  * @example
  * <div><code>
- * var photo1;
- * var photo2;
+ * let photo1;
+ * let photo2;
  *
  * function preload() {
  *   photo1 = loadImage('assets/rockies.jpg');
@@ -688,8 +688,8 @@ p5.Image.prototype.filter = function(operation, value) {
  * http://blogs.adobe.com/webplatform/2013/01/28/blending-features-in-canvas/
  * @example
  * <div><code>
- * var mountains;
- * var bricks;
+ * let mountains;
+ * let bricks;
  *
  * function preload() {
  *   mountains = loadImage('assets/rockies.jpg');
@@ -703,8 +703,8 @@ p5.Image.prototype.filter = function(operation, value) {
  * }
  * </code></div>
  * <div><code>
- * var mountains;
- * var bricks;
+ * let mountains;
+ * let bricks;
  *
  * function preload() {
  *   mountains = loadImage('assets/rockies.jpg');
@@ -718,8 +718,8 @@ p5.Image.prototype.filter = function(operation, value) {
  * }
  * </code></div>
  * <div><code>
- * var mountains;
- * var bricks;
+ * let mountains;
+ * let bricks;
  *
  * function preload() {
  *   mountains = loadImage('assets/rockies.jpg');
@@ -792,7 +792,7 @@ p5.Image.prototype.isModified = function() {
  * @param  {String} extension 'png' or 'jpg'
  * @example
  * <div><code>
- * var photo;
+ * let photo;
  *
  * function preload() {
  *   photo = loadImage('assets/rockies.jpg');

--- a/src/image/pixels.js
+++ b/src/image/pixels.js
@@ -29,15 +29,15 @@ require('../color/p5.Color');
  * contain the R, G, B, A values of the pixel at (1, 0). More generally, to
  * set values for a pixel at (x, y):
  * ```javascript
- * var d = pixelDensity();
- * for (var i = 0; i < d; i++) {
- *   for (var j = 0; j < d; j++) {
+ * let d = pixelDensity();
+ * for (let i = 0; i < d; i++) {
+ *   for (let j = 0; j < d; j++) {
  *     // loop over
- *     idx = 4 * ((y * d + j) * width * d + (x * d + i));
- *     pixels[idx] = r;
- *     pixels[idx+1] = g;
- *     pixels[idx+2] = b;
- *     pixels[idx+3] = a;
+ *     index = 4 * ((y * d + j) * width * d + (x * d + i));
+ *     pixels[index] = r;
+ *     pixels[index+1] = g;
+ *     pixels[index+2] = b;
+ *     pixels[index+3] = a;
  *   }
  * }
  * ```
@@ -60,11 +60,11 @@ require('../color/p5.Color');
  * @example
  * <div>
  * <code>
- * var pink = color(255, 102, 204);
+ * let pink = color(255, 102, 204);
  * loadPixels();
- * var d = pixelDensity();
- * var halfImage = 4 * (width * d) * (height / 2 * d);
- * for (var i = 0; i < halfImage; i += 4) {
+ * let d = pixelDensity();
+ * let halfImage = 4 * (width * d) * (height / 2 * d);
+ * for (let i = 0; i < halfImage; i += 4) {
  *   pixels[i] = red(pink);
  *   pixels[i + 1] = green(pink);
  *   pixels[i + 2] = blue(pink);
@@ -101,8 +101,8 @@ p5.prototype.pixels = [];
  *
  * @example
  * <div><code>
- * var img0;
- * var img1;
+ * let img0;
+ * let img1;
  *
  * function preload() {
  *   img0 = loadImage('assets/rockies.jpg');
@@ -116,8 +116,8 @@ p5.prototype.pixels = [];
  * }
  * </code></div>
  * <div><code>
- * var img0;
- * var img1;
+ * let img0;
+ * let img1;
  *
  * function preload() {
  *   img0 = loadImage('assets/rockies.jpg');
@@ -131,8 +131,8 @@ p5.prototype.pixels = [];
  * }
  * </code></div>
  * <div><code>
- * var img0;
- * var img1;
+ * let img0;
+ * let img1;
  *
  * function preload() {
  *   img0 = loadImage('assets/rockies.jpg');
@@ -195,7 +195,7 @@ p5.prototype.blend = function() {
  *
  * @example
  * <div><code>
- * var img;
+ * let img;
  *
  * function preload() {
  *   img = loadImage('assets/rockies.jpg');
@@ -289,7 +289,7 @@ p5.prototype.copy = function() {
  * @example
  * <div>
  * <code>
- * var img;
+ * let img;
  * function preload() {
  *   img = loadImage('assets/bricks.jpg');
  * }
@@ -302,7 +302,7 @@ p5.prototype.copy = function() {
  *
  * <div>
  * <code>
- * var img;
+ * let img;
  * function preload() {
  *   img = loadImage('assets/bricks.jpg');
  * }
@@ -315,7 +315,7 @@ p5.prototype.copy = function() {
  *
  * <div>
  * <code>
- * var img;
+ * let img;
  * function preload() {
  *   img = loadImage('assets/bricks.jpg');
  * }
@@ -328,7 +328,7 @@ p5.prototype.copy = function() {
  *
  * <div>
  * <code>
- * var img;
+ * let img;
  * function preload() {
  *   img = loadImage('assets/bricks.jpg');
  * }
@@ -341,7 +341,7 @@ p5.prototype.copy = function() {
  *
  * <div>
  * <code>
- * var img;
+ * let img;
  * function preload() {
  *   img = loadImage('assets/bricks.jpg');
  * }
@@ -354,7 +354,7 @@ p5.prototype.copy = function() {
  *
  * <div>
  * <code>
- * var img;
+ * let img;
  * function preload() {
  *   img = loadImage('assets/bricks.jpg');
  * }
@@ -367,7 +367,7 @@ p5.prototype.copy = function() {
  *
  * <div>
  * <code>
- * var img;
+ * let img;
  * function preload() {
  *   img = loadImage('assets/bricks.jpg');
  * }
@@ -380,7 +380,7 @@ p5.prototype.copy = function() {
  *
  * <div>
  * <code>
- * var img;
+ * let img;
  * function preload() {
  *   img = loadImage('assets/bricks.jpg');
  * }
@@ -427,17 +427,17 @@ p5.prototype.filter = function(operation, value) {
  * Getting the color of a single pixel with get(x, y) is easy, but not as fast
  * as grabbing the data directly from <a href="#/p5/pixels">pixels[]</a>. The equivalent statement to
  * get(x, y) using <a href="#/p5/pixels">pixels[]</a> with pixel density d is
- * <code>
- * var x, y, d; // set these to the coordinates
- * var off = (y * width + x) * d * 4;
- * var components = [
+ * ```javascript
+ * let x, y, d; // set these to the coordinates
+ * let off = (y * width + x) * d * 4;
+ * let components = [
  *   pixels[off],
  *   pixels[off + 1],
  *   pixels[off + 2],
  *   pixels[off + 3]
  * ];
  * print(components);
- * </code>
+ * ```
  * <br><br>
  * See the reference for <a href="#/p5/pixels">pixels[]</a> for more information.
  *
@@ -454,13 +454,13 @@ p5.prototype.filter = function(operation, value) {
  * @example
  * <div>
  * <code>
- * var img;
+ * let img;
  * function preload() {
  *   img = loadImage('assets/rockies.jpg');
  * }
  * function setup() {
  *   image(img, 0, 0);
- *   var c = get();
+ *   let c = get();
  *   image(c, width / 2, 0);
  * }
  * </code>
@@ -468,13 +468,13 @@ p5.prototype.filter = function(operation, value) {
  *
  * <div>
  * <code>
- * var img;
+ * let img;
  * function preload() {
  *   img = loadImage('assets/rockies.jpg');
  * }
  * function setup() {
  *   image(img, 0, 0);
- *   var c = get(50, 90);
+ *   let c = get(50, 90);
  *   fill(c);
  *   noStroke();
  *   rect(25, 25, 50, 50);
@@ -527,17 +527,17 @@ p5.prototype.get = function(x, y, w, h) {
  * @example
  * <div>
  * <code>
- * var img;
+ * let img;
  * function preload() {
  *   img = loadImage('assets/rockies.jpg');
  * }
  *
  * function setup() {
  *   image(img, 0, 0);
- *   var d = pixelDensity();
- *   var halfImage = 4 * (img.width * d) * (img.height * d / 2);
+ *   let d = pixelDensity();
+ *   let halfImage = 4 * (img.width * d) * (img.height * d / 2);
  *   loadPixels();
- *   for (var i = 0; i < halfImage; i++) {
+ *   for (let i = 0; i < halfImage; i++) {
  *     pixels[i + halfImage] = pixels[i];
  *   }
  *   updatePixels();
@@ -583,7 +583,7 @@ p5.prototype.loadPixels = function() {
  * @example
  * <div>
  * <code>
- * var black = color(0);
+ * let black = color(0);
  * set(30, 20, black);
  * set(85, 20, black);
  * set(85, 75, black);
@@ -594,9 +594,9 @@ p5.prototype.loadPixels = function() {
  *
  * <div>
  * <code>
- * for (var i = 30; i < width - 15; i++) {
- *   for (var j = 20; j < height - 25; j++) {
- *     var c = color(204 - j, 153 - i, 0);
+ * for (let i = 30; i < width - 15; i++) {
+ *   for (let j = 20; j < height - 25; j++) {
+ *     let c = color(204 - j, 153 - i, 0);
  *     set(i, j, c);
  *   }
  * }
@@ -606,7 +606,7 @@ p5.prototype.loadPixels = function() {
  *
  * <div>
  * <code>
- * var img;
+ * let img;
  * function preload() {
  *   img = loadImage('assets/rockies.jpg');
  * }
@@ -646,17 +646,17 @@ p5.prototype.set = function(x, y, imgOrCol) {
  * @example
  * <div>
  * <code>
- * var img;
+ * let img;
  * function preload() {
  *   img = loadImage('assets/rockies.jpg');
  * }
  *
  * function setup() {
  *   image(img, 0, 0);
- *   var d = pixelDensity();
- *   var halfImage = 4 * (img.width * d) * (img.height * d / 2);
+ *   let d = pixelDensity();
+ *   let halfImage = 4 * (img.width * d) * (img.height * d / 2);
  *   loadPixels();
- *   for (var i = 0; i < halfImage; i++) {
+ *   for (let i = 0; i < halfImage; i++) {
  *     pixels[i + halfImage] = pixels[i];
  *   }
  *   updatePixels();


### PR DESCRIPTION
Fixes - #3387 

- Updated all `@examples` for `@module Image` to ES6
- Changed var to let
- Changed callbacks to `=>` notation
- Changed idx to index in two examples to make it easier to comprehend
- Fixed `<code></code>` block by changing it to `` ```javascript``` `` so it displays correctly