### PR TITLE
unify lighting

### DIFF
--- a/src/webgl/p5.RendererGL.js
+++ b/src/webgl/p5.RendererGL.js
@@ -9,6 +9,11 @@ require('../core/p5.Renderer');
 require('./p5.Matrix');
 var fs = require('fs');
 
+var lightingShader = fs.readFileSync(
+  __dirname + '/shaders/lighting.glsl',
+  'utf-8'
+);
+
 var defaultShaders = {
   immediateVert: fs.readFileSync(
     __dirname + '/shaders/immediate.vert',
@@ -25,13 +30,17 @@ var defaultShaders = {
   normalVert: fs.readFileSync(__dirname + '/shaders/normal.vert', 'utf-8'),
   normalFrag: fs.readFileSync(__dirname + '/shaders/normal.frag', 'utf-8'),
   basicFrag: fs.readFileSync(__dirname + '/shaders/basic.frag', 'utf-8'),
-  lightVert: fs.readFileSync(__dirname + '/shaders/light.vert', 'utf-8'),
+  lightVert:
+    lightingShader +
+    fs.readFileSync(__dirname + '/shaders/light.vert', 'utf-8'),
   lightTextureFrag: fs.readFileSync(
     __dirname + '/shaders/light_texture.frag',
     'utf-8'
   ),
   phongVert: fs.readFileSync(__dirname + '/shaders/phong.vert', 'utf-8'),
-  phongFrag: fs.readFileSync(__dirname + '/shaders/phong.frag', 'utf-8'),
+  phongFrag:
+    lightingShader +
+    fs.readFileSync(__dirname + '/shaders/phong.frag', 'utf-8'),
   fontVert: fs.readFileSync(__dirname + '/shaders/font.vert', 'utf-8'),
   fontFrag: fs.readFileSync(__dirname + '/shaders/font.frag', 'utf-8'),
   lineVert: fs.readFileSync(__dirname + '/shaders/line.vert', 'utf-8'),

--- a/src/webgl/shaders/basic.frag
+++ b/src/webgl/shaders/basic.frag
@@ -1,5 +1,4 @@
 precision mediump float;
-varying vec3 vVertexNormal;
 uniform vec4 uMaterialColor;
 void main(void) {
   gl_FragColor = uMaterialColor;

--- a/src/webgl/shaders/light.vert
+++ b/src/webgl/shaders/light.vert
@@ -1,78 +1,30 @@
+// include lighting.glgl
+
 attribute vec3 aPosition;
 attribute vec3 aNormal;
 attribute vec2 aTexCoord;
 
-uniform mat4 uViewMatrix;
 uniform mat4 uModelViewMatrix;
 uniform mat4 uProjectionMatrix;
 uniform mat3 uNormalMatrix;
-uniform int uAmbientLightCount;
-uniform int uDirectionalLightCount;
-uniform int uPointLightCount;
 
-uniform vec3 uAmbientColor[8];
-uniform vec3 uLightingDirection[8];
-uniform vec3 uDirectionalColor[8];
-uniform vec3 uPointLightLocation[8];
-uniform vec3 uPointLightColor[8];
-uniform bool uSpecular;
-uniform float uShininess;
+varying highp vec2 vVertTexCoord;
+varying vec3 vDiffuseColor;
+varying vec3 vSpecularColor;
 
-varying vec3 vVertexNormal;
-varying vec2 vVertTexCoord;
-varying vec3 vLightWeighting;
+void main(void) {
 
-void main(void){
+  vec4 viewModelPosition = uModelViewMatrix * vec4(aPosition, 1.0);
+  gl_Position = uProjectionMatrix * viewModelPosition;
 
-  vec4 positionVec4 = vec4(aPosition, 1.0);
-  gl_Position = uProjectionMatrix * uModelViewMatrix * positionVec4;
-
-  vec3 vertexNormal = normalize(vec3( uNormalMatrix * aNormal ));
-  vVertexNormal = vertexNormal;
+  vec3 vertexNormal = normalize(uNormalMatrix * aNormal);
   vVertTexCoord = aTexCoord;
 
-  vec4 mvPosition = uModelViewMatrix * vec4(aPosition, 1.0);
-  vec3 eyeDirection = normalize(-mvPosition.xyz);
-
-  float specularFactor = 2.0;
-  float diffuseFactor = 0.3;
-
-  vec3 ambientLightFactor = vec3(0.0);
-  vec3 directionalLightFactor = vec3(0.0);
-  vec3 pointLightFactor = vec3(0.0);
+  totalLight(viewModelPosition.xyz, vertexNormal, vDiffuseColor, vSpecularColor);
 
   for (int i = 0; i < 8; i++) {
-
-    // Calculate ambient light factor
-    if(i < uAmbientLightCount){
-      ambientLightFactor += uAmbientColor[i];
-    } 
-
-    // Calculate directional light factor
-    if(i < uDirectionalLightCount){
-      vec3 dir = (uViewMatrix * vec4(uLightingDirection[i], 0.0)).xyz;
-      float directionalLightWeighting = max(dot(vertexNormal, -dir), 0.0);
-      directionalLightFactor += uDirectionalColor[i] * directionalLightWeighting;
-    }
-
-    // Calculate point light factor
-    if(i < uPointLightCount){
-      vec3 loc = (uViewMatrix * vec4(uPointLightLocation[i], 1.0)).xyz;
-      vec3 lightDirection = normalize(loc - mvPosition.xyz);
-
-      float directionalLightWeighting = max(dot(vertexNormal, lightDirection), 0.0);
-
-      float specularLightWeighting = 0.0;
-      if (uSpecular ){
-        vec3 reflectionDirection = reflect(-lightDirection, vertexNormal);
-        specularLightWeighting = pow(max(dot(reflectionDirection, eyeDirection), 0.0), uShininess);
-      }
-
-      pointLightFactor += uPointLightColor[i] * (specularFactor * specularLightWeighting
-        + directionalLightWeighting * diffuseFactor);
+    if (i < uAmbientLightCount) {
+      vDiffuseColor += uAmbientColor[i];
     }
   }
-
-
-  vLightWeighting =  ambientLightFactor + directionalLightFactor + pointLightFactor;
 }

--- a/src/webgl/shaders/light_texture.frag
+++ b/src/webgl/shaders/light_texture.frag
@@ -3,7 +3,6 @@ precision mediump float;
 uniform vec4 uMaterialColor;
 uniform sampler2D uSampler;
 uniform bool isTexture;
-uniform bool uUseLighting;
 
 varying highp vec2 vVertTexCoord;
 varying vec3 vDiffuseColor;

--- a/src/webgl/shaders/light_texture.frag
+++ b/src/webgl/shaders/light_texture.frag
@@ -5,13 +5,11 @@ uniform sampler2D uSampler;
 uniform bool isTexture;
 uniform bool uUseLighting;
 
-varying vec3 vLightWeighting;
 varying highp vec2 vVertTexCoord;
+varying vec3 vDiffuseColor;
+varying vec3 vSpecularColor;
 
 void main(void) {
-  // Lets init gl_FragColor just to be safe
-  gl_FragColor = vec4(1.0,1.0,1.0,1.0);
-
   gl_FragColor = isTexture ? texture2D(uSampler, vVertTexCoord) : uMaterialColor;
-  if (uUseLighting) gl_FragColor.rgb *= vLightWeighting;
+  gl_FragColor.rgb = gl_FragColor.rgb * vDiffuseColor + vSpecularColor;
 }

--- a/src/webgl/shaders/lighting.glsl
+++ b/src/webgl/shaders/lighting.glsl
@@ -2,6 +2,8 @@ precision mediump float;
 
 uniform mat4 uViewMatrix;
 
+uniform bool uUseLighting;
+
 uniform int uAmbientLightCount;
 uniform vec3 uAmbientColor[8];
 
@@ -58,8 +60,14 @@ void totalLight(
 	out vec3 totalSpecular
 ) {
 
-  totalDiffuse = vec3(0.0);
   totalSpecular = vec3(0.0);
+
+  if (!uUseLighting) {
+    totalDiffuse = vec3(1.0);
+    return;
+  }
+
+  totalDiffuse = vec3(0.0);
 
 	vec3 viewDirection = normalize(-modelPosition);
 

--- a/src/webgl/shaders/lighting.glsl
+++ b/src/webgl/shaders/lighting.glsl
@@ -1,0 +1,92 @@
+precision mediump float;
+
+uniform mat4 uViewMatrix;
+
+uniform int uAmbientLightCount;
+uniform vec3 uAmbientColor[8];
+
+uniform int uDirectionalLightCount;
+uniform vec3 uLightingDirection[8];
+uniform vec3 uDirectionalColor[8];
+
+uniform int uPointLightCount;
+uniform vec3 uPointLightLocation[8];
+uniform vec3 uPointLightColor[8];
+
+uniform bool uSpecular;
+uniform float uShininess;
+
+
+const float specularFactor = 2.0;
+const float diffuseFactor = 0.73;
+
+struct LightResult {
+	float specular;
+	float diffuse;
+};
+
+float _phongSpecular(
+  vec3 lightDirection,
+  vec3 viewDirection,
+  vec3 surfaceNormal,
+  float shininess) {
+
+  vec3 R = reflect(lightDirection, surfaceNormal);
+  return pow(max(0.0, dot(R, viewDirection)), shininess);
+}
+
+float _lambertDiffuse(vec3 lightDirection, vec3 surfaceNormal) {
+  return max(0.0, dot(-lightDirection, surfaceNormal));
+}
+
+LightResult _light(vec3 viewDirection, vec3 normal, vec3 lightVector) {
+
+  vec3 lightDir = normalize(lightVector);
+
+  //compute our diffuse & specular terms
+  LightResult lr;
+  if (uSpecular)
+    lr.specular = _phongSpecular(lightDir, viewDirection, normal, uShininess);
+  lr.diffuse = _lambertDiffuse(lightDir, normal);
+  return lr;
+}
+
+void totalLight(
+	vec3 modelPosition,
+	vec3 normal,
+	out vec3 totalDiffuse,
+	out vec3 totalSpecular
+) {
+
+  totalDiffuse = vec3(0.0);
+  totalSpecular = vec3(0.0);
+
+	vec3 viewDirection = normalize(-modelPosition);
+
+  for (int j = 0; j < 8; j++) {
+    if (j < uDirectionalLightCount) {
+      vec3 lightVector = (uViewMatrix * vec4(uLightingDirection[j], 0.0)).xyz;
+			vec3 lightColor = uDirectionalColor[j];
+      LightResult result = _light(viewDirection, normal, lightVector);
+      totalDiffuse += result.diffuse * lightColor;
+      totalSpecular += result.specular * lightColor;
+    }
+
+    if (j < uPointLightCount) {
+      vec3 lightPosition = (uViewMatrix * vec4(uPointLightLocation[j], 1.0)).xyz;
+      vec3 lightVector = modelPosition - lightPosition;
+    
+      //calculate attenuation
+      float lightDistance = length(lightVector);
+      float falloff = 1.0; // TODO: 500.0 / (lightDistance + 500.0);
+			vec3 lightColor = falloff * uPointLightColor[j];
+
+      LightResult result = _light(viewDirection, normal, lightVector);
+      totalDiffuse += result.diffuse * lightColor;
+      totalSpecular += result.specular * lightColor;
+    }
+  }
+
+	totalDiffuse *= diffuseFactor;
+	totalSpecular *= specularFactor;
+}

--- a/src/webgl/shaders/lighting.glsl
+++ b/src/webgl/shaders/lighting.glsl
@@ -23,8 +23,8 @@ const float specularFactor = 2.0;
 const float diffuseFactor = 0.73;
 
 struct LightResult {
-	float specular;
-	float diffuse;
+  float specular;
+  float diffuse;
 };
 
 float _phongSpecular(
@@ -54,10 +54,10 @@ LightResult _light(vec3 viewDirection, vec3 normal, vec3 lightVector) {
 }
 
 void totalLight(
-	vec3 modelPosition,
-	vec3 normal,
-	out vec3 totalDiffuse,
-	out vec3 totalSpecular
+  vec3 modelPosition,
+  vec3 normal,
+  out vec3 totalDiffuse,
+  out vec3 totalSpecular
 ) {
 
   totalSpecular = vec3(0.0);
@@ -69,12 +69,12 @@ void totalLight(
 
   totalDiffuse = vec3(0.0);
 
-	vec3 viewDirection = normalize(-modelPosition);
+  vec3 viewDirection = normalize(-modelPosition);
 
   for (int j = 0; j < 8; j++) {
     if (j < uDirectionalLightCount) {
       vec3 lightVector = (uViewMatrix * vec4(uLightingDirection[j], 0.0)).xyz;
-			vec3 lightColor = uDirectionalColor[j];
+      vec3 lightColor = uDirectionalColor[j];
       LightResult result = _light(viewDirection, normal, lightVector);
       totalDiffuse += result.diffuse * lightColor;
       totalSpecular += result.specular * lightColor;
@@ -87,7 +87,7 @@ void totalLight(
       //calculate attenuation
       float lightDistance = length(lightVector);
       float falloff = 1.0; // TODO: 500.0 / (lightDistance + 500.0);
-			vec3 lightColor = falloff * uPointLightColor[j];
+      vec3 lightColor = falloff * uPointLightColor[j];
 
       LightResult result = _light(viewDirection, normal, lightVector);
       totalDiffuse += result.diffuse * lightColor;
@@ -95,6 +95,6 @@ void totalLight(
     }
   }
 
-	totalDiffuse *= diffuseFactor;
-	totalSpecular *= specularFactor;
+  totalDiffuse *= diffuseFactor;
+  totalSpecular *= specularFactor;
 }

--- a/src/webgl/shaders/phong.frag
+++ b/src/webgl/shaders/phong.frag
@@ -1,97 +1,21 @@
-precision mediump float;
-
-//uniform mat4 uModelViewMatrix;
-uniform mat4 uViewMatrix;
+// include lighting.glgl
 
 uniform vec4 uMaterialColor;
 uniform sampler2D uSampler;
 uniform bool isTexture;
 uniform bool uUseLighting;
 
-uniform vec3 uLightingDirection[8];
-uniform vec3 uDirectionalColor[8];
-uniform vec3 uPointLightLocation[8];
-uniform vec3 uPointLightColor[8];
-uniform bool uSpecular;
-uniform float uShininess;
-
-uniform int uDirectionalLightCount;
-uniform int uPointLightCount;
-
 varying vec3 vNormal;
 varying vec2 vTexCoord;
 varying vec3 vViewPosition;
 varying vec3 vAmbientColor;
 
-vec3 V;
-vec3 N;
-
-const float specularFactor = 2.0;
-const float diffuseFactor = 0.73;
-
-struct LightResult {
-	float specular;
-	float diffuse;
-};
-
-float phongSpecular(
-  vec3 lightDirection,
-  vec3 viewDirection,
-  vec3 surfaceNormal,
-  float shininess) {
-
-  vec3 R = normalize(reflect(-lightDirection, surfaceNormal));  
-  return pow(max(0.0, dot(R, viewDirection)), shininess);
-}
-
-float lambertDiffuse(
-  vec3 lightDirection,
-  vec3 surfaceNormal) {
-  return max(0.0, dot(-lightDirection, surfaceNormal));
-}
-
-LightResult light(vec3 lightVector) {
-
-  vec3 L = normalize(lightVector);
-
-  //compute our diffuse & specular terms
-  LightResult lr;
-  if (uSpecular)
-    lr.specular = phongSpecular(L, V, N, uShininess);
-  lr.diffuse = lambertDiffuse(L, N);
-  return lr;
-}
-
 void main(void) {
 
-  V = normalize(vViewPosition);
-  N = vNormal;
-
-  vec3 diffuse = vec3(0.0);
-  float specular = 0.0;
-
-  for (int j = 0; j < 8; j++) {
-    if( j < uDirectionalLightCount){
-      vec3 dir = (uViewMatrix * vec4(uLightingDirection[j], 0.0)).xyz;
-      LightResult result = light(dir);
-      diffuse += result.diffuse * uDirectionalColor[j];
-      specular += result.specular;
-    }
-
-    if( j < uPointLightCount){
-      vec3 lightPosition = (uViewMatrix * vec4(uPointLightLocation[j], 1.0)).xyz;
-      vec3 lightVector = vViewPosition - lightPosition;
-    
-      //calculate attenuation
-      float lightDistance = length(lightVector);
-      float falloff = 500.0 / (lightDistance + 500.0);
-
-      LightResult result = light(lightVector);
-      diffuse += result.diffuse * falloff * uPointLightColor[j];
-      specular += result.specular * falloff;
-    }
-  }
+  vec3 diffuse;
+  vec3 specular;
+  totalLight(vViewPosition, normalize(vNormal), diffuse, specular);
 
   gl_FragColor = isTexture ? texture2D(uSampler, vTexCoord) : uMaterialColor;
-  gl_FragColor.rgb = gl_FragColor.rgb * (diffuse * diffuseFactor + vAmbientColor) + specular * specularFactor;
+  gl_FragColor.rgb = gl_FragColor.rgb * (diffuse + vAmbientColor) + specular;
 }

--- a/src/webgl/shaders/phong.frag
+++ b/src/webgl/shaders/phong.frag
@@ -3,7 +3,6 @@
 uniform vec4 uMaterialColor;
 uniform sampler2D uSampler;
 uniform bool isTexture;
-uniform bool uUseLighting;
 
 varying vec3 vNormal;
 varying vec2 vTexCoord;

--- a/src/webgl/shaders/phong.vert
+++ b/src/webgl/shaders/phong.vert
@@ -1,4 +1,5 @@
 precision mediump float;
+precision mediump int;
 
 attribute vec3 aPosition;
 attribute vec3 aNormal;
@@ -16,7 +17,7 @@ varying vec2 vTexCoord;
 varying vec3 vViewPosition;
 varying vec3 vAmbientColor;
 
-void main(void){
+void main(void) {
 
   vec4 viewModelPosition = uModelViewMatrix * vec4(aPosition, 1.0);
 
@@ -24,12 +25,13 @@ void main(void){
   vViewPosition = viewModelPosition.xyz;
   gl_Position = uProjectionMatrix * viewModelPosition;  
 
-  vNormal = normalize(uNormalMatrix * normalize(aNormal));
+  vNormal = uNormalMatrix * aNormal;
   vTexCoord = aTexCoord;
 
+  // TODO: this should be a uniform
   vAmbientColor = vec3(0.0);
   for (int i = 0; i < 8; i++) {
-    if(i < uAmbientLightCount){
+    if (i < uAmbientLightCount) {
       vAmbientColor += uAmbientColor[i];
     }
   }


### PR DESCRIPTION
closes #3774

this splits out the lighting code into a separate file `lighting.glsl` that is shared between both the gouraud fill shader and the per-pixel shader. it fixes the bugs in that issue and removes the differences highlighted there. it also makes it easier to implement changes to the lighting code in the future, by having a single location for that code.

here's the side-by-side comparison again:
![image](https://user-images.githubusercontent.com/1088194/58678696-832fa380-8315-11e9-9910-0d79c335b916.png)


