### PR TITLE
Removed erroneous example

### DIFF
--- a/src/events/keyboard.js
+++ b/src/events/keyboard.js
@@ -135,22 +135,6 @@ p5.prototype.keyCode = 0;
  *   rect(25, 25, 50, 50);
  * }
  * function keyPressed() {
- *   if (value === 0) {
- *     value = 255;
- *   } else {
- *     value = 0;
- *   }
- * }
- * </code>
- * </div>
- * <div>
- * <code>
- * let value = 0;
- * function draw() {
- *   fill(value);
- *   rect(25, 25, 50, 50);
- * }
- * function keyPressed() {
  *   if (keyCode === LEFT_ARROW) {
  *     value = 255;
  *   } else if (keyCode === RIGHT_ARROW) {


### PR DESCRIPTION
In Reference to #3450. 

On going through the code, it seems like the keyPressed function might be overriden by the first example. Not sure why this might be happening, but I'm taking a look alongside to try to fix it. 

Meanwhile, I'm pushing this change to remove unexpected behavior from the website, including just one example.