### PR TITLE
p5.dom links cleanup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,7 +5,6 @@ experiments/*
 lib_old/*
 lib/p5.*
 lib/modules
-lib/addons/p5.dom.min.js
 docs/reference/*
 !*.gitkeep
 examples/3d/

--- a/developer_docs/creating_libraries.md
+++ b/developer_docs/creating_libraries.md
@@ -9,7 +9,7 @@ There are a lot of different ways to write and use JavaScript, so we leave this 
 ## Code
 
 ### You can extend p5 core functionality by adding methods to p5.prototype.
-For example, the following code in p5.dom.js extends p5 to add a `createImg()` method that adds an [HTMLImageElement](https://developer.Mozilla.org/en-US/docs/Web/API/HTMLImageElement) to the DOM. 
+For example, the following code in dom.js extends p5 to add a `createImg()` method that adds an [HTMLImageElement](https://developer.Mozilla.org/en-US/docs/Web/API/HTMLImageElement) to the DOM. 
 
   ```js
   p5.prototype.createImg = function (src) {
@@ -23,7 +23,7 @@ For example, the following code in p5.dom.js extends p5 to add a `createImg()` m
   When the DOM library is included in a project, `createImg()` can be called just like `createCanvas()` or `background()`.
 
 ### Use private functions for internal helpers.
-Functions not intended to be called by users. In the example above `addElement()` is an internal function in [p5.dom.js](https://GitHub.com/processing/p5.js/blob/master/lib/addons/p5.dom.js). It isn't publicly bound to `p5.prototype` though.
+Functions not intended to be called by users. In the example above `addElement()` is an internal function in [dom.js](https://GitHub.com/processing/p5.js/blob/master/src/dom/dom.js). It isn't publicly bound to `p5.prototype` though.
 
 ### You can extend p5.js classes as well, by adding methods to their prototypes.
 In the example below, `p5.Element.prototype` is extended with the `html()` method, that sets the inner html of the element.
@@ -110,7 +110,7 @@ Your library may not extend p5 or p5 classes at all, but instead just offer extr
 
 * **Classes are typically capitalized, and methods and properties begin with lowercase.** Classes in p5 are prefixed with p5. We would like to keep this namespace for p5 core classes only, so when you create your own, **do not include the p5. prefix for class names**. You are welcome to create your own prefix, or just give them non-prefixed names.
 
-* **p5.js library filenames are also prefixed with p5, but the next word is lowercase**, to distinguish them from classes. For example, p5.dom.js and p5.sound.js. You are encouraged to follow this format for naming your file.
+* **p5.js library filenames are also prefixed with p5, but the next word is lowercase**, to distinguish them from classes. For example, p5.sound.js. You are encouraged to follow this format for naming your file.
 
 
 ## Packaging

--- a/docs/yuidoc-p5-theme/helpers/helpers_dev.js
+++ b/docs/yuidoc-p5-theme/helpers/helpers_dev.js
@@ -7,8 +7,7 @@ var configHelpers = {};
 var config = {
   p5SiteRoot: 'http://staging.p5js.org',
   p5Lib: '/lib/p5.min.js',
-  p5SoundLib: '/lib/addons/p5.sound.min.js',
-  p5DomLib: '/lib/addons/p5.dom.min.js'
+  p5SoundLib: '/lib/addons/p5.sound.min.js'
 };
 
 Object.keys(config).forEach(function(key) {

--- a/docs/yuidoc-p5-theme/helpers/helpers_prod.js
+++ b/docs/yuidoc-p5-theme/helpers/helpers_prod.js
@@ -6,8 +6,7 @@ var configHelpers = {};
 var config = {
   p5SiteRoot: '..',
   p5Lib: '../js/p5.min.js',
-  p5SoundLib: '../js/p5.sound.min.js',
-  p5DomLib: '../js/p5.dom.min.js'
+  p5SoundLib: '../js/p5.sound.min.js'
 };
 
 Object.keys(config).forEach(function(key) {
@@ -15,6 +14,5 @@ Object.keys(config).forEach(function(key) {
     return config[key];
   };
 });
-
 
 module.exports = configHelpers;

--- a/docs/yuidoc-p5-theme/layouts/main.handlebars
+++ b/docs/yuidoc-p5-theme/layouts/main.handlebars
@@ -10,7 +10,6 @@
 
     <script src="{{projectAssets}}/js/vendor/jquery-1.12.4.min.js"></script>
     <script src='/assets/js/p5.min.js'></script>
-    <script src='/assets/js/p5.dom.min.js'></script>
     <script src='/assets/js/p5.sound.min.js'></script>
     <script src="{{projectAssets}}/js/vendor/underscore-min.js"></script>
     <script src="{{projectAssets}}/js/vendor/backbone-min.js"></script>

--- a/lib/empty-example/index.html
+++ b/lib/empty-example/index.html
@@ -1,15 +1,22 @@
 <!DOCTYPE html>
 <html lang="">
-  <head>
-    <meta charset="utf-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>p5.js example</title>
-    <style> body {padding: 0; margin: 0;} </style>
-    <script src="../p5.min.js"></script>
-    <script src="../addons/p5.dom.min.js"></script>
-    <script src="../addons/p5.sound.min.js"></script>
-    <script src="sketch.js"></script>
-  </head>
-  <body>
-  </body>
+
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>p5.js example</title>
+  <style>
+    body {
+      padding: 0;
+      margin: 0;
+    }
+  </style>
+  <script src="../p5.js"></script>
+  <script src="../addons/p5.sound.min.js"></script>
+  <script src="sketch.js"></script>
+</head>
+
+<body>
+</body>
+
 </html>

--- a/utils/sample-linter.js
+++ b/utils/sample-linter.js
@@ -4,7 +4,7 @@ import eslint from 'eslint';
 // envs: ['eslint-samples/p5'],
 
 const itemtypes = ['method', 'property'];
-const classes = ['p5', 'p5.dom'];
+const classes = ['p5'];
 
 import dataDoc from '../docs/reference/data.min.json';
 const globals = {};


### PR DESCRIPTION
Found a few old references to `p5.dom` while working on #4117. This PR removes them.

Changes: 
- removes a few broken links to the old separate `p5.dom` javascript file
- removes the string `"p5.dom"` from a few helper files that no longer need it

#### PR Checklist

- [x] `npm run lint` passes
