### PR TITLE
Revamped createImg() to solve issues concerning CORS

### DIFF
--- a/lib/addons/p5.dom.js
+++ b/lib/addons/p5.dom.js
@@ -419,45 +419,39 @@
    * @method createImg
    * @param  {String} src src path or url for image
    * @param  {String} [alt] alternate text to be used if image does not load
+   * @param  {String} [crossOrigin] <a href="https://developer.mozilla.org/en-US/docs/Web/HTML/CORS_settings_attributes">crossOrigin property</a> of the &lt;img&gt; element; use either 'anonymous' or 'use-credentials' to retrieve the image with cross-origin access (for later use with &lt;canvas&gt;; by default, if no value or undefined is passed, CORS is not used
    * @param  {Function} [successCallback] callback to be called once image data is loaded
    * @return {p5.Element} pointer to <a href="#/p5.Element">p5.Element</a> holding created node
    * @example
    * <div class='norender'><code>
-   * createImg('http://p5js.org/img/asterisk-01.png');
+   * createImg('https://p5js.org/assets/img/asterisk-01.png');
    * </code></div>
    */
   /**
    * @method createImg
    * @param  {String} src
    * @param  {Function} successCallback
-   * @return {Object|p5.Element}
+   * @return {p5.Element}
    */
   p5.prototype.createImg = function() {
     p5._validateParameters('createImg', arguments);
     var elt = document.createElement('img');
-    elt.crossOrigin = 'Anonymous';
     var args = arguments;
     var self;
-    var setAttrs = function() {
-      self.width = elt.offsetWidth || elt.width;
-      self.height = elt.offsetHeight || elt.height;
-      if (args.length > 1 && typeof args[1] === 'function') {
-        self.fn = args[1];
-        self.fn();
-      } else if (args.length > 1 && typeof args[2] === 'function') {
-        self.fn = args[2];
-        self.fn();
-      }
-    };
-    elt.src = args[0];
     if (args.length > 1 && typeof args[1] === 'string') {
       elt.alt = args[1];
     }
-    elt.onload = function() {
-      setAttrs();
-    };
-    self = addElement(elt, this);
-    return self;
+    if (args.length > 2 && typeof args[2] === 'string') {
+      elt.crossOrigin = args[2];
+    }
+    elt.addEventListener('load', function() {
+      self.width = elt.offsetWidth || elt.width;
+      self.height = elt.offsetHeight || elt.height;
+      var last = args[args.length - 1];
+      if (typeof last === 'function') last();
+    });
+    elt.src = args[0];
+    return (self = addElement(elt, this));
   };
 
   /**


### PR DESCRIPTION
To solve #3564, `createImg()` in `p5.dom` has been revamped to account for the addition of an optional `crossOrigin` parameter.

Changes involved:
* Reversed 6ed05304fe2da3eef00ab04a0db7d285843aad17, so that we do not use CORS by default.
* Added an optional `crossOrigin` parameter to `createImg()`, enabling the user to explicitly opt for a CORS reuquest, if they intend to use the `<img>` with `<canvas>` without marking it as _tainted_.
* Add corresponding `@param` JSDoc tag documenting the use of the `crossOrigin` parameter.