### PR TITLE
Antialias by default for Safari

### DIFF
--- a/src/webgl/p5.RendererGL.js
+++ b/src/webgl/p5.RendererGL.js
@@ -230,11 +230,13 @@ p5.RendererGL.prototype = Object.create(p5.Renderer.prototype);
 //////////////////////////////////////////////
 
 p5.RendererGL.prototype._setAttributeDefaults = pInst => {
+  // See issue #3850, safer to enable AA in Safari
+  const applyAA = navigator.userAgent.toLowerCase().includes('safari');
   const defaults = {
     alpha: true,
     depth: true,
     stencil: true,
-    antialias: false,
+    antialias: applyAA,
     premultipliedAlpha: false,
     preserveDrawingBuffer: true,
     perPixelLighting: false
@@ -350,7 +352,7 @@ p5.RendererGL.prototype._resetContext = function(options, callback) {
  * of at least 8 bits
  * <br><br>
  * antialias - indicates whether or not to perform anti-aliasing
- * default is false
+ * default is false (true in Safari)
  * <br><br>
  * premultipliedAlpha - indicates that the page compositor will assume
  * the drawing buffer contains colors with pre-multiplied alpha


### PR DESCRIPTION
Resolves #3850 

 Changes: 
This enables antialiasing by default in Safari for the WebGLRenderingContext. Safari creates a strobing effect when a sketch renders in an animation frame without clearing the color buffer _unless_ antialiasing is active. I will file a bug with Safari but it seems best to enable antialiasing by default on all Safari GLRenderingContexts.

Antialiasing can still be deactivated with `noSmooth()` for users that want a performance bump and are calling `background()` every frame. 

I also tested on iOS 13 Safari.