### PR TITLE
Resolves #4456, fix saveFrames()

### DIFF
--- a/src/image/image.js
+++ b/src/image/image.js
@@ -12,13 +12,6 @@
 import p5 from '../core/main';
 import omggif from 'omggif';
 
-// This is not global, but ESLint is not aware that
-// this module is implicitly enclosed with Browserify: this overrides the
-// redefined-global error and permits using the name "frames" for the array
-// of saved animation frames.
-
-/* global frames:true */ let frames = []; // eslint-disable-line no-unused-vars
-
 /**
  * Creates a new <a href="#/p5.Image">p5.Image</a> (the datatype for storing images). This provides a
  * fresh buffer of pixels to play with. Set the size of the buffer with the
@@ -472,8 +465,9 @@ p5.prototype.saveFrames = function(fName, ext, _duration, _fps, callback) {
 
   const makeFrame = p5.prototype._makeFrame;
   const cnv = this._curElement.elt;
+  let frames = [];
   const frameFactory = setInterval(() => {
-    makeFrame(fName + count, ext, cnv);
+    frames.push(makeFrame(fName + count, ext, cnv));
     count++;
   }, 1000 / fps);
 
@@ -525,7 +519,7 @@ p5.prototype._makeFrame = function(filename, extension, _cnv) {
   thisFrame.imageData = imageData;
   thisFrame.filename = filename;
   thisFrame.ext = extension;
-  frames.push(thisFrame);
+  return thisFrame;
 };
 
 export default p5;


### PR DESCRIPTION
<!--
  Thank you for contributing! Please use this pull request (PR) template.


 In the description field of this PR, include "resolves #XXXX" tagging the issue you are fixing. If this PR addresses the issue but doesn't completely resolve it (ie the issue should remain open after your PR is merged), write "addresses #XXXX".-->
Resolves #4456

 Changes:
<!-- Add here what changes were made in this pull request and if possible provide links showcasing the changes. -->
Make `frames` array local to `saveFrames` function, thereby solving a race condition that occurred when two `saveFrames` where called one after the other.


#### PR Checklist
<!--
  To check any option, replace the "[ ]" with a "[x]". Be sure to check out how it looks in the Preview tab! Feel free to remove any portion of the template that is not relevant for your issue.
-->

- [x] `npm run lint` passes
- [ ] [Inline documentation] is included / updated
- [ ] [Unit tests] are included / updated

[Inline documentation]: https://github.com/processing/p5.js/blob/master/contributor_docs/inline_documentation.md
[Unit tests]: https://github.com/processing/p5.js/tree/master/contributor_docs#unit-tests
