### PR TITLE
Removed console.log for WebGL init

### DIFF
--- a/src/webgl/p5.RendererGL.js
+++ b/src/webgl/p5.RendererGL.js
@@ -172,7 +172,6 @@ p5.RendererGL.prototype._initContext = function() {
     if (this.drawingContext === null) {
       throw new Error('Error creating webgl context');
     } else {
-      console.log('p5.RendererGL: enabled webgl context');
       var gl = this.drawingContext;
       gl.enable(gl.DEPTH_TEST);
       gl.depthFunc(gl.LEQUAL);


### PR DESCRIPTION
Implementing fix for issue referenced here. 

Console was printing a message every time a new WebGL instance was created. That has now been deleted.

https://github.com/processing/p5.js/issues/3787