### PR TITLE
blendMode() for WebGL

### DIFF
--- a/src/core/constants.js
+++ b/src/core/constants.js
@@ -405,6 +405,11 @@ module.exports = {
    */
   DIFFERENCE: 'difference',
   /**
+   * @property {String} SUBTRACT
+   * @final
+   */
+  SUBTRACT: 'subtract',
+  /**
    * @property {String} EXCLUSION
    * @final
    */

--- a/src/core/p5.Renderer2D.js
+++ b/src/core/p5.Renderer2D.js
@@ -165,8 +165,30 @@ p5.Renderer2D.prototype._getTintedImageCanvas = function(img) {
 //////////////////////////////////////////////
 
 p5.Renderer2D.prototype.blendMode = function(mode) {
-  this.drawingContext.globalCompositeOperation = mode;
+  if (mode === constants.SUBTRACT) {
+    console.warn('blendMode(SUBTRACT) only works in WEBGL mode.');
+  } else if (
+    mode === constants.BLEND ||
+    mode === constants.DARKEST ||
+    mode === constants.LIGHTEST ||
+    mode === constants.DIFFERENCE ||
+    mode === constants.MULTIPLY ||
+    mode === constants.EXCLUSION ||
+    mode === constants.SCREEN ||
+    mode === constants.REPLACE ||
+    mode === constants.OVERLAY ||
+    mode === constants.HARD_LIGHT ||
+    mode === constants.SOFT_LIGHT ||
+    mode === constants.DODGE ||
+    mode === constants.BURN ||
+    mode === constants.ADD
+  ) {
+    this.drawingContext.globalCompositeOperation = mode;
+  } else {
+    throw new Error('Mode ' + mode + ' not recognized.');
+  }
 };
+
 p5.Renderer2D.prototype.blend = function() {
   var currBlend = this.drawingContext.globalCompositeOperation;
   var blendMode = arguments[arguments.length - 1];

--- a/src/core/rendering.js
+++ b/src/core/rendering.js
@@ -255,23 +255,28 @@ p5.prototype.createGraphics = function(w, h, renderer) {
  * <li><code>REPLACE</code> - the pixels entirely replace the others and
  * don't utilize alpha (transparency) values.</li>
  * <li><code>OVERLAY</code> - mix of <code>MULTIPLY</code> and <code>SCREEN
- * </code>. Multiplies dark values, and screens light values.</li>
+ * </code>. Multiplies dark values, and screens light values. (2D)</li>
  * <li><code>HARD_LIGHT</code> - <code>SCREEN</code> when greater than 50%
- * gray, <code>MULTIPLY</code> when lower.</li>
+ * gray, <code>MULTIPLY</code> when lower. (2D)</li>
  * <li><code>SOFT_LIGHT</code> - mix of <code>DARKEST</code> and
- * <code>LIGHTEST</code>. Works like <code>OVERLAY</code>, but not as harsh.
+ * <code>LIGHTEST</code>. Works like <code>OVERLAY</code>, but not as harsh. (2D)
  * </li>
  * <li><code>DODGE</code> - lightens light tones and increases contrast,
- * ignores darks.</li>
+ * ignores darks. (2D)</li>
  * <li><code>BURN</code> - darker areas are applied, increasing contrast,
- * ignores lights.</li>
+ * ignores lights. (2D)</li>
+ * <li><code>SUBTRACT</code> - remainder of A and B (3D)</li>
  * </ul>
+ * <br><br>
+ * (2D) indicates that this blend mode <b>only</b> works in the 2D renderer.
+ * (3D) indicates that this blend mode <b>only</b> works in the WEBGL renderer.
+ *
  *
  * @method blendMode
  * @param  {Constant} mode blend mode to set for canvas.
  *                either BLEND, DARKEST, LIGHTEST, DIFFERENCE, MULTIPLY,
  *                EXCLUSION, SCREEN, REPLACE, OVERLAY, HARD_LIGHT,
- *                SOFT_LIGHT, DODGE, BURN, or ADD
+ *                SOFT_LIGHT, DODGE, BURN, ADD, or SUBTRACT
  * @example
  * <div>
  * <code>
@@ -300,32 +305,14 @@ p5.prototype.createGraphics = function(w, h, renderer) {
  */
 p5.prototype.blendMode = function(mode) {
   p5._validateParameters('blendMode', arguments);
-  if (
-    mode === constants.BLEND ||
-    mode === constants.DARKEST ||
-    mode === constants.LIGHTEST ||
-    mode === constants.DIFFERENCE ||
-    mode === constants.MULTIPLY ||
-    mode === constants.EXCLUSION ||
-    mode === constants.SCREEN ||
-    mode === constants.REPLACE ||
-    mode === constants.OVERLAY ||
-    mode === constants.HARD_LIGHT ||
-    mode === constants.SOFT_LIGHT ||
-    mode === constants.DODGE ||
-    mode === constants.BURN ||
-    mode === constants.ADD
-  ) {
-    this._renderer.blendMode(mode);
-  } else if (mode === constants.NORMAL) {
+  if (mode === constants.NORMAL) {
     // Warning added 3/26/19, can be deleted in future (1.0 release?)
     console.warn(
       'NORMAL has been deprecated for use in blendMode. defaulting to BLEND instead.'
     );
-    this._renderer.blendMode(constants.BLEND);
-  } else {
-    throw new Error('Mode ' + mode + ' not recognized.');
+    mode = constants.BLEND;
   }
+  this._renderer.blendMode(mode);
 };
 
 module.exports = p5;

--- a/src/core/rendering.js
+++ b/src/core/rendering.js
@@ -255,21 +255,21 @@ p5.prototype.createGraphics = function(w, h, renderer) {
  * <li><code>REPLACE</code> - the pixels entirely replace the others and
  * don't utilize alpha (transparency) values.</li>
  * <li><code>OVERLAY</code> - mix of <code>MULTIPLY</code> and <code>SCREEN
- * </code>. Multiplies dark values, and screens light values. (2D)</li>
+ * </code>. Multiplies dark values, and screens light values. <em>(2D)</em></li>
  * <li><code>HARD_LIGHT</code> - <code>SCREEN</code> when greater than 50%
- * gray, <code>MULTIPLY</code> when lower. (2D)</li>
+ * gray, <code>MULTIPLY</code> when lower. <em>(2D)</em></li>
  * <li><code>SOFT_LIGHT</code> - mix of <code>DARKEST</code> and
- * <code>LIGHTEST</code>. Works like <code>OVERLAY</code>, but not as harsh. (2D)
+ * <code>LIGHTEST</code>. Works like <code>OVERLAY</code>, but not as harsh. <em>(2D)</em>
  * </li>
  * <li><code>DODGE</code> - lightens light tones and increases contrast,
- * ignores darks. (2D)</li>
+ * ignores darks. <em>(2D)</em></li>
  * <li><code>BURN</code> - darker areas are applied, increasing contrast,
- * ignores lights. (2D)</li>
- * <li><code>SUBTRACT</code> - remainder of A and B (3D)</li>
+ * ignores lights. <em>(2D)</em></li>
+ * <li><code>SUBTRACT</code> - remainder of A and B <em>(3D)</em></li>
  * </ul>
  * <br><br>
- * (2D) indicates that this blend mode <b>only</b> works in the 2D renderer.
- * (3D) indicates that this blend mode <b>only</b> works in the WEBGL renderer.
+ * <em>(2D)</em> indicates that this blend mode <b>only</b> works in the 2D renderer.<br>
+ * <em>(3D)</em> indicates that this blend mode <b>only</b> works in the WEBGL renderer.
  *
  *
  * @method blendMode

--- a/src/webgl/material.js
+++ b/src/webgl/material.js
@@ -657,13 +657,78 @@ p5.RendererGL.prototype._applyColorBlend = function(colors) {
   if (isTexture || colors[colors.length - 1] < 1.0) {
     gl.depthMask(isTexture);
     gl.enable(gl.BLEND);
-    gl.blendEquation(gl.FUNC_ADD);
-    gl.blendFunc(gl.SRC_ALPHA, gl.ONE_MINUS_SRC_ALPHA);
+    this._applyBlendMode();
   } else {
     gl.depthMask(true);
     gl.disable(gl.BLEND);
   }
   return colors;
+};
+
+/**
+ * @private sets blending in gl context to curBlendMode
+ * @param  {Number[]} color [description]
+ * @return {Number[]]}  Normalized numbers array
+ */
+p5.RendererGL.prototype._applyBlendMode = function() {
+  var gl = this.GL;
+  switch (this.curBlendMode) {
+    case constants.BLEND:
+    case constants.ADD:
+      gl.blendEquation(gl.FUNC_ADD);
+      gl.blendFunc(gl.SRC_ALPHA, gl.ONE_MINUS_SRC_ALPHA);
+      break;
+    case constants.MULTIPLY:
+      gl.blendEquationSeparate(gl.FUNC_ADD, gl.FUNC_ADD);
+      gl.blendFuncSeparate(gl.ZERO, gl.SRC_COLOR, gl.ONE, gl.ONE);
+      break;
+    case constants.SCREEN:
+      gl.blendEquationSeparate(gl.FUNC_ADD, gl.FUNC_ADD);
+      gl.blendFuncSeparate(gl.ONE_MINUS_DST_COLOR, gl.ONE, gl.ONE, gl.ONE);
+      break;
+    case constants.EXCLUSION:
+      gl.blendEquationSeparate(gl.FUNC_ADD, gl.FUNC_ADD);
+      gl.blendFuncSeparate(
+        gl.ONE_MINUS_DST_COLOR,
+        gl.ONE_MINUS_SRC_COLOR,
+        gl.ONE,
+        gl.ONE
+      );
+      break;
+    case constants.REPLACE:
+      gl.blendEquation(gl.FUNC_ADD);
+      gl.blendFunc(gl.ONE, gl.ZERO);
+      break;
+    case constants.SUBTRACT:
+      gl.blendEquationSeparate(gl.FUNC_REVERSE_SUBTRACT, gl.FUNC_ADD);
+      gl.blendFuncSeparate(gl.SRC_ALPHA, gl.ONE, gl.ONE, gl.ONE);
+      break;
+    case constants.DARKEST:
+      if (this.blendExt) {
+        gl.blendEquationSeparate(this.blendExt.MIN_EXT, gl.FUNC_ADD);
+        gl.blendFuncSeparate(gl.ONE, gl.ONE, gl.ONE, gl.ONE);
+      } else {
+        console.warn(
+          'blendMode(DARKEST) does not work in your browser in WEBGL mode.'
+        );
+      }
+      break;
+    case constants.LIGHTEST:
+      if (this.blendExt) {
+        gl.blendEquationSeparate(this.blendExt.MAX_EXT, gl.FUNC_ADD);
+        gl.blendFuncSeparate(gl.ONE, gl.ONE, gl.ONE, gl.ONE);
+      } else {
+        console.warn(
+          'blendMode(LIGHTEST) does not work in your browser in WEBGL mode.'
+        );
+      }
+      break;
+    default:
+      console.error(
+        'Oops! Somehow RendererGL set curBlendMode to an unsupported mode.'
+      );
+      break;
+  }
 };
 
 module.exports = p5;

--- a/src/webgl/p5.RendererGL.js
+++ b/src/webgl/p5.RendererGL.js
@@ -70,6 +70,8 @@ p5.RendererGL = function(elt, pInst, isMainCanvas, attr) {
 
   this.curFillColor = [1, 1, 1, 1];
   this.curStrokeColor = [0, 0, 0, 1];
+  this.curBlendMode = constants.BLEND;
+  this.blendExt = this.GL.getExtension('EXT_blend_minmax');
 
   this._useSpecularMaterial = false;
   this._useNormalMaterial = false;
@@ -556,8 +558,29 @@ p5.RendererGL.prototype.strokeCap = function(cap) {
 };
 
 p5.RendererGL.prototype.blendMode = function(mode) {
-  // @TODO : to be implemented
-  console.error('Sorry, blendMode() is not yet implemented in WEBGL mode');
+  if (
+    mode === constants.DARKEST ||
+    mode === constants.LIGHTEST ||
+    mode === constants.ADD ||
+    mode === constants.BLEND ||
+    mode === constants.SUBTRACT ||
+    mode === constants.SCREEN ||
+    mode === constants.EXCLUSION ||
+    mode === constants.REPLACE ||
+    mode === constants.MULTIPLY
+  )
+    this.curBlendMode = mode;
+  else if (
+    mode === constants.BURN ||
+    mode === constants.OVERLAY ||
+    mode === constants.HARD_LIGHT ||
+    mode === constants.SOFT_LIGHT ||
+    mode === constants.DODGE
+  ) {
+    console.warn(
+      'BURN, OVERLAY, HARD_LIGHT, SOFT_LIGHT, and DODGE only work for blendMode in 2D mode.'
+    );
+  }
 };
 
 /**

--- a/test/manual-test-examples/webgl/material/blendMode/index.html
+++ b/test/manual-test-examples/webgl/material/blendMode/index.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<html>
+
+<head>
+  <meta charset="utf-8">
+  <meta http-equiv="X-UA-Compatible" content="IE=edge">
+  <title></title>
+  <link rel="stylesheet" href="../../../styles.css">
+  <script language="javascript" type="text/javascript" src="../../../../../lib/p5.js"></script>
+  <!--<script src="../../stats.js"></script>-->
+</head>
+
+<body>
+  <!-- <canvas width = "570" height = "570" id = "my_Canvas"></canvas> -->
+  <header id ='banner' style='text-align: center'>
+    current blendMode is BLEND <br>
+    Click to change blendMode.<br>
+    Key to toggle white/black background.
+  </header>
+  <script language="javascript" type="text/javascript" src="sketch.js"></script>
+</body>
+
+</html>

--- a/test/manual-test-examples/webgl/material/blendMode/sketch.js
+++ b/test/manual-test-examples/webgl/material/blendMode/sketch.js
@@ -1,0 +1,107 @@
+var blendModeIndex = 0;
+var backgroundColor = 255;
+var w = 100;
+var overlap = w / 10;
+var colors;
+
+var img;
+
+function preload() {
+  img = loadImage('../../assets/UV_Grid_Sm.jpg');
+}
+
+function setup() {
+  createCanvas(windowWidth, windowHeight, WEBGL);
+  noStroke();
+  var opac = 122;
+  colors = [
+    color(0, 0, 0, opac),
+    color(255, 255, 255, opac),
+    color(255, 0, 0, opac),
+    color(0, 0, 255, opac),
+    color(100, 0, 100, opac),
+    color(0, 100, 0, opac),
+    color(200, 200, 0, opac),
+    color(0, 200, 200, opac),
+    color(0, 255, 0, opac),
+    color(0, 255, 255, opac)
+  ];
+}
+
+function draw() {
+  background(backgroundColor);
+  for (var y = -w * 2, colorIndex = 0; y <= w * 2; y += w) {
+    drawGradientRow(y, colors[colorIndex], colors[colorIndex + 1]);
+    colorIndex += 2;
+  }
+  texture(img);
+  plane(width / 4);
+}
+
+function drawGradientRow(y, fromColor, toColor) {
+  push();
+  var w = 100;
+  translate(-width / 2, y, 0);
+  for (var x = -width / 2; x < width / 2; x += w) {
+    var col = lerpColor(
+      fromColor,
+      toColor,
+      map(x, -width / 2, width / 2, 0, 1)
+    );
+    fill(col);
+    translate(w - overlap, 0, 0);
+    plane(w);
+  }
+  pop();
+}
+
+function keyPressed() {
+  backgroundColor = backgroundColor === 255 ? 0 : 255;
+}
+
+function changeBanner(msg) {
+  document.getElementById('banner').innerHTML =
+    msg +
+    '<br>' +
+    'Click to change blendMode.<br>' +
+    'Key to toggle white/black background.';
+}
+
+function mousePressed() {
+  let max = 7;
+  blendModeIndex = blendModeIndex < max ? blendModeIndex + 1 : 0;
+  switch (blendModeIndex) {
+    case 0:
+      blendMode(BLEND);
+      changeBanner('current blendMode is BLEND');
+      break;
+    case 1:
+      blendMode(SCREEN);
+      changeBanner('current blendMode is SCREEN (invisible on white)');
+      break;
+    case 2:
+      blendMode(MULTIPLY);
+      changeBanner('current blendMode is MULTIPLY (invisible on black)');
+      break;
+    case 3:
+      blendMode(REPLACE);
+      changeBanner('current blendMode is REPLACE');
+      break;
+    case 4:
+      blendMode(EXCLUSION);
+      changeBanner('current blendMode is EXCLUSION');
+      break;
+    case 5:
+      blendMode(SUBTRACT);
+      changeBanner('current blendMode is SUBTRACT (invisible on black)');
+      break;
+    case 6:
+      blendMode(DARKEST);
+      changeBanner('current blendMode is DARKEST (invisible on black)');
+      break;
+    case 7:
+      blendMode(LIGHTEST);
+      changeBanner('current blendMode is LIGHTEST (invisible on white)');
+      break;
+  }
+}

--- a/test/unit/webgl/p5.RendererGL.js
+++ b/test/unit/webgl/p5.RendererGL.js
@@ -98,4 +98,59 @@ suite('p5.RendererGL', function() {
       done();
     });
   });
+
+  suite('blendMode()', function() {
+    var testBlend = function(mode, intended) {
+      myp5.blendMode(mode);
+      assert.deepEqual(intended, myp5._renderer.curBlendMode);
+    };
+
+    test('blendMode sets _curBlendMode correctly', function(done) {
+      myp5.createCanvas(100, 100, myp5.WEBGL);
+      testBlend(myp5.ADD, myp5.ADD);
+      testBlend(myp5.REPLACE, myp5.REPLACE);
+      testBlend(myp5.SUBTRACT, myp5.SUBTRACT);
+      testBlend(myp5.SCREEN, myp5.SCREEN);
+      testBlend(myp5.EXCLUSION, myp5.EXCLUSION);
+      testBlend(myp5.MULTIPLY, myp5.MULTIPLY);
+      testBlend(myp5.LIGHTEST, myp5.LIGHTEST);
+      testBlend(myp5.DARKEST, myp5.DARKEST);
+      done();
+    });
+
+    test('blendMode doesnt change when mode unavailable in 3D', function(done) {
+      myp5.createCanvas(100, 100, myp5.WEBGL);
+      myp5.blendMode(myp5.DARKEST);
+      testBlend(myp5.BURN, myp5.DARKEST);
+      testBlend(myp5.DODGE, myp5.DARKEST);
+      testBlend(myp5.SOFT_LIGHT, myp5.DARKEST);
+      testBlend(myp5.HARD_LIGHT, myp5.DARKEST);
+      testBlend(myp5.OVERLAY, myp5.DARKEST);
+      done();
+    });
+
+    var mixAndReturn = function(mode, bgCol) {
+      myp5.background(bgCol);
+      myp5.blendMode(mode);
+      myp5.fill(255, 0, 0, 122);
+      myp5.plane(10);
+      myp5.fill(0, 0, 255, 122);
+      myp5.plane(10);
+      return myp5.get(5, 5);
+    };
+
+    test('blendModes change pixel colors as expected', function(done) {
+      myp5.createCanvas(10, 10, myp5.WEBGL);
+      myp5.noStroke();
+      assert.deepEqual([133, 69, 191, 255], mixAndReturn(myp5.ADD, 255));
+      assert.deepEqual([0, 0, 255, 255], mixAndReturn(myp5.REPLACE, 255));
+      assert.deepEqual([133, 255, 133, 255], mixAndReturn(myp5.SUBTRACT, 255));
+      assert.deepEqual([255, 0, 255, 255], mixAndReturn(myp5.SCREEN, 0));
+      assert.deepEqual([0, 255, 0, 255], mixAndReturn(myp5.EXCLUSION, 255));
+      assert.deepEqual([0, 0, 0, 255], mixAndReturn(myp5.MULTIPLY, 255));
+      assert.deepEqual([255, 0, 255, 255], mixAndReturn(myp5.LIGHTEST, 0));
+      assert.deepEqual([0, 0, 0, 255], mixAndReturn(myp5.DARKEST, 255));
+      done();
+    });
+  });
 });


### PR DESCRIPTION
closes #3649 
related to #2756

implements `blendMode()` for WebGL. Some modes don't work as they would require shader-based solutions and I simply went for blend functions. I don't think the missing modes are a big concern as the working modes in 3D are the same as they are for Processing.

This also includes a manual test and thorough unit tests.

Here is a screenshot of the manual test:
![Screenshot (44)](https://user-images.githubusercontent.com/10382506/55038015-26e29780-4fe5-11e9-9148-17122d890e52.png)
