### PR TITLE
Fix: using parametric angles for drawing arc

### DIFF
--- a/src/core/shape/2d_primitives.js
+++ b/src/core/shape/2d_primitives.js
@@ -118,18 +118,6 @@ p5.prototype.arc = function(x, y, w, h, start, stop, mode, detail) {
     }
   }
 
-  //Adjust angles to counter linear scaling.
-  if (start <= constants.HALF_PI) {
-    start = Math.atan(w / h * Math.tan(start));
-  } else if (start > constants.HALF_PI && start <= 3 * constants.HALF_PI) {
-    start = Math.atan(w / h * Math.tan(start)) + constants.PI;
-  }
-  if (stop <= constants.HALF_PI) {
-    stop = Math.atan(w / h * Math.tan(stop));
-  } else if (stop > constants.HALF_PI && stop <= 3 * constants.HALF_PI) {
-    stop = Math.atan(w / h * Math.tan(stop)) + constants.PI;
-  }
-
   // Exceed the interval if necessary in order to preserve the size and
   // orientation of the arc.
   if (start > stop) {


### PR DESCRIPTION
-fixes #3466 
-Earlier angle was calculated as subtended angle until 3*PI/2, and after that it was calculated as parametric angles.
-Now it draws arcs as parametric angles (Processing does the same)