### PR TITLE
enforce use of constants in filter function

### DIFF
--- a/src/image/p5.Image.js
+++ b/src/image/p5.Image.js
@@ -646,7 +646,7 @@ p5.Image.prototype.mask = function(p5Image) {
  * }
  *
  * function setup() {
- *   photo2.filter('gray');
+ *   photo2.filter(GRAY);
  *   image(photo1, 0, 0);
  *   image(photo2, width / 2, 0);
  * }
@@ -657,7 +657,7 @@ p5.Image.prototype.mask = function(p5Image) {
  *
  */
 p5.Image.prototype.filter = function(operation, value) {
-  Filters.apply(this.canvas, Filters[operation.toLowerCase()], value);
+  Filters.apply(this.canvas, Filters[operation], value);
   this.setModified(true);
 };
 

--- a/src/image/pixels.js
+++ b/src/image/pixels.js
@@ -406,9 +406,9 @@ p5.prototype.copy = function() {
 p5.prototype.filter = function(operation, value) {
   p5._validateParameters('filter', arguments);
   if (this.canvas !== undefined) {
-    Filters.apply(this.canvas, Filters[operation.toLowerCase()], value);
+    Filters.apply(this.canvas, Filters[operation], value);
   } else {
-    Filters.apply(this.elt, Filters[operation.toLowerCase()], value);
+    Filters.apply(this.elt, Filters[operation], value);
   }
 };
 


### PR DESCRIPTION
Fixes #3522 

The changes made in this PR are : 
- change `Filters.apply(this.canvas, Filters[operation.toLowerCase()], value);`  to `Filters.apply(this.canvas, Filters[operation], value);` to make use of predefined constants only.
- change filter example to match the new changes.

I request you to review the changes,
Thank you!