### PR TITLE
Fix for p5.Element.prototype.position not applying styling properly

### DIFF
--- a/lib/addons/p5.dom.js
+++ b/lib/addons/p5.dom.js
@@ -1621,6 +1621,17 @@
   p5.Element.prototype.position = function() {
     if (arguments.length === 0) {
       return { x: this.elt.offsetLeft, y: this.elt.offsetTop };
+    } else if (
+      arguments.length === 1 &&
+      (arguments[0] === 'static' ||
+        arguments[0] === 'absolute' ||
+        arguments[0] === 'fixed' ||
+        arguments[0] === 'relative' ||
+        arguments[0] === 'sticky' ||
+        arguments[0] === 'initial' ||
+        arguments[0] === 'inherit')
+    ) {
+      this.elt.style.position = arguments[0];
     } else {
       this.elt.style.position = 'absolute';
       this.elt.style.left = arguments[0] + 'px';


### PR DESCRIPTION
Proposed fix for #3447 where `p5.Element.prototype.position` of p5.dom does not style the element properly as called by e.g. `style('position','fixed')`.

As seen in issue, the problem stems from `p5.Element.prototype.style` however, it seems that the design of this function is to delegate the assignment of transformations to their respective functions.

As such `p5.Element.prototype.position` was modified to be able to handle all cases, explicitly ensuring only valid values for CSS `position` are used.

This is my first PR so hopefully checked all the boxes 🤞