### PR TITLE
fix sample-linter.js error during pre-commit hook

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "test/**/*.js": "eslint",
     "src/**/*.js": [
       "eslint",
-      "node ./utils/sample-linter.js"
+      "node --require @babel/register ./utils/sample-linter.js"
     ]
   },
   "version": "0.9.0",


### PR DESCRIPTION
we've been seeing intermittent issues with the pre-commit hook, where `sample-linter.js` throws an error about an "unexpected token `import`".

i've been puzzled (and frustrated) by this for a while and just realized the missing piece: the pre-commit hook doesn't use `grunt` to run its linting checks.

instead it calls the `eslint` cli directly, as well as `node sample-linter.js`. since its just using the vanilla `node` cli to call that file, we don't get any of the transpiling that babel offers. older versions of node (and maybe even the current one?) don't support `import`, hence the error about the unexpected token.

adding `--require @babel/register` to that call will run any code used through the babel transpiler on they fly, before it is actually used.

-----
cc @lmccart @sanketsingh24 who i know have also hit this recently