### PR TITLE
VSCode Suggested Extensions

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -15,16 +15,8 @@
     "ecmaVersion": 2017
   },
   "rules": {
-    "prettier/prettier": [
-      "error",
-      {
-        "singleQuote": true
-      }
-    ],
-    "no-cond-assign": [
-      2,
-      "except-parens"
-    ],
+    "prettier/prettier": ["error"],
+    "no-cond-assign": [2, "except-parens"],
     "eqeqeq": ["error", "smart"],
     "no-use-before-define": [
       2,

--- a/.gitignore
+++ b/.gitignore
@@ -10,7 +10,6 @@ docs/reference/*
 !*.gitkeep
 examples/3d/
 .idea
-.vscode
 dist/
 p5.zip
 bower-repo/

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,3 @@
+{
+  "singleQuote": true
+}

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,13 @@
+{
+  // See http://go.microsoft.com/fwlink/?LinkId=827846 to learn about workspace recommendations.
+  // Extension identifier format: ${publisher}.${name}. Example: vscode.csharp
+
+  // List of extensions which should be recommended for users of this workspace.
+  "recommendations": [
+    "eg2.vscode-npm-script",
+    "esbenp.prettier-vscode",
+    "yzhang.markdown-all-in-one"
+  ],
+  // List of extensions recommended by VS Code that should not be recommended for users of this workspace.
+  "unwantedRecommendations": []
+}

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -6,7 +6,8 @@
   "recommendations": [
     "eg2.vscode-npm-script",
     "esbenp.prettier-vscode",
-    "yzhang.markdown-all-in-one"
+    "yzhang.markdown-all-in-one",
+    "dbaeumer.vscode-eslint"
   ],
   // List of extensions recommended by VS Code that should not be recommended for users of this workspace.
   "unwantedRecommendations": []

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,4 @@
+{
+  "editor.formatOnSave": true,
+  "editor.tabSize": 2
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,4 +1,5 @@
 {
   "editor.formatOnSave": true,
-  "editor.tabSize": 2
+  "editor.tabSize": 2,
+  "eslint.run": "onSave"
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,5 +1,6 @@
 {
   "editor.formatOnSave": true,
   "editor.tabSize": 2,
-  "eslint.run": "onSave"
+  "eslint.run": "onSave",
+  "prettier.requireConfig": true
 }


### PR DESCRIPTION
This PR adds two config files for vscode:

* `.vscode/extensions.json`, which prompt the user to install a couple vscode extensions when they open the p5 repo (unless they already have them)
* `.vscode/settings.json`, which provides a few settings to make those plugins useful out of the box

The plugins are:

* `eg2.vscode-npm-script`, which allows you to run npm scripts from within vscode
* `esbenp.prettier-vscode`, which runs prettier formatting on save for files edited in vscode.
* `yzhang.markdown-all-in-one`, which adds some handy markdown shortcuts (thinking of `developer_docs/` here)
* `dbaeumer.vscode-eslint`, which will show eslint errors inline while editing code

Additionally, I moved some `prettier` config out of the `eslint` config and into its own config so it can be reused between `eslint` and standalone `prettier`.