### PR TITLE
Add Coding Train contribution process video link to developer docs

### DIFF
--- a/developer_docs/README.md
+++ b/developer_docs/README.md
@@ -124,6 +124,8 @@ A complete guide to unit testing is beyond the scope of the p5.js documentation,
 
 9. Once everything is ready, submit your changes as a [pull request](https://help.github.com/articles/creating-a-pull-request).
 
+This process is also covered [in a video by The Coding Train.](https://youtu.be/Rr3vLyP1Ods) :train::rainbow:
+
 # Building Documentation
 
 Inline comments in p5.js are built into the public-facing [reference manual](https://p5js.org/reference/). You can also view this locally:


### PR DESCRIPTION
This adds a link to the developer docs for [a video by The Coding Train](https://youtu.be/Rr3vLyP1Ods) that explains the development/contribution process.

Thanks for making this @shiffman !