### PR TITLE
Make animation delay a frame-specific value with GIFs

### DIFF
--- a/src/core/p5.Renderer2D.js
+++ b/src/core/p5.Renderer2D.js
@@ -371,7 +371,7 @@ p5.Renderer2D.prototype.updatePixels = function(x, y, w, h) {
   h *= pd;
 
   if (this.gifProperties) {
-    this.gifProperties.frames[this.gifProperties.displayIndex] =
+    this.gifProperties.frames[this.gifProperties.displayIndex].image =
       pixelsState.imageData;
   }
 

--- a/src/image/image.js
+++ b/src/image/image.js
@@ -202,10 +202,8 @@ p5.prototype.saveGif = (pImg, filename) => {
   } else if (loopLimit === null) {
     loopLimit = 0;
   }
-  const gifFormatDelay = props.delay / 10;
   const opts = {
-    loop: loopLimit,
-    delay: gifFormatDelay
+    loop: loopLimit
   };
 
   const buffer = new Uint8Array(
@@ -216,7 +214,7 @@ p5.prototype.saveGif = (pImg, filename) => {
   //loop over frames and build pixel -> palette index for each
   for (let i = 0; i < props.numFrames; i++) {
     const pixelPaletteIndex = new Uint8Array(pImg.width * pImg.height);
-    const data = props.frames[i].data;
+    const data = props.frames[i].image.data;
     const dataLength = data.length;
     for (let j = 0, k = 0; j < dataLength; j += 4, k++) {
       const r = data[j + 0];
@@ -238,6 +236,7 @@ p5.prototype.saveGif = (pImg, filename) => {
     }
     palette.length = powof2;
     opts.palette = new Uint32Array(palette);
+    opts.delay = props.frames[i].delay / 10; // Move timing back into GIF formatting
     gifWriter.addFrame(0, 0, pImg.width, pImg.height, pixelPaletteIndex, opts);
   }
   gifWriter.end();

--- a/test/unit/image/loading.js
+++ b/test/unit/image/loading.js
@@ -241,7 +241,6 @@ suite('loading animated gif images', function() {
           test('gifProperties should be correct after preload', function done() {
             assert.isTrue(gifImage instanceof p5.Image);
             var nyanCatGifProperties = {
-              delay: 100,
               displayIndex: 0,
               loopCount: 0,
               loopLimit: null,
@@ -262,8 +261,9 @@ suite('loading animated gif images', function() {
             );
             for (var i = 0; i < gifImage.gifProperties.numFrames; i++) {
               assert.isTrue(
-                gifImage.gifProperties.frames[i] instanceof ImageData
+                gifImage.gifProperties.frames[i].image instanceof ImageData
               );
+              assert.isTrue(gifImage.gifProperties.frames[i].delay === 100);
             }
           });
           test('should be able to modify gifProperties state', function() {


### PR DESCRIPTION
resolves #3872 

GIF frames are now objects with this format:
```js
{image: ImageData, delay: Number}
```

I chose this route instead of making delay an array because I wanted to keep a conceptual link between the frame image and the frame delay. This occasionally results in verbose code but I think the structure of `gifProperties` is more intelligible this way.

With this PR, the [frame-level delay example](https://hamoid.tumblr.com/post/79459820142/twenty-four-point-fifty-five-seconds-attempt-to) given by @hamoid works correctly in p5. 