### PR TITLE
reset() for p5.Graphics

### DIFF
--- a/src/core/p5.Graphics.js
+++ b/src/core/p5.Graphics.js
@@ -63,6 +63,21 @@ p5.Graphics = function(w, h, renderer, pInst) {
 p5.Graphics.prototype = Object.create(p5.Element.prototype);
 
 /**
+ * End the drawing loop of p5.Graphics object. This resets the transform
+ * matrices and lighting.
+ *
+ * @method endFrame
+ *
+ */
+p5.Graphics.prototype.endFrame = function() {
+  // just reset the matrix in the Renderer for this p5.Graphics object
+  this._renderer.resetMatrix();
+  if (this._renderer.isP3D) {
+    this._renderer._update();
+  }
+};
+
+/**
  * Removes a Graphics object from the page and frees any resources
  * associated with it.
  *

--- a/src/core/p5.Graphics.js
+++ b/src/core/p5.Graphics.js
@@ -63,14 +63,51 @@ p5.Graphics = function(w, h, renderer, pInst) {
 p5.Graphics.prototype = Object.create(p5.Element.prototype);
 
 /**
- * End the drawing loop of p5.Graphics object. This resets the transform
- * matrices and lighting.
+ * Resets certain values such as those modified by functions in the Transform category
+ * and in the Lights category that are not automatically reset
+ * with graphics buffer objects. Calling this in <a href='#/p5/draw'>draw()</a> will copy the behavior
+ * of the standard canvas.
  *
- * @method endFrame
+ * @method reset
+ * @example
+ *
+ * <div><code>
+ * let pg;
+ * function setup() {
+ *   createCanvas(100, 100);
+ *   background(0);
+ *   pg = createGraphics(50, 100);
+ *   pg.fill(0);
+ *   frameRate(5);
+ * }
+ * function draw() {
+ *   image(pg, width / 2, 0);
+ *   pg.background(255);
+ *   // p5.Graphics object behave a bit differently in some cases
+ *   // The normal canvas on the left resets the translate
+ *   // with every loop through draw()
+ *   // the graphics object on the right doesn't automatically reset
+ *   // so translate() is additive and it moves down the screen
+ *   rect(0, 0, width / 2, 5);
+ *   pg.rect(0, 0, width / 2, 5);
+ *   translate(0, 5, 0);
+ *   pg.translate(0, 5, 0);
+ * }
+ * function mouseClicked() {
+ *   // if you click you will see that
+ *   // reset() resets the translate back to the initial state
+ *   // of the Graphics object
+ *   pg.reset();
+ * }
+ * </code></div>
+ *
+ * @alt
+ * A white line on a black background stays still on the top-left half.
+ * A black line animates from top to bottom on a white background on the right half.
+ * When clicked, the black line starts back over at the top.
  *
  */
-p5.Graphics.prototype.endFrame = function() {
-  // just reset the matrix in the Renderer for this p5.Graphics object
+p5.Graphics.prototype.reset = function() {
   this._renderer.resetMatrix();
   if (this._renderer.isP3D) {
     this._renderer._update();


### PR DESCRIPTION
fixes #2586 
fixes #3079 

This PR is extremely simple and is meant primarily as a discussion starter. Currently there is nothing equivalent to [Processing's `beginDraw()` and `endDraw()` for PGraphics objects.](https://processing.org/reference/createGraphics_.html). I think it is nice that this isn't necessary in p5 but it introduces a couple of problems as indicated in the issues listed above.

 Here it is [illustrated by this example.](https://editor.p5js.org/stalgiag/sketches/OwZF0PWtO) As soon as you start the sketch the `rect` in the p5.Graphics flies off the bottom right corner. This is because `translate()` is additive. This is reset during `redraw()` for the p5 drawing context but not for any of the p5.Graphics objs that the user may have made. This encountered less often in 2D because translate is more rarely used, but it is heavily relied on in 3D. This lack of resetting also affects the lighting in GL mode.

The suggestion here is to add a utility function named `endFrame()` as per the discussion in #3079. At first, I thought we should just go with something similar to beginDraw/endDraw in Processing but I don't think that is necessary. Those functions do some setting up of default values for the PApplet and [style property reapplication](https://github.com/processing/processing/blob/master/core/src/processing/core/PGraphics.java#L1019) in Processing which I don't think is necessary for us. So the flanking of drawing inside Graphics would be pointless other than to maintain similarity to Processing. As far as I can tell there are two possible approaches for this:

1. Keep track of all of the p5.Graphics objects that are made and automatically reset them in `redraw`
  - pro: fixes the problem without the user needing to understand what is happening and masks the differences between drawing into p5 normally and drawing into a p5.Graphics.
  - con: no user control over when the reset happens.
2. Add a function for people that want to explicitly reset their p5.Graphics. (this PR currently)
  - pro: simple to implement
  - con: requires an understanding of another function

Note: If we decide to go with the version that this PR suggest (#2) then I'll add more clear documentation and unit tests.