### PR TITLE
Don't append  header for GET requests. Fixes #4457.

### DIFF
--- a/src/io/files.js
+++ b/src/io/files.js
@@ -1080,13 +1080,16 @@ p5.prototype.httpDo = function(...args) {
       }
     }
 
+    let headers =
+      method === 'GET'
+        ? new Headers()
+        : new Headers({ 'Content-Type': contentType });
+
     request = new Request(path, {
       method,
       mode: 'cors',
       body: data,
-      headers: new Headers({
-        'Content-Type': contentType
-      })
+      headers: headers
     });
   }
   // do some sort of smart type checking


### PR DESCRIPTION
<!--
  Thank you for contributing! Please use this pull request (PR) template.


 In the description field of this PR, include "resolves #XXXX" tagging the issue you are fixing. If this PR addresses the issue but doesn't completely resolve it (ie the issue should remain open after your PR is merged), write "addresses #XXXX".-->
Resolves #4457 

 Changes:
<!-- Add here what changes were made in this pull request and if possible provide links showcasing the changes. -->
GET methods pass an empty `Headers` object to the Request, while non-GET methods continue to add the `Content-Type` header.

 Screenshots of the change:
<!-- If applicable, add screenshots depicting the changes. -->

#### PR Checklist
<!--
  To check any option, replace the "[ ]" with a "[x]". Be sure to check out how it looks in the Preview tab! Feel free to remove any portion of the template that is not relevant for your issue.
-->

- [x] `npm run lint` passes
- [x] [Inline documentation] is included / updated
- [ ] [Unit tests] are included / updated

Manually tested the example sketch in the issue, but I wasn't sure how to add an automated test around this with the current setup/tests for `httpDo`, if anyone has suggestions I'd be happy to add them!

[Inline documentation]: https://github.com/processing/p5.js/blob/main/contributor_docs/inline_documentation.md
[Unit tests]: https://github.com/processing/p5.js/tree/main/contributor_docs#unit-tests
