### PR TITLE
Add `rebeccapurple` CSS Colors Level 4 keyword

### DIFF
--- a/src/color/p5.Color.js
+++ b/src/color/p5.Color.js
@@ -583,6 +583,7 @@ const namedColors = {
   plum: '#dda0dd',
   powderblue: '#b0e0e6',
   purple: '#800080',
+  rebeccapurple: '#663399',
   red: '#ff0000',
   rosybrown: '#bc8f8f',
   royalblue: '#4169e1',


### PR DESCRIPTION
Include the `rebeccapurple` color keyword (`#663399`) added on the CSS Color Module Level 4 (https://drafts.csswg.org/css-color/).
A background story read about this color : [To honor web pioneer Eric Meyer](https://codepen.io/trezy/post/honoring-a-great-man).