### PR TITLE
add console message when normalMaterial is used with Immediate Mode

### DIFF
--- a/src/webgl/p5.RendererGL.js
+++ b/src/webgl/p5.RendererGL.js
@@ -912,7 +912,11 @@ p5.RendererGL.prototype._getRetainedStrokeShader =
  */
 p5.RendererGL.prototype._getImmediateFillShader = function() {
   if (this._useNormalMaterial) {
-    return this._getNormalShader();
+    console.log(
+      'Sorry, normalMaterial() does not currently work with custom WebGL geometry' +
+        ' created with beginShape(). Falling back to standard fill material.'
+    );
+    return this._getImmediateModeShader();
   }
 
   var fill = this.userFillShader;


### PR DESCRIPTION
addresses #2963 

Immediate Mode geometry currently does not calculate normals for vertices. Since @Spongman is working on unifying immediate and retained mode, I do not believe it makes sense to add immediate mode normal calculation at this point in time. This pull request simply logs a message and defaults to the standard fill shader when someone tries to combine `normalMaterial()` and `beginShape/endShape`.