### PR TITLE
fix warning during setAttributes

### DIFF
--- a/src/webgl/p5.RendererGL.js
+++ b/src/webgl/p5.RendererGL.js
@@ -328,7 +328,7 @@ p5.RendererGL.prototype._resetContext = function(attr, options, callback) {
  *   rotateX(t * 0.77);
  *   rotateY(t * 0.83);
  *   rotateZ(t * 0.91);
- *   torus(width * 0.3, width * 0.07, 30, 10);
+ *   torus(width * 0.3, width * 0.07, 24, 10);
  * }
  *
  * function mousePressed() {


### PR DESCRIPTION
fixes the `Cannot draw strokes on torus object with more than 24 detailX or 16 detailY` warning