### PR TITLE
Clarified in the documentation that angles also grow clockwise for arc().

### DIFF
--- a/src/core/shape/2d_primitives.js
+++ b/src/core/shape/2d_primitives.js
@@ -105,7 +105,10 @@ p5.prototype._normalizeArcAngles = (
  * The arc is always drawn clockwise from wherever start falls to wherever stop falls on the ellipse.
  * Adding or subtracting TWO_PI to either angle does not change where they fall.
  * If both start and stop fall at the same place, a full ellipse will be drawn. Be aware that the the
- * y-axis increases in the downward direction therefore the values of PI is counter clockwise.
+ * y-axis increases in the downward direction, therefore angles are measured clockwise from the positive
+ * x-direction ("3 o'clock").
+
+
  * @method arc
  * @param  {Number} x      x-coordinate of the arc's ellipse
  * @param  {Number} y      y-coordinate of the arc's ellipse


### PR DESCRIPTION
Addresses #3373, specifically comment https://github.com/processing/p5.js/issues/3733#issuecomment-531463288