### PR TITLE
WEBGL Font error message also reports that .ttf is supported

### DIFF
--- a/src/webgl/text.js
+++ b/src/webgl/text.js
@@ -633,7 +633,9 @@ p5.RendererGL.prototype._renderText = function(p, line, x, y, maxY) {
   }
 
   if (!this._isOpenType()) {
-    console.log('WEBGL: only opentype fonts are supported');
+    console.log(
+      'WEBGL: only Opentype (.otf) and Truetype (.ttf) fonts are supported'
+    );
     return p;
   }
 


### PR DESCRIPTION
Addresses [this comment.](https://github.com/processing/p5.js/issues/3179#issuecomment-501855690)