### PR TITLE
remove last use of setAttribute for setting style

### DIFF
--- a/test/js/p5_helpers.js
+++ b/test/js/p5_helpers.js
@@ -1,3 +1,5 @@
+/* eslint no-unused-vars: 0 */
+
 function promisedSketch(sketch_fn) {
   var myInstance;
   var promise = new Promise(function(resolve, reject) {
@@ -31,7 +33,7 @@ function createP5Iframe(html) {
   var elt = document.createElement('iframe');
 
   document.body.appendChild(elt);
-  elt.setAttribute('style', 'visibility: hidden');
+  elt.style.visibility = 'hidden';
 
   elt.contentDocument.open();
   elt.contentDocument.write(html);


### PR DESCRIPTION
follow on from #3602 for consistency.

@Ajayneethikannan found that setting `style` with `setAttribute` is not recommended as it will remove all other style properties applied prior. i don't think that matters for this use (in `p5_helpers.js`), but i thought it would be good to standardize on setting `style` directly for consistency's sake. (this is the only other place that pattern is used in the codebase.)