### PR TITLE
Quick fix for noErase in WebGL

### DIFF
--- a/src/webgl/material.js
+++ b/src/webgl/material.js
@@ -901,7 +901,9 @@ p5.RendererGL.prototype._applyBlendMode = function() {
       );
       break;
   }
-  this._cachedBlendMode = this.curBlendMode;
+  if (!this._isErasing) {
+    this._cachedBlendMode = this.curBlendMode;
+  }
 };
 
 export default p5;

--- a/src/webgl/p5.RendererGL.js
+++ b/src/webgl/p5.RendererGL.js
@@ -725,26 +725,23 @@ p5.RendererGL.prototype.blendMode = function(mode) {
 
 p5.RendererGL.prototype.erase = function(opacityFill, opacityStroke) {
   if (!this._isErasing) {
-    this._cachedBlendMode = this.curBlendMode;
-    this.blendMode(constants.REMOVE);
+    this._applyBlendMode(constants.REMOVE);
+    this._isErasing = true;
 
     this._cachedFillStyle = this.curFillColor.slice();
     this.curFillColor = [1, 1, 1, opacityFill / 255];
 
     this._cachedStrokeStyle = this.curStrokeColor.slice();
     this.curStrokeColor = [1, 1, 1, opacityStroke / 255];
-
-    this._isErasing = true;
   }
 };
 
 p5.RendererGL.prototype.noErase = function() {
   if (this._isErasing) {
+    this._isErasing = false;
     this.curFillColor = this._cachedFillStyle.slice();
     this.curStrokeColor = this._cachedStrokeStyle.slice();
-
     this.blendMode(this._cachedBlendMode);
-    this._isErasing = false;
   }
 };
 


### PR DESCRIPTION
Resolves #4555

 Changes:

This disables the caching of the blend mode by `RendererGL._applyBlendMode()` when `RendererGL._isErasing` is true.

This is a quick fix. A more thorough reconsideration of blend mode state management for RendererGL is necessary in the long run. To explain --

There is problematic state management of `_cachedBlendMode` and `curBlendMode` in RendererGL. This was introduced by an optimization to `RendererGL._applyBlendMode` that tries to avoid unnecessary GL calls by caching the last applied blend mode. The problem is that `erase()` and `noErase()` also change `_cachedBlendMode`.

`_cachedBlendMode` is being used here to do two conceptually different things.

1. only do a call to `gl.blendFunc()` when the new GL blend mode is different than the applied blend mode. This makes it so that if someone calls `blendMode()` every frame, it won't do unnecessary GL calls.
2. It is used to store the blendMode before calls to `erase()` so that the previous blendMode can be applied after `noErase()`.

To further complicate things, these two uses mutate `_cachedBlendMode()` asynchronously from one another because `_applyBlendMode` is called upon rendering.

Another property that is something like`preEraseBlend` could be added to RendererGL but then the `_cachedBlendMode` use between Renderer2D and RendererGL would diverge because Renderer2D only uses `_cachedBlendMode` to track pre/post eraser blends since it doesn't need the GL optimizations.

This is all to say that the blend state management in RendererGL is very tricky currently and probably should be restructured.

Once this quick fix PR is merged, I can add an issue with the above explanation of the need for a large restructure.

#### PR Checklist

- [x] `npm run lint` passes
- [ ] [Inline documentation] is included / updated
- [ ] [Unit tests] are included / updated