### PR TITLE
[fix] Added dom to modules list in issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/existing-feature-enhancement.md
+++ b/.github/ISSUE_TEMPLATE/existing-feature-enhancement.md
@@ -8,7 +8,7 @@ assignees: ''
 ---
 
 <!--
-Hi there! 
+Hi there!
 
 To check any option, replace the "[ ]" with a "[x]". Be sure to check out how it looks in the Preview tab! Feel free to remove any portion of the template that is not relevant for your issue.
 -->
@@ -18,6 +18,7 @@ To check any option, replace the "[ ]" with a "[x]". Be sure to check out how it
 - [ ] Color
 - [ ] Core/Environment/Rendering
 - [ ] Data
+- [ ] Dom
 - [ ] Events
 - [ ] Image
 - [ ] IO

--- a/.github/ISSUE_TEMPLATE/feature-request.md
+++ b/.github/ISSUE_TEMPLATE/feature-request.md
@@ -8,7 +8,7 @@ assignees: ''
 ---
 
 <!--
-Hi there! 
+Hi there!
 
 To check any option, replace the "[ ]" with a "[x]". Be sure to check out how it looks in the Preview tab! Feel free to remove any portion of the template that is not relevant for your issue.
 -->
@@ -18,6 +18,7 @@ To check any option, replace the "[ ]" with a "[x]". Be sure to check out how it
 - [ ] Color
 - [ ] Core/Environment/Rendering
 - [ ] Data
+- [ ] Dom
 - [ ] Events
 - [ ] Image
 - [ ] IO

--- a/.github/ISSUE_TEMPLATE/found-a-bug.md
+++ b/.github/ISSUE_TEMPLATE/found-a-bug.md
@@ -8,7 +8,7 @@ assignees: ''
 ---
 
 <!--
-Hi there! 
+Hi there!
 
 To check any option, replace the "[ ]" with a "[x]". Be sure to check out how it looks in the Preview tab! Feel free to remove any portion of the template that is not relevant for your issue.
 -->
@@ -18,6 +18,7 @@ To check any option, replace the "[ ]" with a "[x]". Be sure to check out how it
 - [ ] Color
 - [ ] Core/Environment/Rendering
 - [ ] Data
+- [ ] Dom
 - [ ] Events
 - [ ] Image
 - [ ] IO
@@ -27,7 +28,7 @@ To check any option, replace the "[ ]" with a "[x]". Be sure to check out how it
 - [ ] WebGL
 - [ ] Other (specify if possible)
 
-#### Details about the bug: 
+#### Details about the bug:
 
 - p5.js version: <!-- You can first this in the first line of the p5.js file -->
 - Web browser and version: <!-- In the address bar, on Chrome enter "chrome://version", on Firefox enter "about:support". On Safari, use "About Safari". -->


### PR DESCRIPTION
 Changes:
- Added `dom` as an option in issue templates.

 Screenshots of the change:
- 

#### PR Checklist
<!--
  To check any option, replace the "[ ]" with a "[x]". Be sure to check out how it looks in the Preview tab! Feel free to remove any portion of the template that is not relevant for your issue.
-->

- [x] `npm run lint` passes
- [ ] [Inline documentation] is included / updated
- [ ] [Unit tests] are included / updated

[Inline documentation]: https://github.com/processing/p5.js/blob/master/contributor_docs/inline_documentation.md
[Unit tests]: https://github.com/processing/p5.js/tree/master/contributor_docs#unit-tests
