### PR TITLE
shift popMatrix, pushMatrix, printMatrix to legacy.js

### DIFF
--- a/src/core/legacy.js
+++ b/src/core/legacy.js
@@ -20,4 +20,20 @@ p5.prototype.popStyle = function() {
   throw new Error('popStyle() not used, see pop()');
 };
 
+p5.prototype.popMatrix = function() {
+  throw new Error('popMatrix() not used, see pop()');
+};
+
+p5.prototype.printMatrix = function() {
+  throw new Error(
+    'printMatrix() is not implemented in p5.js, ' +
+      'refer to [https://simonsarris.com/a-transformation-class-for-canvas-to-keep-track-of-the-transformation-matrix/] ' +
+      'to add your own implementation.'
+  );
+};
+
+p5.prototype.pushMatrix = function() {
+  throw new Error('pushMatrix() not used, see push()');
+};
+
 module.exports = p5;

--- a/src/core/transform.js
+++ b/src/core/transform.js
@@ -147,18 +147,6 @@ p5.prototype.applyMatrix = function(a, b, c, d, e, f) {
   return this;
 };
 
-p5.prototype.popMatrix = function() {
-  throw new Error('popMatrix() not used, see pop()');
-};
-
-p5.prototype.printMatrix = function() {
-  throw new Error('printMatrix() not implemented');
-};
-
-p5.prototype.pushMatrix = function() {
-  throw new Error('pushMatrix() not used, see push()');
-};
-
 /**
  * Replaces the current matrix with the identity matrix.
  *


### PR DESCRIPTION
Fixes: #3589

The changes made in this PR are : 
- shift pushMatrix, popMatrix, printMatrix methods to legacy.js
- write a note about how to implement tracking of matrix for printMatrix method

I request the maintainers to review this PR,
Thanks !