### PR TITLE
added example to brightness() and changed red() example

### DIFF
--- a/src/color/creating_reading.js
+++ b/src/color/creating_reading.js
@@ -108,9 +108,22 @@ p5.prototype.blue = function(c) {
  * rect(50, 20, 35, 60);
  * </code>
  * </div>
+ * <div>
+ * <code>
+ * noStroke();
+ * colorMode(HSB, 255);
+ * let c = color('hsb(60, 100%, 50%)');
+ * fill(c);
+ * rect(15, 20, 35, 60);
+ * let value = brightness(c); // A 'value' of %50 is 127.5
+ * fill(value);
+ * rect(50, 20, 35, 60);
+ * </code>
+ * </div>
  *
  * @alt
  * Left half of canvas salmon pink and the right half white.
+ * Left half of canvas yellow at half brightness and the right gray .
  *
  */
 p5.prototype.brightness = function(c) {
@@ -532,13 +545,12 @@ p5.prototype.lightness = function(c) {
  * </code>
  * </div>
  *
- * <div>
+ * <div class="norender">
  * <code>
- * colorMode(RGB, 255);
+ * colorMode(RGB, 255); // Set R in RGB range to 255
  * let c = color(127, 255, 0);
- * colorMode(RGB, 1);
+ * colorMode(RGB, 1); // Set R in RGB range to 1
  * let myColor = red(c);
- * print(myColor);
  * </code>
  * </div>
  *

--- a/src/color/creating_reading.js
+++ b/src/color/creating_reading.js
@@ -115,7 +115,7 @@ p5.prototype.blue = function(c) {
  * let c = color('hsb(60, 100%, 50%)');
  * fill(c);
  * rect(15, 20, 35, 60);
- * let value = brightness(c); // A 'value' of %50 is 127.5
+ * let value = brightness(c); // A 'value' of 50% is 127.5
  * fill(value);
  * rect(50, 20, 35, 60);
  * </code>

--- a/src/color/creating_reading.js
+++ b/src/color/creating_reading.js
@@ -551,6 +551,7 @@ p5.prototype.lightness = function(c) {
  * let c = color(127, 255, 0);
  * colorMode(RGB, 1); // Set R in RGB range to 1
  * let myColor = red(c);
+ * print(myColor); // 0.4980392156862745
  * </code>
  * </div>
  *

--- a/src/events/keyboard.js
+++ b/src/events/keyboard.js
@@ -98,6 +98,7 @@ p5.prototype.key = '';
  * }
  * </code></div>
  * <div><code>
+ * function draw(){}
  * function keyPressed() {
  *   background('yellow');
  *   text(key, 10, 40);

--- a/src/events/keyboard.js
+++ b/src/events/keyboard.js
@@ -98,12 +98,13 @@ p5.prototype.key = '';
  * }
  * </code></div>
  * <div><code>
- * function draw(){}
+ * function draw() {}
  * function keyPressed() {
  *   background('yellow');
  *   text(key, 10, 40);
  *   text(keyCode, 10, 60);
  *   print(key, ' ', keyCode);
+ *   return false; // prevent default
  * }
  * </code></div>
  * @alt

--- a/src/events/keyboard.js
+++ b/src/events/keyboard.js
@@ -97,10 +97,17 @@ p5.prototype.key = '';
  *   return false; // prevent default
  * }
  * </code></div>
- *
+ * <div><code>
+ * function keyPressed() {
+ *  background('yellow')
+ *  text(key,10,40)
+ *  text(keyCode,10,60)
+ *  print(key,' ',keyCode)
+ * }
+ * </code></div>
  * @alt
  * Grey rect center. turns white when up arrow pressed and black when down
- *
+ * Display key pressed and its keyCode in a yellow box
  */
 p5.prototype.keyCode = 0;
 
@@ -325,27 +332,16 @@ p5.prototype._onblur = function(e) {
  *
  * function setup() {
  *   createCanvas(512, 512);
+ *   fill(255, 0, 0);
  * }
  *
  * function draw() {
- *   if (keyIsDown(LEFT_ARROW)) {
- *     x -= 5;
- *   }
- *
- *   if (keyIsDown(RIGHT_ARROW)) {
- *     x += 5;
- *   }
- *
- *   if (keyIsDown(UP_ARROW)) {
- *     y -= 5;
- *   }
- *
- *   if (keyIsDown(DOWN_ARROW)) {
- *     y += 5;
- *   }
+ *   if (keyIsDown(LEFT_ARROW))   x -= 5;
+ *   if (keyIsDown(RIGHT_ARROW))  x += 5;
+ *   if (keyIsDown(UP_ARROW))     y -= 5;
+ *   if (keyIsDown(DOWN_ARROW))   y += 5;
  *
  *   clear();
- *   fill(255, 0, 0);
  *   ellipse(x, y, 50, 50);
  * }
  * </code></div>

--- a/src/events/keyboard.js
+++ b/src/events/keyboard.js
@@ -101,8 +101,7 @@ p5.prototype.key = '';
  * function draw() {}
  * function keyPressed() {
  *   background('yellow');
- *   text(key, 10, 40);
- *   text(keyCode, 10, 60);
+ *   text(`${key} ${keyCode}`, 10, 40);
  *   print(key, ' ', keyCode);
  *   return false; // prevent default
  * }

--- a/src/events/keyboard.js
+++ b/src/events/keyboard.js
@@ -100,7 +100,8 @@ p5.prototype.key = '';
  * <div><code>
  * function keyPressed() {
  *   background('yellow');
- *   text(`${key} ${keyCode}`, 10, 40);
+ *   text(key, 10, 40);
+ *   text(keyCode, 10, 60);
  *   print(key, ' ', keyCode);
  * }
  * </code></div>

--- a/src/events/keyboard.js
+++ b/src/events/keyboard.js
@@ -99,10 +99,9 @@ p5.prototype.key = '';
  * </code></div>
  * <div><code>
  * function keyPressed() {
- *  background('yellow')
- *  text(key,10,40)
- *  text(keyCode,10,60)
- *  print(key,' ',keyCode)
+ *   background('yellow');
+ *   text(`${key} ${keyCode}`, 10, 40);
+ *   print(key, ' ', keyCode);
  * }
  * </code></div>
  * @alt
@@ -336,10 +335,10 @@ p5.prototype._onblur = function(e) {
  * }
  *
  * function draw() {
- *   if (keyIsDown(LEFT_ARROW))   x -= 5;
- *   if (keyIsDown(RIGHT_ARROW))  x += 5;
- *   if (keyIsDown(UP_ARROW))     y -= 5;
- *   if (keyIsDown(DOWN_ARROW))   y += 5;
+ *   if (keyIsDown(LEFT_ARROW)) x -= 5;
+ *   if (keyIsDown(RIGHT_ARROW)) x += 5;
+ *   if (keyIsDown(UP_ARROW)) y -= 5;
+ *   if (keyIsDown(DOWN_ARROW)) y += 5;
  *
  *   clear();
  *   ellipse(x, y, 50, 50);


### PR DESCRIPTION
My first pull request to P5.

Added an example to brightness() to show how using color(hsb) corresponds to the brightness() returned value.

red() I added comments and output values to the example.
I still don't get what the 2nd example is doing as a useful example of red(),  but it's now documented better.