### PR TITLE
Fix issue with trying to draw non-existent strokes in WebGL immediate mode

### DIFF
--- a/src/webgl/p5.RendererGL.Immediate.js
+++ b/src/webgl/p5.RendererGL.Immediate.js
@@ -126,8 +126,12 @@ p5.RendererGL.prototype.endShape = function(
 
   if (this.immediateMode.geometry.vertices.length > 1) {
     this._drawImmediateFill();
+  }
+
+  if (this.immediateMode.geometry.lineVertices.length > 1) {
     this._drawImmediateStroke();
   }
+
   this.isBezier = false;
   this.isQuadratic = false;
   this.isCurve = false;


### PR DESCRIPTION
resolves #4323 

Before immediate mode strokes would attempt to render even when line vertices hadn't been calculated. This PR fixes this.
