### PR TITLE
Add doc note to avoid loop() inside setup().

### DIFF
--- a/src/core/structure.js
+++ b/src/core/structure.js
@@ -76,6 +76,8 @@ p5.prototype.noLoop = function() {
  * within it. However, the <a href="#/p5/draw">draw()</a> loop may be stopped by calling <a href="#/p5/noLoop">noLoop()</a>.
  * In that case, the <a href="#/p5/draw">draw()</a> loop can be resumed with loop().
  *
+ * Avoid calling loop() from inside setup().
+ *
  * @method loop
  * @example
  * <div><code>


### PR DESCRIPTION
Documentation change.

I wasted hours trying to debug a sketch in which draw() was somehow unable to access a global variable (it came up as undefined). I had been assuming that I should use noLoop() or loop() in setup(), depending on which I wanted. In fact, I think it used to work. But only noLoop() is OK in setup.