### PR TITLE
Fix get()

### DIFF
--- a/lib/addons/p5.dom.js
+++ b/lib/addons/p5.dom.js
@@ -2880,7 +2880,8 @@
     this.setModified(true);
     return this;
   };
-  p5.MediaElement.prototype.get = function(x, y, w, h) {
+  p5.MediaElement.prototype.get = p5.Renderer2D.prototype.get;
+  p5.MediaElement.prototype._getPixel = function() {
     if (this.loadedmetadata) {
       // wait for metadata
       var currentTime = this.elt.currentTime;
@@ -2889,16 +2890,10 @@
       } else {
         this._ensureCanvas();
       }
-
-      return p5.prototype.get.apply(this, arguments);
-    } else if (typeof x === 'undefined') {
-      return new p5.Image(1, 1);
-    } else if (w > 1) {
-      return new p5.Image(x, y, w, h);
-    } else {
-      return [0, 0, 0, 255];
     }
+    return p5.Renderer2D.prototype._getPixel.apply(this, arguments);
   };
+
   p5.MediaElement.prototype.set = function(x, y, imgOrCol) {
     if (this.loadedmetadata) {
       // wait for metadata

--- a/src/core/p5.Renderer.js
+++ b/src/core/p5.Renderer.js
@@ -110,6 +110,39 @@ p5.Renderer.prototype.resize = function(w, h) {
   }
 };
 
+p5.Renderer.prototype.get = function(x, y, w, h) {
+  var pixelsState = this._pixelsState;
+  var pd = pixelsState._pixelDensity;
+  var canvas = this.canvas;
+
+  if (typeof x === 'undefined' && typeof y === 'undefined') {
+    // get()
+    x = y = 0;
+    w = pixelsState.width;
+    h = pixelsState.height;
+  } else {
+    x *= pd;
+    y *= pd;
+
+    if (typeof w === 'undefined' && typeof h === 'undefined') {
+      // get(x,y)
+      if (x < 0 || y < 0 || x >= canvas.width || y >= canvas.height) {
+        return [0, 0, 0, 0];
+      }
+
+      return this._getPixel(x, y);
+    }
+    // get(x,y,w,h)
+  }
+
+  var region = new p5.Image(w, h);
+  region.canvas
+    .getContext('2d')
+    .drawImage(canvas, x, y, w * pd, h * pd, 0, 0, w, h);
+
+  return region;
+};
+
 p5.Renderer.prototype.textLeading = function(l) {
   if (typeof l === 'number') {
     this._setProperty('_textLeading', l);

--- a/src/core/p5.Renderer2D.js
+++ b/src/core/p5.Renderer2D.js
@@ -239,42 +239,23 @@ p5.Renderer2D._copyHelper = function(
   );
 };
 
-p5.Renderer2D.prototype.get = function(x, y, w, h) {
+// x,y are canvas-relative (pre-scaled by _pixelDensity)
+p5.Renderer2D.prototype._getPixel = function(x, y) {
   var pixelsState = this._pixelsState;
-  var pd = pixelsState._pixelDensity;
-
-  var sx = x * pd;
-  var sy = y * pd;
-  if (w === 1 && h === 1) {
-    var imageData, index;
-    if (pixelsState._pixelsDirty) {
-      imageData = this.drawingContext.getImageData(sx, sy, 1, 1).data;
-      index = 0;
-    } else {
-      imageData = pixelsState.pixels;
-      index = (sx + sy * this.width * pd) * 4;
-    }
-    return [
-      imageData[index + 0],
-      imageData[index + 1],
-      imageData[index + 2],
-      imageData[index + 3]
-    ];
+  var imageData, index;
+  if (pixelsState._pixelsDirty) {
+    imageData = this.drawingContext.getImageData(x, y, 1, 1).data;
+    index = 0;
   } else {
-    //auto constrain the width and height to
-    //dimensions of the source image
-    var dw = Math.min(w, pixelsState.width);
-    var dh = Math.min(h, pixelsState.height);
-    var sw = dw * pd;
-    var sh = dh * pd;
-
-    var region = new p5.Image(dw, dh);
-    region.canvas
-      .getContext('2d')
-      .drawImage(this.canvas, sx, sy, sw, sh, 0, 0, dw, dh);
-
-    return region;
+    imageData = pixelsState.pixels;
+    index = (Math.floor(x) + Math.floor(y) * this.canvas.width) * 4;
   }
+  return [
+    imageData[index + 0],
+    imageData[index + 1],
+    imageData[index + 2],
+    imageData[index + 3]
+  ];
 };
 
 p5.Renderer2D.prototype.loadPixels = function() {

--- a/src/core/p5.Renderer2D.js
+++ b/src/core/p5.Renderer2D.js
@@ -239,6 +239,9 @@ p5.Renderer2D._copyHelper = function(
   );
 };
 
+// p5.Renderer2D.prototype.get = p5.Renderer.prototype.get;
+// .get() is not overridden
+
 // x,y are canvas-relative (pre-scaled by _pixelDensity)
 p5.Renderer2D.prototype._getPixel = function(x, y) {
   var pixelsState = this._pixelsState;

--- a/src/image/p5.Image.js
+++ b/src/image/p5.Image.js
@@ -316,20 +316,17 @@ p5.Image.prototype.updatePixels = function(x, y, w, h) {
 /**
  * Get a region of pixels from an image.
  *
- * If no params are passed, those whole image is returned,
- * if x and y are the only params passed a single pixel is extracted
- * if all params are passed a rectangle region is extracted and a <a href="#/p5.Image">p5.Image</a>
+ * If no params are passed, the whole image is returned.
+ * If x and y are the only params passed a single pixel is extracted.
+ * If all params are passed a rectangle region is extracted and a <a href="#/p5.Image">p5.Image</a>
  * is returned.
  *
- * Returns undefined if the region is outside the bounds of the image
- *
  * @method get
- * @param  {Number}               [x] x-coordinate of the pixel
- * @param  {Number}               [y] y-coordinate of the pixel
- * @param  {Number}               [w] width
- * @param  {Number}               [h] height
- * @return {Number[]|Color|p5.Image}  color of pixel at x,y in array format
- *                                    [R, G, B, A] or <a href="#/p5.Image">p5.Image</a>
+ * @param  {Number}               x x-coordinate of the pixel
+ * @param  {Number}               y y-coordinate of the pixel
+ * @param  {Number}               w width
+ * @param  {Number}               h height
+ * @return {p5.Image}             the rectangle <a href="#/p5.Image">p5.Image</a>
  * @example
  * <div><code>
  * let myImage;
@@ -354,9 +351,22 @@ p5.Image.prototype.updatePixels = function(x, y, w, h) {
  * image of rocky mountains with 50x50 green rect in front
  *
  */
+/**
+ * @method get
+ * @return {p5.Image}      the whole <a href="#/p5.Image">p5.Image</a>
+ */
+/**
+ * @method get
+ * @param  {Number}        x
+ * @param  {Number}        y
+ * @return {Number[]}      color of pixel at x,y in array format [R, G, B, A]
+ */
 p5.Image.prototype.get = function(x, y, w, h) {
-  return p5.prototype.get.call(this, x, y, w, h);
+  p5._validateParameters('p5.Image.get', arguments);
+  return p5.Renderer2D.prototype.get.apply(this, arguments);
 };
+
+p5.Image.prototype._getPixel = p5.Renderer2D.prototype._getPixel;
 
 /**
  * Set the color of a single pixel or write an image into

--- a/src/image/pixels.js
+++ b/src/image/pixels.js
@@ -413,6 +413,8 @@ p5.prototype.filter = function(operation, value) {
 };
 
 /**
+ * Get a region of pixels, or a single pixel, from the canvas.
+ *
  * Returns an array of [R,G,B,A] values for any pixel or grabs a section of
  * an image. If no parameters are specified, the entire image is returned.
  * Use the x and y parameters to get the value of one pixel. Get a section of
@@ -420,8 +422,7 @@ p5.prototype.filter = function(operation, value) {
  * getting an image, the x and y parameters define the coordinates for the
  * upper-left corner of the image, regardless of the current <a href="#/p5/imageMode">imageMode()</a>.
  * <br><br>
- * If the pixel requested is outside of the image window, [0,0,0,255] is
- * returned. To get the numbers scaled according to the current color ranges
+ * To get the color components scaled according to the current color ranges
  * and taking into account <a href="#/p5/colorMode">colorMode</a>, use <a href="#/p5/getColor">getColor</a> instead of get.
  * <br><br>
  * Getting the color of a single pixel with get(x, y) is easy, but not as fast
@@ -439,18 +440,18 @@ p5.prototype.filter = function(operation, value) {
  * print(components);
  * ```
  * <br><br>
+ *
  * See the reference for <a href="#/p5/pixels">pixels[]</a> for more information.
  *
  * If you want to extract an array of colors or a subimage from an p5.Image object,
  * take a look at <a href="#/p5.Image/get">p5.Image.get()</a>
  *
  * @method get
- * @param  {Number}         [x] x-coordinate of the pixel
- * @param  {Number}         [y] y-coordinate of the pixel
- * @param  {Number}         [w] width
- * @param  {Number}         [h] height
- * @return {Number[]|p5.Image}  values of pixel at x,y in array format
- *                              [R, G, B, A] or <a href="#/p5.Image">p5.Image</a>
+ * @param  {Number}         x x-coordinate of the pixel
+ * @param  {Number}         y y-coordinate of the pixel
+ * @param  {Number}         w width
+ * @param  {Number}         h height
+ * @return {p5.Image}       the rectangle <a href="#/p5.Image">p5.Image</a>
  * @example
  * <div>
  * <code>
@@ -487,33 +488,19 @@ p5.prototype.filter = function(operation, value) {
  * Image of the rocky mountains with 50x50 green rect in center of canvas
  *
  */
+/**
+ * @method get
+ * @return {p5.Image}      the whole <a href="#/p5.Image">p5.Image</a>
+ */
+/**
+ * @method get
+ * @param  {Number}        x
+ * @param  {Number}        y
+ * @return {Number[]}      color of pixel at x,y in array format [R, G, B, A]
+ */
 p5.prototype.get = function(x, y, w, h) {
-  if (typeof w === 'undefined' && typeof h === 'undefined') {
-    if (typeof x === 'undefined' && typeof y === 'undefined') {
-      x = y = 0;
-      w = this.width;
-      h = this.height;
-    } else {
-      w = h = 1;
-    }
-  }
-
-  // if the section does not overlap the canvas
-  if (x + w < 0 || y + h < 0 || x >= this.width || y >= this.height) {
-    // TODO: is this valid for w,h > 1 ?
-    return [0, 0, 0, 255];
-  }
-
-  // round down to get integer numbers
-  x = Math.floor(x);
-  y = Math.floor(y);
-  w = Math.floor(w);
-  h = Math.floor(h);
-
-  if (this._renderer) {
-    return this._renderer.get(x, y, w, h);
-  }
-  return p5.Renderer2D.prototype.get.call(this, x, y, w, h);
+  p5._validateParameters('get', arguments);
+  return this._renderer.get.apply(this._renderer, arguments);
 };
 
 /**

--- a/src/webgl/p5.RendererGL.js
+++ b/src/webgl/p5.RendererGL.js
@@ -565,65 +565,18 @@ p5.RendererGL.prototype.strokeWeight = function(w) {
   }
 };
 
-/**
- * Returns an array of [R,G,B,A] values for any pixel or grabs a section of
- * an image. If no parameters are specified, the entire image is returned.
- * Use the x and y parameters to get the value of one pixel. Get a section of
- * the display window by specifying additional w and h parameters. When
- * getting an image, the x and y parameters define the coordinates for the
- * upper-left corner of the image, regardless of the current imageMode().
- * <br><br>
- * If the pixel requested is outside of the image window, [0,0,0,255] is
- * returned.
- * <br><br>
- * Getting the color of a single pixel with get(x, y) is easy, but not as fast
- * as grabbing the data directly from pixels[]. The equivalent statement to
- * get(x, y) is using pixels[] with pixel density d
- *
- * @private
- * @method get
- * @param  {Number}               [x] x-coordinate of the pixel
- * @param  {Number}               [y] y-coordinate of the pixel
- * @param  {Number}               [w] width
- * @param  {Number}               [h] height
- * @return {Number[]|Color|p5.Image}  color of pixel at x,y in array format
- *                                    [R, G, B, A] or <a href="#/p5.Image">p5.Image</a>
- */
-p5.RendererGL.prototype.get = function(x, y, w, h) {
-  var pixelsState = this._pixelsState;
-  var pd = pixelsState._pixelDensity;
-
-  var sx = x * pd;
-  var sy = y * pd;
-
-  if (w === 1 && h === 1) {
-    var pixels = new Uint8Array(4);
-    this.drawingContext.readPixels(
-      sx,
-      sy,
-      1,
-      1,
-      this.drawingContext.RGBA,
-      this.drawingContext.UNSIGNED_BYTE,
-      pixels
-    );
-    return [pixels[0], pixels[1], pixels[2], pixels[3]];
-  } else {
-    //auto constrain the width and height to
-    //dimensions of the source image
-    var dw = Math.min(w, pixelsState.width);
-    var dh = Math.min(h, pixelsState.height);
-    var sw = dw * pd;
-    var sh = dh * pd;
-
-    var region = new p5.Image(dw, dh);
-    region.canvas
-      .getContext('2d') // not sure this is correct
-      .drawImage(this.canvas, sx, sy, sw, sh, 0, 0, dw, dh);
-
-    return region;
-  }
+// x,y are canvas-relative (pre-scaled by _pixelDensity)
+p5.RendererGL.prototype._getPixel = function(x, y) {
+  var pixels = new Uint8Array(4);
+  // prettier-ignore
+  this.drawingContext.readPixels(
+    x, y, 1, 1,
+    this.drawingContext.RGBA, this.drawingContext.UNSIGNED_BYTE,
+    pixels
+  );
+  return [pixels[0], pixels[1], pixels[2], pixels[3]];
 };
+
 /**
  * Loads the pixels data for this canvas into the pixels[] attribute.
  * Note that updatePixels() and set() do not work.

--- a/test/manual-test-examples/p5.Image/loadPixels.js
+++ b/test/manual-test-examples/p5.Image/loadPixels.js
@@ -3,7 +3,6 @@ p5.disableFriendlyErrors = true;
 var img;
 function preload() {
   img = createVideo('../addons/p5.dom/fingers.mov');
-  //img.loop();
   img.hide();
 }
 

--- a/test/unit/image/pixels.js
+++ b/test/unit/image/pixels.js
@@ -39,7 +39,7 @@ suite('pixels', function() {
       img.updatePixels();
     });
 
-    test('works with integers', function() {
+     test('get(x,y) works with integers', function() {
       assert.deepEqual(img.get(25, 25), [255, 0, 0, 255]);
       assert.deepEqual(img.get(25, 26), [0, 0, 255, 255]);
       assert.deepEqual(img.get(0, 0), [255, 0, 0, 255]);

--- a/test/unit/image/pixels.js
+++ b/test/unit/image/pixels.js
@@ -53,7 +53,7 @@ suite('pixels', function() {
       assert.deepEqual(img.get(50, 26), [0, 0, 0, 0]);
     });
 
-    test('get() works', function() {
+    test('get() returns a copy when no arguments are supplied', function() {
       var copy = img.get();
       assert.instanceOf(copy, p5.Image);
       assert.equal(copy.width, img.width);

--- a/test/unit/image/pixels.js
+++ b/test/unit/image/pixels.js
@@ -39,7 +39,7 @@ suite('pixels', function() {
       img.updatePixels();
     });
 
-     test('get(x,y) works with integers', function() {
+    test('get(x,y) works with integers', function() {
       assert.deepEqual(img.get(25, 25), [255, 0, 0, 255]);
       assert.deepEqual(img.get(25, 26), [0, 0, 255, 255]);
       assert.deepEqual(img.get(0, 0), [255, 0, 0, 255]);

--- a/test/unit/image/pixels.js
+++ b/test/unit/image/pixels.js
@@ -46,7 +46,7 @@ suite('pixels', function() {
       assert.deepEqual(img.get(49, 49), [0, 0, 255, 255]);
     });
 
-    test('works when out of bounds', function() {
+    test('get(x,y) returns 0s for out of bounds arguments', function() {
       assert.deepEqual(img.get(25, -1), [0, 0, 0, 0]);
       assert.deepEqual(img.get(-1, 26), [0, 0, 0, 0]);
       assert.deepEqual(img.get(25, 50), [0, 0, 0, 0]);

--- a/test/unit/image/pixels.js
+++ b/test/unit/image/pixels.js
@@ -42,6 +42,39 @@ suite('pixels', function() {
     test('works with integers', function() {
       assert.deepEqual(img.get(25, 25), [255, 0, 0, 255]);
       assert.deepEqual(img.get(25, 26), [0, 0, 255, 255]);
+      assert.deepEqual(img.get(0, 0), [255, 0, 0, 255]);
+      assert.deepEqual(img.get(49, 49), [0, 0, 255, 255]);
+    });
+
+    test('works when out of bounds', function() {
+      assert.deepEqual(img.get(25, -1), [0, 0, 0, 0]);
+      assert.deepEqual(img.get(-1, 26), [0, 0, 0, 0]);
+      assert.deepEqual(img.get(25, 50), [0, 0, 0, 0]);
+      assert.deepEqual(img.get(50, 26), [0, 0, 0, 0]);
+    });
+
+    test('get() works', function() {
+      var copy = img.get();
+      assert.instanceOf(copy, p5.Image);
+      assert.equal(copy.width, img.width);
+      assert.equal(copy.height, img.height);
+
+      assert.deepEqual(copy.get(25, 25), [255, 0, 0, 255]);
+      assert.deepEqual(copy.get(25, 26), [0, 0, 255, 255]);
+      assert.deepEqual(copy.get(0, 0), [255, 0, 0, 255]);
+      assert.deepEqual(copy.get(49, 49), [0, 0, 255, 255]);
+    });
+
+    test('get(x,y,w,h) works', function() {
+      for (var w = 1; w < img.width + 5; w += 2) {
+        for (var x = -w * 2; x <= img.width + w * 2; x += 4) {
+          var copy = img.get(x, x, w, w);
+          assert.instanceOf(copy, p5.Image);
+          assert.equal(copy.width, w);
+          assert.equal(copy.height, w);
+          assert.deepEqual(copy.get(0, 0), img.get(x, x));
+        }
+      }
     });
 
     test('rounds down when given decimal numbers', function() {


### PR DESCRIPTION
~~(based on #3519, i will rebase after that is merged, diffs: https://github.com/Spongman/p5.js/compare/fix-loadPixels...Spongman:fix-get)~~

fixes #3493

* unifies the `get` logic into a single function
* breaks out the renderer-specific code into a separate `_readPixel` function.
* implements type-specific overloads in `get()`
  * get() : returns an image
  * get(x,y) : returns a pixel
  * get(x, y, w, h) : returns an image
* docs for the above
* `get()` now calls `_validateParameters` (no, it's not a perf issue)
* adds some tests to ensure the above.