### PR TITLE
Update p5.js version on website when updating docs

### DIFF
--- a/tasks/release/release-docs.js
+++ b/tasks/release/release-docs.js
@@ -38,7 +38,9 @@ module.exports = function(grunt) {
           console.log('Copying new docs ...');
           return new Promise(function(resolve, reject) {
             exec(
-              `(cp ${src}/data.json ${src}/data.min.json ${dest}) && (cp -r ${src}/assets ${dest})`,
+              `(cp ${src}/data.json ${src}/data.min.json ${dest}) &&
+               (cp -r ${src}/assets ${dest}) &&
+               (cp lib/p5.min.js lib/addons/p5.dom.min.js lib/addons/p5.sound.min.js p5-website/src/assets/js/)`,
               function(err, stdout, stderr) {
                 if (err) {
                   reject(err);


### PR DESCRIPTION
Closes https://github.com/processing/p5.js-website/issues/383

The docs-release step now will also copy the p5.js series of libraries into the asset folder of the website which is then used by the reference and examples.