### PR TITLE
Introduce p5.Vector#rem to calculate the remainder/modulo of a vector.

### DIFF
--- a/src/math/p5.Vector.js
+++ b/src/math/p5.Vector.js
@@ -570,6 +570,20 @@ p5.Vector.prototype.div = function div(n) {
   return this;
 };
 
+p5.Vector.prototype.rem = function rem(n) {
+  if (!(typeof n === 'number' && isFinite(n))) {
+    console.warn(
+      'p5.Vector.prototype.rem:',
+      'n is undefined or not a finite number'
+    );
+    return this;
+  }
+  this.x %= n;
+  this.y %= n;
+  this.z %= n;
+  return this;
+};
+
 /**
  * Calculates the magnitude (length) of the vector and returns the result as
  * a float (this is simply the equation sqrt(x*x + y*y + z*z).)
@@ -1658,6 +1672,16 @@ p5.Vector.div = function div(v, n, target) {
     target.set(v);
   }
   target.div(n);
+  return target;
+};
+
+p5.Vector.rem = function rem(v, n, target) {
+  if (!target) {
+    target = v.copy();
+  } else {
+    target.set(v);
+  }
+  target.rem(n);
   return target;
 };
 

--- a/test/unit/math/p5.Vector.js
+++ b/test/unit/math/p5.Vector.js
@@ -457,6 +457,39 @@ suite('p5.Vector', function() {
     });
   });
 
+  suite('rem()', function() {
+    setup(function() {
+      v.x = -18;
+      v.y = 30;
+      v.z = 31;
+    });
+
+    test('should return the same object', function() {
+      expect(v.rem(0)).to.eql(v);
+    });
+
+    test('should not change x, y, z if no argument is given', function() {
+      v.rem();
+      expect(v.x).to.eql(-18);
+      expect(v.y).to.eql(30);
+      expect(v.z).to.eql(31);
+    });
+
+    test('should not change x, y, z if n is not a finite number', function() {
+      v.rem(NaN);
+      expect(v.x).to.eql(-18);
+      expect(v.y).to.eql(30);
+      expect(v.z).to.eql(31);
+    });
+
+    test('rem(5)', function() {
+      v.rem(5);
+      expect(v.x).to.eql(-3);
+      expect(v.y).to.eql(0);
+      expect(v.z).to.eql(1);
+    });
+  });
+
   suite('dot', function() {
     setup(function() {
       v.x = 1;


### PR DESCRIPTION
https://en.wikipedia.org/wiki/Modulo_operation

This would be helpful for drawing particles that need to wrap when they go offscreen.

For example, instead of:

```js
particle.position.add(this.velocity);
particle.position.set(
  particle.position.x % width,
  particle.position.y % height,
);
```

Now one can write:

```js
particle.position.add(particle.velocity).rem(width);
```

The signature looks like this:

```js
p5.Vector.prototype.rem = function rem(n) {
  ...
};
```

The one-demension (one parameter) behavior matches what we do for `p5.Vector#mult` and `p5.Vector#div`, in contrast to `p5.Vector#add` and `p5.Vector#sub`. One drawback with this design is you can't calculate the remainder of more than one dimension. In the example above, if my canvas was not a square, I would not be able to use `p5.Vector#rem` to wrap particles since the width and height would be different numbers.

I haven't written the docs yet because I'm not yet sure if the one-dimension design is the one we want to go with.

