### PR TITLE
fixes automatic image size in size function in p5.dom.js

### DIFF
--- a/lib/addons/p5.dom.js
+++ b/lib/addons/p5.dom.js
@@ -1965,15 +1965,20 @@
   /**
    *
    * Sets the width and height of the element. AUTO can be used to
-   * only adjust one dimension. If no arguments given returns the width and height
-   * of the element in an object.
+   * only adjust one dimension at a time. If no arguments are given, it
+   * returns the width and height of the element in an object. In case of
+   * elements which need to be loaded, such as images, it is recommended
+   * to call the function after the element has finished loading.
    *
    * @method size
    * @return {Object} the width and height of the element in an object
    * @example
    * <div class='norender'><code>
-   * var div = createDiv('this is a div');
+   * let div = createDiv('this is a div');
    * div.size(100, 100);
+   * let img = createImg('assets/laDefense.jpg', () => {
+   *   img.size(10, AUTO);
+   * });
    * </code></div>
    */
   /**

--- a/src/core/constants.js
+++ b/src/core/constants.js
@@ -348,6 +348,10 @@ module.exports = {
 
   // DOM EXTENSION
   /**
+   * AUTO allows us to automatically set the width or height of an element (but not both),
+   * based on the current height and width of the element. Only one parameter can
+   * be passed to the <a href="/#/p5.Element/size">size</a> function as AUTO, at a time.
+   *
    * @property {String} AUTO
    * @final
    */


### PR DESCRIPTION
This PR tries to solve the issue #3270

The following are the changes made in this PR:

Before assigning the height and width to the image element, the function checks whether the values are numbers or not using isNaN() function . <br/>
Also,

This situation (where sizes are initially zero) occurs only in image elements,
and can be handled separately by using the **image.complete** property (checks whether browser has finished loading the image) , I thought handling the issue using isNaN() would be much shorter.

@lmccart  can you please review the changes?

Thank you!