### PR TITLE
Fix Broken Links in P5.Vector Documentation

### DIFF
--- a/.all-contributorsrc
+++ b/.all-contributorsrc
@@ -1843,6 +1843,15 @@
       "contributions": [
         "doc"
       ]
+    },
+    {
+      "login": "banditelol",
+      "name": "Aditya Rachman Putra",
+      "avatar_url": "https://avatars3.githubusercontent.com/u/5263688?v=4",
+      "profile": "http://adityarp.com",
+      "contributions": [
+        "doc"
+      ]
     }
   ],
   "repoType": "github",

--- a/.all-contributorsrc
+++ b/.all-contributorsrc
@@ -1825,6 +1825,15 @@
       "contributions": [
         "translation"
       ]
+    },
+    {
+      "login": "endurance21",
+      "name": "DIVYANSHU RAJ",
+      "avatar_url": "https://avatars1.githubusercontent.com/u/43696525?v=4",
+      "profile": "http://divyanshuraj.co",
+      "contributions": [
+        "doc"
+      ]
     }
   ],
   "repoType": "github",

--- a/.all-contributorsrc
+++ b/.all-contributorsrc
@@ -1834,6 +1834,15 @@
       "contributions": [
         "doc"
       ]
+    },
+    {
+      "login": "sm7515",
+      "name": "sm7515",
+      "avatar_url": "https://avatars1.githubusercontent.com/u/36653440?v=4",
+      "profile": "https://github.com/sm7515",
+      "contributions": [
+        "doc"
+      ]
     }
   ],
   "repoType": "github",

--- a/.all-contributorsrc
+++ b/.all-contributorsrc
@@ -1816,6 +1816,15 @@
       "contributions": [
         "translation"
       ]
+    },
+    {
+      "login": "SamuelAl",
+      "name": "Samuel Alarco Cantos",
+      "avatar_url": "https://avatars3.githubusercontent.com/u/33717014?v=4",
+      "profile": "https://github.com/SamuelAl",
+      "contributions": [
+        "translation"
+      ]
     }
   ],
   "repoType": "github",

