### PR TITLE
use 'highp int' in font shader

### DIFF
--- a/src/webgl/shaders/font.frag
+++ b/src/webgl/shaders/font.frag
@@ -12,7 +12,7 @@ precision mediump float;
 
 #else
   // use native integer math
-	precision mediump int;
+	precision highp int;
 	#define INT(x) x
 
 	int ifloor(float v) { return int(v); }


### PR DESCRIPTION
closes #3776

increases the precision of int values in the font shader in order to fix the rendering issues on some mobile devices.