### PR TITLE
Multiline text bounds

### DIFF
--- a/src/typography/p5.Font.js
+++ b/src/typography/p5.Font.js
@@ -95,41 +95,62 @@ p5.Font.prototype.textBounds = function(str, x = 0, y = 0, fontSize, opts) {
   }
 
   if (!result) {
-    let minX;
-    let minY;
-    let maxX;
-    let maxY;
-    let pos;
-    const xCoords = [];
-    const yCoords = [];
-    const scale = this._scale(fontSize);
+    var minX = [];
+    var minY;
+    var maxX = [];
+    var maxY;
+    var pos;
+    var xCoords = [];
+    xCoords[0] = [];
+    var yCoords = [];
+    var scale = this._scale(fontSize);
+    var lineCount = 0;
+    var lineHeight = p._renderer.textLeading();
 
-    this.font.forEachGlyph(
-      str,
-      x,
-      y,
-      fontSize,
-      opts,
-      (glyph, gX, gY, gFontSize) => {
-        const gm = glyph.getMetrics();
-        xCoords.push(gX + gm.xMin * scale);
-        xCoords.push(gX + gm.xMax * scale);
-        yCoords.push(gY + -gm.yMin * scale);
-        yCoords.push(gY + -gm.yMax * scale);
+    this.font.forEachGlyph(str, x, y, fontSize, opts, function(
+      glyph,
+      gX,
+      gY,
+      gFontSize
+    ) {
+      var gm = glyph.getMetrics();
+      if (glyph.index === 0 || glyph.index === 10) {
+        lineCount += 1;
+        xCoords[lineCount] = [];
+      } else {
+        xCoords[lineCount].push(gX + gm.xMin * scale);
+        xCoords[lineCount].push(gX + gm.xMax * scale);
+        yCoords.push(gY + lineCount * lineHeight + -gm.yMin * scale);
+        yCoords.push(gY + lineCount * lineHeight + -gm.yMax * scale);
       }
-    );
+    });
 
-    minX = Math.min.apply(null, xCoords);
+    if (xCoords[lineCount].length > 0) {
+      minX[lineCount] = Math.min.apply(null, xCoords[lineCount]);
+      maxX[lineCount] = Math.max.apply(null, xCoords[lineCount]);
+    }
+
+    var finalMaxX = 0;
+    for (var i = 0; i <= lineCount; i++) {
+      minX[i] = Math.min.apply(null, xCoords[i]);
+      maxX[i] = Math.max.apply(null, xCoords[i]);
+
+      var lineLength = maxX[i] - minX[i];
+      if (lineLength > finalMaxX) {
+        finalMaxX = lineLength;
+      }
+    }
+
+    var finalMinX = Math.min.apply(null, minX);
     minY = Math.min.apply(null, yCoords);
-    maxX = Math.max.apply(null, xCoords);
     maxY = Math.max.apply(null, yCoords);
 
     result = {
-      x: minX,
+      x: finalMinX,
       y: minY,
       h: maxY - minY,
-      w: maxX - minX,
-      advance: minX - x
+      w: finalMaxX,
+      advance: finalMinX - x
     };
 
     // Bounds are now calculated, so shift the x & y to match alignment settings

--- a/src/typography/p5.Font.js
+++ b/src/typography/p5.Font.js
@@ -30,7 +30,7 @@ p5.Font = function(p) {
 
 /**
  * Returns a tight bounding box for the given text string using this
- * font (currently only supports single lines)
+ * font
  *
  * @method textBounds
  * @param  {String} line     a line of text
@@ -95,35 +95,37 @@ p5.Font.prototype.textBounds = function(str, x = 0, y = 0, fontSize, opts) {
   }
 
   if (!result) {
-    var minX = [];
-    var minY;
-    var maxX = [];
-    var maxY;
-    var pos;
-    var xCoords = [];
+    let minX = [];
+    let minY;
+    let maxX = [];
+    let maxY;
+    let pos;
+    const xCoords = [];
     xCoords[0] = [];
-    var yCoords = [];
-    var scale = this._scale(fontSize);
-    var lineCount = 0;
-    var lineHeight = p._renderer.textLeading();
+    const yCoords = [];
+    const scale = this._scale(fontSize);
+    const lineHeight = p._renderer.textLeading();
+    let lineCount = 0;
 
-    this.font.forEachGlyph(str, x, y, fontSize, opts, function(
-      glyph,
-      gX,
-      gY,
-      gFontSize
-    ) {
-      var gm = glyph.getMetrics();
-      if (glyph.index === 0 || glyph.index === 10) {
-        lineCount += 1;
-        xCoords[lineCount] = [];
-      } else {
-        xCoords[lineCount].push(gX + gm.xMin * scale);
-        xCoords[lineCount].push(gX + gm.xMax * scale);
-        yCoords.push(gY + lineCount * lineHeight + -gm.yMin * scale);
-        yCoords.push(gY + lineCount * lineHeight + -gm.yMax * scale);
+    this.font.forEachGlyph(
+      str,
+      x,
+      y,
+      fontSize,
+      opts,
+      (glyph, gX, gY, gFontSize) => {
+        const gm = glyph.getMetrics();
+        if (glyph.index === 0 || glyph.index === 10) {
+          lineCount += 1;
+          xCoords[lineCount] = [];
+        } else {
+          xCoords[lineCount].push(gX + gm.xMin * scale);
+          xCoords[lineCount].push(gX + gm.xMax * scale);
+          yCoords.push(gY + lineCount * lineHeight + -gm.yMin * scale);
+          yCoords.push(gY + lineCount * lineHeight + -gm.yMax * scale);
+        }
       }
-    });
+    );
 
     if (xCoords[lineCount].length > 0) {
       minX[lineCount] = Math.min.apply(null, xCoords[lineCount]);

--- a/src/typography/p5.Font.js
+++ b/src/typography/p5.Font.js
@@ -136,7 +136,6 @@ p5.Font.prototype.textBounds = function(str, x = 0, y = 0, fontSize, opts) {
     for (var i = 0; i <= lineCount; i++) {
       minX[i] = Math.min.apply(null, xCoords[i]);
       maxX[i] = Math.max.apply(null, xCoords[i]);
-
       var lineLength = maxX[i] - minX[i];
       if (lineLength > finalMaxX) {
         finalMaxX = lineLength;


### PR DESCRIPTION
Resolves #4449

Changes:
added support in the textBounds() function to split text by newline characters, calculate the longest line, and determine proper height base on lineCount and lineHeight (from renderer.textLeading();)

 Screenshots of the change:
before:
<img width="513" alt="before" src="https://user-images.githubusercontent.com/11671032/79145027-ec819f00-7d8d-11ea-9b12-dc7340a8efe3.png">

after:
<img width="513" alt="after" src="https://user-images.githubusercontent.com/11671032/79144625-49c92080-7d8d-11ea-9f22-7de8aa3184b4.png">
#### PR Checklist
- [x] `npm run lint` passes
- [x] [Inline documentation] is included / updated
- [ ] [Unit tests] are included / updated