### PR TITLE
[fix] Splitting methods in dom module

### DIFF
--- a/src/dom/dom.js
+++ b/src/dom/dom.js
@@ -348,6 +348,11 @@ function addElement(elt, pInst, media) {
  * createDiv('this is some text');
  * </code></div>
  */
+p5.prototype.createDiv = function(html = '') {
+  let elt = document.createElement('div');
+  elt.innerHTML = html;
+  return addElement(elt, this);
+};
 
 /**
  * Creates a &lt;p&gt;&lt;/p&gt; element in the DOM with given inner HTML. Used
@@ -361,6 +366,11 @@ function addElement(elt, pInst, media) {
  * createP('this is some text');
  * </code></div>
  */
+p5.prototype.createP = function(html = '') {
+  let elt = document.createElement('p');
+  elt.innerHTML = html;
+  return addElement(elt, this);
+};
 
 /**
  * Creates a &lt;span&gt;&lt;/span&gt; element in the DOM with given inner HTML.
@@ -373,15 +383,11 @@ function addElement(elt, pInst, media) {
  * createSpan('this is some text');
  * </code></div>
  */
-var tags = ['div', 'p', 'span'];
-tags.forEach(function(tag) {
-  var method = 'create' + tag.charAt(0).toUpperCase() + tag.slice(1);
-  p5.prototype[method] = function(html) {
-    var elt = document.createElement(tag);
-    elt.innerHTML = typeof html === 'undefined' ? '' : html;
-    return addElement(elt, this);
-  };
-});
+p5.prototype.createSpan = function(html = '') {
+  let elt = document.createElement('span');
+  elt.innerHTML = html;
+  return addElement(elt, this);
+};
 
 /**
  * Creates an &lt;img&gt; element in the DOM with given src and


### PR DESCRIPTION
Resolves #4410 

 Changes:
Split up methods for  createDiv, createP, createSpan

 Screenshots of the change:
<!-- If applicable, add screenshots depicting the changes. -->

#### PR Checklist
<!--
  To check any option, replace the "[ ]" with a "[x]". Be sure to check out how it looks in the Preview tab! Feel free to remove any portion of the template that is not relevant for your issue.
-->

- [x] `npm run lint` passes
- [ ] [Inline documentation] is included / updated
- [ ] [Unit tests] are included / updated

[Inline documentation]: https://github.com/processing/p5.js/blob/master/contributor_docs/inline_documentation.md
[Unit tests]: https://github.com/processing/p5.js/tree/master/contributor_docs#unit-tests
