### PR TITLE
usejsdoc.org link updated to jsdoc.app

### DIFF
--- a/contributor_docs/README.md
+++ b/contributor_docs/README.md
@@ -24,7 +24,7 @@ We recognize all types of contributions. This project follows the [all-contribut
 
 Aside from the code itself, you may also need to supply some combination of the following.
 
-- [inline documentation](./inline_documentation.md) in the form of code comments, which explain the code both to other developers and to users. Many of these comments must conform to [JSDoc](https://usejsdoc.org) syntax and will be published on the p5.js website as part of the [online reference manual](https://p5js.org/reference/)
+- [inline documentation](./inline_documentation.md) in the form of code comments, which explain the code both to other developers and to users. Many of these comments must conform to [JSDoc](https://jsdoc.app) syntax and will be published on the p5.js website as part of the [online reference manual](https://p5js.org/reference/)
 - [unit tests](./unit_testing.md), small pieces of code which are separate from the library and are used to verify its behavior
 - [benchmarks](./benchmarking_p5.md) to test performance
 


### PR DESCRIPTION
- domain seems to have changed and the https url wasn't forwarding to the project's new domain like a normal http requested did.

Super tiny edit to help those looking up details of jsdoc – to not hit a dead-link.
Didn't think it needed a whole issue made for it.. just a quick link update.