### PR TITLE
[fix] Fixed bug in dom.removeElements

### DIFF
--- a/src/dom/dom.js
+++ b/src/dom/dom.js
@@ -216,11 +216,10 @@ p5.prototype._wrapElement = function(elt) {
  */
 p5.prototype.removeElements = function(e) {
   p5._validateParameters('removeElements', arguments);
-  for (var i = 0; i < this._elements.length; i++) {
-    if (!(this._elements[i].elt instanceof HTMLCanvasElement)) {
-      this._elements[i].remove();
-    }
-  }
+  // el.remove splices from this._elements, so don't mix iteration with it
+  const isNotCanvasElement = el => !(el.elt instanceof HTMLCanvasElement);
+  const removeableElements = this._elements.filter(isNotCanvasElement);
+  removeableElements.map(el => el.remove());
 };
 
 /**

--- a/test/unit/dom/dom.js
+++ b/test/unit/dom/dom.js
@@ -369,4 +369,47 @@ suite('DOM', function() {
       expect(JSON.stringify(anchor.elt)).to.eql(JSON.stringify(elt));
     });
   });
+
+  suite('p5.prototype.removeElements', function() {
+    let myp5;
+    let myp5Container;
+
+    setup(function(done) {
+      myp5Container = document.createElement('div');
+      document.body.appendChild(myp5Container);
+      new p5(function(p) {
+        p.setup = function() {
+          // configure p5 to not add a canvas by default.
+          p.noCanvas();
+          myp5 = p;
+          done();
+        };
+      }, myp5Container);
+    });
+
+    teardown(function() {
+      myp5.remove();
+      if (myp5Container && myp5Container.parentNode) {
+        myp5Container.parentNode.removeChild(myp5Container);
+      }
+      myp5Container = null;
+    });
+
+    test('should remove all elements created by p5 except Canvas', function() {
+      // creates 6 elements one of which is a canvas, then calls
+      // removeElements and tests if only canvas is left.
+      const tags = ['a', 'button', 'canvas', 'div', 'p', 'video'];
+      for (const tag of tags) {
+        myp5.createElement(tag);
+      }
+      // Check if all elements are created.
+      assert.deepEqual(myp5Container.childElementCount, tags.length);
+
+      // Call removeElements and check if only canvas is remaining
+      myp5.removeElements();
+      assert.deepEqual(myp5Container.childElementCount, 1);
+      const remainingElement = myp5Container.children[0];
+      assert.instanceOf(remainingElement, HTMLCanvasElement);
+    });
+  });
 });


### PR DESCRIPTION
Resolves #4413 
Addresses #4392

 Changes: 
- Updated removeElements to remove all non-canvas elements.
- Updates tests for it.

The current implementation loops through `this._elements` with an index i and once a element which is not a canvas is found, it calls `.remove` on the element. But the catch is that `.remove` is implemented in such a way that it splices `this._elements` and thus `this._elements.length` is obsolete and index `i` is not pointing to the expected element. I tried different approaches to solve this and found the functional approach to be the most clear and efficient, so i replaced the iteration with functional approach.

#### PR Checklist
- [x] `npm run lint` passes
- [ ] [Inline documentation] is included / updated
- [x] [Unit tests] are included / updated
