### PR TITLE
i18n for console and FES messages

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -19,6 +19,7 @@ require('./core/shape/2d_primitives');
 require('./core/shape/attributes');
 require('./core/shape/curves');
 require('./core/shape/vertex');
+require('./core/i18n/locales');
 
 // color
 require('./color/color_conversion');

--- a/src/core/i18n/en.json
+++ b/src/core/i18n/en.json
@@ -1,0 +1,4 @@
+{
+    "HELLO": "Hello World!!!",
+    "HELLO_NAME": "Hello {0}!!!"
+}

--- a/src/core/i18n/es.json
+++ b/src/core/i18n/es.json
@@ -1,0 +1,4 @@
+{
+    "HELLO": "Hola Mundo!!!",
+    "HELLO_NAME": "Hola {0}!!!"
+}

--- a/src/core/i18n/locales.js
+++ b/src/core/i18n/locales.js
@@ -34,13 +34,13 @@ var getString = function(str) {
   return dict[str] || defaultDict[str] || str;
 };
 
-function interpolate(str, args) {
+var interpolate = function(str, args) {
   var regex = /{\d}/;
   var _r = function(p, c) {
     return p.replace(regex, c);
   };
   return args.reduce(_r, str);
-}
+};
 
 var localize = function(str, args) {
   var localizedString = getString(str);

--- a/src/core/i18n/locales.js
+++ b/src/core/i18n/locales.js
@@ -30,16 +30,16 @@ var getString = function(str) {
       break;
   }
 
-  // Fallback on english dict or the original string itself
+  // Fallback to english dict or to the original string itself
   return dict[str] || defaultDict[str] || str;
 };
 
-function interpolate(theString, argumentArray) {
+function interpolate(str, args) {
   var regex = /{\d}/;
   var _r = function(p, c) {
     return p.replace(regex, c);
   };
-  return argumentArray.reduce(_r, theString);
+  return args.reduce(_r, str);
 }
 
 var localize = function(str, args) {

--- a/src/core/i18n/locales.js
+++ b/src/core/i18n/locales.js
@@ -1,0 +1,40 @@
+/**
+ * @module Locales
+ * @submodule Locales
+ * @for p5
+ */
+
+'use strict';
+
+var en = require('./en.json');
+var es = require('./es.json');
+
+var getUserLanguage = function() {
+  var userLanguage = navigator.language || navigator.userLanguage;
+  return userLanguage.split('-')[0];
+};
+
+var getString = function(str) {
+  var defaultDict = en;
+  var dict;
+
+  switch (getUserLanguage()) {
+    case 'en':
+      dict = en;
+      break;
+    case 'es':
+      dict = es;
+      break;
+  }
+
+  // Fallback on english dict or the original string itself
+  return dict[str] || defaultDict[str] || str;
+};
+
+var localize = function(str) {
+  return getString(str);
+};
+
+module.exports = {
+  __: localize
+};

--- a/src/core/i18n/locales.js
+++ b/src/core/i18n/locales.js
@@ -25,14 +25,31 @@ var getString = function(str) {
     case 'es':
       dict = es;
       break;
+    default:
+      dict = en;
+      break;
   }
 
   // Fallback on english dict or the original string itself
   return dict[str] || defaultDict[str] || str;
 };
 
-var localize = function(str) {
-  return getString(str);
+function interpolate(theString, argumentArray) {
+  var regex = /{\d}/;
+  var _r = function(p, c) {
+    return p.replace(regex, c);
+  };
+  return argumentArray.reduce(_r, theString);
+}
+
+var localize = function(str, args) {
+  var localizedString = getString(str);
+
+  if (args) {
+    localizedString = interpolate(localizedString, args);
+  }
+
+  return localizedString;
 };
 
 module.exports = {


### PR DESCRIPTION
This PR aims to provide a simple architecture proposal to internationalize console errors and FES messages. In reference to #3384  and #3390.

Language files are stored in _src/core/i18n/_ as json key/value entries. The language is selected at runtime, depending on the user browser language. If the user language is not supported (there is no dictionary for the language), then the english language file will be used.

`{
    "HELLO": "Hello World!!!",
    "HELLO_NAME": "Hello {0}!!!"
}`

## Usage
Import the module
`var i18n = require('./i18n/locales');`

The simplest scenario:
`console.log(i18n.__('HELLO')); // Hello World!!!`

For parametric strings we need to pass the array of values as second parameter of the function:
`console.log(i18n.__('HELLO_NAME', ['p5.js'])); // Hello p5.js!!!`

A fallback system act as follows:

- If the key is not found on the current language dictionary, the english dictionary is used
- If the key is not found in the english dictionary, print the key itself

Note: this is my first contribution, all kind of feedback is welcome :)
