### PR TITLE
Fix iOS Lighting in WebGL

### DIFF
--- a/src/webgl/shaders/light_texture.frag
+++ b/src/webgl/shaders/light_texture.frag
@@ -1,4 +1,4 @@
-precision mediump float;
+precision highp float;
 
 uniform vec4 uMaterialColor;
 uniform vec4 uTint;

--- a/src/webgl/shaders/lighting.glsl
+++ b/src/webgl/shaders/lighting.glsl
@@ -1,4 +1,5 @@
-precision mediump float;
+precision highp float;
+precision highp int;
 
 uniform mat4 uViewMatrix;
 

--- a/src/webgl/shaders/lighting.glsl
+++ b/src/webgl/shaders/lighting.glsl
@@ -6,25 +6,25 @@ uniform mat4 uViewMatrix;
 uniform bool uUseLighting;
 
 uniform int uAmbientLightCount;
-uniform vec3 uAmbientColor[8];
+uniform vec3 uAmbientColor[5];
 
 uniform int uDirectionalLightCount;
-uniform vec3 uLightingDirection[8];
-uniform vec3 uDirectionalDiffuseColors[8];
-uniform vec3 uDirectionalSpecularColors[8];
+uniform vec3 uLightingDirection[5];
+uniform vec3 uDirectionalDiffuseColors[5];
+uniform vec3 uDirectionalSpecularColors[5];
 
 uniform int uPointLightCount;
-uniform vec3 uPointLightLocation[8];
-uniform vec3 uPointLightDiffuseColors[8];	
-uniform vec3 uPointLightSpecularColors[8];
+uniform vec3 uPointLightLocation[5];
+uniform vec3 uPointLightDiffuseColors[5];	
+uniform vec3 uPointLightSpecularColors[5];
 
 uniform int uSpotLightCount;
-uniform float uSpotLightAngle[8];
-uniform float uSpotLightConc[8];
-uniform vec3 uSpotLightDiffuseColors[8];
-uniform vec3 uSpotLightSpecularColors[8];
-uniform vec3 uSpotLightLocation[8];
-uniform vec3 uSpotLightDirection[8];
+uniform float uSpotLightAngle[5];
+uniform float uSpotLightConc[5];
+uniform vec3 uSpotLightDiffuseColors[5];
+uniform vec3 uSpotLightSpecularColors[5];
+uniform vec3 uSpotLightLocation[5];
+uniform vec3 uSpotLightDirection[5];
 
 uniform bool uSpecular;
 uniform float uShininess;
@@ -85,7 +85,7 @@ void totalLight(
 
   vec3 viewDirection = normalize(-modelPosition);
 
-  for (int j = 0; j < 8; j++) {
+  for (int j = 0; j < 5; j++) {
     if (j < uDirectionalLightCount) {
       vec3 lightVector = (uViewMatrix * vec4(uLightingDirection[j], 0.0)).xyz;
       vec3 lightColor = uDirectionalDiffuseColors[j];

--- a/src/webgl/shaders/phong.frag
+++ b/src/webgl/shaders/phong.frag
@@ -1,5 +1,6 @@
 // include lighting.glsl
 precision highp float;
+precision highp int;
 
 uniform vec4 uMaterialColor;
 uniform sampler2D uSampler;

--- a/src/webgl/shaders/phong.vert
+++ b/src/webgl/shaders/phong.vert
@@ -5,7 +5,7 @@ attribute vec3 aPosition;
 attribute vec3 aNormal;
 attribute vec2 aTexCoord;
 
-uniform vec3 uAmbientColor[8];
+uniform vec3 uAmbientColor[5];
 
 uniform mat4 uModelViewMatrix;
 uniform mat4 uProjectionMatrix;
@@ -30,7 +30,7 @@ void main(void) {
 
   // TODO: this should be a uniform
   vAmbientColor = vec3(0.0);
-  for (int i = 0; i < 8; i++) {
+  for (int i = 0; i < 5; i++) {
     if (i < uAmbientLightCount) {
       vAmbientColor += uAmbientColor[i];
     }

--- a/src/webgl/shaders/phong.vert
+++ b/src/webgl/shaders/phong.vert
@@ -1,5 +1,5 @@
-precision mediump float;
-precision mediump int;
+precision highp float;
+precision highp int;
 
 attribute vec3 aPosition;
 attribute vec3 aNormal;


### PR DESCRIPTION
Resolves #4023 
Related to #3940 

I finally got my hands on the necessary hardware and managed to fix both vertex and pixel lighting for iOS.

 Changes: 
This raises the precision on both ints and floats on all lighting shaders to `highp`. Based on my research this has the broadest support for most mobile devices in use. This also fixes lighting in iOS.

Additionally, in order to fix per-pixel lighting, I had to lower the array length for all lighting uniform arrays from 8 to 5.  iOS currently has a [uniform limit on fragment shaders of 64](https://github.com/mrdoob/three.js/issues/15617).

All manual tests work with good performance on:
Windows 10 Chrome 78.0.3904 & Firefox 70.0.1
iPhone XR iOS 13.1.3 Safari