### PR TITLE
[WIP] Add uTint vector to phong shader and use it to calculate gl_FragColor

### DIFF
--- a/src/webgl/shaders/phong.frag
+++ b/src/webgl/shaders/phong.frag
@@ -3,6 +3,7 @@ precision highp float;
 precision highp int;
 
 uniform vec4 uMaterialColor;
+uniform vec4 uTint;
 uniform sampler2D uSampler;
 uniform bool isTexture;
 uniform bool uEmissive;
@@ -22,7 +23,7 @@ void main(void) {
     gl_FragColor = uMaterialColor;
   }
   else {
-    gl_FragColor = isTexture ? texture2D(uSampler, vTexCoord) : uMaterialColor;
+    gl_FragColor = isTexture ? texture2D(uSampler, vTexCoord) * (uTint / vec4(255, 255, 255, 255)) : uMaterialColor;
     gl_FragColor.rgb = gl_FragColor.rgb * (diffuse + vAmbientColor) + specular;
   }
 }


### PR DESCRIPTION
Resolves #4515 

 Changes:
uTint support was added to phong shader.

Before:
<img width="398" alt="#4515 - before" src="https://user-images.githubusercontent.com/6883643/81572599-b262e780-93a3-11ea-8622-38abd521006a.png">

After:
<img width="690" alt="#4515 - after" src="https://user-images.githubusercontent.com/6883643/81573260-85630480-93a4-11ea-97c2-58de9eb35d1e.png">



- [x] `npm run lint` passes

[Inline documentation]: https://github.com/processing/p5.js/blob/master/contributor_docs/inline_documentation.md
[Unit tests]: https://github.com/processing/p5.js/tree/master/contributor_docs#unit-tests
