### PR TITLE
added option for textToPoints() to allow separated paths

### DIFF
--- a/src/core/shape/2d_primitives.js
+++ b/src/core/shape/2d_primitives.js
@@ -560,6 +560,10 @@ p5.prototype.rect = function() {
   p5._validateParameters('rect', arguments);
 
   if (this._renderer._doStroke || this._renderer._doFill) {
+    if (arguments.length === 3) {
+      arguments[3] = arguments[2];
+    }
+
     const vals = canvas.modeAdjust(
       arguments[0],
       arguments[1],
@@ -567,6 +571,7 @@ p5.prototype.rect = function() {
       arguments[3],
       this._renderer._rectMode
     );
+
     const args = [vals.x, vals.y, vals.w, vals.h];
     // append the additional arguments (either cornder radii, or
     // segment details) to the argument list


### PR DESCRIPTION
Resolves #4086 

 Changes: 
Adds additional option for `textToPoints()`, called `separatePaths: true`, which will instead export a 2D Array `[paths][points]` rather than only the current 1D Array `[points]`. An example has also been added to demonstrate how one should use it.


 Screenshots of the change: 
<img width="545" alt="textToPoints_update" src="https://user-images.githubusercontent.com/570957/66864013-8958b080-ef94-11e9-849b-89017b98b620.png">

`textToPoints()` with 1D array (current function):
<img width="100" alt="textToPoints_1d_array" src="https://user-images.githubusercontent.com/570957/66864044-9aa1bd00-ef94-11e9-8d75-e2b9edfe5d85.png">
`textToPoints()` with 2D array (proposed update):
<img width="104" alt="textToPoints_2d_array" src="https://user-images.githubusercontent.com/570957/66864058-a55c5200-ef94-11e9-86a5-bc95bb789bfd.png">


#### PR Checklist
- [x] `npm run lint` passes
- [x] [Inline documentation] is included / updated
- [ ] [Unit tests] are included / updated
- [ ] [Benchmarks] are included / updated

#### Question
Regarding the JSDoc, not sure how to deal with the fact the `@return` changes if requesting separatePaths? Hopefully it's clear from the description of that option and example, but maybe there's a format for suggesting a 2nd type of return if the option is set?