### PR TITLE
Added note for multiple ids in one page

### DIFF
--- a/src/core/p5.Element.js
+++ b/src/core/p5.Element.js
@@ -123,6 +123,9 @@ p5.Element.prototype.parent = function(p) {
  *
  * Sets the ID of the element. If no ID argument is passed in, it instead
  * returns the current ID of the element.
+ * Note that only one element can have a particular id in a page.
+ * The <a href="#/p5.Element/class">.class()</a> function can be used
+ * to identify multiple elements with the same class name.
  *
  * @method id
  * @param  {String} id ID of the element


### PR DESCRIPTION
Solving #3510

The change made in this PR is : 
Added a note for users that multiple ids cannot be present in a single page , and refer to classes instead.

@lmccart I have made the changes in the documentation as instructed, though it does not close the issue. I request you to review the changes ,

Thank you!