### PR TITLE
Fixed STL Model Error

### DIFF
--- a/src/webgl/loading.js
+++ b/src/webgl/loading.js
@@ -402,26 +402,27 @@ function parseBinarySTL(model, buffer) {
         b = defaultB;
       }
     }
+    
+    const newNormal = new p5.Vector(normalX, normalY, normalZ);
 
     for (let i = 1; i <= 3; i++) {
       const vertexstart = start + i * 12;
 
       const newVertex = new p5.Vector(
         reader.getFloat32(vertexstart, true),
-        reader.getFloat32(vertexstart + 8, true),
-        reader.getFloat32(vertexstart + 4, true)
+        reader.getFloat32(vertexstart + 4, true),
+        reader.getFloat32(vertexstart + 8, true)
       );
 
       model.vertices.push(newVertex);
+      model.vertexNormals.push(newNormal);
 
       if (hasColors) {
         colors.push(r, g, b);
       }
     }
 
-    const newNormal = new p5.Vector(normalX, normalY, normalZ);
 
-    model.vertexNormals.push(newNormal, newNormal, newNormal);
 
     model.faces.push([3 * face, 3 * face + 1, 3 * face + 2]);
     model.uvs.push([0, 0], [0, 0], [0, 0]);

--- a/src/webgl/loading.js
+++ b/src/webgl/loading.js
@@ -402,7 +402,6 @@ function parseBinarySTL(model, buffer) {
         b = defaultB;
       }
     }
-    
     const newNormal = new p5.Vector(normalX, normalY, normalZ);
 
     for (let i = 1; i <= 3; i++) {
@@ -421,8 +420,6 @@ function parseBinarySTL(model, buffer) {
         colors.push(r, g, b);
       }
     }
-
-
 
     model.faces.push([3 * face, 3 * face + 1, 3 * face + 2]);
     model.uvs.push([0, 0], [0, 0], [0, 0]);


### PR DESCRIPTION
Resolves ##4329

 Changes:
* Corrected vertex order in `model.vertices` required for parsing of STL files. 


 Screenshots of the change:
![vid](https://user-images.githubusercontent.com/35900375/75731012-81679600-5d14-11ea-82b9-e7928beb803d.gif)


#### PR Checklist
<!--
  To check any option, replace the "[ ]" with a "[x]". Be sure to check out how it looks in the Preview tab! Feel free to remove any portion of the template that is not relevant for your issue.
-->

- [x] `npm run lint` passes
- [ ] [Inline documentation] is included / updated
- [ ] [Unit tests] are included / updated

[Inline documentation]: https://github.com/processing/p5.js/blob/master/contributor_docs/inline_documentation.md
[Unit tests]: https://github.com/processing/p5.js/tree/master/contributor_docs#unit-tests
