### PR TITLE
Use reject in mocha testing promise

### DIFF
--- a/tasks/test/mocha-chrome.js
+++ b/tasks/test/mocha-chrome.js
@@ -59,11 +59,11 @@ module.exports = function(grunt) {
             eventHandler1.emit.bind(eventHandler1)
           );
 
-          await new Promise(async resolve => {
+          await new Promise(async (resolve, reject) => {
             eventHandler1.on('mocha:end', async results => {
               const { stats, coverage } = results;
               if (stats.failures) {
-                throw new Error(stats);
+                reject(stats);
               }
               await saveCoverage(coverage);
               resolve(stats);


### PR DESCRIPTION
closes #4000 

The issue above was throwing some wrenches in #3978, so I got a little curious and did a `git bisect`.

Based on that, I think it was something in [this commit](https://github.com/stalgiag/p5.js/commit/894489b0f22b6bbfb8ec48131733548ac6c0ecef). I guessed that it was the `Throw` replacement of `reject`. I think this promise is in a nested async callback, with the parent being `grunt.registerMultiTask( ... async function()`  so `Throw` doesn't [work the same as `reject`](https://stackoverflow.com/questions/33445415/javascript-promises-reject-vs-throw). 

@outofambit does this seem right? Not my most familiar area but it was fun to look around a bit.