### PR TITLE
Fix default value in textToPoints doc

### DIFF
--- a/src/typography/p5.Font.js
+++ b/src/typography/p5.Font.js
@@ -164,7 +164,7 @@ p5.Font.prototype.textBounds = function(str, x, y, fontSize, opts) {
  * @param  {Object} [options] an (optional) object that can contain:
  *
  * <br>sampleFactor - the ratio of path-length to number of samples
- * (default=.25); higher values yield more points and are therefore
+ * (default=.1); higher values yield more points and are therefore
  * more precise
  *
  * <br>simplifyThreshold - if set to a non-zero value, collinear points will be


### PR DESCRIPTION
The default value of sampleFactor is actually 0.1, not 0.25. This value can be found at [line 480 in the pathToPoints method](https://github.com/processing/p5.js/blob/master/src/typography/p5.Font.js#L480).