### PR TITLE
fix: point `main` in package.json to minified file

### DIFF
--- a/package.json
+++ b/package.json
@@ -86,7 +86,7 @@
     "whatwg-fetch": "^2.0.4"
   },
   "license": "LGPL-2.1",
-  "main": "./lib/p5.js",
+  "main": "./lib/p5.min.js",
   "files": [
     "license.txt",
     "lib/p5.min.js",


### PR DESCRIPTION
<!--
  Thank you for contributing! Please use this pull request (PR) template.


 In the description field of this PR, include "resolves #XXXX" tagging the issue you are fixing. If this PR addresses the issue but doesn't completely resolve it (ie the issue should remain open after your PR is merged), write "addresses #XXXX".-->
Resolves #2920 #4546

 Changes:
<!-- Add here what changes were made in this pull request and if possible provide links showcasing the changes. -->

The `main` in package.json now points to `lib/p5.min.js`

This results in npm installs of p5 importing the minified version, reducing bundle size.


 Screenshots of the change:
<!-- If applicable, add screenshots depicting the changes. -->

#### PR Checklist
<!--
  To check any option, replace the "[ ]" with a "[x]". Be sure to check out how it looks in the Preview tab! Feel free to remove any portion of the template that is not relevant for your issue.
-->

- [x] `npm run lint` passes
- [x] [Inline documentation] is included / updated
- [x] [Unit tests] are included / updated

[Inline documentation]: https://github.com/processing/p5.js/blob/main/contributor_docs/inline_documentation.md
[Unit tests]: https://github.com/processing/p5.js/tree/main/contributor_docs#unit-tests
