### PR TITLE
Add line-break support to saveStrings function

### DIFF
--- a/src/io/files.js
+++ b/src/io/files.js
@@ -1587,6 +1587,7 @@ p5.prototype.saveJSONArray = p5.prototype.saveJSON;
  *  @param  {String[]} list   string array to be written
  *  @param  {String} filename filename for output
  *  @param  {String} [extension] the filename's extension
+ *  @param  {Boolean} [isCRLF] if true, change line-break to CRLF
  *  @example
  * <div><code>
  * let words = 'apple bear cat dog';
@@ -1618,16 +1619,12 @@ p5.prototype.saveJSONArray = p5.prototype.saveJSON;
  * no image displayed
  *
  */
-p5.prototype.saveStrings = function(list, filename, extension) {
+p5.prototype.saveStrings = function(list, filename, extension, isCRLF) {
   p5._validateParameters('saveStrings', arguments);
   const ext = extension || 'txt';
   const pWriter = this.createWriter(filename, ext);
   for (let i = 0; i < list.length; i++) {
-    if (i < list.length - 1) {
-      pWriter.print(list[i]);
-    } else {
-      pWriter.print(list[i]);
-    }
+    isCRLF ? pWriter.write(list[i] + '\r\n') : pWriter.write(list[i] + '\n');
   }
   pWriter.close();
   pWriter.clear();

--- a/test/unit/io/files.js
+++ b/test/unit/io/files.js
@@ -463,4 +463,12 @@ suite('Files', function() {
       });
     });
   });
+
+  // saveStrings()
+  suite('p5.prototype.saveStrings', function() {
+    test.only('should be a function', function() {
+      assert.ok(myp5.saveStrings);
+      assert.typeOf(myp5.saveStrings, 'function');
+    });
+  });
 });


### PR DESCRIPTION
<!--
  Thank you for contributing! Please use this pull request (PR) template.


 In the description field of this PR, include "resolves #XXXX" tagging the issue you are fixing. If this PR addresses the issue but doesn't completely resolve it (ie the issue should remain open after your PR is merged), write "addresses #XXXX".-->

 Changes: Add new boolean parameter to saveStrings function to check for CRLF line-break
<!-- Add here what changes were made in this pull request and if possible provide links showcasing the changes. -->
Resolves: #3423 

 Screenshots of the change: 
![solution](https://user-images.githubusercontent.com/26370910/72095760-1bc3e280-333f-11ea-9113-6ea4c4cc646b.gif)

<!-- If applicable, add screenshots depicting the changes. -->

#### PR Checklist
<!--
  To check any option, replace the "[ ]" with a "[x]". Be sure to check out how it looks in the Preview tab! Feel free to remove any portion of the template that is not relevant for your issue.
-->

- [x] `npm run lint` passes
- [x] [Inline documentation] is included / updated
- [x] [Unit tests] are included / updated
- [ ] [Benchmarks] are included / updated

[Inline documentation]: https://github.com/processing/p5.js/blob/master/contributor_docs/inline_documentation.md
[Unit tests]: https://github.com/processing/p5.js/tree/master/contributor_docs#unit-tests
[Benchmarks]: https://github.com/processing/p5.js/blob/master/contributor_docs/benchmarking_p5.md
