### PR TITLE
Fix vertical text alignment problem due to long words

### DIFF
--- a/src/core/p5.Renderer.js
+++ b/src/core/p5.Renderer.js
@@ -216,6 +216,7 @@ p5.Renderer.prototype.text = function(str, x, y, maxWidth, maxHeight) {
   let jj;
   let line;
   let testLine;
+  let currentLineLength;
   let testWidth;
   let words;
   let totalHeight;
@@ -236,17 +237,20 @@ p5.Renderer.prototype.text = function(str, x, y, maxWidth, maxHeight) {
 
   if (typeof maxWidth !== 'undefined') {
     totalHeight = 0;
+    currentLineLength = 1;
     for (ii = 0; ii < cars.length; ii++) {
       line = '';
       words = cars[ii].split(' ');
       for (n = 0; n < words.length; n++) {
         testLine = `${line + words[n]} `;
         testWidth = this.textWidth(testLine);
-        if (testWidth > maxWidth) {
+        if (testWidth > maxWidth && currentLineLength > 1) {
           line = `${words[n]} `;
           totalHeight += p.textLeading();
+          currentLineLength = 1;
         } else {
           line = testLine;
+          currentLineLength += 1;
         }
       }
     }


### PR DESCRIPTION
<!--
  Thank you for contributing! Please use this pull request (PR) template.


 In the description field of this PR, include "resolves #XXXX" tagging the issue you are fixing. If this PR addresses the issue but doesn't completely resolve it (ie the issue should remain open after your PR is merged), write "addresses #XXXX".-->
Resolves #4419 

 Changes:
Prevent adjusting of `totalHeight` if the current line has only one word so far, even if that word goes beyond the bounds specified



#### PR Checklist
<!--
  To check any option, replace the "[ ]" with a "[x]". Be sure to check out how it looks in the Preview tab! Feel free to remove any portion of the template that is not relevant for your issue.
-->

- [x] `npm run lint` passes
- [ ] [Inline documentation] is included / updated
- [ ] [Unit tests] are included / updated

[Inline documentation]: https://github.com/processing/p5.js/blob/master/contributor_docs/inline_documentation.md
[Unit tests]: https://github.com/processing/p5.js/tree/master/contributor_docs#unit-tests
