### PR TITLE
A way to verify downloads

### DIFF
--- a/test/js/p5_helpers.js
+++ b/test/js/p5_helpers.js
@@ -24,6 +24,53 @@ function testSketchWithPromise(name, sketch_fn) {
   return test(name, test_fn);
 }
 
+function testWithDownload(name, fn, asyncFn = false) {
+  var test_fn = function(done) {
+    // description of this is also on
+    // https://github.com/processing/p5.js/pull/4418/
+
+    let blobContainer = {};
+
+    // create a backup of createObjectURL
+    let couBackup = window.URL.createObjectURL;
+
+    // file-saver uses createObjectURL as an intermediate step. If we
+    // modify the definition a just a little bit we can capture whenever
+    // it is called and also peek in the data that was passed to it
+    window.URL.createObjectURL = blob => {
+      blobContainer.blob = blob;
+      return couBackup(blob);
+    };
+
+    let error;
+    if (asyncFn) {
+      fn(blobContainer)
+        .then(() => {
+          window.URL.createObjectURL = couBackup;
+        })
+        .catch(err => {
+          error = err;
+        })
+        .finally(() => {
+          // restore createObjectURL to the original one
+          window.URL.createObjectURL = couBackup;
+          error ? done(error) : done();
+        });
+    } else {
+      try {
+        fn(blobContainer);
+      } catch (err) {
+        error = err;
+      }
+      // restore createObjectURL to the original one
+      window.URL.createObjectURL = couBackup;
+      error ? done(error) : done();
+    }
+  };
+
+  return test(name, test_fn);
+}
+
 function parallelSketches(sketch_fns) {
   var setupPromises = [];
   var resultPromises = [];

--- a/test/js/p5_helpers.js
+++ b/test/js/p5_helpers.js
@@ -71,6 +71,11 @@ function testWithDownload(name, fn, asyncFn = false) {
   return test(name, test_fn);
 }
 
+// Tests should run only for the unminified script
+function testUnMinified(name, test_fn) {
+  return !window.IS_TESTING_MINIFIED_VERSION ? test(name, test_fn) : null;
+}
+
 function parallelSketches(sketch_fns) {
   var setupPromises = [];
   var resultPromises = [];

--- a/test/unit/image/downloading.js
+++ b/test/unit/image/downloading.js
@@ -40,5 +40,25 @@ suite('downloading animated gifs', function() {
     test('should not throw an error', function() {
       myp5.saveGif(myGif);
     });
+    test('should download a gif', function() {
+      // create a backup of createObjectURL
+      let couBackup = window.URL.createObjectURL;
+      let gifBlob;
+
+      // file-saver uses createObjectURL as an intermediate step. If we
+      // modify the definition a just a little bit we can capture whenever
+      // it is called and also peek in the data that was passed to it
+      window.URL.createObjectURL = blob => {
+        // now use this gifBlob to verify the downloaded output
+        gifBlob = blob;
+        return couBackup(blob);
+      };
+
+      myp5.saveGif(myGif);
+      console.log(gifBlob);
+      // restore createObjectURL to the original one
+      window.URL.createObjectURL = couBackup;
+      assert.strictEqual(gifBlob.type, 'image/gif');
+    });
   });
 });

