### PR TITLE
FES: spelling and caps detection

### DIFF
--- a/src/core/friendly_errors/browser_errors.js
+++ b/src/core/friendly_errors/browser_errors.js
@@ -1,0 +1,15 @@
+// Browsers use error strings to build their error messages. These can be
+// different across different browsers. We can build a list of these strings
+// so that the FES is able to extract the required info from the errors given
+// by the browser
+const strings = {
+  ReferenceError: [
+    {
+      msg: '{{}} is not defined',
+      type: 'NOTDEFINED',
+      browser: 'all'
+    }
+  ]
+};
+
+export default strings;

--- a/src/core/friendly_errors/browser_errors.js
+++ b/src/core/friendly_errors/browser_errors.js
@@ -1,7 +1,9 @@
-// Browsers use error strings to build their error messages. These can be
-// different across different browsers. We can build a list of these strings
-// so that the FES is able to extract the required info from the errors given
-// by the browser
+// Different browsers may use different error strings for the same error.
+// Extracting info from them is much easier and cleaner if we have a predefined
+// lookup against which we try and match the errors obtained from the browser,
+// classify them into types and extract the required information. The contents
+// of this file serve as that lookup. The FES can use this to give a simplified
+// explanation for all kinds of errors.
 const strings = {
   ReferenceError: [
     {

--- a/src/core/friendly_errors/browser_errors.js
+++ b/src/core/friendly_errors/browser_errors.js
@@ -8,6 +8,11 @@ const strings = {
       msg: '{{}} is not defined',
       type: 'NOTDEFINED',
       browser: 'all'
+    },
+    {
+      msg: "Can't find variable: {{}}",
+      type: 'NOTDEFINED',
+      browser: 'Safari'
     }
   ]
 };

--- a/src/core/friendly_errors/fes_core.js
+++ b/src/core/friendly_errors/fes_core.js
@@ -345,11 +345,15 @@ if (typeof IS_MINIFIED !== 'undefined') {
           string = string.replace('{}', '(?:[a-zA-Z0-9_]+)');
           let matched = error.message.match(string);
           if (matched && matched[1]) {
-            handleMisspelling(
-              matched[1],
-              error,
-              typeof log === 'function' ? log : undefined
-            );
+            switch (obj.type) {
+              case 'NOTDEFINED':
+                handleMisspelling(
+                  matched[1],
+                  error,
+                  typeof log === 'function' ? log : undefined
+                );
+                break;
+            }
           }
         }
         break;

--- a/src/core/friendly_errors/fes_core.js
+++ b/src/core/friendly_errors/fes_core.js
@@ -50,6 +50,10 @@ const typeColors = ['#2D7BB6', '#EE9900', '#4DB200', '#C83C00'];
 let misusedAtTopLevelCode = null;
 let defineMisusedAtTopLevelCode = null;
 
+// the threshold for the maximum allowed levenshtein distance
+// used in misspelling detection
+const EDIT_THRESH = 2;
+
 if (typeof IS_MINIFIED !== 'undefined') {
   p5._friendlyError = p5._checkForUserDefinedFunctions = p5._fesErrorMonitor = () => {};
 } else {
@@ -172,12 +176,56 @@ if (typeof IS_MINIFIED !== 'undefined') {
     console.log(translator('fes.pre', { message }));
   };
 
+  const editDistance = (w1, w2) => {
+    // An implementation of
+    // https://en.wikipedia.org/wiki/Wagner%E2%80%93Fischer_algorithm
+    // to compute the Levenshtein distance
+    const l1 = w1.length,
+      l2 = w2.length;
+    if (l1 === 0) return w2;
+    if (l2 === 0) return w1;
+
+    let prev = [];
+    let cur = [];
+
+    for (let j = 0; j < l2 + 1; j++) {
+      cur[j] = j;
+    }
+
+    prev = cur;
+
+    for (let i = 1; i < l1 + 1; i++) {
+      cur = [];
+      for (let j = 0; j < l2 + 1; j++) {
+        if (j === 0) {
+          cur[j] = i;
+        } else {
+          let a1 = w1[i - 1],
+            a2 = w2[j - 1];
+          let temp = 999999;
+          let cost = a1.toLowerCase() === a2.toLowerCase() ? 0 : 1;
+          temp = temp > cost + prev[j - 1] ? cost + prev[j - 1] : temp;
+          temp = temp > 1 + cur[j - 1] ? 1 + cur[j - 1] : temp;
+          temp = temp > 1 + prev[j] ? 1 + prev[j] : temp;
+          cur[j] = temp;
+        }
+      }
+      prev = cur;
+    }
+
+    return cur[l2];
+  };
+
   // checks if the various functions such as setup, draw, preload have been
   // defined with capitalization mistakes
   const checkForUserDefinedFunctions = context => {
+    if (p5.disableFriendlyErrors) return;
+
     // if using instance mode, this function would be called with the current
     // instance as context
-    context = context instanceof p5 ? context : window;
+    const instanceMode = context instanceof p5;
+    context = instanceMode ? context : window;
+
     const fnNames = [
       'setup',
       'draw',
@@ -200,62 +248,89 @@ if (typeof IS_MINIFIED !== 'undefined') {
       'keyTyped',
       'windowResized'
     ];
+
     const fxns = {};
-    // build the lowercase -> actualName mapping
-    for (let name of fnNames) {
-      fxns[name.toLowerCase()] = name;
-    }
-    for (let prop in context) {
-      let lowercaseProp = prop.toLowerCase();
-      if (fxns.hasOwnProperty(lowercaseProp)) {
-        if (prop !== fxns[lowercaseProp] && !context[fxns[lowercaseProp]]) {
-          const msg = translator('fes.checkUserDefinedFns', {
-            name: prop,
-            actualName: fxns[lowercaseProp]
-          });
-          p5._friendlyError(msg, fxns[lowercaseProp]);
-        }
+    // lowercasename -> actualName mapping
+    fnNames.forEach(symbol => {
+      fxns[symbol.toLowerCase()] = symbol;
+    });
+
+    for (const prop of Object.keys(context)) {
+      const lowercase = prop.toLowerCase();
+
+      // check if the lowercase property name has an entry in fxns, if the
+      // actual name with correct capitalization doesnt exist in context,
+      // and if the user-defined symbol is of the type function
+      if (
+        fxns[lowercase] &&
+        !context[fxns[lowercase]] &&
+        typeof context[prop] === 'function'
+      ) {
+        const msg = translator('fes.checkUserDefinedFns', {
+          name: prop,
+          actualName: fxns[lowercase]
+        });
+        p5._friendlyError(msg, fxns[lowercase]);
       }
     }
   };
 
+  // compares the the symbol caught in the ReferenceErrror to everything
+  // in misusedAtTopLevel ( all public p5 properties ). The use of
+  // misusedAtTopLevel here is for convenience as it was an array that was
+  // already defined when spelling check was implemented. For this particular
+  // use-case, it's a misnomer.
   const detectMisspelling = (errSym, error) => {
     if (!misusedAtTopLevelCode) {
       defineMisusedAtTopLevelCode();
     }
-    let errSymLower = errSym.toLowerCase();
-    misusedAtTopLevelCode.some(symbol => {
-      let lowercase = symbol.name.toLowerCase();
 
-      if (errSymLower === lowercase && errSym !== symbol.name) {
-        const parsed = p5._getErrorStackParser().parse(error);
-        const location =
-          parsed[0] && parsed[0].fileName
-            ? `${parsed[0].fileName}:${parsed[0].lineNumber}:${
-                parsed[0].columnNumber
-              }`
-            : null;
-        const msg = translator('fes.misspelling', {
-          name: errSym,
-          actualName: symbol.name,
-          type: symbol.type,
-          location: location ? translator('fes.location', { location }) : ''
-        });
-
-        p5._friendlyError(msg, symbol.name);
-        return true;
+    let min = 999999,
+      minIndex = 0;
+    // compute the levenshtein distance for the symbol against all known
+    // public p5 properties. Find the property with the minimum distance
+    misusedAtTopLevelCode.forEach((symbol, idx) => {
+      let dist = editDistance(errSym, symbol.name);
+      if (dist < min) {
+        min = dist;
+        minIndex = idx;
       }
     });
+
+    if (min > EDIT_THRESH) return;
+
+    let symbol = misusedAtTopLevelCode[minIndex];
+
+    // Show a message only if the caught symbol and the matched property name
+    // differ in their name ( either letter difference or difference of case )
+    if (errSym !== symbol.name) {
+      const parsed = p5._getErrorStackParser().parse(error);
+      const location =
+        parsed[0] && parsed[0].fileName
+          ? `${parsed[0].fileName}:${parsed[0].lineNumber}:${
+              parsed[0].columnNumber
+            }`
+          : null;
+      const msg = translator('fes.misspelling', {
+        name: errSym,
+        actualName: symbol.name,
+        type: symbol.type,
+        location: location ? translator('fes.location', { location }) : ''
+      });
+
+      p5._friendlyError(msg, symbol.name);
+    }
   };
 
   const fesErrorMonitor = e => {
+    if (p5.disableFriendlyErrors) return;
     // This function can receieve an Error object or an ErrorEvent
     const error = e instanceof ErrorEvent ? e.error : e;
 
     switch (error.name) {
       case 'ReferenceError': {
         const errList = errorTable.ReferenceError;
-        for (let obj of errList) {
+        for (const obj of errList) {
           let string = obj.msg;
           // capture the primary symbol mentioned in the error
           string = string.replace('{{}}', '([a-zA-Z0-9_]+)');
@@ -273,7 +348,7 @@ if (typeof IS_MINIFIED !== 'undefined') {
   p5._fesErrorMonitor = fesErrorMonitor;
   p5._checkForUserDefinedFunctions = checkForUserDefinedFunctions;
 
-  window.addEventListener('load', checkForUserDefinedFunctions);
+  window.addEventListener('load', checkForUserDefinedFunctions, false);
   window.addEventListener('error', p5._fesErrorMonitor, false);
 
   /**

--- a/src/core/init.js
+++ b/src/core/init.js
@@ -54,4 +54,14 @@ const waitForDocumentReady = () =>
 const waitingForTranslator =
   typeof IS_MINIFIED === 'undefined' ? initTranslator() : Promise.resolve();
 
-Promise.all([waitForDocumentReady(), waitingForTranslator]).then(_globalInit);
+Promise.all([waitForDocumentReady(), waitingForTranslator])
+  .then(_globalInit)
+  .catch(e => {
+    // set fesErrorMonitor to catch and process any errors in the fulfillment
+    // of the promise. ( .then(_globalInit) gives a Promise, so this would
+    // catch the errors in the initialization as well as inside the sketch )
+    p5._fesErrorMonitor ? p5._fesErrorMonitor(e) : null;
+
+    // Should also display the original error
+    throw e;
+  });

--- a/src/core/init.js
+++ b/src/core/init.js
@@ -54,14 +54,4 @@ const waitForDocumentReady = () =>
 const waitingForTranslator =
   typeof IS_MINIFIED === 'undefined' ? initTranslator() : Promise.resolve();
 
-Promise.all([waitForDocumentReady(), waitingForTranslator])
-  .then(_globalInit)
-  .catch(e => {
-    // set fesErrorMonitor to catch and process any errors in the fulfillment
-    // of the promise. ( .then(_globalInit) gives a Promise, so this would
-    // catch the errors in the initialization as well as inside the sketch )
-    p5._fesErrorMonitor ? p5._fesErrorMonitor(e) : null;
-
-    // Should also display the original error
-    throw e;
-  });
+Promise.all([waitForDocumentReady(), waitingForTranslator]).then(_globalInit);

--- a/src/core/main.js
+++ b/src/core/main.js
@@ -538,10 +538,6 @@ class p5 {
 
       // Run a check to see if the user has missplelled setup, draw, etc
       p5._checkForUserDefinedFunctions(this);
-
-      // set up the fesErrorMonitor to catch and parse any errors while
-      // running the sketch.
-      window.addEventListener('error', p5._fesErrorMonitor, false);
     }
 
     // Bind events to window (not using container div bc key events don't work)

--- a/src/core/main.js
+++ b/src/core/main.js
@@ -536,7 +536,8 @@ class p5 {
       // user-provided 'setup', 'draw', etc. properties on this instance of p5
       sketch(this);
 
-      // Run a check to see if the user has missplelled setup, draw, etc
+      // Run a check to see if the user has misspelled 'setup', 'draw', etc
+      // detects capitalization mistakes only ( Setup, SETUP, MouseClicked, etc)
       p5._checkForUserDefinedFunctions(this);
     }
 

--- a/src/core/main.js
+++ b/src/core/main.js
@@ -535,6 +535,13 @@ class p5 {
       // Else, the user has passed in a sketch closure that may set
       // user-provided 'setup', 'draw', etc. properties on this instance of p5
       sketch(this);
+
+      // Run a check to see if the user has missplelled setup, draw, etc
+      p5._checkForUserDefinedFunctions(this);
+
+      // set up the fesErrorMonitor to catch and parse any errors while
+      // running the sketch.
+      window.addEventListener('error', p5._fesErrorMonitor, false);
     }
 
     // Bind events to window (not using container div bc key events don't work)

--- a/tasks/build/browserify.js
+++ b/tasks/build/browserify.js
@@ -40,6 +40,7 @@ module.exports = function(grunt) {
           .exclude('../../docs/reference/data.json')
           .exclude('../../../docs/parameterData.json')
           .exclude('../../translations')
+          .exclude('./browser_errors')
           .ignore('i18next')
           .ignore('i18next-browser-languagedetector');
       }

--- a/translations/en/translation.json
+++ b/translations/en/translation.json
@@ -1,6 +1,7 @@
 {
   "fes": {
     "autoplay": "The media that tried to play (with '{{src}}') wasn't allowed to by this browser, most likely due to the browser's autoplay policy. Check out {{link}} for more information about why.",
+    "checkUserDefinedFns": "It seems you just tried to define {{name}} function for p5.js.\n\nPlease note that it should be written as {{actualName}}. Note the difference in capitalization",
     "fileLoadError": {
       "bytes": "It looks like there was a problem loading your file. {{suggestion}}",
       "font": "It looks like there was a problem loading your font. {{suggestion}}",
@@ -20,6 +21,7 @@
       "type_WRONG_TYPE": "{{func}}() was expecting {{formatType}} for the {{position}} parameter, received {{argType}} instead. {{location}}"
     },
     "location": "(at {{location}})",
+    "misspelling": "It seems that you just tried to use {{name}} {{location}}.\n\nIf you meant to use the {{type}} from p5.js, please note that it should be written as {{actualName}}. Note the difference in capitalization",
     "misusedTopLevel": "Did you just try to use p5.js's {{symbolName}} {{symbolType}}? If so, you may want to move it into your sketch's setup() function.\n\nFor more details, see: {{link}}",
     "positions": {
       "p_1": "first",

--- a/translations/en/translation.json
+++ b/translations/en/translation.json
@@ -1,7 +1,7 @@
 {
   "fes": {
     "autoplay": "The media that tried to play (with '{{src}}') wasn't allowed to by this browser, most likely due to the browser's autoplay policy. Check out {{link}} for more information about why.",
-    "checkUserDefinedFns": "It seems you just tried to define {{name}} function for p5.js.\n\nPlease note that it should be written as {{actualName}}. Note the difference in capitalization",
+    "checkUserDefinedFns": "It seems that you may have accidently written {{name}} instead of {{actualName}}.\n\nPlease correct it if it's not intentional.",
     "fileLoadError": {
       "bytes": "It looks like there was a problem loading your file. {{suggestion}}",
       "font": "It looks like there was a problem loading your font. {{suggestion}}",
@@ -21,7 +21,7 @@
       "type_WRONG_TYPE": "{{func}}() was expecting {{formatType}} for the {{position}} parameter, received {{argType}} instead. {{location}}"
     },
     "location": "(at {{location}})",
-    "misspelling": "It seems that you just tried to use {{name}} {{location}}.\n\nIf you meant to use the {{type}} from p5.js, please note that it should be written as {{actualName}}. Note the difference in capitalization",
+    "misspelling": "It seems that you may have accidently written {{name}} instead of {{actualName}} {{location}}.\n\nPlease correct it to {{actualName}} if you wish to use the {{type}} from p5.js",
     "misusedTopLevel": "Did you just try to use p5.js's {{symbolName}} {{symbolType}}? If so, you may want to move it into your sketch's setup() function.\n\nFor more details, see: {{link}}",
     "positions": {
       "p_1": "first",

--- a/translations/es/translation.json
+++ b/translations/es/translation.json
@@ -1,6 +1,7 @@
 {
   "fes": {
     "autoplay": "Su browser impidío un medio tocar (de '{{src}}'), posiblemente porque las reglas de autoplay. Para aprender más, visite {{link}}.",
+    "checkUserDefinedFns": "",
     "fileLoadError": {
       "bytes": "",
       "font": "",
@@ -20,6 +21,7 @@
       "type_WRONG_TYPE": ""
     },
     "location": "",
+    "misspelling": "",
     "misusedTopLevel": "",
     "positions": {
       "p_1": "",


### PR DESCRIPTION
<!--
  Thank you for contributing! Please use this pull request (PR) template.


 In the description field of this PR, include "resolves #XXXX" tagging the issue you are fixing. If this PR addresses the issue but doesn't completely resolve it (ie the issue should remain open after your PR is merged), write "addresses #XXXX".-->
Resolves #4637 

### Changes:
I have tried the simpler check using `toLowerCase()` as suggested by @limzykenneth .
Seems to work well to capture all kinds of mistakes in capitalization. For the sketch
```js
function Setup() {
  background(100);
}
```
and for the sketch
```js
let sketch = function(p) {
    p.Setup = () => {
        p.background(100);
    }
}
let myp5 = new p5(sketch);
```
We get
```
🌸 p5.js says: It seems that you may have accidently written Setup instead of setup.

Please correct it if it's not intentional. (http://p5js.org/reference/#/p5/setup)
```

And for
```js
function setup() {
  createcanvas(400, 400);
  background(100);
}
```
We get
```
🌸 p5.js says: It seems that you may have accidently written createcanvas instead of createCanvas (at http://localhost:8000/lib/empty-example/sketch.js:2:5).

Please correct it to createCanvas if you wish to use the function from p5.js (http://p5js.org/reference/#/p5/createCanvas)
```

Performance-wise the only concern was `checkForUserDefinedFunctions` as it would have to run the check regardless of whether there is an actual error or not. But it seems to run in under a millisecond and it will run only once, after p5 is initialized. `fesErrorMonitor` shouldn't be a problem for performance as it only runs when we have an actual error.

This only captures capitalization mistakes.
I will try to capture the ones for spelling now and also add tests

### Update: 
Now works for spelling mistakes too. For
```js
function setup() {
  Colour();
}
```
```
🌸 p5.js says: It seems that you may have accidently written Colour instead of color (at http://localhost:8000/lib/empty-example/sketch.js:11:3).

Please correct it to color if you wish to use the function from p5.js (http://p5js.org/reference/#/p5/color)
```

Also added a few tests
#### PR Checklist
<!--
  To check any option, replace the "[ ]" with a "[x]". Be sure to check out how it looks in the Preview tab! Feel free to remove any portion of the template that is not relevant for your issue.
-->

- [x] `npm run lint` passes
- [ ] [Inline documentation] is included / updated
- [x] [Unit tests] are included / updated

[Inline documentation]: https://github.com/processing/p5.js/blob/main/contributor_docs/inline_documentation.md
[Unit tests]: https://github.com/processing/p5.js/tree/main/contributor_docs#unit-tests
