### PR TITLE
solve validatateParameters issues

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,4 @@ p5-website/
 coverage/
 lib/p5-test.js
 release/
+parameterData.json

--- a/src/core/error_helpers.js
+++ b/src/core/error_helpers.js
@@ -313,7 +313,7 @@ if (typeof IS_MINIFIED !== 'undefined') {
   //                - seen: true
   // seen: true signifies that this argument was also seen as the last
   // argument in a call. Now in the second run of the sketch, it would traverse
-  // the existing tree and see get seen: true, i.e this sequence was seen
+  // the existing tree and see seen: true, i.e this sequence was seen
   // before and so scoring can be skipped. This also prevents logging multiple
   // validation messages for the same thing.
 
@@ -769,6 +769,11 @@ if (typeof IS_MINIFIED !== 'undefined') {
     for (let key of Object.keys(argumentTree)) {
       delete argumentTree[key];
     }
+  };
+
+  // allowing access to argumentTree for testing
+  p5._getValidateParamsArgTree = function getValidateParamsArgTree() {
+    return argumentTree;
   };
 
   /**

--- a/test/unit/core/error_helpers.js
+++ b/test/unit/core/error_helpers.js
@@ -5,6 +5,7 @@ suite('Error Helpers', function() {
     new p5(function(p) {
       p.setup = function() {
         myp5 = p;
+        p5._clearValidateParamsCache();
         done();
       };
     });

--- a/test/unit/core/error_helpers.js
+++ b/test/unit/core/error_helpers.js
@@ -123,6 +123,76 @@ suite('Error Helpers', function() {
     }
   );
 
+  suite('validateParameters: argument tree', function() {
+    // should not throw a validation error for the same kind of wrong args
+    // more than once. This prevents repetetive validation logs for a
+    // function that is called in a loop or draw()
+    testUnMinified(
+      'no repeated validation error for the same wrong arguments',
+      function() {
+        assert.validationError(function() {
+          myp5.color();
+        });
+
+        assert.doesNotThrow(
+          function() {
+            myp5.color(); // Same type of wrong arguments as above
+          },
+          p5.ValidationError,
+          'got unwanted ValidationError'
+        );
+      }
+    );
+
+    testUnMinified(
+      'should throw validation errors for different wrong args',
+      function() {
+        assert.validationError(function() {
+          myp5.color();
+        });
+
+        assert.validationError(function() {
+          myp5.color(false);
+        });
+      }
+    );
+
+    testUnMinified('arg tree is built properly', function() {
+      let myArgTree = p5._getValidateParamsArgTree();
+      myp5.random();
+      myp5.random(50);
+      myp5.random([50, 70, 10]);
+      assert.strictEqual(
+        myArgTree.random.seen,
+        true,
+        'tree built correctly for random()'
+      );
+      assert.strictEqual(
+        myArgTree.random.number.seen,
+        true,
+        'tree built correctly for random(min: Number)'
+      );
+      assert.strictEqual(
+        myArgTree.random.as.number.number.number.seen,
+        true,
+        'tree built correctly for random(choices: Array)'
+      );
+
+      let c = myp5.color(10);
+      myp5.alpha(c);
+      assert.strictEqual(
+        myArgTree.color.number.seen,
+        true,
+        'tree built correctly for color(gray: Number)'
+      );
+      assert.strictEqual(
+        myArgTree.alpha.Color.seen,
+        true,
+        'tree built correctly for alpha(color: p5.Color)'
+      );
+    });
+  });
+
   suite('validateParameters: multi-format', function() {
     test('color(): no friendly-err-msg', function() {
       assert.doesNotThrow(


### PR DESCRIPTION
<!--
  Thank you for contributing! Please use this pull request (PR) template.


 In the description field of this PR, include "resolves #XXXX" tagging the issue you are fixing. If this PR addresses the issue but doesn't completely resolve it (ie the issue should remain open after your PR is merged), write "addresses #XXXX".-->
Resolves #4558 

Changes:
<!-- Add here what changes were made in this pull request and if possible provide links showcasing the changes. -->
1. Store argument types to increase speed a bit and to prevent
   repetitive logging
2. Create new JSON file parameterData.json from data.json and
   use it for the FES instead so as to reduce library size

Running on the following sketch for testing on Chrome
```js
let iterations = 10000000;
function setup() {
  console.time('timer random');
  for(let i = 0; i<iterations; i++){
    random();
  }
  console.timeEnd('timer random');

  console.time('timer randomGaussian');
  for(let i = 0; i<iterations; i++){
    randomGaussian(10, 2);
  }
  console.timeEnd('timer randomGaussian');

  console.time('timer color');
  for(let i = 0; i<iterations; i++){
    color(10, 10, 10);
  }
  console.timeEnd('timer color');
  
}
```

Before
```
timer random: 693.552978515625ms
timer randomGaussian: 1639.44287109375ms
timer color: 4085.77392578125ms
```

After
```
timer random: 581.656982421875ms
timer randomGaussian: 1254.043212890625ms
timer color: 2215.990234375ms
```

I found that the performance improvement is only significant for functions with a lot of formats and overloads like `color()`.
However, this now prevents repetitive logging.
Earlier
![image](https://user-images.githubusercontent.com/38867671/82273456-2ea88c80-999b-11ea-9bd2-902c08c3c78f.png)

Now
![image](https://user-images.githubusercontent.com/38867671/82273570-6c0d1a00-999b-11ea-90fe-be64121c7739.png)


And the size of the compiled library now comes down to 3.5 MB. The source on master gives a final js file of size 4.7 MB

data.json is built by yui docs and it allows us to preprocess the data in preprocessor.js. But since data.json is used for generating the reference pages, I am leaving it untouched and creating another file parameterData.json. I am doing this bit in preprocessor.js but I am not sure if it is the correct place to do this. So until that is confirmed, I am keeping this PR as draft.

EDIT:
`int()` doesn't use validateParameters, my bad. Removing it from the above sketch.
`randomGaussian` doesn't use validateParameters directly but makes calls to `random()` within it. So a speedup of random speeds up `randomGaussian` too.

#### PR Checklist
<!--
  To check any option, replace the "[ ]" with a "[x]". Be sure to check out how it looks in the Preview tab! Feel free to remove any portion of the template that is not relevant for your issue.
-->

- [x] `npm run lint` passes
- [ ] [Inline documentation] is included / updated
- [x] [Unit tests] are included / updated

[Inline documentation]: https://github.com/processing/p5.js/blob/master/contributor_docs/inline_documentation.md
[Unit tests]: https://github.com/processing/p5.js/tree/master/contributor_docs#unit-tests
