### PR TITLE
Add functions to help work with localStorage

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -28,6 +28,7 @@ require('./color/setting');
 
 // data
 require('./data/p5.TypedDict');
+require('./data/local_storage.js');
 
 // events
 require('./events/acceleration');

--- a/src/data/local_storage.js
+++ b/src/data/local_storage.js
@@ -64,6 +64,9 @@ p5.prototype.storeItem = function(key, value) {
       value = value.toString();
       break;
     case 'object':
+      if (value instanceof p5.Color) {
+        type = 'p5.Color';
+      }
       value = JSON.stringify(value);
       break;
     case 'string':
@@ -138,10 +141,10 @@ p5.prototype.getItem = function(key) {
         break;
       case 'object':
         value = JSON.parse(value);
-        //If an object is meant to be a p5.Color
-        if (typeof value.maxes !== 'undefined') {
-          value = this.color.apply(this, value.levels);
-        }
+        break;
+      case 'p5.Color':
+        value = JSON.parse(value);
+        value = this.color.apply(this, value.levels);
         break;
       case 'string':
       default:

--- a/src/data/local_storage.js
+++ b/src/data/local_storage.js
@@ -10,9 +10,15 @@
 var p5 = require('../core/main');
 /**
  *
- * Stores a value in local storage under the key name. The key can
- * be the name of the variable but it does not have to be. To retrieve
- * stored items see <a href="#/p5/getItem">getItem</a>.
+ * Stores a value in local storage under the key name.
+ * Local storage is saved in the browser and persists
+ * between browsing sessions and page reloads.
+ * The key can be the name of the variable but doesn't
+ * have to be. To retrieve stored items
+ * see <a href="#/p5/getItem">getItem</a>.
+ * <br><br>
+ * Sensitive data such as passwords or personal information
+ * should not be stored in local storage.
  *
  * @method storeItem
  * @for p5

--- a/src/data/local_storage.js
+++ b/src/data/local_storage.js
@@ -54,7 +54,7 @@ var p5 = require('../core/main');
  *
  */
 p5.prototype.storeItem = function(key, value) {
-  if (value === 'undefined') {
+  if (typeof value === 'undefined') {
     console.log('You cannot store undefined variables using storeItem()');
   }
   var type = typeof value;
@@ -122,7 +122,7 @@ p5.prototype.storeItem = function(key, value) {
 p5.prototype.loadItem = function(key) {
   var value = localStorage.getItem(key);
   var type = localStorage.getItem(key + 'Type');
-  if (type === undefined) {
+  if (typeof type === 'undefined') {
     console.log(
       'Unable to determine type of item stored under ' +
         key +
@@ -139,7 +139,7 @@ p5.prototype.loadItem = function(key) {
       case 'object':
         value = JSON.parse(value);
         //If an object is meant to be a p5.Color
-        if (value.maxes.hsb !== undefined) {
+        if (typeof value.maxes.hsb !== 'undefined') {
           value = this.color.apply(this, value.levels);
         }
         break;

--- a/src/data/local_storage.js
+++ b/src/data/local_storage.js
@@ -72,7 +72,7 @@ p5.prototype.storeItem = function(key, value) {
   }
 
   localStorage.setItem(key, value);
-  var typeKey = key + 'Type';
+  var typeKey = key + 'p5TypeID';
   localStorage.setItem(typeKey, type);
 };
 
@@ -121,7 +121,7 @@ p5.prototype.storeItem = function(key, value) {
  */
 p5.prototype.getItem = function(key) {
   var value = localStorage.getItem(key);
-  var type = localStorage.getItem(key + 'Type');
+  var type = localStorage.getItem(key + 'p5TypeID');
   if (typeof type === 'undefined') {
     console.log(
       'Unable to determine type of item stored under ' +
@@ -208,5 +208,5 @@ p5.prototype.removeItem = function(key) {
     );
   }
   localStorage.removeItem(key);
-  localStorage.removeItem(key + 'Type');
+  localStorage.removeItem(key + 'p5TypeID');
 };

--- a/src/data/local_storage.js
+++ b/src/data/local_storage.js
@@ -1,0 +1,212 @@
+/**
+ * @module Data
+ * @submodule LocalStorage
+ * @requires core
+ *
+ * This module defines the p5 methods for working with local storage
+ */
+
+'use strict';
+var p5 = require('../core/main');
+/**
+ *
+ * Stores a value in local storage under the key name. The key can
+ * be the name of the variable but it does not have to be. To retrieve
+ * stored items see <a href="#/p5/loadItem">loadItem</a>.
+ *
+ * @method storeItem
+ * @for p5
+ * @param {String} key
+ * @param {String|Number|Object|Boolean|p5.Color} value
+ *
+ * @example
+ * <div><code>
+ * // Type to change the letter in the
+ * // center of the canvas.
+ * // If you reload the page, it will
+ * // still display the last key you entered
+ *
+ * let myText;
+ *
+ * function setup() {
+ *   createCanvas(100, 100);
+ *   myText = loadItem('myText');
+ *   if (myText === null) {
+ *     myText = '';
+ *   }
+ * }
+ *
+ * function draw() {
+ *   textSize(40);
+ *   background(255);
+ *   text(myText, width / 2, height / 2);
+ * }
+ *
+ * function keyPressed() {
+ *   myText = key;
+ *   storeItem('myText', myText);
+ * }
+ * </code></div>
+ *
+ * @alt
+ * When you type the key name is displayed as black text on white background.
+ * If you reload the page, the last letter typed is still displaying.
+ *
+ */
+p5.prototype.storeItem = function(key, value) {
+  if (value === 'undefined') {
+    console.log('You cannot store undefined variables using storeItem()');
+  }
+  var type = typeof value;
+  switch (type) {
+    case 'number':
+    case 'boolean':
+      value = value.toString();
+      break;
+    case 'object':
+      value = JSON.stringify(value);
+      break;
+    case 'string':
+    default:
+      break;
+  }
+
+  localStorage.setItem(key, value);
+  var typeKey = key + 'Type';
+  localStorage.setItem(typeKey, type);
+};
+
+/**
+ *
+ * Returns the value of an item that was stored in local storage
+ * using storeItem()
+ *
+ * @method loadItem
+ * @for p5
+ * @param {String} key name that you wish to use to store in local storage
+ * @return {Number|Object|String|Boolean|p5.Color} Value of stored item
+ *
+ * @example
+ * <div><code>
+ * // Click the mouse to change
+ * // the color of the background
+ * // Once you have changed the color
+ * // it will stay changed even when you
+ * // reload the page.
+ *
+ * let myColor;
+ *
+ * function setup() {
+ *   createCanvas(100, 100);
+ *   myColor = loadItem('myColor');
+ * }
+ *
+ * function draw() {
+ *   if (myColor !== null) {
+ *     background(myColor);
+ *   }
+ * }
+ *
+ * function mousePressed() {
+ *   myColor = color(random(255), random(255), random(255));
+ *   storeItem('myColor', myColor);
+ * }
+ * </code></div>
+ *
+ * @alt
+ * If you click, the canvas changes to a random color.
+ * If you reload the page, the canvas is still the color it
+ * was when the page was previously loaded.
+ *
+ */
+p5.prototype.loadItem = function(key) {
+  var value = localStorage.getItem(key);
+  var type = localStorage.getItem(key + 'Type');
+  if (type === undefined) {
+    console.log(
+      'Unable to determine type of item stored under ' +
+        key +
+        'in local storage. Did you save the item with something other than setItem()?'
+    );
+  } else if (value !== null) {
+    switch (type) {
+      case 'number':
+        value = parseInt(value);
+        break;
+      case 'boolean':
+        value = value === 'true';
+        break;
+      case 'object':
+        value = JSON.parse(value);
+        //If an object is meant to be a p5.Color
+        if (value.maxes.hsb !== undefined) {
+          value = this.color.apply(this, value.levels);
+        }
+        break;
+      case 'string':
+      default:
+        break;
+    }
+  }
+  return value;
+};
+
+/**
+ *
+ * Clears all local storage items set with storeItem()
+ * for the current domain.
+ *
+ * @method clearStorage
+ * @for p5
+ *
+ * @example
+ * <div class="norender">
+ * <code>
+ * function setup() {
+ *   let myNum = 10;
+ *   let myBool = false;
+ *   storeItem('myNum', myNum);
+ *   storeItem('myBool', myBool);
+ *   print(loadItem('myNum')); // logs 10 to the console
+ *   print(loadItem('myBool')); // logs false to the console
+ *   clearStorage();
+ *   print(loadItem('myNum')); // logs null to the console
+ *   print(loadItem('myBool')); // logs null to the console
+ * }
+ * </code></div>
+ */
+p5.prototype.clearStorage = function() {
+  localStorage.clear();
+};
+
+/**
+ *
+ * Removes an item that was stored with storeItem()
+ *
+ * @method removeItem
+ * @param {String} key
+ * @for p5
+ *
+ * @example
+ * <div class="norender">
+ * <code>
+ * function setup() {
+ *   let myVar = 10;
+ *   storeItem('myVar', myVar);
+ *   print(loadItem('myVar')); // logs 10 to the console
+ *   removeItem('myVar');
+ *   print(loadItem('myVar')); // logs null to the console
+ * }
+ * </code></div>
+ */
+p5.prototype.removeItem = function(key) {
+  if (typeof key !== 'string') {
+    console.log(
+      'The argument that you passed to removeItem() - ' +
+        key +
+        ' is not a string.'
+    );
+  }
+  localStorage.removeItem(key);
+  localStorage.removeItem(key + 'Type');
+};

--- a/src/data/local_storage.js
+++ b/src/data/local_storage.js
@@ -12,7 +12,7 @@ var p5 = require('../core/main');
  *
  * Stores a value in local storage under the key name. The key can
  * be the name of the variable but it does not have to be. To retrieve
- * stored items see <a href="#/p5/loadItem">loadItem</a>.
+ * stored items see <a href="#/p5/getItem">getItem</a>.
  *
  * @method storeItem
  * @for p5
@@ -30,7 +30,7 @@ var p5 = require('../core/main');
  *
  * function setup() {
  *   createCanvas(100, 100);
- *   myText = loadItem('myText');
+ *   myText = getItem('myText');
  *   if (myText === null) {
  *     myText = '';
  *   }
@@ -81,7 +81,7 @@ p5.prototype.storeItem = function(key, value) {
  * Returns the value of an item that was stored in local storage
  * using storeItem()
  *
- * @method loadItem
+ * @method getItem
  * @for p5
  * @param {String} key name that you wish to use to store in local storage
  * @return {Number|Object|String|Boolean|p5.Color} Value of stored item
@@ -98,7 +98,7 @@ p5.prototype.storeItem = function(key, value) {
  *
  * function setup() {
  *   createCanvas(100, 100);
- *   myColor = loadItem('myColor');
+ *   myColor = getItem('myColor');
  * }
  *
  * function draw() {
@@ -119,7 +119,7 @@ p5.prototype.storeItem = function(key, value) {
  * was when the page was previously loaded.
  *
  */
-p5.prototype.loadItem = function(key) {
+p5.prototype.getItem = function(key) {
   var value = localStorage.getItem(key);
   var type = localStorage.getItem(key + 'Type');
   if (typeof type === 'undefined') {
@@ -167,11 +167,11 @@ p5.prototype.loadItem = function(key) {
  *   let myBool = false;
  *   storeItem('myNum', myNum);
  *   storeItem('myBool', myBool);
- *   print(loadItem('myNum')); // logs 10 to the console
- *   print(loadItem('myBool')); // logs false to the console
+ *   print(getItem('myNum')); // logs 10 to the console
+ *   print(getItem('myBool')); // logs false to the console
  *   clearStorage();
- *   print(loadItem('myNum')); // logs null to the console
- *   print(loadItem('myBool')); // logs null to the console
+ *   print(getItem('myNum')); // logs null to the console
+ *   print(getItem('myBool')); // logs null to the console
  * }
  * </code></div>
  */
@@ -193,9 +193,9 @@ p5.prototype.clearStorage = function() {
  * function setup() {
  *   let myVar = 10;
  *   storeItem('myVar', myVar);
- *   print(loadItem('myVar')); // logs 10 to the console
+ *   print(getItem('myVar')); // logs 10 to the console
  *   removeItem('myVar');
- *   print(loadItem('myVar')); // logs null to the console
+ *   print(getItem('myVar')); // logs null to the console
  * }
  * </code></div>
  */

--- a/src/data/local_storage.js
+++ b/src/data/local_storage.js
@@ -139,7 +139,7 @@ p5.prototype.getItem = function(key) {
       case 'object':
         value = JSON.parse(value);
         //If an object is meant to be a p5.Color
-        if (typeof value.maxes.hsb !== 'undefined') {
+        if (typeof value.maxes !== 'undefined') {
           value = this.color.apply(this, value.levels);
         }
         break;

--- a/test/unit/data/local_storage.js
+++ b/test/unit/data/local_storage.js
@@ -1,0 +1,61 @@
+suite('local storage', function() {
+  var myp5;
+  var myBoolean = false;
+  var myObject = { one: 1, two: { nested: true } };
+  var myNumber = 46;
+  var myString = 'coolio';
+  var myColor;
+
+  setup(function(done) {
+    new p5(function(p) {
+      p.setup = function() {
+        myp5 = p;
+        myColor = myp5.color(40, 100, 70);
+        myp5.storeItem('myBoolean', myBoolean);
+        myp5.storeItem('myObject', myObject);
+        myp5.storeItem('myNumber', myNumber);
+        myp5.storeItem('myString', myString);
+        myp5.storeItem('myColor', myColor);
+        done();
+      };
+    });
+  });
+
+  teardown(function() {
+    myp5.remove();
+  });
+
+  suite('all keys and type keys should exist in local storage', function() {
+    test('boolean storage retrieval should work', function() {
+      assert.isTrue(myp5.getItem('myBoolean') === false);
+    });
+    test('boolean storage should store the correct type ID', function() {
+      assert.isTrue(localStorage.getItem('myBooleanp5TypeID') === 'boolean');
+    });
+    test('object storage should work', function() {
+      console.log(myp5.getItem('myObject'));
+      assert.deepEqual(myp5.getItem('myObject'), {
+        one: 1,
+        two: { nested: true }
+      });
+    });
+    test('object storage retrieval should store the correct type ID', function() {
+      assert.isTrue(localStorage.getItem('myObjectp5TypeID') === 'object');
+    });
+    test('number storage retrieval should work', function() {
+      assert.isTrue(myp5.getItem('myNumber') === 46);
+    });
+    test('number storage should store the correct type ID', function() {
+      assert.isTrue(localStorage.getItem('myNumberp5TypeID') === 'number');
+    });
+    test('string storage retrieval should work', function() {
+      assert.isTrue(myp5.getItem('myString') === 'coolio');
+    });
+    test('string storage should store the correct type ID', function() {
+      assert.isTrue(localStorage.getItem('myStringp5TypeID') === 'string');
+    });
+    test('p5 Color should retrieve as p5 Color', function() {
+      assert.isTrue(myp5.getItem('myColor') instanceof p5.Color);
+    });
+  });
+});

--- a/test/unit/data/local_storage.js
+++ b/test/unit/data/local_storage.js
@@ -6,6 +6,8 @@ suite('local storage', function() {
   var myString = 'coolio';
   var myColor;
 
+  var hardCodedTypeID = 'p5TypeID';
+
   setup(function(done) {
     new p5(function(p) {
       p.setup = function() {
@@ -30,32 +32,67 @@ suite('local storage', function() {
       assert.isTrue(myp5.getItem('myBoolean') === false);
     });
     test('boolean storage should store the correct type ID', function() {
-      assert.isTrue(localStorage.getItem('myBooleanp5TypeID') === 'boolean');
+      assert.isTrue(
+        localStorage.getItem('myBoolean' + hardCodedTypeID) === 'boolean'
+      );
     });
     test('object storage should work', function() {
-      console.log(myp5.getItem('myObject'));
       assert.deepEqual(myp5.getItem('myObject'), {
         one: 1,
         two: { nested: true }
       });
     });
     test('object storage retrieval should store the correct type ID', function() {
-      assert.isTrue(localStorage.getItem('myObjectp5TypeID') === 'object');
+      assert.isTrue(
+        localStorage.getItem('myObject' + hardCodedTypeID) === 'object'
+      );
     });
     test('number storage retrieval should work', function() {
       assert.isTrue(myp5.getItem('myNumber') === 46);
     });
     test('number storage should store the correct type ID', function() {
-      assert.isTrue(localStorage.getItem('myNumberp5TypeID') === 'number');
+      assert.isTrue(
+        localStorage.getItem('myNumber' + hardCodedTypeID) === 'number'
+      );
     });
     test('string storage retrieval should work', function() {
       assert.isTrue(myp5.getItem('myString') === 'coolio');
     });
     test('string storage should store the correct type ID', function() {
-      assert.isTrue(localStorage.getItem('myStringp5TypeID') === 'string');
+      assert.isTrue(
+        localStorage.getItem('myString' + hardCodedTypeID) === 'string'
+      );
     });
     test('p5 Color should retrieve as p5 Color', function() {
       assert.isTrue(myp5.getItem('myColor') instanceof p5.Color);
+    });
+  });
+
+  var checkRemoval = function(key) {
+    myp5.removeItem(key);
+    assert.deepEqual(myp5.getItem(key), null);
+    assert.deepEqual(myp5.getItem(key + hardCodedTypeID), null);
+  };
+
+  suite('should be able to remove all items', function() {
+    test('boolean should be removable', function() {
+      checkRemoval('myBoolean');
+    });
+
+    test('number should be removable', function() {
+      checkRemoval('myNumber');
+    });
+
+    test('object should be removable', function() {
+      checkRemoval('myObject');
+    });
+
+    test('string should be removable', function() {
+      checkRemoval('myString');
+    });
+
+    test('color should be removable', function() {
+      checkRemoval('myColor');
     });
   });
 });

--- a/test/unit/spec.js
+++ b/test/unit/spec.js
@@ -14,7 +14,7 @@ var spec = {
     'transform',
     'vertex'
   ],
-  data: ['p5.TypedDict'],
+  data: ['p5.TypedDict', 'local_storage'],
   events: ['keyboard', 'mouse', 'touch'],
   image: ['loading', 'pixels'],
   io: [


### PR DESCRIPTION
This PR is a first pass at adding some [localStorage](https://developer.mozilla.org/en-US/docs/Web/API/Window/localStorage) features into p5.

This currently adds:
```
storeItem(String - key, String|Number|Object|Boolean|p5.Color - value)
    nothing returned

loadItem(String - key)
    returns String|Number|Object|Boolean|p5.Color

removeItem(String - key)
    nothing returned

clearStorage()
    nothing returned
```

Window.localStorage only accepts string values. So the main benefit of these functions is that they handle mutation of values into strings for storage and back into original data type upon retrieval. This is done by storing two values whenever `storeItem()` is called. The first is the actual data is the passed key/value pair with value in string form:
```
key: key
value: value (as string)
```
 the second is formatted as
```
key: passedKey + 'Type'
value: typeof value
```
This way the value can be changed back into original type before returning in `loadItem()`. I decided to store these into two values  separately rather than simply adding the type info into the first stored item so that people won't run into trouble if they mix and match working with Window.localStorage and these p5 functions.

This still needs unit tests. But just wanted to get opinions and a second set of eyes looking for oversights in case I missed something. No rush since this isn't urgent but would you mind looking over this when you get a chance @outofambit?

closes #3703 