### PR TITLE
material.js shader() example / remove Mandel

### DIFF
--- a/docs/yuidoc-p5-theme/assets/shader-gradient.frag
+++ b/docs/yuidoc-p5-theme/assets/shader-gradient.frag
@@ -1,0 +1,19 @@
+// Code adopted from "Creating a Gradient Color in Fragment Shader"
+// by Bahadır on stackoverflow.com
+// https://stackoverflow.com/questions/47376499/creating-a-gradient-color-in-fragment-shader
+
+precision highp float; varying vec2 vPos;
+uniform float pos;
+
+void main() {
+
+  vec2 st = vPos.xy + vec2(0,pos);
+
+  vec3 color1 = vec3(1.9,0.55,0);
+  vec3 color2 = vec3(0.226,0.000,0.615);
+
+  float mixValue = distance(st,vec2(0,1));
+  vec3 color = mix(color1,color2,mixValue);
+
+  gl_FragColor = vec4(color,mixValue);
+}

--- a/docs/yuidoc-p5-theme/assets/shader-gradient.frag
+++ b/docs/yuidoc-p5-theme/assets/shader-gradient.frag
@@ -2,18 +2,21 @@
 // by Bahadır on stackoverflow.com
 // https://stackoverflow.com/questions/47376499/creating-a-gradient-color-in-fragment-shader
 
+
 precision highp float; varying vec2 vPos;
-uniform float pos;
+uniform vec2 offset;
+uniform vec3 colorCenter;
+uniform vec3 colorBackground;
 
 void main() {
 
-  vec2 st = vPos.xy + vec2(0,pos);
+  vec2 st = vPos.xy + offset.xy;
 
-  vec3 color1 = vec3(1.9,0.55,0);
-  vec3 color2 = vec3(0.226,0.000,0.615);
+  // color1 = vec3(1.0,0.55,0);
+  // color2 = vec3(0.226,0.000,0.615);
 
   float mixValue = distance(st,vec2(0,1));
-  vec3 color = mix(color1,color2,mixValue);
+  vec3 color = mix(colorCenter,colorBackground,mixValue);
 
   gl_FragColor = vec4(color,mixValue);
 }

--- a/src/webgl/material.js
+++ b/src/webgl/material.js
@@ -188,6 +188,49 @@ p5.prototype.createShader = function(vertSrc, fragSrc) {
  * @chainable
  * @param {p5.Shader} [s] the desired <a href="#/p5.Shader">p5.Shader</a> to use for rendering
  * shapes.
+ *
+ * @example
+ * <div modernizr='webgl'>
+ * <code>
+ * // Click within the image to toggle
+ * // the shader used by the quad shape
+ *
+ * let mandel;
+ * let gradient;
+ * let useMandel = false;
+ *
+ * function preload() {
+ *   // load the shader definitions from files
+ *   mandel = loadShader('assets/shader.vert', 'assets/shader.frag');
+ *   gradient = loadShader('assets/shader.vert', 'assets/shader-gradient.frag');
+ * }
+ * function setup() {
+ *   createCanvas(100, 100, WEBGL);
+ *   // initially use the gradient shader
+ *   shader(gradient);
+ *   noStroke();
+ * }
+ *
+ * function draw() {
+ *   mandel.setUniform('r', 1.5 * exp(-6.5 * (1 + sin(millis() / 2000))));
+ *   gradient.setUniform('pos', sin(millis() / 2000) + 1);
+ *   quad(-1, -1, 1, -1, 1, 1, -1, 1);
+ * }
+ *
+ * function mouseClicked() {
+ *   useMandel = !useMandel;
+ *   if (useMandel === true) {
+ *     shader(mandel);
+ *     mandel.setUniform('p', [-0.74364388703, 0.13182590421]);
+ *   } else {
+ *     shader(gradient);
+ *   }
+ * }
+ * </code>
+ * </div>
+ *
+ * @alt
+ * canvas toggles between a circular gradient of orange and blue moving up and down. and an infinitely detailed fractal with mouse click/press.
  */
 p5.prototype.shader = function(s) {
   this._assert3d('shader');

--- a/src/webgl/material.js
+++ b/src/webgl/material.js
@@ -195,42 +195,56 @@ p5.prototype.createShader = function(vertSrc, fragSrc) {
  * // Click within the image to toggle
  * // the shader used by the quad shape
  *
- * let mandel;
- * let gradient;
- * let useMandel = false;
+ * let redGreen;
+ * let orangeBlue;
+ * let showRedGreen = false;
  *
  * function preload() {
- *   // load the shader definitions from files
- *   mandel = loadShader('assets/shader.vert', 'assets/shader.frag');
- *   gradient = loadShader('assets/shader.vert', 'assets/shader-gradient.frag');
+ *   // note that we are using two instances
+ *   // of the same vertex and fragment shaders
+ *   redGreen = loadShader('assets/shader.vert', 'assets/shader-gradient.frag');
+ *   orangeBlue = loadShader('assets/shader.vert', 'assets/shader-gradient.frag');
  * }
+ *
  * function setup() {
  *   createCanvas(100, 100, WEBGL);
- *   // initially use the gradient shader
- *   shader(gradient);
+ *
+ *   // initialize the colors for redGreen shader
+ *   shader(redGreen);
+ *   redGreen.setUniform('colorCenter', [1.0, 0.0, 0.0]);
+ *   redGreen.setUniform('colorBackground', [0.0, 1.0, 0.0]);
+ *
+ *   // initialize the colors for orangeBlue shader
+ *   shader(orangeBlue);
+ *   orangeBlue.setUniform('colorCenter', [1.0, 0.5, 0.0]);
+ *   orangeBlue.setUniform('colorBackground', [0.226, 0.0, 0.615]);
+ *
  *   noStroke();
  * }
  *
  * function draw() {
- *   mandel.setUniform('r', 1.5 * exp(-6.5 * (1 + sin(millis() / 2000))));
- *   gradient.setUniform('pos', sin(millis() / 2000) + 1);
+ *   // update the offset values for each shader,
+ *   // moving orangeBlue in vertical and redGreen
+ *   // in horizontal direction
+ *   orangeBlue.setUniform('offset', [0, sin(millis() / 2000) + 1]);
+ *   redGreen.setUniform('offset', [sin(millis() / 2000), 1]);
+ *
+ *   if (showRedGreen === true) {
+ *     shader(redGreen);
+ *   } else {
+ *     shader(orangeBlue);
+ *   }
  *   quad(-1, -1, 1, -1, 1, 1, -1, 1);
  * }
  *
  * function mouseClicked() {
- *   useMandel = !useMandel;
- *   if (useMandel === true) {
- *     shader(mandel);
- *     mandel.setUniform('p', [-0.74364388703, 0.13182590421]);
- *   } else {
- *     shader(gradient);
- *   }
+ *   showRedGreen = !showRedGreen;
  * }
  * </code>
  * </div>
  *
  * @alt
- * canvas toggles between a circular gradient of orange and blue moving up and down. and an infinitely detailed fractal with mouse click/press.
+ * canvas toggles between a circular gradient of orange and blue vertically. and a circular gradient of red and green moving horizontally when mouse is clicked/pressed.
  */
 p5.prototype.shader = function(s) {
   this._assert3d('shader');


### PR DESCRIPTION
addresses #1954
- [x] https://p5js.org/reference/#/p5/shader

resolves #3720 

extends the loadShader example to allow for toggling between 2 shaders on mouse click/press.

@stalgiag let me know what you think :thumbsup:
