### PR TITLE
Update .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,5 +4,4 @@ node_js:
   - "10"
 install: for i in {1..3}; do travis_wait 5 npm install && break; rm -rf node_modules; done
 script: npm run grunt
-sudo: false
 services: docker


### PR DESCRIPTION
`sudo: required` no longer is. Travis are now recommending removing the sudo tag.

["If you currently specify sudo: in your .travis.yml, we recommend removing that configuration"](https://blog.travis-ci.com/2018-11-19-required-linux-infrastructure-migration)