### PR TITLE
Added gl.FLOAT_VEC series in isArray check

### DIFF
--- a/src/webgl/p5.Shader.js
+++ b/src/webgl/p5.Shader.js
@@ -181,6 +181,9 @@ p5.Shader.prototype._loadUniforms = function() {
     uniform.isArray =
       uniform.type === gl.FLOAT_MAT3 ||
       uniform.type === gl.FLOAT_MAT4 ||
+      uniform.type === gl.FLOAT_VEC2 ||
+      uniform.type === gl.FLOAT_VEC3 ||
+      uniform.type === gl.FLOAT_VEC4 ||
       uniform.type === gl.INT_VEC2 ||
       uniform.type === gl.INT_VEC3 ||
       uniform.type === gl.INT_VEC4;


### PR DESCRIPTION
<!--
  Thank you for contributing! Please use this pull request (PR) template.


 In the description field of this PR, include "resolves #XXXX" tagging the issue you are fixing. If this PR addresses the issue but doesn't completely resolve it (ie the issue should remain open after your PR is merged), write "addresses #XXXX".-->
Resolves #4391 

 Changes:
Add missing `gl.FLOAT_VEC2`, `gl.FLOAT_VEC3` and `gl.FLOAT_VEC4` for isArray check so that they are treated as arrays


#### PR Checklist
<!--
  To check any option, replace the "[ ]" with a "[x]". Be sure to check out how it looks in the Preview tab! Feel free to remove any portion of the template that is not relevant for your issue.
-->

- [x] `npm run lint` passes
- [ ] [Inline documentation] is included / updated
- [ ] [Unit tests] are included / updated

[Inline documentation]: https://github.com/processing/p5.js/blob/master/contributor_docs/inline_documentation.md
[Unit tests]: https://github.com/processing/p5.js/tree/master/contributor_docs#unit-tests
