### PR TITLE
invalidURL is not invalid

### DIFF
--- a/src/io/files.js
+++ b/src/io/files.js
@@ -900,7 +900,7 @@ p5.prototype.httpGet = function() {
  *
  *
  * <div><code>
- * let url = 'https://invalidURL'; // A bad URL that will cause errors
+ * let url = 'ttps://invalidURL'; // A bad URL that will cause errors
  * let postData = { title: 'p5 Clicked!', body: 'p5.js is way cool.' };
  *
  * function setup() {


### PR DESCRIPTION
in OpenProcessing.org at least, the 'https://invalidURL' does not return as invalid, whereas a truly bad URL : 'ttps://invalidURL'  does.

<!--
  Thank you for contributing! Please use this pull request (PR) template.


 In the description field of this PR, include "resolves #XXXX" tagging the issue you are fixing. If this PR addresses the issue but doesn't completely resolve it (ie the issue should remain open after your PR is merged), write "addresses #XXXX".-->
Resolves #[Add issue number here]

 Changes:
<!-- Add here what changes were made in this pull request and if possible provide links showcasing the changes. -->


 Screenshots of the change:
<!-- If applicable, add screenshots depicting the changes. -->

#### PR Checklist
<!--
  To check any option, replace the "[ ]" with a "[x]". Be sure to check out how it looks in the Preview tab! Feel free to remove any portion of the template that is not relevant for your issue.
-->

- [ ] `npm run lint` passes
- [ ] [Inline documentation] is included / updated
- [ ] [Unit tests] are included / updated

[Inline documentation]: https://github.com/processing/p5.js/blob/master/contributor_docs/inline_documentation.md
[Unit tests]: https://github.com/processing/p5.js/tree/master/contributor_docs#unit-tests
