### PR TITLE
fix radians/degrees conversion error in rotate

### DIFF
--- a/src/webgl/p5.Camera.js
+++ b/src/webgl/p5.Camera.js
@@ -456,7 +456,7 @@ p5.Camera.prototype._rotateView = function(a, x, y, z) {
   centerZ -= this.eyeZ;
 
   var rotation = p5.Matrix.identity(this._renderer._pInst);
-  rotation.rotate(a, x, y, z);
+  rotation.rotate(this._renderer._pInst._toRadians(a), x, y, z);
 
   // prettier-ignore
   var rotatedCenter = [

--- a/src/webgl/p5.RendererGL.js
+++ b/src/webgl/p5.RendererGL.js
@@ -753,7 +753,6 @@ p5.RendererGL.prototype.rotate = function(rad, axis) {
   if (typeof axis === 'undefined') {
     return this.rotateZ(rad);
   }
-  arguments[0] = this._pInst._fromRadians(rad);
   p5.Matrix.prototype.rotate.apply(this.uMVMatrix, arguments);
   return this;
 };

--- a/test/unit/webgl/p5.Camera.js
+++ b/test/unit/webgl/p5.Camera.js
@@ -216,6 +216,62 @@ suite('p5.Camera', function() {
     });
   });
 
+  suite('Rotation with angleMode(DEGREES)', function() {
+    setup(function() {
+      myp5.push();
+      myp5.angleMode(myp5.DEGREES);
+    });
+
+    teardown(function() {
+      myp5.pop();
+    });
+
+    test('Pan() with positive parameter sets correct matrix w/o changing\
+     eyeXYZ or upXYZ', function() {
+      var orig = getVals(myCam);
+
+      //prettier-ignore
+      var expectedMatrix = new Float32Array([
+        0.5403022766113281, -0, 0.8414710164070129, 0,
+        0, 1, 0, 0,
+        -0.8414710164070129, 0, 0.5403022766113281, 0,
+        72.87352752685547, 0, -46.79154968261719, 1
+        ]);
+
+      myCam.pan(1 * 180 / Math.PI);
+
+      assert.deepEqual(myCam.cameraMatrix.mat4, expectedMatrix);
+
+      assert.strictEqual(myCam.eyeX, orig.ex, 'eye X pos changed');
+      assert.strictEqual(myCam.eyeY, orig.ey, 'eye Y pos changed');
+      assert.strictEqual(myCam.eyeZ, orig.ez, 'eye Z pos changed');
+
+      assert.strictEqual(myCam.upX, orig.ux, 'up X pos changed');
+      assert.strictEqual(myCam.upY, orig.uy, 'up Y pos changed');
+      assert.strictEqual(myCam.upZ, orig.uz, 'up Z pos changed');
+    });
+
+    test('Tilt() with positive parameter sets correct Matrix w/o \
+    changing eyeXYZ', function() {
+      var orig = getVals(myCam);
+
+      //prettier-ignore
+      var expectedMatrix = new Float32Array(
+        [1, 0, 0, 0,
+          0, 0.07073719799518585, -0.9974949955940247, 0,
+          -0, 0.9974949955940247, 0.07073719799518585, 0,
+          0, -86.3855972290039, -6.126020908355713, 1]);
+
+      myCam.tilt(1.5 * 180 / Math.PI);
+
+      assert.deepEqual(myCam.cameraMatrix.mat4, expectedMatrix);
+
+      assert.strictEqual(myCam.eyeX, orig.ex, 'eye X pos changed');
+      assert.strictEqual(myCam.eyeY, orig.ey, 'eye Y pos changed');
+      assert.strictEqual(myCam.eyeZ, orig.ez, 'eye Z pos changed');
+    });
+  });
+
   suite('Position / Orientation', function() {
     suite('Camera()', function() {
       test('Camera() with positive parameters sets eye, center, and \


### PR DESCRIPTION
closes #3490 

this fixes an error in angle units conversion related to the camera changes.

the matrix methods _only_ _ever_ take radians. this fixes two places where either degrees or mode-dependent units were passed.