### PR TITLE
Modify gruntfile to watch glsl files

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -193,7 +193,12 @@ module.exports = grunt => {
     // documentation.
     watch: {
       quick: {
-        files: ['src/**/*.js', 'src/**/*.frag', 'src/**/*.vert'],
+        files: [
+          'src/**/*.js',
+          'src/**/*.frag',
+          'src/**/*.vert',
+          'src/**/*.glsl'
+        ],
         tasks: ['browserify'],
         options: {
           livereload: true
@@ -223,7 +228,8 @@ module.exports = grunt => {
           'src/**/*.js',
           'lib/addons/*.js',
           'src/**/*.frag',
-          'src/**/*.vert'
+          'src/**/*.vert',
+          'src/**/*.glsl'
         ],
         tasks: [
           'browserify',


### PR DESCRIPTION
This change will enable to watch the `.glsl` files present in `/src/webgl/shaders`