--- a/test/unit/image/downloading.js
+++ b/test/unit/image/downloading.js
@@ -40,24 +40,9 @@ suite('downloading animated gifs', function() {
     test('should not throw an error', function() {
       myp5.saveGif(myGif);
     });
-    test('should download a gif', function() {
-      // create a backup of createObjectURL
-      let couBackup = window.URL.createObjectURL;
-      let gifBlob;
-
-      // file-saver uses createObjectURL as an intermediate step. If we
-      // modify the definition a just a little bit we can capture whenever
-      // it is called and also peek in the data that was passed to it
-      window.URL.createObjectURL = blob => {
-        // now use this gifBlob to verify the downloaded output
-        gifBlob = blob;
-        return couBackup(blob);
-      };
-
+    testWithDownload('should download a gif', function(blobContainer) {
       myp5.saveGif(myGif);
-      console.log(gifBlob);
-      // restore createObjectURL to the original one
-      window.URL.createObjectURL = couBackup;
+      let gifBlob = blobContainer.blob;
       assert.strictEqual(gifBlob.type, 'image/gif');
     });
   });

--- a/test/unit/image/downloading.js
+++ b/test/unit/image/downloading.js
@@ -223,3 +223,100 @@ suite('p5.prototype.saveCanvas', function() {
     true
   );
 });
+
+suite('p5.prototype.saveFrames', function() {
+  setup(function(done) {
+    new p5(function(p) {
+      p.setup = function() {
+        myp5 = p;
+        p.createCanvas(10, 10);
+        done();
+      };
+    });
+  });
+
+  teardown(function() {
+    myp5.remove();
+  });
+
+  test('should be a function', function() {
+    assert.ok(myp5.saveFrames);
+    assert.typeOf(myp5.saveFrames, 'function');
+  });
+
+  test('no friendly-err-msg I', function() {
+    assert.doesNotThrow(
+      function() {
+        myp5.saveFrames('out', 'png', 0.1, 25);
+      },
+      Error,
+      'got unwanted exception'
+    );
+  });
+  test('no friendly-err-msg II', function(done) {
+    assert.doesNotThrow(
+      function() {
+        myp5.saveFrames('out', 'png', 0.1, 25, () => {
+          done();
+        });
+      },
+      Error,
+      'got unwanted exception'
+    );
+  });
+
+  testUnMinified('missing param #2 #3', function() {
+    assert.validationError(function() {
+      myp5.saveFrames('out', 'png');
+    });
+  });
+  testUnMinified('wrong param type #0', function() {
+    assert.validationError(function() {
+      myp5.saveFrames(0, 'png', 0.1, 25);
+    });
+  });
+  testUnMinified('wrong param type #1', function() {
+    assert.validationError(function() {
+      myp5.saveFrames('out', 1, 0.1, 25);
+    });
+  });
+  testUnMinified('wrong param type #2', function() {
+    assert.validationError(function() {
+      myp5.saveFrames('out', 'png', 'a', 25);
+    });
+  });
+  testUnMinified('wrong param type #3', function() {
+    assert.validationError(function() {
+      myp5.saveFrames('out', 'png', 0.1, 'b');
+    });
+  });
+  testUnMinified('wrong param type #4', function() {
+    assert.validationError(function() {
+      myp5.saveFrames('out', 'png', 0.1, 25, 5);
+    });
+  });
+
+  test('should get frames in callback (png)', function(done) {
+    myp5.saveFrames('aaa', 'png', 0.5, 25, function cb1(arr) {
+      assert.typeOf(arr, 'array', 'we got an array');
+      for (let i = 0; i < arr.length; i++) {
+        assert.ok(arr[i].imageData);
+        assert.strictEqual(arr[i].ext, 'png');
+        assert.strictEqual(arr[i].filename, `aaa${i}`);
+      }
+      done();
+    });
+  });
+
+  test('should get frames in callback (jpg)', function(done) {
+    myp5.saveFrames('bbb', 'jpg', 0.5, 25, function cb2(arr2) {
+      assert.typeOf(arr2, 'array', 'we got an array');
+      for (let i = 0; i < arr2.length; i++) {
+        assert.ok(arr2[i].imageData);
+        assert.strictEqual(arr2[i].ext, 'jpg');
+        assert.strictEqual(arr2[i].filename, `bbb${i}`);
+      }
+      done();
+    });
+  });
+});

--- a/test/unit/image/downloading.js
+++ b/test/unit/image/downloading.js
@@ -47,3 +47,179 @@ suite('downloading animated gifs', function() {
     });
   });
 });
