### PR TITLE
Add erase() and noErase()

### DIFF
--- a/src/color/setting.js
+++ b/src/color/setting.js
@@ -762,12 +762,35 @@ p5.prototype.stroke = function(...args) {
  * @alt
  * 60x60 TODO!
  */
-p5.prototype.erase = function() {
+p5.prototype.erase = function(opacityFill, opacityStroke) {
   this._renderer._isErasing = true;
+
+  opacityFill = typeof opacityFill == 'undefined' ? 255 : opacityFill;
+  opacityStroke = typeof opacityStroke == 'undefined' ? 255 : opacityStroke;
+
   if (this._renderer.isP3D) {
     this._renderer._cachedBlendMode = this._renderer.curBlendMode;
     this._renderer.blendMode(constants.REMOVE);
+
+    this._renderer._cachedFillStyle = this._renderer.curFillColor.splice(0, 4);
+    this._renderer.curFillColor = [1, 1, 1, opacityFill / 255];
+
+    this._renderer._cachedStrokeStyle = this._renderer.curStrokeColor.splice(
+      0,
+      4
+    );
+    this._renderer.curStrokeColor = [1, 1, 1, opacityStroke / 255];
   } else {
+    // cache the fill style
+    this._renderer._cachedFillStyle = this.drawingContext.fillStyle;
+    const newFill = this.color(255, opacityFill).toString();
+    this.drawingContext.fillStyle = newFill;
+
+    //cache the stroke style
+    this._renderer._cachedStrokeStyle = this.drawingContext.strokeStyle;
+    const newStroke = this.color(255, opacityFill).toString();
+    this.drawingContext.strokeStyle = newStroke;
+
     const tempBlendMode = this._renderer._cachedBlendMode;
     this._renderer.blendMode(constants.REMOVE);
     this._renderer._cachedBlendMode = tempBlendMode;
@@ -794,6 +817,19 @@ p5.prototype.erase = function() {
 
 p5.prototype.noErase = function() {
   this._renderer._isErasing = false;
+
+  // restore previous stroke and fill
+  if (this._renderer.isP3D) {
+    this._renderer.curFillColor = this._renderer._cachedFillStyle.splice(0, 4);
+    this._renderer.curStrokeColor = this._renderer._cachedStrokeStyle.splice(
+      0,
+      4
+    );
+  } else {
+    this.drawingContext.fillStyle = this._renderer._cachedFillStyle;
+    this.drawingContext.strokeStyle = this._renderer._cachedStrokeStyle;
+  }
+
   this._renderer.blendMode(this._renderer._cachedBlendMode);
   return this;
 };

--- a/src/color/setting.js
+++ b/src/color/setting.js
@@ -746,4 +746,47 @@ p5.prototype.stroke = function(...args) {
   return this;
 };
 
+/**
+ * Sets the canvas to erase
+ *
+ * @method erase
+ * @chainable
+ * @example
+ * <div>
+ * <code>
+ * erase();
+ * rect(20, 20, 60, 60);
+ * </code>
+ * </div>
+ *
+ * @alt
+ * 60x60 TODO!
+ */
+p5.prototype.erase = function() {
+  this._renderer.blendMode(constants.REMOVE);
+  return this;
+};
+
+/**
+ * Ends erasing in the canvas
+ *
+ * @method noErase
+ * @chainable
+ * @example
+ * <div>
+ * <code>
+ * noErase();
+ * rect(20, 20, 60, 60);
+ * </code>
+ * </div>
+ *
+ * @alt
+ * 60x60 TODO!
+ */
+
+p5.prototype.noErase = function() {
+  this.blendMode(constants.BLEND);
+  return this;
+};
+
 export default p5;

--- a/src/color/setting.js
+++ b/src/color/setting.js
@@ -747,20 +747,78 @@ p5.prototype.stroke = function(...args) {
 };
 
 /**
- * Sets the canvas to erase
+ * All drawing that follows <a href="#/p5/erase">erase()</a> will subtract from the canvas.
+ * Erased areas will reveal the web page underneath the canvas.
+ * Erasing can be canceled with <a href="#/p5/noErase">noErase()</a>.
+ * <br><br>
+ * Drawing done with <a href="#/p5/image">image()</a>
+ * and <a href="#/p5/background">background()</a> will not be affected by <a href="#/p5/erase">erase()</a>
+ * <br><br>
  *
  * @method erase
+ * @param  {Number}   [strengthFill]      A number (0-255) for the strength of erasing for a shape's fill.
+ *                                        This will default to 255 when no argument is given, which
+ *                                        is full strength.
+ * @param  {Number}   [strengthStroke]    A number (0-255) for the strength of erasing for a shape's stroke.
+ *                                        This will default to 255 when no argument is given, which
+ *                                        is full strength.
+ *
  * @chainable
  * @example
  * <div>
  * <code>
- * erase();
+ * background(100, 100, 250);
+ * fill(250, 100, 100);
  * rect(20, 20, 60, 60);
+ * erase();
+ * ellipse(25, 30, 30);
+ * noErase();
+ * </code>
+ * </div>
+ *
+ * <div>
+ * <code>
+ * background(150, 250, 150);
+ * fill(100, 100, 250);
+ * rect(20, 20, 60, 60);
+ * strokeWeight(5);
+ * erase(150, 255);
+ * triangle(50, 10, 70, 50, 90, 10);
+ * noErase();
+ * </code>
+ * </div>
+ *
+ * <div>
+ * <code>
+ * function setup() {
+ *   smooth();
+ *   createCanvas(100, 100, WEBGL);
+ *   // Make a &lt;p&gt; element and put it behind the canvas
+ *   let p = createP('I am a dom element');
+ *   p.center();
+ *   p.style('font-size', '20px');
+ *   p.style('text-align', 'center');
+ *   p.style('z-index', '-9999');
+ * }
+ *
+ * function draw() {
+ *   background(250, 250, 150);
+ *   fill(15, 195, 185);
+ *   noStroke();
+ *   sphere(30);
+ *   erase();
+ *   rotateY(frameCount * 0.02);
+ *   translate(0, 0, 40);
+ *   torus(15, 5);
+ *   noErase();
+ * }
  * </code>
  * </div>
  *
  * @alt
- * 60x60 TODO!
+ * 60x60 centered pink rect, purple background. Elliptical area in top-left of rect is erased white.
+ * 60x60 centered purple rect, mint green background. Triangle in top-right is partially erased with fully erased outline.
+ * 60x60 centered teal sphere, yellow background. Torus rotating around sphere erases to reveal black text underneath.
  */
 p5.prototype.erase = function(opacityFill = 255, opacityStroke = 255) {
   this._renderer.erase(opacityFill, opacityStroke);
@@ -769,20 +827,29 @@ p5.prototype.erase = function(opacityFill = 255, opacityStroke = 255) {
 };
 
 /**
- * Ends erasing in the canvas
+ * Ends erasing that was started with <a href="#/p5/erase">erase()</a>.
+ * The <a href="#/p5/fill">fill()</a>, <a href="#/p5/stroke">stroke()</a>, and
+ * <a href="#/p5/blendMode">blendMode()</a> settings will return to what they were
+ * prior to calling <a href="#/p5/erase">erase()</a>.
  *
  * @method noErase
  * @chainable
  * @example
  * <div>
  * <code>
+ * background(235, 145, 15);
+ * noStroke();
+ * fill(30, 45, 220);
+ * rect(30, 10, 10, 80);
+ * erase();
+ * ellipse(50, 50, 60);
  * noErase();
- * rect(20, 20, 60, 60);
+ * rect(70, 10, 10, 80);
  * </code>
  * </div>
  *
  * @alt
- * 60x60 TODO!
+ * Orange background, with two tall blue rectangles. A centered ellipse erased the first blue rect but not the second.
  */
 
 p5.prototype.noErase = function() {

--- a/src/color/setting.js
+++ b/src/color/setting.js
@@ -762,10 +762,7 @@ p5.prototype.stroke = function(...args) {
  * @alt
  * 60x60 TODO!
  */
-p5.prototype.erase = function(opacityFill, opacityStroke) {
-  opacityFill = typeof opacityFill == 'undefined' ? 255 : opacityFill;
-  opacityStroke = typeof opacityStroke == 'undefined' ? 255 : opacityStroke;
-
+p5.prototype.erase = function(opacityFill = 255, opacityStroke = 255) {
   this._renderer.erase(opacityFill, opacityStroke);
 
   return this;

--- a/src/color/setting.js
+++ b/src/color/setting.js
@@ -763,38 +763,11 @@ p5.prototype.stroke = function(...args) {
  * 60x60 TODO!
  */
 p5.prototype.erase = function(opacityFill, opacityStroke) {
-  this._renderer._isErasing = true;
-
   opacityFill = typeof opacityFill == 'undefined' ? 255 : opacityFill;
   opacityStroke = typeof opacityStroke == 'undefined' ? 255 : opacityStroke;
 
-  if (this._renderer.isP3D) {
-    this._renderer._cachedBlendMode = this._renderer.curBlendMode;
-    this._renderer.blendMode(constants.REMOVE);
+  this._renderer.erase(opacityFill, opacityStroke);
 
-    this._renderer._cachedFillStyle = this._renderer.curFillColor.splice(0, 4);
-    this._renderer.curFillColor = [1, 1, 1, opacityFill / 255];
-
-    this._renderer._cachedStrokeStyle = this._renderer.curStrokeColor.splice(
-      0,
-      4
-    );
-    this._renderer.curStrokeColor = [1, 1, 1, opacityStroke / 255];
-  } else {
-    // cache the fill style
-    this._renderer._cachedFillStyle = this.drawingContext.fillStyle;
-    const newFill = this.color(255, opacityFill).toString();
-    this.drawingContext.fillStyle = newFill;
-
-    //cache the stroke style
-    this._renderer._cachedStrokeStyle = this.drawingContext.strokeStyle;
-    const newStroke = this.color(255, opacityFill).toString();
-    this.drawingContext.strokeStyle = newStroke;
-
-    const tempBlendMode = this._renderer._cachedBlendMode;
-    this._renderer.blendMode(constants.REMOVE);
-    this._renderer._cachedBlendMode = tempBlendMode;
-  }
   return this;
 };
 
@@ -816,21 +789,7 @@ p5.prototype.erase = function(opacityFill, opacityStroke) {
  */
 
 p5.prototype.noErase = function() {
-  this._renderer._isErasing = false;
-
-  // restore previous stroke and fill
-  if (this._renderer.isP3D) {
-    this._renderer.curFillColor = this._renderer._cachedFillStyle.splice(0, 4);
-    this._renderer.curStrokeColor = this._renderer._cachedStrokeStyle.splice(
-      0,
-      4
-    );
-  } else {
-    this.drawingContext.fillStyle = this._renderer._cachedFillStyle;
-    this.drawingContext.strokeStyle = this._renderer._cachedStrokeStyle;
-  }
-
-  this._renderer.blendMode(this._renderer._cachedBlendMode);
+  this._renderer.noErase();
   return this;
 };
 

--- a/src/color/setting.js
+++ b/src/color/setting.js
@@ -763,7 +763,8 @@ p5.prototype.stroke = function(...args) {
  * 60x60 TODO!
  */
 p5.prototype.erase = function() {
-  this._renderer.blendMode(constants.REMOVE);
+  this._renderer._isErasing = true;
+  this.drawingContext.globalCompositeOperation = constants.REMOVE;
   return this;
 };
 
@@ -785,7 +786,8 @@ p5.prototype.erase = function() {
  */
 
 p5.prototype.noErase = function() {
-  this.blendMode(constants.BLEND);
+  this._renderer._isErasing = false;
+  this._renderer.blendMode(this._renderer._cachedBlendMode);
   return this;
 };
 

--- a/src/color/setting.js
+++ b/src/color/setting.js
@@ -764,7 +764,14 @@ p5.prototype.stroke = function(...args) {
  */
 p5.prototype.erase = function() {
   this._renderer._isErasing = true;
-  this.drawingContext.globalCompositeOperation = constants.REMOVE;
+  if (this._renderer.isP3D) {
+    this._renderer._cachedBlendMode = this._renderer.curBlendMode;
+    this._renderer.blendMode(constants.REMOVE);
+  } else {
+    const tempBlendMode = this._renderer._cachedBlendMode;
+    this._renderer.blendMode(constants.REMOVE);
+    this._renderer._cachedBlendMode = tempBlendMode;
+  }
   return this;
 };
 

--- a/src/core/constants.js
+++ b/src/core/constants.js
@@ -437,6 +437,12 @@ export const UP_ARROW = 38;
  */
 export const BLEND = 'source-over';
 /**
+ * @property {String} REMOVE
+ * @final
+ * @default destination-out
+ */
+export const REMOVE = 'destination-out';
+/**
  * @property {String} ADD
  * @final
  * @default lighter

--- a/src/core/p5.Renderer2D.js
+++ b/src/core/p5.Renderer2D.js
@@ -171,6 +171,7 @@ p5.Renderer2D.prototype.blendMode = function(mode) {
     console.warn('blendMode(SUBTRACT) only works in WEBGL mode.');
   } else if (
     mode === constants.BLEND ||
+    mode === constants.REMOVE ||
     mode === constants.DARKEST ||
     mode === constants.LIGHTEST ||
     mode === constants.DIFFERENCE ||

--- a/src/core/p5.Renderer2D.js
+++ b/src/core/p5.Renderer2D.js
@@ -91,6 +91,37 @@ p5.Renderer2D.prototype.stroke = function(...args) {
   this._setStroke(color.toString());
 };
 
+p5.Renderer2D.prototype.erase = function(opacityFill, opacityStroke) {
+  if (!this._isErasing) {
+    // cache the fill style
+    this._cachedFillStyle = this.drawingContext.fillStyle;
+    const newFill = this._pInst.color(255, opacityFill).toString();
+    this.drawingContext.fillStyle = newFill;
+
+    //cache the stroke style
+    this._cachedStrokeStyle = this.drawingContext.strokeStyle;
+    const newStroke = this._pInst.color(255, opacityStroke).toString();
+    this.drawingContext.strokeStyle = newStroke;
+
+    //cache blendMode
+    const tempBlendMode = this._cachedBlendMode;
+    this.blendMode(constants.REMOVE);
+    this._cachedBlendMode = tempBlendMode;
+
+    this._isErasing = true;
+  }
+};
+
+p5.Renderer2D.prototype.noErase = function() {
+  if (this._isErasing) {
+    this.drawingContext.fillStyle = this._cachedFillStyle;
+    this.drawingContext.strokeStyle = this._cachedStrokeStyle;
+
+    this.blendMode(this._cachedBlendMode);
+    this._isErasing = false;
+  }
+};
+
 //////////////////////////////////////////////
 // IMAGE | Loading & Displaying
 //////////////////////////////////////////////
@@ -222,37 +253,6 @@ p5.Renderer2D.prototype.blend = function(...args) {
   }
   // reset to prior blend mode
   this.drawingContext.globalCompositeOperation = this._cachedBlendMode;
-};
-
-p5.Renderer2D.prototype.erase = function(opacityFill, opacityStroke) {
-  if (!this._isErasing) {
-    // cache the fill style
-    this._cachedFillStyle = this.drawingContext.fillStyle;
-    const newFill = this._pInst.color(255, opacityFill).toString();
-    this.drawingContext.fillStyle = newFill;
-
-    //cache the stroke style
-    this._cachedStrokeStyle = this.drawingContext.strokeStyle;
-    const newStroke = this._pInst.color(255, opacityStroke).toString();
-    this.drawingContext.strokeStyle = newStroke;
-
-    //cache blendMode
-    const tempBlendMode = this._cachedBlendMode;
-    this.blendMode(constants.REMOVE);
-    this._cachedBlendMode = tempBlendMode;
-
-    this._isErasing = true;
-  }
-};
-
-p5.Renderer2D.prototype.noErase = function() {
-  if (this._isErasing) {
-    this.drawingContext.fillStyle = this._cachedFillStyle;
-    this.drawingContext.strokeStyle = this._cachedStrokeStyle;
-
-    this.blendMode(this._cachedBlendMode);
-    this._isErasing = false;
-  }
 };
 
 p5.Renderer2D.prototype.copy = function(...args) {

--- a/src/core/p5.Renderer2D.js
+++ b/src/core/p5.Renderer2D.js
@@ -224,6 +224,37 @@ p5.Renderer2D.prototype.blend = function(...args) {
   this.drawingContext.globalCompositeOperation = this._cachedBlendMode;
 };
 
+p5.Renderer2D.prototype.erase = function(opacityFill, opacityStroke) {
+  if (!this._isErasing) {
+    // cache the fill style
+    this._cachedFillStyle = this.drawingContext.fillStyle;
+    const newFill = this._pInst.color(255, opacityFill).toString();
+    this.drawingContext.fillStyle = newFill;
+
+    //cache the stroke style
+    this._cachedStrokeStyle = this.drawingContext.strokeStyle;
+    const newStroke = this._pInst.color(255, opacityStroke).toString();
+    this.drawingContext.strokeStyle = newStroke;
+
+    //cache blendMode
+    const tempBlendMode = this._cachedBlendMode;
+    this.blendMode(constants.REMOVE);
+    this._cachedBlendMode = tempBlendMode;
+
+    this._isErasing = true;
+  }
+};
+
+p5.Renderer2D.prototype.noErase = function() {
+  if (this._isErasing) {
+    this.drawingContext.fillStyle = this._cachedFillStyle;
+    this.drawingContext.strokeStyle = this._cachedStrokeStyle;
+
+    this.blendMode(this._cachedBlendMode);
+    this._isErasing = false;
+  }
+};
+
 p5.Renderer2D.prototype.copy = function(...args) {
   let srcImage, sx, sy, sw, sh, dx, dy, dw, dh;
   if (args.length === 9) {

--- a/src/core/rendering.js
+++ b/src/core/rendering.js
@@ -250,6 +250,7 @@ p5.prototype.createGraphics = function(w, h, renderer) {
  * colors.</li>
  * <li><code>REPLACE</code> - the pixels entirely replace the others and
  * don't utilize alpha (transparency) values.</li>
+ * <li><code>REMOVE</code> - removes pixels from B with the alpha strength of A.</li>
  * <li><code>OVERLAY</code> - mix of <code>MULTIPLY</code> and <code>SCREEN
  * </code>. Multiplies dark values, and screens light values. <em>(2D)</em></li>
  * <li><code>HARD_LIGHT</code> - <code>SCREEN</code> when greater than 50%
@@ -272,7 +273,7 @@ p5.prototype.createGraphics = function(w, h, renderer) {
  * @param  {Constant} mode blend mode to set for canvas.
  *                either BLEND, DARKEST, LIGHTEST, DIFFERENCE, MULTIPLY,
  *                EXCLUSION, SCREEN, REPLACE, OVERLAY, HARD_LIGHT,
- *                SOFT_LIGHT, DODGE, BURN, ADD, or SUBTRACT
+ *                SOFT_LIGHT, DODGE, BURN, ADD, REMOVE or SUBTRACT
  * @example
  * <div>
  * <code>

--- a/src/webgl/3d_primitives.js
+++ b/src/webgl/3d_primitives.js
@@ -1484,6 +1484,10 @@ p5.RendererGL.prototype.image = function(
   dWidth,
   dHeight
 ) {
+  if (this._isErasing) {
+    this.blendMode(this._cachedBlendMode);
+  }
+
   this._pInst.push();
 
   this._pInst.texture(img);
@@ -1517,6 +1521,10 @@ p5.RendererGL.prototype.image = function(
   this.endShape(constants.CLOSE);
 
   this._pInst.pop();
+
+  if (this._isErasing) {
+    this.blendMode(constants.REMOVE);
+  }
 };
 
 export default p5;

--- a/src/webgl/material.js
+++ b/src/webgl/material.js
@@ -782,7 +782,7 @@ p5.RendererGL.prototype._applyColorBlend = function(colors) {
   const gl = this.GL;
 
   const isTexture = this.drawMode === constants.TEXTURE;
-  if (isTexture || colors[colors.length - 1] < 1.0) {
+  if (isTexture || colors[colors.length - 1] < 1.0 || this._isErasing) {
     gl.depthMask(isTexture);
     gl.enable(gl.BLEND);
     this._applyBlendMode();
@@ -805,6 +805,10 @@ p5.RendererGL.prototype._applyBlendMode = function() {
     case constants.ADD:
       gl.blendEquation(gl.FUNC_ADD);
       gl.blendFunc(gl.SRC_ALPHA, gl.ONE_MINUS_SRC_ALPHA);
+      break;
+    case constants.REMOVE:
+      gl.blendEquation(gl.FUNC_REVERSE_SUBTRACT);
+      gl.blendFunc(gl.SRC_ALPHA, gl.DST_ALPHA);
       break;
     case constants.MULTIPLY:
       gl.blendEquationSeparate(gl.FUNC_ADD, gl.FUNC_ADD);

--- a/src/webgl/p5.RendererGL.js
+++ b/src/webgl/p5.RendererGL.js
@@ -664,7 +664,7 @@ p5.RendererGL.prototype.erase = function(opacityFill, opacityStroke) {
     this._cachedBlendMode = this.curBlendMode;
     this.blendMode(constants.REMOVE);
 
-    this._cachedFillStyle[0] = this.curFillColor.slice();
+    this._cachedFillStyle = this.curFillColor.slice();
     this.curFillColor = [1, 1, 1, opacityFill / 255];
 
     this._cachedStrokeStyle = this.curStrokeColor.slice();

--- a/src/webgl/p5.RendererGL.js
+++ b/src/webgl/p5.RendererGL.js
@@ -65,6 +65,9 @@ p5.RendererGL = function(elt, pInst, isMainCanvas, attr) {
   this.isP3D = true; //lets us know we're in 3d mode
   this.GL = this.drawingContext;
 
+  // erasing
+  this._isErasing = false;
+
   // lights
   this._enableLighting = false;
 
@@ -90,6 +93,7 @@ p5.RendererGL = function(elt, pInst, isMainCanvas, attr) {
   this.curFillColor = [1, 1, 1, 1];
   this.curStrokeColor = [0, 0, 0, 1];
   this.curBlendMode = constants.BLEND;
+  this._cachedBlendMode = constants.BLEND;
   this.blendExt = this.GL.getExtension('EXT_blend_minmax');
 
   this._useSpecularMaterial = false;
@@ -637,7 +641,8 @@ p5.RendererGL.prototype.blendMode = function(mode) {
     mode === constants.SCREEN ||
     mode === constants.EXCLUSION ||
     mode === constants.REPLACE ||
-    mode === constants.MULTIPLY
+    mode === constants.MULTIPLY ||
+    mode === constants.REMOVE
   )
     this.curBlendMode = mode;
   else if (

--- a/src/webgl/p5.RendererGL.js
+++ b/src/webgl/p5.RendererGL.js
@@ -659,6 +659,31 @@ p5.RendererGL.prototype.blendMode = function(mode) {
   }
 };
 
+p5.RendererGL.prototype.erase = function(opacityFill, opacityStroke) {
+  if (!this._isErasing) {
+    this._cachedBlendMode = this.curBlendMode;
+    this.blendMode(constants.REMOVE);
+
+    this._cachedFillStyle[0] = this.curFillColor.slice();
+    this.curFillColor = [1, 1, 1, opacityFill / 255];
+
+    this._cachedStrokeStyle = this.curStrokeColor.slice();
+    this.curStrokeColor = [1, 1, 1, opacityStroke / 255];
+
+    this._isErasing = true;
+  }
+};
+
+p5.RendererGL.prototype.noErase = function() {
+  if (this._isErasing) {
+    this.curFillColor = this._cachedFillStyle.slice();
+    this.curStrokeColor = this._cachedStrokeStyle.slice();
+
+    this.blendMode(this._cachedBlendMode);
+    this._isErasing = false;
+  }
+};
+
 /**
  * Change weight of stroke
  * @method  strokeWeight

--- a/src/webgl/p5.RendererGL.js
+++ b/src/webgl/p5.RendererGL.js
@@ -90,10 +90,11 @@ p5.RendererGL = function(elt, pInst, isMainCanvas, attr) {
   this.spotLightConc = [];
 
   this.drawMode = constants.FILL;
-  this.curFillColor = [1, 1, 1, 1];
-  this.curStrokeColor = [0, 0, 0, 1];
-  this.curBlendMode = constants.BLEND;
-  this._cachedBlendMode = constants.BLEND;
+
+  this.curFillColor = this._cachedFillStyle = [1, 1, 1, 1];
+  this.curStrokeColor = this._cachedStrokeStyle = [0, 0, 0, 1];
+
+  this.curBlendMode = this._cachedBlendMode = constants.BLEND;
   this.blendExt = this.GL.getExtension('EXT_blend_minmax');
 
   this._useSpecularMaterial = false;

--- a/test/unit/color/setting.js
+++ b/test/unit/color/setting.js
@@ -1,18 +1,166 @@
 suite('color/Setting', function() {
-  // p5 instance
-  var myp5;
-
+  let myp5; // sketch without WEBGL Mode
+  let my3D; // skecth with WEBGL mode
   setup(function(done) {
     new p5(function(p) {
       p.setup = function() {
         myp5 = p;
-        done();
       };
     });
+    new p5(function(p) {
+      p.setup = function() {
+        p.createCanvas(100, 100, p.WEBGL);
+        my3D = p;
+      };
+    });
+    done();
   });
 
   teardown(function() {
     myp5.remove();
+    my3D.remove();
+  });
+
+  suite('p5.prototype.erase', function() {
+    test('should be a function', function() {
+      assert.ok(myp5.erase);
+    });
+
+    test('should set renderer to erasing state', function() {
+      myp5.erase();
+      assert.isTrue(myp5._renderer._isErasing);
+    });
+
+    test('should cache renderer fill', function() {
+      myp5.fill(255, 0, 0);
+      const fillStyle = myp5.drawingContext.fillStyle;
+      myp5.erase();
+      assert.deepEqual(myp5._renderer._cachedFillStyle, fillStyle);
+    });
+
+    test('should cache renderer stroke', function() {
+      myp5.stroke(255, 0, 0);
+      const strokeStyle = myp5.drawingContext.strokeStyle;
+      myp5.erase();
+      assert.deepEqual(myp5._renderer._cachedStrokeStyle, strokeStyle);
+    });
+
+    test('should cache renderer blend', function() {
+      myp5.blendMode(myp5.SCREEN);
+      myp5.erase();
+      assert.deepEqual(myp5._renderer._cachedBlendMode, myp5.SCREEN);
+    });
+
+    test('should set fill strength', function() {
+      myp5.erase(125);
+      assert.equal(
+        myp5.color(myp5.drawingContext.fillStyle).array,
+        myp5.color(255, 125).array
+      );
+    });
+
+    test('should set stroke strength', function() {
+      myp5.erase(255, 50);
+      assert.equal(
+        myp5.color(myp5.drawingContext.strokeStyle).array,
+        myp5.color(255, 50).array
+      );
+    });
+  });
+
+  suite('p5.RendererGL.prototype.erase', function() {
+    test('should set renderer to erasing state', function() {
+      my3D.erase();
+      assert.isTrue(my3D._renderer._isErasing);
+    });
+
+    test('should cache renderer fill', function() {
+      my3D.fill(255, 0, 0);
+      const curFillColor = my3D._renderer.curFillColor;
+      my3D.erase();
+      assert.deepEqual(my3D._renderer._cachedFillStyle, curFillColor);
+    });
+
+    test('should cache renderer stroke', function() {
+      my3D.stroke(255, 0, 0);
+      const strokeStyle = my3D._renderer.curStrokeColor;
+      my3D.erase();
+      assert.deepEqual(my3D._renderer._cachedStrokeStyle, strokeStyle);
+    });
+
+    test('should cache renderer blend', function() {
+      my3D.blendMode(my3D.SCREEN);
+      my3D.erase();
+      assert.deepEqual(my3D._renderer._cachedBlendMode, my3D.SCREEN);
+    });
+
+    test('should set fill strength', function() {
+      my3D.erase(125);
+      assert.deepEqual(my3D._renderer.curFillColor, [1, 1, 1, 125 / 255]);
+    });
+
+    test('should set stroke strength', function() {
+      my3D.erase(255, 50);
+      assert.deepEqual(my3D._renderer.curStrokeColor, [1, 1, 1, 50 / 255]);
+    });
+
+    test('should set default values when no arguments', function() {
+      my3D.erase();
+      assert.deepEqual(my3D._renderer.curFillColor, [1, 1, 1, 1]);
+      assert.deepEqual(my3D._renderer.curStrokeColor, [1, 1, 1, 1]);
+    });
+  });
+
+  suite('p5.prototype.noErase', function() {
+    test('should be a function', function() {
+      assert.ok(myp5.noErase);
+    });
+
+    test('should turn off renderer erasing state', function() {
+      myp5.erase();
+      myp5.noErase();
+      assert.isFalse(myp5._renderer._isErasing);
+    });
+
+    test('should restore cached renderer fill', function() {
+      myp5.fill(255, 0, 0);
+      const fillStyle = myp5.drawingContext.fillStyle;
+      myp5.erase();
+      myp5.noErase();
+      assert.deepEqual(myp5.drawingContext.fillStyle, fillStyle);
+    });
+
+    test('should restore cached renderer stroke', function() {
+      myp5.stroke(255, 0, 0);
+      const strokeStyle = myp5.drawingContext.strokeStyle;
+      myp5.erase();
+      myp5.noErase();
+      assert.deepEqual(myp5.drawingContext.strokeStyle, strokeStyle);
+    });
+  });
+
+  suite('p5.RendererGL.prototype.noErase', function() {
+    test('should turn off renderer erasing state', function() {
+      my3D.erase();
+      my3D.noErase();
+      assert.isFalse(my3D._renderer._isErasing);
+    });
+
+    test('should restore cached renderer fill', function() {
+      my3D.fill(255, 0, 0);
+      const fillStyle = my3D._renderer.curFillColor.slice();
+      my3D.erase();
+      my3D.noErase();
+      assert.deepEqual([1, 0, 0, 1], fillStyle);
+    });
+
+    test('should restore cached renderer stroke', function() {
+      my3D.stroke(255, 0, 0);
+      const strokeStyle = my3D._renderer.curStrokeColor.slice();
+      my3D.erase();
+      my3D.noErase();
+      assert.deepEqual([1, 0, 0, 1], strokeStyle);
+    });
   });
 
   suite('p5.prototype.colorMode', function() {

--- a/test/unit/color/setting.js
+++ b/test/unit/color/setting.js
@@ -1,6 +1,6 @@
 suite('color/Setting', function() {
   let myp5; // sketch without WEBGL Mode
-  let my3D; // skecth with WEBGL mode
+  let my3D; // sketch with WEBGL mode
   setup(function(done) {
     new p5(function(p) {
       p.setup = function() {


### PR DESCRIPTION
closes #3759 

I have an [early example in the editor here](https://editor.p5js.org/stalgiag/sketches/1WJC1MtvS). This opens up some neat opportunities for layering graphics, and exposing hidden HTML elements behind the canvas.

#### Currently:
  1. `erase()` activates a state in which all drawing (see 3. for exceptions) is subtractive from its destination canvas
  2. `noErase()` deactivates  that state
  3. `image()` and `background()` do not become erasers during the `erase()` state. This is consistent with `fill()` and prevents behavior that will rarely be desired (using the background or image as an eraser). If someone still wants that behavior they can use `blendMode(REMOVE)` which is added with this PR.
  4. In order to accomplish 3, the most recent change to the `globalCompositingOperation` is stored as `p5.Renderer2D._cachedBlendMode`
  5. The strength (or opacity) of the erasing is dictating by the current fill and stroke color
  6. **No docs/examples/tests yet**
  7. ~~No WEBGL erasing. This might be difficult due to the clearing style of WEBGL. I can give it a shot though.~~

#### Open Questions:
  1. Do we like this interface? ie `erase()`/`noErase()` as opposed to other options (see discussion in issue at top)
  2. Related to 5 above, should the strength of the erase be based on current fill, or should `erase()` accept a parameter of a number between 0 - 255?
  3. Currently `stroke()` also erases. Should we keep this behavior?

#### My opinions
  1. There may be use cases I am missing, but this combined with the option for `blendMode(REMOVE)` seems to work nicely.
  2. Requiring a parameter makes sense  to me(ala `fill()`) but this contradicts my answer to 3 below.
  3. I like that it is possible to erase with `stroke()`. This may create unexpected effects at first but is relatively intuitive and offers a lot of flexibility. Adding a parameter is complicated by this though.