### PR TITLE
improve examples of loadPixels, updatePixels

### DIFF
--- a/src/image/p5.Image.js
+++ b/src/image/p5.Image.js
@@ -244,7 +244,7 @@ p5.Image.prototype._setProperty = function(prop, value) {
  *
  * function setup() {
  *   myImage.loadPixels();
- *   halfImage = 4 * width * height / 2;
+ *   halfImage = 4 * myImage.width * myImage.height / 2;
  *   for (let i = 0; i < halfImage; i++) {
  *     myImage.pixels[i + halfImage] = myImage.pixels[i];
  *   }
@@ -252,7 +252,7 @@ p5.Image.prototype._setProperty = function(prop, value) {
  * }
  *
  * function draw() {
- *   image(myImage, 0, 0);
+ *   image(myImage, 0, 0, width, height);
  * }
  * </code></div>
  *
@@ -289,7 +289,7 @@ p5.Image.prototype.loadPixels = function() {
  *
  * function setup() {
  *   myImage.loadPixels();
- *   halfImage = 4 * width * height / 2;
+ *   halfImage = 4 * myImage.width * myImage.height / 2;
  *   for (let i = 0; i < halfImage; i++) {
  *     myImage.pixels[i + halfImage] = myImage.pixels[i];
  *   }
@@ -297,7 +297,7 @@ p5.Image.prototype.loadPixels = function() {
  * }
  *
  * function draw() {
- *   image(myImage, 0, 0);
+ *   image(myImage, 0, 0, width, height);
  * }
  * </code></div>
  *

--- a/src/image/pixels.js
+++ b/src/image/pixels.js
@@ -519,9 +519,9 @@ p5.prototype.get = function(x, y, w, h) {
  * }
  *
  * function setup() {
- *   image(img, 0, 0);
+ *   image(img, 0, 0, width, height);
  *   let d = pixelDensity();
- *   let halfImage = 4 * (img.width * d) * (img.height * d / 2);
+ *   let halfImage = 4 * (width * d) * (height * d / 2);
  *   loadPixels();
  *   for (let i = 0; i < halfImage; i++) {
  *     pixels[i + halfImage] = pixels[i];
@@ -638,9 +638,9 @@ p5.prototype.set = function(x, y, imgOrCol) {
  * }
  *
  * function setup() {
- *   image(img, 0, 0);
+ *   image(img, 0, 0, width, height);
  *   let d = pixelDensity();
- *   let halfImage = 4 * (img.width * d) * (img.height * d / 2);
+ *   let halfImage = 4 * (width * d) * (height * d / 2);
  *   loadPixels();
  *   for (let i = 0; i < halfImage; i++) {
  *     pixels[i + halfImage] = pixels[i];


### PR DESCRIPTION
Fixes : #3635

The changes made in this PR are : 
- Changing the calculation logic for halfImage index in p5.Image.prototype.loadPixels and p5.prototype.loadPixels, according to the example . ( loadPixels for image should calculate halfImage , with respect to the image instance, and for main canvas, calculate with respect to the canvas window, taking pixelDensity into consideration )
- Drawing the image, so that it fits the full canvas, so that when an user checks out the example using other images, the code would run as expected for bigger and smaller images

I request the maintainers to review the PR,
Thanks !