### PR TITLE
Webgl pixels

### DIFF
--- a/src/webgl/p5.RendererGL.Retained.js
+++ b/src/webgl/p5.RendererGL.Retained.js
@@ -366,6 +366,7 @@ p5.RendererGL.prototype._drawPoints = function(vertices, vertexBuffer) {
   gl.drawArrays(gl.Points, 0, vertices.length);
 
   pointShader.unbindShader();
+  this._pixelsState._pixelsDirty = true;
 };
 
 module.exports = p5.RendererGL;

--- a/test/unit/webgl/p5.RendererGL.js
+++ b/test/unit/webgl/p5.RendererGL.js
@@ -58,6 +58,16 @@ suite('p5.RendererGL', function() {
       assert.deepEqual(pixels[3], 255);
       done();
     });
+
+    test('get() singlePixel color and size, with loadPixels', function(done) {
+      myp5.createCanvas(100, 100, myp5.WEBGL);
+      myp5.background(100, 115, 100);
+      myp5.loadPixels();
+      var img = myp5.get(0, 0);
+      assert.isTrue(img[1] === 115);
+      assert.isTrue(img.length === 4);
+      done();
+    });
   });
 
   suite('get()', function() {
@@ -78,6 +88,10 @@ suite('p5.RendererGL', function() {
     test('get() singlePixel color and size', function(done) {
       myp5.createCanvas(100, 100, myp5.WEBGL);
       myp5.background(100, 115, 100);
+      img = myp5.get(0, 0);
+      assert.isTrue(img[1] === 115);
+      assert.isTrue(img.length === 4);
+      myp5.loadPixels();
       img = myp5.get(0, 0);
       assert.isTrue(img[1] === 115);
       assert.isTrue(img.length === 4);


### PR DESCRIPTION
~~(based on #3520, diffs: https://github.com/Spongman/p5.js/compare/fix-get...Spongman:webgl-pixels)~~

this corrects the `_pixelsDirty` handling of the `pixels` array in the webgl renderer, and adds a couple of tests for this.