### PR TITLE
Safer content-type checking and warning for images with no header.

### DIFF
--- a/src/image/loading_displaying.js
+++ b/src/image/loading_displaying.js
@@ -74,7 +74,13 @@ p5.prototype.loadImage = function(path, successCallback, failureCallback) {
 
   fetch(path, req).then(response => {
     // GIF section
-    if (response.headers.get('content-type').includes('image/gif')) {
+    const contentType = response.headers.get('content-type');
+    if (contentType === null) {
+      console.warn(
+        'The image you loaded does not have a Content-Type header. If you are using the online editor consider reuploading the asset.'
+      );
+    }
+    if (contentType && contentType.includes('image/gif')) {
       response.arrayBuffer().then(
         arrayBuffer => {
           if (arrayBuffer) {


### PR DESCRIPTION

**Related to [discussion on the editor repo.](https://github.com/processing/p5.js-web-editor/pull/1200#issuecomment-545170925)**

 Changes: 
<!-- Add here what changes were made in this pull request and if possible provide links showcasing the changes. -->

Adds console warning for loading images without headers.

Additionally, the content-type check during image loading is now null-safe.

#### PR Checklist
<!--
  To check any option, replace the "[ ]" with a "[x]". Be sure to check out how it looks in the Preview tab! Feel free to remove any portion of the template that is not relevant for your issue.
-->

- [x] `npm run lint` passes
- [ ] [Inline documentation] is included / updated
- [ ] [Unit tests] are included / updated
- [ ] [Benchmarks] are included / updated
