### PR TITLE
Fix error in TRIANGLE_STRIP edge calculation

### DIFF
--- a/src/webgl/p5.RendererGL.Immediate.js
+++ b/src/webgl/p5.RendererGL.Immediate.js
@@ -192,7 +192,7 @@ p5.RendererGL.prototype._calculateEdges = function(
   let i = 0;
   switch (shapeMode) {
     case constants.TRIANGLE_STRIP:
-      for (i = 0; i < verts - 2; i++) {
+      for (i = 0; i < verts.length - 2; i++) {
         res.push([i, i + 1]);
         res.push([i, i + 2]);
       }


### PR DESCRIPTION
Resolves #4530

 Changes:
Fix for loop not referencing array length but array itself.

Screenshots of the change:
Before:
![image](https://user-images.githubusercontent.com/39579264/81560347-d3d3cb80-93c3-11ea-98eb-1c6428fe4bc1.png)

After:
![image](https://user-images.githubusercontent.com/39579264/81560287-adae2b80-93c3-11ea-8cfd-385feebc404c.png)



#### PR Checklist

- [x] `npm run lint` passes
- [ ] [Inline documentation] is included / updated
- [ ] [Unit tests] are included / updated

Inline documentation and unit tests don't need updates for this PR.