### PR TITLE
Fix square() argument handling

### DIFF
--- a/src/core/shape/2d_primitives.js
+++ b/src/core/shape/2d_primitives.js
@@ -618,17 +618,16 @@ p5.prototype.rect = function() {
  */
 p5.prototype.square = function(x, y, s, tl, tr, br, bl) {
   p5._validateParameters('square', arguments);
-  return this._renderRect.apply(this, arguments);
+  // duplicate width for height as only one value given
+  let args = Array.prototype.slice.call(arguments, 0, 3);
+  args.push(arguments[2]);
+  args = args.concat(Array.prototype.slice.call(arguments, 4));
+  return this._renderRect.apply(this, args);
 };
 
 // internal method to have renderer draw a rectangle
 p5.prototype._renderRect = function() {
   if (this._renderer._doStroke || this._renderer._doFill) {
-    // duplicate width for height if only one value given
-    if (arguments.length === 3) {
-      arguments[3] = arguments[2];
-    }
-
     const vals = canvas.modeAdjust(
       arguments[0],
       arguments[1],

--- a/src/core/shape/2d_primitives.js
+++ b/src/core/shape/2d_primitives.js
@@ -619,7 +619,7 @@ p5.prototype.rect = function() {
 p5.prototype.square = function(x, y, s, tl, tr, br, bl) {
   p5._validateParameters('square', arguments);
   // duplicate width for height in case of square
-  return this._renderRect.apply(this, [x, y, s, s, tl, tr, br, bl]);
+  return this._renderRect.call(this, x, y, s, s, tl, tr, br, bl);
 };
 
 // internal method to have renderer draw a rectangle

--- a/src/core/shape/2d_primitives.js
+++ b/src/core/shape/2d_primitives.js
@@ -618,16 +618,17 @@ p5.prototype.rect = function() {
  */
 p5.prototype.square = function(x, y, s, tl, tr, br, bl) {
   p5._validateParameters('square', arguments);
-  // duplicate width for height as only one value given
-  let args = Array.prototype.slice.call(arguments, 0, 3);
-  args.push(arguments[2]);
-  args = args.concat(Array.prototype.slice.call(arguments, 4));
-  return this._renderRect.apply(this, args);
+  // duplicate width for height in case of square
+  return this._renderRect.apply(this, [x, y, s, s, tl, tr, br, bl]);
 };
 
 // internal method to have renderer draw a rectangle
 p5.prototype._renderRect = function() {
   if (this._renderer._doStroke || this._renderer._doFill) {
+    // duplicate width for height in case only 3 arguments is provided
+    if (arguments.length === 3) {
+      arguments[3] = arguments[2];
+    }
     const vals = canvas.modeAdjust(
       arguments[0],
       arguments[1],


### PR DESCRIPTION
Resolves #4343

 Changes:
* Fixed 1.0.0 broke syntax for square with rounded corners
* Corrected parameters passed from `p5.prototype.square` to `p5.prototype._renderRect`
* Removed redundant code for the square in `p5.prototype._renderRect`


 Screenshots of the change:
`square(30, 20, 55);`
![image](https://user-images.githubusercontent.com/35900375/75853427-13a29380-5e14-11ea-9e81-ddacf42e450b.png)
`square(30, 20, 55, 20);`
![image](https://user-images.githubusercontent.com/35900375/75853472-2ddc7180-5e14-11ea-8dce-4d7967a2f410.png)
`square(30, 20, 55, 20, 15, 10, 5);`
![image](https://user-images.githubusercontent.com/35900375/75853496-3df45100-5e14-11ea-8665-c361bb23b56e.png)
`rect(30, 20, 55, 55);`
![image](https://user-images.githubusercontent.com/35900375/75853531-52384e00-5e14-11ea-9597-208afca8f3fc.png)
`rect(30, 20, 55, 55, 20);`
![image](https://user-images.githubusercontent.com/35900375/75853562-6a0fd200-5e14-11ea-9c3b-88ea4f22c3a6.png)
`rect(30, 20, 55, 55, 20, 15, 10, 5);`
![image](https://user-images.githubusercontent.com/35900375/75853597-7e53cf00-5e14-11ea-9d3d-1c2f37605307.png)




#### PR Checklist
- [x] Every function working correctly
- [x] `npm run lint` passes
- [ ] [Inline documentation] is included / updated
- [ ] [Unit tests] are included / updated

[Inline documentation]: https://github.com/processing/p5.js/blob/master/contributor_docs/inline_documentation.md
[Unit tests]: https://github.com/processing/p5.js/tree/master/contributor_docs#unit-tests
