### PR TITLE
Fixed issue #3830

### DIFF
--- a/lib/addons/p5.dom.js
+++ b/lib/addons/p5.dom.js
@@ -98,6 +98,7 @@
       }
     }
     if (res) {
+      addElement(res, this);
       return this._wrapElement(res);
     } else {
       return null;


### PR DESCRIPTION
In `select()` method `_wrapElement(res)` method returns a `createSelect()` element without adding the element to `this._elements` array. The `removeElements()` method thus gives an error since the select element created is not a part of the `_elements` array. I added `addElement(res, this)` before the element is returned so that it's pushed to the `_elements` array which fixes the error thrown.