### PR TITLE
Optional zoom sensitivity argument for orbitControl

### DIFF
--- a/src/webgl/interaction.js
+++ b/src/webgl/interaction.js
@@ -22,6 +22,7 @@ import * as constants from '../core/constants';
  * @for p5
  * @param  {Number} [sensitivityX] sensitivity to mouse movement along X axis
  * @param  {Number} [sensitivityY] sensitivity to mouse movement along Y axis
+ * @param  {Number} [sensitivityZoom] sensitivity to scroll movement along Z axis
  * @chainable
  * @example
  * <div>
@@ -45,7 +46,11 @@ import * as constants from '../core/constants';
 
 // implementation based on three.js 'orbitControls':
 // https://github.com/mrdoob/three.js/blob/dev/examples/js/controls/OrbitControls.js
-p5.prototype.orbitControl = function(sensitivityX, sensitivityY) {
+p5.prototype.orbitControl = function(
+  sensitivityX,
+  sensitivityY,
+  sensitivityZoom
+) {
   this._assert3d('orbitControl');
   p5._validateParameters('orbitControl', arguments);
 
@@ -64,6 +69,9 @@ p5.prototype.orbitControl = function(sensitivityX, sensitivityY) {
   }
   if (typeof sensitivityY === 'undefined') {
     sensitivityY = sensitivityX;
+  }
+  if (typeof sensitivityZoom === 'undefined') {
+    sensitivityZoom = 0.5;
   }
 
   // default right-mouse and mouse-wheel behaviors (context menu and scrolling,
@@ -90,9 +98,9 @@ p5.prototype.orbitControl = function(sensitivityX, sensitivityY) {
   if (this._mouseWheelDeltaY !== this._pmouseWheelDeltaY) {
     // zoom according to direction of mouseWheelDeltaY rather than value
     if (this._mouseWheelDeltaY > 0) {
-      this._renderer._curCamera._orbit(0, 0, 0.5 * scaleFactor);
+      this._renderer._curCamera._orbit(0, 0, sensitivityZoom * scaleFactor);
     } else {
-      this._renderer._curCamera._orbit(0, 0, -0.5 * scaleFactor);
+      this._renderer._curCamera._orbit(0, 0, -sensitivityZoom * scaleFactor);
     }
   }
 

--- a/src/webgl/interaction.js
+++ b/src/webgl/interaction.js
@@ -22,7 +22,7 @@ import * as constants from '../core/constants';
  * @for p5
  * @param  {Number} [sensitivityX] sensitivity to mouse movement along X axis
  * @param  {Number} [sensitivityY] sensitivity to mouse movement along Y axis
- * @param  {Number} [sensitivityZoom] sensitivity to scroll movement along Z axis
+ * @param  {Number} [sensitivityZ] sensitivity to scroll movement along Z axis
  * @chainable
  * @example
  * <div>
@@ -46,11 +46,7 @@ import * as constants from '../core/constants';
 
 // implementation based on three.js 'orbitControls':
 // https://github.com/mrdoob/three.js/blob/dev/examples/js/controls/OrbitControls.js
-p5.prototype.orbitControl = function(
-  sensitivityX,
-  sensitivityY,
-  sensitivityZoom
-) {
+p5.prototype.orbitControl = function(sensitivityX, sensitivityY, sensitivityZ) {
   this._assert3d('orbitControl');
   p5._validateParameters('orbitControl', arguments);
 
@@ -70,8 +66,8 @@ p5.prototype.orbitControl = function(
   if (typeof sensitivityY === 'undefined') {
     sensitivityY = sensitivityX;
   }
-  if (typeof sensitivityZoom === 'undefined') {
-    sensitivityZoom = 0.5;
+  if (typeof sensitivityZ === 'undefined') {
+    sensitivityZ = 0.5;
   }
 
   // default right-mouse and mouse-wheel behaviors (context menu and scrolling,
@@ -98,9 +94,9 @@ p5.prototype.orbitControl = function(
   if (this._mouseWheelDeltaY !== this._pmouseWheelDeltaY) {
     // zoom according to direction of mouseWheelDeltaY rather than value
     if (this._mouseWheelDeltaY > 0) {
-      this._renderer._curCamera._orbit(0, 0, sensitivityZoom * scaleFactor);
+      this._renderer._curCamera._orbit(0, 0, sensitivityZ * scaleFactor);
     } else {
-      this._renderer._curCamera._orbit(0, 0, -sensitivityZoom * scaleFactor);
+      this._renderer._curCamera._orbit(0, 0, -sensitivityZ * scaleFactor);
     }
   }
 

--- a/test/manual-test-examples/webgl/interaction/orbitControl/sketch.js
+++ b/test/manual-test-examples/webgl/interaction/orbitControl/sketch.js
@@ -9,7 +9,7 @@ function draw() {
   background(250);
   var radius = width;
 
-  orbitControl();
+  orbitControl(1, 1, 0.1);
 
   normalMaterial();
 


### PR DESCRIPTION
closes #3914 

Adds optional third parameter for `orbitControl()` that dictates the sensitivity of zoom or scroll movement in the z-axis.