### PR TITLE
Fix copy so that it works with a 3D graphics object destination

### DIFF
--- a/src/core/p5.Renderer2D.js
+++ b/src/core/p5.Renderer2D.js
@@ -250,11 +250,15 @@ p5.Renderer2D._copyHelper = (
 ) => {
   srcImage.loadPixels();
   const s = srcImage.canvas.width / srcImage.width;
-  const sxMod = srcImage._renderer.isP3D ? srcImage.width / 2 : 0;
-  const syMod = srcImage._renderer.isP3D ? srcImage.height / 2 : 0;
+  // adjust coord system for 3D when renderer
+  // ie top-left = -width/2, -height/2
+  let sxMod = 0;
+  let syMod = 0;
+  if (srcImage._renderer && srcImage._renderer.isP3D) {
+    sxMod = srcImage.width / 2;
+    syMod = srcImage.height / 2;
+  }
   if (dstImage.isP3D) {
-    // adjust coord system for 3D
-    // ie top-left = -width/2, -height/2
     p5.RendererGL.prototype.image.call(
       dstImage,
       srcImage,

--- a/src/core/p5.Renderer2D.js
+++ b/src/core/p5.Renderer2D.js
@@ -250,17 +250,32 @@ p5.Renderer2D._copyHelper = (
 ) => {
   srcImage.loadPixels();
   const s = srcImage.canvas.width / srcImage.width;
-  dstImage.drawingContext.drawImage(
-    srcImage.canvas,
-    s * sx,
-    s * sy,
-    s * sw,
-    s * sh,
-    dx,
-    dy,
-    dw,
-    dh
-  );
+  if (dstImage.isP3D) {
+    p5.RendererGL.prototype.image.call(
+      dstImage,
+      srcImage,
+      sx,
+      sy,
+      sw,
+      sh,
+      dx,
+      dy,
+      dw,
+      dh
+    );
+  } else {
+    dstImage.drawingContext.drawImage(
+      srcImage.canvas,
+      s * sx,
+      s * sy,
+      s * sw,
+      s * sh,
+      dx,
+      dy,
+      dw,
+      dh
+    );
+  }
 };
 
 // p5.Renderer2D.prototype.get = p5.Renderer.prototype.get;

--- a/src/core/p5.Renderer2D.js
+++ b/src/core/p5.Renderer2D.js
@@ -250,12 +250,16 @@ p5.Renderer2D._copyHelper = (
 ) => {
   srcImage.loadPixels();
   const s = srcImage.canvas.width / srcImage.width;
+  const sxMod = srcImage._renderer.isP3D ? srcImage.width / 2 : 0;
+  const syMod = srcImage._renderer.isP3D ? srcImage.height / 2 : 0;
   if (dstImage.isP3D) {
+    // adjust coord system for 3D
+    // ie top-left = -width/2, -height/2
     p5.RendererGL.prototype.image.call(
       dstImage,
       srcImage,
-      sx,
-      sy,
+      sx + sxMod,
+      sy + syMod,
       sw,
       sh,
       dx,

--- a/src/core/p5.Renderer2D.js
+++ b/src/core/p5.Renderer2D.js
@@ -270,8 +270,8 @@ p5.Renderer2D._copyHelper = (
   } else {
     dstImage.drawingContext.drawImage(
       srcImage.canvas,
-      s * sx,
-      s * sy,
+      s * (sx + sxMod),
+      s * (sy + syMod),
       s * sw,
       s * sh,
       dx,

--- a/src/core/p5.Renderer2D.js
+++ b/src/core/p5.Renderer2D.js
@@ -198,92 +198,10 @@ p5.Renderer2D.prototype.blend = function(...args) {
   const copyArgs = Array.prototype.slice.call(args, 0, args.length - 1);
 
   this.drawingContext.globalCompositeOperation = blendMode;
-  if (this._pInst) {
-    this._pInst.copy(...copyArgs);
-  } else {
-    this.copy(...copyArgs);
-  }
+
+  p5.prototype.copy.apply(this, copyArgs);
+
   this.drawingContext.globalCompositeOperation = currBlend;
-};
-
-p5.Renderer2D.prototype.copy = function(...args) {
-  let srcImage, sx, sy, sw, sh, dx, dy, dw, dh;
-  if (args.length === 9) {
-    srcImage = args[0];
-    sx = args[1];
-    sy = args[2];
-    sw = args[3];
-    sh = args[4];
-    dx = args[5];
-    dy = args[6];
-    dw = args[7];
-    dh = args[8];
-  } else if (args.length === 8) {
-    srcImage = this._pInst;
-    sx = args[0];
-    sy = args[1];
-    sw = args[2];
-    sh = args[3];
-    dx = args[4];
-    dy = args[5];
-    dw = args[6];
-    dh = args[7];
-  } else {
-    throw new Error('Signature not supported');
-  }
-  p5.Renderer2D._copyHelper(this, srcImage, sx, sy, sw, sh, dx, dy, dw, dh);
-
-  this._pixelsState._pixelsDirty = true;
-};
-
-p5.Renderer2D._copyHelper = (
-  dstImage,
-  srcImage,
-  sx,
-  sy,
-  sw,
-  sh,
-  dx,
-  dy,
-  dw,
-  dh
-) => {
-  srcImage.loadPixels();
-  const s = srcImage.canvas.width / srcImage.width;
-  // adjust coord system for 3D when renderer
-  // ie top-left = -width/2, -height/2
-  let sxMod = 0;
-  let syMod = 0;
-  if (srcImage._renderer && srcImage._renderer.isP3D) {
-    sxMod = srcImage.width / 2;
-    syMod = srcImage.height / 2;
-  }
-  if (dstImage.isP3D) {
-    p5.RendererGL.prototype.image.call(
-      dstImage,
-      srcImage,
-      sx + sxMod,
-      sy + syMod,
-      sw,
-      sh,
-      dx,
-      dy,
-      dw,
-      dh
-    );
-  } else {
-    dstImage.drawingContext.drawImage(
-      srcImage.canvas,
-      s * (sx + sxMod),
-      s * (sy + syMod),
-      s * sw,
-      s * sh,
-      dx,
-      dy,
-      dw,
-      dh
-    );
-  }
 };
 
 // p5.Renderer2D.prototype.get = p5.Renderer.prototype.get;

--- a/src/dom/dom.js
+++ b/src/dom/dom.js
@@ -2930,7 +2930,7 @@ p5.MediaElement.prototype.set = function(x, y, imgOrCol) {
 };
 p5.MediaElement.prototype.copy = function() {
   this._ensureCanvas();
-  p5.Renderer2D.prototype.copy.apply(this, arguments);
+  p5.prototype.copy.apply(this, arguments);
 };
 p5.MediaElement.prototype.mask = function() {
   this.loadPixels();

--- a/src/image/p5.Image.js
+++ b/src/image/p5.Image.js
@@ -603,32 +603,7 @@ p5.Image.prototype.resize = function(width, height) {
  * @param  {Integer} dh
  */
 p5.Image.prototype.copy = function(...args) {
-  let srcImage, sx, sy, sw, sh, dx, dy, dw, dh;
-  if (args.length === 9) {
-    srcImage = args[0];
-    sx = args[1];
-    sy = args[2];
-    sw = args[3];
-    sh = args[4];
-    dx = args[5];
-    dy = args[6];
-    dw = args[7];
-    dh = args[8];
-  } else if (args.length === 8) {
-    srcImage = this;
-    sx = args[0];
-    sy = args[1];
-    sw = args[2];
-    sh = args[3];
-    dx = args[4];
-    dy = args[5];
-    dw = args[6];
-    dh = args[7];
-  } else {
-    throw new Error('Signature not supported');
-  }
-  p5.Renderer2D._copyHelper(this, srcImage, sx, sy, sw, sh, dx, dy, dw, dh);
-  this._pixelsDirty = true;
+  p5.prototype.copy.apply(this, args);
 };
 
 /**

--- a/src/image/pixels.js
+++ b/src/image/pixels.js
@@ -228,7 +228,85 @@ p5.prototype.blend = function(...args) {
  */
 p5.prototype.copy = function(...args) {
   p5._validateParameters('copy', args);
-  p5.Renderer2D.prototype.copy.apply(this._renderer, args);
+
+  let srcImage, sx, sy, sw, sh, dx, dy, dw, dh;
+  if (args.length === 9) {
+    srcImage = args[0];
+    sx = args[1];
+    sy = args[2];
+    sw = args[3];
+    sh = args[4];
+    dx = args[5];
+    dy = args[6];
+    dw = args[7];
+    dh = args[8];
+  } else if (args.length === 8) {
+    srcImage = this;
+    sx = args[0];
+    sy = args[1];
+    sw = args[2];
+    sh = args[3];
+    dx = args[4];
+    dy = args[5];
+    dw = args[6];
+    dh = args[7];
+  } else {
+    throw new Error('Signature not supported');
+  }
+
+  p5.prototype._copyHelper(this, srcImage, sx, sy, sw, sh, dx, dy, dw, dh);
+
+  this._pixelsDirty = true;
+};
+
+p5.prototype._copyHelper = (
+  dstImage,
+  srcImage,
+  sx,
+  sy,
+  sw,
+  sh,
+  dx,
+  dy,
+  dw,
+  dh
+) => {
+  srcImage.loadPixels();
+  const s = srcImage.canvas.width / srcImage.width;
+  // adjust coord system for 3D when renderer
+  // ie top-left = -width/2, -height/2
+  let sxMod = 0;
+  let syMod = 0;
+  if (srcImage._renderer && srcImage._renderer.isP3D) {
+    sxMod = srcImage.width / 2;
+    syMod = srcImage.height / 2;
+  }
+  if (dstImage._renderer && dstImage._renderer.isP3D) {
+    p5.RendererGL.prototype.image.call(
+      dstImage._renderer,
+      srcImage,
+      sx + sxMod,
+      sy + syMod,
+      sw,
+      sh,
+      dx,
+      dy,
+      dw,
+      dh
+    );
+  } else {
+    dstImage.drawingContext.drawImage(
+      srcImage.canvas,
+      s * (sx + sxMod),
+      s * (sy + syMod),
+      s * sw,
+      s * sh,
+      dx,
+      dy,
+      dw,
+      dh
+    );
+  }
 };
 
 /**

--- a/test/unit/image/pixels.js
+++ b/test/unit/image/pixels.js
@@ -228,7 +228,7 @@ suite('pixels', function() {
       assert.throw(function() {
         let img = myp5.createImage(50, 50);
         img.copy(0, 0, 10, 10, 0, 10, 10);
-      }, 'Signature not supported');
+      });
     });
   });
 });


### PR DESCRIPTION
closes #3932 

So there are some quirks with this, thus the draft status for the PR. Basically I tried to find the minimal intervention way to get copy working for WebGL graphics objects. WebGL drawing contexts do not have a way of placing pixel data directly into them, so instead `image` is used to simply create geometry and assign a texture to that geometry. The minimal intervention approach meant that I ended up adding the logic for handling 3D destinations inside of the Renderer2D prototype for copy. This is a bit counter-intuitive so may need to go back further on the chain but the fix would then require a significant amount more code much of which would be redundant.

This seems to work in the most obvious cases including the one listed in the above issue but I only tested for a few things. @figraham would you mind looking this over and testing in a few different ways? I anticipate there will be problems but not sure where to start so help is appreciated. Thanks!
