### PR TITLE
docs for `createVideo`: change `video()` to `image()`

### DIFF
--- a/src/dom/dom.js
+++ b/src/dom/dom.js
@@ -1173,7 +1173,7 @@ function createMedia(pInst, type, src, callback) {
 /**
  * Creates an HTML5 &lt;video&gt; element in the DOM for simple playback
  * of audio/video. Shown by default, can be hidden with .<a href="#/p5.Element/hide">hide()</a>
- * and drawn into canvas using video(). The first parameter
+ * and drawn into canvas using <a href="#/p5/image">image()</a>. The first parameter
  * can be either a single string path to a video file, or an array of string
  * paths to different formats of the same video. This is useful for ensuring
  * that your video can play across different browsers, as each supports


### PR DESCRIPTION
As examples like https://p5js.org/examples/dom-video-canvas.html suggest, you use the `image()` function to draw a video to the canvas. (There is no `video()` function.)

(I assume a PR template is not require for documentation typo fixes, but please let me know if there's something else I should provide here. Thanks so much!)