### PR TITLE
Dom Drop's second callback should be called with the raw drop event

### DIFF
--- a/lib/addons/p5.dom.js
+++ b/lib/addons/p5.dom.js
@@ -2074,8 +2074,8 @@
    * whereas the first callback will trigger for each loaded file.
    *
    * @method drop
-   * @param  {Function} callback  callback to receive loaded file.
-   * @param  {Function} [fxn]     callback triggered when files are dropped.
+   * @param  {Function} callback  callback to receive loaded file, called for each file dropped.
+   * @param  {Function} [fxn]     callback triggered once when files are dropped with the drop event.
    * @chainable
    * @example
    * <div><code>
@@ -2138,17 +2138,15 @@
         this.elt.addEventListener('dragleave', preventDefault);
       }
 
-      // Attach the second argument as a callback that receives the raw drop event
-      if (typeof fxn !== 'undefined') {
-        p5.Element._attachListener('drop', fxn, this);
-      }
-
       // Deal with the files
       p5.Element._attachListener(
         'drop',
         function(evt) {
           evt.preventDefault();
-
+          // Call the second argument as a callback that receives the raw drop event
+          if (typeof fxn === 'function') {
+            fxn.call(this, evt);
+          }
           // A FileList
           var files = evt.dataTransfer.files;
 

--- a/test/unit/addons/p5.dom.js
+++ b/test/unit/addons/p5.dom.js
@@ -79,4 +79,45 @@ suite('DOM', function() {
       };
     });
   });
+  suite('p5.prototype.drop', function() {
+    testSketchWithPromise('drop fires multiple events', function(
+      sketch,
+      resolve,
+      reject
+    ) {
+      var myElt;
+      var myFileFnCounter = 0;
+      var myEventFnCounter = 0;
+      sketch.setup = function() {
+        myFileFnCounter = 0;
+        myEventFnCounter = 0;
+        myElt = sketch.createDiv('drop stuff');
+        function hasFinished() {
+          if (myFileFnCounter > 1 && myEventFnCounter === 1) {
+            resolve();
+          }
+        }
+        var myFileFn = function() {
+          myFileFnCounter++;
+          hasFinished();
+        };
+        var myEventFn = function() {
+          myEventFnCounter++;
+          hasFinished();
+        };
+        myElt.drop(myFileFn, myEventFn);
+        assert.isFunction(myElt._events.drop);
+        //Mock A File Drop Event.
+        var file1 = new File(['foo'], 'foo.txt', {
+          type: 'text/plain'
+        });
+        var file2 = new File(['foo'], 'foo.txt', {
+          type: 'text/plain'
+        });
+        var myMockedEvent = new Event('drop');
+        myMockedEvent.dataTransfer = { files: [file1, file2] };
+        myElt.elt.dispatchEvent(myMockedEvent);
+      };
+    });
+  });
 });


### PR DESCRIPTION
The dom library has a Element.drop() which is documented to take two
callbacks, the first should be fired for every file dropped, the second
should fire with the raw dom event. The second event was not being
called. I have fixed this bug, improved documentation, and wrote
a mocha test to cover this issue.

Resolves: #3591
See also: #3303