### PR TITLE
[feature] Mark strokeJoin as not implemented in WebGL Renderer 

### DIFF
--- a/src/webgl/p5.RendererGL.js
+++ b/src/webgl/p5.RendererGL.js
@@ -632,6 +632,12 @@ p5.RendererGL.prototype.strokeCap = cap => {
   console.error('Sorry, strokeCap() is not yet implemented in WEBGL mode');
 };
 
+p5.RendererGL.prototype.strokeJoin = join => {
+  // @TODO : to be implemented
+  // https://processing.org/reference/strokeJoin_.html
+  console.error('Sorry, strokeJoin() is not yet implemented in WEBGL mode');
+};
+
 p5.RendererGL.prototype.blendMode = function(mode) {
   if (
     mode === constants.DARKEST ||


### PR DESCRIPTION
## Notes

- Addresses issue #4047
- Used `console.error` rather than `console.warn` for consistency with how we handled this for the `strokeCap` function immediately above this one.