### PR TITLE
Prevent multiple init on multiple imports

### DIFF
--- a/src/core/init.js
+++ b/src/core/init.js
@@ -18,9 +18,10 @@ const _globalInit = () => {
   // If that property is already a part of the global object,
   // this code has already run before, likely due to a duplicate import
   if (typeof window._setupDone !== 'undefined') {
-    throw new Error(
+    console.warn(
       'p5.js seems to have been imported multiple times. Please remove the duplicate import'
     );
+    return;
   }
 
   if (!window.mocha) {

--- a/src/core/init.js
+++ b/src/core/init.js
@@ -14,6 +14,15 @@ import { initialize as initTranslator } from './internationalization';
  * @return {Undefined}
  */
 const _globalInit = () => {
+  // Could have been any property defined within the p5 constructor.
+  // If that property is already a part of the global object,
+  // this code has already run before, likely due to a duplicate import
+  if (typeof window._setupDone !== 'undefined') {
+    throw new Error(
+      'p5.js seems to have been imported multiple times. Please remove the duplicate import'
+    );
+  }
+
   if (!window.mocha) {
     // If there is a setup or draw function on the window
     // then instantiate p5 in "global" mode


### PR DESCRIPTION
<!--
  Thank you for contributing! Please use this pull request (PR) template.


 In the description field of this PR, include "resolves #XXXX" tagging the issue you are fixing. If this PR addresses the issue but doesn't completely resolve it (ie the issue should remain open after your PR is merged), write "addresses #XXXX".-->
Resolves #2681 

 Changes:
<!-- Add here what changes were made in this pull request and if possible provide links showcasing the changes. -->
- check if p5 has already been initialised globally. 
This is done by checking if a property initialised in the constructor exists in the global object.




#### PR Checklist
<!--
  To check any option, replace the "[ ]" with a "[x]". Be sure to check out how it looks in the Preview tab! Feel free to remove any portion of the template that is not relevant for your issue.
-->

- [x] `npm run lint` passes
- [ ] [Inline documentation] is included / updated
- [ ] [Unit tests] are included / updated

[Inline documentation]: https://github.com/processing/p5.js/blob/master/contributor_docs/inline_documentation.md
[Unit tests]: https://github.com/processing/p5.js/tree/master/contributor_docs#unit-tests
