### PR TITLE
Improve norm function reference

### DIFF
--- a/src/math/calculation.js
+++ b/src/math/calculation.js
@@ -579,8 +579,7 @@ p5.prototype.min = function() {
  * Normalizes a number from another range into a value between 0 and 1.
  * Identical to map(value, low, high, 0, 1).
  * Numbers outside of the range are not clamped to 0 and 1, because
- * out-of-range values are often intentional and useful. (See the second
- * example above.)
+ * out-of-range values are often intentional and useful. (See the example above.)
  *
  * @method norm
  * @param  {Number} value incoming value to be normalized
@@ -596,6 +595,7 @@ p5.prototype.min = function() {
  *   let upperBound = width; //100;
  *   let normalized = norm(currentNum, lowerBound, upperBound);
  *   let lineY = 70;
+ *   stroke(3);
  *   line(0, lineY, width, lineY);
  *   //Draw an ellipse mapped to the non-normalized value.
  *   noStroke();


### PR DESCRIPTION
The changes made in this PR are: 

- Add the guide line, which was not being drawn in subsequent draw calls due to noStroke( ) called below it.
- Rewrite 'refer to second example above' as 'refer to example above' as only one example is present and it already explains about out of range normalized values. 

I request the maintainers to review this PR,
Thank you !