### PR TITLE
prevent recursive `draw()` calls, explicitly and from within `loop()`

### DIFF
--- a/src/core/structure.js
+++ b/src/core/structure.js
@@ -341,8 +341,7 @@ p5.prototype.redraw = function(n) {
       this._inUserDraw = true;
       try {
         userDraw();
-      }
-      catch (err) {
+      } catch (err) {
         this._inUserDraw = false;
         throw err;
       }

--- a/src/core/structure.js
+++ b/src/core/structure.js
@@ -109,8 +109,12 @@ p5.prototype.noLoop = function() {
  */
 
 p5.prototype.loop = function() {
-  this._loop = true;
-  this._draw();
+  if (!this._loop) {
+    this._loop = true;
+    if (this._setupDone) {
+      this._draw();
+    }
+  }
 };
 
 /**
@@ -308,6 +312,10 @@ p5.prototype.pop = function() {
  *
  */
 p5.prototype.redraw = function(n) {
+  if (this._inUserDraw || !this._setupDone) {
+    return;
+  }
+
   var numberOfRedraws = parseInt(n);
   if (isNaN(numberOfRedraws) || numberOfRedraws < 1) {
     numberOfRedraws = 1;
@@ -330,7 +338,14 @@ p5.prototype.redraw = function(n) {
       }
       context._setProperty('frameCount', context.frameCount + 1);
       context._registeredMethods.pre.forEach(callMethod);
-      userDraw();
+      this._inUserDraw = true;
+      try {
+        userDraw();
+      }
+      catch (err) {
+        this._inUserDraw = false;
+        throw err;
+      }
       context._registeredMethods.post.forEach(callMethod);
     }
   }

--- a/src/core/structure.js
+++ b/src/core/structure.js
@@ -341,9 +341,8 @@ p5.prototype.redraw = function(n) {
       this._inUserDraw = true;
       try {
         userDraw();
-      } catch (err) {
+      } finally {
         this._inUserDraw = false;
-        throw err;
       }
       context._registeredMethods.post.forEach(callMethod);
     }

--- a/test/unit/core/structure.js
+++ b/test/unit/core/structure.js
@@ -312,4 +312,35 @@ suite('Structure', function() {
       });
     });
   });
+
+  suite('loop', function() {
+    testSketchWithPromise('loop in setup does not call draw', function(
+      sketch,
+      resolve,
+      reject
+    ) {
+      sketch.setup = function() {
+        sketch.loop();
+        resolve();
+      };
+
+      sketch.draw = function() {
+        reject(new Error('Entered draw during loop()'));
+      };
+    });
+
+    testSketchWithPromise('loop in draw does not call draw', function(
+      sketch,
+      resolve,
+      reject
+    ) {
+      sketch.draw = function() {
+        if (sketch.frameCount > 1) {
+          reject(new Error('re-entered draw during loop() call'));
+        }
+        sketch.loop();
+        resolve();
+      };
+    });
+  });
 });


### PR DESCRIPTION
closes #3496 
re: #3242, #3495

this prevents recursive calls of `draw()` from within itself, within `setup()` and from within `loop()` all of which cause various issues discussed above.