### PR TITLE
Migrate build and release tasks from ES5 to ES6

### DIFF
--- a/tasks/build/browserify.js
+++ b/tasks/build/browserify.js
@@ -1,33 +1,33 @@
 'use strict';
 
-var path = require('path');
-var browserify = require('browserify');
-var derequire = require('derequire');
+const path = require('path');
+const browserify = require('browserify');
+const derequire = require('derequire');
 
-var bannerTemplate =
+const bannerTemplate =
   '/*! p5.js v<%= pkg.version %> <%= grunt.template.today("mmmm dd, yyyy") %> */';
 
 module.exports = function(grunt) {
-  var srcFilePath = require.resolve('../../src/app.js');
+  const srcFilePath = require.resolve('../../src/app.js');
 
   grunt.registerTask(
     'browserify',
     'Compile the p5.js source with Browserify',
     function(param) {
-      var isMin = param === 'min';
-      var filename = isMin ? 'p5.pre-min.js' : 'p5.js';
+      const isMin = param === 'min';
+      const filename = isMin ? 'p5.pre-min.js' : 'p5.js';
 
       // This file will not exist until it has been built
-      var libFilePath = path.resolve('lib/' + filename);
+      const libFilePath = path.resolve('lib/' + filename);
 
       // Reading and writing files is asynchronous
-      var done = this.async();
+      const done = this.async();
 
       // Render the banner for the top of the file
-      var banner = grunt.template.process(bannerTemplate);
+      const banner = grunt.template.process(bannerTemplate);
 
       // Invoke Browserify programatically to bundle the code
-      var browseified = browserify(srcFilePath, {
+      let browseified = browserify(srcFilePath, {
         standalone: 'p5'
       });
 
@@ -35,10 +35,10 @@ module.exports = function(grunt) {
         browseified = browseified.exclude('../../docs/reference/data.json');
       }
 
-      var bundle = browseified.transform('brfs').bundle();
+      const bundle = browseified.transform('brfs').bundle();
 
       // Start the generated output with the banner comment,
-      var code = banner + '\n';
+      let code = banner + '\n';
 
       // Then read the bundle into memory so we can run it through derequire
       bundle

--- a/tasks/build/combineModules.js
+++ b/tasks/build/combineModules.js
@@ -1,9 +1,9 @@
 'use strict';
 
-var fs = require('fs');
-var path = require('path');
-var browserify = require('browserify');
-var derequire = require('derequire');
+const fs = require('fs');
+const path = require('path');
+const browserify = require('browserify');
+const derequire = require('derequire');
 
 module.exports = function(grunt) {
   grunt.registerTask(
@@ -11,43 +11,41 @@ module.exports = function(grunt) {
     'Compile and combine certain modules with Browserify',
     function(args) {
       // Reading and writing files is asynchronous
-      var done = this.async();
+      const done = this.async();
 
       // Module sources are space separated names in a single string (enter within quotes)
-      var module_src,
-        temp = [];
-      for (var i in arguments) {
-        temp.push(arguments[i]);
+      const temp = [];
+      for (const arg of arguments) {
+        temp.push(arg);
       }
-      module_src = temp.join(', ');
+      const module_src = temp.join(', ');
 
       // Render the banner for the top of the file. Includes the Module name.
-      var bannerTemplate =
-        '/*! Custom p5.js v<%= pkg.version %> <%= grunt.template.today("mmmm dd, yyyy") %> \nContains the following modules : ' +
-        module_src +
-        '*/';
-      var banner = grunt.template.process(bannerTemplate);
+      const bannerTemplate = `/*! Custom p5.js v<%= pkg.version %> <%= grunt.template.today("mmmm dd, yyyy") %> 
+        Contains the following modules : ${module_src}*/`;
+      const banner = grunt.template.process(bannerTemplate);
 
       // Make a list of sources from app.js in that sequence only
-      var sources = [];
-      var dump = fs.readFileSync('./src/app.js', 'utf8');
-      var regexp = /\('.+'/g;
-      var match;
+      const sources = [];
+      const dump = fs.readFileSync('./src/app.js', 'utf8');
+      const regexp = /\('.+'/g;
+      let match;
       while ((match = regexp.exec(dump)) != null) {
-        var text = match[0];
+        let text = match[0];
         text = text.substring(text.indexOf('./') + 2, text.length - 1);
         sources.push(text);
       }
 
       // Populate the source file path array with concerned files' path
-      var srcDirPath = './src';
-      var srcFilePath = [];
+      const srcDirPath = './src';
+      const srcFilePath = [];
       for (var j = 0; j < sources.length; j++) {
         var source = sources[j];
         var base = source.substring(0, source.lastIndexOf('/'));
         if (base === 'core' || module_src.search(base) !== -1) {
           // Push the resolved paths directly
-          var filePath = source.search('.js') !== -1 ? source : source + '.js';
+          const filePath =
+            source.search('.js') !== -1 ? source : source + '.js';
           var fullPath = path.resolve(srcDirPath, filePath);
           srcFilePath.push(fullPath);
         }
@@ -55,17 +53,17 @@ module.exports = function(grunt) {
 
       console.log(srcFilePath);
       // Target file path
-      var libFilePath = path.resolve('lib/modules/p5Custom.js');
+      const libFilePath = path.resolve('lib/modules/p5Custom.js');
 
       // Invoke Browserify programatically to bundle the code
-      var bundle = browserify(srcFilePath, {
+      const bundle = browserify(srcFilePath, {
         standalone: 'p5'
       })
         .transform('brfs')
         .bundle();
 
       // Start the generated output with the banner comment,
-      var code = banner + '\n';
+      let code = banner + '\n';
 
       // Then read the bundle into memory so we can run it through derequire
       bundle

--- a/tasks/build/eslint-samples.js
+++ b/tasks/build/eslint-samples.js
@@ -22,7 +22,7 @@ module.exports = grunt => {
         return true;
       }
 
-      var linter = require('../../utils/sample-linter.js');
+      const linter = require('../../utils/sample-linter.js');
       const result = linter.eslintFiles(opts, this.filesSrc);
       const report = result.report;
       const output = result.output;

--- a/tasks/release/release-bower.js
+++ b/tasks/release/release-bower.js
@@ -9,21 +9,21 @@ module.exports = function(grunt) {
     'Publishes the new release of p5.js on Bower',
     function() {
       // Async Task
-      var done = this.async();
+      const done = this.async();
       // Keep the version handy
-      var version = require('../../package.json').version;
+      const version = require('../../package.json').version;
       // Keep the release-party ready
-      var releaseParty = grunt.config.get('bowerReleaser');
+      const releaseParty = grunt.config.get('bowerReleaser');
       // Avoiding Callback Hell and using Promises
-      new Promise(function(resolve, reject) {
+      new Promise((resolve, reject) => {
         // Clone the repo. NEEDS TO BE QUIET. Took 3 hours to realise this.
         // Otherwise the stdout screws up
         console.log('Cloning the Release repo ...');
         exec(
-          'rm -rf bower-repo/ && git clone -q https://github.com/' +
-            releaseParty +
-            '/p5.js-release.git bower-repo',
-          function(err, stdout, stderr) {
+          `rm -rf bower-repo/ && git clone -q \
+          https://github.com/${releaseParty}/p5.js-release.git \
+          bower-repo`,
+          (err, stdout, stderr) => {
             if (err) {
               reject(err);
             }
@@ -39,32 +39,29 @@ module.exports = function(grunt) {
           // NOTE : Uses 'cp' of UNIX. Make sure it is unaliased in your .bashrc,
           // otherwise it may prompt always for overwrite (not desirable)
           console.log('Copying new files ...');
-          return new Promise(function(resolve, reject) {
-            exec('cp -R lib/*.js lib/addons bower-repo/lib', function(
-              err,
-              stdout,
-              stderr
-            ) {
-              if (err) {
-                reject(err);
+          return new Promise((resolve, reject) => {
+            exec(
+              'cp -R lib/*.js lib/addons bower-repo/lib',
+              (err, stdout, stderr) => {
+                if (err) {
+                  reject(err);
+                }
+                if (stderr) {
+                  reject(stderr);
+                }
+                resolve();
               }
-              if (stderr) {
-                reject(stderr);
-              }
-              resolve();
-            });
+            );
           });
         })
-        .then(function(resolve, reject) {
+        .then((resolve, reject) => {
           // Git add, commit, push
           console.log('Pushing out changes ...');
           return new Promise(function(resolve, reject) {
             exec(
-              'git add --all && git commit -am "' +
-                version +
-                '" && git push -q',
+              `git add --all && git commit -am "${version}" && git push -q`,
               { cwd: './bower-repo' },
-              function(err, stdout, stderr) {
+              (err, stdout, stderr) => {
                 if (err) {
                   reject(err);
                 }
@@ -78,7 +75,7 @@ module.exports = function(grunt) {
             );
           });
         })
-        .catch(function(err) {
+        .catch(err => {
           console.log('Failed to Release on Bower!');
           throw new Error(err);
         });

--- a/tasks/release/release-docs.js
+++ b/tasks/release/release-docs.js
@@ -9,20 +9,20 @@ module.exports = function(grunt) {
     'Publishes the new docs of p5.js on the website',
     function() {
       // Async Task
-      var done = this.async();
+      const done = this.async();
       // Keep the version handy
-      var version = require('../../package.json').version;
+      const version = require('../../package.json').version;
       // Keep the release-party ready
-      var releaseParty = grunt.config.get('docsReleaser');
+      const releaseParty = grunt.config.get('docsReleaser');
       // Avoiding Callback Hell and using Promises
-      new Promise(function(resolve, reject) {
+      new Promise((resolve, reject) => {
         // Clone the website locally
         console.log('Cloning the website ...');
         exec(
-          'rm -rf p5-website/ && git clone -q https://github.com/' +
-            releaseParty +
-            '/p5.js-website.git p5-website',
-          function(err, stdout, stderr) {
+          `rm -rf p5-website/ && \
+          git clone -q https://github.com/${releaseParty}/p5.js-website.git \
+          p5-website`,
+          (err, stdout, stderr) => {
             if (err) {
               reject(err);
             }
@@ -41,7 +41,7 @@ module.exports = function(grunt) {
           return new Promise(function(resolve, reject) {
             exec(
               `(cp ${src}/data.json ${src}/data.min.json ${dest}) && (cp -r ${src}/assets ${dest})`,
-              function(err, stdout, stderr) {
+              (err, stdout, stderr) => {
                 if (err) {
                   reject(err);
                 }
@@ -53,16 +53,16 @@ module.exports = function(grunt) {
             );
           });
         })
-        .then(function() {
+        .then(() => {
           // Add, Commit, Push
           console.log('Pushing to GitHub ...');
           return new Promise(function(resolve, reject) {
             exec(
-              'git add --all && git commit -am "Updated Reference for version ' +
-                version +
-                '" && git push',
+              `git add --all && \
+              git commit -am "Updated Reference for version ${version}" && \
+              git push`,
               { cwd: './p5-website' },
-              function(err, stdout, stderr) {
+              (err, stdout, stderr) => {
                 if (err) {
                   reject(err);
                 }
@@ -74,7 +74,7 @@ module.exports = function(grunt) {
             );
           });
         })
-        .then(function() {
+        .then(() => {
           console.log('Released Docs on Website!');
           done();
         })

--- a/tasks/release/release-github.js
+++ b/tasks/release/release-github.js
@@ -1,19 +1,19 @@
 /* Grunt task to release p5.js on GitHub */
 
-var fs = require('fs');
-var req = require('request');
+const fs = require('fs');
+const req = require('request');
 
 module.exports = function(grunt) {
   grunt.registerTask('release-github', 'Publish a Release on GitHub', function(
     args
   ) {
     // Async Task
-    var done = this.async();
+    const done = this.async();
     // Keep the release-party ready
-    var releaseParty = grunt.config.get('githubReleaser');
+    const releaseParty = grunt.config.get('githubReleaser');
 
     // Prepare the data
-    var data = {
+    const data = {
       tag_name: '',
       target_commitish: 'master',
       name: '',
@@ -22,29 +22,28 @@ module.exports = function(grunt) {
       prerelease: false
     };
 
-    var newTag = require('../../package.json').version;
+    const newTag = require('../../package.json').version;
     data.tag_name = newTag;
     data.name = newTag;
 
     // Set up vars for requests
-    var accessTokenParam = '?access_token=' + process.env.GITHUB_TOKEN;
-    var createURL =
+    const accessTokenParam = `?access_token=${process.env.GITHUB_TOKEN}`;
+    const createURL =
       'https://api.github.com/repos/' +
       releaseParty +
       '/p5.js/releases' +
       accessTokenParam;
-    var uploadURL =
-      'https://uploads.github.com/repos/' + releaseParty + '/p5.js/releases/';
-    var ID = '';
-    var count = 0;
+    const uploadURL = `https://uploads.github.com/repos/${releaseParty}/p5.js/releases/`;
+    let ID = '';
+    let count = 0;
 
-    var createReleaseData = {
+    const createReleaseData = {
       url: createURL,
       headers: { 'User-Agent': 'Grunt Task' },
       body: JSON.stringify(data)
     };
 
-    var uploadReleaseData = {
+    const uploadReleaseData = {
       p5js: ['p5.js', './lib/p5.js', 'application/javascript'],
       p5minjs: ['p5.min.js', './lib/p5.min.js', 'application/javascript'],
       p5domjs: [
@@ -70,24 +69,25 @@ module.exports = function(grunt) {
       p5zip: ['p5.zip', './p5.zip', 'application/zip']
     };
 
-    var uploadAsset = function(arr) {
-      console.log('Uploading ' + arr[0] + ' ...');
+    const uploadAsset = arr => {
+      console.log(`Uploading ${arr[0]} ...`);
       fs.createReadStream(arr[1]).pipe(
         req.post(
           {
             url:
-              uploadURL + ID + '/assets' + accessTokenParam + '&name=' + arr[0],
+              // uploadURL + ID + '/assets' + accessTokenParam + '&name=' + arr[0],
+              `${uploadURL}${ID}/assets${accessTokenParam}&name=${arr[0]}`,
             headers: {
               'User-Agent': 'Grunt',
               'Content-Type': arr[2],
               'Content-Length': fs.statSync(arr[1]).size
             }
           },
-          function(err, resp, body) {
+          (err, resp, body) => {
             if (err) {
               throw err;
             }
-            console.log('Uploaded ' + arr[0]);
+            console.log(`Uploaded ${arr[0]}`);
             count++;
             if (count === 7) {
               done();
@@ -98,22 +98,22 @@ module.exports = function(grunt) {
       );
     };
 
-    new Promise(function(resolve, reject) {
+    new Promise((resolve, reject) => {
       // Create the release
       console.log('Posting Release ...');
-      req.post(createReleaseData, function(error, response, body) {
+      req.post(createReleaseData, (error, response, body) => {
         if (error) {
           reject(error);
         }
         resolve(JSON.parse(body).id);
       });
     })
-      .then(function(releaseID) {
+      .then(releaseID => {
         // Upload the Library
         console.log('Uploading Assets ...');
         ID = releaseID;
         // Upload assets
-        for (var file in uploadReleaseData) {
+        for (const file in uploadReleaseData) {
           let arr = uploadReleaseData[file];
           uploadAsset(arr);
         }

--- a/tasks/release/release-p5.js
+++ b/tasks/release/release-p5.js
@@ -8,7 +8,7 @@ MUST HAVES BEFOREHAND :
 
 module.exports = function(grunt) {
   // Options for this custom task
-  var opts = {
+  const opts = {
     releaseIt: {
       options: {
         'non-interactive': true,


### PR DESCRIPTION
 With respect to #3372, migrates the build and release tasks from ES5 to ES6. Following are the major syntactical changes made: 
- Converted `var` declarations to `let` and const
- Used template strings wherever possible and would lead to a cleaner code
- Converted traditional function definitions and declarations (`function(){}`) to fat arrow syntax (`(...)=>{}`)