### PR TITLE
Clear Depth every frame in WEBGL to match 2D traced artifacts behavior

### DIFF
--- a/src/webgl/p5.RendererGL.js
+++ b/src/webgl/p5.RendererGL.js
@@ -469,6 +469,9 @@ p5.RendererGL.prototype._update = function() {
 
   //reset tint value for new frame
   this._tint = [255, 255, 255, 255];
+
+  //Clear depth every frame
+  this.GL.clear(this.GL.DEPTH_BUFFER_BIT);
 };
 
 /**


### PR DESCRIPTION
This clears the depth buffer every frame so that users can achieve a tracing effect similar to 2D mode when drawing without calling `background()`. This changes a small subset of sketches but it is desirable feature for some users.

closes #3762 