### PR TITLE
Use random(arr) in loadStrings() inline example

### DIFF
--- a/src/io/files.js
+++ b/src/io/files.js
@@ -216,8 +216,7 @@ p5.prototype.loadJSON = function(...args) {
 
  * function setup() {
  *   background(200);
- *   let ind = floor(random(result.length));
- *   text(result[ind], 10, 10, 80, 80);
+ *   text(random(result), 10, 10, 80, 80);
  * }
  * </code></div>
  *
@@ -231,8 +230,7 @@ p5.prototype.loadJSON = function(...args) {
  *
  * function pickString(result) {
  *   background(200);
- *   let ind = floor(random(result.length));
- *   text(result[ind], 10, 10, 80, 80);
+ *   text(random(result), 10, 10, 80, 80);
  * }
  * </code></div>
  *


### PR DESCRIPTION
Switched the examples loadStrings() from the inline docs
to use random(arr) rather than ix = floor(random(arr.length)) etc

This makes it simpler to read and the intention clearer to grasp.