### PR TITLE
updating createFileInput reference example

### DIFF
--- a/lib/addons/p5.dom.js
+++ b/lib/addons/p5.dom.js
@@ -1002,9 +1002,9 @@
    * @param  {String} [multiple] optional to allow multiple files selected
    * @return {p5.Element} pointer to <a href="#/p5.Element">p5.Element</a> holding created DOM element
    * @example
-   * <div class='norender'><code>
-   * var input;
-   * var img;
+   * <div><code>
+   * let input;
+   * let img;
    *
    * function setup() {
    *   input = createFileInput(handleFile);
@@ -1012,6 +1012,7 @@
    * }
    *
    * function draw() {
+   *   background(255);
    *   if (img) {
    *     image(img, 0, 0, width, height);
    *   }
@@ -1022,6 +1023,8 @@
    *   if (file.type === 'image') {
    *     img = createImg(file.data);
    *     img.hide();
+   *   } else {
+   *     img = null;
    *   }
    * }
    * </code></div>


### PR DESCRIPTION
This commit updates the reference example used in createFileInput in p5.dom.js

**Changes made  :** 
  

1.  Since the existing example has a draw method and ability to show images ,  I believe it makes sense to render the example in the canvas. So **class = 'no render'** was removed.

2.   Earlier when the user uploaded a file other than an image, the previous image kept on rendering on the canvas . This was corrected by setting the image value to null.

3.    var to let conversion by ES6 standards.
   
The  updated example can be tested through this sketch in p5.js web-editor
https://editor.p5js.org/TheSkepticSniper/sketches/RU7TPM-B1

