### PR TITLE
renderer has own styles so it can call push/pop itself

### DIFF
--- a/src/core/main.js
+++ b/src/core/main.js
@@ -562,7 +562,7 @@ var p5 = function(sketch, node, sync) {
 };
 
 p5.prototype._initializeInstanceVariables = function() {
-  this._styles = [];
+  this._colorModes = [];
 
   this._bezierDetail = 20;
   this._curveDetail = 20;

--- a/src/core/p5.Renderer.js
+++ b/src/core/p5.Renderer.js
@@ -38,6 +38,8 @@ p5.Renderer = function(elt, pInst, isMainCanvas) {
     this._styles = []; // non-main elt styles stored in p5.Renderer
   }
 
+  this.styles = [];
+
   this._textSize = 12;
   this._textLeading = 15;
   this._textFont = 'sans-serif';
@@ -87,7 +89,17 @@ p5.Renderer.prototype.push = function() {
 // a pop() operation is in progress
 // the renderer is passed the 'style' object that it returned
 // from its push() method.
-p5.Renderer.prototype.pop = function(style) {
+p5.Renderer.prototype.pop = function() {
+  var style = this.styles.pop();
+  if (typeof style === 'undefined') {
+    var errorMessage = 'You called pop() without first calling push()!';
+    if (this.isP3D) {
+      //prettier-ignore
+      errorMessage += ' Note that in 3D mode calling setAttributes resets push().';
+    }
+    console.error(errorMessage);
+    return;
+  }
   if (style.properties) {
     // copy the style properties back into the renderer
     Object.assign(this, style.properties);

--- a/src/core/p5.Renderer.js
+++ b/src/core/p5.Renderer.js
@@ -92,12 +92,7 @@ p5.Renderer.prototype.push = function() {
 p5.Renderer.prototype.pop = function() {
   var style = this.styles.pop();
   if (typeof style === 'undefined') {
-    var errorMessage = 'You called pop() without first calling push()!';
-    if (this.isP3D) {
-      //prettier-ignore
-      errorMessage += ' Note that in 3D mode calling setAttributes resets push().';
-    }
-    console.error(errorMessage);
+    console.error('You called pop() without first calling push()!');
     return;
   }
   if (style.properties) {

--- a/src/core/p5.Renderer2D.js
+++ b/src/core/p5.Renderer2D.js
@@ -1239,9 +1239,11 @@ p5.Renderer2D.prototype._applyTextProperties = function() {
 // to fetch the base style object.
 p5.Renderer2D.prototype.push = function() {
   this.drawingContext.save();
-
   // get the base renderer style
-  return p5.Renderer.prototype.push.apply(this);
+  var style = p5.Renderer.prototype.push.apply(this);
+
+  this.styles.push(style);
+  return style;
 };
 
 // a pop() operation is in progress
@@ -1249,13 +1251,13 @@ p5.Renderer2D.prototype.push = function() {
 // from its push() method.
 // derived renderers should pass this object to their base
 // class' pop method
-p5.Renderer2D.prototype.pop = function(style) {
+p5.Renderer2D.prototype.pop = function() {
   this.drawingContext.restore();
   // Re-cache the fill / stroke state
   this._cachedFillStyle = this.drawingContext.fillStyle;
   this._cachedStrokeStyle = this.drawingContext.strokeStyle;
 
-  p5.Renderer.prototype.pop.call(this, style);
+  p5.Renderer.prototype.pop.call(this);
 };
 
 module.exports = p5.Renderer2D;

--- a/src/core/structure.js
+++ b/src/core/structure.js
@@ -176,12 +176,8 @@ p5.prototype.loop = function() {
  *
  */
 p5.prototype.push = function() {
-  this._styles.push({
-    props: {
-      _colorMode: this._colorMode
-    },
-    renderer: this._renderer.push()
-  });
+  this._colorModes.push(this._colorMode);
+  this._renderer.push();
 };
 
 /**
@@ -241,13 +237,9 @@ p5.prototype.push = function() {
  *
  */
 p5.prototype.pop = function() {
-  var style = this._styles.pop();
-  if (style) {
-    this._renderer.pop(style.renderer);
-    Object.assign(this, style.props);
-  } else {
-    console.warn('pop() was called without matching push()');
-  }
+  this._colorMode = this._colorModes.pop();
+  this._renderer.pop();
+  //renderers can handle "pop() without push()" warnings
 };
 
 /**

--- a/src/core/structure.js
+++ b/src/core/structure.js
@@ -237,9 +237,13 @@ p5.prototype.push = function() {
  *
  */
 p5.prototype.pop = function() {
-  this._colorMode = this._colorModes.pop();
-  this._renderer.pop();
-  //renderers can handle "pop() without push()" warnings
+  var colorMode = this._colorModes.pop();
+  if (typeof colorMode === 'undefined') {
+    console.warn('pop() was called without matching push()');
+  } else {
+    this._colorMode = colorMode;
+    this._renderer.pop();
+  }
 };
 
 /**

--- a/src/core/structure.js
+++ b/src/core/structure.js
@@ -133,6 +133,10 @@ p5.prototype.loop = function() {
  * <a href="#/p5/stroke">stroke()</a>, <a href="#/p5/tint">tint()</a>, <a href="#/p5/strokeWeight">strokeWeight()</a>, <a href="#/p5/strokeCap">strokeCap()</a>, <a href="#/p5/strokeJoin">strokeJoin()</a>,
  * <a href="#/p5/imageMode">imageMode()</a>, <a href="#/p5/rectMode">rectMode()</a>, <a href="#/p5/ellipseMode">ellipseMode()</a>, <a href="#/p5/colorMode">colorMode()</a>, <a href="#/p5/textAlign">textAlign()</a>,
  * <a href="#/p5/textFont">textFont()</a>, <a href="#/p5/textSize">textSize()</a>, <a href="#/p5/textLeading">textLeading()</a>.
+ * <br><br>
+ * In WEBGL mode additional style settings are stored. These are controlled by the following functions: <a href="#/p5/setCamera">setCamera()</a>, <a href="#/p5/ambientLight">ambientLight()</a>, <a href="#/p5/directionalLight">directionalLight()</a>,
+ * <a href="#/p5/pointLight">pointLight()</a>, <a href="#/p5/texture">texture()</a>, <a href="#/p5/specularMaterial">specularMaterial()</a>, <a href="#/p5/shininess">shininess()</a>, <a href="#/p5/normalMaterial">normalMaterial()</a>
+ * and <a href="#/p5/shader">shader()</a>.
  *
  * @method push
  * @example
@@ -194,6 +198,10 @@ p5.prototype.push = function() {
  * <a href="#/p5/stroke">stroke()</a>, <a href="#/p5/tint">tint()</a>, <a href="#/p5/strokeWeight">strokeWeight()</a>, <a href="#/p5/strokeCap">strokeCap()</a>, <a href="#/p5/strokeJoin">strokeJoin()</a>,
  * <a href="#/p5/imageMode">imageMode()</a>, <a href="#/p5/rectMode">rectMode()</a>, <a href="#/p5/ellipseMode">ellipseMode()</a>, <a href="#/p5/colorMode">colorMode()</a>, <a href="#/p5/textAlign">textAlign()</a>,
  * <a href="#/p5/textFont">textFont()</a>, <a href="#/p5/textSize">textSize()</a>, <a href="#/p5/textLeading">textLeading()</a>.
+ * <br><br>
+ * In WEBGL mode additional style settings are stored. These are controlled by the following functions: <a href="#/p5/setCamera">setCamera()</a>, <a href="#/p5/ambientLight">ambientLight()</a>, <a href="#/p5/directionalLight">directionalLight()</a>,
+ * <a href="#/p5/pointLight">pointLight()</a>, <a href="#/p5/texture">texture()</a>, <a href="#/p5/specularMaterial">specularMaterial()</a>, <a href="#/p5/shininess">shininess()</a>, <a href="#/p5/normalMaterial">normalMaterial()</a>
+ * and <a href="#/p5/shader">shader()</a>.
  *
  * @method pop
  * @example

--- a/src/webgl/p5.RendererGL.js
+++ b/src/webgl/p5.RendererGL.js
@@ -389,13 +389,9 @@ p5.prototype.setAttributes = function(key, value, successCallback) {
   if (!this._renderer.isP3D || unchanged) {
     return;
   }
+
   // have to retain renderer level styles across the
   // reset of the renderer
-  if (this._renderer.styles.length > 0 && !this._setupDone) {
-    //prettier-ignore
-    console.error('You should not use setAttributes inbetween push() and pop() inside of setup().');
-    return;
-  }
   this.push();
   var styles = this._renderer.styles.slice();
   this._renderer._resetContext();

--- a/src/webgl/p5.RendererGL.js
+++ b/src/webgl/p5.RendererGL.js
@@ -366,7 +366,7 @@ p5.RendererGL.prototype._resetContext = function(callback, options) {
  * @for p5
  * @param  {Object}  obj object with key-value pairs
  */
-p5.prototype.setAttributes = function(key, value, successCallback) {
+p5.prototype.setAttributes = function(key, value) {
   var unchanged = true;
   if (typeof value !== 'undefined') {
     //first time modifying the attributes
@@ -399,9 +399,6 @@ p5.prototype.setAttributes = function(key, value, successCallback) {
   this.pop();
   if (this._renderer._curCamera) {
     this._renderer._curCamera._renderer = this._renderer;
-  }
-  if (typeof successCallback === 'function') {
-    successCallback(this._renderer);
   }
 };
 

--- a/test/unit/webgl/p5.Camera.js
+++ b/test/unit/webgl/p5.Camera.js
@@ -647,9 +647,13 @@ suite('p5.Camera', function() {
     });
     test("Camera's Renderer is correctly set after setAttributes", function() {
       var myCam2 = myp5.createCamera();
+      myp5.setCamera(myCam2);
       assert.deepEqual(myCam2, myp5._renderer._curCamera);
-      myp5.setAttributes('antialias', true);
-      assert.deepEqual(myCam2._renderer, myp5._renderer);
+      return new Promise(function(resolve) {
+        myp5.setAttributes('antialias', true, resolve);
+      }).then(function() {
+        assert.deepEqual(myCam2._renderer, myp5._renderer);
+      });
     });
   });
 });

--- a/test/unit/webgl/p5.Camera.js
+++ b/test/unit/webgl/p5.Camera.js
@@ -649,11 +649,8 @@ suite('p5.Camera', function() {
       var myCam2 = myp5.createCamera();
       myp5.setCamera(myCam2);
       assert.deepEqual(myCam2, myp5._renderer._curCamera);
-      return new Promise(function(resolve) {
-        myp5.setAttributes('antialias', true, resolve);
-      }).then(function() {
-        assert.deepEqual(myCam2._renderer, myp5._renderer);
-      });
+      myp5.setAttributes('antialias', true);
+      assert.deepEqual(myCam2._renderer, myp5._renderer);
     });
   });
 });

--- a/test/unit/webgl/p5.RendererGL.js
+++ b/test/unit/webgl/p5.RendererGL.js
@@ -48,6 +48,138 @@ suite('p5.RendererGL', function() {
     });
   });
 
+  suite('push() and pop() work in WEBGL Mode', function() {
+    test('push/pop and translation works as expected in WEBGL Mode', function(done) {
+      myp5.createCanvas(100, 100, myp5.WEBGL);
+      var modelView = myp5._renderer.uMVMatrix.copy();
+      myp5.push();
+      myp5.rotateX(Math.random(0, 100));
+      myp5.translate(20, 100, 5);
+      assert.notEqual(modelView.mat4, myp5._renderer.uMVMatrix.mat4);
+      myp5.pop();
+      assert.deepEqual(modelView.mat4, myp5._renderer.uMVMatrix.mat4);
+      done();
+    });
+    test('push/pop and directionalLight() works', function(done) {
+      myp5.createCanvas(100, 100, myp5.WEBGL);
+      myp5.directionalLight(255, 0, 0, 0, 0, 0);
+      var dirColors = myp5._renderer.directionalLightColors.slice();
+      var dirLightDirections = myp5._renderer.directionalLightDirections.slice();
+      myp5.push();
+      myp5.directionalLight(0, 0, 255, 0, 10, 5);
+      assert.notEqual(dirColors, myp5._renderer.directionalLightColors);
+      assert.notEqual(
+        dirLightDirections,
+        myp5._renderer.directionalLightDirections
+      );
+      myp5.pop();
+      assert.deepEqual(dirColors, myp5._renderer.directionalLightColors);
+      assert.deepEqual(
+        dirLightDirections,
+        myp5._renderer.directionalLightDirections
+      );
+      done();
+    });
+
+    test('push/pop and ambientLight() works', function(done) {
+      myp5.createCanvas(100, 100, myp5.WEBGL);
+      myp5.ambientLight(100, 0, 100);
+      myp5.ambientLight(0, 0, 200);
+      var ambColors = myp5._renderer.ambientLightColors.slice();
+      myp5.push();
+      myp5.ambientLight(0, 0, 0);
+      assert.notEqual(ambColors, myp5._renderer.ambientLightColors);
+      myp5.pop();
+      assert.deepEqual(ambColors, myp5._renderer.ambientLightColors);
+      done();
+    });
+
+    test('push/pop and pointLight() works', function(done) {
+      myp5.createCanvas(100, 100, myp5.WEBGL);
+      myp5.pointLight(255, 0, 0, 0, 0, 0);
+      var pointColors = myp5._renderer.pointLightColors.slice();
+      var pointLocs = myp5._renderer.pointLightPositions.slice();
+      myp5.push();
+      myp5.pointLight(0, 0, 255, 0, 10, 5);
+      assert.notEqual(pointColors, myp5._renderer.pointLightColors);
+      assert.notEqual(pointLocs, myp5._renderer.pointLightPositions);
+      myp5.pop();
+      assert.deepEqual(pointColors, myp5._renderer.pointLightColors);
+      assert.deepEqual(pointLocs, myp5._renderer.pointLightPositions);
+      done();
+    });
+
+    test('push/pop and pointLight() works', function(done) {
+      myp5.createCanvas(100, 100, myp5.WEBGL);
+      myp5.pointLight(255, 0, 0, 0, 0, 0);
+      var pointColors = myp5._renderer.pointLightColors.slice();
+      var pointLocs = myp5._renderer.pointLightPositions.slice();
+      myp5.push();
+      myp5.pointLight(0, 0, 255, 0, 10, 5);
+      assert.notEqual(pointColors, myp5._renderer.pointLightColors);
+      assert.notEqual(pointLocs, myp5._renderer.pointLightPositions);
+      myp5.pop();
+      assert.deepEqual(pointColors, myp5._renderer.pointLightColors);
+      assert.deepEqual(pointLocs, myp5._renderer.pointLightPositions);
+      done();
+    });
+
+    test('push/pop and texture() works', function(done) {
+      myp5.createCanvas(100, 100, myp5.WEBGL);
+      var tex1 = myp5.createGraphics(1, 1);
+      myp5.texture(tex1);
+      assert.equal(tex1, myp5._renderer._tex);
+      myp5.push();
+      var tex2 = myp5.createGraphics(2, 2);
+      myp5.texture(tex2);
+      assert.equal(tex2, myp5._renderer._tex);
+      assert.notEqual(tex1, myp5._renderer._tex);
+      myp5.pop();
+      assert.equal(tex1, myp5._renderer._tex);
+      done();
+    });
+
+    test('push/pop and shader() works with fill', function(done) {
+      myp5.createCanvas(100, 100, myp5.WEBGL);
+      var fillShader1 = myp5._renderer._getLightShader();
+      var fillShader2 = myp5._renderer._getColorShader();
+      myp5.shader(fillShader1);
+      assert.equal(fillShader1, myp5._renderer.userFillShader);
+      myp5.push();
+      myp5.shader(fillShader2);
+      assert.equal(fillShader2, myp5._renderer.userFillShader);
+      assert.notEqual(fillShader1, myp5._renderer.userFillShader);
+      myp5.pop();
+      assert.equal(fillShader1, myp5._renderer.userFillShader);
+      done();
+    });
+
+    test('push/pop builds/unbuilds stack properly', function(done) {
+      myp5.createCanvas(100, 100, myp5.WEBGL);
+      var col1 = myp5.color(255, 0, 0);
+      var col2 = myp5.color(0, 255, 0);
+      for (var i = 0; i < 10; i++) {
+        myp5.push();
+        if (i % 2 === 0) {
+          myp5.fill(col1);
+        } else {
+          myp5.fill(col2);
+        }
+      }
+      for (var j = i; j > 0; j--) {
+        // console.log(myp5._renderer.styles.slice());
+        if (j % 2 === 0) {
+          assert.deepEqual(col2._array, myp5._renderer.curFillColor);
+        } else {
+          assert.deepEqual(col1._array, myp5._renderer.curFillColor);
+        }
+        myp5.pop();
+      }
+      assert.isTrue(myp5._renderer.styles.length === 0);
+      done();
+    });
+  });
+
   suite('loadpixels()', function() {
     test('loadPixels color check', function(done) {
       myp5.createCanvas(100, 100, myp5.WEBGL);


### PR DESCRIPTION
closes #2946 

This moves the style properties to `p5.Renderer`. The only style related settings retained by the `p5.instance` is `_colorMode`. This is based on old design of `p5.instance.styles` holding objects structured like 
```
{
_colorMode: this._colorMode,
 renderer: {all other styles}
}
```
I haven’t worked with `_colorMode` and I assumed that there is some logic for keeping this separate and tried to keep that separation intact as much as possible. Renderers can still call their own push/pop methods since they won't likely be changing the color mode (?). Can move this modification into the Renderer if it makes sense.

Also wrote some simple unit tests to bring WebGL's testing of push/pop closer to full coverage. I realized after writing them in a very verbose fashion that it probably just makes more sense to write them in a more condensed fashion as [in the 2D renderer push/pop unit tests.](https://github.com/processing/p5.js/blob/master/test/unit/core/structure.js#L110). That said, my personal opinion is that the `suite.test` structure of unit tests forces an organized readability and that the long-form tests are fine given this format. I am willing to go back and condense them though.