### PR TITLE
Fix "it's" typo in p5.Image mask documentation

### DIFF
--- a/src/image/p5.Image.js
+++ b/src/image/p5.Image.js
@@ -605,7 +605,7 @@ p5.Image.prototype.copy = function(...args) {
 
 /**
  * Masks part of an image from displaying by loading another
- * image and using it's alpha channel as an alpha channel for
+ * image and using its alpha channel as an alpha channel for
  * this image.
  *
  * @method mask
@@ -635,7 +635,7 @@ p5.Image.prototype.copy = function(...args) {
 // TODO: - Accept an array of alpha values.
 //       - Use other channels of an image. p5 uses the
 //       blue channel (which feels kind of arbitrary). Note: at the
-//       moment this method does not match native processings original
+//       moment this method does not match native processing's original
 //       functionality exactly.
 p5.Image.prototype.mask = function(p5Image) {
   if (p5Image === undefined) {


### PR DESCRIPTION
Changes: 
<!-- Add here what changes were made in this pull request and if possible provide links showcasing the changes. -->

- Fix typo in p5.Image mask docs

#### PR Checklist

- [x] [Inline documentation] is included / updated

[Inline documentation]: https://github.com/processing/p5.js/blob/master/developer_docs/inline_documentation.md