### PR TITLE
Add YUIDoc for disableFriendlyErrors

### DIFF
--- a/src/core/main.js
+++ b/src/core/main.js
@@ -589,7 +589,11 @@ p5.instance = null;
  * @property {Boolean} disableFriendlyErrors
  * @example
  * <div class="norender notest"><code>
- * p5.disableFriendlyErrors = true; // Disables FES
+ * p5.disableFriendlyErrors = true;
+ *
+ * function setup() {
+ *   createCanvas(100, 50);
+ * }
  * </code></div>
  */
 p5.disableFriendlyErrors = false;

--- a/src/core/main.js
+++ b/src/core/main.js
@@ -580,8 +580,18 @@ p5.prototype._initializeInstanceVariables = function() {
 // global mode.
 p5.instance = null;
 
-// Allows for the friendly error system to be turned off when creating a sketch,
-// which can give a significant boost to performance when needed.
+/**
+ * Allows for the friendly error system (FES) to be turned off when creating a sketch,
+ * which can give a significant boost to performance when needed.
+ * See <a href='https://github.com/processing/p5.js/wiki/Optimizing-p5.js-Code-for-Performance#disable-the-friendly-error-system-fes'>
+ * disabling the friendly error system</a>.
+ *
+ * @property {Boolean} disableFriendlyErrors
+ * @example
+ * <div class="norender notest"><code>
+ * p5.disableFriendlyErrors = true; // Disables FES
+ * </code></div>
+ */
 p5.disableFriendlyErrors = false;
 
 // attach constants to p5 prototype


### PR DESCRIPTION
Adds YUIDoc for disableFriendlyErrors property so it can be referenced from p5.ts.

Docs look kind of weird with this in since it places it in the middle of the "Structure" section, and the "syntax" section doesn't show that it's supposed to be used like `p5.disableFriendlyErrors`. The "syntax" just shows `disableFriendlyErrors` since it's based purely off the property name. I included an example to hopefully mitigate that.