### PR TITLE
Promise preloads, loadPromise and loadPromiseAsync

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -7,6 +7,7 @@ require('./core/environment');
 require('./core/error_helpers');
 require('./core/helpers');
 require('./core/legacy');
+require('./core/preload');
 require('./core/p5.Element');
 require('./core/p5.Graphics');
 require('./core/p5.Renderer');

--- a/src/app.js
+++ b/src/app.js
@@ -45,6 +45,7 @@ require('./image/pixels');
 
 // io
 require('./io/files');
+require('./io/loadPromiseAsync');
 require('./io/p5.Table');
 require('./io/p5.TableRow');
 require('./io/p5.XML');

--- a/src/core/main.js
+++ b/src/core/main.js
@@ -268,6 +268,7 @@ var p5 = function(sketch, node, sync) {
         this._registeredPreloadMethods[method] = obj[method];
         obj[method] = this._wrapPreload(obj, method);
       }
+      this._setupPromisePreloads();
 
       userPreload();
       this._runIfPreloadsAreDone();

--- a/src/core/preload.js
+++ b/src/core/preload.js
@@ -16,6 +16,14 @@ p5.prototype._promisePreloads = [
     }
   }
   */
+  {
+    target: p5.prototype,
+    method: 'loadPromiseAsync',
+    addCallbacks: true,
+    legacyPreloadSetup: {
+      method: 'loadPromise'
+    }
+  }
 ];
 
 p5.prototype.registerPromisePreload = function(setup) {

--- a/src/core/preload.js
+++ b/src/core/preload.js
@@ -1,0 +1,142 @@
+'use strict';
+
+var p5 = require('./main');
+
+p5.prototype._promisePreloads = [
+  /* Example object
+  {
+    target: p5.prototype, // The target object to have the method modified
+    method: 'loadXAsync', // The name of the preload function to wrap
+    addCallbacks: true,   // Whether to automatically handle the p5 callbacks
+    legacyPreloadSetup: { // Optional object to generate a legacy-style preload
+      method: 'loadX',    // The name of the legacy preload function to generate
+      createBaseObject: function() {
+        return {};
+      } // An optional function to create the base object for the legacy preload.
+    }
+  }
+  */
+];
+
+p5.prototype.registerPromisePreload = function(setup) {
+  p5.prototype._promisePreloads.push(setup);
+};
+
+p5.prototype._setupPromisePreloads = function() {
+  for (var i in this._promisePreloads) {
+    var preloadSetup = this._promisePreloads[i];
+    // Get the target object that the preload gets assigned to by default,
+    // that is the current object.
+    var target = preloadSetup.target || this;
+    // If the target is the p5 prototype, then set it to the current object instead.
+    if (target === p5.prototype) {
+      target = this;
+    }
+    var method = preloadSetup.method;
+    // Option to add the p5 callback and errorCallback automatically to the function
+    // when setting up the preload.
+    var addCallbacks = preloadSetup.addCallbacks;
+    // Optional setup for a legacy preload that will return an object immediately
+    var legacyPreloadSetup = preloadSetup.legacyPreloadSetup;
+    // Replace the original method with a wrapped version
+    target[method] = this._wrapPromisePreload(
+      target,
+      target[method],
+      addCallbacks
+    );
+    // If we are a global p5 instance and the target of the preload is this then
+    // also add it to the window
+    if (target === this && this._isGlobal) {
+      window[method] = target[method];
+    }
+    // If a legacy preload is required
+    if (legacyPreloadSetup) {
+      // What is the name for this legacy preload
+      var legacyMethod = legacyPreloadSetup.method;
+      // Wrap the already wrapped Promise-returning method with the legacy setup
+      target[legacyMethod] = this._legacyPreloadGenerator(
+        legacyPreloadSetup,
+        target[method]
+      );
+      if (target === this && this._isGlobal) {
+        // If we are a global p5 instance and the target of the preload is this then
+        // also add it to the window
+        window[legacyMethod] = target[legacyMethod];
+      }
+    }
+  }
+};
+
+p5.prototype._wrapPromisePreload = function(target, fn, addCallbacks) {
+  return function() {
+    // Uses the current preload counting mechanism for now.
+    this._incrementPreload();
+    // The arguments to be passed into the wrapped function
+    var args = arguments;
+    // A variable for the callback function if specified
+    var callback;
+    // A variable for the errorCallback function if specified
+    var errorCallback;
+    if (addCallbacks) {
+      // We need to call array methods, so make args an actual array
+      args = Array.prototype.slice.call(arguments);
+      // Temporary holder for callbacks
+      var fns = [];
+      // Loop from the end of the args array, pulling up to two functions off of
+      // the end and putting them in fns
+      for (var i = args.length - 1; i >= 0 && fns.length < 2; i--) {
+        if (typeof args[i] !== 'function') {
+          break;
+        }
+        fns.unshift(args.pop());
+      }
+      // Set our callback variables
+      callback = fns[0];
+      errorCallback = fns[1];
+    }
+    // Call the underlying funciton and pass it to Promise.resolve,
+    // so that even if it didn't return a promise we can still
+    // act on the result as if it did.
+    var promise = Promise.resolve(fn.apply(target, args));
+    // Add the optional callbacks
+    if (callback) {
+      promise.then(callback);
+    }
+    if (errorCallback) {
+      promise.catch(errorCallback);
+    }
+    // Decrement the preload counter only if the promise resolved
+    promise.then(this._decrementPreload.bind(this));
+    // Return the original promise so that neither callback changes the result.
+    return promise;
+  }.bind(this);
+};
+
+var objectCreator = function() {
+  return {};
+};
+
+p5.prototype._legacyPreloadGenerator = function(legacyPreloadSetup, fn) {
+  // Create a function that will generate an object before the preload is
+  // launched. For example, if the object should be an array or be an instance
+  // of a specific class.
+  var baseValueGenerator = legacyPreloadSetup.createBaseObject || objectCreator;
+  return function() {
+    // Our then clause needs to run before setup, so we also increment the preload counter
+    this._incrementPreload();
+    // Generate the return value based on the generator.
+    var returnValue = baseValueGenerator.apply(this, arguments);
+    // Run the original wrapper
+    fn
+      .apply(this, arguments)
+      .then(function(data) {
+        // Copy each key from the resolved value into returnValue
+        for (var key in data) {
+          returnValue[key] = data[key];
+        }
+      })
+      // Decrement the preload counter, to allow setup to continue.
+      .then(this._decrementPreload.bind(this));
+    return returnValue;
+  }.bind(this);
+};

--- a/src/io/loadPromiseAsync.js
+++ b/src/io/loadPromiseAsync.js
@@ -1,0 +1,116 @@
+/**
+ * @module IO
+ * @submodule Preload
+ * @for p5
+ * @requires core
+ */
+'use strict';
+
+var p5 = require('../core/main');
+
+/**
+ * This is a helper function to allow the use of promises in the preload function.
+ * The returned object will have be an approximation of the promise's resolved value,
+ * but for complicated return values, the callback function should be preferred.
+ * <br><br>
+ * This function should never be called outside of preload. If you want to use a promise
+ * outside of preload, you should use the promise's built-in then and catch functionality.
+ * @method loadPromise
+ * @param  {Promise}       promise    The original promise.
+ * @param  {function}      [callback] function to be executed after promise completes, data is passed
+ *                                    in as the first argument
+ * @param  {function}      [errorCallback] function to be executed if
+ *                                    there is an error, the error is passed
+ *                                    in as the first argument
+ * @return {Object}                   An object representing the value from the promise.
+ * @example
+ * <div><code>
+ * // Examples use USGS Earthquake API:
+ * //   https://earthquake.usgs.gov/fdsnws/event/1/#methods
+ * let earthquakes;
+ * function preload() {
+ *   // Get the most recent earthquake in the database
+ *   let url =
+    'https://earthquake.usgs.gov/earthquakes/feed/v1.0/' +
+ *     'summary/all_day.geojson';
+ *   let promise = fetch(url).then(resp => resp.json());
+ *   earthquakes = loadPromise(promise);
+ * }
+ *
+ * function setup() {
+ *   noLoop();
+ * }
+ *
+ * function draw() {
+ *   background(200);
+ *   // Get the magnitude and name of the earthquake out of the loaded JSON
+ *   let earthquakeMag = earthquakes.features[0].properties.mag;
+ *   let earthquakeName = earthquakes.features[0].properties.place;
+ *   ellipse(width / 2, height / 2, earthquakeMag * 10, earthquakeMag * 10);
+ *   textAlign(CENTER);
+ *   text(earthquakeName, 0, height - 30, width, 30);
+ * }
+ * </code></div>
+ *
+ * @alt
+ * An ellipse with a size based on the magnitude of the most recent earthquake with the location written as text
+ *
+ */
+/**
+ *
+ * This is a preload function to make p5 wait for the promise passed in to resolve
+ * before entering setup.
+ * <br><br>
+ * Avoid attaching then clauses onto the returned promise because these can execute
+ * after the sketches' setup function.
+ * <br><br>
+ * This function should never be called outside of preload. If you want to use a promise
+ * outside of preload, you should use the promise's built-in then and catch functionality.
+ *
+ * @method loadPromiseAsync
+ * @param  {Promise}       promise    The promise that p5 should wait on
+ * @param  {function}      [callback] function to be executed after promise completes, data is passed
+ *                                    in as the first argument
+ * @param  {function}      [errorCallback] function to be executed if
+ *                                    there is an error, the error is passed
+ *                                    in as the first argument
+ * @return {Promise}                  The resulting promise
+ * @example
+ *
+ * <div><code>
+ * // Examples use USGS Earthquake API:
+ * //   https://earthquake.usgs.gov/fdsnws/event/1/#methods
+ * let earthquakes;
+ * function preload() {
+ *   // Get the most recent earthquake in the database
+ *   let url =
+    'https://earthquake.usgs.gov/earthquakes/feed/v1.0/' +
+ *     'summary/all_day.geojson';
+ *   let promise = fetch(url).then(resp => resp.json());
+ *   loadPromiseAsync(promise, function(data) {
+ *     earthquakes = data;
+ *   });
+ * }
+ *
+ * function setup() {
+ *   noLoop();
+ * }
+ *
+ * function draw() {
+ *   background(200);
+ *   // Get the magnitude and name of the earthquake out of the loaded JSON
+ *   let earthquakeMag = earthquakes.features[0].properties.mag;
+ *   let earthquakeName = earthquakes.features[0].properties.place;
+ *   ellipse(width / 2, height / 2, earthquakeMag * 10, earthquakeMag * 10);
+ *   textAlign(CENTER);
+ *   text(earthquakeName, 0, height - 30, width, 30);
+ * }
+ * </code></div>
+ *
+ * @alt
+ * An ellipse with a size based on the magnitude of the most recent earthquake with the location written as text
+ *
+ */
+p5.prototype.loadPromiseAsync = function(promise) {
+  return promise;
+};

--- a/test/unit/io/loadPromise.js
+++ b/test/unit/io/loadPromise.js
@@ -1,0 +1,122 @@
+suite('loadPromise', function() {
+  const result = {
+    testKey: true
+  };
+  const successPromise = Promise.resolve(result);
+
+  const error = new Error('This is a test error');
+  const errorPromise = Promise.reject(error);
+
+  testSketchWithPromise('error prevents sketch continuing', function(
+    sketch,
+    resolve,
+    reject
+  ) {
+    sketch.preload = function() {
+      sketch.loadPromise(errorPromise, reject, function() {
+        setTimeout(resolve, 50);
+      });
+    };
+
+    sketch.setup = function() {
+      reject(new Error('Entered setup'));
+    };
+
+    sketch.draw = function() {
+      reject(new Error('Entered draw'));
+    };
+  });
+
+  testSketchWithPromise('error callback is called', function(
+    sketch,
+    resolve,
+    reject
+  ) {
+    sketch.preload = function() {
+      sketch.loadPromise(
+        errorPromise,
+        function() {
+          reject(new Error('Success callback executed.'));
+        },
+        function() {
+          // Wait a bit so that if both callbacks are executed we will get an error.
+          setTimeout(resolve, 50);
+        }
+      );
+    };
+  });
+
+  testSketchWithPromise('loading correctly triggers setup', function(
+    sketch,
+    resolve,
+    reject
+  ) {
+    sketch.preload = function() {
+      sketch.loadPromise(successPromise);
+    };
+
+    sketch.setup = function() {
+      resolve();
+    };
+  });
+
+  testSketchWithPromise('success callback is called', function(
+    sketch,
+    resolve,
+    reject
+  ) {
+    var hasBeenCalled = false;
+    sketch.preload = function() {
+      sketch.loadPromise(
+        successPromise,
+        function() {
+          hasBeenCalled = true;
+        },
+        function(err) {
+          reject(new Error('Error callback was entered: ' + err));
+        }
+      );
+    };
+
+    sketch.setup = function() {
+      if (!hasBeenCalled) {
+        reject(new Error('Setup called prior to success callback'));
+      } else {
+        setTimeout(resolve, 50);
+      }
+    };
+  });
+
+  test('returns an object with right keys', async function() {
+    const returnValue = await promisedSketch(function(sketch, resolve, reject) {
+      var returnValue;
+      sketch.preload = function() {
+        returnValue = sketch.loadPromise(successPromise, function() {}, reject);
+      };
+
+      sketch.setup = function() {
+        resolve(returnValue);
+      };
+    });
+    assert.deepEqual(returnValue, result);
+  });
+
+  test('passes result to success callback', async function() {
+    const json = await promisedSketch(function(sketch, resolve, reject) {
+      sketch.preload = function() {
+        sketch.loadPromise(successPromise, resolve, reject);
+      };
+    });
+    assert.isObject(json);
+    assert.equal(json, result);
+  });
+
+  test('passes error to error callback', async function() {
+    const returnValue = await promisedSketch(function(sketch, resolve, reject) {
+      sketch.preload = function() {
+        sketch.loadPromise(errorPromise, reject, resolve);
+      };
+    });
+    assert.equal(returnValue, error);
+  });
+});

--- a/test/unit/io/loadPromiseAsync.js
+++ b/test/unit/io/loadPromiseAsync.js
@@ -1,0 +1,152 @@
+suite('loadPromiseAsync', function() {
+  const result = {};
+  const successPromise = Promise.resolve(result);
+
+  const error = new Error('This is a test error');
+  const errorPromise = Promise.reject(error);
+
+  testSketchWithPromise('error prevents sketch continuing', function(
+    sketch,
+    resolve,
+    reject
+  ) {
+    sketch.preload = function() {
+      sketch.loadPromiseAsync(errorPromise, reject, function() {
+        setTimeout(resolve, 50);
+      });
+    };
+
+    sketch.setup = function() {
+      reject(new Error('Entered setup'));
+    };
+
+    sketch.draw = function() {
+      reject(new Error('Entered draw'));
+    };
+  });
+
+  testSketchWithPromise('error callback is called', function(
+    sketch,
+    resolve,
+    reject
+  ) {
+    sketch.preload = function() {
+      sketch.loadPromiseAsync(
+        errorPromise,
+        function() {
+          reject(new Error('Success callback executed.'));
+        },
+        function() {
+          // Wait a bit so that if both callbacks are executed we will get an error.
+          setTimeout(resolve, 50);
+        }
+      );
+    };
+  });
+
+  testSketchWithPromise('loading correctly triggers setup', function(
+    sketch,
+    resolve,
+    reject
+  ) {
+    sketch.preload = function() {
+      sketch.loadPromiseAsync(successPromise);
+    };
+
+    sketch.setup = function() {
+      resolve();
+    };
+  });
+
+  testSketchWithPromise('success callback is called', function(
+    sketch,
+    resolve,
+    reject
+  ) {
+    var hasBeenCalled = false;
+    sketch.preload = function() {
+      sketch.loadPromiseAsync(
+        successPromise,
+        function() {
+          hasBeenCalled = true;
+        },
+        function(err) {
+          reject(new Error('Error callback was entered: ' + err));
+        }
+      );
+    };
+
+    sketch.setup = function() {
+      if (!hasBeenCalled) {
+        reject(new Error('Setup called prior to success callback'));
+      } else {
+        setTimeout(resolve, 50);
+      }
+    };
+  });
+
+  test('returns a resolving promise correctly', async function() {
+    const returnValue = await promisedSketch(function(sketch, resolve, reject) {
+      var returnValue;
+      sketch.preload = function() {
+        returnValue = sketch.loadPromiseAsync(
+          successPromise,
+          function() {},
+          reject
+        );
+      };
+
+      sketch.setup = function() {
+        // This prevents the promise from being evaluated inside resolve()
+        resolve({
+          promise: returnValue
+        });
+      };
+    });
+    const promise = returnValue.promise;
+    assert.instanceOf(promise, Promise);
+    const promiseResult = await promise;
+    assert.equal(promiseResult, result);
+  });
+
+  test('passes result to success callback', async function() {
+    const json = await promisedSketch(function(sketch, resolve, reject) {
+      sketch.preload = function() {
+        sketch.loadPromiseAsync(successPromise, resolve, reject);
+      };
+    });
+    assert.isObject(json);
+    assert.equal(json, result);
+  });
+
+  test('returns an erroring promise correctly', async function() {
+    const returnValue = await promisedSketch(function(sketch, resolve, reject) {
+      var returnValue;
+      sketch.preload = function() {
+        returnValue = sketch.loadPromiseAsync(errorPromise, reject);
+        // This prevents the promise from being evaluated inside resolve()
+        resolve({
+          promise: returnValue
+        });
+      };
+    });
+    const promise = returnValue.promise;
+    assert.instanceOf(promise, Promise);
+    try {
+      await promise;
+    } catch (promiseError) {
+      assert.equal(promiseError, error);
+      return;
+    }
+    throw new Error('Returned promise did not throw an error');
+  });
+
+  test('passes error to error callback', async function() {
+    const returnValue = await promisedSketch(function(sketch, resolve, reject) {
+      sketch.preload = function() {
+        sketch.loadPromiseAsync(errorPromise, reject, resolve);
+      };
+    });
+    assert.equal(returnValue, error);
+  });
+});

--- a/test/unit/spec.js
+++ b/test/unit/spec.js
@@ -21,7 +21,9 @@ var spec = {
     'loadJSON',
     'loadTable',
     'loadImage',
-    'loadModel'
+    'loadModel',
+    'loadPromise',
+    'loadPromiseAsync'
   ],
   math: ['calculation', 'noise', 'p5.Vector', 'random', 'trigonometry'],
   typography: ['loadFont'],


### PR DESCRIPTION
This is a big PR that adds the following:

A preload system that works similarly to the current one, but also does the following:
- Handles calling `this._decrementPreload` automatically, which could be problematic for other libraries to do reliably (They might not have access to the `this` instance)
- Can handle adding the standard `callback` and `errorCallback` in p5 flavour to the end of the arguments automatically so that they can be handled reliably & in one place which will hopefully reduce the verbosity of the current preloads
- Can handle automatically generating a 'legacy-style' preload (So, given a preload of the form `loadXAsync` the returns a promise it can generate a `loadX` that will return an object. This has the same set of problems as the `loadJSON` does currently, in that it won't work correctly with arrays and other return types necessarily. It should be sufficient for most use cases, though.

An example `loadPromiseAsync` which takes in a promise and makes p5 wait for the promise before starting the sketch. A `loadPromise` which is generated using the preload system. Both of these have a reasonable test suite modeled on the other preload functions. These will be useful to users of other libraries that load with promises (I'm thinking ml5, tfjs, etc.)

I have also spun out this preload system into its own file so that it is easier to see which bits are related to the preload system, as well as implementing `loadPromise` in its own file for a similar reason (It definitely doesn't belong in `files.js` in my opinion.)

This is the majority of #2698, I should think.