### PR TITLE
Remove unused parameter of p5.Element constructor in p5.Graphics file

### DIFF
--- a/src/core/p5.Graphics.js
+++ b/src/core/p5.Graphics.js
@@ -30,7 +30,7 @@ p5.Graphics = function(w, h, renderer, pInst) {
   var node = pInst._userNode || document.body;
   node.appendChild(this.canvas);
 
-  p5.Element.call(this, this.canvas, pInst, false);
+  p5.Element.call(this, this.canvas, pInst);
 
   // bind methods and props of p5 to the new object
   for (var p in p5.prototype) {


### PR DESCRIPTION
The change made in this PR is : 
- Remove the third parameter (false) in p5.Element function called in p5.Graphics file as p5.Element constructor function accepts only two parameters, the element (elt) and the p5 instance (pInst).

I request the maintainers to review  this PR,
Thank you !