### PR TITLE
🌈 Assorted arc() fixes

### DIFF
--- a/src/core/p5.Renderer2D.js
+++ b/src/core/p5.Renderer2D.js
@@ -450,7 +450,7 @@ p5.Renderer2D.prototype.arc = function(x, y, w, h, start, stop, mode) {
   y += ry;
 
   // Create curves
-  while (stop - start > epsilon) {
+  while (stop - start >= epsilon) {
     arcToDraw = Math.min(stop - start, constants.HALF_PI);
     curves.push(this._acuteArcToBezier(start, arcToDraw));
     start += arcToDraw;

--- a/src/core/p5.Renderer2D.js
+++ b/src/core/p5.Renderer2D.js
@@ -431,6 +431,13 @@ p5.Renderer2D.prototype._acuteArcToBezier = function _acuteArcToBezier(
   };
 };
 
+/*
+ * This function requires that:
+ *
+ *   0 <= start < TWO_PI
+ *
+ *   start <= stop < start + TWO_PI
+ */
 p5.Renderer2D.prototype.arc = function(x, y, w, h, start, stop, mode) {
   var ctx = this.drawingContext;
   var rx = w / 2.0;

--- a/src/core/shape/2d_primitives.js
+++ b/src/core/shape/2d_primitives.js
@@ -100,23 +100,9 @@ p5.prototype.arc = function(x, y, w, h, start, stop, mode, detail) {
   while (stop < 0) {
     stop += constants.TWO_PI;
   }
-
-  if (typeof start !== 'undefined' && typeof stop !== 'undefined') {
-    // don't display anything if the angles are same or they have a difference of 0 - TWO_PI
-    if (
-      stop.toFixed(10) === start.toFixed(10) ||
-      Math.abs(stop - start) === constants.TWO_PI
-    ) {
-      start %= constants.TWO_PI;
-      stop %= constants.TWO_PI;
-      start += constants.TWO_PI;
-    } else if (Math.abs(stop - start) > constants.TWO_PI) {
-      // display a full circle if the difference between them is greater than 0 - TWO_PI
-      start %= constants.TWO_PI;
-      stop %= constants.TWO_PI;
-      stop += constants.TWO_PI;
-    }
-  }
+  // ...and confine them to the interval [0,TWO_PI).
+  start %= constants.TWO_PI;
+  stop %= constants.TWO_PI;
 
   //Adjust angles to counter linear scaling.
   if (start <= constants.HALF_PI) {

--- a/src/core/shape/2d_primitives.js
+++ b/src/core/shape/2d_primitives.js
@@ -122,6 +122,8 @@ p5.prototype.arc = function(x, y, w, h, start, stop, mode, detail) {
 
   // Exceed the interval if necessary in order to preserve the size and
   // orientation of the arc.
+  //
+  // This leaves 0 <= start < TWO_PI; and start <= stop < start + TWO_PI.
   if (start > stop) {
     stop += constants.TWO_PI;
   }

--- a/src/core/shape/2d_primitives.js
+++ b/src/core/shape/2d_primitives.js
@@ -104,16 +104,20 @@ p5.prototype.arc = function(x, y, w, h, start, stop, mode, detail) {
   start %= constants.TWO_PI;
   stop %= constants.TWO_PI;
 
-  //Adjust angles to counter linear scaling.
+  // Adjust angles to counter linear scaling.
   if (start <= constants.HALF_PI) {
     start = Math.atan(w / h * Math.tan(start));
   } else if (start > constants.HALF_PI && start <= 3 * constants.HALF_PI) {
     start = Math.atan(w / h * Math.tan(start)) + constants.PI;
+  } else {
+    start = Math.atan(w / h * Math.tan(start)) + constants.TWO_PI;
   }
   if (stop <= constants.HALF_PI) {
     stop = Math.atan(w / h * Math.tan(stop));
   } else if (stop > constants.HALF_PI && stop <= 3 * constants.HALF_PI) {
     stop = Math.atan(w / h * Math.tan(stop)) + constants.PI;
+  } else {
+    stop = Math.atan(w / h * Math.tan(stop)) + constants.TWO_PI;
   }
 
   // Exceed the interval if necessary in order to preserve the size and

--- a/test/manual-test-examples/p5.Renderer2D/arc/scalingCorrection/index.html
+++ b/test/manual-test-examples/p5.Renderer2D/arc/scalingCorrection/index.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<html>
+
+<head>
+  <meta charset="utf-8">
+  <meta http-equiv="X-UA-Compatible" content="IE=edge">
+  <title></title>
+  <link rel="stylesheet" href="../../../styles.css">
+  <script language="javascript" type="text/javascript" src="../../../../../lib/p5.js"></script>
+  <script language="javascript" type="text/javascript" src="sketch.js"></script>
+</head>
+
+<body>
+</body>
+
+</html>

--- a/test/manual-test-examples/p5.Renderer2D/arc/scalingCorrection/sketch.js
+++ b/test/manual-test-examples/p5.Renderer2D/arc/scalingCorrection/sketch.js
@@ -1,0 +1,35 @@
+var a, b;
+var w, h;
+var theta = 0;
+var phi = 0;
+
+function setup() {
+  createCanvas(600, 600);
+  strokeWeight(2);
+}
+
+function draw() {
+  background(230);
+
+  // Should draw a growing/shrinking ellipse with alternating colour in
+  // each quadrant.
+  w = 300 + 250 * cos(phi);
+  h = 300 + 250 * sin(phi);
+  noStroke();
+  fill(255);
+  arc(300, 300, w, h, theta, theta + PI / 2);
+  arc(300, 300, w, h, theta + PI, theta + 3 * PI / 2);
+  fill(200);
+  arc(300, 300, w, h, theta + PI / 2, theta + PI);
+  arc(300, 300, w, h, theta + 3 * PI / 2, theta);
+
+  // Draws dividers between rotating quadrants.
+  stroke(237, 34, 93);
+  a = 425 * cos(theta);
+  b = 425 * sin(theta);
+  line(300 - a, 300 - b, 300 + a, 300 + b);
+  line(300 - b, 300 + a, 300 + b, 300 - a);
+
+  theta += 0.01;
+  phi += 0.0123;
+}

--- a/test/manual-test-examples/p5.Renderer2D/arc/startStopWrapping/index.html
+++ b/test/manual-test-examples/p5.Renderer2D/arc/startStopWrapping/index.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<html>
+
+<head>
+  <meta charset="utf-8">
+  <meta http-equiv="X-UA-Compatible" content="IE=edge">
+  <title></title>
+  <link rel="stylesheet" href="../../../styles.css">
+  <script language="javascript" type="text/javascript" src="../../../../../lib/p5.js"></script>
+  <script language="javascript" type="text/javascript" src="sketch.js"></script>
+</head>
+
+<body>
+</body>
+
+</html>

--- a/test/manual-test-examples/p5.Renderer2D/arc/startStopWrapping/sketch.js
+++ b/test/manual-test-examples/p5.Renderer2D/arc/startStopWrapping/sketch.js
@@ -1,0 +1,25 @@
+var angle_1 = 0;
+var angle_2 = 30;
+
+function setup() {
+  createCanvas(800, 600);
+}
+
+function draw() {
+  background(230);
+  strokeWeight(3);
+  stroke(237, 34, 93);
+  fill(255);
+  arc(100, 150, 150, 150, radians(angle_1), radians(angle_2), OPEN);
+  arc(300, 150, 150, 150, radians(angle_1), radians(angle_2), CHORD);
+  arc(500, 150, 150, 150, radians(angle_1), radians(angle_2), PIE);
+  arc(700, 150, 150, 150, radians(angle_1), radians(angle_2));
+  noFill();
+  arc(100, 450, 150, 150, radians(angle_1), radians(angle_2), OPEN);
+  arc(300, 450, 150, 150, radians(angle_1), radians(angle_2), CHORD);
+  arc(500, 450, 150, 150, radians(angle_1), radians(angle_2), PIE);
+  arc(700, 450, 150, 150, radians(angle_1), radians(angle_2));
+
+  angle_1 = angle_1 + 1;
+  angle_2 = angle_2 + 2;
+}

--- a/test/manual-test-examples/webgl/arc/scalingCorrection/index.html
+++ b/test/manual-test-examples/webgl/arc/scalingCorrection/index.html
@@ -5,10 +5,10 @@
   <meta charset="utf-8">
   <meta http-equiv="X-UA-Compatible" content="IE=edge">
   <title></title>
-  <link rel="stylesheet" href="../../styles.css">
-  <script language="javascript" type="text/javascript" src="../../../../lib/p5.js"></script>
+  <link rel="stylesheet" href="../../../styles.css">
+  <script language="javascript" type="text/javascript" src="../../../../../lib/p5.js"></script>
   <script language="javascript" type="text/javascript" src="sketch.js"></script>
-  <script src="../stats.js"></script>
+  <script src="../../stats.js"></script>
 </head>
 
 <body>

--- a/test/manual-test-examples/webgl/arc/scalingCorrection/sketch.js
+++ b/test/manual-test-examples/webgl/arc/scalingCorrection/sketch.js
@@ -1,0 +1,36 @@
+var a, b;
+var w, h;
+var theta = 0;
+var phi = 0;
+
+function setup() {
+  createCanvas(600, 600, WEBGL);
+  setAttributes('antialias', true);
+  strokeWeight(2);
+}
+
+function draw() {
+  background(230);
+
+  // Draws dividers between rotating quadrants.
+  stroke(237, 34, 93);
+  a = 425 * cos(theta);
+  b = 425 * sin(theta);
+  line(-a, -b, a, b);
+  line(-b, a, b, -a);
+
+  // Should draw a growing/shrinking ellipse with alternating colour in
+  // each quadrant.
+  w = 300 + 250 * cos(phi);
+  h = 300 + 250 * sin(phi);
+  noStroke();
+  fill(255);
+  arc(0, 0, w, h, theta, theta + PI / 2);
+  arc(0, 0, w, h, theta + PI, theta + 3 * PI / 2);
+  fill(200);
+  arc(0, 0, w, h, theta + PI / 2, theta + PI);
+  arc(0, 0, w, h, theta + 3 * PI / 2, theta);
+
+  theta += 0.01;
+  phi += 0.0123;
+}

--- a/test/manual-test-examples/webgl/arc/startStopWrapping/index.html
+++ b/test/manual-test-examples/webgl/arc/startStopWrapping/index.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html>
+
+<head>
+  <meta charset="utf-8">
+  <meta http-equiv="X-UA-Compatible" content="IE=edge">
+  <title></title>
+  <link rel="stylesheet" href="../../../styles.css">
+  <script language="javascript" type="text/javascript" src="../../../../../lib/p5.js"></script>
+  <script language="javascript" type="text/javascript" src="sketch.js"></script>
+  <script src="../../stats.js"></script>
+</head>
+
+<body>
+</body>
+
+</html>

--- a/test/manual-test-examples/webgl/arc/startStopWrapping/sketch.js
+++ b/test/manual-test-examples/webgl/arc/startStopWrapping/sketch.js
@@ -23,10 +23,4 @@ function draw() {
 
   angle_1 = angle_1 + 1;
   angle_2 = angle_2 + 2;
-
-  if (angle_2 >= 360) {
-    angle_2 = 0;
-  } else if (angle_1 >= 360) {
-    angle_1 = 0;
-  }
 }

--- a/test/unit/core/2d_primitives.js
+++ b/test/unit/core/2d_primitives.js
@@ -285,4 +285,211 @@ suite('2D Primitives', function() {
       });
     });
   });
+
+  suite('p5.prototype._normalizeArcAngles', function() {
+    test('start/stop both at zero', function() {
+      var i, j, angles;
+      for (i = -2; i <= 2; i++) {
+        for (j = -2; j <= 2; j++) {
+          angles = myp5._normalizeArcAngles(
+            2 * Math.PI * i,
+            2 * Math.PI * j,
+            500,
+            5,
+            false
+          );
+          assert.approximately(angles.start, 0, 0.000005);
+          assert.approximately(angles.stop, 0, 0.000005);
+          assert.isTrue(angles.correspondToSamePoint);
+        }
+      }
+    });
+    test('start/stop same but non-zero', function() {
+      var i, j, angles;
+      for (i = -2; i <= 2; i++) {
+        for (j = -2; j <= 2; j++) {
+          angles = myp5._normalizeArcAngles(
+            2 * Math.PI * i + 1,
+            2 * Math.PI * j + 1,
+            500,
+            5,
+            false
+          );
+          assert.approximately(angles.start, 1, 0.000005);
+          assert.approximately(angles.stop, 1, 0.000005);
+          assert.isTrue(angles.correspondToSamePoint);
+        }
+      }
+    });
+    test('start/stop both close to zero, start < stop', function() {
+      var i, j, angles;
+      for (i = -2; i <= 2; i++) {
+        for (j = -2; j <= 2; j++) {
+          angles = myp5._normalizeArcAngles(
+            2 * Math.PI * i - 0.000001,
+            2 * Math.PI * j + 0.000001,
+            500,
+            5,
+            false
+          );
+          assert.approximately(angles.start, 2 * Math.PI - 0.000001, 0.000005);
+          assert.approximately(angles.stop, 2 * Math.PI + 0.000001, 0.000005);
+          assert.isTrue(angles.correspondToSamePoint);
+        }
+      }
+    });
+    test('start/stop both close to zero, start > stop', function() {
+      var i, j, angles;
+      for (i = -2; i <= 2; i++) {
+        for (j = -2; j <= 2; j++) {
+          angles = myp5._normalizeArcAngles(
+            2 * Math.PI * i + 0.000001,
+            2 * Math.PI * j - 0.000001,
+            500,
+            5,
+            false
+          );
+          assert.approximately(angles.start, 0.000001, 0.000005);
+          assert.approximately(angles.stop, 2 * Math.PI - 0.000001, 0.000005);
+          assert.isTrue(angles.correspondToSamePoint);
+        }
+      }
+    });
+    test('start/stop both close to same non-zero, start < stop', function() {
+      var i, j, angles;
+      for (i = -2; i <= 2; i++) {
+        for (j = -2; j <= 2; j++) {
+          angles = myp5._normalizeArcAngles(
+            2 * Math.PI * i + 0.999999,
+            2 * Math.PI * j + 1.000001,
+            500,
+            5,
+            false
+          );
+          assert.approximately(angles.start, 0.999999, 0.000005);
+          assert.approximately(angles.stop, 1.000001, 0.000005);
+          assert.isTrue(angles.correspondToSamePoint);
+        }
+      }
+    });
+    test('start/stop both close to same non-zero, start > stop', function() {
+      var i, j, angles;
+      for (i = -2; i <= 2; i++) {
+        for (j = -2; j <= 2; j++) {
+          angles = myp5._normalizeArcAngles(
+            2 * Math.PI * i + 1.000001,
+            2 * Math.PI * j + 0.999999,
+            500,
+            5,
+            false
+          );
+          assert.approximately(angles.start, 1.000001, 0.000005);
+          assert.approximately(angles.stop, 2 * Math.PI + 0.999999, 0.000005);
+          assert.isTrue(angles.correspondToSamePoint);
+        }
+      }
+    });
+    test('start/stop around zero but not close, start < stop', function() {
+      var i, j, angles;
+      for (i = -2; i <= 2; i++) {
+        for (j = -2; j <= 2; j++) {
+          angles = myp5._normalizeArcAngles(
+            2 * Math.PI * i - 0.1,
+            2 * Math.PI * j + 0.1,
+            500,
+            5,
+            false
+          );
+          assert.approximately(angles.start, 2 * Math.PI - 0.1, 0.000005);
+          assert.approximately(angles.stop, 2 * Math.PI + 0.1, 0.000005);
+          assert.isFalse(angles.correspondToSamePoint);
+        }
+      }
+    });
+    test('start/stop around zero but not close, start > stop', function() {
+      var i, j, angles;
+      for (i = -2; i <= 2; i++) {
+        for (j = -2; j <= 2; j++) {
+          angles = myp5._normalizeArcAngles(
+            2 * Math.PI * i + 0.1,
+            2 * Math.PI * j - 0.1,
+            500,
+            5,
+            false
+          );
+          assert.approximately(angles.start, 0.1, 0.000005);
+          assert.approximately(angles.stop, 2 * Math.PI - 0.1, 0.000005);
+          assert.isFalse(angles.correspondToSamePoint);
+        }
+      }
+    });
+    test('start/stop away from zero and not close, start < stop', function() {
+      var i, j, angles;
+      for (i = -2; i <= 2; i++) {
+        for (j = -2; j <= 2; j++) {
+          angles = myp5._normalizeArcAngles(
+            2 * Math.PI * i + 0.9,
+            2 * Math.PI * j + 1.1,
+            500,
+            5,
+            false
+          );
+          assert.approximately(angles.start, 0.9, 0.000005);
+          assert.approximately(angles.stop, 1.1, 0.000005);
+          assert.isFalse(angles.correspondToSamePoint);
+        }
+      }
+    });
+    test('start/stop away from zero and not close, start > stop', function() {
+      var i, j, angles;
+      for (i = -2; i <= 2; i++) {
+        for (j = -2; j <= 2; j++) {
+          angles = myp5._normalizeArcAngles(
+            2 * Math.PI * i + 1.1,
+            2 * Math.PI * j + 0.9,
+            500,
+            5,
+            false
+          );
+          assert.approximately(angles.start, 1.1, 0.000005);
+          assert.approximately(angles.stop, 2 * Math.PI + 0.9, 0.000005);
+          assert.isFalse(angles.correspondToSamePoint);
+        }
+      }
+    });
+    test('scaling correction, quadrants 1 and 3', function() {
+      var i, j, angles;
+      for (i = -2; i <= 2; i++) {
+        for (j = -2; j <= 2; j++) {
+          angles = myp5._normalizeArcAngles(
+            2 * Math.PI * (i + 40 / 360),
+            2 * Math.PI * (j + 230 / 360),
+            500,
+            5,
+            true
+          );
+          assert.approximately(angles.start, 1.558879, 0.000005);
+          assert.approximately(angles.stop, 4.703998, 0.000005);
+          assert.isFalse(angles.correspondToSamePoint);
+        }
+      }
+    });
+    test('scaling correction, quadrants 2 and 4', function() {
+      var i, j, angles;
+      for (i = -2; i <= 2; i++) {
+        for (j = -2; j <= 2; j++) {
+          angles = myp5._normalizeArcAngles(
+            2 * Math.PI * (i + 320 / 360),
+            2 * Math.PI * (j + 130 / 360),
+            500,
+            5,
+            true
+          );
+          assert.approximately(angles.start, 4.724306, 0.000005);
+          assert.approximately(angles.stop, 7.862372, 0.000005);
+          assert.isFalse(angles.correspondToSamePoint);
+        }
+      }
+    });
+  });
 });


### PR DESCRIPTION
Apologies for taking so very long to get around to this!

This PR addresses the issues directly reported in the three open `arc()` bugs, as well as some tangential inconsistencies that we’ve picked up along the way. `arc()` should now:

1.  __Always draw an ellipse when `start` and `stop` correspond to the same point__   
  WebGL has always done this to some extent. Renderer2D originally didn’t (which was unpopular) and recently started doing so, but unreliably. Now they both behave the same :+1:  
  _Closes #2919, closes #3318_  
  
2. __Draw `start`/`stop` angles in the 4th quadrant correctly when `width !== height`__  
  The branch for that quadrant was removed when the WebGL implementation was added, although it largely went unnoticed 😆  
   _Closes #3466_  
  
3. __Support `start`/`stop` angles outside of `[0, TWO_PI)`__  
  We had this functionality way back when, but it got a bit broken when we started adding exceptions for (1) above. Now we have both working together 🎉 

I’ve extracted the angle normalisation code into a helper and added tests for it. The normalisation steps are necessarily quite coupled, and in the past we’ve ended up in a pickle by patching one part without checking how it interacts with the others. The tests should now serve as a flag for this, and hopefully the documentation in the helper better explains the scope.

I’ve also added some more ‘manual test’ examples so it’s easier to check visually when things have gone awry.