### PR TITLE
Don't enable image smoothing with 3D renderers in smooth()

### DIFF
--- a/src/core/shape/attributes.js
+++ b/src/core/shape/attributes.js
@@ -105,8 +105,10 @@ p5.prototype.ellipseMode = function(m) {
  */
 p5.prototype.noSmooth = function() {
   this.setAttributes('antialias', false);
-  if ('imageSmoothingEnabled' in this.drawingContext) {
-    this.drawingContext.imageSmoothingEnabled = false;
+  if (!this._renderer.isP3D) {
+    if ('imageSmoothingEnabled' in this.drawingContext) {
+      this.drawingContext.imageSmoothingEnabled = false;
+    }
   }
   return this;
 };

--- a/src/core/shape/attributes.js
+++ b/src/core/shape/attributes.js
@@ -208,8 +208,10 @@ p5.prototype.rectMode = function(m) {
  */
 p5.prototype.smooth = function() {
   this.setAttributes('antialias', true);
-  if ('imageSmoothingEnabled' in this.drawingContext) {
-    this.drawingContext.imageSmoothingEnabled = true;
+  if (!this._renderer.isP3D) {
+    if ('imageSmoothingEnabled' in this.drawingContext) {
+      this.drawingContext.imageSmoothingEnabled = true;
+    }
   }
   return this;
 };


### PR DESCRIPTION
closes #3919 

`smooth`/`noSmooth` no longer modifies `imageSmoothingEnabled` when the renderer is 3D.