### PR TITLE
fix video.get, always check for new frame time

### DIFF
--- a/lib/addons/p5.dom.js
+++ b/lib/addons/p5.dom.js
@@ -2889,12 +2889,10 @@
   };
   p5.MediaElement.prototype.pixels = [];
   p5.MediaElement.prototype._ensureCanvas = function() {
-    if (!this.canvas) this.loadPixels();
-  };
-  p5.MediaElement.prototype.loadPixels = function() {
     if (!this.canvas) {
       this.canvas = document.createElement('canvas');
       this.drawingContext = this.canvas.getContext('2d');
+      this.setModified(true);
     }
     if (this.loadedmetadata) {
       // wait for metadata for w/h
@@ -2920,11 +2918,13 @@
           this.canvas.width,
           this.canvas.height
         );
-        p5.Renderer2D.prototype.loadPixels.call(this);
+        this.setModified(true);
       }
     }
-    this.setModified(true);
-    return this;
+  };
+  p5.MediaElement.prototype.loadPixels = function() {
+    this._ensureCanvas();
+    return p5.Renderer2D.prototype.loadPixels.apply(this, arguments);
   };
   p5.MediaElement.prototype.updatePixels = function(x, y, w, h) {
     if (this.loadedmetadata) {
@@ -2940,15 +2940,7 @@
     return p5.Renderer2D.prototype.get.apply(this, arguments);
   };
   p5.MediaElement.prototype._getPixel = function() {
-    if (this.loadedmetadata) {
-      // wait for metadata
-      var currentTime = this.elt.currentTime;
-      if (this._pixelsTime !== currentTime) {
-        this.loadPixels();
-      } else {
-        this._ensureCanvas();
-      }
-    }
+    this.loadPixels();
     return p5.Renderer2D.prototype._getPixel.apply(this, arguments);
   };
 


### PR DESCRIPTION
closes #3779 

this ensures that `_ensureCanvas` always checks the video's frame time. this allow the logic for `_getPixel` and `loadPixels` to be simplified.