### PR TITLE
fix small error in FES doc example

### DIFF
--- a/developer_docs/friendly_error_system.md
+++ b/developer_docs/friendly_error_system.md
@@ -22,7 +22,7 @@ FES provides a generalized error message generation system that developers may u
 /// missing font file
 let myFont;
 function preload() {
-  myFont = sketch.loadFont('assets/OpenSans-Regular.ttf');
+  myFont = loadFont('assets/OpenSans-Regular.ttf');
 };
 function setup() {
   fill('#ED225D');


### PR DESCRIPTION
The change made in this PR is : 
- remove undefined variable `sketch` from FES example.

I request the maintainers to review this PR,
Thank you !