### PR TITLE
Fix loadJSON() usage with JSONP

### DIFF
--- a/src/io/files.js
+++ b/src/io/files.js
@@ -1141,7 +1141,10 @@ p5.prototype.httpDo = function() {
       err.ok = false;
       throw err;
     } else {
-      var fileSize = res.headers.get('content-length');
+      var fileSize = 0;
+      if (type !== 'jsonp') {
+        fileSize = res.headers.get('content-length');
+      }
       if (fileSize && fileSize > 64000000) {
         p5._friendlyFileLoadError(7, path);
       }


### PR DESCRIPTION
Fixes #3684 

Disables size check for JSONP requests. I don't know if there is a way to check for JSONP request size or not seeing that it basically creates script tags and I'm not even sure if there is a size limit for JSONP so I just disable the header checks for JSONP requests as they don't return headers.