### PR TITLE
Fix_misaligning_strokes

### DIFF
--- a/src/core/p5.Renderer2D.js
+++ b/src/core/p5.Renderer2D.js
@@ -532,17 +532,10 @@ p5.Renderer2D.prototype.line = function(x1, y1, x2, y2) {
   } else if (this._getStroke() === styleEmpty) {
     return this;
   }
-  // Translate the line by (0.5, 0.5) to draw it crisp
-  if (ctx.lineWidth % 2 === 1) {
-    ctx.translate(0.5, 0.5);
-  }
   ctx.beginPath();
   ctx.moveTo(x1, y1);
   ctx.lineTo(x2, y2);
   ctx.stroke();
-  if (ctx.lineWidth % 2 === 1) {
-    ctx.translate(-0.5, -0.5);
-  }
   this._pixelsState._pixelsDirty = true;
   return this;
 };
@@ -621,10 +614,6 @@ p5.Renderer2D.prototype.rect = function(args) {
       return this;
     }
   }
-  // Translate the line by (0.5, 0.5) to draw a crisp rectangle border
-  if (this._doStroke && ctx.lineWidth % 2 === 1) {
-    ctx.translate(0.5, 0.5);
-  }
   ctx.beginPath();
 
   if (typeof tl === 'undefined') {
@@ -686,9 +675,6 @@ p5.Renderer2D.prototype.rect = function(args) {
   }
   if (this._doStroke) {
     ctx.stroke();
-  }
-  if (this._doStroke && ctx.lineWidth % 2 === 1) {
-    ctx.translate(-0.5, -0.5);
   }
   this._pixelsState._pixelsDirty = true;
   return this;


### PR DESCRIPTION
Fixes #3576

The change made in this PR is : 
- remove translating by half pixel code in p5.Renderer2d.prototype.rect and p5.Renderer2d.prototype.line

Reason for removal : 
 I think even though this translation was done to obtain cleaner lines for odd width strokes, 
the problem associated with it is when we need to align some shape with other objects which do not need this translation, like images, ellipses, etc, it leads to misalignment. 
 
@lmccart please review this PR,
Thank you!
