### PR TITLE
Fix style function in p5.dom.js

### DIFF
--- a/lib/addons/p5.dom.js
+++ b/lib/addons/p5.dom.js
@@ -2010,10 +2010,8 @@
           }
           this.elt.setAttribute('width', aW * this._pInst._pixelDensity);
           this.elt.setAttribute('height', aH * this._pInst._pixelDensity);
-          this.elt.setAttribute(
-            'style',
-            'width:' + aW + 'px; height:' + aH + 'px'
-          );
+          this.elt.style.width = aW + 'px';
+          this.elt.style.height = aH + 'px';
           this._pInst.scale(
             this._pInst._pixelDensity,
             this._pInst._pixelDensity
@@ -2026,8 +2024,6 @@
           this.elt.style.height = aH + 'px';
           this.elt.width = aW;
           this.elt.height = aH;
-          this.width = aW;
-          this.height = aH;
         }
 
         this.width = this.elt.offsetWidth;


### PR DESCRIPTION
Fixes #3548

The changes made in this PR are : 
- Remove setting style using setAttribute and use the style property of the element to set the style instead
  (using setAtrribute to set style [overrides some already set style properties of the element](https://www.w3schools.com/jsref/met_element_setattribute.asp)

- Remove repeated `this.width = aw` and `this.height = aH` line.

I request the maintainers to review this PR,
Thank you!