### PR TITLE
Fix personal alias in Contributors

### DIFF
--- a/.all-contributorsrc
+++ b/.all-contributorsrc
@@ -1200,10 +1200,10 @@
       "contributions": []
     },
     {
-      "login": "max-devjs",
-      "name": "max_devjs",
+      "login": "maxdevjs",
+      "name": "maxdevjs",
       "avatar_url": "https://avatars2.githubusercontent.com/u/22229196?v=4",
-      "profile": "http://twitter.com/max_devjs",
+      "profile": "http://twitter.com/maxdevjs",
       "contributions": []
     },
     {


### PR DESCRIPTION
Recently I have modified Github and Twitter username.

Fixes in Contributors section:

- displayed username
- Twitter link