### PR TITLE
Remove erroneous .only() and fix tests

### DIFF
--- a/src/core/error_helpers.js
+++ b/src/core/error_helpers.js
@@ -805,13 +805,21 @@ const helpForMisusedAtTopLevelCode = (e, log) => {
     if (e.message && e.message.match(`\\W?${symbol.name}\\W`) !== null) {
       const symbolName =
         symbol.type === 'function' ? `${symbol.name}()` : symbol.name;
-      log(
-        translator('fes.misusedTopLevel', {
-          symbolName,
-          symbolType: symbol.type,
-          link: FAQ_URL
-        })
-      );
+      if (typeof IS_MINIFIED !== 'undefined') {
+        log(
+          `Did you just try to use p5.js's ${symbolName} ${
+            symbol.type
+          }? If so, you may want to move it into your sketch's setup() function.\n\nFor more details, see: ${FAQ_URL}`
+        );
+      } else {
+        log(
+          translator('fes.misusedTopLevel', {
+            symbolName,
+            symbolType: symbol.type,
+            link: FAQ_URL
+          })
+        );
+      }
       return true;
     }
   });

--- a/test/unit/core/error_helpers.js
+++ b/test/unit/core/error_helpers.js
@@ -18,7 +18,7 @@ suite('Error Helpers', function() {
     test('basic', function() {
       assert.doesNotThrow(
         function() {
-          p5._friendlyError('basic');
+          p5._friendlyError('basic', 'basic');
         },
         Error,
         'got unwanted exception'

--- a/test/unit/io/files.js
+++ b/test/unit/io/files.js
@@ -466,7 +466,7 @@ suite('Files', function() {
 
   // saveStrings()
   suite('p5.prototype.saveStrings', function() {
-    test.only('should be a function', function() {
+    test('should be a function', function() {
       assert.ok(myp5.saveStrings);
       assert.typeOf(myp5.saveStrings, 'function');
     });

--- a/test/unit/utilities/time_date.js
+++ b/test/unit/utilities/time_date.js
@@ -108,9 +108,9 @@ suite('time and date', function() {
 
     test('result should be greater than running time', function() {
       var runningTime = 50;
-      var init_date = Date.now();
+      var init_date = window.performance.now();
       // wait :\
-      while (Date.now() - init_date < runningTime) {
+      while (window.performance.now() - init_date < runningTime) {
         /* no-op */
       }
       assert.operator(myp5.millis(), '>', runningTime, 'everything is ok');


### PR DESCRIPTION
<!--
  Thank you for contributing! Please use this pull request (PR) template.


 In the description field of this PR, include "resolves #XXXX" tagging the issue you are fixing. If this PR addresses the issue but doesn't completely resolve it (ie the issue should remain open after your PR is merged), write "addresses #XXXX".-->
Resolves #4347 

 Changes:
- Remove the erroneous .only()
- Pass `method` argument for _friendlyError Test
- Fix the test for result should be greater than running time
- log without translator for minified library


<!-- If applicable, add screenshots depicting the changes. -->

#### PR Checklist
<!--
  To check any option, replace the "[ ]" with a "[x]". Be sure to check out how it looks in the Preview tab! Feel free to remove any portion of the template that is not relevant for your issue.
-->

- [x] `npm run lint` passes
- [ ] [Inline documentation] is included / updated
- [x] [Unit tests] are included / updated

[Inline documentation]: https://github.com/processing/p5.js/blob/master/contributor_docs/inline_documentation.md
[Unit tests]: https://github.com/processing/p5.js/tree/master/contributor_docs#unit-tests
