### PR TITLE
Fixes stroke issue with 2D vertex()

### DIFF
--- a/src/core/p5.Renderer2D.js
+++ b/src/core/p5.Renderer2D.js
@@ -1083,13 +1083,14 @@ p5.Renderer2D.prototype.curve = function(x1, y1, x2, y2, x3, y3, x4, y4) {
 //////////////////////////////////////////////
 
 p5.Renderer2D.prototype._doFillStrokeClose = function() {
+  this.drawingContext.closePath();
+
   if (this._doFill) {
     this.drawingContext.fill();
   }
   if (this._doStroke) {
     this.drawingContext.stroke();
   }
-  this.drawingContext.closePath();
 
   this._pInst._pixelsDirty = true;
 };


### PR DESCRIPTION
Fixes round stroke issue with 2D vertex. Tested on `p5.gui` ngon() and star() function:
Closes #3430
```
function setup()
{
	createCanvas(600, 600);
	noLoop();
	stroke(0, 221, 255);
	fill(180, 255, 255);
	strokeWeight(50);
}

function draw()
{
	background(240);
	star(6, 450, 300, 150/sqrt(3), 150);
	ngon(3, 150, 300, 150);
}

function ngon(n, x, y, d) {
  beginShape();
  for(var i = 0; i < n; i++) {
    var angle = TWO_PI / n * i;
    var px = x + sin(angle) * d / 2;
    var py = y - cos(angle) * d / 2;
    vertex(px, py);
  }
  endShape(CLOSE);
}

function star(n, x, y, d1, d2) {
  beginShape();
  for(var i = 0; i < 2 * n; i++) {
    var d = (i % 2 === 1) ? d1 : d2;
    var angle = PI / n * i;
    var px = x + sin(angle) * d / 2;
    var py = y - cos(angle) * d / 2;
    vertex(px, py);
  }
  endShape(CLOSE);
}
```
Before this fix             |  After this fix
:-------------------------:|:-------------------------:
![2](https://user-images.githubusercontent.com/15272015/50573179-72bfdf00-0df0-11e9-965f-b9c09374f50f.PNG) |  ![1](https://user-images.githubusercontent.com/15272015/50573192-97b45200-0df0-11e9-9dd2-05563c7b2ee3.PNG)


