### PR TITLE
Changes html() to user Javascript insertAdjacentHTML instead of innerHTML

### DIFF
--- a/src/dom/dom.js
+++ b/src/dom/dom.js
@@ -1612,7 +1612,7 @@ p5.Element.prototype.html = function() {
   if (arguments.length === 0) {
     return this.elt.innerHTML;
   } else if (arguments[1]) {
-    this.elt.innerHTML += arguments[0];
+    this.elt.insertAdjacentHTML('beforeend', arguments[0]);
     return this;
   } else {
     this.elt.innerHTML = arguments[0];

--- a/src/dom/dom.js
+++ b/src/dom/dom.js
@@ -1118,10 +1118,10 @@ p5.prototype.createVideo = function(src, callback) {
 
 /**
  * Creates a hidden HTML5 &lt;audio&gt; element in the DOM for simple audio
- * playback. The first parameter can be either a single string path to a 
+ * playback. The first parameter can be either a single string path to a
  * audio file, or an array of string paths to different formats of the same
- * audio. This is useful for ensuring that your audio can play across 
- * different browsers, as each supports different formats. 
+ * audio. This is useful for ensuring that your audio can play across
+ * different browsers, as each supports different formats.
  * See <a href='https://developer.mozilla.org/en-US/docs/Web/HTML/Supported_media_formats'>this
  * page for further information about supported formats</a>.
  *

--- a/test/manual-test-examples/dom/html/index.html
+++ b/test/manual-test-examples/dom/html/index.html
@@ -1,0 +1,8 @@
+<head>
+  <script language="javascript" type="text/javascript" src="../../../../../lib/p5.js"></script>
+  <script language="javascript" type="text/javascript" src="sketch.js"></script>        
+</head>
+
+<body>
+	<div id="test"></div>
+</body>

--- a/test/manual-test-examples/dom/html/sketch.js
+++ b/test/manual-test-examples/dom/html/sketch.js
@@ -1,0 +1,22 @@
+let canvas;
+let canvasContainer;
+
+function setup() {
+  canvasContainer = createDiv('<p>Canvas will be added to this container</p>');
+  canvas = createCanvas(200, 200);
+  canvas.parent(canvasContainer);
+  ellipseMode(CENTER);
+}
+
+function draw() {
+  background(0);
+  translate(100, 100);
+  let t = millis() / 500;
+  circle(50 * sin(t), 50 * cos(t), 100);
+}
+
+function keyPressed() {
+  //Calling html('something', 'true') on the
+  //div containing the sketch shall **not** break the animation
+  canvasContainer.html('<p>New line with p5.js html() function</p>', true);
+}


### PR DESCRIPTION
Resolves #4064 

Unit tests were not implemented. If others have recommendations on how to do implement a "animation still works"-kind of test I'm happy to implement it.  This particular bug does not cause an exception to be thrown and is a side effect of using innerHTML.

 Changes: 
Change p5.dom.js `html()` function to use [insertAdjacentHTML](https://developer.mozilla.org/en-US/docs/Web/API/Element/insertAdjacentHTML) instead of appending to innerHTML using `+=`.

#### PR Checklist
- [x] `npm run lint` passes
- [] [Inline documentation] is included / updated
  Documentation was correct; bug was only in the implementation
- [] [Unit tests] are included / updated
   Unit tests **not** implemented, however a manual test was added to `manual-test-examples/dom/html` following the other examples. 
- [ ] [Benchmarks] are included / updated

[Inline documentation]: https://github.com/processing/p5.js/blob/master/developer_docs/inline_documentation.md
[Unit tests]: https://github.com/processing/p5.js/tree/master/developer_docs#unit-tests
[Benchmarks]: https://github.com/processing/p5.js/blob/master/developer_docs/benchmarking_p5.md
