### PR TITLE
[WIP] Remove redundant call to image function in p5.prototype.background

### DIFF
--- a/src/color/setting.js
+++ b/src/color/setting.js
@@ -174,11 +174,7 @@ require('./p5.Color');
  */
 
 p5.prototype.background = function() {
-  if (arguments[0] instanceof p5.Image) {
-    this.image(arguments[0], 0, 0, this.width, this.height);
-  } else {
-    this._renderer.background.apply(this._renderer, arguments);
-  }
+  this._renderer.background.apply(this._renderer, arguments);
   return this;
 };
 


### PR DESCRIPTION
Fixes #3639 

The changes made in this PR are : 
- Remove calling image function in p5.prototype.background, as it's logic is already handled inside p5.Renderer2D.prototype.background.

As suggested by @lmccart , I will wait for the image functionality to be implemented in WEBGL, after which changes will be made if necessary.

Thank you !