### PR TITLE
Updated Structure Reference Examples to ES6

### DIFF
--- a/src/core/main.js
+++ b/src/core/main.js
@@ -62,8 +62,8 @@ var p5 = function(sketch, node, sync) {
    * @method preload
    * @example
    * <div><code>
-   * var img;
-   * var c;
+   * let img;
+   * let c;
    * function preload() {
    *   // preload() runs once
    *   img = loadImage('assets/laDefense.jpg');
@@ -100,7 +100,7 @@ var p5 = function(sketch, node, sync) {
    * @method setup
    * @example
    * <div><code>
-   * var a = 0;
+   * let a = 0;
    *
    * function setup() {
    *   background(0);
@@ -148,7 +148,7 @@ var p5 = function(sketch, node, sync) {
    * @method draw
    * @example
    * <div><code>
-   * var yPos = 0;
+   * let yPos = 0;
    * function setup() {
    *   // setup() runs once
    *   frameRate(30);

--- a/src/core/structure.js
+++ b/src/core/structure.js
@@ -40,7 +40,7 @@ var p5 = require('./main');
  * </code></div>
  *
  * <div><code>
- * var x = 0;
+ * let x = 0;
  * function setup() {
  *   createCanvas(100, 100);
  * }
@@ -79,7 +79,7 @@ p5.prototype.noLoop = function() {
  * @method loop
  * @example
  * <div><code>
- * var x = 0;
+ * let x = 0;
  * function setup() {
  *   createCanvas(100, 100);
  *   noLoop();
@@ -265,7 +265,7 @@ p5.prototype.pop = function() {
  * @param  {Integer} [n] Redraw for n-times. The default value is 1.
  * @example
  * <div><code>
- * var x = 0;
+ * let x = 0;
  *
  * function setup() {
  *   createCanvas(100, 100);
@@ -284,7 +284,7 @@ p5.prototype.pop = function() {
  * </code></div>
  *
  * <div class='norender'><code>
- * var x = 0;
+ * let x = 0;
  *
  * function setup() {
  *   createCanvas(100, 100);


### PR DESCRIPTION
Update the Structure section of the [p5js reference](https://p5js.org/reference/) to ES6.

closes #3373 