### PR TITLE
Fixed broken building task of combineModules

### DIFF
--- a/tasks/build/combineModules.js
+++ b/tasks/build/combineModules.js
@@ -42,21 +42,25 @@ module.exports = function(grunt) {
       }
 
       // Populate the source file path array with concerned files' path
-      const srcDirPath = './src';
-      const srcFilePath = [];
+      var srcFilePath = [];
+      const imp = 'import ';
       for (var j = 0; j < sources.length; j++) {
         var source = sources[j];
         var base = source.substring(0, source.lastIndexOf('/'));
         if (base === 'core' || module_src.search(base) !== -1) {
-          // Push the resolved paths directly
-          const filePath =
-            source.search('.js') !== -1 ? source : source + '.js';
-          var fullPath = path.resolve(srcDirPath, filePath);
+          var fullPath;
+          if (source === 'core/main') {
+            fullPath = imp + 'p5 from ' + "'./" + source + "';";
+          } else {
+            fullPath = imp + "'./" + source + "';";
+          }
           srcFilePath.push(fullPath);
         }
       }
 
-      console.log(srcFilePath);
+      srcFilePath = srcFilePath.join('\n');
+      srcFilePath += '\nmodule.exports = p5;';
+      fs.writeFileSync('./src/app2.js', srcFilePath, 'utf8');
       // Check whether combineModules is minified
       const isMin = args === 'min';
       const filename = isMin ? 'p5Custom.pre-min.js' : 'p5Custom.js';
@@ -65,7 +69,7 @@ module.exports = function(grunt) {
       const libFilePath = path.resolve('lib/modules/' + filename);
 
       // Invoke Browserify programatically to bundle the code
-      let browseified = browserify(srcFilePath, {
+      let browseified = browserify(require.resolve('../../src/app2.js'), {
         standalone: 'p5'
       });
 


### PR DESCRIPTION
<!--
  Thank you for contributing! Please use this pull request (PR) template.


 In the description field of this PR, include "resolves #XXXX" tagging the issue you are fixing. If this PR addresses the issue but doesn't completely resolve it (ie the issue should remain open after your PR is merged), write "addresses #XXXX".-->
Resolves #3883 

 Changes: 
<!-- Add here what changes were made in this pull request and if possible provide links showcasing the changes. -->
* Updated the logic to generate custom build by creating a clone of `app.js` temporarily but with only the required modules mentioned as imports. This had to be done so as to introduce a single file entry point for bundling, as otherwise the `p5` class was not exported as it should, and its bindings were lost. 

<!-- If applicable, add screenshots depicting the changes. -->

#### PR Checklist
<!--
  To check any option, replace the "[ ]" with a "[x]". Be sure to check out how it looks in the Preview tab! Feel free to remove any portion of the template that is not relevant for your issue.
-->

- [x] `npm run lint` passes
- [x] [Inline documentation] is included / updated
- [ ] [Unit tests] are included / updated
- [ ] [Benchmarks] are included / updated

[Inline documentation]: https://github.com/processing/p5.js/blob/master/contributor_docs/inline_documentation.md
[Unit tests]: https://github.com/processing/p5.js/tree/master/contributor_docs#unit-tests
[Benchmarks]: https://github.com/processing/p5.js/blob/master/contributor_docs/benchmarking_p5.md
