### PR TITLE
Added ssv option in loadTable function

### DIFF
--- a/src/io/files.js
+++ b/src/io/files.js
@@ -421,6 +421,13 @@ p5.prototype.loadTable = function(path) {
           sep = ',';
           separatorSet = true;
         }
+      } else if (arguments[i] === 'ssv') {
+        if (separatorSet) {
+          throw new Error('Cannot set multiple separator types.');
+        } else {
+          sep = ';';
+          separatorSet = true;
+        }
       } else if (arguments[i] === 'tsv') {
         if (separatorSet) {
           throw new Error('Cannot set multiple separator types.');

--- a/src/io/files.js
+++ b/src/io/files.js
@@ -302,6 +302,7 @@ p5.prototype.loadStrings = function(...args) {
  * <p>Possible options include:
  * <ul>
  * <li>csv - parse the table as comma-separated values</li>
+ * <li>ssv - parse the table as semicolon-separated values</li>
  * <li>tsv - parse the table as tab-separated values</li>
  * <li>header - this table has a header (title) row</li>
  * </ul>
@@ -327,7 +328,7 @@ p5.prototype.loadStrings = function(...args) {
  * This method is suitable for fetching files up to size of 64MB.
  * @method loadTable
  * @param  {String}         filename   name of the file or URL to load
- * @param  {String}         options  "header" "csv" "tsv"
+ * @param  {String}         options  "header" "csv" "ssv" "tsv"
  * @param  {function}       [callback] function to be executed after
  *                                     <a href="#/p5/loadTable">loadTable()</a> completes. On success, the
  *                                     <a href="#/p5.Table">Table</a> object is passed in as the


### PR DESCRIPTION
FeatureRequest

 Changes:
Just added the option to pick semicolon (';') (Semicolon Seperated Value) as separator for the p5.prototype.loadTable function.

 Screenshots of the change:
Befor:
![befor](https://www.bildhochladen.de/images/2020/05/22/pullrequest.jpg "befor")
Added in between:
![after](https://www.bildhochladen.de/images/2020/05/22/pullrequest_after.jpg "after")

#### PR Checklist
<!--
  To check any option, replace the "[ ]" with a "[x]". Be sure to check out how it looks in the Preview tab! Feel free to remove any portion of the template that is not relevant for your issue.
-->

- [x] `npm run lint` passes
- [ ] [Inline documentation] is included / updated
- [ ] [Unit tests] are included / updated

[Inline documentation]: https://github.com/processing/p5.js/blob/master/contributor_docs/inline_documentation.md
[Unit tests]: https://github.com/processing/p5.js/tree/master/contributor_docs#unit-tests
