### PR TITLE
Corner rounding for rect with negative width and height

### DIFF
--- a/src/core/p5.Renderer2D.js
+++ b/src/core/p5.Renderer2D.js
@@ -669,32 +669,35 @@ p5.Renderer2D.prototype.rect = function(args) {
       bl = br;
     }
 
-    const hw = w / 2;
-    const hh = h / 2;
+    // corner rounding must always be positive
+    const absW = Math.abs(w);
+    const absH = Math.abs(h);
+    const hw = absW / 2;
+    const hh = absH / 2;
 
     // Clip radii
-    if (w < 2 * tl) {
+    if (absW < 2 * tl) {
       tl = hw;
     }
-    if (h < 2 * tl) {
+    if (absH < 2 * tl) {
       tl = hh;
     }
-    if (w < 2 * tr) {
+    if (absW < 2 * tr) {
       tr = hw;
     }
-    if (h < 2 * tr) {
+    if (absH < 2 * tr) {
       tr = hh;
     }
-    if (w < 2 * br) {
+    if (absW < 2 * br) {
       br = hw;
     }
-    if (h < 2 * br) {
+    if (absH < 2 * br) {
       br = hh;
     }
-    if (w < 2 * bl) {
+    if (absW < 2 * bl) {
       bl = hw;
     }
-    if (h < 2 * bl) {
+    if (absH < 2 * bl) {
       bl = hh;
     }
 


### PR DESCRIPTION
closes #3929 

Currently `rect()` will work well with negative width and height as long as corner round is not used. This PR allows that as well.

It does this by:
- Using absolute values for width and height when checking to see if corner rounding values are higher than half of the width or height.
- Making the clipping values for half width and half height absolute numbers as the corner rounding values must always be positive