### PR TITLE
Explain Value to the Number Parameter:

### DIFF
--- a/src/color/setting.js
+++ b/src/color/setting.js
@@ -153,7 +153,7 @@ require('./p5.Color');
  *                        color mode)
  * @param {Number} v3     blue or brightness value (depending on the current
  *                        color mode)
- * @param  {Number} [a]
+ * @param  {Number} [a]   alpha value relative to current color range (default is 0–255)
  * @chainable
  */
 


### PR DESCRIPTION
The explanation for an `alpha` value is missing here, but listed at
the URL https://p5js.org/reference/#/p5/color. Thus, that
explanation is copied and pasted here, replacing the regular dash
with an en-dash in the number range.