### PR TITLE
checking for _doFIll and _doStroke in endShape() #4350

### DIFF
--- a/src/webgl/p5.RendererGL.Immediate.js
+++ b/src/webgl/p5.RendererGL.Immediate.js
@@ -123,13 +123,15 @@ p5.RendererGL.prototype.endShape = function(
     return this;
   }
   this._processVertices(...arguments);
-
-  if (this.immediateMode.geometry.vertices.length > 1) {
-    this._drawImmediateFill();
+  if (this._doFill) {
+    if (this.immediateMode.geometry.vertices.length > 1) {
+      this._drawImmediateFill();
+    }
   }
-
-  if (this.immediateMode.geometry.lineVertices.length > 1) {
-    this._drawImmediateStroke();
+  if (this._doStroke) {
+    if (this.immediateMode.geometry.lineVertices.length > 1) {
+      this._drawImmediateStroke();
+    }
   }
 
   this.isBezier = false;


### PR DESCRIPTION
<!--
  Thank you for contributing! Please use this pull request (PR) template.


 In the description field of this PR, include "resolves #XXXX" tagging the issue you are fixing. If this PR addresses the issue but doesn't completely resolve it (ie the issue should remain open after your PR is merged), write "addresses #XXXX".-->
Resolves #4350 

 Changes:
<!-- Add here what changes were made in this pull request and if possible provide links showcasing the changes. -->
Checks for _doFill before calling _drawImmediateFill() and _doStroke before calling _drawImmediateStroke() in endShape() method in WEBGL Immediate Mode.

 Screenshots of the change:
<!-- If applicable, add screenshots depicting the changes. -->
![Screenshot from 2020-03-13 17-16-58](https://user-images.githubusercontent.com/39771050/76618454-9cc17500-654e-11ea-9aad-6739be8579c3.png)
![Screenshot from 2020-03-13 17-14-52](https://user-images.githubusercontent.com/39771050/76618466-a2b75600-654e-11ea-8cd4-9f3d10917ad6.png)

#### PR Checklist
<!--
  To check any option, replace the "[ ]" with a "[x]". Be sure to check out how it looks in the Preview tab! Feel free to remove any portion of the template that is not relevant for your issue.
-->

- [ X] `npm run lint` passes
- [ ] [Inline documentation] is included / updated
- [ ] [Unit tests] are included / updated

[Inline documentation]: https://github.com/processing/p5.js/blob/master/contributor_docs/inline_documentation.md
[Unit tests]: https://github.com/processing/p5.js/tree/master/contributor_docs#unit-tests
