### PR TITLE
Minor formatting improvement to createSelect() docs

### DIFF
--- a/lib/addons/p5.dom.js
+++ b/lib/addons/p5.dom.js
@@ -671,7 +671,7 @@
    * function mySelectEvent() {
    *   var item = sel.value();
    *   background(200);
-   *   text('it is a' + item + '!', 50, 50);
+   *   text('It is a ' + item + '!', 50, 50);
    * }
    * </code></div>
    */


### PR DESCRIPTION
In the current documentation, it shows `"it is apear!"` or `"it is akiwi!"`, without the space between the `"it is a"` string and the `item` variable.