### PR TITLE
Fix suite structure for p5.Element.prototype.position

### DIFF
--- a/test/unit/dom/dom.js
+++ b/test/unit/dom/dom.js
@@ -224,14 +224,40 @@ suite('DOM', function() {
   });
 
   suite('p5.Element.prototype.position', function() {
-    let paragraph = myp5.createP('out of box');
-    paragraph.position(20, 20, 'static');
+    var myp5;
 
-    elt = document.createElement('p', 'out of box');
-    elt.style.position = 'static';
-    elt.style.left = '20px';
-    elt.style.top = '20px';
-    expect(JSON.stringify(paragraph.elt)).to.eql(JSON.stringify(elt));
+    setup(function(done) {
+      new p5(function(p) {
+        p.setup = function() {
+          myp5 = p;
+          done();
+        };
+      });
+    });
+
+    teardown(function() {
+      myp5.remove();
+    });
+
+    var elt;
+
+    teardown(function() {
+      if (elt && elt.parentNode) {
+        elt.parentNode.removeChild(elt);
+        elt = null;
+      }
+    });
+
+    test('should match properties with dummy element', function() {
+      let paragraph = myp5.createP('out of box');
+      paragraph.position(20, 20, 'static');
+
+      elt = document.createElement('p', 'out of box');
+      elt.style.position = 'static';
+      elt.style.left = '20px';
+      elt.style.top = '20px';
+      expect(JSON.stringify(paragraph.elt)).to.eql(JSON.stringify(elt));
+    });
   });
 
   suite('p5.prototype.createSlider', function() {


### PR DESCRIPTION
<!--
  Thank you for contributing! Please use this pull request (PR) template.


 In the description field of this PR, include "resolves #XXXX" tagging the issue you are fixing. If this PR addresses the issue but doesn't completely resolve it (ie the issue should remain open after your PR is merged), write "addresses #XXXX".-->
Resolves #4374 

 Changes:
As described in the issue, change the format of suite `p5.Element.prototype.position` to prevent the framework from considering all subsequent suites as being a part of this suite. 
The issue was evident when a subsequent suite, `downloading animated gifs`, was tested using a .only() and the output caused a bit of confusion.

The difference can be observed from the indentation of the very next suite in [this PR](https://github.com/processing/p5.js/pull/4375/checks?check_run_id=507746719#step:5:5045) and on [master](https://github.com/processing/p5.js/runs/507291467#step:5:5033)


This is a minor change I think, as the issue did not seem to have any other side effects
#### PR Checklist
<!--
  To check any option, replace the "[ ]" with a "[x]". Be sure to check out how it looks in the Preview tab! Feel free to remove any portion of the template that is not relevant for your issue.
-->

- [x] `npm run lint` passes
- [ ] [Inline documentation] is included / updated
- [x] [Unit tests] are included / updated

[Inline documentation]: https://github.com/processing/p5.js/blob/master/contributor_docs/inline_documentation.md
[Unit tests]: https://github.com/processing/p5.js/tree/master/contributor_docs#unit-tests
