### PR TITLE
adjusting text to account for maxWidth only

### DIFF
--- a/src/core/p5.Renderer2D.js
+++ b/src/core/p5.Renderer2D.js
@@ -1148,7 +1148,7 @@ p5.Renderer2D.prototype.text = function(str, x, y, maxWidth, maxHeight) {
   // A temporary fix to conform to Processing's implementation
   // of BASELINE vertical alignment in a bounding box
 
-  if (typeof maxWidth !== 'undefined' && typeof maxHeight !== 'undefined') {
+  if (typeof maxWidth !== 'undefined') {
     if (this.drawingContext.textBaseline === constants.BASELINE) {
       baselineHacked = true;
       this.drawingContext.textBaseline = constants.TOP;


### PR DESCRIPTION
fixing text to account for alignment when maxWidth is given but no maxHeight. closes #3355