### PR TITLE
Removed legacy printMatrix method

### DIFF
--- a/src/core/legacy.js
+++ b/src/core/legacy.js
@@ -22,14 +22,6 @@ p5.prototype.popMatrix = function() {
   throw new Error('popMatrix() not used, see pop()');
 };
 
-p5.prototype.printMatrix = function() {
-  throw new Error(
-    'printMatrix() is not implemented in p5.js, ' +
-      'refer to [https://simonsarris.com/a-transformation-class-for-canvas-to-keep-track-of-the-transformation-matrix/] ' +
-      'to add your own implementation.'
-  );
-};
-
 p5.prototype.pushMatrix = function() {
   throw new Error('pushMatrix() not used, see push()');
 };


### PR DESCRIPTION
fixes #4261
- [x] `npm run lint` passes
- [ ] [Inline documentation] is included / updated
- [ ] [Unit tests] are included / updated