+
+suite('p5.prototype.saveCanvas', function() {
+  let myp5;
+  let myCanvas;
+
+  let waitForBlob = async function(blc) {
+    let sleep = function(ms) {
+      return new Promise(r => setTimeout(r, ms));
+    };
+    while (!blc.blob) {
+      await sleep(5);
+    }
+  };
+  setup(function(done) {
+    new p5(function(p) {
+      p.setup = function() {
+        myp5 = p;
+        myCanvas = p.createCanvas(20, 20);
+        p.background(255, 0, 0);
+        done();
+      };
+    });
+  });
+
+  teardown(function() {
+    myp5.remove();
+  });
+
+  test('should be a function', function() {
+    assert.ok(myp5.saveCanvas);
+    assert.typeOf(myp5.saveCanvas, 'function');
+  });
+
+  // Why use testWithDownload for 'no friendly-err' tests here?
+  // saveCanvas uses htmlcanvas.toBlob which uses a callback
+  // mechanism and the download is triggered in its callback.
+  // It may happen that the test get out of sync and the only way
+  // to know if the callback has been called is if the blob has
+  // been made available to us
+  testWithDownload(
+    'no friendly-err-msg I',
+    async function(blc) {
+      assert.doesNotThrow(
+        function() {
+          myp5.saveCanvas();
+        },
+        Error,
+        'got unwanted exception'
+      );
+      await waitForBlob(blc);
+    },
+    true
+  );
+  testWithDownload(
+    'no friendly-err-msg II',
+    async function(blc) {
+      assert.doesNotThrow(
+        function() {
+          myp5.saveCanvas('filename');
+        },
+        Error,
+        'got unwanted exception'
+      );
+      await waitForBlob(blc);
+    },
+    true
+  );
+  testWithDownload(
+    'no friendly-err-msg III',
+    async function(blc) {
+      assert.doesNotThrow(
+        function() {
+          myp5.saveCanvas('filename', 'png');
+        },
+        Error,
+        'got unwanted exception'
+      );
+      await waitForBlob(blc);
+    },
+    true
+  );
+  testWithDownload(
+    'no friendly-err-msg IV',
+    async function(blc) {
+      assert.doesNotThrow(
+        function() {
+          myp5.saveCanvas(myCanvas, 'filename');
+        },
+        Error,
+        'got unwanted exception'
+      );
+      await waitForBlob(blc);
+    },
+    true
+  );
+  testWithDownload(
+    'no friendly-err-msg V',
+    async function(blc) {
+      assert.doesNotThrow(
+        function() {
+          myp5.saveCanvas(myCanvas, 'filename', 'png');
+        },
+        Error,
+        'got unwanted exception'
+      );
+    },
+    true
+  );
+  testWithDownload(
+    'no friendly-err-msg VI',
+    async function(blc) {
+      assert.doesNotThrow(
+        function() {
+          myp5.saveCanvas(myCanvas, 'filename', 'png');
+        },
+        Error,
+        'got unwanted exception'
+      );
+      await waitForBlob(blc);
+    },
+    true
+  );
+
+  testUnMinified('wrong param type #0', function() {
+    assert.validationError(function() {
+      myp5.saveCanvas(5);
+    });
+  });
+
+  testUnMinified('wrong param type #1', function() {
+    assert.validationError(function() {
+      myp5.saveCanvas(myCanvas, 5);
+    });
+  });
+
+  testUnMinified('wrong param type #2', function() {
+    assert.validationError(function() {
+      myp5.saveCanvas(myCanvas, 'filename', 5);
+    });
+  });
+
+  testWithDownload(
+    'should download a png file',
+    async function(blobContainer) {
+      myp5.saveCanvas();
+      // since a function with callback is used in saveCanvas
+      // until the blob is made available to us.
+      await waitForBlob(blobContainer);
+      let myBlob = blobContainer.blob;
+      assert.strictEqual(myBlob.type, 'image/png');
+    },
+    true
+  );
+
+  testWithDownload(
+    'should download a jpg file I',
+    async function(blobContainer) {
+      myp5.saveCanvas('filename.jpg');
+      await waitForBlob(blobContainer);
+      let myBlob = blobContainer.blob;
+      assert.strictEqual(myBlob.type, 'image/jpeg');
+    },
+    true
+  );
+
+  testWithDownload(
+    'should download a jpg file II',
+    async function(blobContainer) {
+      myp5.saveCanvas('filename', 'jpg');
+      await waitForBlob(blobContainer);
+      let myBlob = blobContainer.blob;
+      assert.strictEqual(myBlob.type, 'image/jpeg');
+    },
+    true
+  );
+});

--- a/test/unit/io/files.js
+++ b/test/unit/io/files.js
@@ -615,4 +615,44 @@ suite('Files', function() {
       true // asyncFn = true
     );
   });
