### PR TITLE
Modify comment for p5.Image._modified

### DIFF
--- a/src/image/p5.Image.js
+++ b/src/image/p5.Image.js
@@ -147,9 +147,9 @@ p5.Image = function(width, height) {
   this.drawingContext = this.canvas.getContext('2d');
   this._pixelsState = this;
   this._pixelDensity = 1;
-  //used for webgl texturing only
-  this._modified = false;
   this._pixelsDirty = true;
+  //used for webgl texturing only determines whether to reupload texture to GPU
+  this._modified = false;
   /**
    * Array containing the values for all the pixels in the display window.
    * These values are numbers. This array is the size (include an appropriate

--- a/src/image/p5.Image.js
+++ b/src/image/p5.Image.js
@@ -148,7 +148,7 @@ p5.Image = function(width, height) {
   this._pixelsState = this;
   this._pixelDensity = 1;
   this._pixelsDirty = true;
-  //used for webgl texturing only determines whether to reupload texture to GPU
+  //For WebGL Texturing only: used to determine whether to reupload texture to GPU
   this._modified = false;
   /**
    * Array containing the values for all the pixels in the display window.


### PR DESCRIPTION
Just adding a comment to make it more clear what the `_modified` property does on p5.Image. 

Also moving the `_pixelsDirty` property out from under the "//used for webgl texturing only comment" as that is not true for `_pixelsDirty`.

closes #3726