### PR TITLE
FES: Add detection for trailing undefined arguments

### DIFF
--- a/src/core/friendly_errors/validate_params.js
+++ b/src/core/friendly_errors/validate_params.js
@@ -467,10 +467,11 @@ if (typeof IS_MINIFIED !== 'undefined') {
   // tests when expecting validation errors
   p5.ValidationError = (name => {
     class err extends Error {
-      constructor(message, func) {
+      constructor(message, func, type) {
         super();
         this.message = message;
         this.func = func;
+        this.type = type;
         if ('captureStackTrace' in Error) Error.captureStackTrace(this, err);
         else this.stack = new Error().stack;
       }
@@ -537,7 +538,7 @@ if (typeof IS_MINIFIED !== 'undefined') {
           return;
         }
         if (p5._throwValidationErrors) {
-          throw new p5.ValidationError(message);
+          throw new p5.ValidationError(message, func, errorObj.type);
         }
         const location = `${parsed[3].fileName}:${parsed[3].lineNumber}:${
           parsed[3].columnNumber
@@ -603,8 +604,10 @@ if (typeof IS_MINIFIED !== 'undefined') {
     const docs = docCache[func] || (docCache[func] = lookupParamDoc(func));
     const overloads = docs.overloads;
 
-    // ignore any trailing `undefined` arguments
     let argCount = args.length;
+
+    // the following line ignores trailing undefined arguments, commenting
+    // it to resolve https://github.com/processing/p5.js/issues/4571
     // '== null' checks for 'null' and typeof 'undefined'
     // while (argCount > 0 && args[argCount - 1] == null) argCount--;
 

--- a/src/core/friendly_errors/validate_params.js
+++ b/src/core/friendly_errors/validate_params.js
@@ -401,7 +401,7 @@ if (typeof IS_MINIFIED !== 'undefined') {
       const format = formats[p];
       // '== null' checks for 'null' and typeof 'undefined'
       if (arg == null) {
-        // handle non-optional and non-trailing undefined args
+        // handle undefined args
         if (!format.optional || p < minParams || p < argCount) {
           score += 1;
         }
@@ -442,7 +442,7 @@ if (typeof IS_MINIFIED !== 'undefined') {
       const format = formats[p];
       // '== null' checks for 'null' and typeof 'undefined'
       if (arg == null) {
-        // handle non-optional and non-trailing undefined args
+        // handle undefined args
         if (!format.optional || p < minParams || p < argCount) {
           errorArray.push({
             type: 'EMPTY_VAR',
@@ -606,7 +606,7 @@ if (typeof IS_MINIFIED !== 'undefined') {
     // ignore any trailing `undefined` arguments
     let argCount = args.length;
     // '== null' checks for 'null' and typeof 'undefined'
-    while (argCount > 0 && args[argCount - 1] == null) argCount--;
+    // while (argCount > 0 && args[argCount - 1] == null) argCount--;
 
     // find the overload with the best score
     let minScore = 99999;


### PR DESCRIPTION
<!--
  Thank you for contributing! Please use this pull request (PR) template.


 In the description field of this PR, include "resolves #XXXX" tagging the issue you are fixing. If this PR addresses the issue but doesn't completely resolve it (ie the issue should remain open after your PR is merged), write "addresses #XXXX".-->
Resolves #4571 

 Changes:
<!-- Add here what changes were made in this pull request and if possible provide links showcasing the changes. -->
1. Make the FES detect trailing undefined arguments
Consider the following few examples
```js
let r, g, b;
function setup() {
  let r = 50;
  color(r, g, b);
}
```
Here g and b are undefined. But earlier as color with only one argument was still a valid overload, the FES did not log a message. But as it is passed 3 arguments, it is likely that them being undefined is unintentional and so a message should be displayed.

Now it shows:
`🌸 p5.js says: color() was expecting Number for parameter #1 (zero-based index), received an empty variable instead`

`🌸 p5.js says: color() was expecting Number for parameter #2 (zero-based index), received an empty variable instead
`

Similarly:
```js
function setup() {
  let a = document.getElementById('nonexistant');
  select('hgg', a);
}
```
would not have logged an error before this, as the undefined argument is trailing and select(string) is a valid overload. A message here is important to let the user know that `a` is empty ( i.e `notexistant` was not found )

Now it shows:
`🌸 p5.js says: select() was expecting String|p5.Element|HTMLElement for parameter #1 (zero-based index), received an empty variable instead.`

Also for
```js
let r;
circle(10, 10, r);
```
Earlier we used to get 
`🌸 p5.js says: circle() was expecting at least 3 arguments, but received only 2`

Now it correctly shows:
`🌸 p5.js says: circle() was expecting Number for parameter #2 (zero-based index), received an empty variable instead.`

2. Pass the error type to the ValidationError constructor so that it could be accessed in tests
3. Add tests for the edge cases in #2740 
4. Add tests for detection of trailing undefined arguments

#### PR Checklist
<!--
  To check any option, replace the "[ ]" with a "[x]". Be sure to check out how it looks in the Preview tab! Feel free to remove any portion of the template that is not relevant for your issue.
-->

- [x] `npm run lint` passes
- [ ] [Inline documentation] is included / updated
- [x] [Unit tests] are included / updated

[Inline documentation]: https://github.com/processing/p5.js/blob/master/contributor_docs/inline_documentation.md
[Unit tests]: https://github.com/processing/p5.js/tree/master/contributor_docs#unit-tests
