### PR TITLE
Removes perspective on stroke when in custom cameraType

### DIFF
--- a/developer_docs/webgl_mode_architecture.md
+++ b/developer_docs/webgl_mode_architecture.md
@@ -101,6 +101,7 @@ The normal shader is set when `normalMaterial()` is in use. It uses the surfaceâ
 |`uniform mat4 uModelViewMatrix;` |x          |x              |x           |x            |x           |
 |`uniform mat4 uProjectionMatrix;`|x          |x              |x           |x            |x           |
 |`uniform vec4 uViewPort;`        |x          |               |            |             |            |
+|`uniform vec4 uPerspective;`     |x          |               |            |             |            |
 
 
 #### Geometry Attributes and Uniforms

--- a/src/webgl/p5.Camera.js
+++ b/src/webgl/p5.Camera.js
@@ -361,7 +361,7 @@ p5.Camera = function(renderer) {
  * @for p5.Camera
  */
 p5.Camera.prototype.perspective = function(fovy, aspect, near, far) {
-  const isCustom = arguments.length > 0;
+  this.cameraType = arguments.length > 0 ? 'custom' : 'default';
   if (typeof fovy === 'undefined') {
     fovy = this.defaultCameraFOV;
     // this avoids issue where setting angleMode(DEGREES) before calling
@@ -431,8 +431,6 @@ p5.Camera.prototype.perspective = function(fovy, aspect, near, far) {
       this.projMatrix.mat4[15]
     );
   }
-
-  this.cameraType = isCustom ? 'custom' : 'default';
 };
 
 /**

--- a/src/webgl/p5.Camera.js
+++ b/src/webgl/p5.Camera.js
@@ -361,6 +361,7 @@ p5.Camera = function(renderer) {
  * @for p5.Camera
  */
 p5.Camera.prototype.perspective = function(fovy, aspect, near, far) {
+  const isCustom = arguments.length > 0;
   if (typeof fovy === 'undefined') {
     fovy = this.defaultCameraFOV;
     // this avoids issue where setting angleMode(DEGREES) before calling
@@ -431,7 +432,7 @@ p5.Camera.prototype.perspective = function(fovy, aspect, near, far) {
     );
   }
 
-  this.cameraType = 'custom';
+  this.cameraType = isCustom ? 'custom' : 'default';
 };
 
 /**

--- a/src/webgl/p5.Shader.js
+++ b/src/webgl/p5.Shader.js
@@ -250,6 +250,15 @@ p5.Shader.prototype.unbindTextures = () => {
 
 p5.Shader.prototype._setMatrixUniforms = function() {
   this.setUniform('uProjectionMatrix', this._renderer.uPMatrix.mat4);
+  if (this.isStrokeShader()) {
+    if (this._renderer._curCamera.cameraType === 'default') {
+      // strokes scale up as they approach camera, default
+      this.setUniform('uPerspective', 1);
+    } else {
+      // strokes have uniform scale regardless of distance from camera
+      this.setUniform('uPerspective', 0);
+    }
+  }
   this.setUniform('uModelViewMatrix', this._renderer.uMVMatrix.mat4);
   this.setUniform('uViewMatrix', this._renderer._curCamera.cameraMatrix.mat4);
   if (this.uniforms.uNormalMatrix) {

--- a/src/webgl/shaders/line.vert
+++ b/src/webgl/shaders/line.vert
@@ -23,6 +23,7 @@ uniform mat4 uProjectionMatrix;
 uniform float uStrokeWeight;
 
 uniform vec4 uViewport;
+uniform int uPerspective;
 
 attribute vec4 aPosition;
 attribute vec4 aDirection;
@@ -76,18 +77,21 @@ void main() {
   float thickness = aDirection.w * uStrokeWeight;
   vec2 offset = normal * thickness / 2.0;
 
-  // Perspective ---
-  // convert from world to clip by multiplying with projection scaling factor
-  // to get the right thickness (see https://github.com/processing/processing/issues/5182)
-  // invert Y, projections in Processing invert Y
-  vec2 perspScale = (uProjectionMatrix * vec4(1, -1, 0, 0)).xy;
+  vec2 curPerspScale;
 
-  // No Perspective ---
-  // multiply by W (to cancel out division by W later in the pipeline) and
-  // convert from screen to clip (derived from clip to screen above)
-  vec2 noPerspScale = p.w / (0.5 * uViewport.zw);
+  if(uPerspective == 1) {
+    // Perspective ---
+    // convert from world to clip by multiplying with projection scaling factor
+    // to get the right thickness (see https://github.com/processing/processing/issues/5182)
+    // invert Y, projections in Processing invert Y
+    curPerspScale = (uProjectionMatrix * vec4(1, -1, 0, 0)).xy;
+  } else {
+    // No Perspective ---
+    // multiply by W (to cancel out division by W later in the pipeline) and
+    // convert from screen to clip (derived from clip to screen above)
+    curPerspScale = p.w / (0.5 * uViewport.zw);
+  }
 
-  //gl_Position.xy = p.xy + offset.xy * mix(noPerspScale, perspScale, float(perspective > 0));
-  gl_Position.xy = p.xy + offset.xy * perspScale;
+  gl_Position.xy = p.xy + offset.xy * curPerspScale;
   gl_Position.zw = p.zw;
 }

--- a/test/unit/webgl/p5.Camera.js
+++ b/test/unit/webgl/p5.Camera.js
@@ -528,6 +528,11 @@ suite('p5.Camera', function() {
         myCam.ortho();
         assert.deepEqual(myCam.projMatrix.mat4, expectedMatrix);
       });
+
+      test('ortho() with sets cameraType to custom', function() {
+        myCam.ortho();
+        assert.deepEqual(myCam.cameraType, 'custom');
+      });
     });
     suite('perspective()', function() {
       test('perspective() sets renderer uPMatrix', function() {
@@ -561,6 +566,11 @@ suite('p5.Camera', function() {
 
         assert.deepEqual(myCam.projMatrix.mat4, expectedMatrix);
       });
+
+      test('perspective() with no parameters sets cameraType to default', function() {
+        myCam.perspective();
+        assert.deepEqual(myCam.cameraType, 'default');
+      });
     });
     suite('frustum()', function() {
       test('frustum() sets renderer uPMatrix', function() {
@@ -593,6 +603,11 @@ suite('p5.Camera', function() {
         myCam.frustum();
 
         assert.deepEqual(myCam.projMatrix.mat4, expectedMatrix);
+      });
+
+      test('frustum() sets cameraType to custom', function() {
+        myCam.frustum(-1, 1, -1, 1, -2, 2);
+        assert.deepEqual(myCam.cameraType, 'custom');
       });
     });
   });


### PR DESCRIPTION
closes #3965 

See discussion in the above issue.

This pull request adds a `uPerspective` uniform to line.vert. This value is 1 by default which means that stroke geometry that is further from the camera will appear thinner. When a custom view is set with `ortho()`, `frustum()`, or `perspective(with args)` the `cameraType` of the camera is set to 'custom' and the `uPerspective` uniform will be set to 0. This means that stroke geometry is a uniform width regardless of distance from the camera.