### PR TITLE
Only run GitHub Actions CI on "Pull request" events

### DIFF
--- a/.github/workflows/ci-lint-examples.yml
+++ b/.github/workflows/ci-lint-examples.yml
@@ -1,6 +1,12 @@
 name: Linting Examples
 
-on: pull_request
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+    branches:
+      - '*'
 
 jobs:
   lint:

--- a/.github/workflows/ci-lint-examples.yml
+++ b/.github/workflows/ci-lint-examples.yml
@@ -4,18 +4,17 @@ on: pull_request
 
 jobs:
   lint:
-
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v1
-    - name: Use Node.js 12.x
-      uses: actions/setup-node@v1
-      with:
-        node-version: 12.x
-    - name: Get node modules
-      run: npm ci
-      env:
-        CI: true
-    - name: Lint examples
-      run: npm run lint:samples
+      - uses: actions/checkout@v1
+      - name: Use Node.js 12.x
+        uses: actions/setup-node@v1
+        with:
+          node-version: 12.x
+      - name: Get node modules
+        run: npm ci
+        env:
+          CI: true
+      - name: Lint examples
+        run: npm run lint:samples

--- a/.github/workflows/ci-lint-examples.yml
+++ b/.github/workflows/ci-lint-examples.yml
@@ -1,6 +1,6 @@
 name: Linting Examples
 
-on: [push, pull_request]
+on: pull_request
 
 jobs:
   lint:

--- a/.github/workflows/ci-lint.yml
+++ b/.github/workflows/ci-lint.yml
@@ -1,6 +1,6 @@
 name: Linting Code
 
-on: [push, pull_request]
+on: pull_request
 
 jobs:
   lint:

--- a/.github/workflows/ci-lint.yml
+++ b/.github/workflows/ci-lint.yml
@@ -1,6 +1,12 @@
 name: Linting Code
 
-on: pull_request
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+    branches:
+      - '*'
 
 jobs:
   lint:

--- a/.github/workflows/ci-lint.yml
+++ b/.github/workflows/ci-lint.yml
@@ -4,18 +4,17 @@ on: pull_request
 
 jobs:
   lint:
-
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v1
-    - name: Use Node.js 12.x
-      uses: actions/setup-node@v1
-      with:
-        node-version: 12.x
-    - name: Get node modules
-      run: npm ci
-      env:
-        CI: true
-    - name: Lint source code
-      run: npm run lint:source
+      - uses: actions/checkout@v1
+      - name: Use Node.js 12.x
+        uses: actions/setup-node@v1
+        with:
+          node-version: 12.x
+      - name: Get node modules
+        run: npm ci
+        env:
+          CI: true
+      - name: Lint source code
+        run: npm run lint:source

--- a/.github/workflows/ci-test.yml
+++ b/.github/workflows/ci-test.yml
@@ -1,6 +1,6 @@
 name: Testing
 
-on: [push, pull_request]
+on: pull_request
 
 jobs:
   test:

--- a/.github/workflows/ci-test.yml
+++ b/.github/workflows/ci-test.yml
@@ -1,6 +1,12 @@
 name: Testing
 
-on: pull_request
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+    branches:
+      - '*'
 
 jobs:
   test:


### PR DESCRIPTION
## Changes: 
<!-- Add here what changes were made in this pull request and if possible provide links showcasing the changes. -->
- restricted the `push` event trigger for GitHub actions to only work on the master branch, since its causing duplicate test runs for pull requests. (because we are using the `pull_request` event trigger.)
- some formatting

this means we won't run CI for branches that aren't in a pull request, except for the `master` branch.

#### PR Checklist
<!--
  To check any option, replace the "[ ]" with a "[x]". Be sure to check out how it looks in the Preview tab! Feel free to remove any portion of the template that is not relevant for your issue.
-->

- [x] `npm run lint` passes