### PR TITLE
Table getObject() function now returns an array of objects

### DIFF
--- a/src/io/p5.Table.js
+++ b/src/io/p5.Table.js
@@ -1270,7 +1270,7 @@ p5.Table.prototype.getString = function(row, column) {
  *
  */
 p5.Table.prototype.getObject = function(headerColumn) {
-  var tableObject = {};
+  var tableObject = [];
   var obj, cPos, index;
 
   for (var i = 0; i < this.rows.length; i++) {


### PR DESCRIPTION
The function now returns an array of objects.

It is more consistent with other libraries and makes it possible to use vanilla js array operators, such as `foreach()`.

[Unit tests](https://github.com/processing/p5.js/tree/master/developer_docs#unit-tests) were performed and passed.

Closes #3277.