### PR TITLE
Fix get function for p5.MediaElement

### DIFF
--- a/lib/addons/p5.dom.js
+++ b/lib/addons/p5.dom.js
@@ -2947,7 +2947,10 @@
     this.setModified(true);
     return this;
   };
-  p5.MediaElement.prototype.get = p5.Renderer2D.prototype.get;
+  p5.MediaElement.prototype.get = function() {
+    this._ensureCanvas();
+    return p5.Renderer2D.prototype.get.apply(this, arguments);
+  };
   p5.MediaElement.prototype._getPixel = function() {
     if (this.loadedmetadata) {
       // wait for metadata


### PR DESCRIPTION
Fixes #3051 

The change made in this PR is: 

- call this._ensureCanvas( ) in p5.MediaElement.prototype.get( ) to make sure that the canvas exists before getting the pixel or image value.

I request the maintainers to review this PR, 
Thank you ! 