### PR TITLE
Conversion of variables rotationX according to angleMode

### DIFF
--- a/src/events/acceleration.js
+++ b/src/events/acceleration.js
@@ -3,9 +3,11 @@
  * @submodule Acceleration
  * @for p5
  * @requires core
+ * @requires constants
  */
 
 import p5 from '../core/main';
+import * as constants from '../core/constants';
 
 /**
  * The system variable deviceOrientation always contains the orientation of
@@ -627,6 +629,11 @@ p5.prototype.setShakeThreshold = function(val) {
 
 p5.prototype._ondeviceorientation = function(e) {
   this._updatePRotations();
+  if (this._angleMode === constants.radians) {
+    e.beta = e.beta * (_PI / 180.0);
+    e.gamma = e.gamma * (_PI / 180.0);
+    e.alpha = e.alpha * (_PI / 180.0);
+  }
   this._setProperty('rotationX', e.beta);
   this._setProperty('rotationY', e.gamma);
   this._setProperty('rotationZ', e.alpha);

--- a/src/events/acceleration.js
+++ b/src/events/acceleration.js
@@ -629,7 +629,7 @@ p5.prototype.setShakeThreshold = function(val) {
 
 p5.prototype._ondeviceorientation = function(e) {
   this._updatePRotations();
-  if (this._angleMode === constants.RADIANS) {
+  if (this._angleMode === constants.radians) {
     e.beta = e.beta * (_PI / 180.0);
     e.gamma = e.gamma * (_PI / 180.0);
     e.alpha = e.alpha * (_PI / 180.0);

--- a/src/events/acceleration.js
+++ b/src/events/acceleration.js
@@ -629,7 +629,7 @@ p5.prototype.setShakeThreshold = function(val) {
 
 p5.prototype._ondeviceorientation = function(e) {
   this._updatePRotations();
-  if (this._angleMode === constants.radians) {
+  if (this._angleMode === constants.RADIANS) {
     e.beta = e.beta * (_PI / 180.0);
     e.gamma = e.gamma * (_PI / 180.0);
     e.alpha = e.alpha * (_PI / 180.0);


### PR DESCRIPTION


<!--
  Thank you for contributing! Please use this pull request (PR) template.


 In the description field of this PR, include "resolves #XXXX" tagging the issue you are fixing. If this PR addresses the issue but doesn't completely resolve it (ie the issue should remain open after your PR is merged), write "addresses #XXXX".-->
Resolves ##4154

 Changes:
Device rotation variables, namely rotationX, rotationY and rotationZ were always in degrees, now the follow angleMode


 Screenshots of the change:
<!-- If applicable, add screenshots depicting the changes. -->

#### PR Checklist
<!--
  To check any option, replace the "[ ]" with a "[x]". Be sure to check out how it looks in the Preview tab! Feel free to remove any portion of the template that is not relevant for your issue.
-->

- [ ] `npm run lint` passes
- [ ] [Inline documentation] is included / updated
- [ ] [Unit tests] are included / updated

[Inline documentation]: https://github.com/processing/p5.js/blob/master/contributor_docs/inline_documentation.md
[Unit tests]: https://github.com/processing/p5.js/tree/master/contributor_docs#unit-tests
