### PR TITLE
Change object member functions to use regular functions

### DIFF
--- a/src/color/color_conversion.js
+++ b/src/color/color_conversion.js
@@ -19,7 +19,7 @@ p5.ColorConversion = {};
 /**
  * Convert an HSBA array to HSLA.
  */
-p5.ColorConversion._hsbaToHSLA = hsba => {
+p5.ColorConversion._hsbaToHSLA = function(hsba) {
   const hue = hsba[0];
   let sat = hsba[1];
   const val = hsba[2];
@@ -45,7 +45,7 @@ p5.ColorConversion._hsbaToHSLA = hsba => {
 /**
  * Convert an HSBA array to RGBA.
  */
-p5.ColorConversion._hsbaToRGBA = hsba => {
+p5.ColorConversion._hsbaToRGBA = function(hsba) {
   const hue = hsba[0] * 6; // We will split hue into 6 sectors.
   const sat = hsba[1];
   const val = hsba[2];
@@ -100,7 +100,7 @@ p5.ColorConversion._hsbaToRGBA = hsba => {
 /**
  * Convert an HSLA array to HSBA.
  */
-p5.ColorConversion._hslaToHSBA = hsla => {
+p5.ColorConversion._hslaToHSBA = function(hsla) {
   const hue = hsla[0];
   let sat = hsla[1];
   const li = hsla[2];
@@ -128,7 +128,7 @@ p5.ColorConversion._hslaToHSBA = hsla => {
  * components, and pick a convenient third one ('zest') so that we don't need
  * to calculate formal HSBA saturation.
  */
-p5.ColorConversion._hslaToRGBA = hsla => {
+p5.ColorConversion._hslaToRGBA = function(hsla) {
   const hue = hsla[0] * 6; // We will split hue into 6 sectors.
   const sat = hsla[1];
   const li = hsla[2];
@@ -187,7 +187,7 @@ p5.ColorConversion._hslaToRGBA = hsla => {
 /**
  * Convert an RGBA array to HSBA.
  */
-p5.ColorConversion._rgbaToHSBA = rgba => {
+p5.ColorConversion._rgbaToHSBA = function(rgba) {
   const red = rgba[0];
   const green = rgba[1];
   const blue = rgba[2];
@@ -226,7 +226,7 @@ p5.ColorConversion._rgbaToHSBA = rgba => {
 /**
  * Convert an RGBA array to HSLA.
  */
-p5.ColorConversion._rgbaToHSLA = rgba => {
+p5.ColorConversion._rgbaToHSLA = function(rgba) {
   const red = rgba[0];
   const green = rgba[1];
   const blue = rgba[2];

--- a/src/core/environment.js
+++ b/src/core/environment.js
@@ -40,7 +40,7 @@ const _windowPrint = window.print;
  * @alt
  * default grey canvas
  */
-p5.prototype.print = (...args) => {
+p5.prototype.print = function(...args) {
   if (!args.length) {
     _windowPrint();
   } else {
@@ -733,7 +733,7 @@ p5.prototype.getURLPath = () =>
  * no display.
  *
  */
-p5.prototype.getURLParams = () => {
+p5.prototype.getURLParams = function() {
   const re = /[?&]([^&=]+)(?:[&=])([^&=]+)/gim;
   let m;
   const v = {};

--- a/src/core/error_helpers.js
+++ b/src/core/error_helpers.js
@@ -191,7 +191,7 @@ if (typeof IS_MINIFIED !== 'undefined') {
    * @param  {Number} errorType
    * @param  {String} filePath
    */
-  p5._friendlyFileLoadError = (errorType, filePath) => {
+  p5._friendlyFileLoadError = function(errorType, filePath) {
     const errorInfo = fileLoadErrorCases[errorType];
     let message;
     if (errorType === 7 || errorType === 8) {
@@ -214,7 +214,7 @@ if (typeof IS_MINIFIED !== 'undefined') {
    * @param  {Number} message message to be printed
    * @param  {String} method name of method
    */
-  p5._friendlyError = (message, method) => {
+  p5._friendlyError = function(message, method) {
     report(message, method);
   };
 
@@ -224,7 +224,7 @@ if (typeof IS_MINIFIED !== 'undefined') {
    * @method _friendlyAutoplayError
    * @private
    */
-  p5._friendlyAutoplayError = src => {
+  p5._friendlyAutoplayError = function(src) {
     report(
       `The media that tried to play (with "${src}") wasn't allowed to by this browser, most likely due to the browser's autoplay policy. Check out https://developer.mozilla.org/en-US/docs/Web/Media/Autoplay_guide for more information about why.`,
       'autoplay'
@@ -552,7 +552,7 @@ if (typeof IS_MINIFIED !== 'undefined') {
   })('ValidationError');
 
   // function for generating console.log() msg
-  p5._friendlyParamError = (errorObj, func) => {
+  p5._friendlyParamError = function(errorObj, func) {
     let message;
 
     function formatType() {

--- a/src/core/legacy.js
+++ b/src/core/legacy.js
@@ -10,19 +10,19 @@
 
 import p5 from './main';
 
-p5.prototype.pushStyle = () => {
+p5.prototype.pushStyle = function() {
   throw new Error('pushStyle() not used, see push()');
 };
 
-p5.prototype.popStyle = () => {
+p5.prototype.popStyle = function() {
   throw new Error('popStyle() not used, see pop()');
 };
 
-p5.prototype.popMatrix = () => {
+p5.prototype.popMatrix = function() {
   throw new Error('popMatrix() not used, see pop()');
 };
 
-p5.prototype.printMatrix = () => {
+p5.prototype.printMatrix = function() {
   throw new Error(
     'printMatrix() is not implemented in p5.js, ' +
       'refer to [https://simonsarris.com/a-transformation-class-for-canvas-to-keep-track-of-the-transformation-matrix/] ' +
@@ -30,7 +30,7 @@ p5.prototype.printMatrix = () => {
   );
 };
 
-p5.prototype.pushMatrix = () => {
+p5.prototype.pushMatrix = function() {
   throw new Error('pushMatrix() not used, see push()');
 };
 

--- a/src/core/p5.Element.js
+++ b/src/core/p5.Element.js
@@ -836,7 +836,7 @@ p5.Element._adjustListener = function(ev, fxn, ctx) {
   return this;
 };
 
-p5.Element._attachListener = (ev, fxn, ctx) => {
+p5.Element._attachListener = function(ev, fxn, ctx) {
   // detach the old listener if there was one
   if (ctx._events[ev]) {
     p5.Element._detachListener(ev, ctx);
@@ -846,7 +846,7 @@ p5.Element._attachListener = (ev, fxn, ctx) => {
   ctx._events[ev] = f;
 };
 
-p5.Element._detachListener = (ev, ctx) => {
+p5.Element._detachListener = function(ev, ctx) {
   const f = ctx._events[ev];
   ctx.elt.removeEventListener(ev, f, false);
   ctx._events[ev] = null;

--- a/src/data/local_storage.js
+++ b/src/data/local_storage.js
@@ -58,7 +58,7 @@ import p5 from '../core/main';
  * If you reload the page, the last letter typed is still displaying.
  *
  */
-p5.prototype.storeItem = (key, value) => {
+p5.prototype.storeItem = function(key, value) {
   if (typeof value === 'undefined') {
     console.log('You cannot store undefined variables using storeItem()');
   }
@@ -189,7 +189,7 @@ p5.prototype.getItem = function(key) {
  * }
  * </code></div>
  */
-p5.prototype.clearStorage = () => {
+p5.prototype.clearStorage = function() {
   localStorage.clear();
 };
 
@@ -213,7 +213,7 @@ p5.prototype.clearStorage = () => {
  * }
  * </code></div>
  */
-p5.prototype.removeItem = key => {
+p5.prototype.removeItem = function(key) {
   if (typeof key !== 'string') {
     console.log(
       `The argument that you passed to removeItem() - ${key} is not a string.`

--- a/src/events/mouse.js
+++ b/src/events/mouse.js
@@ -1074,7 +1074,7 @@ p5.prototype.requestPointerLock = function() {
  * cursor gets locked / unlocked on mouse-click
  *
  */
-p5.prototype.exitPointerLock = () => {
+p5.prototype.exitPointerLock = function() {
   document.exitPointerLock();
 };
 

--- a/src/image/filters.js
+++ b/src/image/filters.js
@@ -31,7 +31,7 @@ const Filters = {};
  *                                   the data in thc RGBA order, with integer
  *                                   values between 0 and 255
  */
-Filters._toPixels = canvas => {
+Filters._toPixels = function(canvas) {
   if (canvas instanceof ImageData) {
     return canvas.data;
   } else {
@@ -52,7 +52,7 @@ Filters._toPixels = canvas => {
  * @return {Integer}                32 bit integer value representing
  *                                  ARGB value.
  */
-Filters._getARGB = (data, i) => {
+Filters._getARGB = function(data, i) {
   const offset = i * 4;
   return (
     ((data[offset + 3] << 24) & 0xff000000) |
@@ -71,7 +71,7 @@ Filters._getARGB = (data, i) => {
  * @param {Int32Array}        data   source 1D array where each value
  *                                   represents ARGB values
  */
-Filters._setPixels = (pixels, data) => {
+Filters._setPixels = function(pixels, data) {
   let offset = 0;
   for (let i = 0, al = pixels.length; i < al; i++) {
     offset = i * 4;
@@ -92,7 +92,7 @@ Filters._setPixels = (pixels, data) => {
  * @return {ImageData}               Holder of pixel data (and width and
  *                                   height) for a canvas
  */
-Filters._toImageData = canvas => {
+Filters._toImageData = function(canvas) {
   if (canvas instanceof ImageData) {
     return canvas;
   } else {
@@ -136,7 +136,7 @@ Filters._createImageData = function(width, height) {
  * @param  {function(ImageData,Object)} func   [description]
  * @param  {Object} filterParam  [description]
  */
-Filters.apply = (canvas, func, filterParam) => {
+Filters.apply = function(canvas, func, filterParam) {
   const pixelsState = canvas.getContext('2d');
   const imageData = pixelsState.getImageData(0, 0, canvas.width, canvas.height);
 
@@ -181,7 +181,7 @@ Filters.apply = (canvas, func, filterParam) => {
  * @param  {Canvas} canvas
  * @param  {Float} level
  */
-Filters.threshold = (canvas, level) => {
+Filters.threshold = function(canvas, level) {
   const pixels = Filters._toPixels(canvas);
 
   if (level === undefined) {
@@ -213,7 +213,7 @@ Filters.threshold = (canvas, level) => {
  * @private
  * @param {Canvas} canvas
  */
-Filters.gray = canvas => {
+Filters.gray = function(canvas) {
   const pixels = Filters._toPixels(canvas);
 
   for (let i = 0; i < pixels.length; i += 4) {
@@ -233,7 +233,7 @@ Filters.gray = canvas => {
  * @private
  * @param {Canvas} canvas
  */
-Filters.opaque = canvas => {
+Filters.opaque = function(canvas) {
   const pixels = Filters._toPixels(canvas);
 
   for (let i = 0; i < pixels.length; i += 4) {
@@ -248,7 +248,7 @@ Filters.opaque = canvas => {
  * @private
  * @param  {Canvas} canvas
  */
-Filters.invert = canvas => {
+Filters.invert = function(canvas) {
   const pixels = Filters._toPixels(canvas);
 
   for (let i = 0; i < pixels.length; i += 4) {
@@ -269,7 +269,7 @@ Filters.invert = canvas => {
  * @param  {Canvas} canvas
  * @param  {Integer} level
  */
-Filters.posterize = (canvas, level) => {
+Filters.posterize = function(canvas, level) {
   const pixels = Filters._toPixels(canvas);
 
   if (level < 2 || level > 255) {
@@ -296,7 +296,7 @@ Filters.posterize = (canvas, level) => {
  * @param  {Canvas} canvas
  *
  */
-Filters.dilate = canvas => {
+Filters.dilate = function(canvas) {
   const pixels = Filters._toPixels(canvas);
   let currIdx = 0;
   const maxIdx = pixels.length ? pixels.length / 4 : 0;
@@ -384,7 +384,7 @@ Filters.dilate = canvas => {
  * @param  {Canvas} canvas
  *
  */
-Filters.erode = canvas => {
+Filters.erode = function(canvas) {
   const pixels = Filters._toPixels(canvas);
   let currIdx = 0;
   const maxIdx = pixels.length ? pixels.length / 4 : 0;
@@ -615,7 +615,7 @@ function blurARGB(canvas, radius) {
   Filters._setPixels(pixels, argb);
 }
 
-Filters.blur = (canvas, radius) => {
+Filters.blur = function(canvas, radius) {
   blurARGB(canvas, radius);
 };
 

--- a/src/image/image.js
+++ b/src/image/image.js
@@ -192,7 +192,7 @@ p5.prototype.saveCanvas = function() {
   }, mimeType);
 };
 
-p5.prototype.saveGif = (pImg, filename) => {
+p5.prototype.saveGif = function(pImg, filename) {
   const props = pImg.gifProperties;
 
   //convert loopLimit back into Netscape Block formatting

--- a/src/io/files.js
+++ b/src/io/files.js
@@ -1035,7 +1035,7 @@ p5.prototype.httpPost = function() {
  * @param  {function}      [errorCallback]
  * @return {Promise}
  */
-p5.prototype.httpDo = (...args) => {
+p5.prototype.httpDo = function(...args) {
   let type;
   let callback;
   let errorCallback;
@@ -1783,7 +1783,7 @@ p5.prototype.saveTable = function(table, filename, options) {
  *  @param  {String} [extension]
  *  @private
  */
-p5.prototype.writeFile = (dataToDownload, filename, extension) => {
+p5.prototype.writeFile = function(dataToDownload, filename, extension) {
   let type = 'application/octet-stream';
   if (p5.prototype._isSafari()) {
     type = 'text/plain';
@@ -1807,7 +1807,7 @@ p5.prototype.writeFile = (dataToDownload, filename, extension) => {
  *  @param  {String} [filename]
  *  @param  {String} [extension]
  */
-p5.prototype.downloadFile = (data, fName, extension) => {
+p5.prototype.downloadFile = function(data, fName, extension) {
   const fx = _checkFileExtension(fName, extension);
   const filename = fx[0];
 
@@ -1880,7 +1880,7 @@ p5.prototype._checkFileExtension = _checkFileExtension;
  *  @return  {Boolean} [description]
  *  @private
  */
-p5.prototype._isSafari = () => {
+p5.prototype._isSafari = function() {
   const x = Object.prototype.toString.call(window.HTMLElement);
   return x.indexOf('Constructor') > 0;
 };

--- a/src/math/calculation.js
+++ b/src/math/calculation.js
@@ -170,7 +170,7 @@ p5.prototype.constrain = function(n, low, high) {
  * @param  {Number} z2 z-coordinate of the second point
  * @return {Number}    distance between the two points
  */
-p5.prototype.dist = (...args) => {
+p5.prototype.dist = function(...args) {
   p5._validateParameters('dist', args);
   if (args.length === 4) {
     //2D
@@ -510,7 +510,7 @@ p5.prototype.map = function(n, start1, stop1, start2, stop2, withinBounds) {
  * @param  {Number[]} nums Numbers to compare
  * @return {Number}
  */
-p5.prototype.max = (...args) => {
+p5.prototype.max = function(...args) {
   p5._validateParameters('max', args);
   if (args[0] instanceof Array) {
     return Math.max.apply(null, args[0]);
@@ -560,7 +560,7 @@ p5.prototype.max = (...args) => {
  * @param  {Number[]} nums Numbers to compare
  * @return {Number}
  */
-p5.prototype.min = (...args) => {
+p5.prototype.min = function(...args) {
   p5._validateParameters('min', args);
   if (args[0] instanceof Array) {
     return Math.min.apply(null, args[0]);
@@ -705,7 +705,7 @@ p5.prototype.pow = Math.pow;
  * horizontal center line squared values displayed on top and regular on bottom.
  *
  */
-p5.prototype.round = (n, decimals) => {
+p5.prototype.round = function(n, decimals) {
   if (!decimals) {
     return Math.round(n);
   }

--- a/src/math/noise.js
+++ b/src/math/noise.js
@@ -100,7 +100,7 @@ let perlin; // will be initialized lazily by noise() or noiseSeed()
  *
  */
 
-p5.prototype.noise = (x, y = 0, z = 0) => {
+p5.prototype.noise = function(x, y = 0, z = 0) {
   if (perlin == null) {
     perlin = new Array(PERLIN_SIZE + 1);
     for (let i = 0; i < PERLIN_SIZE + 1; i++) {
@@ -234,7 +234,7 @@ p5.prototype.noise = (x, y = 0, z = 0) => {
  * 2 vertical grey smokey patterns affected my mouse x-position and noise.
  *
  */
-p5.prototype.noiseDetail = (lod, falloff) => {
+p5.prototype.noiseDetail = function(lod, falloff) {
   if (lod > 0) {
     perlin_octaves = lod;
   }
@@ -272,7 +272,7 @@ p5.prototype.noiseDetail = (lod, falloff) => {
  * vertical grey lines drawing in pattern affected by noise.
  *
  */
-p5.prototype.noiseSeed = seed => {
+p5.prototype.noiseSeed = function(seed) {
   // Linear Congruential Generator
   // Variant of a Lehman Generator
   const lcg = (() => {

--- a/src/math/p5.Vector.js
+++ b/src/math/p5.Vector.js
@@ -1513,7 +1513,7 @@ p5.Vector.fromAngle = function fromAngle(angle, length) {
  * </code>
  * </div>
  */
-p5.Vector.fromAngles = (theta, phi, length) => {
+p5.Vector.fromAngles = function(theta, phi, length) {
   if (typeof length === 'undefined') {
     length = 1;
   }

--- a/src/utilities/array_functions.js
+++ b/src/utilities/array_functions.js
@@ -27,7 +27,7 @@ import p5 from '../core/main';
  * }
  * </code></div>
  */
-p5.prototype.append = (array, value) => {
+p5.prototype.append = function(array, value) {
   array.push(value);
   return array;
 };
@@ -77,7 +77,7 @@ p5.prototype.append = (array, value) => {
  * @param {Array}  dst
  * @param {Integer} [length]
  */
-p5.prototype.arrayCopy = (src, srcPosition, dst, dstPosition, length) => {
+p5.prototype.arrayCopy = function(src, srcPosition, dst, dstPosition, length) {
   // the index to begin splicing from dst array
   let start;
   let end;
@@ -177,7 +177,7 @@ p5.prototype.reverse = list => list.reverse();
  * }
  * </code></div>
  */
-p5.prototype.shorten = list => {
+p5.prototype.shorten = function(list) {
   list.pop();
   return list;
 };
@@ -206,7 +206,7 @@ p5.prototype.shorten = list => {
  * }
  * </code></div>
  */
-p5.prototype.shuffle = (arr, bool) => {
+p5.prototype.shuffle = function(arr, bool) {
   const isView = ArrayBuffer && ArrayBuffer.isView && ArrayBuffer.isView(arr);
   arr = bool || isView ? arr : arr.slice();
 
@@ -259,7 +259,7 @@ p5.prototype.shuffle = (arr, bool) => {
  * }
  * </code></div>
  */
-p5.prototype.sort = (list, count) => {
+p5.prototype.sort = function(list, count) {
   let arr = count ? list.slice(0, Math.min(count, list.length)) : list;
   const rest = count ? list.slice(Math.min(count, list.length)) : [];
   if (typeof arr[0] === 'string') {
@@ -298,7 +298,7 @@ p5.prototype.sort = (list, count) => {
  * }
  * </code></div>
  */
-p5.prototype.splice = (list, value, index) => {
+p5.prototype.splice = function(list, value, index) {
   // note that splice returns spliced elements and not an array
   Array.prototype.splice.apply(list, [index, 0].concat(value));
 
@@ -333,7 +333,7 @@ p5.prototype.splice = (list, value, index) => {
  * }
  * </code></div>
  */
-p5.prototype.subset = (list, start, count) => {
+p5.prototype.subset = function(list, start, count) {
   if (typeof count !== 'undefined') {
     return list.slice(start, start + count);
   } else {

--- a/src/utilities/conversion.js
+++ b/src/utilities/conversion.js
@@ -35,7 +35,7 @@ import p5 from '../core/main';
  * 20 by 20 white ellipse in the center of the canvas
  *
  */
-p5.prototype.float = str => {
+p5.prototype.float = function(str) {
   if (str instanceof Array) {
     return str.map(parseFloat);
   }
@@ -69,7 +69,7 @@ p5.prototype.float = str => {
  * @param {Array} ns                    values to parse
  * @return {Number[]}                   integer representation of values
  */
-p5.prototype.int = (n, radix = 10) => {
+p5.prototype.int = function(n, radix = 10) {
   if (n === Infinity || n === 'Infinity') {
     return Infinity;
   } else if (n === -Infinity || n === '-Infinity') {
@@ -103,7 +103,7 @@ p5.prototype.int = (n, radix = 10) => {
  * print(str([true, '10.3', 9.8])); // [ "true", "10.3", "9.8" ]
  * </code></div>
  */
-p5.prototype.str = n => {
+p5.prototype.str = function(n) {
   if (n instanceof Array) {
     return n.map(p5.prototype.str);
   } else {
@@ -131,7 +131,7 @@ p5.prototype.str = n => {
  * print(boolean([0, 12, 'true'])); // [false, true, true]
  * </code></div>
  */
-p5.prototype.boolean = n => {
+p5.prototype.boolean = function(n) {
   if (typeof n === 'number') {
     return n !== 0;
   } else if (typeof n === 'string') {
@@ -170,7 +170,7 @@ p5.prototype.boolean = n => {
  * @param {Array} ns                   values to parse
  * @return {Number[]}                  array of byte representation of values
  */
-p5.prototype.byte = n => {
+p5.prototype.byte = function(n) {
   const nn = p5.prototype.int(n, 10);
   if (typeof nn === 'number') {
     return (nn + 128) % 256 - 128;
@@ -203,7 +203,7 @@ p5.prototype.byte = n => {
  * @param {Array} ns              values to parse
  * @return {String[]}             array of string representation of values
  */
-p5.prototype.char = n => {
+p5.prototype.char = function(n) {
   if (typeof n === 'number' && !isNaN(n)) {
     return String.fromCharCode(n);
   } else if (n instanceof Array) {
@@ -234,7 +234,7 @@ p5.prototype.char = n => {
  * @param {Array} ns       values to parse
  * @return {Number[]}      integer representation of values
  */
-p5.prototype.unchar = n => {
+p5.prototype.unchar = function(n) {
   if (typeof n === 'string' && n.length === 1) {
     return n.charCodeAt(0);
   } else if (n instanceof Array) {
@@ -268,7 +268,7 @@ p5.prototype.unchar = n => {
  * @param {Number} [digits]
  * @return {String[]}      hexadecimal string representation of values
  */
-p5.prototype.hex = (n, digits) => {
+p5.prototype.hex = function(n, digits) {
   digits = digits === undefined || digits === null ? (digits = 8) : digits;
   if (n instanceof Array) {
     return n.map(n => p5.prototype.hex(n, digits));
@@ -313,7 +313,7 @@ p5.prototype.hex = (n, digits) => {
  * @param {Array} ns values to parse
  * @return {Number[]}      integer representations of hexadecimal value
  */
-p5.prototype.unhex = n => {
+p5.prototype.unhex = function(n) {
   if (n instanceof Array) {
     return n.map(p5.prototype.unhex);
   } else {

--- a/src/webgl/p5.RendererGL.js
+++ b/src/webgl/p5.RendererGL.js
@@ -229,7 +229,7 @@ p5.RendererGL.prototype = Object.create(p5.Renderer.prototype);
 // Setting
 //////////////////////////////////////////////
 
-p5.RendererGL.prototype._setAttributeDefaults = pInst => {
+p5.RendererGL.prototype._setAttributeDefaults = function(pInst) {
   // See issue #3850, safer to enable AA in Safari
   const applyAA = navigator.userAgent.toLowerCase().includes('safari');
   const defaults = {
@@ -685,18 +685,18 @@ p5.RendererGL.prototype.stroke = function(r, g, b, a) {
   this.curStrokeColor = color._array;
 };
 
-p5.RendererGL.prototype.strokeCap = cap => {
+p5.RendererGL.prototype.strokeCap = function(cap) {
   // @TODO : to be implemented
   console.error('Sorry, strokeCap() is not yet implemented in WEBGL mode');
 };
 
-p5.RendererGL.prototype.strokeJoin = join => {
+p5.RendererGL.prototype.strokeJoin = function(join) {
   // @TODO : to be implemented
   // https://processing.org/reference/strokeJoin_.html
   console.error('Sorry, strokeJoin() is not yet implemented in WEBGL mode');
 };
 
-p5.RendererGL.prototype.filter = filterType => {
+p5.RendererGL.prototype.filter = function(filterType) {
   // filter can be achieved using custom shaders.
   // https://github.com/aferriss/p5jsShaderExamples
   // https://itp-xstory.github.io/p5js-shaders/#/
@@ -1374,7 +1374,7 @@ p5.RendererGL.prototype._isTypedArray = function(arr) {
  * @return {Array}     1-dimensional array
  * [[1, 2, 3],[4, 5, 6]] -> [1, 2, 3, 4, 5, 6]
  */
-p5.RendererGL.prototype._flatten = arr => {
+p5.RendererGL.prototype._flatten = function(arr) {
   //when empty, return empty
   if (arr.length === 0) {
     return [];
@@ -1412,7 +1412,7 @@ p5.RendererGL.prototype._flatten = arr => {
  * [p5.Vector(1, 2, 3), p5.Vector(4, 5, 6)] ->
  * [1, 2, 3, 4, 5, 6]
  */
-p5.RendererGL.prototype._vToNArray = arr => {
+p5.RendererGL.prototype._vToNArray = function(arr) {
   const ret = [];
 
   for (const item of arr) {
@@ -1498,7 +1498,7 @@ p5.RendererGL.prototype._triangulate = function(contours) {
 };
 
 // function to calculate BezierVertex Coefficients
-p5.RendererGL.prototype._bezierCoefficients = t => {
+p5.RendererGL.prototype._bezierCoefficients = function(t) {
   const t2 = t * t;
   const t3 = t2 * t;
   const mt = 1 - t;
@@ -1508,7 +1508,7 @@ p5.RendererGL.prototype._bezierCoefficients = t => {
 };
 
 // function to calculate QuadraticVertex Coefficients
-p5.RendererGL.prototype._quadraticCoefficients = t => {
+p5.RendererGL.prototype._quadraticCoefficients = function(t) {
   const t2 = t * t;
   const mt = 1 - t;
   const mt2 = mt * mt;

--- a/src/webgl/p5.Shader.js
+++ b/src/webgl/p5.Shader.js
@@ -190,7 +190,7 @@ p5.Shader.prototype._loadUniforms = function() {
   this._loadedUniforms = true;
 };
 
-p5.Shader.prototype.compile = () => {
+p5.Shader.prototype.compile = function() {
   // TODO
 };
 
@@ -252,7 +252,7 @@ p5.Shader.prototype.updateTextures = function() {
   }
 };
 
-p5.Shader.prototype.unbindTextures = () => {
+p5.Shader.prototype.unbindTextures = function() {
   // TODO: migrate stuff from material.js here
   // - OR - have material.js define this function
 };

--- a/src/webgl/text.js
+++ b/src/webgl/text.js
@@ -5,7 +5,7 @@ import './p5.RendererGL.Retained';
 
 // Text/Typography
 // @TODO:
-p5.RendererGL.prototype._applyTextProperties = () => {
+p5.RendererGL.prototype._applyTextProperties = function() {
   //@TODO finish implementation
   //console.error('text commands not yet implemented in webgl');
 };


### PR DESCRIPTION
<!--
  Thank you for contributing! Please use this pull request (PR) template.


 In the description field of this PR, include "resolves #XXXX" tagging the issue you are fixing. If this PR addresses the issue but doesn't completely resolve it (ie the issue should remain open after your PR is merged), write "addresses #XXXX".-->
Resolves #3875 

 Changes: 
<!-- Add here what changes were made in this pull request and if possible provide links showcasing the changes. -->
As per the issue, prototype methods are all reverted to using regular function regardless of whether they use `this` in the function body or not. One additional thing I think is necessary but I'm not 100% sure about (90% sure) is static methods of objects. From what I found, in particular this [stackoverflow question](https://stackoverflow.com/questions/52269317/es6-javascript-calling-static-methods-from-classes-with-arrow-functions), it seems it is good practice to use regular functions for static members but I found only reference to `class` syntax static members only.

In any case, none of the converted functions use `this` in their function body so the functionalities will be exactly the same as before.

#### PR Checklist
<!--
  To check any option, replace the "[ ]" with a "[x]". Be sure to check out how it looks in the Preview tab! Feel free to remove any portion of the template that is not relevant for your issue.
-->

- [x] `npm run lint` passes
- [ ] [Inline documentation] is included / updated
- [ ] [Unit tests] are included / updated
- [ ] [Benchmarks] are included / updated

[Inline documentation]: https://github.com/processing/p5.js/blob/master/contributor_docs/inline_documentation.md
[Unit tests]: https://github.com/processing/p5.js/tree/master/contributor_docs#unit-tests
[Benchmarks]: https://github.com/processing/p5.js/blob/master/contributor_docs/benchmarking_p5.md
