### PR TITLE
selectAll docs: include missing param types

### DIFF
--- a/src/dom/dom.js
+++ b/src/dom/dom.js
@@ -117,10 +117,14 @@ p5.prototype.select = function(e, p) {
  * a = selectAll('button', '#myContainer');
  *
  * let d = select('#container');
- * a = selectAll('p', d);
+ * if (d) {
+ *   a = selectAll('p', d);
+ * }
  *
  * let f = document.getElementById('beep');
- * a = select('.blah', f);
+ * if (f) {
+ *   a = selectAll('.blah', f);
+ * }
  *
  * a; // unused
  * </code></div>

--- a/src/dom/dom.js
+++ b/src/dom/dom.js
@@ -94,7 +94,8 @@ p5.prototype.select = function(e, p) {
  *
  * @method selectAll
  * @param  {String} name class or tag name of elements to search for
- * @param  {String} [container] id, <a href="#/p5.Element">p5.Element</a>, or HTML element to search within
+ * @param  {String|p5.Element|HTMLElement} [container] id, <a href="#/p5.Element">p5.Element</a>, or
+ *                                             HTML element to search within
  * @return {p5.Element[]} Array of <a href="#/p5.Element">p5.Element</a>s containing nodes found
  * @example
  * <div class='norender'><code>


### PR DESCRIPTION
<!--
  Thank you for contributing! Please use this pull request (PR) template.


 In the description field of this PR, include "resolves #XXXX" tagging the issue you are fixing. If this PR addresses the issue but doesn't completely resolve it (ie the issue should remain open after your PR is merged), write "addresses #XXXX".-->
Resolves #4579

 Changes:
Include missing types ( HTMLElement and p5.Element ) for the 2nd parameter in selectAll documentation

Quite a minor change but needed this for working on #4571 :sweat_smile: 

While we are at it, can I also update the example so that we select an element that exists in the reference tests ( perhaps `#mocha` or `head` or `body` instead of `beep` ) ?

#### PR Checklist
<!--
  To check any option, replace the "[ ]" with a "[x]". Be sure to check out how it looks in the Preview tab! Feel free to remove any portion of the template that is not relevant for your issue.
-->

- [x] `npm run lint` passes
- [x] [Inline documentation] is included / updated
- [ ] [Unit tests] are included / updated

[Inline documentation]: https://github.com/processing/p5.js/blob/master/contributor_docs/inline_documentation.md
[Unit tests]: https://github.com/processing/p5.js/tree/master/contributor_docs#unit-tests
