### PR TITLE
Escape the asterisk charecters in the mag function jsdoc 

### DIFF
--- a/.all-contributorsrc
+++ b/.all-contributorsrc
@@ -1616,6 +1616,15 @@
         "code",
         "doc"
       ]
+    },
+    {
+      "login": "jjkaufman",
+      "name": "Jon Kaufman",
+      "avatar_url": "https://avatars0.githubusercontent.com/u/1706950?s=460&v=4",
+      "profile": "https://github.com/jjkaufman",
+      "contributions": [
+        "doc"
+      ]
     }
   ],
   "repoType": "github",

--- a/src/math/p5.Vector.js
+++ b/src/math/p5.Vector.js
@@ -570,7 +570,7 @@ p5.Vector.prototype.div = function div(n) {
 
 /**
  * Calculates the magnitude (length) of the vector and returns the result as
- * a float (this is simply the equation sqrt(x*x + y*y + z*z).)
+ * a float (this is simply the equation sqrt(x\*x + y\*y + z\*z).)
  *
  * @method mag
  * @return {Number} magnitude of the vector
@@ -618,7 +618,7 @@ p5.Vector.prototype.mag = function mag() {
 
 /**
  * Calculates the squared magnitude of the vector and returns the result
- * as a float (this is simply the equation <em>(x*x + y*y + z*z)</em>.)
+ * as a float (this is simply the equation <em>(x\*x + y\*y + z\*z)</em>.)
  * Faster if the real length is not required in the
  * case of comparing vectors, etc.
  *


### PR DESCRIPTION
<!--
  Thank you for contributing! Please use this pull request (PR) template.


 In the description field of this PR, include "resolves #XXXX" tagging the issue you are fixing. If this PR addresses the issue but doesn't completely resolve it (ie the issue should remain open after your PR is merged), write "addresses #XXXX".-->
Resolves #4148

 Changes: 
<!-- Add here what changes were made in this pull request and if possible provide links showcasing the changes. -->

Asterisks in the mag jsdoc were escaped using a backslash. Reference screenshot below to see asterisks now rendering as expected. 

 Screenshots of the change: 
<!-- If applicable, add screenshots depicting the changes. -->

<img width="825" alt="Screen Shot 2019-11-20 at 7 20 53 PM" src="https://user-images.githubusercontent.com/1706950/69301788-4a89cc00-0bcc-11ea-8152-250980f5fe73.png">


#### PR Checklist
<!--
  To check any option, replace the "[ ]" with a "[x]". Be sure to check out how it looks in the Preview tab! Feel free to remove any portion of the template that is not relevant for your issue.
-->

- [x] [Inline documentation] is included / updated

[Inline documentation]: https://github.com/processing/p5.js/blob/master/developer_docs/inline_documentation.md
[Unit tests]: https://github.com/processing/p5.js/tree/master/developer_docs#unit-tests
[Benchmarks]: https://github.com/processing/p5.js/blob/master/developer_docs/benchmarking_p5.md
