### PR TITLE
Check if vertex() has uv's before warning

### DIFF
--- a/src/webgl/p5.RendererGL.Immediate.js
+++ b/src/webgl/p5.RendererGL.Immediate.js
@@ -108,7 +108,8 @@ p5.RendererGL.prototype.vertex = function(x, y) {
         u /= this.textureImage.width;
         v /= this.textureImage.height;
       }
-    } else {
+    } else if (this.textureImage === undefined && arguments.length >= 4) {
+      // Only throw this warning if custom uv's have  been provided
       console.warn(
         'You must first call texture() before using' +
           ' vertex() with image based u and v coordinates'

--- a/test/manual-test-examples/webgl/material/textureMode/sketch.js
+++ b/test/manual-test-examples/webgl/material/textureMode/sketch.js
@@ -2,7 +2,6 @@
  * webgl texture mode example
  */
 var img;
-var theta = 0;
 
 function preload() {
   img = loadImage('assets/UV_Grid_Sm.jpg');


### PR DESCRIPTION
Before we start warning about needing a call to texture(), check that uv's have actually been provided. This should prevent calls to functions like bezier() from polluting the console with warnings about the texture mode. 

Resolves https://github.com/processing/p5.js/issues/3414 and part 1 of https://github.com/processing/p5.js/issues/3439