### PR TITLE
added rem() method on p5.Vector

### DIFF
--- a/src/math/p5.Vector.js
+++ b/src/math/p5.Vector.js
@@ -346,17 +346,26 @@ const calculateRemainder2D = function(xComponent, yComponent) {
 const calculateRemainder3D = function(xComponent, yComponent, zComponent) {
   if (xComponent === 0 && yComponent === 0 && zComponent === 0) {
     return this;
-  } else if (xComponent === 0) {
+  } else if (xComponent === 0 && yComponent !== 0 && zComponent !== 0) {
     this.y = this.y % yComponent;
     this.z = this.z % zComponent;
     return this;
-  } else if (yComponent === 0) {
+  } else if (xComponent !== 0 && yComponent === 0 && zComponent !== 0) {
     this.x = this.x % xComponent;
     this.z = this.z % zComponent;
     return this;
-  } else if (zComponent === 0) {
+  } else if (xComponent !== 0 && yComponent !== 0 && zComponent === 0) {
     this.x = this.x % xComponent;
     this.y = this.y % yComponent;
+    return this;
+  } else if (xComponent === 0 && yComponent === 0 && zComponent !== 0) {
+    this.z = this.z % zComponent;
+    return this;
+  } else if (xComponent === 0 && yComponent !== 0 && zComponent === 0) {
+    this.y = this.y % yComponent;
+    return this;
+  } else if (xComponent !== 0 && yComponent === 0 && zComponent === 0) {
+    this.x = this.x % xComponent;
     return this;
   } else {
     this.x = this.x % xComponent;

--- a/src/math/p5.Vector.js
+++ b/src/math/p5.Vector.js
@@ -326,6 +326,45 @@ p5.Vector.prototype.add = function add(x, y, z) {
   return this;
 };
 
+/// HELPERS FOR REMAINDER METHOD
+const calculateRemainder2D = function(xComponent, yComponent) {
+  if (xComponent === 0 && yComponent === 0) {
+    return this;
+  } else if (xComponent === 0) {
+    this.y = this.y % x[1];
+    return this;
+  } else if (yComponent === 0) {
+    this.x = this.x % x[0];
+    return this;
+  } else {
+    this.x = this.x % xComponent;
+    this.y = this.y % yComponent;
+    return this;
+  }
+};
+
+const calculateRemainder3D = function(xComponent, yComponent, zComponent) {
+  if (xComponent === 0 && yComponent === 0 && zComponent === 0) {
+    return this;
+  } else if (xComponent === 0) {
+    this.y = this.y % yComponent;
+    this.z = this.z % zComponent;
+    return this;
+  } else if (yComponent === 0) {
+    this.x = this.x % xComponent;
+    this.z = this.z % zComponent;
+    return this;
+  } else if (zComponent === 0) {
+    this.x = this.x % xComponent;
+    this.y = this.y % yComponent;
+    return this;
+  } else {
+    this.x = this.x % xComponent;
+    this.y = this.y % yComponent;
+    this.z = this.z % zComponent;
+    return this;
+  }
+};
 /**
  * Gives remainder of a vector when it is divided by another vector.
  * See examples for more context.
@@ -361,97 +400,46 @@ p5.Vector.prototype.add = function add(x, y, z) {
  * @chainable
  */
 p5.Vector.prototype.rem = function rem(x, y, z) {
-  const calculateRemainder3D = (xComponent, yComponent, zComponent) => {
-    if (xComponent === 0 && yComponent === 0 && zComponent === 0) {
-      return this;
-    }
-    if (xComponent === 0 && yComponent !== 0 && zComponent !== 0) {
-      this.y = this.y % yComponent;
-      this.z = this.z % zComponent;
-      return this;
-    }
-    if (xComponent !== 0 && yComponent === 0 && zComponent !== 0) {
-      this.x = this.x % xComponent;
-      this.z = this.z % zComponent;
-      return this;
-    }
-    if (xComponent !== 0 && yComponent !== 0 && zComponent === 0) {
-      this.x = this.x % xComponent;
-      this.y = this.y % yComponent;
-      return this;
-    }
-    this.x = this.x % xComponent;
-    this.y = this.y % yComponent;
-    this.z = this.z % zComponent;
-    return this;
-  };
-
-  const calculateRemainder2D = (xComponent, yComponent) => {
-    if (xComponent === 0 && yComponent === 0) {
-      return this;
-    }
-    if (xComponent === 0 && yComponent !== 0) {
-      this.y = this.y % x[1];
-      return this;
-    }
-    if (xComponent !== 0 && yComponent === 0) {
-      this.x = this.x % x[0];
-      return this;
-    }
-    this.x = this.x % xComponent;
-    this.y = this.y % yComponent;
-    return this;
-  };
-
   if (x instanceof p5.Vector) {
     if (Number.isFinite(x.x) && Number.isFinite(x.y) && Number.isFinite(x.z)) {
-      var xComponent = parseFloat(x.x);
-      var yComponent = parseFloat(x.y);
-      var zComponent = parseFloat(x.z);
-      calculateRemainder3D(xComponent, yComponent, zComponent);
+      const xComponent = parseFloat(x.x);
+      const yComponent = parseFloat(x.y);
+      const zComponent = parseFloat(x.z);
+      calculateRemainder3D.call(this, xComponent, yComponent, zComponent);
     }
-  }
-
-  if (x instanceof Array) {
+  } else if (x instanceof Array) {
     if (x.every(element => Number.isFinite(element))) {
       if (x.length === 2) {
-        calculateRemainder2D(x[0], x[1]);
+        calculateRemainder2D.call(this, x[0], x[1]);
       }
       if (x.length === 3) {
-        calculateRemainder3D(x[0], x[1], x[2]);
+        calculateRemainder3D.call(this, x[0], x[1], x[2]);
       }
     }
-  }
-
-  if (arguments.length === 0) {
-    if (arguments[0] === undefined) {
-      return this;
-    }
-  }
-
-  if (arguments.length === 1) {
+  } else if (arguments.length === 1) {
     if (Number.isFinite(arguments[0]) && arguments[0] !== 0) {
       this.x = this.x % arguments[0];
       this.y = this.y % arguments[0];
       this.z = this.z % arguments[0];
       return this;
     }
-  }
-
-  if (arguments.length === 2) {
+  } else if (arguments.length === 2) {
     const vectorComponents = [...arguments];
     if (vectorComponents.every(element => Number.isFinite(element))) {
       if (vectorComponents.length === 2) {
-        calculateRemainder2D(vectorComponents[0], vectorComponents[1]);
+        calculateRemainder2D.call(
+          this,
+          vectorComponents[0],
+          vectorComponents[1]
+        );
       }
     }
-  }
-
-  if (arguments.length === 3) {
+  } else if (arguments.length === 3) {
     const vectorComponents = [...arguments];
     if (vectorComponents.every(element => Number.isFinite(element))) {
       if (vectorComponents.length === 3) {
-        calculateRemainder3D(
+        calculateRemainder3D.call(
+          this,
           vectorComponents[0],
           vectorComponents[1],
           vectorComponents[2]
@@ -1777,7 +1765,6 @@ p5.Vector.add = function add(v1, v2, target) {
  * @static
  * @param  {p5.Vector} v1 dividend <a href="#/p5.Vector">p5.Vector</a>
  * @param  {p5.Vector} v2 divisor <a href="#/p5.Vector">p5.Vector</a>
- * @param  {p5.Vector} target the vector to receive the result
  */
 /**
  * @method rem
@@ -1787,14 +1774,12 @@ p5.Vector.add = function add(v1, v2, target) {
  * @return {p5.Vector} the resulting <a href="#/p5.Vector">p5.Vector</a>
  *
  */
-p5.Vector.rem = function rem(v1, v2, target) {
-  if (!target) {
-    target = v1.copy();
-  } else {
-    target.set(v1);
+p5.Vector.rem = function rem(v1, v2) {
+  if (v1 instanceof p5.Vector && v2 instanceof p5.Vector) {
+    let target = v1.copy();
+    target.rem(v2);
+    return target;
   }
-  target.rem(v2);
-  return target;
 };
 
 /*

--- a/src/math/p5.Vector.js
+++ b/src/math/p5.Vector.js
@@ -326,6 +326,38 @@ p5.Vector.prototype.add = function add(x, y, z) {
   return this;
 };
 
+p5.Vector.prototype.rem = function rem(x, y, z) {
+  if (x instanceof p5.Vector) {
+    if (isFinite(x.x) && isFinite(x.y) && isFinite(x.z)) {
+      var xComponent = parseFloat(x.x);
+      var yComponent = parseFloat(x.y);
+      var zComponent = parseFloat(x.z);
+      if (xComponent === 0 && yComponent === 0 && zComponent === 0) {
+        return this;
+      }
+      if (xComponent === 0 && yComponent !== 0 && zComponent !== 0) {
+        this.y = this.y % yComponent;
+        this.z = this.z % zComponent;
+        return this;
+      }
+      if (xComponent !== 0 && yComponent === 0 && zComponent !== 0) {
+        this.x = this.x % xComponent;
+        this.z = this.z % zComponent;
+        return this;
+      }
+      if (xComponent !== 0 && yComponent !== 0 && zComponent === 0) {
+        this.x = this.x % xComponent;
+        this.y = this.y % yComponent;
+        return this;
+      }
+      this.x = this.x % xComponent;
+      this.y = this.y % yComponent;
+      this.z = this.z % zComponent;
+      return this;
+    }
+  }
+};
+
 /**
  * Subtracts x, y, and z components from a vector, subtracts one vector from
  * another, or subtracts two independent vectors. The version of the method

--- a/src/math/p5.Vector.js
+++ b/src/math/p5.Vector.js
@@ -389,6 +389,12 @@ p5.Vector.prototype.rem = function rem(x, y, z) {
     }
   }
 
+  if (arguments.length === 0) {
+    if (arguments[0] === undefined) {
+      return this;
+    }
+  }
+
   if (arguments.length === 1) {
     if (Number.isFinite(arguments[0]) && arguments[0] !== 0) {
       this.x = this.x % arguments[0];

--- a/src/math/p5.Vector.js
+++ b/src/math/p5.Vector.js
@@ -404,7 +404,7 @@ p5.Vector.prototype.rem = function rem(x, y, z) {
   };
 
   if (x instanceof p5.Vector) {
-    if (isFinite(x.x) && isFinite(x.y) && isFinite(x.z)) {
+    if (Number.isFinite(x.x) && Number.isFinite(x.y) && Number.isFinite(x.z)) {
       var xComponent = parseFloat(x.x);
       var yComponent = parseFloat(x.y);
       var zComponent = parseFloat(x.z);

--- a/src/math/p5.Vector.js
+++ b/src/math/p5.Vector.js
@@ -326,6 +326,30 @@ p5.Vector.prototype.add = function add(x, y, z) {
   return this;
 };
 
+/**
+ * Gives remainder of a vector when it is divided by another vector.
+ * See examples for more context.
+ *
+ * @method rem
+ * @param {Number} x the x component of vector that divides
+ * @param {Number} y the y component of vector that divides
+ * @param {Number} z the z component of vector that divides
+ * @chainable
+ * @example
+ * <div class='norender'>
+ * <code>
+ * let v = createVector(3, 4, 5);
+ * v.rem(2, 3, 4);
+ * // v's components are set to [1, 1, 1]
+ * console.log(v.toString());
+ * </code>
+ * </div>
+ */
+/**
+ * @method rem
+ * @param {p5.Vector | Number[]}  value  the vector that gives remainder
+ * @chainable
+ */
 p5.Vector.prototype.rem = function rem(x, y, z) {
   const calculateRemainder3D = (xComponent, yComponent, zComponent) => {
     if (xComponent === 0 && yComponent === 0 && zComponent === 0) {

--- a/src/math/p5.Vector.js
+++ b/src/math/p5.Vector.js
@@ -331,9 +331,9 @@ p5.Vector.prototype.add = function add(x, y, z) {
  * See examples for more context.
  *
  * @method rem
- * @param {Number} x the x component of vector that divides
- * @param {Number} y the y component of vector that divides
- * @param {Number} z the z component of vector that divides
+ * @param {Number} x the x component of divisor vector
+ * @param {Number} y the y component of divisor vector
+ * @param {Number} z the z component of divisor vector
  * @chainable
  * @example
  * <div class='norender'>
@@ -341,13 +341,23 @@ p5.Vector.prototype.add = function add(x, y, z) {
  * let v = createVector(3, 4, 5);
  * v.rem(2, 3, 4);
  * // v's components are set to [1, 1, 1]
- * console.log(v.toString());
+ * </code>
+ * </div>
+ * <div class="norender">
+ * <code>
+ * // Static method
+ * let v1 = createVector(3, 4, 5);
+ * let v2 = createVector(2, 3, 4);
+ *
+ * let v3 = p5.Vector.rem(v1, v2);
+ * // v3 has components [1, 1, 1]
+ * print(v3);
  * </code>
  * </div>
  */
 /**
  * @method rem
- * @param {p5.Vector | Number[]}  value  the vector that gives remainder
+ * @param {p5.Vector | Number[]}  value  divisor vector
  * @chainable
  */
 p5.Vector.prototype.rem = function rem(x, y, z) {
@@ -1758,6 +1768,32 @@ p5.Vector.add = function add(v1, v2, target) {
     target.set(v1);
   }
   target.add(v2);
+  return target;
+};
+
+// Returns a vector remainder when it is divided by another vector
+/**
+ * @method rem
+ * @static
+ * @param  {p5.Vector} v1 dividend <a href="#/p5.Vector">p5.Vector</a>
+ * @param  {p5.Vector} v2 divisor <a href="#/p5.Vector">p5.Vector</a>
+ * @param  {p5.Vector} target the vector to receive the result
+ */
+/**
+ * @method rem
+ * @static
+ * @param  {p5.Vector} v1
+ * @param  {p5.Vector} v2
+ * @return {p5.Vector} the resulting <a href="#/p5.Vector">p5.Vector</a>
+ *
+ */
+p5.Vector.rem = function rem(v1, v2, target) {
+  if (!target) {
+    target = v1.copy();
+  } else {
+    target.set(v1);
+  }
+  target.rem(v2);
   return target;
 };
 

--- a/src/math/p5.Vector.js
+++ b/src/math/p5.Vector.js
@@ -328,51 +328,26 @@ p5.Vector.prototype.add = function add(x, y, z) {
 
 /// HELPERS FOR REMAINDER METHOD
 const calculateRemainder2D = function(xComponent, yComponent) {
-  if (xComponent === 0 && yComponent === 0) {
-    return this;
-  } else if (xComponent === 0) {
-    this.y = this.y % x[1];
-    return this;
-  } else if (yComponent === 0) {
-    this.x = this.x % x[0];
-    return this;
-  } else {
+  if (xComponent !== 0) {
     this.x = this.x % xComponent;
-    this.y = this.y % yComponent;
-    return this;
   }
+  if (yComponent !== 0) {
+    this.y = this.y % yComponent;
+  }
+  return this;
 };
 
 const calculateRemainder3D = function(xComponent, yComponent, zComponent) {
-  if (xComponent === 0 && yComponent === 0 && zComponent === 0) {
-    return this;
-  } else if (xComponent === 0 && yComponent !== 0 && zComponent !== 0) {
-    this.y = this.y % yComponent;
-    this.z = this.z % zComponent;
-    return this;
-  } else if (xComponent !== 0 && yComponent === 0 && zComponent !== 0) {
+  if (xComponent !== 0) {
     this.x = this.x % xComponent;
-    this.z = this.z % zComponent;
-    return this;
-  } else if (xComponent !== 0 && yComponent !== 0 && zComponent === 0) {
-    this.x = this.x % xComponent;
-    this.y = this.y % yComponent;
-    return this;
-  } else if (xComponent === 0 && yComponent === 0 && zComponent !== 0) {
-    this.z = this.z % zComponent;
-    return this;
-  } else if (xComponent === 0 && yComponent !== 0 && zComponent === 0) {
-    this.y = this.y % yComponent;
-    return this;
-  } else if (xComponent !== 0 && yComponent === 0 && zComponent === 0) {
-    this.x = this.x % xComponent;
-    return this;
-  } else {
-    this.x = this.x % xComponent;
-    this.y = this.y % yComponent;
-    this.z = this.z % zComponent;
-    return this;
   }
+  if (yComponent !== 0) {
+    this.y = this.y % yComponent;
+  }
+  if (zComponent !== 0) {
+    this.z = this.z % zComponent;
+  }
+  return this;
 };
 /**
  * Gives remainder of a vector when it is divided by another vector.

--- a/src/math/p5.Vector.js
+++ b/src/math/p5.Vector.js
@@ -327,7 +327,7 @@ p5.Vector.prototype.add = function add(x, y, z) {
 };
 
 p5.Vector.prototype.rem = function rem(x, y, z) {
-  const calculateRemainder = (xComponent, yComponent, zComponent) => {
+  const calculateRemainder3D = (xComponent, yComponent, zComponent) => {
     if (xComponent === 0 && yComponent === 0 && zComponent === 0) {
       return this;
     }
@@ -352,35 +352,70 @@ p5.Vector.prototype.rem = function rem(x, y, z) {
     return this;
   };
 
+  const calculateRemainder2D = (xComponent, yComponent) => {
+    if (xComponent === 0 && yComponent === 0) {
+      return this;
+    }
+    if (xComponent === 0 && yComponent !== 0) {
+      this.y = this.y % x[1];
+      return this;
+    }
+    if (xComponent !== 0 && yComponent === 0) {
+      this.x = this.x % x[0];
+      return this;
+    }
+    this.x = this.x % xComponent;
+    this.y = this.y % yComponent;
+    return this;
+  };
+
   if (x instanceof p5.Vector) {
     if (isFinite(x.x) && isFinite(x.y) && isFinite(x.z)) {
       var xComponent = parseFloat(x.x);
       var yComponent = parseFloat(x.y);
       var zComponent = parseFloat(x.z);
-      calculateRemainder(xComponent, yComponent, zComponent);
+      calculateRemainder3D(xComponent, yComponent, zComponent);
     }
   }
 
   if (x instanceof Array) {
     if (x.every(element => Number.isFinite(element))) {
       if (x.length === 2) {
-        if (x[0] === 0 && x[1] === 0) {
-          return this;
-        }
-        if (x[0] === 0 && x[1] !== 0) {
-          this.y = this.y % x[1];
-          return this;
-        }
-        if (x[0] !== 0 && x[1] === 0) {
-          this.x = this.x % x[0];
-          return this;
-        }
-        this.x = this.x % x[0];
-        this.y = this.y % x[1];
-        return this;
+        calculateRemainder2D(x[0], x[1]);
       }
       if (x.length === 3) {
-        calculateRemainder(x[0], x[1], x[2]);
+        calculateRemainder3D(x[0], x[1], x[2]);
+      }
+    }
+  }
+
+  if (arguments.length === 1) {
+    if (Number.isFinite(arguments[0]) && arguments[0] !== 0) {
+      this.x = this.x % arguments[0];
+      this.y = this.y % arguments[0];
+      this.z = this.z % arguments[0];
+      return this;
+    }
+  }
+
+  if (arguments.length === 2) {
+    const vectorComponents = [...arguments];
+    if (vectorComponents.every(element => Number.isFinite(element))) {
+      if (vectorComponents.length === 2) {
+        calculateRemainder2D(vectorComponents[0], vectorComponents[1]);
+      }
+    }
+  }
+
+  if (arguments.length === 3) {
+    const vectorComponents = [...arguments];
+    if (vectorComponents.every(element => Number.isFinite(element))) {
+      if (vectorComponents.length === 3) {
+        calculateRemainder3D(
+          vectorComponents[0],
+          vectorComponents[1],
+          vectorComponents[2]
+        );
       }
     }
   }

--- a/src/math/p5.Vector.js
+++ b/src/math/p5.Vector.js
@@ -327,33 +327,61 @@ p5.Vector.prototype.add = function add(x, y, z) {
 };
 
 p5.Vector.prototype.rem = function rem(x, y, z) {
+  const calculateRemainder = (xComponent, yComponent, zComponent) => {
+    if (xComponent === 0 && yComponent === 0 && zComponent === 0) {
+      return this;
+    }
+    if (xComponent === 0 && yComponent !== 0 && zComponent !== 0) {
+      this.y = this.y % yComponent;
+      this.z = this.z % zComponent;
+      return this;
+    }
+    if (xComponent !== 0 && yComponent === 0 && zComponent !== 0) {
+      this.x = this.x % xComponent;
+      this.z = this.z % zComponent;
+      return this;
+    }
+    if (xComponent !== 0 && yComponent !== 0 && zComponent === 0) {
+      this.x = this.x % xComponent;
+      this.y = this.y % yComponent;
+      return this;
+    }
+    this.x = this.x % xComponent;
+    this.y = this.y % yComponent;
+    this.z = this.z % zComponent;
+    return this;
+  };
+
   if (x instanceof p5.Vector) {
     if (isFinite(x.x) && isFinite(x.y) && isFinite(x.z)) {
       var xComponent = parseFloat(x.x);
       var yComponent = parseFloat(x.y);
       var zComponent = parseFloat(x.z);
-      if (xComponent === 0 && yComponent === 0 && zComponent === 0) {
+      calculateRemainder(xComponent, yComponent, zComponent);
+    }
+  }
+
+  if (x instanceof Array) {
+    if (x.every(element => Number.isFinite(element))) {
+      if (x.length === 2) {
+        if (x[0] === 0 && x[1] === 0) {
+          return this;
+        }
+        if (x[0] === 0 && x[1] !== 0) {
+          this.y = this.y % x[1];
+          return this;
+        }
+        if (x[0] !== 0 && x[1] === 0) {
+          this.x = this.x % x[0];
+          return this;
+        }
+        this.x = this.x % x[0];
+        this.y = this.y % x[1];
         return this;
       }
-      if (xComponent === 0 && yComponent !== 0 && zComponent !== 0) {
-        this.y = this.y % yComponent;
-        this.z = this.z % zComponent;
-        return this;
+      if (x.length === 3) {
+        calculateRemainder(x[0], x[1], x[2]);
       }
-      if (xComponent !== 0 && yComponent === 0 && zComponent !== 0) {
-        this.x = this.x % xComponent;
-        this.z = this.z % zComponent;
-        return this;
-      }
-      if (xComponent !== 0 && yComponent !== 0 && zComponent === 0) {
-        this.x = this.x % xComponent;
-        this.y = this.y % yComponent;
-        return this;
-      }
-      this.x = this.x % xComponent;
-      this.y = this.y % yComponent;
-      this.z = this.z % zComponent;
-      return this;
     }
   }
 };

--- a/test/unit/math/p5.Vector.js
+++ b/test/unit/math/p5.Vector.js
@@ -274,6 +274,7 @@ suite('p5.Vector', function() {
       });
     });
   });
+
   suite('rem()', function() {
     setup(function() {
       v = myp5.createVector(3, 4, 5);
@@ -291,6 +292,28 @@ suite('p5.Vector', function() {
         expect(v.x).to.eql(3);
         expect(v.y).to.eql(1);
         expect(v.z).to.eql(1);
+      });
+    });
+
+    suite('with Arrays', function() {
+      test('should return remainder of vector components for 3D vector', function() {
+        v.rem([2, 3, 0]);
+        expect(v.x).to.eql(1);
+        expect(v.y).to.eql(1);
+        expect(v.z).to.eql(5);
+      });
+      test('should return remainder of vector components for 2D vector', function() {
+        v.rem([2, 3]);
+        expect(v.x).to.eql(1);
+        expect(v.y).to.eql(1);
+        expect(v.z).to.eql(5);
+      });
+
+      test('should return same vector if any vector component is non-finite number', () => {
+        v.rem([2, 3, Infinity]);
+        expect(v.x).to.eql(3);
+        expect(v.y).to.eql(4);
+        expect(v.z).to.eql(5);
       });
     });
   });

--- a/test/unit/math/p5.Vector.js
+++ b/test/unit/math/p5.Vector.js
@@ -365,6 +365,13 @@ suite('p5.Vector', function() {
         expect(v.z).to.eql(5);
       });
 
+      test('should return correct output if x,y components are zero for 2D vector', () => {
+        v.rem([0, 0]);
+        expect(v.x).to.eql(3);
+        expect(v.y).to.eql(4);
+        expect(v.z).to.eql(5);
+      });
+
       test('should return same vector if any vector component is non-finite number', () => {
         v.rem([2, 3, Infinity]);
         expect(v.x).to.eql(3);

--- a/test/unit/math/p5.Vector.js
+++ b/test/unit/math/p5.Vector.js
@@ -309,10 +309,10 @@ suite('p5.Vector', function() {
     });
 
     suite('with p5.Vector', function() {
-      test('should return remainder of vector components', function() {
-        v.rem(new p5.Vector(2, 3, 4));
-        expect(v.x).to.eql(1);
-        expect(v.y).to.eql(1);
+      test('should return correct output if only one component is non-zero', function() {
+        v.rem(new p5.Vector(0, 0, 4));
+        expect(v.x).to.eql(3);
+        expect(v.y).to.eql(4);
         expect(v.z).to.eql(1);
       });
 
@@ -321,6 +321,20 @@ suite('p5.Vector', function() {
         expect(v.x).to.eql(3);
         expect(v.y).to.eql(1);
         expect(v.z).to.eql(1);
+      });
+
+      test('should return correct output if all components are non-zero', () => {
+        v.rem(new p5.Vector(2, 3, 4));
+        expect(v.x).to.eql(1);
+        expect(v.y).to.eql(1);
+        expect(v.z).to.eql(1);
+      });
+
+      test('should return same vector if all components are zero', () => {
+        v.rem(new p5.Vector(0, 0, 0));
+        expect(v.x).to.eql(3);
+        expect(v.y).to.eql(4);
+        expect(v.z).to.eql(5);
       });
     });
 

--- a/test/unit/math/p5.Vector.js
+++ b/test/unit/math/p5.Vector.js
@@ -358,6 +358,26 @@ suite('p5.Vector', function() {
         expect(v.z).to.eql(5);
       });
     });
+
+    suite('p5.Vector.rem(v1,v2)', function() {
+      var v1, v2, res;
+      setup(function() {
+        v1 = new p5.Vector(2, 3, 4);
+        v2 = new p5.Vector(1, 2, 3);
+        res = p5.Vector.rem(v1, v2);
+      });
+
+      test('should return neither v1 nor v2', function() {
+        expect(res).to.not.eql(v1);
+        expect(res).to.not.eql(v2);
+      });
+
+      test('should be v1 % v2', function() {
+        expect(res.x).to.eql(v1.x % v2.x);
+        expect(res.y).to.eql(v1.y % v2.y);
+        expect(res.z).to.eql(v1.z % v2.z);
+      });
+    });
   });
 
   suite('sub()', function() {

--- a/test/unit/math/p5.Vector.js
+++ b/test/unit/math/p5.Vector.js
@@ -279,6 +279,28 @@ suite('p5.Vector', function() {
     setup(function() {
       v = myp5.createVector(3, 4, 5);
     });
+
+    test('should give correct output if passed only one numeric value', function() {
+      v.rem(2);
+      expect(v.x).to.eql(1);
+      expect(v.y).to.eql(0);
+      expect(v.z).to.eql(1);
+    });
+
+    test('should give correct output if passed two numeric value', function() {
+      v.rem(2, 3);
+      expect(v.x).to.eql(1);
+      expect(v.y).to.eql(1);
+      expect(v.z).to.eql(5);
+    });
+
+    test('should give correct output if passed three numeric value', function() {
+      v.rem(2, 3, 4);
+      expect(v.x).to.eql(1);
+      expect(v.y).to.eql(1);
+      expect(v.z).to.eql(1);
+    });
+
     suite('with p5.Vector', function() {
       test('should return remainder of vector components', function() {
         v.rem(new p5.Vector(2, 3, 4));
@@ -292,6 +314,19 @@ suite('p5.Vector', function() {
         expect(v.x).to.eql(3);
         expect(v.y).to.eql(1);
         expect(v.z).to.eql(1);
+      });
+    });
+
+    suite('with negative vectors', function() {
+      let v;
+      setup(function() {
+        v = new p5.Vector(-15, -5, -2);
+      });
+      test('should return correct output', () => {
+        v.rem(new p5.Vector(2, 3, 3));
+        expect(v.x).to.eql(-1);
+        expect(v.y).to.eql(-2);
+        expect(v.z).to.eql(-2);
       });
     });
 

--- a/test/unit/math/p5.Vector.js
+++ b/test/unit/math/p5.Vector.js
@@ -360,7 +360,7 @@ suite('p5.Vector', function() {
     });
 
     suite('p5.Vector.rem(v1,v2)', function() {
-      var v1, v2, res;
+      let v1, v2, res;
       setup(function() {
         v1 = new p5.Vector(2, 3, 4);
         v2 = new p5.Vector(1, 2, 3);

--- a/test/unit/math/p5.Vector.js
+++ b/test/unit/math/p5.Vector.js
@@ -274,6 +274,26 @@ suite('p5.Vector', function() {
       });
     });
   });
+  suite('rem()', function() {
+    setup(function() {
+      v = myp5.createVector(3, 4, 5);
+    });
+    suite('with p5.Vector', function() {
+      test('should return remainder of vector components', function() {
+        v.rem(new p5.Vector(2, 3, 4));
+        expect(v.x).to.eql(1);
+        expect(v.y).to.eql(1);
+        expect(v.z).to.eql(1);
+      });
+
+      test('should return correct output if x component is zero', () => {
+        v.rem(new p5.Vector(0, 3, 4));
+        expect(v.x).to.eql(3);
+        expect(v.y).to.eql(1);
+        expect(v.z).to.eql(1);
+      });
+    });
+  });
 
   suite('sub()', function() {
     setup(function() {

--- a/test/unit/math/p5.Vector.js
+++ b/test/unit/math/p5.Vector.js
@@ -280,6 +280,13 @@ suite('p5.Vector', function() {
       v = myp5.createVector(3, 4, 5);
     });
 
+    test('should give same vector if nothing passed as parameter', function() {
+      v.rem();
+      expect(v.x).to.eql(3);
+      expect(v.y).to.eql(4);
+      expect(v.z).to.eql(5);
+    });
+
     test('should give correct output if passed only one numeric value', function() {
       v.rem(2);
       expect(v.x).to.eql(1);


### PR DESCRIPTION
<!--
  Thank you for contributing! Please use this pull request (PR) template.


 In the description field of this PR, include "resolves #XXXX" tagging the issue you are fixing. If this PR addresses the issue but doesn't completely resolve it (ie the issue should remain open after your PR is merged), write "addresses #XXXX".-->
Resolves #3861 

 Changes: 
<!-- Add here what changes were made in this pull request and if possible provide links showcasing the changes. -->
Adding support for remainder operation for p5.Vector objects.

 Screenshots of the change: 
<!-- If applicable, add screenshots depicting the changes. -->

#### PR Checklist
<!--
  To check any option, replace the "[ ]" with a "[x]". Be sure to check out how it looks in the Preview tab! Feel free to remove any portion of the template that is not relevant for your issue.
-->

- [x] `npm run lint` passes
- [x] [Inline documentation] is included / updated
- [x] [Unit tests] are included / updated
- [ ] [Benchmarks] are included / updated

[Inline documentation]: https://github.com/processing/p5.js/blob/master/contributor_docs/inline_documentation.md
[Unit tests]: https://github.com/processing/p5.js/tree/master/contributor_docs#unit-tests
[Benchmarks]: https://github.com/processing/p5.js/blob/master/contributor_docs/benchmarking_p5.md
