### PR TITLE
Removes break statements from lighting shaders

### DIFF
--- a/src/webgl/shaders/light.vert
+++ b/src/webgl/shaders/light.vert
@@ -38,41 +38,41 @@ void main(void){
   float diffuseFactor = 0.3;
 
   vec3 ambientLightFactor = vec3(0.0);
-
-  for (int i = 0; i < 8; i++) {
-    if (uAmbientLightCount == i) break;
-    ambientLightFactor += uAmbientColor[i];
-  }
-
-
   vec3 directionalLightFactor = vec3(0.0);
-
-  for (int j = 0; j < 8; j++) {
-    if (uDirectionalLightCount == j) break;
-    vec3 dir = (uViewMatrix * vec4(uLightingDirection[j], 0.0)).xyz;
-    float directionalLightWeighting = max(dot(vertexNormal, -dir), 0.0);
-    directionalLightFactor += uDirectionalColor[j] * directionalLightWeighting;
-  }
-
-
   vec3 pointLightFactor = vec3(0.0);
 
-  for (int k = 0; k < 8; k++) {
-    if (uPointLightCount == k) break;
-    vec3 loc = (uViewMatrix * vec4(uPointLightLocation[k], 1.0)).xyz;
-    vec3 lightDirection = normalize(loc - mvPosition.xyz);
+  for (int i = 0; i < 8; i++) {
 
-    float directionalLightWeighting = max(dot(vertexNormal, lightDirection), 0.0);
+    // Calculate ambient light factor
+    if(i < uAmbientLightCount){
+      ambientLightFactor += uAmbientColor[i];
+    } 
 
-    float specularLightWeighting = 0.0;
-    if (uSpecular ){
-      vec3 reflectionDirection = reflect(-lightDirection, vertexNormal);
-      specularLightWeighting = pow(max(dot(reflectionDirection, eyeDirection), 0.0), uShininess);
+    // Calculate directional light factor
+    if(i < uDirectionalLightCount){
+      vec3 dir = (uViewMatrix * vec4(uLightingDirection[i], 0.0)).xyz;
+      float directionalLightWeighting = max(dot(vertexNormal, -dir), 0.0);
+      directionalLightFactor += uDirectionalColor[i] * directionalLightWeighting;
     }
 
-    pointLightFactor += uPointLightColor[k] * (specularFactor * specularLightWeighting
-      + directionalLightWeighting * diffuseFactor);
+    // Calculate point light factor
+    if(i < uPointLightCount){
+      vec3 loc = (uViewMatrix * vec4(uPointLightLocation[i], 1.0)).xyz;
+      vec3 lightDirection = normalize(loc - mvPosition.xyz);
+
+      float directionalLightWeighting = max(dot(vertexNormal, lightDirection), 0.0);
+
+      float specularLightWeighting = 0.0;
+      if (uSpecular ){
+        vec3 reflectionDirection = reflect(-lightDirection, vertexNormal);
+        specularLightWeighting = pow(max(dot(reflectionDirection, eyeDirection), 0.0), uShininess);
+      }
+
+      pointLightFactor += uPointLightColor[i] * (specularFactor * specularLightWeighting
+        + directionalLightWeighting * diffuseFactor);
+    }
   }
+
 
   vLightWeighting =  ambientLightFactor + directionalLightFactor + pointLightFactor;
 }

--- a/src/webgl/shaders/light_texture.frag
+++ b/src/webgl/shaders/light_texture.frag
@@ -9,7 +9,9 @@ varying vec3 vLightWeighting;
 varying highp vec2 vVertTexCoord;
 
 void main(void) {
+  // Lets init gl_FragColor just to be safe
+  gl_FragColor = vec4(1.0,1.0,1.0,1.0);
+
   gl_FragColor = isTexture ? texture2D(uSampler, vVertTexCoord) : uMaterialColor;
-  if (uUseLighting)
-    gl_FragColor.rgb *= vLightWeighting;
+  if (uUseLighting) gl_FragColor.rgb *= vLightWeighting;
 }

--- a/src/webgl/shaders/line.vert
+++ b/src/webgl/shaders/line.vert
@@ -24,15 +24,15 @@ uniform float uStrokeWeight;
 
 uniform vec4 uViewport;
 
-// using a scale <1 moves the lines towards the camera
-// in order to prevent popping effects due to half of
-// the line disappearing behind the geometry faces.
-vec3 scale = vec3(0.9995);
-
 attribute vec4 aPosition;
 attribute vec4 aDirection;
   
 void main() {
+  // using a scale <1 moves the lines towards the camera
+  // in order to prevent popping effects due to half of
+  // the line disappearing behind the geometry faces.
+  vec3 scale = vec3(0.9995);
+
   vec4 posp = uModelViewMatrix * aPosition;
   vec4 posq = uModelViewMatrix * (aPosition + vec4(aDirection.xyz, 0));
 

--- a/src/webgl/shaders/phong.frag
+++ b/src/webgl/shaders/phong.frag
@@ -71,27 +71,25 @@ void main(void) {
   float specular = 0.0;
 
   for (int j = 0; j < 8; j++) {
-    if (uDirectionalLightCount == j) break;
+    if( j < uDirectionalLightCount){
+      vec3 dir = (uViewMatrix * vec4(uLightingDirection[j], 0.0)).xyz;
+      LightResult result = light(dir);
+      diffuse += result.diffuse * uDirectionalColor[j];
+      specular += result.specular;
+    }
 
-    vec3 dir = (uViewMatrix * vec4(uLightingDirection[j], 0.0)).xyz;
-    LightResult result = light(dir);
-    diffuse += result.diffuse * uDirectionalColor[j];
-    specular += result.specular;
-  }
+    if( j < uPointLightCount){
+      vec3 lightPosition = (uViewMatrix * vec4(uPointLightLocation[j], 1.0)).xyz;
+      vec3 lightVector = vViewPosition - lightPosition;
+    
+      //calculate attenuation
+      float lightDistance = length(lightVector);
+      float falloff = 500.0 / (lightDistance + 500.0);
 
-  for (int k = 0; k < 8; k++) {
-    if (uPointLightCount == k) break;
-
-    vec3 lightPosition = (uViewMatrix * vec4(uPointLightLocation[k], 1.0)).xyz;
-    vec3 lightVector = vViewPosition - lightPosition;
-	
-    //calculate attenuation
-    float lightDistance = length(lightVector);
-    float falloff = 500.0 / (lightDistance + 500.0);
-
-    LightResult result = light(lightVector);
-    diffuse += result.diffuse * falloff * uPointLightColor[k];
-    specular += result.specular * falloff;
+      LightResult result = light(lightVector);
+      diffuse += result.diffuse * falloff * uPointLightColor[j];
+      specular += result.specular * falloff;
+    }
   }
 
   gl_FragColor = isTexture ? texture2D(uSampler, vTexCoord) : uMaterialColor;

--- a/src/webgl/shaders/phong.vert
+++ b/src/webgl/shaders/phong.vert
@@ -29,7 +29,8 @@ void main(void){
 
   vAmbientColor = vec3(0.0);
   for (int i = 0; i < 8; i++) {
-    if (uAmbientLightCount == i) break;
-    vAmbientColor += uAmbientColor[i];
+    if(i < uAmbientLightCount){
+      vAmbientColor += uAmbientColor[i];
+    }
   }
 }


### PR DESCRIPTION
For whatever reason, the break statements within loops in the lighting shaders were causing the shaders to fail to execute. 

I amended the shaders to just check if current loop index was less than the light count in all instances that I could find. This also allowed me to reduce the amount of loops being called in the shader.

It might be worth doing some tests to see if this check is really necessary, it might be just as performant to avoid the conditional and do our light calculations all 8 times. 