### PR TITLE
Make downKeys variable instance specific, fixes #3193

### DIFF
--- a/src/core/main.js
+++ b/src/core/main.js
@@ -575,6 +575,8 @@ p5.prototype._initializeInstanceVariables = function() {
   };
 
   this._pixelsDirty = true;
+
+  this.downKeys = {}; //Holds the key codes of currently pressed keys
 };
 
 // This is a pointer to our global mode p5 instance, if we're in

--- a/src/core/main.js
+++ b/src/core/main.js
@@ -576,7 +576,7 @@ p5.prototype._initializeInstanceVariables = function() {
 
   this._pixelsDirty = true;
 
-  this.downKeys = {}; //Holds the key codes of currently pressed keys
+  this._downKeys = {}; //Holds the key codes of currently pressed keys
 };
 
 // This is a pointer to our global mode p5 instance, if we're in

--- a/src/events/keyboard.js
+++ b/src/events/keyboard.js
@@ -10,12 +10,6 @@
 var p5 = require('../core/main');
 
 /**
- * Holds the key codes of currently pressed keys.
- * @private
- */
-var downKeys = {};
-
-/**
  * The boolean system variable <a href="#/p5/keyIsPressed">keyIsPressed</a> is true if any key is pressed
  * and false if no keys are pressed.
  *
@@ -174,14 +168,14 @@ p5.prototype.keyCode = 0;
  *
  */
 p5.prototype._onkeydown = function(e) {
-  if (downKeys[e.which]) {
+  if (this.downKeys[e.which]) {
     // prevent multiple firings
     return;
   }
   this._setProperty('isKeyPressed', true);
   this._setProperty('keyIsPressed', true);
   this._setProperty('keyCode', e.which);
-  downKeys[e.which] = true;
+  this.downKeys[e.which] = true;
   this._setProperty('key', e.key || String.fromCharCode(e.which) || e.which);
   var keyPressed = this.keyPressed || window.keyPressed;
   if (typeof keyPressed === 'function' && !e.charCode) {
@@ -224,9 +218,9 @@ p5.prototype._onkeydown = function(e) {
  */
 p5.prototype._onkeyup = function(e) {
   var keyReleased = this.keyReleased || window.keyReleased;
-  downKeys[e.which] = false;
+  this.downKeys[e.which] = false;
 
-  if (!areDownKeys()) {
+  if (!this._areDownKeys()) {
     this._setProperty('isKeyPressed', false);
     this._setProperty('keyIsPressed', false);
   }
@@ -304,7 +298,7 @@ p5.prototype._onkeypress = function(e) {
  * been released.
  */
 p5.prototype._onblur = function(e) {
-  downKeys = {};
+  this.downKeys = {};
 };
 
 /**
@@ -381,25 +375,25 @@ p5.prototype._onblur = function(e) {
  */
 p5.prototype.keyIsDown = function(code) {
   p5._validateParameters('keyIsDown', arguments);
-  return downKeys[code];
+  return this.downKeys[code];
 };
 
 /**
- * The checkDownKeys function returns a boolean true if any keys pressed
+ * The _areDownKeys function returns a boolean true if any keys pressed
  * and a false if no keys are currently pressed.
 
- * Helps avoid instances where a multiple keys are pressed simultaneously and
+ * Helps avoid instances where multiple keys are pressed simultaneously and
  * releasing a single key will then switch the
  * keyIsPressed property to true.
  * @private
 **/
-function areDownKeys() {
-  for (var key in downKeys) {
-    if (downKeys.hasOwnProperty(key) && downKeys[key] === true) {
+p5.prototype._areDownKeys = function() {
+  for (var key in this.downKeys) {
+    if (this.downKeys.hasOwnProperty(key) && this.downKeys[key] === true) {
       return true;
     }
   }
   return false;
-}
+};
 
 module.exports = p5;

--- a/src/events/keyboard.js
+++ b/src/events/keyboard.js
@@ -168,14 +168,14 @@ p5.prototype.keyCode = 0;
  *
  */
 p5.prototype._onkeydown = function(e) {
-  if (this.downKeys[e.which]) {
+  if (this._downKeys[e.which]) {
     // prevent multiple firings
     return;
   }
   this._setProperty('isKeyPressed', true);
   this._setProperty('keyIsPressed', true);
   this._setProperty('keyCode', e.which);
-  this.downKeys[e.which] = true;
+  this._downKeys[e.which] = true;
   this._setProperty('key', e.key || String.fromCharCode(e.which) || e.which);
   var keyPressed = this.keyPressed || window.keyPressed;
   if (typeof keyPressed === 'function' && !e.charCode) {
@@ -218,7 +218,7 @@ p5.prototype._onkeydown = function(e) {
  */
 p5.prototype._onkeyup = function(e) {
   var keyReleased = this.keyReleased || window.keyReleased;
-  this.downKeys[e.which] = false;
+  this._downKeys[e.which] = false;
 
   if (!this._areDownKeys()) {
     this._setProperty('isKeyPressed', false);
@@ -298,7 +298,7 @@ p5.prototype._onkeypress = function(e) {
  * been released.
  */
 p5.prototype._onblur = function(e) {
-  this.downKeys = {};
+  this._downKeys = {};
 };
 
 /**
@@ -375,7 +375,7 @@ p5.prototype._onblur = function(e) {
  */
 p5.prototype.keyIsDown = function(code) {
   p5._validateParameters('keyIsDown', arguments);
-  return this.downKeys[code];
+  return this._downKeys[code];
 };
 
 /**
@@ -388,8 +388,8 @@ p5.prototype.keyIsDown = function(code) {
  * @private
 **/
 p5.prototype._areDownKeys = function() {
-  for (var key in this.downKeys) {
-    if (this.downKeys.hasOwnProperty(key) && this.downKeys[key] === true) {
+  for (var key in this._downKeys) {
+    if (this._downKeys.hasOwnProperty(key) && this._downKeys[key] === true) {
       return true;
     }
   }

--- a/test/unit/events/keyboard.js
+++ b/test/unit/events/keyboard.js
@@ -1,0 +1,22 @@
+suite('Keyboard Events', function() {
+  suite('keyPressed', function() {
+    test('keyPressed functions on multiple instances must run once', async function() {
+      let sketchFn = function(sketch, resolve, reject) {
+        let count = 0;
+        sketch.keyPressed = function() {
+          count += 1;
+        };
+
+        sketch.finish = function() {
+          resolve(count);
+        };
+      };
+      let sketches = parallelSketches([sketchFn, sketchFn]); //create two sketches
+      await sketches.setup; //wait for all sketches to setup
+      window.dispatchEvent(new KeyboardEvent('keydown')); //dipatch a keyboard event to trigger the keyPressed functions
+      sketches.end(); //resolve all sketches by calling their finish functions
+      let counts = await sketches.result; //get array holding number of times keyPressed was called. Rejected sketches also thrown here
+      assert.deepEqual(counts, [1, 1]); //check if every keyPressed function was called once
+    });
+  });
+});

--- a/test/unit/spec.js
+++ b/test/unit/spec.js
@@ -12,6 +12,7 @@ var spec = {
     'structure'
   ],
   data: ['p5.TypedDict'],
+  events: ['keyboard'],
   image: ['loading', 'pixels'],
   io: [
     'files',


### PR DESCRIPTION
Fixes #3193 

The changes made in this PR are ,
- Change downKeys variable from global to separate for every instance , so that every instance's keyPressed function is allowed to run .
- Write a unit test, which confirms this behavior.  (with great help from @meiamsome ) 

I request the maintainers to review the PR and suggest the changes , if necessary .
Thank you !