### PR TITLE
Remove parameterData.json from minified js

### DIFF
--- a/tasks/build/browserify.js
+++ b/tasks/build/browserify.js
@@ -38,6 +38,7 @@ module.exports = function(grunt) {
       if (isMin) {
         browseified = browseified
           .exclude('../../docs/reference/data.json')
+          .exclude('../../../docs/parameterData.json')
           .ignore('../../translations/index.js');
       }
 

--- a/tasks/build/combineModules.js
+++ b/tasks/build/combineModules.js
@@ -57,7 +57,9 @@ module.exports = function(grunt) {
       });
 
       if (isMin) {
-        browseified = browseified.exclude('../../docs/reference/data.json');
+        browseified = browseified
+          .exclude('../../docs/reference/data.json')
+          .exclude('../../../docs/parameterData.json');
       }
 
       const babelifyOpts = { plugins: ['static-fs'] };


### PR DESCRIPTION
<!--
  Thank you for contributing! Please use this pull request (PR) template.


 In the description field of this PR, include "resolves #XXXX" tagging the issue you are fixing. If this PR addresses the issue but doesn't completely resolve it (ie the issue should remain open after your PR is merged), write "addresses #XXXX".-->
Addresses #4558 

 Changes:
<!-- Add here what changes were made in this pull request and if possible provide links showcasing the changes. -->
In #4561, I replaced the use of `data.json` in favour of a new file, `parameterData.json`  but I forgot to configure browserify to ignore this file for the minified js. So I had accidentally increased the size of the minified library by about 200 KB :see_no_evil: .  This PR fixes that.

After #4561
![image](https://user-images.githubusercontent.com/38867671/83947774-bfee7e80-a836-11ea-88e6-20bdeaf7559f.png)


Now
![image](https://user-images.githubusercontent.com/38867671/83947788-dc8ab680-a836-11ea-8602-f9156457bcf6.png)



#### PR Checklist
<!--
  To check any option, replace the "[ ]" with a "[x]". Be sure to check out how it looks in the Preview tab! Feel free to remove any portion of the template that is not relevant for your issue.
-->

- [x] `npm run lint` passes
- [ ] [Inline documentation] is included / updated
- [ ] [Unit tests] are included / updated

[Inline documentation]: https://github.com/processing/p5.js/blob/master/contributor_docs/inline_documentation.md
[Unit tests]: https://github.com/processing/p5.js/tree/master/contributor_docs#unit-tests
