### PR TITLE
[feat] Updating inline documentation of color module

### DIFF
--- a/contributor_docs/inline_documentation.md
+++ b/contributor_docs/inline_documentation.md
@@ -267,7 +267,7 @@ horizontal wave pattern effected by mouse x-position & updating noise values.
 
 ## Template for methods
 Here is an example for a well documentated method. To create a new method, you can use [this template](https://github.com/processing/p5.js/tree/master/contributor_docs/method.example.js). You can replace the text with your method's variables and remove the remaining ones.
-![Image showing inline documentation example for methods](https://github.com/processing/p5.js/tree/master/contributor_docs/images/method-template-example.png)
+![Image showing inline documentation example for methods](https://raw.githubusercontent.com/processing/p5.js/master/contributor_docs/images/method-template-example.png)
 
 
 ## Generating documentation
@@ -275,6 +275,7 @@ Here is an example for a well documentated method. To create a new method, you c
 Run `grunt yui:build` once first to generate all local files needed, as well as a copy of the reference from the source code. Run it again anytime you make changes to the core JS files behind the yuidoc reference page. These are changes in files located in the yuidoc-p5-theme-src folder, NOT inline documentation changes to src. If you only made changes to the source code, you can just run `grunt yui`, though `grunt yui:build` will also do the trick. 
 
 The build reference can be found in docs/reference. To preview it locally, run `grunt yui:dev` and view it as http://localhost:9001/docs/reference/.
+
 
 ## Spanish language version
 

--- a/src/color/creating_reading.js
+++ b/src/color/creating_reading.js
@@ -18,6 +18,7 @@ import '../core/error_helpers';
  * @param {p5.Color|Number[]|String} color <a href="#/p5.Color">p5.Color</a> object, color components,
  *                                         or CSS color
  * @return {Number} the alpha value
+ *
  * @example
  * <div>
  * <code>
@@ -33,23 +34,6 @@ import '../core/error_helpers';
  *
  * @alt
  * Left half of canvas light blue and right half light charcoal grey.
- * Left half of canvas light purple and right half a royal blue.
- * Left half of canvas salmon pink and the right half white.
- * Yellow rect in middle right of canvas, with 55 pixel width and height.
- * Yellow ellipse in top left canvas, black ellipse in bottom right,both 80x80.
- * Bright fuchsia rect in middle of canvas, 60 pixel width and height.
- * Two bright green rects on opposite sides of the canvas, both 45x80.
- * Four blue rects in each corner of the canvas, each are 35x35.
- * Bright sea green rect on left and darker rect on right of canvas, both 45x80.
- * Dark green rect on left and light green rect on right of canvas, both 45x80.
- * Dark blue rect on left and light teal rect on right of canvas, both 45x80.
- * blue rect on left and green on right, both with black outlines & 35x60.
- * salmon pink rect on left and black on right, both 35x60.
- * 4 rects, tan, brown, brownish purple and purple, with white outlines & 20x60.
- * light pastel green rect on left and dark grey rect on right, both 35x60.
- * yellow rect on left and red rect on right, both with black outlines & 35x60.
- * grey canvas
- * deep pink rect on left and grey rect on right, both 35x60.
  */
 p5.prototype.alpha = function(c) {
   p5._validateParameters('alpha', arguments);
@@ -66,20 +50,17 @@ p5.prototype.alpha = function(c) {
  * @example
  * <div>
  * <code>
- * let c = color(175, 100, 220); // Define color 'c'
- * fill(c); // Use color variable 'c' as fill color
+ * let c = color(175, 100, 220);
+ * fill(c);
  * rect(15, 20, 35, 60); // Draw left rectangle
- *
- * let blueValue = blue(c); // Get blue in 'c'
- * print(blueValue); // Prints "220.0"
- * fill(0, 0, blueValue); // Use 'blueValue' in new fill
+ * let blueValue = blue(c);
+ * fill(0, 0, blueValue);
  * rect(50, 20, 35, 60); // Draw right rectangle
  * </code>
  * </div>
  *
  * @alt
  * Left half of canvas light purple and right half a royal blue.
- *
  */
 p5.prototype.blue = function(c) {
   p5._validateParameters('blue', arguments);
@@ -93,6 +74,7 @@ p5.prototype.blue = function(c) {
  * @param {p5.Color|Number[]|String} color <a href="#/p5.Color">p5.Color</a> object, color components,
  *                                         or CSS color
  * @return {Number} the brightness value
+ *
  * @example
  * <div>
  * <code>
@@ -106,6 +88,7 @@ p5.prototype.blue = function(c) {
  * rect(50, 20, 35, 60);
  * </code>
  * </div>
+ *
  * <div>
  * <code>
  * noStroke();
@@ -120,9 +103,8 @@ p5.prototype.blue = function(c) {
  * </div>
  *
  * @alt
- * Left half of canvas salmon pink and the right half white.
- * Left half of canvas yellow at half brightness and the right gray .
- *
+ * Left half of canvas salmon pink and the right half with it's brightness colored white.
+ * Left half of canvas olive colored and the right half with it's brightness color gray.
  */
 p5.prototype.brightness = function(c) {
   p5._validateParameters('brightness', arguments);
@@ -135,145 +117,127 @@ p5.prototype.brightness = function(c) {
  * current <a href="#/p5/colorMode">colorMode()</a>. The default mode is RGB values from 0 to 255
  * and, therefore, the function call color(255, 204, 0) will return a
  * bright yellow color.
- * <br><br>
+ *
  * Note that if only one value is provided to <a href="#/p5/color">color()</a>, it will be interpreted
  * as a grayscale value. Add a second value, and it will be used for alpha
  * transparency. When three values are specified, they are interpreted as
  * either RGB or HSB values. Adding a fourth value applies alpha
  * transparency.
- * <br><br>
+ *
  * If a single string argument is provided, RGB, RGBA and Hex CSS color
  * strings and all named color strings are supported. In this case, an alpha
  * number value as a second argument is not supported, the RGBA form should be
  * used.
  *
  * @method color
- * @param  {Number}        gray    number specifying value between white
- *                                 and black.
- * @param  {Number}        [alpha] alpha value relative to current color range
+ * @param  {Number} gray number specifying value between white and black.
+ * @param  {Number} [alpha] alpha value relative to current color range
  *                                 (default is 0-255)
- * @return {p5.Color}              resulting color
+ * @return {p5.Color} resulting color
  *
  * @example
  * <div>
  * <code>
- * let c = color(255, 204, 0); // Define color 'c'
- * fill(c); // Use color variable 'c' as fill color
- * noStroke(); // Don't draw a stroke around shapes
- * rect(30, 20, 55, 55); // Draw rectangle
+ * let c = color(255, 204, 0);
+ * fill(c);
+ * noStroke();
+ * rect(30, 20, 55, 55);
  * </code>
  * </div>
  *
  * <div>
  * <code>
- * let c = color(255, 204, 0); // Define color 'c'
- * fill(c); // Use color variable 'c' as fill color
- * noStroke(); // Don't draw a stroke around shapes
+ * let c = color(255, 204, 0);
+ * fill(c);
+ * noStroke();
  * ellipse(25, 25, 80, 80); // Draw left circle
- *
- * // Using only one value with color()
- * // generates a grayscale value.
- * c = color(65); // Update 'c' with grayscale value
- * fill(c); // Use updated 'c' as fill color
- * ellipse(75, 75, 80, 80); // Draw right circle
+ * // Using only one value generates a grayscale value.
+ * c = color(65);
+ * fill(c);
+ * ellipse(75, 75, 80, 80);
  * </code>
  * </div>
  *
  * <div>
  * <code>
- * // Named SVG & CSS colors may be used,
+ * // You can use named SVG & CSS colors
  * let c = color('magenta');
- * fill(c); // Use 'c' as fill color
- * noStroke(); // Don't draw a stroke around shapes
- * rect(20, 20, 60, 60); // Draw rectangle
+ * fill(c);
+ * noStroke();
+ * rect(20, 20, 60, 60);
  * </code>
  * </div>
  *
  * <div>
  * <code>
- * // as can hex color codes:
- * noStroke(); // Don't draw a stroke around shapes
+ * // Example of hex color codes
+ * noStroke();
  * let c = color('#0f0');
- * fill(c); // Use 'c' as fill color
- * rect(0, 10, 45, 80); // Draw rectangle
- *
+ * fill(c);
+ * rect(0, 10, 45, 80);
  * c = color('#00ff00');
- * fill(c); // Use updated 'c' as fill color
- * rect(55, 10, 45, 80); // Draw rectangle
+ * fill(c);
+ * rect(55, 10, 45, 80);
  * </code>
  * </div>
  *
  * <div>
  * <code>
- * // RGB and RGBA color strings are also supported:
+ * // RGB and RGBA color strings are also supported
  * // these all set to the same color (solid blue)
  * let c;
- * noStroke(); // Don't draw a stroke around shapes
+ * noStroke();
  * c = color('rgb(0,0,255)');
- * fill(c); // Use 'c' as fill color
+ * fill(c);
  * rect(10, 10, 35, 35); // Draw rectangle
- *
  * c = color('rgb(0%, 0%, 100%)');
- * fill(c); // Use updated 'c' as fill color
+ * fill(c);
  * rect(55, 10, 35, 35); // Draw rectangle
- *
  * c = color('rgba(0, 0, 255, 1)');
- * fill(c); // Use updated 'c' as fill color
+ * fill(c);
  * rect(10, 55, 35, 35); // Draw rectangle
- *
  * c = color('rgba(0%, 0%, 100%, 1)');
- * fill(c); // Use updated 'c' as fill color
+ * fill(c);
  * rect(55, 55, 35, 35); // Draw rectangle
  * </code>
  * </div>
  *
  * <div>
  * <code>
- * // HSL color is also supported and can be specified
- * // by value
- * let c;
- * noStroke(); // Don't draw a stroke around shapes
- * c = color('hsl(160, 100%, 50%)');
- * fill(c); // Use 'c' as fill color
+ * // HSL color can also be specified by value
+ * let c = color('hsl(160, 100%, 50%)');
+ * noStroke();
+ * fill(c);
  * rect(0, 10, 45, 80); // Draw rectangle
- *
  * c = color('hsla(160, 100%, 50%, 0.5)');
- * fill(c); // Use updated 'c' as fill color
+ * fill(c);
  * rect(55, 10, 45, 80); // Draw rectangle
  * </code>
  * </div>
  *
  * <div>
  * <code>
- * // HSB color is also supported and can be specified
- * // by value
- * let c;
- * noStroke(); // Don't draw a stroke around shapes
- * c = color('hsb(160, 100%, 50%)');
- * fill(c); // Use 'c' as fill color
+ * // HSB color can also be specified
+ * let c = color('hsb(160, 100%, 50%)');
+ * noStroke();
+ * fill(c);
  * rect(0, 10, 45, 80); // Draw rectangle
- *
  * c = color('hsba(160, 100%, 50%, 0.5)');
- * fill(c); // Use updated 'c' as fill color
+ * fill(c);
  * rect(55, 10, 45, 80); // Draw rectangle
  * </code>
  * </div>
  *
  * <div>
  * <code>
- * let c; // Declare color 'c'
- * noStroke(); // Don't draw a stroke around shapes
- *
- * // If no colorMode is specified, then the
- * // default of RGB with scale of 0-255 is used.
- * c = color(50, 55, 100); // Create a color for 'c'
- * fill(c); // Use color variable 'c' as fill color
+ * noStroke();
+ * let c = color(50, 55, 100);
+ * fill(c);
  * rect(0, 10, 45, 80); // Draw left rect
- *
- * colorMode(HSB, 100); // Use HSB with scale of 0-100
- * c = color(50, 55, 100); // Update 'c' with new color
- * fill(c); // Use updated 'c' as fill color
- * rect(55, 10, 45, 80); // Draw right rect
+ * colorMode(HSB, 100);
+ * c = color(50, 55, 100);
+ * fill(c);
+ * rect(55, 10, 45, 80);
  * </code>
  * </div>
  *
@@ -286,8 +250,8 @@ p5.prototype.brightness = function(c) {
  * Bright sea green rect on left and darker rect on right of canvas, both 45x80.
  * Dark green rect on left and lighter green rect on right of canvas, both 45x80.
  * Dark blue rect on left and light teal rect on right of canvas, both 45x80.
- *
  */
+
 /**
  * @method color
  * @param  {Number}        v1      red or hue value relative to
@@ -305,18 +269,19 @@ p5.prototype.brightness = function(c) {
  * @param  {String}        value   a color string
  * @return {p5.Color}
  */
+
 /**
  * @method color
  * @param  {Number[]}      values  an array containing the red,green,blue &
  *                                 and alpha components of the color
  * @return {p5.Color}
  */
+
 /**
  * @method color
  * @param  {p5.Color}     color
  * @return {p5.Color}
  */
-
 p5.prototype.color = function() {
   p5._validateParameters('color', arguments);
   if (arguments[0] instanceof p5.Color) {
@@ -352,7 +317,6 @@ p5.prototype.color = function() {
  * blue rect on left and green on right, both with black outlines & 35x60.
  *
  */
-
 p5.prototype.green = function(c) {
   p5._validateParameters('green', arguments);
   return this.color(c)._getGreen();
@@ -389,7 +353,6 @@ p5.prototype.green = function(c) {
  * salmon pink rect on left and black on right, both 35x60.
  *
  */
-
 p5.prototype.hue = function(c) {
   p5._validateParameters('hue', arguments);
   return this.color(c)._getHue();
@@ -403,7 +366,7 @@ p5.prototype.hue = function(c) {
  * above 1 will be capped at 1. This is different from the behavior of <a href="#/p5/lerp">lerp()</a>,
  * but necessary because otherwise numbers outside the range will produce
  * strange and unexpected colors.
- * <br><br>
+ *
  * The way that colors are interpolated depends on the current color mode.
  *
  * @method lerpColor
@@ -411,6 +374,7 @@ p5.prototype.hue = function(c) {
  * @param  {p5.Color} c2  interpolate to this color
  * @param  {Number}       amt number between 0 and 1
  * @return {p5.Color}     interpolated color
+ *
  * @example
  * <div>
  * <code>
@@ -435,7 +399,6 @@ p5.prototype.hue = function(c) {
  *
  * @alt
  * 4 rects one tan, brown, brownish purple, purple, with white outlines & 20x60
- *
  */
 
 p5.prototype.lerpColor = function(c1, c2, amt) {
@@ -493,6 +456,7 @@ p5.prototype.lerpColor = function(c1, c2, amt) {
  * @param {p5.Color|Number[]|String} color <a href="#/p5.Color">p5.Color</a> object, color components,
  *                                         or CSS color
  * @return {Number} the lightness
+ *
  * @example
  * <div>
  * <code>
@@ -586,7 +550,6 @@ p5.prototype.red = function(c) {
  *deep pink rect on left and grey rect on right, both 35x60.
  *
  */
-
 p5.prototype.saturation = function(c) {
   p5._validateParameters('saturation', arguments);
   return this.color(c)._getSaturation();

--- a/src/color/p5.Color.js
+++ b/src/color/p5.Color.js
@@ -51,6 +51,7 @@ p5.Color = function(pInst, vals) {
 /**
  * This function returns the color formatted as a string. This can be useful
  * for debugging, or for using p5.js with other libraries.
+ *
  * @method toString
  * @param {String} [format] How the color string will be formatted.
  * Leaving this empty formats the string as rgba(r, g, b, a).
@@ -59,28 +60,24 @@ p5.Color = function(pInst, vals) {
  * 'rgba' 'hsba' and 'hsla' are the same as above but with alpha channels.
  * 'rgb%' 'hsb%' 'hsl%' 'rgba%' 'hsba%' and 'hsla%' format as percentages.
  * @return {String} the formatted string
+ *
  * @example
  * <div>
  * <code>
+ * createCanvas(200, 100);
  * let myColor;
- * function setup() {
- *   createCanvas(200, 200);
- *   stroke(255);
- *   myColor = color(100, 100, 250);
- *   fill(myColor);
- * }
- *
- * function draw() {
- *   rotate(HALF_PI);
- *   text(myColor.toString(), 0, -5);
- *   text(myColor.toString('#rrggbb'), 0, -30);
- *   text(myColor.toString('rgba%'), 0, -55);
- * }
+ * stroke(255);
+ * myColor = color(100, 100, 250);
+ * fill(myColor);
+ * rotate(HALF_PI);
+ * text(myColor.toString(), 0, -5);
+ * text(myColor.toString('#rrggbb'), 0, -30);
+ * text(myColor.toString('rgba%'), 0, -55);
  * </code>
  * </div>
  *
  * @alt
- * canvas with text representation of color
+ * A canvas with 3 text representation of thier color.
  */
 p5.Color.prototype.toString = function(format) {
   const a = this.levels;
@@ -286,12 +283,7 @@ p5.Color.prototype.setRed = function(new_red) {
  * @example
  * <div>
  * <code>
- * let backgroundColor;
- *
- * function setup() {
- *   backgroundColor = color(100, 50, 150);
- * }
- *
+ * let backgroundColor = color(100, 50, 150);
  * function draw() {
  *   backgroundColor.setGreen(128 + 128 * sin(millis() / 1000));
  *   background(backgroundColor);
@@ -315,12 +307,7 @@ p5.Color.prototype.setGreen = function(new_green) {
  * @example
  * <div>
  * <code>
- * let backgroundColor;
- *
- * function setup() {
- *   backgroundColor = color(100, 50, 150);
- * }
- *
+ * let backgroundColor = color(100, 50, 150);
  * function draw() {
  *   backgroundColor.setBlue(128 + 128 * sin(millis() / 1000));
  *   background(backgroundColor);
@@ -344,31 +331,19 @@ p5.Color.prototype.setBlue = function(new_blue) {
  * @example
  * <div>
  * <code>
- * let squareColor;
- *
- * function setup() {
- *   ellipseMode(CORNERS);
- *   strokeWeight(4);
- *   squareColor = color(100, 50, 150);
- * }
- *
  * function draw() {
- *   background(255);
- *
- *   noFill();
- *   stroke(0);
- *   ellipse(10, 10, width - 10, height - 10);
- *
+ *   clear();
+ *   background(200);
+ *   squareColor = color(100, 50, 100);
  *   squareColor.setAlpha(128 + 128 * sin(millis() / 1000));
  *   fill(squareColor);
- *   noStroke();
  *   rect(13, 13, width - 26, height - 26);
  * }
  * </code>
  * </div>
  *
  * @alt
- * circle behind a square with gradually changing opacity
+ * a square with gradually changing opacity on a gray background
  **/
 p5.Color.prototype.setAlpha = function(new_alpha) {
   this._array[3] = new_alpha / this.maxes[this.mode][3];

--- a/src/color/setting.js
+++ b/src/color/setting.js
@@ -11,26 +11,28 @@ import * as constants from '../core/constants';
 import './p5.Color';
 
 /**
- * The <a href="#/p5/background">background()</a> function sets the color used for the background of the
- * p5.js canvas. The default background is transparent. This function is
- * typically used within <a href="#/p5/draw">draw()</a> to clear the display window at the beginning
- * of each frame, but it can be used inside <a href="#/p5/setup">setup()</a> to set the background on
- * the first frame of animation or if the background need only be set once.
- * <br><br>
- * The color is either specified in terms of the RGB, HSB, or HSL color
- * depending on the current <a href="#/p5/colorMode">colorMode</a>. (The default color space is RGB, with
- * each value in the range from 0 to 255). The alpha range by default is also 0 to 255.
- * <br><br>
+ * The <a href="#/p5/background">background()</a> function sets the color used
+ * for the background of the p5.js canvas. The default background is transparent.
+ * This function is typically used within <a href="#/p5/draw">draw()</a> to clear
+ * the display window at the beginning of each frame, but it can be used inside
+ * <a href="#/p5/setup">setup()</a> to set the background on the first frame of
+ * animation or if the background need only be set once.
+ *
+ * The color is either specified in terms of the RGB, HSB, or HSL color depending
+ * on the current <a href="#/p5/colorMode">colorMode</a>. (The default color space
+ * is RGB, with each value in the range from 0 to 255). The alpha range by default
+ * is also 0 to 255.<br><br>
+ *
  * If a single string argument is provided, RGB, RGBA and Hex CSS color strings
  * and all named color strings are supported. In this case, an alpha number
  * value as a second argument is not supported, the RGBA form should be used.
- * <br><br>
+ *
  * A <a href="#/p5.Color">p5.Color</a> object can also be provided to set the background color.
- * <br><br>
+ *
  * A <a href="#/p5.Image">p5.Image</a> can also be provided to set the background image.
  *
  * @method background
- * @param {p5.Color} color     any value created by the <a href="#/p5/color">color()</a> function
+ * @param {p5.Color} color  any value created by the <a href="#/p5/color">color()</a> function
  * @chainable
  *
  * @example
@@ -170,7 +172,6 @@ import './p5.Color';
  * @param  {Number}  [a]
  * @chainable
  */
-
 p5.prototype.background = function(...args) {
   this._renderer.background(...args);
   return this;
@@ -191,22 +192,18 @@ p5.prototype.background = function(...args) {
  * <div>
  * <code>
  * // Clear the screen on mouse press.
- * function setup() {
- *   createCanvas(100, 100);
- * }
- *
  * function draw() {
  *   ellipse(mouseX, mouseY, 20, 20);
  * }
- *
  * function mousePressed() {
  *   clear();
+ *   background(128);
  * }
  * </code>
  * </div>
  *
  * @alt
- * 20x20 white ellipses are continually drawn at mouse x and y coordinates.
+ * small white ellipses are continually drawn at mouse's x and y coordinates.
  *
  */
 
@@ -216,16 +213,16 @@ p5.prototype.clear = function() {
 };
 
 /**
- * <a href="#/p5/colorMode">colorMode()</a> changes the way p5.js interprets color data. By default, the
- * parameters for <a href="#/p5/fill">fill()</a>, <a href="#/p5/stroke">stroke()</a>, <a href="#/p5/background">background()</a>, and <a href="#/p5/color">color()</a> are defined by
- * values between 0 and 255 using the RGB color model. This is equivalent to
- * setting colorMode(RGB, 255). Setting colorMode(HSB) lets you use the HSB
- * system instead. By default, this is colorMode(HSB, 360, 100, 100, 1). You
- * can also use HSL.
- * <br><br>
+ * <a href="#/p5/colorMode">colorMode()</a> changes the way p5.js interprets
+ * color data. By default, the parameters for <a href="#/p5/fill">fill()</a>,
+ * <a href="#/p5/stroke">stroke()</a>, <a href="#/p5/background">background()</a>,
+ * and <a href="#/p5/color">color()</a> are defined by values between 0 and 255
+ * using the RGB color model. This is equivalent to setting colorMode(RGB, 255).
+ * Setting colorMode(HSB) lets you use the HSB system instead. By default, this
+ * is colorMode(HSB, 360, 100, 100, 1). You can also use HSL.
+ *
  * Note: existing color objects remember the mode that they were created in,
  * so you can change modes as you like without affecting their appearance.
- *
  *
  * @method colorMode
  * @param {Constant} mode   either RGB, HSB or HSL, corresponding to
@@ -265,7 +262,6 @@ p5.prototype.clear = function() {
  * <code>
  * colorMode(RGB, 255);
  * let c = color(127, 255, 0);
- *
  * colorMode(RGB, 1);
  * let myColor = c._getRed();
  * text(myColor, 10, 10, 80, 80);
@@ -277,7 +273,6 @@ p5.prototype.clear = function() {
  * noFill();
  * colorMode(RGB, 255, 255, 255, 1);
  * background(255);
- *
  * strokeWeight(4);
  * stroke(255, 0, 10, 0.3);
  * ellipse(40, 40, 50, 50);
@@ -290,8 +285,8 @@ p5.prototype.clear = function() {
  *Rainbow gradient from left to right. Brightness increasing to white at top.
  *unknown image.
  *50x50 ellipse at middle L & 40x40 ellipse at center. Translucent pink outlines.
- *
  */
+
 /**
  * @method colorMode
  * @param {Constant} mode
@@ -337,16 +332,17 @@ p5.prototype.colorMode = function(mode, max1, max2, max3, maxA) {
 };
 
 /**
- * Sets the color used to fill shapes. For example, if you run
- * fill(204, 102, 0), all shapes drawn after the fill command will be filled with the color orange. This
- * color is either specified in terms of the RGB or HSB color depending on
- * the current <a href="#/p5/colorMode">colorMode()</a>. (The default color space is RGB, with each value
- * in the range from 0 to 255). The alpha range by default is also 0 to 255.
- * <br><br>
+ * Sets the color used to fill shapes. For example, if you run fill(204, 102, 0),
+ * all shapes drawn after the fill command will be filled with the color orange.
+ * This color is either specified in terms of the RGB or HSB color depending on
+ * the current <a href="#/p5/colorMode">colorMode()</a>. (The default color space
+ * is RGB, with each value in the range from 0 to 255). The alpha range by default
+ * is also 0 to 255.
+ *
  * If a single string argument is provided, RGB, RGBA and Hex CSS color strings
  * and all named color strings are supported. In this case, an alpha number
  * value as a second argument is not supported, the RGBA form should be used.
- * <br><br>
+ *
  * A p5 <a href="#/p5.Color">Color</a> object can also be provided to set the fill color.
  *
  * @method fill
@@ -447,6 +443,7 @@ p5.prototype.colorMode = function(mode, max1, max2, max3, maxA) {
  * rect(20, 20, 60, 60);
  * </code>
  * </div>
+ *
  * @alt
  * 60x60 dark charcoal grey rect with black outline in center of canvas.
  * 60x60 yellow rect with black outline in center of canvas.
@@ -577,14 +574,15 @@ p5.prototype.noStroke = function() {
 /**
  * Sets the color used to draw lines and borders around shapes. This color
  * is either specified in terms of the RGB or HSB color depending on the
- * current <a href="#/p5/colorMode">colorMode()</a> (the default color space is RGB, with each value in
- * the range from 0 to 255). The alpha range by default is also 0 to 255.
- * <br><br>
+ * current <a href="#/p5/colorMode">colorMode()</a> (the default color space
+ * is RGB, with each value in the range from 0 to 255). The alpha range by
+ * default is also 0 to 255.
+ *
  * If a single string argument is provided, RGB, RGBA and Hex CSS color
  * strings and all named color strings are supported. In this case, an alpha
  * number value as a second argument is not supported, the RGBA form should be
  * used.
- * <br><br>
+ *
  * A p5 <a href="#/p5.Color">Color</a> object can also be provided to set the stroke color.
  *
  *
@@ -747,13 +745,12 @@ p5.prototype.stroke = function(...args) {
 };
 
 /**
- * All drawing that follows <a href="#/p5/erase">erase()</a> will subtract from the canvas.
- * Erased areas will reveal the web page underneath the canvas.
- * Erasing can be canceled with <a href="#/p5/noErase">noErase()</a>.
- * <br><br>
- * Drawing done with <a href="#/p5/image">image()</a>
- * and <a href="#/p5/background">background()</a> will not be affected by <a href="#/p5/erase">erase()</a>
- * <br><br>
+ * All drawing that follows <a href="#/p5/erase">erase()</a> will subtract from
+ * the canvas.Erased areas will reveal the web page underneath the canvas.Erasing
+ * can be canceled with <a href="#/p5/noErase">noErase()</a>.
+ *
+ * Drawing done with <a href="#/p5/image">image()</a> and <a href="#/p5/background">
+ * background()</a> will not be affected by <a href="#/p5/erase">erase()</a>
  *
  * @method erase
  * @param  {Number}   [strengthFill]      A number (0-255) for the strength of erasing for a shape's fill.


### PR DESCRIPTION
To resolve the issue #4368, I am updating the codebase, modules by modules. This PR covers the [`color`](https://github.com/processing/p5.js/tree/master/src/color) module.

Changes:
- [fix] Updated image url in inline_documentation with raw github url.
- Updated inline documentation of color module to be consistent with template.
- Reworded some method descriptions to be simple, consise and clear.
- Refactored some examples.

#### PR Checklist
<!--
  To check any option, replace the "[ ]" with a "[x]". Be sure to check out how it looks in the Preview tab! Feel free to remove any portion of the template that is not relevant for your issue.
-->

- [x] `npm run lint` passes
- [x] [Inline documentation] is included / updated
- [ ] [Unit tests] are included / updated

[Inline documentation]: https://github.com/processing/p5.js/blob/master/contributor_docs/inline_documentation.md
[Unit tests]: https://github.com/processing/p5.js/tree/master/contributor_docs#unit-tests
