### PR TITLE
fix cylinder and cone uv bug

### DIFF
--- a/src/webgl/3d_primitives.js
+++ b/src/webgl/3d_primitives.js
@@ -353,7 +353,7 @@ const _truncatedCone = function(
 
     y -= height / 2; //shift coordiate origin to the center of object
     for (ii = 0; ii < detailX; ++ii) {
-      const u = ii / detailX;
+      const u = ii / (detailX - 1);
       const ur = 2 * Math.PI * u;
       const sur = Math.sin(ur);
       const cur = Math.cos(ur);


### PR DESCRIPTION

Resolves https://github.com/processing/p5.js/issues/4284

 Changes: Fixed an off by one bug that was preventing uv's on cones and cylinders from being calculated correctly.


#### PR Checklist

- [X] `npm run lint` passes
