### PR TITLE
Fix texture error in STL loader

### DIFF
--- a/src/webgl/loading.js
+++ b/src/webgl/loading.js
@@ -421,6 +421,7 @@ function parseBinarySTL(model, buffer) {
     model.vertexNormals.push(newNormal, newNormal, newNormal);
 
     model.faces.push([3 * face, 3 * face + 1, 3 * face + 2]);
+    model.uvs.push([0, 0], [0, 0], [0, 0]);
   }
   if (hasColors) {
     // add support for colors here.
@@ -512,6 +513,7 @@ function parseASCIISTL(model, lines) {
             parseFloat(parts[3])
           );
           model.vertices.push(newVertex);
+          model.uvs.push([0, 0]);
           curVertexIndex.push(model.vertices.indexOf(newVertex));
         } else if (parts[0] === 'endloop') {
           // End of vertices


### PR DESCRIPTION
Fixes: #3892 

Pushing `[0,0]` to `model.uvs` everytime a new vertex is pushed in, as explained [here](https://github.com/processing/p5.js/pull/3675#issuecomment-497970726)

Edit:I don't have a windows machine with me, so I couldn't test this.