### PR TITLE
Unify immediate and retained modes

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -83,6 +83,7 @@ import './webgl/p5.RendererGL.Immediate';
 import './webgl/p5.RendererGL';
 import './webgl/p5.RendererGL.Retained';
 import './webgl/p5.Shader';
+import './webgl/p5.RenderBuffer';
 import './webgl/p5.Texture';
 import './webgl/text';
 

--- a/src/core/constants.js
+++ b/src/core/constants.js
@@ -282,6 +282,12 @@ export const QUADS = 'quads';
  */
 export const QUAD_STRIP = 'quad_strip';
 /**
+ * @property {String} TESS
+ * @final
+ * @default tess
+ */
+export const TESS = 'tess';
+/**
  * @property {String} CLOSE
  * @final
  */

--- a/src/core/shape/vertex.js
+++ b/src/core/shape/vertex.js
@@ -73,7 +73,7 @@ p5.prototype.beginContour = function() {
  * specified, the shape can be any irregular polygon.
  * <br><br>
  * The parameters available for <a href="#/p5/beginShape">beginShape()</a> are POINTS, LINES, TRIANGLES,
- * TRIANGLE_FAN, TRIANGLE_STRIP, QUADS, and QUAD_STRIP. After calling the
+ * TRIANGLE_FAN, TRIANGLE_STRIP, QUADS, QUAD_STRIP, and TESS (WebGL only). After calling the
  * <a href="#/p5/beginShape">beginShape()</a> function, a series of <a href="#/p5/vertex">vertex()</a> commands must follow. To stop
  * drawing the shape, call <a href="#/p5/endShape">endShape()</a>. Each shape will be outlined with the
  * current stroke color and filled with the fill color.
@@ -84,7 +84,7 @@ p5.prototype.beginContour = function() {
  *
  * @method beginShape
  * @param  {Constant} [kind] either POINTS, LINES, TRIANGLES, TRIANGLE_FAN
- *                                TRIANGLE_STRIP, QUADS, or QUAD_STRIP
+ *                                TRIANGLE_STRIP, QUADS, QUAD_STRIP or TESS
  * @chainable
  * @example
  * <div>
@@ -915,7 +915,7 @@ p5.prototype.quadraticVertex = function(...args) {
  * }
  *
  * function ngon(n, x, y, d) {
- *   beginShape();
+ *   beginShape(TESS);
  *   for (let i = 0; i < n + 1; i++) {
  *     angle = TWO_PI / n * i;
  *     px = x + sin(angle) * d / 2;

--- a/src/webgl/3d_primitives.js
+++ b/src/webgl/3d_primitives.js
@@ -1389,7 +1389,7 @@ p5.RendererGL.prototype.line = function(...args) {
     this.vertex(args[3], args[4], args[5]);
     this.endShape();
   } else if (args.length === 4) {
-    this.beginShape();
+    this.beginShape(constants.LINES);
     this.vertex(args[0], args[1], 0);
     this.vertex(args[2], args[3], 0);
     this.endShape();

--- a/src/webgl/3d_primitives.js
+++ b/src/webgl/3d_primitives.js
@@ -992,7 +992,7 @@ p5.RendererGL.prototype.point = function(x, y, z) {
 
   const _vertex = [];
   _vertex.push(new p5.Vector(x, y, z));
-  this._drawPoints(_vertex, this._pointVertexBuffer);
+  this._drawPoints(_vertex, this.immediateMode.buffers.point);
 
   return this;
 };

--- a/src/webgl/3d_primitives.js
+++ b/src/webgl/3d_primitives.js
@@ -1384,7 +1384,7 @@ p5.RendererGL.prototype.curve = function(
  */
 p5.RendererGL.prototype.line = function(...args) {
   if (args.length === 6) {
-    this.beginShape();
+    this.beginShape(constants.LINES);
     this.vertex(args[0], args[1], args[2]);
     this.vertex(args[3], args[4], args[5]);
     this.endShape();

--- a/src/webgl/material.js
+++ b/src/webgl/material.js
@@ -784,6 +784,7 @@ p5.RendererGL.prototype._applyColorBlend = function(colors) {
   const isTexture = this.drawMode === constants.TEXTURE;
   const doBlend =
     isTexture || colors[colors.length - 1] < 1.0 || this._isErasing;
+
   if (doBlend !== this._isBlending) {
     if (doBlend) {
       gl.depthMask(isTexture);

--- a/src/webgl/p5.Geometry.js
+++ b/src/webgl/p5.Geometry.js
@@ -45,9 +45,9 @@ p5.Geometry = function(detailX, detailY, callback) {
   // a 2D array containing edge connectivity pattern for create line vertices
   //based on faces for most objects;
   this.edges = [];
+  this.vertexColors = [];
   this.detailX = detailX !== undefined ? detailX : 1;
   this.detailY = detailY !== undefined ? detailY : 1;
-
   this.dirtyFlags = {};
 
   if (callback instanceof Function) {

--- a/src/webgl/p5.RenderBuffer.js
+++ b/src/webgl/p5.RenderBuffer.js
@@ -9,6 +9,13 @@ p5.RenderBuffer = function(size, src, dst, attr, renderer, map) {
   this.map = map; // optional, a transformation function to apply to src
 };
 
+/**
+ * Enables and binds the buffers used by shader when the appropriate data exists in geometry.
+ * Must always be done prior to drawing geometry in WebGL.
+ * @param {p5.Geometry} geometry Geometry that is going to be drawn
+ * @param {p5.Shader} shader Active shader
+ * @private
+ */
 p5.RenderBuffer.prototype._prepareBuffer = function(geometry, shader) {
   const attributes = shader.attributes;
   const gl = this._renderer.GL;

--- a/src/webgl/p5.RenderBuffer.js
+++ b/src/webgl/p5.RenderBuffer.js
@@ -22,16 +22,12 @@ p5.RenderBuffer.prototype._prepareBuffer = function(geometry, shader) {
   // loop through each of the buffer definitions
   const attr = attributes[this.attr];
   if (!attr) {
-    // console.log('NOT: ' + this.src);
     return;
   }
 
   // check if the model has the appropriate source array
   let buffer = geometry[this.dst];
   const src = model[this.src];
-  // console.log(src);
-  // console.log(geometry);
-  // console.log(this._glBuffer);
   if (src) {
     // check if we need to create the GL buffer
     const createBuffer = !buffer;

--- a/src/webgl/p5.RenderBuffer.js
+++ b/src/webgl/p5.RenderBuffer.js
@@ -28,7 +28,7 @@ p5.RenderBuffer.prototype._prepareBuffer = function(geometry, shader) {
   // check if the model has the appropriate source array
   let buffer = geometry[this.dst];
   const src = model[this.src];
-  if (src) {
+  if (src.length > 0) {
     // check if we need to create the GL buffer
     const createBuffer = !buffer;
     if (createBuffer) {
@@ -43,7 +43,6 @@ p5.RenderBuffer.prototype._prepareBuffer = function(geometry, shader) {
       const map = this.map;
       // get the values from the model, possibly transformed
       const values = map ? map(src) : src;
-
       // fill the buffer with the values
       this._renderer._bindBuffer(buffer, gl.ARRAY_BUFFER, values);
 
@@ -52,14 +51,6 @@ p5.RenderBuffer.prototype._prepareBuffer = function(geometry, shader) {
     }
     // enable the attribute
     shader.enableAttrib(attr, this.size);
-  } else {
-    if (buffer) {
-      // remove the unused buffer
-      gl.deleteBuffer(buffer);
-      geometry[this.dst] = null;
-    }
-    // disable the vertex
-    gl.disableVertexAttribArray(attr.index);
   }
 };
 

--- a/src/webgl/p5.RenderBuffer.js
+++ b/src/webgl/p5.RenderBuffer.js
@@ -1,0 +1,70 @@
+import p5 from '../core/main';
+
+p5.RenderBuffer = function(size, src, dst, attr, renderer, map) {
+  this.size = size; // the number of FLOATs in each vertex
+  this.src = src; // the name of the model's source array
+  this.dst = dst; // the name of the geometry's buffer
+  this.attr = attr; // the name of the vertex attribute
+  this._renderer = renderer;
+  this.map = map; // optional, a transformation function to apply to src
+};
+
+p5.RenderBuffer.prototype._prepareBuffer = function(geometry, shader) {
+  const attributes = shader.attributes;
+  const gl = this._renderer.GL;
+  let model;
+  if (geometry.model) {
+    model = geometry.model;
+  } else {
+    model = geometry;
+  }
+
+  // loop through each of the buffer definitions
+  const attr = attributes[this.attr];
+  if (!attr) {
+    // console.log('NOT: ' + this.src);
+    return;
+  }
+
+  // check if the model has the appropriate source array
+  let buffer = geometry[this.dst];
+  const src = model[this.src];
+  // console.log(src);
+  // console.log(geometry);
+  // console.log(this._glBuffer);
+  if (src) {
+    // check if we need to create the GL buffer
+    const createBuffer = !buffer;
+    if (createBuffer) {
+      // create and remember the buffer
+      geometry[this.dst] = buffer = gl.createBuffer();
+    }
+    // bind the buffer
+    gl.bindBuffer(gl.ARRAY_BUFFER, buffer);
+
+    // check if we need to fill the buffer with data
+    if (createBuffer || model.dirtyFlags[this.src] !== false) {
+      const map = this.map;
+      // get the values from the model, possibly transformed
+      const values = map ? map(src) : src;
+
+      // fill the buffer with the values
+      this._renderer._bindBuffer(buffer, gl.ARRAY_BUFFER, values);
+
+      // mark the model's source array as clean
+      model.dirtyFlags[this.src] = false;
+    }
+    // enable the attribute
+    shader.enableAttrib(attr, this.size);
+  } else {
+    if (buffer) {
+      // remove the unused buffer
+      gl.deleteBuffer(buffer);
+      geometry[this.dst] = null;
+    }
+    // disable the vertex
+    gl.disableVertexAttribArray(attr.index);
+  }
+};
+
+export default p5.RenderBuffer;

--- a/src/webgl/p5.RendererGL.Immediate.js
+++ b/src/webgl/p5.RendererGL.Immediate.js
@@ -15,9 +15,6 @@ import p5 from '../core/main';
 import * as constants from '../core/constants';
 import './p5.RenderBuffer';
 
-const _flatten = p5.RendererGL.prototype._flatten;
-const _vToNArray = p5.RendererGL.prototype._vToNArray;
-
 /**
  * Begin shape drawing.  This is a helpful way of generating
  * custom shapes quickly.  However in WEBGL mode, application
@@ -35,33 +32,7 @@ const _vToNArray = p5.RendererGL.prototype._vToNArray;
 p5.RendererGL.prototype.beginShape = function(mode) {
   this.immediateMode.shapeMode =
     mode !== undefined ? mode : constants.LINE_STRIP;
-  //if we haven't yet initialized our
-  //immediateMode vertices & buffers, create them now!
-  if (this.immediateMode.geometry === undefined) {
-    this.immediateMode.geometry = new p5.Geometry();
-    if (this.immediateMode.buffers === undefined) {
-      this.immediateMode.buffers = {
-        // prettier-ignore
-        fill: [
-          new p5.RenderBuffer(3, 'vertices', 'vertexBuffer', 'aPosition', this, _vToNArray),
-          new p5.RenderBuffer(3, 'vertexNormals', 'normalBuffer', 'aNormal', this, _vToNArray),
-          new p5.RenderBuffer(4, 'vertexColors', 'colorBuffer', 'aVertexColor', this),
-          new p5.RenderBuffer(3, 'vertexAmbients', 'ambientBuffer', 'aAmbientColor', this),
-          new p5.RenderBuffer(2, 'uvs', 'uvBuffer', 'aTexCoord', this, _flatten)
-          ],
-        // prettier-ignore
-        stroke: [
-          new p5.RenderBuffer(3, 'lineVertices', 'lineVertexBuffer', 'aPosition', this, _flatten),
-          new p5.RenderBuffer(4, 'lineNormals', 'lineNormalBuffer', 'aDirection', this, _flatten)
-          ]
-      };
-    }
-    this.immediateMode._bezierVertex = [];
-    this.immediateMode._quadraticVertex = [];
-    this.immediateMode._curveVertex = [];
-  } else {
-    this.immediateMode.geometry.reset();
-  }
+  this.immediateMode.geometry.reset();
   return this;
 };
 

--- a/src/webgl/p5.RendererGL.Immediate.js
+++ b/src/webgl/p5.RendererGL.Immediate.js
@@ -157,12 +157,12 @@ p5.RendererGL.prototype.endShape = function(
       this.immediateMode.geometry.vertices,
       this._pointVertexBuffer
     );
-    return;
+    return this;
   }
   this._processVertices(...arguments);
   if (this.immediateMode.geometry.vertices.length > 1) {
-    this._drawImmediateStroke();
     this._drawImmediateFill();
+    this._drawImmediateStroke();
   }
   this.isBezier = false;
   this.isQuadratic = false;

--- a/src/webgl/p5.RendererGL.Immediate.js
+++ b/src/webgl/p5.RendererGL.Immediate.js
@@ -118,7 +118,7 @@ p5.RendererGL.prototype.endShape = function(
   if (this.immediateMode.shapeMode === constants.POINTS) {
     this._drawPoints(
       this.immediateMode.geometry.vertices,
-      this._pointVertexBuffer
+      this.immediateMode.buffers.point
     );
     return this;
   }
@@ -219,8 +219,10 @@ p5.RendererGL.prototype._tesselateShape = function() {
 p5.RendererGL.prototype._drawImmediateFill = function() {
   const gl = this.GL;
   const shader = this._getImmediateFillShader();
+
   this._calculateNormals(shader, this.immediateMode.geometry);
   this._setFillUniforms(shader);
+
   for (const buff of this.immediateMode.buffers.fill) {
     buff._prepareBuffer(this.immediateMode.geometry, shader);
   }
@@ -240,12 +242,14 @@ p5.RendererGL.prototype._drawImmediateFill = function() {
         break;
     }
   }
+
   this._applyColorBlend(this.curFillColor);
   gl.drawArrays(
     this.immediateMode.shapeMode,
     0,
     this.immediateMode.geometry.vertices.length
   );
+
   shader.unbindShader();
 };
 

--- a/src/webgl/p5.RendererGL.Immediate.js
+++ b/src/webgl/p5.RendererGL.Immediate.js
@@ -141,9 +141,9 @@ p5.RendererGL.prototype.endShape = function(
     return;
   }
   this._processVertices(...arguments);
-  this._drawImmediateStroke();
-  if (this.immediateMode.geometry.vertices.length > 0) {
+  if (this.immediateMode.geometry.vertices.length > 1) {
     this._drawImmediateFill();
+    this._drawImmediateStroke();
   }
   this.isBezier = false;
   this.isQuadratic = false;
@@ -261,7 +261,7 @@ p5.RendererGL.prototype._drawImmediateFill = function() {
         break;
     }
   }
-
+  this._applyColorBlend(this.curFillColor);
   gl.drawArrays(
     this.immediateMode.shapeMode,
     0,
@@ -277,6 +277,7 @@ p5.RendererGL.prototype._drawImmediateStroke = function() {
   for (const buff of this.immediateMode.buffers.stroke) {
     buff._prepareBuffer(this.immediateMode.geometry, shader);
   }
+  this._applyColorBlend(this.curStrokeColor);
   gl.drawArrays(
     gl.TRIANGLES,
     0,
@@ -286,12 +287,13 @@ p5.RendererGL.prototype._drawImmediateStroke = function() {
 };
 
 p5.RendererGL.prototype._calculateNormals = function(shader, geometry) {
-  // Rework, currently doesn't work when vertices don't make proper "faces"
-  return;
-  // if (shader.attributes['aNormal']) {
-  //   geometry.computeFaces();
-  //   geometry.computeNormals();
-  // }
+  if (geometry.vertices % 3 !== 0) {
+    return;
+  }
+  if (shader.attributes['aNormal']) {
+    geometry.computeFaces();
+    geometry.computeNormals();
+  }
 };
 
 export default p5.RendererGL;

--- a/src/webgl/p5.RendererGL.Immediate.js
+++ b/src/webgl/p5.RendererGL.Immediate.js
@@ -29,7 +29,7 @@ const _vToNArray = p5.RendererGL.prototype._vToNArray;
  * @param  {Number} mode webgl primitives mode.  beginShape supports the
  *                       following modes:
  *                       POINTS,LINES,LINE_STRIP,LINE_LOOP,TRIANGLES,
- *                       TRIANGLE_STRIP,and TRIANGLE_FAN.
+ *                       TRIANGLE_STRIP, TRIANGLE_FAN and TESS(WEBGL only)
  * @chainable
  */
 p5.RendererGL.prototype.beginShape = function(mode) {
@@ -59,8 +59,6 @@ p5.RendererGL.prototype.beginShape = function(mode) {
     this.immediateMode._bezierVertex = [];
     this.immediateMode._quadraticVertex = [];
     this.immediateMode._curveVertex = [];
-    this.immediateMode._isCoplanar = true;
-    this.immediateMode._testIfCoplanar = null;
   } else {
     this.immediateMode.geometry.reset();
   }
@@ -96,13 +94,7 @@ p5.RendererGL.prototype.vertex = function(x, y) {
     u = arguments[3];
     v = arguments[4];
   }
-  if (this.immediateMode._testIfCoplanar == null) {
-    this.immediateMode._testIfCoplanar = z;
-  } else if (this.immediateMode._testIfCoplanar !== z) {
-    this.immediateMode._isCoplanar = false;
-  }
   const vert = new p5.Vector(x, y, z);
-  // this.immediateMode.vertices.push(vert);
   this.immediateMode.geometry.vertices.push(vert);
   const vertexColor = this.curFillColor || [0.5, 0.5, 0.5, 1.0];
   this.immediateMode.geometry.vertexColors.push(
@@ -186,12 +178,8 @@ p5.RendererGL.prototype._processVertices = function(mode) {
     );
     this.immediateMode.geometry._edgesToVertices();
   }
-  // For hollow shapes, must be default line_strip and
-  // must be coplanar
-  const convexShape =
-    this.immediateMode.shapeMode === constants.LINE_STRIP &&
-    this.drawMode === constants.FILL &&
-    this.immediateMode._isCoplanar;
+  // For hollow shapes, user must set mode to TESS
+  const convexShape = this.immediateMode.shapeMode === constants.TESS;
   // We tesselate when drawing curves or convex shapes
   const shouldTess =
     (this.isBezier || this.isQuadratic || this.isCurve || convexShape) &&

--- a/src/webgl/p5.RendererGL.Immediate.js
+++ b/src/webgl/p5.RendererGL.Immediate.js
@@ -31,7 +31,7 @@ import './p5.RenderBuffer';
  */
 p5.RendererGL.prototype.beginShape = function(mode) {
   this.immediateMode.shapeMode =
-    mode !== undefined ? mode : constants.LINE_STRIP;
+    mode !== undefined ? mode : constants.TRIANGLE_FAN;
   this.immediateMode.geometry.reset();
   return this;
 };
@@ -123,6 +123,7 @@ p5.RendererGL.prototype.endShape = function(
     return this;
   }
   this._processVertices(...arguments);
+
   if (this.immediateMode.geometry.vertices.length > 1) {
     this._drawImmediateFill();
     this._drawImmediateStroke();
@@ -227,20 +228,11 @@ p5.RendererGL.prototype._drawImmediateFill = function() {
     buff._prepareBuffer(this.immediateMode.geometry, shader);
   }
 
-  if (this.drawMode === constants.FILL || this.drawMode === constants.TEXTURE) {
-    switch (this.immediateMode.shapeMode) {
-      case constants.LINE_STRIP:
-      case constants.LINES:
-        this.immediateMode.shapeMode = constants.TRIANGLE_FAN;
-        break;
-    }
-  } else {
-    switch (this.immediateMode.shapeMode) {
-      case constants.LINE_STRIP:
-      case constants.LINES:
-        this.immediateMode.shapeMode = constants.LINE_LOOP;
-        break;
-    }
+  if (
+    this.immediateMode.shapeMode === constants.LINE_STRIP ||
+    this.immediateMode.shapeMode === constants.LINES
+  ) {
+    this.immediateMode.shapeMode = constants.TRIANGLE_FAN;
   }
 
   this._applyColorBlend(this.curFillColor);

--- a/src/webgl/p5.RendererGL.Immediate.js
+++ b/src/webgl/p5.RendererGL.Immediate.js
@@ -137,6 +137,15 @@ p5.RendererGL.prototype.endShape = function(
   return this;
 };
 
+/**
+ * Called from endShape(). This function calculates the stroke vertices for custom shapes and
+ * tesselates shapes when applicable.
+ * @private
+ * @param  {Number} mode webgl primitives mode.  beginShape supports the
+ *                       following modes:
+ *                       POINTS,LINES,LINE_STRIP,LINE_LOOP,TRIANGLES,
+ *                       TRIANGLE_STRIP, TRIANGLE_FAN and TESS(WEBGL only)
+ */
 p5.RendererGL.prototype._processVertices = function(mode) {
   if (this.immediateMode.geometry.vertices.length === 0) return;
 
@@ -162,6 +171,12 @@ p5.RendererGL.prototype._processVertices = function(mode) {
   }
 };
 
+/**
+ * Called from _processVertices(). This function calculates the stroke vertices for custom shapes and
+ * tesselates shapes when applicable.
+ * @private
+ * @returns  {Array[Number]} indices for custom shape vertices indicating edges.
+ */
 p5.RendererGL.prototype._calculateEdges = function(
   shapeMode,
   verts,
@@ -201,6 +216,10 @@ p5.RendererGL.prototype._calculateEdges = function(
   return res;
 };
 
+/**
+ * Called from _processVertices() when applicable. This function tesselates immediateMode.geometry.
+ * @private
+ */
 p5.RendererGL.prototype._tesselateShape = function() {
   this.immediateMode.shapeMode = constants.TRIANGLES;
   const contours = [
@@ -217,17 +236,24 @@ p5.RendererGL.prototype._tesselateShape = function() {
   }
 };
 
+/**
+ * Called from endShape(). Responsible for calculating normals, setting shader uniforms,
+ * enabling all appropriate buffers, applying color blend, and drawing the fill geometry.
+ * @private
+ */
 p5.RendererGL.prototype._drawImmediateFill = function() {
   const gl = this.GL;
   const shader = this._getImmediateFillShader();
 
-  this._calculateNormals(shader, this.immediateMode.geometry);
+  this._calculateNormals(this.immediateMode.geometry);
   this._setFillUniforms(shader);
 
   for (const buff of this.immediateMode.buffers.fill) {
     buff._prepareBuffer(this.immediateMode.geometry, shader);
   }
 
+  // LINE_STRIP and LINES are not used for rendering, instead
+  // they only indicate a way to modify vertices during the _processVertices() step
   if (
     this.immediateMode.shapeMode === constants.LINE_STRIP ||
     this.immediateMode.shapeMode === constants.LINES
@@ -245,6 +271,11 @@ p5.RendererGL.prototype._drawImmediateFill = function() {
   shader.unbindShader();
 };
 
+/**
+ * Called from endShape(). Responsible for calculating normals, setting shader uniforms,
+ * enabling all appropriate buffers, applying color blend, and drawing the stroke geometry.
+ * @private
+ */
 p5.RendererGL.prototype._drawImmediateStroke = function() {
   const gl = this.GL;
   const shader = this._getImmediateStrokeShader();
@@ -261,7 +292,13 @@ p5.RendererGL.prototype._drawImmediateStroke = function() {
   shader.unbindShader();
 };
 
-p5.RendererGL.prototype._calculateNormals = function(shader, geometry) {
+/**
+ * Called from _drawImmediateFill(). Currently adds default normals which
+ * only work for flat shapes.
+ * @parem
+ * @private
+ */
+p5.RendererGL.prototype._calculateNormals = function(geometry) {
   geometry.vertices.forEach(() => {
     geometry.vertexNormals.push(new p5.Vector(0, 0, 1));
   });

--- a/src/webgl/p5.RendererGL.Immediate.js
+++ b/src/webgl/p5.RendererGL.Immediate.js
@@ -13,66 +13,55 @@
  */
 import p5 from '../core/main';
 import * as constants from '../core/constants';
+import './p5.RenderBuffer';
 
-/**
- * Begin shape drawing.  This is a helpful way of generating
- * custom shapes quickly.  However in WEBGL mode, application
- * performance will likely drop as a result of too many calls to
- * <a href="#/p5/beginShape">beginShape()</a> / <a href="#/p5/endShape">endShape()</a>.  As a high performance alternative,
- * please use p5.js geometry primitives.
- * @private
- * @method beginShape
- * @param  {Number} mode webgl primitives mode.  beginShape supports the
- *                       following modes:
- *                       POINTS,LINES,LINE_STRIP,LINE_LOOP,TRIANGLES,
- *                       TRIANGLE_STRIP,and TRIANGLE_FAN.
- * @chainable
- */
+const _flatten = p5.RendererGL.prototype._flatten;
+const _vToNArray = p5.RendererGL.prototype._vToNArray;
+
 p5.RendererGL.prototype.beginShape = function(mode) {
-  //default shape mode is line_strip
   this.immediateMode.shapeMode =
     mode !== undefined ? mode : constants.LINE_STRIP;
   //if we haven't yet initialized our
   //immediateMode vertices & buffers, create them now!
-  if (this.immediateMode.vertices === undefined) {
-    this.immediateMode.vertices = [];
-    this.immediateMode.edges = [];
-    this.immediateMode.lineVertices = [];
-    this.immediateMode.vertexColors = [];
-    this.immediateMode.lineNormals = [];
-    this.immediateMode.uvCoords = [];
-    this.immediateMode.vertexBuffer = this.GL.createBuffer();
-    this.immediateMode.colorBuffer = this.GL.createBuffer();
-    this.immediateMode.uvBuffer = this.GL.createBuffer();
-    this.immediateMode.lineVertexBuffer = this.GL.createBuffer();
-    this.immediateMode.lineNormalBuffer = this.GL.createBuffer();
-    this.immediateMode.pointVertexBuffer = this.GL.createBuffer();
+  if (this.immediateMode.geometry === undefined) {
+    this.immediateMode.geometry = new p5.Geometry();
+    if (this.immediateMode.buffers === undefined) {
+      this.immediateMode.buffers = {
+        // prettier-ignore
+        fill: [
+          new p5.RenderBuffer(3, 'vertices', 'vertexBuffer', 'aPosition', this, _vToNArray),
+          new p5.RenderBuffer(3, 'vertexNormals', 'normalBuffer', 'aNormal', this, _vToNArray),
+          new p5.RenderBuffer(4, 'vertexColors', 'colorBuffer', 'aVertexColor', this),
+          new p5.RenderBuffer(3, 'vertexAmbients', 'ambientBuffer', 'aAmbientColor', this),
+          new p5.RenderBuffer(2, 'uvs', 'uvBuffer', 'aTexCoord', this, _flatten)
+          ],
+        // prettier-ignore
+        stroke: [
+          new p5.RenderBuffer(3, 'lineVertices', 'lineVertexBuffer', 'aPosition', this, _flatten),
+          new p5.RenderBuffer(4, 'lineNormals', 'lineNormalBuffer', 'aDirection', this, _flatten)
+          ]
+      };
+    }
     this.immediateMode._bezierVertex = [];
     this.immediateMode._quadraticVertex = [];
     this.immediateMode._curveVertex = [];
     this.immediateMode._isCoplanar = true;
     this.immediateMode._testIfCoplanar = null;
   } else {
-    this.immediateMode.vertices.length = 0;
-    this.immediateMode.edges.length = 0;
-    this.immediateMode.lineVertices.length = 0;
-    this.immediateMode.lineNormals.length = 0;
-    this.immediateMode.vertexColors.length = 0;
-    this.immediateMode.uvCoords.length = 0;
+    this.immediateMode.geometry.reset();
   }
-  this.isImmediateDrawing = true;
-  return this;
 };
-/**
- * adds a vertex to be drawn in a custom Shape.
- * @private
- * @method vertex
- * @param  {Number} x x-coordinate of vertex
- * @param  {Number} y y-coordinate of vertex
- * @param  {Number} z z-coordinate of vertex
- * @chainable
- * @TODO implement handling of <a href="#/p5.Vector">p5.Vector</a> args
- */
+
+p5.RendererGL.prototype._prepareBuffersImm = function(
+  geometry,
+  shader,
+  buffers
+) {
+  for (const buff of buffers) {
+    buff._prepareBuffer(geometry, shader);
+  }
+};
+
 p5.RendererGL.prototype.vertex = function(x, y) {
   let z, u, v;
 
@@ -92,15 +81,16 @@ p5.RendererGL.prototype.vertex = function(x, y) {
     u = arguments[3];
     v = arguments[4];
   }
-  if (this.immediateMode._testIfCoplanar == null) {
-    this.immediateMode._testIfCoplanar = z;
-  } else if (this.immediateMode._testIfCoplanar !== z) {
-    this.immediateMode._isCoplanar = false;
-  }
+  // if (this.immediateMode._testIfCoplanar == null) {
+  //   this.immediateMode._testIfCoplanar = z;
+  // } else if (this.immediateMode._testIfCoplanar !== z) {
+  //   this.immediateMode._isCoplanar = false;
+  // }
   const vert = new p5.Vector(x, y, z);
-  this.immediateMode.vertices.push(vert);
+  // this.immediateMode.vertices.push(vert);
+  this.immediateMode.geometry.vertices.push(vert);
   const vertexColor = this.curFillColor || [0.5, 0.5, 0.5, 1.0];
-  this.immediateMode.vertexColors.push(
+  this.immediateMode.geometry.vertexColors.push(
     vertexColor[0],
     vertexColor[1],
     vertexColor[2],
@@ -122,7 +112,7 @@ p5.RendererGL.prototype.vertex = function(x, y) {
     }
   }
 
-  this.immediateMode.uvCoords.push(u, v);
+  this.immediateMode.geometry.uvs.push(u, v);
 
   this.immediateMode._bezierVertex[0] = x;
   this.immediateMode._bezierVertex[1] = y;
@@ -135,10 +125,6 @@ p5.RendererGL.prototype.vertex = function(x, y) {
   return this;
 };
 
-/**
- * End shape drawing and render vertices to screen.
- * @chainable
- */
 p5.RendererGL.prototype.endShape = function(
   mode,
   isCurve,
@@ -149,155 +135,117 @@ p5.RendererGL.prototype.endShape = function(
 ) {
   if (this.immediateMode.shapeMode === constants.POINTS) {
     this._drawPoints(
-      this.immediateMode.vertices,
-      this.immediateMode.pointVertexBuffer
+      this.immediateMode.geometry.vertices,
+      this._pointVertexBuffer
     );
-  } else if (this.immediateMode.vertices.length > 1) {
-    if (this._doStroke && this.drawMode !== constants.TEXTURE) {
-      if (this.immediateMode.shapeMode === constants.TRIANGLE_STRIP) {
-        let i;
-        for (i = 0; i < this.immediateMode.vertices.length - 2; i++) {
-          this.immediateMode.edges.push([i, i + 1]);
-          this.immediateMode.edges.push([i, i + 2]);
-        }
-        this.immediateMode.edges.push([i, i + 1]);
-      } else if (this.immediateMode.shapeMode === constants.TRIANGLES) {
-        for (let i = 0; i < this.immediateMode.vertices.length - 2; i = i + 3) {
-          this.immediateMode.edges.push([i, i + 1]);
-          this.immediateMode.edges.push([i + 1, i + 2]);
-          this.immediateMode.edges.push([i + 2, i]);
-        }
-      } else if (this.immediateMode.shapeMode === constants.LINES) {
-        for (let i = 0; i < this.immediateMode.vertices.length - 1; i = i + 2) {
-          this.immediateMode.edges.push([i, i + 1]);
-        }
-      } else {
-        for (let i = 0; i < this.immediateMode.vertices.length - 1; i++) {
-          this.immediateMode.edges.push([i, i + 1]);
-        }
-      }
-      if (mode === constants.CLOSE) {
-        this.immediateMode.edges.push([
-          this.immediateMode.vertices.length - 1,
-          0
-        ]);
-      }
-
-      p5.Geometry.prototype._edgesToVertices.call(this.immediateMode);
-      this._drawStrokeImmediateMode();
-    }
-
-    if (this._doFill && this.immediateMode.shapeMode !== constants.LINES) {
-      if (
-        this.isBezier ||
-        this.isQuadratic ||
-        this.isCurve ||
-        (this.immediateMode.shapeMode === constants.LINE_STRIP &&
-          this.drawMode === constants.FILL &&
-          this.immediateMode._isCoplanar === true)
-      ) {
-        this.immediateMode.shapeMode = constants.TRIANGLES;
-        const contours = [
-          new Float32Array(this._vToNArray(this.immediateMode.vertices))
-        ];
-        const polyTriangles = this._triangulate(contours);
-        this.immediateMode.vertices = [];
-        for (
-          let j = 0, polyTriLength = polyTriangles.length;
-          j < polyTriLength;
-          j = j + 3
-        ) {
-          this.vertex(
-            polyTriangles[j],
-            polyTriangles[j + 1],
-            polyTriangles[j + 2]
-          );
-        }
-      }
-      if (this.immediateMode.vertices.length > 0) {
-        this._drawFillImmediateMode(
-          mode,
-          isCurve,
-          isBezier,
-          isQuadratic,
-          isContour,
-          shapeKind
-        );
-      }
-    }
+    return;
   }
-  //clear out our vertexPositions & colors arrays
-  //after rendering
-  this.immediateMode.vertices.length = 0;
-  this.immediateMode.vertexColors.length = 0;
-  this.immediateMode.uvCoords.length = 0;
-  this.isImmediateDrawing = false;
+  this._processVertices(...arguments);
+  this._drawImmediateStroke();
+  if (this.immediateMode.geometry.vertices.length > 0) {
+    this._drawImmediateFill();
+  }
   this.isBezier = false;
   this.isQuadratic = false;
   this.isCurve = false;
   this.immediateMode._bezierVertex.length = 0;
   this.immediateMode._quadraticVertex.length = 0;
   this.immediateMode._curveVertex.length = 0;
-  this.immediateMode._isCoplanar = true;
-  this.immediateMode._testIfCoplanar = null;
-
   return this;
 };
 
-p5.RendererGL.prototype._drawFillImmediateMode = function(
-  mode,
-  isCurve,
-  isBezier,
-  isQuadratic,
-  isContour,
-  shapeKind
+p5.RendererGL.prototype._processVertices = function(mode) {
+  if (this.immediateMode.geometry.vertices.length === 0) return;
+
+  const calculateStroke = this._doStroke && this.drawMode !== constants.TEXTURE;
+  const shouldClose = mode === constants.CLOSE;
+  if (calculateStroke) {
+    this.immediateMode.geometry.edges = this._calculateEdges(
+      this.immediateMode.shapeMode,
+      this.immediateMode.geometry.vertices,
+      shouldClose
+    );
+    this.immediateMode.geometry._edgesToVertices();
+  }
+
+  if (this._doFill && this.immediateMode.shapeMode !== constants.LINES) {
+    if (
+      this.isBezier ||
+      this.isQuadratic ||
+      this.isCurve ||
+      (this.immediateMode.shapeMode === constants.LINE_STRIP &&
+        this.drawMode === constants.FILL &&
+        this.immediateMode._isCoplanar === true)
+    ) {
+      this.immediateMode.shapeMode = constants.TRIANGLES;
+      const contours = [
+        new Float32Array(this._vToNArray(this.immediateMode.geometry.vertices))
+      ];
+      const polyTriangles = this._triangulate(contours);
+      this.immediateMode.geometry.vertices = [];
+      for (
+        let j = 0, polyTriLength = polyTriangles.length;
+        j < polyTriLength;
+        j = j + 3
+      ) {
+        this.vertex(
+          polyTriangles[j],
+          polyTriangles[j + 1],
+          polyTriangles[j + 2]
+        );
+      }
+    }
+  }
+};
+
+p5.RendererGL.prototype._calculateEdges = function(
+  shapeMode,
+  verts,
+  shouldClose
 ) {
+  const res = [];
+  let i = 0;
+  switch (shapeMode) {
+    case constants.TRIANGLE_STRIP:
+      for (i = 0; i < verts - 2; i++) {
+        res.push([i, i + 1]);
+        res.push([i, i + 2]);
+      }
+      res.push([i, i + 1]);
+      break;
+    case constants.TRIANGLES:
+      for (i = 0; i < verts.length - 2; i = i + 3) {
+        res.push([i, i + 1]);
+        res.push([i + 1, i + 2]);
+        res.push([i + 2, i]);
+      }
+      break;
+    case constants.LINES:
+      for (i = 0; i < verts.length - 1; i = i + 2) {
+        res.push([i, i + 1]);
+      }
+      break;
+    default:
+      for (i = 0; i < verts.length - 1; i++) {
+        res.push([i, i + 1]);
+      }
+      break;
+  }
+  if (shouldClose) {
+    res.push([verts.length - 1, 0]);
+  }
+  return res;
+};
+
+p5.RendererGL.prototype._drawImmediateFill = function() {
   const gl = this.GL;
   const shader = this._getImmediateFillShader();
+  this._calculateNormals(shader, this.immediateMode.geometry);
   this._setFillUniforms(shader);
-
-  // initialize the fill shader's 'aPosition' buffer
-  if (shader.attributes.aPosition) {
-    //vertex position Attribute
-    this._bindBuffer(
-      this.immediateMode.vertexBuffer,
-      gl.ARRAY_BUFFER,
-      this._vToNArray(this.immediateMode.vertices),
-      Float32Array,
-      gl.DYNAMIC_DRAW
-    );
-
-    shader.enableAttrib(shader.attributes.aPosition, 3);
+  for (const buff of this.immediateMode.buffers.fill) {
+    buff._prepareBuffer(this.immediateMode.geometry, shader);
   }
 
-  // initialize the fill shader's 'aVertexColor' buffer
-  if (this.drawMode === constants.FILL && shader.attributes.aVertexColor) {
-    this._bindBuffer(
-      this.immediateMode.colorBuffer,
-      gl.ARRAY_BUFFER,
-      this.immediateMode.vertexColors,
-      Float32Array,
-      gl.DYNAMIC_DRAW
-    );
-
-    shader.enableAttrib(shader.attributes.aVertexColor, 4);
-  }
-
-  // initialize the fill shader's 'aTexCoord' buffer
-  if (this.drawMode === constants.TEXTURE && shader.attributes.aTexCoord) {
-    //texture coordinate Attribute
-    this._bindBuffer(
-      this.immediateMode.uvBuffer,
-      gl.ARRAY_BUFFER,
-      this.immediateMode.uvCoords,
-      Float32Array,
-      gl.DYNAMIC_DRAW
-    );
-
-    shader.enableAttrib(shader.attributes.aTexCoord, 2);
-  }
-
-  //if (true || mode) {
   if (this.drawMode === constants.FILL || this.drawMode === constants.TEXTURE) {
     switch (this.immediateMode.shapeMode) {
       case constants.LINE_STRIP:
@@ -313,65 +261,37 @@ p5.RendererGL.prototype._drawFillImmediateMode = function(
         break;
     }
   }
-  //}
-  //QUADS & QUAD_STRIP are not supported primitives modes
-  //in webgl.
-  if (
-    this.immediateMode.shapeMode === constants.QUADS ||
-    this.immediateMode.shapeMode === constants.QUAD_STRIP
-  ) {
-    throw new Error(
-      `sorry, ${
-        this.immediateMode.shapeMode
-      } not yet implemented in webgl mode.`
-    );
-  } else {
-    this._applyColorBlend(this.curFillColor);
-    gl.enable(gl.BLEND);
-    gl.drawArrays(
-      this.immediateMode.shapeMode,
-      0,
-      this.immediateMode.vertices.length
-    );
-  }
-  // todo / optimizations? leave bound until another shader is set?
+
+  gl.drawArrays(
+    this.immediateMode.shapeMode,
+    0,
+    this.immediateMode.geometry.vertices.length
+  );
   shader.unbindShader();
 };
 
-p5.RendererGL.prototype._drawStrokeImmediateMode = function() {
+p5.RendererGL.prototype._drawImmediateStroke = function() {
   const gl = this.GL;
   const shader = this._getImmediateStrokeShader();
   this._setStrokeUniforms(shader);
-
-  // initialize the stroke shader's 'aPosition' buffer
-  if (shader.attributes.aPosition) {
-    this._bindBuffer(
-      this.immediateMode.lineVertexBuffer,
-      gl.ARRAY_BUFFER,
-      this._flatten(this.immediateMode.lineVertices),
-      Float32Array,
-      gl.STATIC_DRAW
-    );
-
-    shader.enableAttrib(shader.attributes.aPosition, 3);
+  for (const buff of this.immediateMode.buffers.stroke) {
+    buff._prepareBuffer(this.immediateMode.geometry, shader);
   }
-
-  // initialize the stroke shader's 'aDirection' buffer
-  if (shader.attributes.aDirection) {
-    this._bindBuffer(
-      this.immediateMode.lineNormalBuffer,
-      gl.ARRAY_BUFFER,
-      this._flatten(this.immediateMode.lineNormals),
-      Float32Array,
-      gl.STATIC_DRAW
-    );
-    shader.enableAttrib(shader.attributes.aDirection, 4);
-  }
-
-  this._applyColorBlend(this.curStrokeColor);
-  gl.drawArrays(gl.TRIANGLES, 0, this.immediateMode.lineVertices.length);
-
+  gl.drawArrays(
+    gl.TRIANGLES,
+    0,
+    this.immediateMode.geometry.lineVertices.length
+  );
   shader.unbindShader();
+};
+
+p5.RendererGL.prototype._calculateNormals = function(shader, geometry) {
+  // Rework, currently doesn't work when vertices don't make proper "faces"
+  return;
+  // if (shader.attributes['aNormal']) {
+  //   geometry.computeFaces();
+  //   geometry.computeNormals();
+  // }
 };
 
 export default p5.RendererGL;

--- a/src/webgl/p5.RendererGL.Immediate.js
+++ b/src/webgl/p5.RendererGL.Immediate.js
@@ -262,12 +262,9 @@ p5.RendererGL.prototype._drawImmediateStroke = function() {
 };
 
 p5.RendererGL.prototype._calculateNormals = function(shader, geometry) {
-  if (geometry.vertices % 3 !== 0) {
-    return;
-  }
-  if (shader.attributes['aNormal']) {
-    geometry.computeFaces().computerNormals();
-  }
+  geometry.vertices.forEach(() => {
+    geometry.vertexNormals.push(new p5.Vector(0, 0, 1));
+  });
 };
 
 export default p5.RendererGL;

--- a/src/webgl/p5.RendererGL.Retained.js
+++ b/src/webgl/p5.RendererGL.Retained.js
@@ -16,25 +16,25 @@ let hashCount = 0;
 p5.RendererGL.prototype._initBufferDefaults = function(gId) {
   this._freeBuffers(gId);
 
-  //@TODO remove this limit on hashes in gHash
+  //@TODO remove this limit on hashes in retainedMode.geometry
   hashCount++;
   if (hashCount > 1000) {
-    const key = Object.keys(this.gHash)[0];
-    delete this.gHash[key];
+    const key = Object.keys(this.retainedMode.geometry)[0];
+    delete this.retainedMode.geometry[key];
     hashCount--;
   }
 
-  //create a new entry in our gHash
-  return (this.gHash[gId] = {});
+  //create a new entry in our retainedMode.geometry
+  return (this.retainedMode.geometry[gId] = {});
 };
 
 p5.RendererGL.prototype._freeBuffers = function(gId) {
-  const buffers = this.gHash[gId];
+  const buffers = this.retainedMode.geometry[gId];
   if (!buffers) {
     return;
   }
 
-  delete this.gHash[gId];
+  delete this.retainedMode.geometry[gId];
   hashCount--;
 
   const gl = this.GL;
@@ -102,7 +102,7 @@ p5.RendererGL.prototype.createBuffers = function(gId, model) {
  */
 p5.RendererGL.prototype.drawBuffers = function(gId) {
   const gl = this.GL;
-  const geometry = this.gHash[gId];
+  const geometry = this.retainedMode.geometry[gId];
 
   if (this._doStroke && geometry.lineVertexCount > 0) {
     const strokeShader = this._getRetainedStrokeShader();
@@ -163,12 +163,16 @@ p5.RendererGL.prototype.drawBuffersScaled = function(
 };
 
 p5.RendererGL.prototype._drawArrays = function(drawMode, gId) {
-  this.GL.drawArrays(drawMode, 0, this.gHash[gId].lineVertexCount);
+  this.GL.drawArrays(
+    drawMode,
+    0,
+    this.retainedMode.geometry[gId].lineVertexCount
+  );
   return this;
 };
 
 p5.RendererGL.prototype._drawElements = function(drawMode, gId) {
-  const buffers = this.gHash[gId];
+  const buffers = this.retainedMode.geometry[gId];
   const gl = this.GL;
   // render the fill
   if (buffers.indexBuffer) {

--- a/src/webgl/p5.RendererGL.Retained.js
+++ b/src/webgl/p5.RendererGL.Retained.js
@@ -52,63 +52,8 @@ p5.RendererGL.prototype._freeBuffers = function(gId) {
   }
 
   // free all the buffers
-<<<<<<< HEAD
-  freeBuffers(strokeBuffers);
-  freeBuffers(fillBuffers);
-};
-
-p5.RendererGL.prototype._prepareBuffers = function(buffers, shader, defs) {
-  const model = buffers.model;
-  const attributes = shader.attributes;
-  const gl = this.GL;
-
-  // loop through each of the buffer definitions
-  for (const def of defs) {
-    const attr = attributes[def.attr];
-    if (!attr) continue;
-
-    let buffer = buffers[def.dst];
-
-    // check if the model has the appropriate source array
-    const src = model[def.src];
-    if (src) {
-      // check if we need to create the GL buffer
-      const createBuffer = !buffer;
-      if (createBuffer) {
-        // create and remember the buffer
-        buffers[def.dst] = buffer = gl.createBuffer();
-      }
-      // bind the buffer
-      gl.bindBuffer(gl.ARRAY_BUFFER, buffer);
-
-      // check if we need to fill the buffer with data
-      if (createBuffer || model.dirtyFlags[def.src] !== false) {
-        const map = def.map;
-        // get the values from the model, possibly transformed
-        const values = map ? map(src) : src;
-
-        // fill the buffer with the values
-        this._bindBuffer(buffer, gl.ARRAY_BUFFER, values);
-
-        // mark the model's source array as clean
-        model.dirtyFlags[def.src] = false;
-      }
-      // enable the attribute
-      shader.enableAttrib(attr, def.size);
-    } else {
-      if (buffer) {
-        // remove the unused buffer
-        gl.deleteBuffer(buffer);
-        buffers[def.dst] = null;
-      }
-      // no need to disable
-      // gl.disableVertexAttribArray(attr.index);
-    }
-  }
-=======
   freeBuffers(this.retainedMode.buffers.stroke);
   freeBuffers(this.retainedMode.buffers.fill);
->>>>>>> Unify attribute management and geometry between immediate and retained
 };
 
 /**

--- a/src/webgl/p5.RendererGL.js
+++ b/src/webgl/p5.RendererGL.js
@@ -168,6 +168,7 @@ p5.RendererGL = function(elt, pInst, isMainCanvas, attr) {
   // Geometry and Material hashes stored here
   this.immediateMode = {
     geometry: new p5.Geometry(),
+    shapeMode: constants.TRIANGLE_FAN,
     _bezierVertex: [],
     _quadraticVertex: [],
     _curveVertex: [],

--- a/src/webgl/p5.RendererGL.js
+++ b/src/webgl/p5.RendererGL.js
@@ -1053,15 +1053,12 @@ p5.RendererGL.prototype._getRetainedStrokeShader =
  * for use with begin/endShape and immediate vertex mode.
  */
 p5.RendererGL.prototype._getImmediateFillShader = function() {
-  if (this._useNormalMaterial) {
-    console.log(
-      'Sorry, normalMaterial() does not currently work with custom WebGL geometry' +
-        ' created with beginShape(). Falling back to standard fill material.'
-    );
-    return this._getImmediateModeShader();
-  }
-
   const fill = this.userFillShader;
+  if (this._useNormalMaterial) {
+    if (!fill || !fill.isNormalShader()) {
+      return this._getNormalShader();
+    }
+  }
   if (this._enableLighting) {
     if (!fill || !fill.isLightShader()) {
       return this._getLightShader();

--- a/src/webgl/p5.RendererGL.js
+++ b/src/webgl/p5.RendererGL.js
@@ -133,8 +133,6 @@ p5.RendererGL = function(elt, pInst, isMainCanvas, attr) {
   this._defaultColorShader = undefined;
   this._defaultPointShader = undefined;
 
-  this._pointVertexBuffer = this.GL.createBuffer();
-
   this.userFillShader = undefined;
   this.userStrokeShader = undefined;
   this.userPointShader = undefined;
@@ -186,7 +184,8 @@ p5.RendererGL = function(elt, pInst, isMainCanvas, attr) {
       stroke: [
       new p5.RenderBuffer(3, 'lineVertices', 'lineVertexBuffer', 'aPosition', this, this._flatten),
       new p5.RenderBuffer(4, 'lineNormals', 'lineNormalBuffer', 'aDirection', this, this._flatten)
-      ]
+      ],
+      point: this.GL.createBuffer()
     }
   };
 

--- a/src/webgl/p5.RendererGL.js
+++ b/src/webgl/p5.RendererGL.js
@@ -144,7 +144,6 @@ p5.RendererGL = function(elt, pInst, isMainCanvas, attr) {
 
   //Imediate Mode
   //default drawing is done in Retained Mode
-  this.isImmediateDrawing = false;
   this.immediateMode = {};
 
   this.retainedMode = {
@@ -1054,12 +1053,15 @@ p5.RendererGL.prototype._getRetainedStrokeShader =
  * for use with begin/endShape and immediate vertex mode.
  */
 p5.RendererGL.prototype._getImmediateFillShader = function() {
-  const fill = this.userFillShader;
   if (this._useNormalMaterial) {
-    if (!fill || !fill.isNormalShader()) {
-      return this._getNormalShader();
-    }
+    console.log(
+      'Sorry, normalMaterial() does not currently work with custom WebGL geometry' +
+        ' created with beginShape(). Falling back to standard fill material.'
+    );
+    return this._getImmediateModeShader();
   }
+
+  const fill = this.userFillShader;
   if (this._enableLighting) {
     if (!fill || !fill.isLightShader()) {
       return this._getLightShader();

--- a/src/webgl/p5.RendererGL.js
+++ b/src/webgl/p5.RendererGL.js
@@ -127,9 +127,6 @@ p5.RendererGL = function(elt, pInst, isMainCanvas, attr) {
   this._curCamera._computeCameraDefaultSettings();
   this._curCamera._setDefaultCamera();
 
-  //Geometry & Material hashes
-  this.gHash = {};
-
   this._defaultLightShader = undefined;
   this._defaultImmediateModeShader = undefined;
   this._defaultNormalShader = undefined;
@@ -142,11 +139,10 @@ p5.RendererGL = function(elt, pInst, isMainCanvas, attr) {
   this.userStrokeShader = undefined;
   this.userPointShader = undefined;
 
-  //Imediate Mode
-  //default drawing is done in Retained Mode
-  this.immediateMode = {};
-
+  // Default drawing is done in Retained Mode
+  // Geometry and Material hashes stored here
   this.retainedMode = {
+    geometry: {},
     buffers: {
       // prettier-ignore
       stroke: [
@@ -166,6 +162,30 @@ p5.RendererGL = function(elt, pInst, isMainCanvas, attr) {
       text: [
         new p5.RenderBuffer(3, 'vertices', 'vertexBuffer', 'aPosition',this, this._vToNArray),
         new p5.RenderBuffer(2, 'uvs', 'uvBuffer', 'aTexCoord', this, this._flatten)
+      ]
+    }
+  };
+
+  // Imediate Mode
+  // Geometry and Material hashes stored here
+  this.immediateMode = {
+    geometry: new p5.Geometry(),
+    _bezierVertex: [],
+    _quadraticVertex: [],
+    _curveVertex: [],
+    buffers: {
+      // prettier-ignore
+      fill: [
+      new p5.RenderBuffer(3, 'vertices', 'vertexBuffer', 'aPosition', this, this._vToNArray),
+      new p5.RenderBuffer(3, 'vertexNormals', 'normalBuffer', 'aNormal', this, this._vToNArray),
+      new p5.RenderBuffer(4, 'vertexColors', 'colorBuffer', 'aVertexColor', this),
+      new p5.RenderBuffer(3, 'vertexAmbients', 'ambientBuffer', 'aAmbientColor', this),
+      new p5.RenderBuffer(2, 'uvs', 'uvBuffer', 'aTexCoord', this, this._flatten)
+      ],
+      // prettier-ignore
+      stroke: [
+      new p5.RenderBuffer(3, 'lineVertices', 'lineVertexBuffer', 'aPosition', this, this._flatten),
+      new p5.RenderBuffer(4, 'lineNormals', 'lineNormalBuffer', 'aDirection', this, this._flatten)
       ]
     }
   };
@@ -484,8 +504,8 @@ p5.prototype.setAttributes = function(key, value) {
   }
 
   if (!this._setupDone) {
-    for (const x in this._renderer.gHash) {
-      if (this._renderer.gHash.hasOwnProperty(x)) {
+    for (const x in this._renderer.retainedMode.geometry) {
+      if (this._renderer.retainedMode.geometry.hasOwnProperty(x)) {
         console.error(
           'Sorry, Could not set the attributes, you need to call setAttributes() ' +
             'before calling the other drawing methods in setup()'
@@ -843,7 +863,7 @@ p5.RendererGL.prototype.loadPixels = function() {
 //////////////////////////////////////////////
 
 p5.RendererGL.prototype.geometryInHash = function(gId) {
-  return this.gHash[gId] !== undefined;
+  return this.retainedMode.geometry[gId] !== undefined;
 };
 
 /**

--- a/src/webgl/p5.Shader.js
+++ b/src/webgl/p5.Shader.js
@@ -485,6 +485,10 @@ p5.Shader.prototype.isLightShader = function() {
   );
 };
 
+p5.Shader.prototype.isNormalShader = function() {
+  return this.attributes.aNormal !== undefined;
+};
+
 p5.Shader.prototype.isTextureShader = function() {
   return this.samplerIndex > 0;
 };

--- a/src/webgl/text.js
+++ b/src/webgl/text.js
@@ -678,7 +678,7 @@ p5.RendererGL.prototype._renderText = function(p, line, x, y, maxY) {
   }
   this._applyColorBlend(this.curFillColor);
 
-  let g = this.gHash['glyph'];
+  let g = this.retainedMode.geometry['glyph'];
   if (!g) {
     // create the geometry for rendering a quad
     const geom = (this._textGeom = new p5.Geometry(1, 1, function() {

--- a/src/webgl/text.js
+++ b/src/webgl/text.js
@@ -694,7 +694,9 @@ p5.RendererGL.prototype._renderText = function(p, line, x, y, maxY) {
   }
 
   // bind the shader buffers
-  this._prepareBuffers(g, sh, p5.RendererGL._textBuffers);
+  for (const buff of this.retainedMode.buffers.text) {
+    buff._prepareBuffer(g, sh);
+  }
   this._bindBuffer(g.indexBuffer, gl.ELEMENT_ARRAY_BUFFER);
 
   // this will have to do for now...

--- a/test/manual-test-examples/webgl/geometryImmediate/sketch.js
+++ b/test/manual-test-examples/webgl/geometryImmediate/sketch.js
@@ -27,7 +27,7 @@ function draw() {
 }
 
 function ngon(n, x, y, d) {
-  beginShape();
+  beginShape(TESS);
   for (let i = 0; i < n + 1; i++) {
     angle = TWO_PI / n * i;
     px = x + sin(angle) * d / 2;

--- a/test/unit/webgl/p5.RendererGL.js
+++ b/test/unit/webgl/p5.RendererGL.js
@@ -445,7 +445,7 @@ suite('p5.RendererGL', function() {
       myp5.stroke(255);
       myp5.triangle(0, 0, 1, 0, 0, 1);
 
-      var buffers = renderer.gHash['tri'];
+      var buffers = renderer.retainedMode.geometry['tri'];
 
       assert.isObject(buffers);
       assert.isDefined(buffers.indexBuffer);


### PR DESCRIPTION
Resolves #3620 
Resolves #2963 
Resolves #4141 

Apologies for the big pull request!

This is a refactor of immediate mode. This does the following:
1. Merges use of `p5.RenderBuffer` and `p5.Geometry` across both retained and immediate modes
2. Breaks up the immediate mode rendering into discrete chunks for readability.
3. Adds `TESS` as a possible argument to `beginShape()`. This isn't an ideal solution, but the implicit tesselation of custom shapes introduced in #3680 has caused a number of problems. Switching to a requirement for explicit tesselation reduces the complexity in the code.
4. Adds simplified normals `(0, 0, 1)` to custom shapes. For truly 3D custom shapes, these normals will not be correct, but this brings behavior and appearance in line with Processing (as far as I can tell). This in combination with 1. means that materials (lit and otherwise) now work with flat custom shapes.