### PR TITLE
Accept number strings for arguments of ellipse/circle

### DIFF
--- a/src/core/p5.Renderer2D.js
+++ b/src/core/p5.Renderer2D.js
@@ -520,10 +520,10 @@ p5.Renderer2D.prototype.ellipse = function(args) {
   const ctx = this.drawingContext;
   const doFill = this._doFill,
     doStroke = this._doStroke;
-  const x = args[0],
-    y = args[1],
-    w = args[2],
-    h = args[3];
+  const x = parseFloat(args[0]),
+    y = parseFloat(args[1]),
+    w = parseFloat(args[2]),
+    h = parseFloat(args[3]);
   if (doFill && !doStroke) {
     if (this._getFill() === styleEmpty) {
       return this;


### PR DESCRIPTION
Fixes #3943

FES should be able to catch the mismatched type but I'm not sure why it doesn't. With this new fix numbers passed as string will be parsed as numbers while invalid strings will be caught correctly by FES and reported as suuch.