### PR TITLE
Fixing TypeError when calling createCapture function

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1232,8 +1232,7 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/aproba/-/aproba-1.2.0.tgz",
       "integrity": "sha512-Y9J6ZjXtoYh8RnXVCMOU/ttDmk1aBjunq9vO0ta5x85WDQiQfUF9sIPBITdbiiIVcBo03Hi3jMxigBtsddlXRw==",
-      "dev": true,
-      "optional": true
+      "dev": true
     },
     "archiver": {
       "version": "1.3.0",
@@ -1342,7 +1341,6 @@
       "resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.1.4.tgz",
       "integrity": "sha1-u13KOCu5TwXhUZQ3PRb9O6HKEQ0=",
       "dev": true,
-      "optional": true,
       "requires": {
         "delegates": "^1.0.0",
         "readable-stream": "^2.0.6"
@@ -1993,7 +1991,6 @@
       "resolved": "https://registry.npmjs.org/boom/-/boom-0.4.2.tgz",
       "integrity": "sha1-emNune1O/O+xnO9JR6PGffrukRs=",
       "dev": true,
-      "optional": true,
       "requires": {
         "hoek": "0.9.x"
       },
@@ -2002,8 +1999,7 @@
           "version": "0.9.1",
           "resolved": "https://registry.npmjs.org/hoek/-/hoek-0.9.1.tgz",
           "integrity": "sha1-PTIkYrrfB3Fup+uFuviAec3c5QU=",
-          "dev": true,
-          "optional": true
+          "dev": true
         }
       }
     },
@@ -2955,8 +2951,7 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
       "integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4=",
-      "dev": true,
-      "optional": true
+      "dev": true
     },
     "constants-browserify": {
       "version": "1.0.0",
@@ -3423,8 +3418,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz",
       "integrity": "sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o=",
-      "dev": true,
-      "optional": true
+      "dev": true
     },
     "depd": {
       "version": "1.1.2",
@@ -5183,7 +5177,6 @@
       "resolved": "https://registry.npmjs.org/fstream/-/fstream-1.0.12.tgz",
       "integrity": "sha512-WvJ193OHa0GHPEL+AycEJgxvBEwyfRkN1vhjca23OaPVMCaLCXTd5qAu82AjTcgP1UJmytkOKb63Ypde7raDIg==",
       "dev": true,
-      "optional": true,
       "requires": {
         "graceful-fs": "^4.1.2",
         "inherits": "~2.0.0",
@@ -5208,7 +5201,6 @@
       "resolved": "https://registry.npmjs.org/gauge/-/gauge-2.7.4.tgz",
       "integrity": "sha1-LANAXHU4w51+s3sxcCLjJfsBi/c=",
       "dev": true,
-      "optional": true,
       "requires": {
         "aproba": "^1.0.3",
         "console-control-strings": "^1.0.0",
@@ -6524,8 +6516,7 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/has-unicode/-/has-unicode-2.0.1.tgz",
       "integrity": "sha1-4Ob+aijPUROIVeCG0Wkedx3iqLk=",
-      "dev": true,
-      "optional": true
+      "dev": true
     },
     "has-value": {
       "version": "1.0.0",
@@ -9652,7 +9643,6 @@
       "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-4.1.2.tgz",
       "integrity": "sha512-2uUqazuKlTaSI/dC8AzicUck7+IrEaOnN/e0jd3Xtt1KcGpwx30v50mL7oPyr/h9bL3E4aZccVwpwP+5W9Vjkg==",
       "dev": true,
-      "optional": true,
       "requires": {
         "are-we-there-yet": "~1.1.2",
         "console-control-strings": "~1.1.0",
@@ -11663,7 +11653,6 @@
       "resolved": "https://registry.npmjs.org/pump/-/pump-1.0.3.tgz",
       "integrity": "sha512-8k0JupWme55+9tCVE+FS5ULT3K6AbgqrGa58lTT49RpyfwwcGedHqaC5LlQNdEAumn/wFsu6aPwkuPMioy8kqw==",
       "dev": true,
-      "optional": true,
       "requires": {
         "end-of-stream": "^1.1.0",
         "once": "^1.3.1"
@@ -12321,8 +12310,7 @@
       "version": "2.2.8",
       "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.2.8.tgz",
       "integrity": "sha1-5Dm+Kq7jJzIZUnMPmaiSnk/FBYI=",
-      "dev": true,
-      "optional": true
+      "dev": true
     },
     "ripemd160": {
       "version": "2.0.2",
@@ -14347,7 +14335,6 @@
       "resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.2.tgz",
       "integrity": "sha512-ijDLlyQ7s6x1JgCLur53osjm/UXUYD9+0PbYKrBsYisYXzCxN+HC3mYDNy/dWdmf3AwqwU3CXwDCvsNgGK1S0w==",
       "dev": true,
-      "optional": true,
       "requires": {
         "string-width": "^1.0.2"
       }

--- a/src/dom/dom.js
+++ b/src/dom/dom.js
@@ -1320,9 +1320,10 @@ p5.prototype.createCapture = function() {
   // set width and height onload metadata
   elt.addEventListener('loadedmetadata', function() {
     elt.play();
+
     if (elt.width) {
-      c.width = elt.videoWidth = elt.width;
-      c.height = elt.videoHeight = elt.height;
+      c.width = elt.width;
+      c.height = elt.height;
     } else {
       c.width = c.elt.width = elt.videoWidth;
       c.height = c.elt.height = elt.videoHeight;


### PR DESCRIPTION
<!--
  Thank you for contributing! Please use this pull request (PR) template.


 In the description field of this PR, include "resolves #XXXX" tagging the issue you are fixing. If this PR addresses the issue but doesn't completely resolve it (ie the issue should remain open after your PR is merged), write "addresses #XXXX".-->
Addresses #4116

 Changes: 
<!-- Add here what changes were made in this pull request and if possible provide links showcasing the changes. -->
Removed code that trying to change read-only properties [videoWidth](https://developer.mozilla.org/en-US/docs/Web/API/HTMLVideoElement/videoWidth) and [videoHeight](https://developer.mozilla.org/en-US/docs/Web/API/HTMLVideoElement/videoWidth) of `<video>` element. It causes `TypeError: Cannot assign to read only property 'videoWidth' of object '#<HTMLVideoElement>'`.

#### PR Checklist
<!--
  To check any option, replace the "[ ]" with a "[x]". Be sure to check out how it looks in the Preview tab! Feel free to remove any portion of the template that is not relevant for your issue.
-->

- [x] `npm run lint` passes
- [ ] [Inline documentation] is included / updated
- [ ] [Unit tests] are included / updated
- [ ] [Benchmarks] are included / updated

[Inline documentation]: https://github.com/processing/p5.js/blob/master/developer_docs/inline_documentation.md
[Unit tests]: https://github.com/processing/p5.js/tree/master/developer_docs#unit-tests
[Benchmarks]: https://github.com/processing/p5.js/blob/master/developer_docs/benchmarking_p5.md