+
+  // writeFile
+  suite('p5.prototype.writeFile', function() {
+    test('should be a function', function() {
+      assert.ok(myp5.writeFile);
+      assert.typeOf(myp5.writeFile, 'function');
+    });
+    testWithDownload(
+      'should download a file with expected contents (text)',
+      async function(blobContainer) {
+        let myArray = ['hello', 'hi'];
+
+        myp5.writeFile(myArray, 'myfile');
+        let myBlob = blobContainer.blob;
+        let text = await myBlob.text();
+        assert.strictEqual(text, myArray.join(''));
+      },
+      true // asyncFn = true
+    );
+  });
+
+  // downloadFile
+  suite('p5.prototype.downloadFile', function() {
+    test('should be a function', function() {
+      assert.ok(myp5.writeFile);
+      assert.typeOf(myp5.writeFile, 'function');
+    });
+    testWithDownload(
+      'should download a file with expected contents',
+      async function(blobContainer) {
+        let myArray = ['hello', 'hi'];
+        let inBlob = new Blob(myArray);
+        myp5.downloadFile(inBlob, 'myfile');
+        let myBlob = blobContainer.blob;
+        let text = await myBlob.text();
+        assert.strictEqual(text, myArray.join(''));
+      },
+      true // asyncFn = true
+    );
+  });
 });

--- a/test/unit/io/files.js
+++ b/test/unit/io/files.js
@@ -470,5 +470,149 @@ suite('Files', function() {
       assert.ok(myp5.saveStrings);
       assert.typeOf(myp5.saveStrings, 'function');
     });
+
+    test('no friendly-err-msg I', function() {
+      assert.doesNotThrow(
+        function() {
+          let strings = ['some', 'words'];
+          myp5.saveStrings(strings, 'myfile');
+        },
+        Error,
+        'got unwanted exception'
+      );
+    });
+    test('no friendly-err-msg II', function() {
+      assert.doesNotThrow(
+        function() {
+          let strings = ['some', 'words'];
+          myp5.saveStrings(strings, 'myfile', 'txt');
+        },
+        Error,
+        'got unwanted exception'
+      );
+    });
+
+    test('no friendly-err-msg III', function() {
+      assert.doesNotThrow(
+        function() {
+          let strings = ['some', 'words'];
+          myp5.saveStrings(strings, 'myfile', 'txt', true);
+        },
+        Error,
+        'got unwanted exception'
+      );
+    });
+
+    test('missing param #1', function() {
+      assert.validationError(function() {
+        let strings = ['some', 'words'];
+        myp5.saveStrings(strings);
+      });
+    });
+
+    test('wrong param type at #0', function() {
+      assert.validationError(function() {
+        let strings = 'some words';
+        myp5.saveStrings(strings);
+      });
+    });
+
+    testWithDownload(
+      'should download a file with expected contents',
+      async function(blobContainer) {
+        let strings = ['some', 'words'];
+
+        myp5.saveStrings(strings, 'myfile');
+
+        let myBlob = blobContainer.blob;
+        let text = await myBlob.text();
+        // Each element on a separate line with a trailing line-break
+        assert.strictEqual(text, strings.join('\n') + '\n');
+      },
+      true
+    );
+
+    testWithDownload(
+      'should download a file with expected contents with CRLF',
+      async function(blobContainer) {
+        let strings = ['some', 'words'];
+
+        myp5.saveStrings(strings, 'myfile', 'txt', true);
+        let myBlob = blobContainer.blob;
+        let text = await myBlob.text();
+        // Each element on a separate line with a trailing CRLF
+        assert.strictEqual(text, strings.join('\r\n') + '\r\n');
+      },
+      true
+    );
+  });
+
+  // saveJSON()
+  suite('p5.prototype.saveJSON', function() {
+    test('should be a function', function() {
+      assert.ok(myp5.saveJSON);
+      assert.typeOf(myp5.saveJSON, 'function');
+    });
+
+    test('no friendly-err-msg I', function() {
+      assert.doesNotThrow(
+        function() {
+          let myObj = { hi: 'hello' };
+          myp5.saveJSON(myObj, 'myfile');
+        },
+        Error,
+        'got unwanted exception'
+      );
+    });
+    test('no friendly-err-msg II', function() {
+      assert.doesNotThrow(
+        function() {
+          let myObj = [{ hi: 'hello' }];
+          myp5.saveJSON(myObj, 'myfile');
+        },
+        Error,
+        'got unwanted exception'
+      );
+    });
+
+    test('no friendly-err-msg III', function() {
+      assert.doesNotThrow(
+        function() {
+          let myObj = { hi: 'hello' };
+          myp5.saveJSON(myObj, 'myfile', true);
+        },
+        Error,
+        'got unwanted exception'
+      );
+    });
+
+    test('missing param #1', function() {
+      assert.validationError(function() {
+        let myObj = { hi: 'hello' };
+        myp5.saveJSON(myObj);
+      });
+    });
+
+    test('wrong param type at #0', function() {
+      assert.validationError(function() {
+        let myObj = 'some words';
+        myp5.saveJSON(myObj);
+      });
+    });
+
+    testWithDownload(
+      'should download a file with expected contents',
+      async function(blobContainer) {
+        let myObj = { hi: 'hello' };
+
+        myp5.saveJSON(myObj, 'myfile');
+        let myBlob = blobContainer.blob;
+        let text = await myBlob.text();
+        let json = JSON.parse(text);
+        // Each element on a separate line with a trailing line-break
+        assert.deepEqual(myObj, json);
+      },
+      true // asyncFn = true
+    );
   });
 });

