### PR TITLE
Added  Feature to stop streaming in remove() method(#4085)(#4140).

### DIFF
--- a/src/dom/dom.js
+++ b/src/dom/dom.js
@@ -2066,14 +2066,13 @@ p5.Element.prototype.remove = function() {
   // stop all audios/videos and detach all devices like microphone/camera etc
   // used as input/output for audios/videos.
   if (this instanceof p5.MediaElement) {
-    var stream = this.elt.srcObject;
-    var tracks = stream.getTracks();
+    const tracks = this.elt.srcObject.getTracks();
 
     tracks.forEach(function(track) {
       track.stop();
     });
 
-    stream = null;
+    this.elt.srcObject = null;
   }
 
   // deregister events

--- a/src/dom/dom.js
+++ b/src/dom/dom.js
@@ -2063,6 +2063,17 @@ p5.Element.prototype.size = function(w, h) {
  * </code></div>
  */
 p5.Element.prototype.remove = function() {
+  if (this instanceof p5.MediaElement) {
+    var stream = this.elt.srcObject;
+    var tracks = stream.getTracks();
+
+    tracks.forEach(function(track) {
+      track.stop();
+    });
+
+    stream = null;
+  }
+
   // deregister events
   for (var ev in this._events) {
     this.elt.removeEventListener(ev, this._events[ev]);

--- a/src/dom/dom.js
+++ b/src/dom/dom.js
@@ -2063,6 +2063,8 @@ p5.Element.prototype.size = function(w, h) {
  * </code></div>
  */
 p5.Element.prototype.remove = function() {
+  // stops all audios/videos and detach all devices like microphone/camera
+  // used as input/output for audio/video.
   if (this instanceof p5.MediaElement) {
     var stream = this.elt.srcObject;
     var tracks = stream.getTracks();

--- a/src/dom/dom.js
+++ b/src/dom/dom.js
@@ -2063,8 +2063,8 @@ p5.Element.prototype.size = function(w, h) {
  * </code></div>
  */
 p5.Element.prototype.remove = function() {
-  // stops all audios/videos and detach all devices like microphone/camera
-  // used as input/output for audio/video.
+  // stop all audios/videos and detach all devices like microphone/camera etc
+  // used as input/output for audios/videos.
   if (this instanceof p5.MediaElement) {
     var stream = this.elt.srcObject;
     var tracks = stream.getTracks();


### PR DESCRIPTION
Resolves (#4085 )(#4140 )

 Changes: 
Added feature in the remove() method (in p5.Element) to stop streaming caused the createCapture().


- [x] `npm run lint` passes
- [x] [Inline documentation] is included / updated
- [x] [Unit tests] are included / updated
- [x] [Benchmarks] are included / updated

[Inline documentation]: https://github.com/processing/p5.js/blob/master/contributor_docs/inline_documentation.md
[Unit tests]: https://github.com/processing/p5.js/tree/master/contributor_docs#unit-tests
[Benchmarks]: https://github.com/processing/p5.js/blob/master/contributor_docs/benchmarking_p5.md
