### PR TITLE
Remove NORMAL argument in blendMode, add error for GL blendMode

### DIFF
--- a/src/core/rendering.js
+++ b/src/core/rendering.js
@@ -239,7 +239,7 @@ p5.prototype.createGraphics = function(w, h, renderer) {
  * with the ones of pixels already in the display window (B):
  * <ul>
  * <li><code>BLEND</code> - linear interpolation of colours: C =
- * A\*factor + B. This is the default blending mode.</li>
+ * A\*factor + B. <b>This is the default blending mode.</b></li>
  * <li><code>ADD</code> - sum of A and B</li>
  * <li><code>DARKEST</code> - only the darkest colour succeeds: C =
  * min(A\*factor, B).</li>
@@ -271,7 +271,7 @@ p5.prototype.createGraphics = function(w, h, renderer) {
  * @param  {Constant} mode blend mode to set for canvas.
  *                either BLEND, DARKEST, LIGHTEST, DIFFERENCE, MULTIPLY,
  *                EXCLUSION, SCREEN, REPLACE, OVERLAY, HARD_LIGHT,
- *                SOFT_LIGHT, DODGE, BURN, ADD or NORMAL
+ *                SOFT_LIGHT, DODGE, BURN, or ADD
  * @example
  * <div>
  * <code>
@@ -314,10 +314,15 @@ p5.prototype.blendMode = function(mode) {
     mode === constants.SOFT_LIGHT ||
     mode === constants.DODGE ||
     mode === constants.BURN ||
-    mode === constants.ADD ||
-    mode === constants.NORMAL
+    mode === constants.ADD
   ) {
     this._renderer.blendMode(mode);
+  } else if (mode === constants.NORMAL) {
+    // Warning added 3/26/19, can be deleted in future (1.0 release?)
+    console.warn(
+      'NORMAL has been deprecated for use in blendMode. defaulting to BLEND instead.'
+    );
+    this._renderer.blendMode(constants.BLEND);
   } else {
     throw new Error('Mode ' + mode + ' not recognized.');
   }

--- a/src/webgl/p5.RendererGL.js
+++ b/src/webgl/p5.RendererGL.js
@@ -555,6 +555,11 @@ p5.RendererGL.prototype.strokeCap = function(cap) {
   console.error('Sorry, strokeCap() is not yet implemented in WEBGL mode');
 };
 
+p5.RendererGL.prototype.blendMode = function(mode) {
+  // @TODO : to be implemented
+  console.error('Sorry, blendMode() is not yet implemented in WEBGL mode');
+};
+
 /**
  * Change weight of stroke
  * @method  strokeWeight


### PR DESCRIPTION
closes #3579 

- Removes NORMAL as possible argument to `blendMode` in docs. 
- Temporary deprecation message and NORMAL default to BLEND in blendMode
- Adds emphasis to the fact that BLEND is the default in `blendMode` docs
- Adds stub for `RendererGL.blendMode` that throws an error
