### PR TITLE
Get rid of _pixelsDirty and _pixelsTime

### DIFF
--- a/src/core/environment.js
+++ b/src/core/environment.js
@@ -599,7 +599,6 @@ p5.prototype.pixelDensity = function(val) {
   if (typeof val === 'number') {
     if (val !== this._pixelDensity) {
       this._pixelDensity = val;
-      this._pixelsDirty = true;
     }
     returnValue = this;
     this.resizeCanvas(this.width, this.height, true); // as a side effect, it will clear the canvas

--- a/src/core/main.js
+++ b/src/core/main.js
@@ -576,8 +576,6 @@ class p5 {
       hsl: [360, 100, 100, 1]
     };
 
-    this._pixelsDirty = true;
-
     this._downKeys = {}; //Holds the key codes of currently pressed keys
   }
 

--- a/src/dom/dom.js
+++ b/src/dom/dom.js
@@ -2224,8 +2224,6 @@ p5.MediaElement = function(elt, pInst) {
   this._pixelsState = this;
   this._pixelDensity = 1;
   this._modified = false;
-  this._pixelsDirty = true;
-  this._pixelsTime = -1; // the time at which we last updated 'pixels'
 
   /**
    * Path to the media element source.
@@ -2877,25 +2875,16 @@ p5.MediaElement.prototype._ensureCanvas = function() {
       this.canvas.height = this.elt.height;
       this.width = this.canvas.width;
       this.height = this.canvas.height;
-      this._pixelsDirty = true;
     }
 
-    var currentTime = this.elt.currentTime;
-    if (this._pixelsDirty || this._pixelsTime !== currentTime) {
-      // only update the pixels array if it's dirty, or
-      // if the video time has changed.
-      this._pixelsTime = currentTime;
-      this._pixelsDirty = true;
-
-      this.drawingContext.drawImage(
-        this.elt,
-        0,
-        0,
-        this.canvas.width,
-        this.canvas.height
-      );
-      this.setModified(true);
-    }
+    this.drawingContext.drawImage(
+      this.elt,
+      0,
+      0,
+      this.canvas.width,
+      this.canvas.height
+    );
+    this.setModified(true);
   }
 };
 p5.MediaElement.prototype.loadPixels = function() {

--- a/src/image/p5.Image.js
+++ b/src/image/p5.Image.js
@@ -145,7 +145,6 @@ p5.Image = function(width, height) {
   this.drawingContext = this.canvas.getContext('2d');
   this._pixelsState = this;
   this._pixelDensity = 1;
-  this._pixelsDirty = true;
   //Object for working with GIFs, defaults to null
   this.gifProperties = null;
   //For WebGL Texturing only: used to determine whether to reupload texture to GPU
@@ -242,7 +241,6 @@ p5.Image.prototype._animateGif = function(pInst) {
       const ind = props.displayIndex % props.numFrames;
       this.drawingContext.putImageData(props.frames[ind], 0, 0);
       props.displayIndex = ind;
-      this._pixelsDirty = true;
       this.setModified(true);
     }
   }
@@ -547,7 +545,6 @@ p5.Image.prototype.resize = function(width, height) {
   }
 
   this.setModified(true);
-  this._pixelsDirty = true;
 };
 
 /**

--- a/src/image/pixels.js
+++ b/src/image/pixels.js
@@ -255,8 +255,6 @@ p5.prototype.copy = function(...args) {
   }
 
   p5.prototype._copyHelper(this, srcImage, sx, sy, sw, sh, dx, dy, dw, dh);
-
-  this._pixelsDirty = true;
 };
 
 p5.prototype._copyHelper = (

--- a/src/webgl/p5.RendererGL.Immediate.js
+++ b/src/webgl/p5.RendererGL.Immediate.js
@@ -333,8 +333,6 @@ p5.RendererGL.prototype._drawFillImmediateMode = function(
       0,
       this.immediateMode.vertices.length
     );
-
-    this._pixelsState._pixelsDirty = true;
   }
   // todo / optimizations? leave bound until another shader is set?
   shader.unbindShader();
@@ -372,8 +370,6 @@ p5.RendererGL.prototype._drawStrokeImmediateMode = function() {
 
   this._applyColorBlend(this.curStrokeColor);
   gl.drawArrays(gl.TRIANGLES, 0, this.immediateMode.lineVertices.length);
-
-  this._pixelsState._pixelsDirty = true;
 
   shader.unbindShader();
 };

--- a/src/webgl/p5.RendererGL.Retained.js
+++ b/src/webgl/p5.RendererGL.Retained.js
@@ -240,7 +240,6 @@ p5.RendererGL.prototype.drawBuffersScaled = function(
 
 p5.RendererGL.prototype._drawArrays = function(drawMode, gId) {
   this.GL.drawArrays(drawMode, 0, this.gHash[gId].lineVertexCount);
-  this._pixelsState._pixelsDirty = true;
   return this;
 };
 
@@ -255,7 +254,6 @@ p5.RendererGL.prototype._drawElements = function(drawMode, gId) {
     // drawing vertices
     gl.drawArrays(drawMode || gl.TRIANGLES, 0, buffers.vertexCount);
   }
-  this._pixelsState._pixelsDirty = true;
 };
 
 p5.RendererGL.prototype._drawPoints = function(vertices, vertexBuffer) {
@@ -276,7 +274,6 @@ p5.RendererGL.prototype._drawPoints = function(vertices, vertexBuffer) {
   gl.drawArrays(gl.Points, 0, vertices.length);
 
   pointShader.unbindShader();
-  this._pixelsState._pixelsDirty = true;
 };
 
 export default p5.RendererGL;

--- a/src/webgl/p5.RendererGL.js
+++ b/src/webgl/p5.RendererGL.js
@@ -540,7 +540,6 @@ p5.RendererGL.prototype.background = function(...args) {
   this.GL.clearColor(_r, _g, _b, _a);
   this.GL.depthMask(true);
   this.GL.clear(this.GL.COLOR_BUFFER_BIT | this.GL.DEPTH_BUFFER_BIT);
-  this._pixelsState._pixelsDirty = true;
 };
 
 //////////////////////////////////////////////
@@ -733,21 +732,15 @@ p5.RendererGL.prototype.strokeWeight = function(w) {
 
 // x,y are canvas-relative (pre-scaled by _pixelDensity)
 p5.RendererGL.prototype._getPixel = function(x, y) {
-  const pixelsState = this._pixelsState;
   let imageData, index;
-  if (pixelsState._pixelsDirty) {
-    imageData = new Uint8Array(4);
-    // prettier-ignore
-    this.drawingContext.readPixels(
+  imageData = new Uint8Array(4);
+  // prettier-ignore
+  this.drawingContext.readPixels(
       x, y, 1, 1,
       this.drawingContext.RGBA, this.drawingContext.UNSIGNED_BYTE,
       imageData
     );
-    index = 0;
-  } else {
-    imageData = pixelsState.pixels;
-    index = (Math.floor(x) + Math.floor(y) * this.canvas.width) * 4;
-  }
+  index = 0;
   return [
     imageData[index + 0],
     imageData[index + 1],
@@ -768,8 +761,6 @@ p5.RendererGL.prototype._getPixel = function(x, y) {
 
 p5.RendererGL.prototype.loadPixels = function() {
   const pixelsState = this._pixelsState;
-  if (!pixelsState._pixelsDirty) return;
-  pixelsState._pixelsDirty = false;
 
   //@todo_FES
   if (this._pInst._glAttributes.preserveDrawingBuffer !== true) {
@@ -825,7 +816,6 @@ p5.RendererGL.prototype.resize = function(w, h) {
 
   //resize pixels buffer
   const pixelsState = this._pixelsState;
-  pixelsState._pixelsDirty = true;
   if (typeof pixelsState.pixels !== 'undefined') {
     pixelsState._setProperty(
       'pixels',
@@ -852,7 +842,6 @@ p5.RendererGL.prototype.clear = function(...args) {
   const _a = args[3] || 0;
   this.GL.clearColor(_r, _g, _b, _a);
   this.GL.clear(this.GL.COLOR_BUFFER_BIT | this.GL.DEPTH_BUFFER_BIT);
-  this._pixelsState._pixelsDirty = true;
 };
 
 p5.RendererGL.prototype.applyMatrix = function(a, b, c, d, e, f) {

--- a/src/webgl/text.js
+++ b/src/webgl/text.js
@@ -741,6 +741,5 @@ p5.RendererGL.prototype._renderText = function(p, line, x, y, maxY) {
     p.pop();
   }
 
-  this._pixelsState._pixelsDirty = true;
   return p;
 };


### PR DESCRIPTION
Resolves #3741 

#### Changes: 
Removes `_pixelsDirty` and `_pixelsTime`. 

These were optimization that prevented functions such as `get()` and `loadPixels()` from updating the `pixels` array unless a visual change had occurred. These visual changes were tracked by setting `pixelsDirty` to true with every drawing function with all canvas. And checking for differences between `MediaElement.elt.currentTime` and `pixelsTime` with all video elements.

Both of these approaches were prone to breaking. In a discussion in #3741 it was decided that the gains in optimization are not worth the difficulty in maintaining. 

It is worth noting that for 99% of sketches, this optimization was not necessary. The only sketches that would have benefited from this optimization were sketches in which the user only modifies the drawing in the canvas sometimes, but loads the pixels constantly. I think the user can be relied on to handle this optimization if they desire.

#### PR Checklist
<!--
  To check any option, replace the "[ ]" with a "[x]". Be sure to check out how it looks in the Preview tab! Feel free to remove any portion of the template that is not relevant for your issue.
-->

- [x] `npm run lint` passes
- [ ] [Inline documentation] is included / updated
- [ ] [Unit tests] are included / updated
- [ ] [Benchmarks] are included / updated
