### PR TITLE
use rect() with 3 parameters, similar to how ellipse() works

### DIFF
--- a/src/core/shape/2d_primitives.js
+++ b/src/core/shape/2d_primitives.js
@@ -560,6 +560,10 @@ p5.prototype.rect = function() {
   p5._validateParameters('rect', arguments);
 
   if (this._renderer._doStroke || this._renderer._doFill) {
+    if (arguments.length === 3) {
+      arguments[3] = arguments[2];
+    }
+
     const vals = canvas.modeAdjust(
       arguments[0],
       arguments[1],
@@ -567,6 +571,7 @@ p5.prototype.rect = function() {
       arguments[3],
       this._renderer._rectMode
     );
+
     const args = [vals.x, vals.y, vals.w, vals.h];
     // append the additional arguments (either cornder radii, or
     // segment details) to the argument list

--- a/src/core/shape/2d_primitives.js
+++ b/src/core/shape/2d_primitives.js
@@ -512,7 +512,7 @@ p5.prototype.quad = function(...args) {
  * @param  {Number} x  x-coordinate of the rectangle.
  * @param  {Number} y  y-coordinate of the rectangle.
  * @param  {Number} w  width of the rectangle.
- * @param  {Number} h  height of the rectangle.
+ * @param  {Number} [h]  height of the rectangle.
  * @param  {Number} [tl] optional radius of top-left corner.
  * @param  {Number} [tr] optional radius of top-right corner.
  * @param  {Number} [br] optional radius of bottom-right corner.

--- a/test/unit/core/2d_primitives.js
+++ b/test/unit/core/2d_primitives.js
@@ -192,7 +192,7 @@ suite('2D Primitives', function() {
     test('no friendly-err-msg, format I', function() {
       assert.doesNotThrow(
         function() {
-          myp5.rect(0, 0, 100, 100);
+          myp5.rect(0, 0, 100);
         },
         Error,
         'got unwanted exception'
@@ -206,11 +206,6 @@ suite('2D Primitives', function() {
         Error,
         'got unwanted exception'
       );
-    });
-    test('missing param #3', function() {
-      assert.validationError(function() {
-        myp5.rect(0, 0, Math.PI);
-      });
     });
     test('missing param #4', function() {
       // this err case escapes

--- a/test/unit/core/error_helpers.js
+++ b/test/unit/core/error_helpers.js
@@ -87,11 +87,6 @@ suite('Error Helpers', function() {
         'got unwanted exception'
       );
     });
-    test('rect(): missing param #3', function() {
-      assert.validationError(function() {
-        p5._validateParameters('rect', [1, 1, 10.5]);
-      });
-    });
     test('rect(): wrong param type at #0', function() {
       assert.validationError(function() {
         p5._validateParameters('rect', ['a', 1, 10.5, 10, 0, Math.PI]);


### PR DESCRIPTION
Resolves #4163 

 Changes: 
As mentioned in issue, simply allows `rect()` to work with just 3 parameters, like `ellipse()` so the words can be easily swapped while sketching. The question has come up on the issue referenced above what happens if one is using rounded corners– however this enhancement is simply to deal with just 3 parameters that `ellipse()` can handle. If one wants to add rounded corners, then the additional height should be added or square used. 

- [x] `npm run lint` passes
- [x] [Inline documentation] is included / updated
- [x] [Unit tests] are included / updated
- [ ] [Benchmarks] are included / updated