### PR TITLE
p5.Vector.reflect method

### DIFF
--- a/src/math/p5.Vector.js
+++ b/src/math/p5.Vector.js
@@ -1287,6 +1287,61 @@ p5.Vector.prototype.lerp = function lerp(x, y, z, amt) {
 };
 
 /**
+ * Reflect the incoming vector about a normal to a line in 2D, or about a normal to a plane in 3D
+ * This method acts on the vector directly
+ *
+ * @method reflect
+ * @param  {p5.Vector} surfaceNormal   the <a href="#/p5.Vector">p5.Vector</a> to reflect about, will be normalized by this method
+ * @chainable
+ * @example
+ * <div class="norender">
+ * <code>
+ * let v = createVector(4, 6); // incoming vector, this example vector is heading to the right and downward
+ * let n = createVector(0, -1); // surface normal to a plane (this example normal points directly upwards)
+ * v.reflect(n); // v is reflected about the surface normal n.  v's components are now set to [4, -6]
+ * </code>
+ * </div>
+ *
+ * <div>
+ * <code>
+ * function draw() {
+ *   background(240);
+ *
+ *   let v0 = createVector(0, 0);
+ *   let v1 = createVector(mouseX, mouseY);
+ *   drawArrow(v0, v1, 'red');
+ *
+ *   let n = createVector(0, -30);
+ *   drawArrow(v1, n, 'blue');
+ *
+ *   let r = v1.copy();
+ *   r.reflect(n);
+ *   drawArrow(v1, r, 'purple');
+ * }
+ *
+ * // draw an arrow for a vector at a given base position
+ * function drawArrow(base, vec, myColor) {
+ *   push();
+ *   stroke(myColor);
+ *   strokeWeight(3);
+ *   fill(myColor);
+ *   translate(base.x, base.y);
+ *   line(0, 0, vec.x, vec.y);
+ *   rotate(vec.heading());
+ *   let arrowSize = 7;
+ *   translate(vec.mag() - arrowSize, 0);
+ *   triangle(0, arrowSize / 2, 0, -arrowSize / 2, arrowSize, 0);
+ *   pop();
+ * }
+ * </code>
+ * </div>
+ */
+p5.Vector.prototype.reflect = function reflect(surfaceNormal) {
+  surfaceNormal.normalize();
+  return this.sub(surfaceNormal.mult(2 * this.dot(surfaceNormal)));
+};
+
+/**
  * Return a representation of this vector as a float array. This is only
  * for temporary use. If used in any other fashion, the contents should be
  * copied by using the <b>p5.Vector.<a href="#/p5.Vector/copy">copy()</a></b> method to copy into your own

--- a/test/unit/math/p5.Vector.js
+++ b/test/unit/math/p5.Vector.js
@@ -922,4 +922,69 @@ suite('p5.Vector', function() {
       expect(v.array()).to.eql([1, 23, 4]);
     });
   });
+
+  suite('reflect', function() {
+    setup(function() {
+      incoming_x = 1;
+      incoming_y = 1;
+      incoming_z = 1;
+      original_incoming = myp5.createVector(incoming_x, incoming_y, incoming_z);
+
+      x_normal = myp5.createVector(3, 0, 0);
+      y_normal = myp5.createVector(0, 3, 0);
+      z_normal = myp5.createVector(0, 0, 3);
+
+      x_bounce_incoming = myp5.createVector(incoming_x, incoming_y, incoming_z);
+      x_bounce_outgoing = x_bounce_incoming.reflect(x_normal);
+
+      y_bounce_incoming = myp5.createVector(incoming_x, incoming_y, incoming_z);
+      y_bounce_outgoing = y_bounce_incoming.reflect(y_normal);
+
+      z_bounce_incoming = myp5.createVector(incoming_x, incoming_y, incoming_z);
+      z_bounce_outgoing = z_bounce_incoming.reflect(z_normal);
+    });
+
+    test('should return a p5.Vector', function() {
+      expect(x_bounce_incoming).to.be.an.instanceof(p5.Vector);
+      expect(y_bounce_incoming).to.be.an.instanceof(p5.Vector);
+      expect(z_bounce_incoming).to.be.an.instanceof(p5.Vector);
+    });
+
+    test('should update this', function() {
+      assert.equal(x_bounce_incoming, x_bounce_outgoing);
+      assert.equal(y_bounce_incoming, y_bounce_outgoing);
+      assert.equal(z_bounce_incoming, z_bounce_outgoing);
+    });
+
+    test('x-normal should flip incoming x component and maintain y,z components', function() {
+      expect(x_bounce_outgoing.x).to.be.closeTo(-1, 0.01);
+      expect(x_bounce_outgoing.y).to.be.closeTo(1, 0.01);
+      expect(x_bounce_outgoing.z).to.be.closeTo(1, 0.01);
+    });
+    test('y-normal should flip incoming y component and maintain x,z components', function() {
+      expect(y_bounce_outgoing.x).to.be.closeTo(1, 0.01);
+      expect(y_bounce_outgoing.y).to.be.closeTo(-1, 0.01);
+      expect(y_bounce_outgoing.z).to.be.closeTo(1, 0.01);
+    });
+    test('z-normal should flip incoming z component and maintain x,y components', function() {
+      expect(z_bounce_outgoing.x).to.be.closeTo(1, 0.01);
+      expect(z_bounce_outgoing.y).to.be.closeTo(1, 0.01);
+      expect(z_bounce_outgoing.z).to.be.closeTo(-1, 0.01);
+    });
+
+    test('angle of incidence should match angle of reflection', function() {
+      expect(Math.abs(x_normal.angleBetween(original_incoming))).to.be.closeTo(
+        Math.abs(x_normal.angleBetween(x_bounce_outgoing.mult(-1))),
+        0.01
+      );
+      expect(Math.abs(y_normal.angleBetween(original_incoming))).to.be.closeTo(
+        Math.abs(y_normal.angleBetween(y_bounce_outgoing.mult(-1))),
+        0.01
+      );
+      expect(Math.abs(z_normal.angleBetween(original_incoming))).to.be.closeTo(
+        Math.abs(z_normal.angleBetween(z_bounce_outgoing.mult(-1))),
+        0.01
+      );
+    });
+  });
 });


### PR DESCRIPTION
Resolves #4121

Changes: 
This PR adds a method to p5.Vector called reflect. The purpose and details of this method are described in #4121. On top of this, the implementation and inline documentation are derived from the changes in the (currently) open PR #4118. @erichlof had done some prior work there, however I was unsure on how to contribute directly to that PR so I have opened this one. I have used the same implementation, however my changes **have passed linting** and I **added unit tests** for the reflect method as well. 

I am not sure if discussion on these changes should be moved over to this PR and to close #4118, or if this PR should be closed since there is some duplication between them however I wanted to make clear my addition of unit tests and the fact that my changes pass linting.

- [x] `npm run lint` passes
- [x] [Inline documentation] is included / updated
- [x] [Unit tests] are included / updated
- [ ] [Benchmarks] are included / updated

Thanks to @erichlof and @limzykenneth for continuing discussion on this improvement. 