### PR TITLE
fix failing ci

### DIFF
--- a/lib/addons/p5.dom.js
+++ b/lib/addons/p5.dom.js
@@ -2111,7 +2111,7 @@
     for (var ev in this._events) {
       this.elt.removeEventListener(ev, this._events[ev]);
     }
-    if (this.elt.parentNode) {
+    if (this.elt && this.elt.parentNode) {
       this.elt.parentNode.removeChild(this.elt);
     }
     delete this;

--- a/src/core/main.js
+++ b/src/core/main.js
@@ -446,7 +446,7 @@ var p5 = function(sketch, node, sync) {
       // remove DOM elements created by p5, and listeners
       for (var i = 0; i < this._elements.length; i++) {
         var e = this._elements[i];
-        if (e.elt.parentNode) {
+        if (e.elt && e.elt.parentNode) {
           e.elt.parentNode.removeChild(e.elt);
         }
         for (var elt_ev in e._events) {


### PR DESCRIPTION
this addresses the error encountered in https://travis-ci.org/processing/p5.js/builds/555160007 which i was able to reproduce locally.

i added a check for null in places where we go to remove elements
_____

```
751 passing (34s)
  2 failing
  1) lib/addons/p5.dom.js
       changed documentation
         "after each" hook for "example #1 works":
     TypeError: Cannot read property 'parentNode' of undefined
      at p5.<anonymous> (http://localhost:9001/lib/p5.js:56581:29)
      at Context.<anonymous> (test-reference.html:111:16)
  2) lib/addons/p5.dom.js
       createSelect documentation
         "after each" hook for "example #1 works":
     TypeError: Cannot read property 'parentNode' of undefined
      at p5.<anonymous> (http://localhost:9001/lib/p5.js:56581:29)
      at Context.<anonymous> (test-reference.html:111:16)
```