### PR TITLE
Raise float precision in phong frag shader

### DIFF
--- a/src/webgl/shaders/phong.frag
+++ b/src/webgl/shaders/phong.frag
@@ -1,4 +1,5 @@
-// include lighting.glgl
+// include lighting.glsl
+precision highp float;
 
 uniform vec4 uMaterialColor;
 uniform sampler2D uSampler;


### PR DESCRIPTION
closes #4024 (hopefully)

Potentially related to #4023 

I have only tested on Android 8.0 but high float precision in `phong.frag` fixes per-pixel lighting on this device.