### PR TITLE
friendly autoplay warning

### DIFF
--- a/src/core/error_helpers.js
+++ b/src/core/error_helpers.js
@@ -218,6 +218,19 @@ if (typeof IS_MINIFIED !== 'undefined') {
     report(message, method);
   };
 
+  /**
+   * This is called internally if there is a error with autoplay.
+   *
+   * @method _friendlyAutoplayError
+   * @private
+   */
+  p5._friendlyAutoplayError = src => {
+    report(
+      `The media that tried to play (with "${src}") wasn't allowed to by this browser, most likely due to the browser's autoplay policy. Check out https://developer.mozilla.org/en-US/docs/Web/Media/Autoplay_guide for more information about why.`,
+      'autoplay'
+    );
+  };
+
   const docCache = {};
   const builtinTypes = [
     'null',

--- a/src/core/error_helpers.js
+++ b/src/core/error_helpers.js
@@ -137,7 +137,8 @@ if (typeof IS_MINIFIED !== 'undefined') {
     }
   };
 
-  const errorCases = {
+  // mapping used by `_friendlyFileLoadError`
+  const fileLoadErrorCases = {
     '0': {
       fileType: 'image',
       method: 'loadImage',
@@ -191,7 +192,7 @@ if (typeof IS_MINIFIED !== 'undefined') {
    * @param  {String} filePath
    */
   p5._friendlyFileLoadError = (errorType, filePath) => {
-    const errorInfo = errorCases[errorType];
+    const errorInfo = fileLoadErrorCases[errorType];
     let message;
     if (errorType === 7 || errorType === 8) {
       message = errorInfo.message;

--- a/src/dom/dom.js
+++ b/src/dom/dom.js
@@ -2322,10 +2322,18 @@ p5.MediaElement.prototype.play = function() {
   }
   if (promise && promise.catch) {
     promise.catch(function(e) {
-      console.log(
-        'WARN: Element play method raised an error asynchronously',
-        e
-      );
+      // if it's an autoplay failure error
+      if (e.name === 'NotAllowedError') {
+        p5._friendlyError(
+          `The media that tried to play (with "${
+            this.src
+          }") wasn't allowed to by this browser, most likely due to the browser's autoplay policy. Check out https://developer.mozilla.org/en-US/docs/Web/Media/Autoplay_guide for more information about why.`,
+          'play'
+        );
+      } else {
+        // any other kind of error
+        console.error('Media play method encountered an unexpected error', e);
+      }
     });
   }
   return this;

--- a/src/dom/dom.js
+++ b/src/dom/dom.js
@@ -2324,12 +2324,7 @@ p5.MediaElement.prototype.play = function() {
     promise.catch(function(e) {
       // if it's an autoplay failure error
       if (e.name === 'NotAllowedError') {
-        p5._friendlyError(
-          `The media that tried to play (with "${
-            this.src
-          }") wasn't allowed to by this browser, most likely due to the browser's autoplay policy. Check out https://developer.mozilla.org/en-US/docs/Web/Media/Autoplay_guide for more information about why.`,
-          'play'
-        );
+        p5._friendlyAutoplayError(this.src);
       } else {
         // any other kind of error
         console.error('Media play method encountered an unexpected error', e);

--- a/src/dom/dom.js
+++ b/src/dom/dom.js
@@ -2594,12 +2594,14 @@ p5.MediaElement.prototype.autoplay = function(val) {
   this.elt.setAttribute('autoplay', val);
   // if we turned on autoplay
   if (val && !oldVal) {
+    // bind method to this scope
+    const setupAutoplayFailDetection = () => this._setupAutoplayFailDetection();
     // if media is ready to play, schedule check now
     if (this.elt.readyState === 4) {
-      this._setupAutoplayFailDetection();
+      setupAutoplayFailDetection();
     } else {
       // otherwise, schedule check whenever it is ready
-      this.elt.addEventListener('canplay', this._setupAutoplayFailDetection, {
+      this.elt.addEventListener('canplay', setupAutoplayFailDetection, {
         passive: true,
         once: true
       });


### PR DESCRIPTION
Resolves #3368 

## Changes

Covers two possible ways to have autoplay fail:
- from a programmatic call to `play()`
  - this was pretty straightforward, as this error is explicitly thrown by the browser if the play violates the autoplay policy
- setting `autoplay(true)`, which instructs the browser to autoplay as soon as its ready
  - this was a bit more involved, as there is no event you can listen for this kind of failure. i've written logic that takes a best guess—if autoplay is enabled, it waits for the media to be loaded enough to play, and then sends an error message if the media _doesn't_ actually play in the next half second.

#### PR Checklist

- [x] `npm run lint` passes
- [x] [Inline documentation] is included / updated
