### PR TITLE
Optimize color to string

### DIFF
--- a/src/color/p5.Color.js
+++ b/src/color/p5.Color.js
@@ -246,7 +246,7 @@ p5.Color.prototype.toString = function(format) {
 
     case 'rgba':
     default:
-      return 'rgba('.concat(a[0], ', ', a[1], ', ', a[2], ', ', alpha, ')');
+      return 'rgba('.concat(a[0], ',', a[1], ',', a[2], ',', alpha, ')');
   }
 };
 

--- a/src/color/p5.Color.js
+++ b/src/color/p5.Color.js
@@ -84,9 +84,6 @@ p5.Color = function(pInst, vals) {
  * canvas with text representation of color
  */
 p5.Color.prototype.toString = function(format) {
-  if (!this.hsba) this.hsba = color_conversion._rgbaToHSBA(this._array);
-  if (!this.hsla) this.hsla = color_conversion._rgbaToHSLA(this._array);
-
   var a = this.levels;
   var f = this._array;
   var alpha = f[3]; // String representation uses normalized alpha
@@ -149,6 +146,7 @@ p5.Color.prototype.toString = function(format) {
 
     case 'hsb':
     case 'hsv':
+      if (!this.hsba) this.hsba = color_conversion._rgbaToHSBA(this._array);
       return 'hsb('.concat(
         this.hsba[0] * this.maxes[constants.HSB][0],
         ', ',
@@ -160,6 +158,7 @@ p5.Color.prototype.toString = function(format) {
 
     case 'hsb%':
     case 'hsv%':
+      if (!this.hsba) this.hsba = color_conversion._rgbaToHSBA(this._array);
       return 'hsb('.concat(
         (100 * this.hsba[0]).toPrecision(3),
         '%, ',
@@ -171,6 +170,7 @@ p5.Color.prototype.toString = function(format) {
 
     case 'hsba':
     case 'hsva':
+      if (!this.hsba) this.hsba = color_conversion._rgbaToHSBA(this._array);
       return 'hsba('.concat(
         this.hsba[0] * this.maxes[constants.HSB][0],
         ', ',
@@ -184,6 +184,7 @@ p5.Color.prototype.toString = function(format) {
 
     case 'hsba%':
     case 'hsva%':
+      if (!this.hsba) this.hsba = color_conversion._rgbaToHSBA(this._array);
       return 'hsba('.concat(
         (100 * this.hsba[0]).toPrecision(3),
         '%, ',
@@ -196,6 +197,7 @@ p5.Color.prototype.toString = function(format) {
       );
 
     case 'hsl':
+      if (!this.hsla) this.hsla = color_conversion._rgbaToHSLA(this._array);
       return 'hsl('.concat(
         this.hsla[0] * this.maxes[constants.HSL][0],
         ', ',
@@ -206,6 +208,7 @@ p5.Color.prototype.toString = function(format) {
       );
 
     case 'hsl%':
+      if (!this.hsla) this.hsla = color_conversion._rgbaToHSLA(this._array);
       return 'hsl('.concat(
         (100 * this.hsla[0]).toPrecision(3),
         '%, ',
@@ -216,6 +219,7 @@ p5.Color.prototype.toString = function(format) {
       );
 
     case 'hsla':
+      if (!this.hsla) this.hsla = color_conversion._rgbaToHSLA(this._array);
       return 'hsla('.concat(
         this.hsla[0] * this.maxes[constants.HSL][0],
         ', ',
@@ -228,6 +232,7 @@ p5.Color.prototype.toString = function(format) {
       );
 
     case 'hsla%':
+      if (!this.hsla) this.hsla = color_conversion._rgbaToHSLA(this._array);
       return 'hsl('.concat(
         (100 * this.hsla[0]).toPrecision(3),
         '%, ',
@@ -241,7 +246,7 @@ p5.Color.prototype.toString = function(format) {
 
     case 'rgba':
     default:
-      return 'rgba(' + a[0] + ',' + a[1] + ',' + a[2] + ',' + alpha + ')';
+      return 'rgba('.concat(a[0], ', ', a[1], ', ', a[2], ', ', alpha, ')');
   }
 };
 


### PR DESCRIPTION
fixes #3505 

- don't compute HSB or HSL coefficients unless they are used.
- use `string.concat()` to build return value.