--- a/README.md
+++ b/README.md
@@ -366,10 +366,14 @@ We recognize all types of contributions. This project follows the [all-contribut
     <td align="center"><a href="https://github.com/mjaything"><img src="https://avatars1.githubusercontent.com/u/13192500?v=4" width="100px;" alt=""/><br /><sub><b>Minjun Kim</b></sub></a><br /><a href="https://github.com/processing/p5.js/issues?q=author%3Amjaything" title="Bug reports">🐛</a> <a href="#translation-mjaything" title="Translation">🌍</a></td>
     <td align="center"><a href="https://github.com/fisherdiede"><img src="https://avatars2.githubusercontent.com/u/11671032?s=400&u=212a5392a3a1d3c68a5c41527529fed19cb72e23&v=4" width="100px;" alt=""/><br /><sub><b>Fisher Diede</b></sub></a><br /><a href="https://github.com/processing/p5.js/commits?author=fisherdiede" title="Code">💻</a></td>
     <td align="center"><a href="https://github.com/karinaxlpz"><img src="https://avatars2.githubusercontent.com/u/64159159?v=4" width="100px;" alt=""/><br /><sub><b>karinaxlpz</b></sub></a><br /><a href="#translation-karinaxlpz" title="Translation">🌍</a></td>
+<<<<<<< HEAD
     <td align="center"><a href="https://github.com/SamuelAl"><img src="https://avatars3.githubusercontent.com/u/33717014?v=4" width="100px;" alt=""/><br /><sub><b>Samuel Alarco Cantos</b></sub></a><br /><a href="#translation-SamuelAl" title="Translation">🌍</a></td>
     <td align="center"><a href="http://divyanshuraj.co"><img src="https://avatars1.githubusercontent.com/u/43696525?v=4" width="100px;" alt=""/><br /><sub><b>DIVYANSHU RAJ</b></sub></a><br /><a href="https://github.com/processing/p5.js/commits?author=endurance21" title="Documentation">📖</a></td>
     <td align="center"><a href="https://github.com/sm7515"><img src="https://avatars1.githubusercontent.com/u/36653440?v=4" width="100px;" alt=""/><br /><sub><b>sm7515</b></sub></a><br /><a href="https://github.com/processing/p5.js/commits?author=sm7515" title="Documentation">📖</a></td>
     <td align="center"><a href="http://adityarp.com"><img src="https://avatars3.githubusercontent.com/u/5263688?v=4" width="100px;" alt=""/><br /><sub><b>Aditya Rachman Putra</b></sub></a><br /><a href="https://github.com/processing/p5.js/commits?author=banditelol" title="Documentation">📖</a></td>
+=======
+    <td align="center"><a href="https://github.com/banditelol"><img src="https://avatars2.githubusercontent.com/u/5263688?s=460&v=4" width="100px;" alt=""/><br /><sub><b>Aditya Rachman Putra</b></sub></a><br /><a href="https://github.com/processing/p5.js/commits?author=banditelol" title="Documentation">📖</a></td>
+>>>>>>> 9d8600727ae943dc397cc94d709fbe1c3034d544
   </tr>
 </table>
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 # [p5.js](https://p5js.org)
 
- Welcome! 👋👋🏿👋🏽👋🏻👋🏾👋🏼 
+ Welcome! 👋👋🏿👋🏽👋🏻👋🏾👋🏼
 
 p5.js is a JavaScript library for creative coding, with a focus on making coding accessible and inclusive for artists, designers, educators, beginners, and anyone else! p5.js is free and open-source because we believe software, and the tools to learn it, should be accessible to everyone.
 

--- a/README.md
+++ b/README.md
@@ -368,6 +368,7 @@ We recognize all types of contributions. This project follows the [all-contribut
     <td align="center"><a href="https://github.com/karinaxlpz"><img src="https://avatars2.githubusercontent.com/u/64159159?v=4" width="100px;" alt=""/><br /><sub><b>karinaxlpz</b></sub></a><br /><a href="#translation-karinaxlpz" title="Translation">🌍</a></td>
     <td align="center"><a href="https://github.com/SamuelAl"><img src="https://avatars3.githubusercontent.com/u/33717014?v=4" width="100px;" alt=""/><br /><sub><b>Samuel Alarco Cantos</b></sub></a><br /><a href="#translation-SamuelAl" title="Translation">🌍</a></td>
     <td align="center"><a href="http://divyanshuraj.co"><img src="https://avatars1.githubusercontent.com/u/43696525?v=4" width="100px;" alt=""/><br /><sub><b>DIVYANSHU RAJ</b></sub></a><br /><a href="https://github.com/processing/p5.js/commits?author=endurance21" title="Documentation">📖</a></td>
+    <td align="center"><a href="https://github.com/sm7515"><img src="https://avatars1.githubusercontent.com/u/36653440?v=4" width="100px;" alt=""/><br /><sub><b>sm7515</b></sub></a><br /><a href="https://github.com/processing/p5.js/commits?author=sm7515" title="Documentation">📖</a></td>
   </tr>
 </table>
 

--- a/README.md
+++ b/README.md
@@ -366,6 +366,7 @@ We recognize all types of contributions. This project follows the [all-contribut
     <td align="center"><a href="https://github.com/mjaything"><img src="https://avatars1.githubusercontent.com/u/13192500?v=4" width="100px;" alt=""/><br /><sub><b>Minjun Kim</b></sub></a><br /><a href="https://github.com/processing/p5.js/issues?q=author%3Amjaything" title="Bug reports">🐛</a> <a href="#translation-mjaything" title="Translation">🌍</a></td>
     <td align="center"><a href="https://github.com/fisherdiede"><img src="https://avatars2.githubusercontent.com/u/11671032?s=400&u=212a5392a3a1d3c68a5c41527529fed19cb72e23&v=4" width="100px;" alt=""/><br /><sub><b>Fisher Diede</b></sub></a><br /><a href="https://github.com/processing/p5.js/commits?author=fisherdiede" title="Code">💻</a></td>
     <td align="center"><a href="https://github.com/karinaxlpz"><img src="https://avatars2.githubusercontent.com/u/64159159?v=4" width="100px;" alt=""/><br /><sub><b>karinaxlpz</b></sub></a><br /><a href="#translation-karinaxlpz" title="Translation">🌍</a></td>
+    <td align="center"><a href="https://github.com/SamuelAl"><img src="https://avatars3.githubusercontent.com/u/33717014?v=4" width="100px;" alt=""/><br /><sub><b>Samuel Alarco Cantos</b></sub></a><br /><a href="#translation-SamuelAl" title="Translation">🌍</a></td>
   </tr>
 </table>
 

--- a/README.md
+++ b/README.md
@@ -369,6 +369,7 @@ We recognize all types of contributions. This project follows the [all-contribut
     <td align="center"><a href="https://github.com/SamuelAl"><img src="https://avatars3.githubusercontent.com/u/33717014?v=4" width="100px;" alt=""/><br /><sub><b>Samuel Alarco Cantos</b></sub></a><br /><a href="#translation-SamuelAl" title="Translation">🌍</a></td>
     <td align="center"><a href="http://divyanshuraj.co"><img src="https://avatars1.githubusercontent.com/u/43696525?v=4" width="100px;" alt=""/><br /><sub><b>DIVYANSHU RAJ</b></sub></a><br /><a href="https://github.com/processing/p5.js/commits?author=endurance21" title="Documentation">📖</a></td>
     <td align="center"><a href="https://github.com/sm7515"><img src="https://avatars1.githubusercontent.com/u/36653440?v=4" width="100px;" alt=""/><br /><sub><b>sm7515</b></sub></a><br /><a href="https://github.com/processing/p5.js/commits?author=sm7515" title="Documentation">📖</a></td>
+    <td align="center"><a href="http://adityarp.com"><img src="https://avatars3.githubusercontent.com/u/5263688?v=4" width="100px;" alt=""/><br /><sub><b>Aditya Rachman Putra</b></sub></a><br /><a href="https://github.com/processing/p5.js/commits?author=banditelol" title="Documentation">📖</a></td>
   </tr>
 </table>
 

--- a/README.md
+++ b/README.md
@@ -367,6 +367,7 @@ We recognize all types of contributions. This project follows the [all-contribut
     <td align="center"><a href="https://github.com/fisherdiede"><img src="https://avatars2.githubusercontent.com/u/11671032?s=400&u=212a5392a3a1d3c68a5c41527529fed19cb72e23&v=4" width="100px;" alt=""/><br /><sub><b>Fisher Diede</b></sub></a><br /><a href="https://github.com/processing/p5.js/commits?author=fisherdiede" title="Code">💻</a></td>
     <td align="center"><a href="https://github.com/karinaxlpz"><img src="https://avatars2.githubusercontent.com/u/64159159?v=4" width="100px;" alt=""/><br /><sub><b>karinaxlpz</b></sub></a><br /><a href="#translation-karinaxlpz" title="Translation">🌍</a></td>
     <td align="center"><a href="https://github.com/SamuelAl"><img src="https://avatars3.githubusercontent.com/u/33717014?v=4" width="100px;" alt=""/><br /><sub><b>Samuel Alarco Cantos</b></sub></a><br /><a href="#translation-SamuelAl" title="Translation">🌍</a></td>
+    <td align="center"><a href="http://divyanshuraj.co"><img src="https://avatars1.githubusercontent.com/u/43696525?v=4" width="100px;" alt=""/><br /><sub><b>DIVYANSHU RAJ</b></sub></a><br /><a href="https://github.com/processing/p5.js/commits?author=endurance21" title="Documentation">📖</a></td>
   </tr>
 </table>
 

--- a/src/image/loading_displaying.js
+++ b/src/image/loading_displaying.js
@@ -25,6 +25,9 @@ import '../core/error_helpers';
  * that links in your sketch. Loading an image from a URL or other
  * remote location may be blocked due to your browser's built-in
  * security.
+
+ * You can also pass in a string of a base64 encoded image as an alternative to the file path.
+ * Remember to add "data:image/png;base64," in front of the string.
  *
  * @method loadImage
  * @param  {String} path Path of the image to be loaded

--- a/src/math/p5.Vector.js
+++ b/src/math/p5.Vector.js
@@ -12,7 +12,7 @@ import * as constants from '../core/constants';
  * a Euclidean (also known as geometric) vector. A vector is an entity
  * that has both magnitude and direction. The datatype, however, stores
  * the components of the vector (x, y for 2D, and x, y, z for 3D). The magnitude
- * and direction can be accessed via the methods <a href="#/p5/mag">mag()</a> and <a href="#/p5/heading">heading()</a>.
+ * and direction can be accessed via the methods <a href="#/p5.Vector/mag">mag()</a> and <a href="#/p5.Vector/heading">heading()</a>.
  * <br><br>
  * In many of the p5.js examples, you will see <a href="#/p5.Vector">p5.Vector</a> used to describe a
  * position, velocity, or acceleration. For example, if you consider a rectangle
@@ -1371,7 +1371,7 @@ p5.Vector.prototype.setMag = function setMag(n) {
 };
 
 /**
- * Calculate the angle of rotation for this vector (only 2D vectors)
+ * Calculate the angle of rotation for this vector in radians(only 2D vectors)
  *
  * @method heading
  * @return {Number} the angle of rotation

--- a/src/math/p5.Vector.js
+++ b/src/math/p5.Vector.js
@@ -1371,7 +1371,10 @@ p5.Vector.prototype.setMag = function setMag(n) {
 };
 
 /**
- * Calculate the angle of rotation for this vector in radians(only 2D vectors)
+ * Calculate the angle of rotation for this vector(only 2D vectors).
+ * p5.Vectors created using <a src="#/p5/createVector">createVector()</a>
+ * will take the current <a = src="#/p5/angleMode">angleMode</a> into consideration, and give the angle
+ * in radians or degree accordingly.
  *
  * @method heading
  * @return {Number} the angle of rotation


### PR DESCRIPTION
<!--
  Thank you for contributing! Please use this pull request (PR) template.


 In the description field of this PR, include "resolves #XXXX" tagging the issue you are fixing. If this PR addresses the issue but doesn't completely resolve it (ie the issue should remain open after your PR is merged), write "addresses #XXXX".-->
Resolves   #4484 

 Changes:
<!-- Add here what changes were made in this pull request and if possible provide links showcasing the changes. -->
Fix broken links inside P5.Vector Documentation. So that the links for mag() and heading method() refer to the methods inside P5.Vector instead of the general P5 functions.


#### PR Checklist
<!--
  To check any option, replace the "[ ]" with a "[x]". Be sure to check out how it looks in the Preview tab! Feel free to remove any portion of the template that is not relevant for your issue.
-->

- [X] `npm run lint` passes
- [X] [Inline documentation] is included / updated

[Inline documentation]: https://github.com/processing/p5.js/blob/master/contributor_docs/inline_documentation.md
[Unit tests]: https://github.com/processing/p5.js/tree/master/contributor_docs#unit-tests
