### PR TITLE
fix quad drawing (textureMode test)

### DIFF
--- a/src/webgl/p5.RendererGL.Immediate.js
+++ b/src/webgl/p5.RendererGL.Immediate.js
@@ -198,6 +198,7 @@ p5.RendererGL.prototype.endShape = function(
           this.drawMode === constants.FILL &&
           this.immediateMode._isCoplanar === true)
       ) {
+        this.immediateMode.shapeMode = constants.TRIANGLES;
         var contours = [
           new Float32Array(this._vToNArray(this.immediateMode.vertices))
         ];
@@ -303,15 +304,7 @@ p5.RendererGL.prototype._drawFillImmediateMode = function(
     switch (this.immediateMode.shapeMode) {
       case constants.LINE_STRIP:
       case constants.LINES:
-      case constants.TRIANGLES:
-        this.immediateMode.shapeMode =
-          this.isBezier ||
-          this.isQuadratic ||
-          this.isCurve ||
-          this.immediateMode.shapeMode === constants.LINE_STRIP ||
-          this.immediateMode.shapeMode === constants.TRIANGLES
-            ? constants.TRIANGLES
-            : constants.TRIANGLE_FAN;
+        this.immediateMode.shapeMode = constants.TRIANGLE_FAN;
         break;
     }
   } else {


### PR DESCRIPTION
fixes #3784

I am no expert on the different permutations that are possible with immediateMode drawing but I think this covers everything as well as it was before. No manual test or reference example broken, hollow fill tessellation still working for coplanar shapes and the code is a teeny bit more simple.