### PR TITLE
millis() to be counted per instance

### DIFF
--- a/src/core/main.js
+++ b/src/core/main.js
@@ -201,6 +201,7 @@ class p5 {
       resize: null,
       blur: null
     };
+    this._millisStart = -1;
 
     // States used in the custom random generators
     this._lcg_random_state = null;
@@ -329,6 +330,9 @@ class p5 {
           }
         }
       }
+
+      // Record the time when sketch starts
+      this._millisStart = window.performance.now();
 
       // Short-circuit on this, in case someone used the library in "global"
       // mode earlier

--- a/src/utilities/time_date.js
+++ b/src/utilities/time_date.js
@@ -75,11 +75,11 @@ p5.prototype.minute = function() {
 
 /**
  * Returns the number of milliseconds (thousandths of a second) since
- * starting the sketch. This information is often used for timing events and
- * animation sequences.
+ * starting the sketch (when `setup()` is called). This information is often
+ * used for timing events and animation sequences.
  *
  * @method millis
- * @return {Number} the number of milliseconds since starting the program
+ * @return {Number} the number of milliseconds since starting the sketch
  * @example
  * <div>
  * <code>
@@ -89,7 +89,7 @@ p5.prototype.minute = function() {
  * </div>
  *
  * @alt
- * number of milliseconds since program has started displayed
+ * number of milliseconds since sketch has started displayed
  *
  */
 p5.prototype.millis = function() {

--- a/src/utilities/time_date.js
+++ b/src/utilities/time_date.js
@@ -25,7 +25,9 @@ import p5 from '../core/main';
  * Current day is displayed
  *
  */
-p5.prototype.day = () => new Date().getDate();
+p5.prototype.day = function() {
+  return new Date().getDate();
+};
 
 /**
  * p5.js communicates with the clock on your computer. The <a href="#/p5/hour">hour()</a> function
@@ -45,7 +47,9 @@ p5.prototype.day = () => new Date().getDate();
  * Current hour is displayed
  *
  */
-p5.prototype.hour = () => new Date().getHours();
+p5.prototype.hour = function() {
+  return new Date().getHours();
+};
 
 /**
  * p5.js communicates with the clock on your computer. The <a href="#/p5/minute">minute()</a> function
@@ -65,11 +69,13 @@ p5.prototype.hour = () => new Date().getHours();
  * Current minute is displayed
  *
  */
-p5.prototype.minute = () => new Date().getMinutes();
+p5.prototype.minute = function() {
+  return new Date().getMinutes();
+};
 
 /**
  * Returns the number of milliseconds (thousandths of a second) since
- * starting the program. This information is often used for timing events and
+ * starting the sketch. This information is often used for timing events and
  * animation sequences.
  *
  * @method millis
@@ -86,7 +92,14 @@ p5.prototype.minute = () => new Date().getMinutes();
  * number of milliseconds since program has started displayed
  *
  */
-p5.prototype.millis = () => window.performance.now();
+p5.prototype.millis = function() {
+  if (this._millisStart === -1) {
+    // Sketch has not started
+    return 0;
+  } else {
+    return window.performance.now() - this._millisStart;
+  }
+};
 
 /**
  * p5.js communicates with the clock on your computer. The <a href="#/p5/month">month()</a> function
@@ -106,9 +119,10 @@ p5.prototype.millis = () => window.performance.now();
  * Current month is displayed
  *
  */
-p5.prototype.month = () =>
+p5.prototype.month = function() {
   //January is 0!
-  new Date().getMonth() + 1;
+  return new Date().getMonth() + 1;
+};
 
 /**
  * p5.js communicates with the clock on your computer. The <a href="#/p5/second">second()</a> function
@@ -128,7 +142,9 @@ p5.prototype.month = () =>
  * Current second is displayed
  *
  */
-p5.prototype.second = () => new Date().getSeconds();
+p5.prototype.second = function() {
+  return new Date().getSeconds();
+};
 
 /**
  * p5.js communicates with the clock on your computer. The <a href="#/p5/year">year()</a> function
@@ -148,6 +164,8 @@ p5.prototype.second = () => new Date().getSeconds();
  * Current year is displayed
  *
  */
-p5.prototype.year = () => new Date().getFullYear();
+p5.prototype.year = function() {
+  return new Date().getFullYear();
+};
 
 export default p5;


### PR DESCRIPTION
<!--
  Thank you for contributing! Please use this pull request (PR) template.


 In the description field of this PR, include "resolves #XXXX" tagging the issue you are fixing. If this PR addresses the issue but doesn't completely resolve it (ie the issue should remain open after your PR is merged), write "addresses #XXXX".-->
Resolves #4264 

 Changes:
<!-- Add here what changes were made in this pull request and if possible provide links showcasing the changes. -->
`millis()` will now be counted by each instance of p5 independently starting just before the user's `setup()` function is called.

Also some additional prototype members that were not converted back to regular functions before are now converted.


#### PR Checklist
<!--
  To check any option, replace the "[ ]" with a "[x]". Be sure to check out how it looks in the Preview tab! Feel free to remove any portion of the template that is not relevant for your issue.
-->

- [x] `npm run lint` passes
- [x] [Inline documentation] is included / updated
- [x] [Unit tests] are included / updated

[Inline documentation]: https://github.com/processing/p5.js/blob/master/contributor_docs/inline_documentation.md
[Unit tests]: https://github.com/processing/p5.js/tree/master/contributor_docs#unit-tests
