### PR TITLE
Change timing for texture binding

### DIFF
--- a/src/webgl/p5.RendererGL.js
+++ b/src/webgl/p5.RendererGL.js
@@ -1062,6 +1062,7 @@ p5.RendererGL.prototype._setFillUniforms = function(fillShader) {
   var ambientLightCount = this.ambientLightColors.length / 3;
   fillShader.setUniform('uAmbientLightCount', ambientLightCount);
   fillShader.setUniform('uAmbientColor', this.ambientLightColors);
+  fillShader.bindTextures();
 };
 
 p5.RendererGL.prototype._setPointUniforms = function(pointShader) {

--- a/src/webgl/p5.Shader.js
+++ b/src/webgl/p5.Shader.js
@@ -190,7 +190,6 @@ p5.Shader.prototype.bindShader = function() {
   if (!this._bound) {
     this.useProgram();
     this._bound = true;
-    this.bindTextures();
 
     this._setMatrixUniforms();
 

--- a/test/manual-test-examples/webgl/texture/multipleTextures/index.html
+++ b/test/manual-test-examples/webgl/texture/multipleTextures/index.html
@@ -13,6 +13,7 @@
 </head>
 
 <body>
+  <header><h1 style='text-align: center'>Grid texture should be on left, Cat texture on right</h1></header>
 </body>
 
 </html>

--- a/test/manual-test-examples/webgl/texture/multipleTextures/sketch.js
+++ b/test/manual-test-examples/webgl/texture/multipleTextures/sketch.js
@@ -1,8 +1,8 @@
-var im1, im2;
+var grid, cat;
 
 function preload() {
-  im1 = loadImage('../../assets/UV_Grid_Sm.jpg');
-  im2 = loadImage('../../assets/cat.jpg');
+  grid = loadImage('../../assets/UV_Grid_Sm.jpg');
+  cat = loadImage('../../assets/cat.jpg');
 }
 
 function setup() {
@@ -13,30 +13,24 @@ function setup() {
 function draw() {
   background(255);
 
-  var halfw = im1.width / 2 * 0.5;
-  var halfh = im1.height / 2 * 0.5;
+  drawSquare(-width / 4, 0, 200, 200, grid);
+  drawSquare(width / 4, 0, 200, 200, cat);
+}
 
-  var i = 0;
-  for (var x = -width / 2 + halfw; x <= width / 2 - halfw; x += halfw * 2) {
-    for (var y = -height / 2 + halfh; y <= height / 2 - halfh; y += halfh * 2) {
-      push();
-      if (i % 2 === 0) {
-        texture(im1);
-      } else {
-        texture(im2);
-      }
-      translate(x, y);
-      rotateZ(frameCount * 0.01);
-      beginShape(TRIANGLES);
-      vertex(-halfw, -halfh, 0, 0, 0);
-      vertex(halfw, -halfh, 0, 1, 0);
-      vertex(halfw, halfh, 0, 1, 1);
-      vertex(halfw, halfh, 0, 1, 1);
-      vertex(-halfw, halfh, 0, 0, 1);
-      vertex(-halfw, -halfh, 0, 0, 0);
-      endShape();
-      pop();
-      i++;
-    }
-  }
+function drawSquare(x, y, w, h, tex) {
+  push();
+  texture(tex);
+  var halfW = w / 2;
+  var halfH = h / 2;
+  translate(x, 0);
+  rotateZ(frameCount * 0.01);
+  beginShape(TRIANGLES);
+  vertex(-halfW, -halfH, 0, 0, 0);
+  vertex(halfW, -halfH, 0, 1, 0);
+  vertex(halfW, halfH, 0, 1, 1);
+  vertex(halfW, halfH, 0, 1, 1);
+  vertex(-halfW, halfH, 0, 0, 1);
+  vertex(-halfW, -halfH, 0, 0, 0);
+  endShape();
+  pop();
 }


### PR DESCRIPTION
closes #3636 

Okay! I had a lot of trouble tracking this down for some reason. Essentially #3535 introduced a bug that caused all sketches with multiple different textures to apply those textures incorrectly. This escaped testing because with our multiple textures manual test it isn't possible to visually glance and know which object should have which texture. It escaped the unit tests because the unit tests can't test what texture is actually bound to a shader. 

The problem turned out to be that textures were bound when shaders were bound. The shader was binding its texture before the texture uniform had been updated to match the current `_tex` and [an out-of-sync texture was still stored in the uniform](https://github.com/processing/p5.js/blob/master/src/webgl/p5.Shader.js#L219). Just moving the call to `bindTextures` out of `Shader.prototype.bindShader` and into `RendererGL.prototype._setFillUniforms`.