### PR TITLE
Change state for blending and depth-testing in WebGL

### DIFF
--- a/src/webgl/material.js
+++ b/src/webgl/material.js
@@ -784,7 +784,11 @@ p5.RendererGL.prototype._applyColorBlend = function(colors) {
     isTexture || colors[colors.length - 1] < 1.0 || this._isErasing;
 
   if (doBlend !== this._isBlending) {
-    if (doBlend) {
+    if (
+      doBlend ||
+      (this.curBlendMode !== constants.BLEND &&
+        this.curBlendMode !== constants.ADD)
+    ) {
       gl.depthMask(isTexture);
       gl.enable(gl.BLEND);
     } else {

--- a/src/webgl/material.js
+++ b/src/webgl/material.js
@@ -771,8 +771,8 @@ p5.prototype.shininess = function(shine) {
 
 /**
  * @private blends colors according to color components.
- * If alpha value is less than 1, we need to enable blending
- * on our gl context.  Otherwise opaque objects need to a depthMask.
+ * If alpha value is less than 1, or non-standard blendMode
+ * we need to enable blending on our gl context.
  * @param  {Number[]} color [description]
  * @return {Number[]]}  Normalized numbers array
  */
@@ -789,12 +789,11 @@ p5.RendererGL.prototype._applyColorBlend = function(colors) {
       (this.curBlendMode !== constants.BLEND &&
         this.curBlendMode !== constants.ADD)
     ) {
-      gl.depthMask(isTexture);
       gl.enable(gl.BLEND);
     } else {
-      gl.depthMask(true);
       gl.disable(gl.BLEND);
     }
+    gl.depthMask(true);
     this._isBlending = doBlend;
   }
   this._applyBlendMode();

--- a/src/webgl/p5.RendererGL.js
+++ b/src/webgl/p5.RendererGL.js
@@ -591,7 +591,6 @@ p5.RendererGL.prototype.background = function(...args) {
   const _a = _col.levels[3] / 255;
   this.GL.clearColor(_r, _g, _b, _a);
 
-  this.GL.depthMask(true);
   this.GL.clear(this.GL.COLOR_BUFFER_BIT);
 };
 

--- a/src/webgl/p5.RendererGL.js
+++ b/src/webgl/p5.RendererGL.js
@@ -217,7 +217,6 @@ p5.RendererGL = function(elt, pInst, isMainCanvas, attr) {
 
   this.fontInfos = {};
 
-  this._cachedBackground = undefined;
   this._curShader = undefined;
 
   return this;
@@ -586,18 +585,13 @@ p5.RendererGL.prototype._update = function() {
  */
 p5.RendererGL.prototype.background = function(...args) {
   const _col = this._pInst.color(...args);
-  const needsUpdate =
-    this._cachedBackground === undefined ||
-    !this._arraysEqual(_col._array, this._cachedBackground);
-  if (needsUpdate) {
-    const _r = _col.levels[0] / 255;
-    const _g = _col.levels[1] / 255;
-    const _b = _col.levels[2] / 255;
-    const _a = _col.levels[3] / 255;
-    this.GL.clearColor(_r, _g, _b, _a);
-    this.GL.depthMask(true);
-    this._cachedBackground = _col._array.slice(0);
-  }
+  const _r = _col.levels[0] / 255;
+  const _g = _col.levels[1] / 255;
+  const _b = _col.levels[2] / 255;
+  const _a = _col.levels[3] / 255;
+  this.GL.clearColor(_r, _g, _b, _a);
+
+  this.GL.depthMask(true);
   this.GL.clear(this.GL.COLOR_BUFFER_BIT);
 };
 


### PR DESCRIPTION
This adjust the logic for blending and depth-testing in WEBGL mode.

WIP as I still need to test for other scenarios, and consider adding different behavior for disabled depth buffer ala #3736 

closes #4266 
closes #4262 
closes #4320