--- a/test/unit/io/saveTable.js
+++ b/test/unit/io/saveTable.js
@@ -36,11 +36,6 @@ suite('saveTable', function() {
     assert.typeOf(myp5.saveTable, 'function');
   });
 
-  test('should be a function', function() {
-    assert.ok(myp5.saveTable);
-    assert.typeOf(myp5.saveTable, 'function');
-  });
-
   test('no friendly-err-msg I', function() {
     assert.doesNotThrow(
       function() {

--- a/test/unit/io/saveTable.js
+++ b/test/unit/io/saveTable.js
@@ -1,0 +1,147 @@
+suite('saveTable', function() {
+  let validFile = 'unit/assets/csv.csv';
+  let myp5;
+  let myTable;
+
+  setup(function(done) {
+    new p5(function(p) {
+      p.setup = function() {
+        myp5 = p;
+        done();
+      };
+    });
+  });
+
+  teardown(function() {
+    myp5.remove();
+  });
+
+  setup(function disableFileLoadError() {
+    sinon.stub(p5, '_friendlyFileLoadError');
+  });
+
+  teardown(function restoreFileLoadError() {
+    p5._friendlyFileLoadError.restore();
+  });
+
+  setup(function loadMyTable(done) {
+    myp5.loadTable(validFile, 'csv', 'header', function(table) {
+      myTable = table;
+      done();
+    });
+  });
+
+  test('should be a function', function() {
+    assert.ok(myp5.saveTable);
+    assert.typeOf(myp5.saveTable, 'function');
+  });
+
+  test('should be a function', function() {
+    assert.ok(myp5.saveTable);
+    assert.typeOf(myp5.saveTable, 'function');
+  });
+
+  test('no friendly-err-msg I', function() {
+    assert.doesNotThrow(
+      function() {
+        myp5.saveTable(myTable, 'myfile');
+      },
+      Error,
+      'got unwanted exception'
+    );
+  });
+
+  test('no friendly-err-msg II', function() {
+    assert.doesNotThrow(
+      function() {
+        myp5.saveTable(myTable, 'myfile', 'csv');
+      },
+      Error,
+      'got unwanted exception'
+    );
+  });
+
+  testUnMinified('missing param #1', function() {
+    assert.validationError(function() {
+      myp5.saveTable(myTable);
+    });
+  });
+
+  testUnMinified('wrong param type #0', function() {
+    assert.validationError(function() {
+      myp5.saveTable('myTable', 'myfile');
+    });
+  });
+
+  testUnMinified('wrong param type #1', function() {
+    assert.validationError(function() {
+      myp5.saveTable(myTable, 2);
+    });
+  });
+
+  testUnMinified('wrong param type #2', function() {
+    assert.validationError(function() {
+      myp5.saveTable(myTable, 'myfile', 2);
+    });
+  });
+
+  testWithDownload(
+    'should download a file with expected contents',
+    async function(blobContainer) {
+      myp5.saveTable(myTable, 'filename');
+      let myBlob = blobContainer.blob;
+      let text = await myBlob.text();
+      let myTableStr = myTable.columns.join(',') + '\n';
+      for (let i = 0; i < myTable.rows.length; i++) {
+        myTableStr += myTable.rows[i].arr.join(',') + '\n';
+      }
+
+      assert.strictEqual(text, myTableStr);
+    },
+    true
+  );
+
+  testWithDownload(
+    'should download a file with expected contents (tsv)',
+    async function(blobContainer) {
+      myp5.saveTable(myTable, 'filename', 'tsv');
+      let myBlob = blobContainer.blob;
+      let text = await myBlob.text();
+      let myTableStr = myTable.columns.join('\t') + '\n';
+      for (let i = 0; i < myTable.rows.length; i++) {
+        myTableStr += myTable.rows[i].arr.join('\t') + '\n';
+      }
+      assert.strictEqual(text, myTableStr);
+    },
+    true
+  );
+
+  testWithDownload(
+    'should download a file with expected contents (html)',
+    async function(blobContainer) {
+      myp5.saveTable(myTable, 'filename', 'html');
+      let myBlob = blobContainer.blob;
+      let text = await myBlob.text();
+      let domparser = new DOMParser();
+      let htmldom = domparser.parseFromString(text, 'text/html');
+      let trs = htmldom.querySelectorAll('tr');
+      for (let i = 0; i < trs.length; i++) {
+        let tds = trs[i].querySelectorAll('td');
+        for (let j = 0; j < tds.length; j++) {
+          // saveTable generates an HTML file with indentation spaces and line-breaks. The browser ignores these
+          // while displaying. But they will still remain a part of the parsed DOM and hence must be removed.
+          // More info at: https://developer.mozilla.org/en-US/docs/Web/API/Document_Object_Model/Whitespace
+          let tdText = tds[j].innerHTML.trim().replace(/\n/g, '');
+          let tbText;
+          if (i === 0) {
+            tbText = myTable.columns[j].trim().replace(/\n/g, '');
+          } else {
+            tbText = myTable.rows[i - 1].arr[j].trim().replace(/\n/g, '');
+          }
+          assert.strictEqual(tdText, tbText);
+        }
+      }
+    },
+    true
+  );
+});

--- a/test/unit/spec.js
+++ b/test/unit/spec.js
@@ -26,6 +26,7 @@ var spec = {
     'loadXML',
     'loadJSON',
     'loadTable',
+    'saveTable',
     'loadImage',
     'loadModel',
     'loadShader'


### PR DESCRIPTION
<!--
  Thank you for contributing! Please use this pull request (PR) template.


 In the description field of this PR, include "resolves #XXXX" tagging the issue you are fixing. If this PR addresses the issue but doesn't completely resolve it (ie the issue should remain open after your PR is merged), write "addresses #XXXX".-->


 Changes:
<!-- Add here what changes were made in this pull request and if possible provide links showcasing the changes. -->
Until now there was no way to verify functions that download something to the user's system. I went through the ['file-saver' module](https://github.com/eligrey/FileSaver.js/blob/master/src/FileSaver.js ) which is used in p5 to facilitate downloads and found that it uses `createObjectURL()` function which we can temporarily override in tests to capture the file that is just about to be downloaded. This makes unit testing for download functions possible, without the need to restructure the src function itself.

I have created a helper function in the tests `testWithDownload` which uses the above approach.

I added another helper function: `testUnMinified` , which when used, only runs that test on the unminified library. It is meant to be used for testing invalid arguments on the function.

I felt this was needed because `assert.validationError` is currently defined as, 
```js
assert.validationError = function(fn) {
  if (p5.ValidationError) {
    assert.throws(fn, p5.ValidationError);
  } else {
    assert.doesNotThrow(fn, Error, 'got unwanted exception');
  }
};
```
It would expect **no error** to be thrown when running for the minified version. But some p5 functions will naturally throw an error for wrong arguments when they try to perform operations which the passed arguments simply do not support. 

`testUnMinified` would make things much simpler.

This PR adds tests for:
- saveGif
- saveCanvas
- saveFrames
- saveStrings
- saveJSON
- writeFile
- downloadFile
- save
- saveTable


<!-- If applicable, add screenshots depicting the changes. -->

#### PR Checklist
<!--
  To check any option, replace the "[ ]" with a "[x]". Be sure to check out how it looks in the Preview tab! Feel free to remove any portion of the template that is not relevant for your issue.
-->

- [x] `npm run lint` passes
- [ ] [Inline documentation] is included / updated
- [x] [Unit tests] are included / updated

[Inline documentation]: https://github.com/processing/p5.js/blob/master/contributor_docs/inline_documentation.md
[Unit tests]: https://github.com/processing/p5.js/tree/master/contributor_docs#unit-tests
