### PR TITLE
Resolve #3292, Pass JSON text in data for drop event

### DIFF
--- a/src/dom/dom.js
+++ b/src/dom/dom.js
@@ -3436,7 +3436,8 @@ p5.File = function(file, pInst) {
   this.size = file.size;
 
   /**
-   * URL string containing image data or the text contents of the file.
+   * URL string containing either image data, the text contents of the file or
+   * a parsed object if file is JSON and p5.XML if XML
    *
    * @property data
    */
@@ -3447,7 +3448,17 @@ p5.File._createLoader = function(theFile, callback) {
   var reader = new FileReader();
   reader.onload = function(e) {
     var p5file = new p5.File(theFile);
-    p5file.data = e.target.result;
+    if (p5file.file.type === 'application/json') {
+      // Parse JSON and store the result in data
+      p5file.data = JSON.parse(e.target.result);
+    } else if (p5file.file.type === 'text/xml') {
+      // Parse XML, wrap it in p5.XML and store the result in data
+      const parser = new DOMParser();
+      const xml = parser.parseFromString(e.target.result, 'text/xml');
+      p5file.data = new p5.XML(xml.documentElement);
+    } else {
+      p5file.data = e.target.result;
+    }
     callback(p5file);
   };
   return reader;

--- a/src/dom/dom.js
+++ b/src/dom/dom.js
@@ -3456,7 +3456,7 @@ p5.File._createLoader = function(theFile, callback) {
 p5.File._load = function(f, callback) {
   // Text or data?
   // This should likely be improved
-  if (/^text\/|json/.test(f.type)) {
+  if (/^text\//.test(f.type) || f.type === 'application/json') {
     p5.File._createLoader(f, callback).readAsText(f);
   } else if (!/^(video|audio)\//.test(f.type)) {
     p5.File._createLoader(f, callback).readAsDataURL(f);

--- a/src/dom/dom.js
+++ b/src/dom/dom.js
@@ -3436,7 +3436,7 @@ p5.File = function(file, pInst) {
   this.size = file.size;
 
   /**
-   * URL string containing image data.
+   * URL string containing image data or the text contents of the file.
    *
    * @property data
    */
@@ -3456,7 +3456,7 @@ p5.File._createLoader = function(theFile, callback) {
 p5.File._load = function(f, callback) {
   // Text or data?
   // This should likely be improved
-  if (/^text\//.test(f.type)) {
+  if (/^text\/|json/.test(f.type)) {
     p5.File._createLoader(f, callback).readAsText(f);
   } else if (!/^(video|audio)\//.test(f.type)) {
     p5.File._createLoader(f, callback).readAsDataURL(f);


### PR DESCRIPTION
<!--
  Thank you for contributing! Please use this pull request (PR) template.


 In the description field of this PR, include "resolves #XXXX" tagging the issue you are fixing. If this PR addresses the issue but doesn't completely resolve it (ie the issue should remain open after your PR is merged), write "addresses #XXXX".-->
Resolves #3292
 Changes:
<!-- Add here what changes were made in this pull request and if possible provide links showcasing the changes. -->

Earlier, when the drop event had to deal with a json file it returned the data URL of the file as the MIME Type of json is application/json. A small patch fixes this so that even JSON is handled like text

#### PR Checklist
<!--
  To check any option, replace the "[ ]" with a "[x]". Be sure to check out how it looks in the Preview tab! Feel free to remove any portion of the template that is not relevant for your issue.
-->

- [x] `npm run lint` passes
- [x] [Inline documentation] is included / updated
- [ ] [Unit tests] are included / updated

[Inline documentation]: https://github.com/processing/p5.js/blob/master/contributor_docs/inline_documentation.md
[Unit tests]: https://github.com/processing/p5.js/tree/master/contributor_docs#unit-tests
