### PR TITLE
get rid of obsolete variable textureImage in RendererGL

### DIFF
--- a/src/webgl/material.js
+++ b/src/webgl/material.js
@@ -458,8 +458,8 @@ p5.prototype.textureMode = function(mode) {
  * function draw() {
  *   background(0);
  *
- *   let dX = mouseX / width;
- *   let dY = mouseY / height;
+ *   let dX = mouseX;
+ *   let dY = mouseY;
  *
  *   let u = lerp(1.0, 2.0, dX);
  *   let v = lerp(1.0, 2.0, dY);

--- a/src/webgl/p5.RendererGL.Immediate.js
+++ b/src/webgl/p5.RendererGL.Immediate.js
@@ -103,12 +103,12 @@ p5.RendererGL.prototype.vertex = function(x, y) {
   );
 
   if (this.textureMode === constants.IMAGE) {
-    if (this.textureImage !== undefined) {
-      if (this.textureImage.width > 0 && this.textureImage.height > 0) {
-        u /= this.textureImage.width;
-        v /= this.textureImage.height;
+    if (this._tex !== null) {
+      if (this._tex.width > 0 && this._tex.height > 0) {
+        u /= this._tex.width;
+        v /= this._tex.height;
       }
-    } else if (this.textureImage === undefined && arguments.length >= 4) {
+    } else if (this._tex === null && arguments.length >= 4) {
       // Only throw this warning if custom uv's have  been provided
       console.warn(
         'You must first call texture() before using' +

--- a/src/webgl/p5.RendererGL.js
+++ b/src/webgl/p5.RendererGL.js
@@ -126,7 +126,7 @@ p5.RendererGL = function(elt, pInst, isMainCanvas, attr) {
 
   // array of textures created in this gl context via this.getTexture(src)
   this.textures = [];
-  this.textureImage = undefined;
+
   this.textureMode = constants.IMAGE;
   // default wrap settings
   this.textureWrapX = constants.CLAMP;


### PR DESCRIPTION
vaguely related to #3555 but really just wanted to clear out an old variable that is no longer used when calculating image uvs.