### PR TITLE
Append canvas to main

### DIFF
--- a/lib/empty-example/index.html
+++ b/lib/empty-example/index.html
@@ -17,6 +17,8 @@
 </head>
 
 <body>
+  <main>
+  </main>
 </body>
 
 </html>

--- a/src/core/rendering.js
+++ b/src/core/rendering.js
@@ -90,7 +90,13 @@ p5.prototype.createCanvas = function(w, h, renderer) {
     // user input node case
     this._userNode.appendChild(c);
   } else {
-    document.body.appendChild(c);
+    //create main element
+    if (document.getElementsByTagName('main').length === 0) {
+      let m = document.createElement('main');
+      document.body.appendChild(m);
+    }
+    //append canvas to main
+    document.getElementsByTagName('main')[0].appendChild(c);
   }
 
   // Init our graphics renderer


### PR DESCRIPTION
 Changes:
Appends canvas to the &lt;main&gt; element. This is important because the &lt;main&gt; element behaves like a main landmark role and can be used by assistive technology to quickly identify and navigate to the dominant part of the body. &lt;main&gt;  doesn't contribute to the document's outline and doesn't affect the DOM's concept of the structure of the page. 

If &lt;main&gt;  does not yet exist in the html, it creates element &lt;main&gt;  in &lt;body&gt;  before appending canvas.

This change doesn't affect user input node cases. 

#### PR Checklist

- [x] `npm run lint` passes

