### PR TITLE
FES: Global Error Catching

### DIFF
--- a/src/core/friendly_errors/browser_errors.js
+++ b/src/core/friendly_errors/browser_errors.js
@@ -16,6 +16,40 @@ const strings = {
       type: 'NOTDEFINED',
       browser: 'Safari'
     }
+  ],
+  SyntaxError: [
+    {
+      msg: 'illegal character',
+      type: 'INVALIDTOKEN',
+      browser: 'Firefox'
+    },
+    {
+      msg: 'Invalid character',
+      type: 'INVALIDTOKEN',
+      browser: 'Safari'
+    },
+    {
+      msg: 'Invalid or unexpected token',
+      type: 'INVALIDTOKEN',
+      browser: 'Chrome'
+    },
+    {
+      msg: "Unexpected token '{{.}}'",
+      type: 'UNEXPECTEDTOKEN',
+      browser: 'Chrome'
+    },
+    {
+      msg: "expected {{.}}, got '{{.}}'",
+      type: 'UNEXPECTEDTOKEN',
+      browser: 'Chrome'
+    }
+  ],
+  TypeError: [
+    {
+      msg: '{{.}} is not a function',
+      type: 'NOTFUNC',
+      browser: 'all'
+    }
   ]
 };
 

--- a/src/core/friendly_errors/fes_core.js
+++ b/src/core/friendly_errors/fes_core.js
@@ -335,6 +335,97 @@ if (typeof IS_MINIFIED !== 'undefined') {
     }
   };
 
+  const processStack = (error, stacktrace) => {
+    // Responsible for removing internal library calls from the stacktrace
+    // and also for detectiong if the error happened inside the library
+
+    // cannot process a stacktrace that doesn't exist
+    if (!stacktrace) return [false, null];
+
+    stacktrace.forEach(frame => {
+      frame.functionName = frame.functionName || '';
+    });
+
+    let isInternal = false;
+    let p5FileName, friendlyStack;
+    for (let i = stacktrace.length - 1; i >= 0; i--) {
+      let splitted = stacktrace[i].functionName.split('.');
+      if (entryPoints.includes(splitted[splitted.length - 1])) {
+        // remove everything below an entry point function (setup, draw, etc).
+        // (it's usually the internal initialization calls)
+        friendlyStack = stacktrace.slice(0, i + 1);
+        for (let j = 0; j < i; j++) {
+          // Due to the current build process, all p5 functions have
+          // _main.default in their names in the final build. This is the
+          // easiest way to check if a function is inside the p5 library
+          if (stacktrace[j].functionName.search('_main.default') !== -1) {
+            isInternal = true;
+            p5FileName = stacktrace[j].fileName;
+            break;
+          }
+        }
+        break;
+      }
+    }
+
+    if (!friendlyStack) friendlyStack = stacktrace;
+
+    if (isInternal) {
+      friendlyStack = friendlyStack
+        .map((frame, index) => {
+          frame.frameIndex = index;
+          return frame;
+        })
+        .filter(frame => frame.fileName !== p5FileName);
+
+      const func = stacktrace[friendlyStack[0].frameIndex - 1].functionName
+        .split('.')
+        .slice(-1)[0];
+
+      const location = `${friendlyStack[0].fileName}:${
+        friendlyStack[0].lineNumber
+      }:${friendlyStack[0].columnNumber}`;
+
+      // If already been handled by another component of the FES
+      if (p5._fesLogCache[location]) return [true, null];
+      // Library error
+      p5._friendlyError(
+        translator('fes.globalErrors.libraryError', {
+          func: func,
+          location: location,
+          error: error.message
+        }),
+        func
+      );
+    }
+    return [isInternal, friendlyStack];
+  };
+
+  const printFriendlyStack = friendlyStack => {
+    if (friendlyStack.length > 1) {
+      let stacktraceMsg = '';
+      friendlyStack.forEach((frame, idx) => {
+        const location = `${frame.fileName}:${frame.lineNumber}:${
+          frame.columnNumber
+        }`;
+        let frameMsg,
+          translationObj = {
+            func: frame.functionName,
+            line: frame.lineNumber,
+            location: location,
+            file: frame.fileName.split('/').slice(-1)
+          };
+        if (idx === 0) {
+          frameMsg = translator('fes.globalErrors.stackTop', translationObj);
+        } else {
+          frameMsg = translator('fes.globalErrors.stackSubseq', translationObj);
+        }
+        stacktraceMsg += frameMsg;
+      });
+      console.log(stacktraceMsg);
+    }
+  };
+
   const fesErrorMonitor = e => {
     if (p5.disableFriendlyErrors) return;
     // Try to get the error object from e
@@ -355,98 +446,9 @@ if (typeof IS_MINIFIED !== 'undefined') {
     if (error.name === 'SyntaxError') return;
 
     let stacktrace = p5._getErrorStackParser().parse(error);
-
-    if (!stacktrace) return;
-
-    for (let i = 0; i < stacktrace.length; i++) {
-      stacktrace[i].functionName = stacktrace[i].functionName || '';
-    }
-
-    if (stacktrace[0]) {
-      let errLoc = `${stacktrace[0].fileName}:${stacktrace[0].lineNumber}:${
-        stacktrace[0].columnNumber
-      }`;
-      if (p5._fesLogCache[errLoc]) return;
-      p5._fesLogCache[errLoc] = true;
-    }
-    let isInternal = false;
-    let p5FileName;
-    for (let i = stacktrace.length - 1; i >= 0; i--) {
-      let splitted = stacktrace[i].functionName.split('.');
-      if (entryPoints.includes(splitted[splitted.length - 1])) {
-        stacktrace = stacktrace.slice(0, i + 1);
-        for (let j = 0; j < i; j++) {
-          // Due to the current build process, all p5 functions get
-          // _main.default in their names in the final build. This is the
-          // easiest way to check if a function is inside the p5 library
-          if (stacktrace[j].functionName.search('_main.default') !== -1) {
-            isInternal = true;
-            p5FileName = stacktrace[j].fileName;
-            break;
-          }
-        }
-        break;
-      }
-    }
-
-    if (isInternal) {
-      let userIndices = [];
-      let translationObj = {};
-      translationObj.error = error.message;
-
-      let simpleStack = stacktrace.filter((e, idx) => {
-        if (e.fileName !== p5FileName) {
-          userIndices.push(idx);
-          return true;
-        } else {
-          return false;
-        }
-      });
-
-      let firstUserFrame = stacktrace[userIndices[0]];
-      const func = stacktrace[userIndices[0] - 1].functionName
-        .split('.')
-        .slice(-1)[0];
-      translationObj.func = func;
-
-      const location = `${firstUserFrame.fileName}:${
-        firstUserFrame.lineNumber
-      }:${firstUserFrame.columnNumber}`;
-      translationObj.location = translator('fes.location', { location });
-
-      stacktrace = simpleStack;
-      p5._friendlyError(
-        translator('fes.globalErrors.libraryError', translationObj),
-        func
-      );
-    }
-
-    if (stacktrace.length > 1) {
-      let stacktraceMsg = '';
-      stacktrace.forEach((frame, idx) => {
-        const location = `${frame.fileName}:${frame.lineNumber}:${
-          frame.columnNumber
-        }`;
-        let frameMsg,
-          translationObj = {
-            func: frame.functionName,
-            line: frame.lineNumber,
-            location: location,
-            file: frame.fileName.split('/').slice(-1)
-          };
-        if (idx === 0) {
-          frameMsg = translator('fes.globalErrors.stackTop', translationObj);
-        } else {
-          frameMsg = translator('fes.globalErrors.stackSubseq', translationObj);
-        }
-        stacktraceMsg += frameMsg;
-      });
-      console.log(stacktraceMsg);
-    }
-
-    // If the error happened inside the library
-    if (isInternal) return;
-
+    let [isInternal, friendlyStack] = processStack(error, stacktrace);
+    if (isInternal || !friendlyStack) return;
+    printFriendlyStack(friendlyStack);
     switch (error.name) {
       case 'ReferenceError': {
         const errList = errorTable.ReferenceError;

--- a/src/core/friendly_errors/validate_params.js
+++ b/src/core/friendly_errors/validate_params.js
@@ -573,6 +573,7 @@ if (typeof IS_MINIFIED !== 'undefined') {
         }`;
         if (location) {
           translationObj.location = translator('fes.location', { location });
+          p5._fesLogCache[location] = true;
         }
       } catch (err) {
         if (err instanceof p5.ValidationError) {

--- a/src/core/friendly_errors/validate_params.js
+++ b/src/core/friendly_errors/validate_params.js
@@ -568,11 +568,27 @@ if (typeof IS_MINIFIED !== 'undefined') {
         if (p5._throwValidationErrors) {
           throw new p5.ValidationError(message, func, errorObj.type);
         }
-        const location = `${parsed[3].fileName}:${parsed[3].lineNumber}:${
+
+        // try to extract the location from where the function was called
+        if (
+          parsed[3] &&
+          parsed[3].fileName &&
+          parsed[3].lineNumber &&
           parsed[3].columnNumber
-        }`;
-        if (location) {
-          translationObj.location = translator('fes.location', { location });
+        ) {
+          let location = `${parsed[3].fileName}:${parsed[3].lineNumber}:${
+            parsed[3].columnNumber
+          }`;
+
+          translationObj.location = translator('fes.location', {
+            location: location,
+            // for e.g. get "sketch.js" from "https://example.com/abc/sketch.js"
+            file: parsed[3].fileName.split('/').slice(-1),
+            line: parsed[3].lineNumber
+          });
+
+          // tell fesErrorMonitor that we have already given a friendly message
+          // for this line, so it need not to do the same in case of an error
           p5._fesLogCache[location] = true;
         }
       } catch (err) {

--- a/test/unit/core/error_helpers.js
+++ b/test/unit/core/error_helpers.js
@@ -547,11 +547,6 @@ suite('Global Error Handling', function() {
 
   testUnMinified('correctly identifies errors in preload', function() {
     return new Promise(function(resolve) {
-      // quite an unusual way to test, but the error listerner doesn't work
-      // under mocha. Also the stacktrace gets filled with mocha internal
-      // function calls. Using this method solves both of these problems.
-      // This method also allows us to test for SyntaxError without messing
-      // with flow of the other tests
       iframe = createP5Iframe(
         [
           P5_SCRIPT_TAG,
@@ -595,29 +590,6 @@ suite('Global Error Handling', function() {
       assert.strictEqual(log.length, 1);
       assert.match(log[0], /asdfg/);
       assert.match(log[0], /not being defined in the current scope/);
-    });
-  });
-
-  testUnMinified('correctly identifies errors in user code II', function() {
-    return new Promise(function(resolve) {
-      iframe = createP5Iframe(
-        [
-          P5_SCRIPT_TAG,
-          WAIT_AND_RESOLVE,
-          '<script>',
-          'function setup() {',
-          'let x = “not a string”', // SyntaxError: Invalid or unexpected token
-          '}',
-          '</script>'
-        ].join('\n')
-      );
-      log = [];
-      iframe.elt.contentWindow.logger = logger;
-      iframe.elt.contentWindow.afterSetup = resolve;
-    }).then(function() {
-      assert.strictEqual(log.length, 1);
-      assert.match(log[0], /syntax error/);
-      assert.match(log[0], /JavaScript doesn't recognize/);
     });
   });
 

--- a/test/unit/core/error_helpers.js
+++ b/test/unit/core/error_helpers.js
@@ -480,3 +480,358 @@ suite('Error Helpers', function() {
     );
   });
 });
+
+// seperating in another suite because these don't need to initialize myp5
+// for each test. Instead they initialize p5 in the iframe. These tests are
+// also slower than the above ones.
+suite('Global Error Handling', function() {
+  let log;
+  const WAIT_AND_RESOLVE = [
+    '<script>',
+    'p5._fesLogger = window.logger',
+    'let flag = false;',
+    'setInterval(() => {',
+    // just because the log has one element doesn't necessarily mean that the
+    // handler has finished its job. The flag allows it to take some more time
+    // after adding the first log message
+    '  if (window.logger.length > 0) {',
+    '    if (flag) window.afterSetup();',
+    '    flag = true;',
+    '  }',
+    '}, 50);',
+    '</script>'
+  ].join('\n');
+  const logger = function(err) {
+    log.push(err);
+  };
+  setup(function() {
+    log = [];
+    p5._fesLogger = logger;
+  });
+
+  teardown(function() {
+    p5._fesLogger = null;
+  });
+
+  testUnMinified(
+    'correctly identifies errors happenning internally',
+    function() {
+      return new Promise(function(resolve) {
+        // quite an unusual way to test, but the error listerner doesn't work
+        // under mocha. Also the stacktrace gets filled with mocha internal
+        // function calls. Using this method solves both of these problems.
+        // This method also allows us to test for SyntaxError without messing
+        // with flow of the other tests
+        iframe = createP5Iframe(
+          [
+            P5_SCRIPT_TAG,
+            WAIT_AND_RESOLVE,
+            '<script>',
+            'function setup() {',
+            'let cnv = createCanvas(400, 400);',
+            'cnv.mouseClicked();', // Error in p5 library as no callback passed
+            '}',
+            '</script>'
+          ].join('\n')
+        );
+        log = [];
+        iframe.elt.contentWindow.logger = logger;
+        iframe.elt.contentWindow.afterSetup = resolve;
+      }).then(function() {
+        assert.strictEqual(log.length, 1);
+        assert.match(log[0], /inside the p5js library/);
+        assert.match(log[0], /mouseClicked/);
+      });
+    }
+  );
+
+  testUnMinified('correctly identifies errors in preload', function() {
+    return new Promise(function(resolve) {
+      // quite an unusual way to test, but the error listerner doesn't work
+      // under mocha. Also the stacktrace gets filled with mocha internal
+      // function calls. Using this method solves both of these problems.
+      // This method also allows us to test for SyntaxError without messing
+      // with flow of the other tests
+      iframe = createP5Iframe(
+        [
+          P5_SCRIPT_TAG,
+          WAIT_AND_RESOLVE,
+          '<script>',
+          'function preload() {',
+          'circle(5, 5, 2);', // error
+          '}',
+          'function setup() {',
+          'createCanvas(10, 10);',
+          '}',
+          '</script>'
+        ].join('\n')
+      );
+      log = [];
+      iframe.elt.contentWindow.logger = logger;
+      iframe.elt.contentWindow.afterSetup = resolve;
+    }).then(function() {
+      assert.strictEqual(log.length, 1);
+      assert.match(log[0], /"circle" being called from preload/);
+    });
+  });
+
+  testUnMinified('correctly identifies errors in user code I', function() {
+    return new Promise(function(resolve) {
+      iframe = createP5Iframe(
+        [
+          P5_SCRIPT_TAG,
+          WAIT_AND_RESOLVE,
+          '<script>',
+          'function setup() {',
+          'let x = asdfg + 5;', // ReferenceError: asdfg is not defined
+          '}',
+          '</script>'
+        ].join('\n')
+      );
+      log = [];
+      iframe.elt.contentWindow.logger = logger;
+      iframe.elt.contentWindow.afterSetup = resolve;
+    }).then(function() {
+      assert.strictEqual(log.length, 1);
+      assert.match(log[0], /asdfg/);
+      assert.match(log[0], /not being defined in the current scope/);
+    });
+  });
+
+  testUnMinified('correctly identifies errors in user code II', function() {
+    return new Promise(function(resolve) {
+      iframe = createP5Iframe(
+        [
+          P5_SCRIPT_TAG,
+          WAIT_AND_RESOLVE,
+          '<script>',
+          'function setup() {',
+          'let x = “not a string”', // SyntaxError: Invalid or unexpected token
+          '}',
+          '</script>'
+        ].join('\n')
+      );
+      log = [];
+      iframe.elt.contentWindow.logger = logger;
+      iframe.elt.contentWindow.afterSetup = resolve;
+    }).then(function() {
+      assert.strictEqual(log.length, 1);
+      assert.match(log[0], /syntax error/);
+      assert.match(log[0], /JavaScript doesn't recognize/);
+    });
+  });
+
+  testUnMinified('correctly identifies errors in user code II', function() {
+    return new Promise(function(resolve) {
+      iframe = createP5Iframe(
+        [
+          P5_SCRIPT_TAG,
+          WAIT_AND_RESOLVE,
+          '<script>',
+          'function setup() {',
+          'let x = “not a string”', // SyntaxError: Invalid or unexpected token
+          '}',
+          '</script>'
+        ].join('\n')
+      );
+      log = [];
+      iframe.elt.contentWindow.logger = logger;
+      iframe.elt.contentWindow.afterSetup = resolve;
+    }).then(function() {
+      assert.strictEqual(log.length, 1);
+      assert.match(log[0], /syntax error/);
+      assert.match(log[0], /JavaScript doesn't recognize/);
+    });
+  });
+
+  testUnMinified('correctly identifies errors in user code III', function() {
+    return new Promise(function(resolve) {
+      iframe = createP5Iframe(
+        [
+          P5_SCRIPT_TAG,
+          WAIT_AND_RESOLVE,
+          '<script>',
+          'function setup() {',
+          'for (let i = 0; i < 5,; ++i) {}', // SyntaxError: Unexpected token
+          '}',
+          '</script>'
+        ].join('\n')
+      );
+      log = [];
+      iframe.elt.contentWindow.logger = logger;
+      iframe.elt.contentWindow.afterSetup = resolve;
+    }).then(function() {
+      assert.strictEqual(log.length, 1);
+      assert.match(log[0], /syntax error/);
+      assert.match(log[0], /typo/);
+    });
+  });
+
+  testUnMinified('correctly identifies errors in user code IV', function() {
+    return new Promise(function(resolve) {
+      iframe = createP5Iframe(
+        [
+          P5_SCRIPT_TAG,
+          WAIT_AND_RESOLVE,
+          '<script>',
+          'function setup() {',
+          'let asdfg = 5',
+          'asdfg()', // TypeError: asdfg is not a function
+          '}',
+          '</script>'
+        ].join('\n')
+      );
+      log = [];
+      iframe.elt.contentWindow.logger = logger;
+      iframe.elt.contentWindow.afterSetup = resolve;
+    }).then(function() {
+      assert.strictEqual(log.length, 1);
+      assert.match(log[0], /"asdfg" could not be called as a function/);
+    });
+  });
+
+  testUnMinified('correctly identifies errors in user code IV', function() {
+    return new Promise(function(resolve) {
+      iframe = createP5Iframe(
+        [
+          P5_SCRIPT_TAG,
+          WAIT_AND_RESOLVE,
+          '<script>',
+          'function setup() {',
+          'let asdfg = {}',
+          'asdfg.abcd()', // TypeError: abcd is not a function
+          '}',
+          '</script>'
+        ].join('\n')
+      );
+      log = [];
+      iframe.elt.contentWindow.logger = logger;
+      iframe.elt.contentWindow.afterSetup = resolve;
+    }).then(function() {
+      assert.strictEqual(log.length, 1);
+      assert.match(log[0], /"abcd" could not be called as a function/);
+      assert.match(log[0], /"asdfg" has "abcd" in it/);
+    });
+  });
+
+  testUnMinified('correctly builds friendlyStack', function() {
+    return new Promise(function(resolve) {
+      iframe = createP5Iframe(
+        [
+          P5_SCRIPT_TAG,
+          WAIT_AND_RESOLVE,
+          '<script>',
+          'function myfun(){',
+          'asdfg()', // ReferenceError
+          '}',
+          'function setup() {',
+          'myfun()',
+          '}',
+          '</script>'
+        ].join('\n')
+      );
+      log = [];
+      iframe.elt.contentWindow.logger = logger;
+      iframe.elt.contentWindow.afterSetup = resolve;
+    }).then(function() {
+      assert.strictEqual(log.length, 2);
+      let temp = log[1].split('\n');
+      temp = temp.filter(e => e.trim().length > 0);
+      assert.strictEqual(temp.length, 2);
+      assert.match(log[0], /"asdfg" not being defined/);
+      assert.match(temp[0], /Error at/);
+      assert.match(temp[0], /myfun/);
+      assert.match(temp[1], /Called from/);
+      assert.match(temp[1], /setup/);
+    });
+  });
+
+  testUnMinified(
+    'correctly indentifies internal error - instance mode',
+    function() {
+      return new Promise(function(resolve) {
+        iframe = createP5Iframe(
+          [
+            P5_SCRIPT_TAG,
+            WAIT_AND_RESOLVE,
+            '<script>',
+            'function sketch(p) {',
+            '  p.setup = function() {',
+            '    p.stroke();', // error
+            '  }',
+            '}',
+            'new p5(sketch);',
+            '</script>'
+          ].join('\n')
+        );
+        log = [];
+        iframe.elt.contentWindow.logger = logger;
+        iframe.elt.contentWindow.afterSetup = resolve;
+      }).then(function() {
+        assert.strictEqual(log.length, 1);
+        assert.match(log[0], /stroke/);
+        assert.match(log[0], /inside the p5js library/);
+      });
+    }
+  );
+
+  testUnMinified(
+    'correctly indentifies error in preload - instance mode',
+    function() {
+      return new Promise(function(resolve) {
+        iframe = createP5Iframe(
+          [
+            P5_SCRIPT_TAG,
+            WAIT_AND_RESOLVE,
+            '<script>',
+            'function sketch(p) {',
+            '  p.preload = function() {',
+            '    p.circle(2, 2, 2);', // error
+            '  }',
+            '  p.setup = function() {',
+            '    p.createCanvas(5, 5);',
+            '  }',
+            '}',
+            'new p5(sketch);',
+            '</script>'
+          ].join('\n')
+        );
+        log = [];
+        iframe.elt.contentWindow.logger = logger;
+        iframe.elt.contentWindow.afterSetup = resolve;
+      }).then(function() {
+        assert.strictEqual(log.length, 1);
+        assert.match(log[0], /"circle" being called from preload/);
+      });
+    }
+  );
+
+  testUnMinified(
+    'correctly indentifies error in user code - instance mode',
+    function() {
+      return new Promise(function(resolve) {
+        iframe = createP5Iframe(
+          [
+            P5_SCRIPT_TAG,
+            WAIT_AND_RESOLVE,
+            '<script>',
+            'function sketch(p) {',
+            '  p.setup = function() {',
+            '    myfun();', // ReferenceError: myfun is not defined
+            '  }',
+            '}',
+            'new p5(sketch);',
+            '</script>'
+          ].join('\n')
+        );
+        log = [];
+        iframe.elt.contentWindow.logger = logger;
+        iframe.elt.contentWindow.afterSetup = resolve;
+      }).then(function() {
+        assert.strictEqual(log.length, 1);
+        assert.match(log[0], /myfun/);
+        assert.match(log[0], /not being defined in the current scope/);
+      });
+    }
+  );
+});

--- a/translations/en/translation.json
+++ b/translations/en/translation.json
@@ -22,12 +22,12 @@
     },
     "globalErrors": {
       "reference": {
-        "notDefined": "There's an error due to \"{{symbol}}\" not being defined in the current scope {{location}}.\n\nIf you had defined it in your code, check its scope, spelling, and letter-casing (JavaScript is case-sensitive). For more:\n{{url1}}\n{{url2}}"
+        "notDefined": "There's an error due to \"{{symbol}}\" not being defined in the current scope {{location}}.\n\nIf you have defined it in your code, you should check its scope, spelling, and letter-casing (JavaScript is case-sensitive). For more:\n{{url1}}\n{{url2}}"
       },
       "stackSubseq": "▶️ Called from line {{line}} in \"{{func}}\" in {{file}} ({{location}})\n\n",
       "stackTop": "▶️ Error at line {{line}} in \"{{func}}\" in {{file}} ({{location}})\n\n",
       "syntax": {
-        "invalidToken": "There's a syntax error due to a symbol that JavaScript doesn't recognize or didn't expect at it's place.\nUsually this can when copying code from some other place. For example \" is supported but “ isn't.\nFor more: {{url}}",
+        "invalidToken": "There's a syntax error due to a symbol that JavaScript doesn't recognize or didn't expect at it's place.\nFor more: {{url}}",
         "unexpectedToken": "There's a syntax error due to a symbol that wasn't expected at it's place.\nUsually this is due to a typo. Check the line number in the error below for anything missing/extra.\nFor more: {{url}}"
       },
       "type": {

--- a/translations/en/translation.json
+++ b/translations/en/translation.json
@@ -22,8 +22,19 @@
     },
     "globalErrors": {
       "libraryError": "An error with message \"{{error}}\" was thrown inside the p5js library when you called {{func}} {{location}}\nIf not stated otherwise, it is likely an issue with the arguments passed to {{func}}.",
+      "reference": {
+        "notDefined": "There's an error due to \"{{symbol}}\" not being defined in the current scope {{location}}.\n\nIf you had defined it in your code, check its scope, spelling, and letter-casing (JavaScript is case-sensitive). For more:\n{{url1}}\n{{url2}}"
+      },
       "stackSubseq": "▶️ Called from line {{line}} in function {{func}} in {{file}} ({{location}})\n\n",
-      "stackTop": "▶️ Error at line {{line}} in function {{func}} in {{file}} ({{location}})\n\n"
+      "stackTop": "▶️ Error at line {{line}} in function {{func}} in {{file}} ({{location}})\n\n",
+      "syntax": {
+        "invalidToken": "There's a syntax error due to a symbol that JavaScript doesn't recognize or didn't expect at it's place.\nUsually this can when copying code from some other place. For example \" is supported but “ isn't.\nFor more: {{url}}",
+        "unexpectedToken": "There's a syntax error due to a symbol that wasn't expected at it's place.\nUsually this is due to a typo. Check the line number in the error below for anything missing/extra.\nFor more: {{url}}"
+      },
+      "type": {
+        "notfunc": "There's an error as \"{{symbol}}\" could not be called as a function {{location}}.\nCheck the spelling, letter-casing (Javacript is case-sensitive) and its type.\nFor more: {{url}}",
+        "notfuncObj": "There's an error as \"{{symbol}}\" could not be called as a function {{location}}.\nVerify whether \"{{obj}}\" has \"{{symbol}}\" in it and check the spelling, letter-casing (Javacript is case-sensitive) and its type.\nFor more: {{url}}"
+      }
     },
     "location": "(at {{location}})",
     "misspelling": "It seems that you may have accidently written {{name}} instead of {{actualName}} {{location}}.\n\nPlease correct it to {{actualName}} if you wish to use the {{type}} from p5.js",

--- a/translations/en/translation.json
+++ b/translations/en/translation.json
@@ -36,7 +36,7 @@
       }
     },
     "libraryError": "An error with message \"{{error}}\" occured inside the p5js library when you called {{func}} {{location}}\n\nIf not stated otherwise, it might be an issue with the arguments passed to {{func}}.",
-    "location": "(at {{location}})",
+    "location": "(on line {{line}} in {{file}} [{{location}}])",
     "misspelling": "It seems that you may have accidently written {{name}} instead of {{actualName}} {{location}}.\n\nPlease correct it to {{actualName}} if you wish to use the {{type}} from p5.js",
     "misusedTopLevel": "Did you just try to use p5.js's {{symbolName}} {{symbolType}}? If so, you may want to move it into your sketch's setup() function.\n\nFor more details, see: {{link}}",
     "positions": {
@@ -53,7 +53,7 @@
       "p_8": "eighth",
       "p_9": "ninth"
     },
-    "pre": "🌸 p5.js says: {{message}}",
+    "pre": "\n🌸 p5.js says: {{message}}",
     "welcome": "Welcome! This is your friendly debugger. To turn me off, switch to using p5.min.js.",
     "wrongPreload": "An error with message \"{{error}}\" occured inside the p5js library when you called {{func}} {{location}}.\n\nIf not stated otherwise, it might be due to {{func}} being called from preload. Nothing besides load calls (loadImage, loadJSON, loadFont, loadStrings, etc.) should be inside the preload function."
   }

--- a/translations/en/translation.json
+++ b/translations/en/translation.json
@@ -21,7 +21,6 @@
       "type_WRONG_TYPE": "{{func}}() was expecting {{formatType}} for the {{position}} parameter, received {{argType}} instead. {{location}}"
     },
     "globalErrors": {
-      "libraryError": "An error with message \"{{error}}\" was thrown inside the p5js library when you called {{func}} {{location}}\nIf not stated otherwise, it is likely an issue with the arguments passed to {{func}}.",
       "reference": {
         "notDefined": "There's an error due to \"{{symbol}}\" not being defined in the current scope {{location}}.\n\nIf you had defined it in your code, check its scope, spelling, and letter-casing (JavaScript is case-sensitive). For more:\n{{url1}}\n{{url2}}"
       },
@@ -36,6 +35,7 @@
         "notfuncObj": "There's an error as \"{{symbol}}\" could not be called as a function {{location}}.\nVerify whether \"{{obj}}\" has \"{{symbol}}\" in it and check the spelling, letter-casing (Javacript is case-sensitive) and its type.\nFor more: {{url}}"
       }
     },
+    "libraryError": "An error with message \"{{error}}\" occured inside the p5js library when you called {{func}} {{location}}\n\nIf not stated otherwise, it might be an issue with the arguments passed to {{func}}.",
     "location": "(at {{location}})",
     "misspelling": "It seems that you may have accidently written {{name}} instead of {{actualName}} {{location}}.\n\nPlease correct it to {{actualName}} if you wish to use the {{type}} from p5.js",
     "misusedTopLevel": "Did you just try to use p5.js's {{symbolName}} {{symbolType}}? If so, you may want to move it into your sketch's setup() function.\n\nFor more details, see: {{link}}",
@@ -54,6 +54,7 @@
       "p_9": "ninth"
     },
     "pre": "🌸 p5.js says: {{message}}",
-    "welcome": "Welcome! This is your friendly debugger. To turn me off, switch to using p5.min.js."
+    "welcome": "Welcome! This is your friendly debugger. To turn me off, switch to using p5.min.js.",
+    "wrongPreload": "An error with message \"{{error}}\" occured inside the p5js library when you called {{func}} {{location}}.\n\nIf not stated otherwise, it might be due to {{func}} being called from preload. Nothing besides load calls (loadImage, loadJSON, loadFont, loadStrings, etc.) should be inside the preload function."
   }
 }

--- a/translations/en/translation.json
+++ b/translations/en/translation.json
@@ -24,8 +24,8 @@
       "reference": {
         "notDefined": "There's an error due to \"{{symbol}}\" not being defined in the current scope {{location}}.\n\nIf you had defined it in your code, check its scope, spelling, and letter-casing (JavaScript is case-sensitive). For more:\n{{url1}}\n{{url2}}"
       },
-      "stackSubseq": "▶️ Called from line {{line}} in function {{func}} in {{file}} ({{location}})\n\n",
-      "stackTop": "▶️ Error at line {{line}} in function {{func}} in {{file}} ({{location}})\n\n",
+      "stackSubseq": "▶️ Called from line {{line}} in \"{{func}}\" in {{file}} ({{location}})\n\n",
+      "stackTop": "▶️ Error at line {{line}} in \"{{func}}\" in {{file}} ({{location}})\n\n",
       "syntax": {
         "invalidToken": "There's a syntax error due to a symbol that JavaScript doesn't recognize or didn't expect at it's place.\nUsually this can when copying code from some other place. For example \" is supported but “ isn't.\nFor more: {{url}}",
         "unexpectedToken": "There's a syntax error due to a symbol that wasn't expected at it's place.\nUsually this is due to a typo. Check the line number in the error below for anything missing/extra.\nFor more: {{url}}"
@@ -35,7 +35,7 @@
         "notfuncObj": "There's an error as \"{{symbol}}\" could not be called as a function {{location}}.\nVerify whether \"{{obj}}\" has \"{{symbol}}\" in it and check the spelling, letter-casing (Javacript is case-sensitive) and its type.\nFor more: {{url}}"
       }
     },
-    "libraryError": "An error with message \"{{error}}\" occured inside the p5js library when you called {{func}} {{location}}\n\nIf not stated otherwise, it might be an issue with the arguments passed to {{func}}.",
+    "libraryError": "An error with message \"{{error}}\" occured inside the p5js library when {{func}} was called {{location}}\n\nIf not stated otherwise, it might be an issue with the arguments passed to {{func}}.",
     "location": "(on line {{line}} in {{file}} [{{location}}])",
     "misspelling": "It seems that you may have accidently written {{name}} instead of {{actualName}} {{location}}.\n\nPlease correct it to {{actualName}} if you wish to use the {{type}} from p5.js",
     "misusedTopLevel": "Did you just try to use p5.js's {{symbolName}} {{symbolType}}? If so, you may want to move it into your sketch's setup() function.\n\nFor more details, see: {{link}}",
@@ -55,6 +55,6 @@
     },
     "pre": "\n🌸 p5.js says: {{message}}",
     "welcome": "Welcome! This is your friendly debugger. To turn me off, switch to using p5.min.js.",
-    "wrongPreload": "An error with message \"{{error}}\" occured inside the p5js library when you called {{func}} {{location}}.\n\nIf not stated otherwise, it might be due to {{func}} being called from preload. Nothing besides load calls (loadImage, loadJSON, loadFont, loadStrings, etc.) should be inside the preload function."
+    "wrongPreload": "An error with message \"{{error}}\" occured inside the p5js library when \"{{func}}\" was called {{location}}.\n\nIf not stated otherwise, it might be due to \"{{func}}\" being called from preload. Nothing besides load calls (loadImage, loadJSON, loadFont, loadStrings, etc.) should be inside the preload function."
   }
 }

--- a/translations/en/translation.json
+++ b/translations/en/translation.json
@@ -20,6 +20,11 @@
       "type_TOO_MANY_ARGUMENTS": "{{func}}() was expecting no more than {{maxParams}} arguments, but received {{argCount}}. {{location}}",
       "type_WRONG_TYPE": "{{func}}() was expecting {{formatType}} for the {{position}} parameter, received {{argType}} instead. {{location}}"
     },
+    "globalErrors": {
+      "libraryError": "An error with message \"{{error}}\" was thrown inside the p5js library when you called {{func}} {{location}}\nIf not stated otherwise, it is likely an issue with the arguments passed to {{func}}.",
+      "stackSubseq": "▶️ Called from line {{line}} in function {{func}} in {{file}} ({{location}})\n\n",
+      "stackTop": "▶️ Error at line {{line}} in function {{func}} in {{file}} ({{location}})\n\n"
+    },
     "location": "(at {{location}})",
     "misspelling": "It seems that you may have accidently written {{name}} instead of {{actualName}} {{location}}.\n\nPlease correct it to {{actualName}} if you wish to use the {{type}} from p5.js",
     "misusedTopLevel": "Did you just try to use p5.js's {{symbolName}} {{symbolType}}? If so, you may want to move it into your sketch's setup() function.\n\nFor more details, see: {{link}}",

--- a/translations/es/translation.json
+++ b/translations/es/translation.json
@@ -22,8 +22,19 @@
     },
     "globalErrors": {
       "libraryError": "",
+      "reference": {
+        "notDefined": ""
+      },
       "stackSubseq": "",
-      "stackTop": ""
+      "stackTop": "",
+      "syntax": {
+        "invalidToken": "",
+        "unexpectedToken": ""
+      },
+      "type": {
+        "notfunc": "",
+        "notfuncObj": ""
+      }
     },
     "location": "",
     "misspelling": "",

--- a/translations/es/translation.json
+++ b/translations/es/translation.json
@@ -21,7 +21,6 @@
       "type_WRONG_TYPE": ""
     },
     "globalErrors": {
-      "libraryError": "",
       "reference": {
         "notDefined": ""
       },
@@ -36,6 +35,7 @@
         "notfuncObj": ""
       }
     },
+    "libraryError": "",
     "location": "",
     "misspelling": "",
     "misusedTopLevel": "",
@@ -54,6 +54,7 @@
       "p_9": ""
     },
     "pre": "🌸 p5.js dice: {{message}}",
-    "welcome": ""
+    "welcome": "",
+    "wrongPreload": ""
   }
 }

--- a/translations/es/translation.json
+++ b/translations/es/translation.json
@@ -20,6 +20,11 @@
       "type_TOO_MANY_ARGUMENTS": "",
       "type_WRONG_TYPE": ""
     },
+    "globalErrors": {
+      "libraryError": "",
+      "stackSubseq": "",
+      "stackTop": ""
+    },
     "location": "",
     "misspelling": "",
     "misusedTopLevel": "",


### PR DESCRIPTION
<!--
  Thank you for contributing! Please use this pull request (PR) template.


 In the description field of this PR, include "resolves #XXXX" tagging the issue you are fixing. If this PR addresses the issue but doesn't completely resolve it (ie the issue should remain open after your PR is merged), write "addresses #XXXX".-->
Resolves #4662
### Changes:
- [x] Detect internal library errors and log accordingly
- [x] A simpler stack trace by filtering out the internal call details

Pending
- [x] Explanation for various kinds of errors and suggestions to address them
     - [x] SyntaxErrors
     - [x] ReferenceErrors
     - [x] TypeErrors

![image](https://user-images.githubusercontent.com/38867671/86429155-50bc5b00-bd0c-11ea-8bf7-7aa5f160c509.png)

There may be unintentional errors that happen inside the p5js library. Often these are due to wrong arguments but may sometimes be due to other reasons. There are also a [bunch of intentional errors](https://github.com/processing/p5.js/search?l=JavaScript&p=2&q=throw+new+Error+path%3A%22src%2F%22) that the library can throw. These are often confusing as they point to a line inside the library and the stacktrace is filled with internal calls. These can be simplified by focusing on the lines in the sketch that led to it.  As seen above, the error from the browser can be confusing and the FES can quickly inform about the relevant details.

It may be good to consider using some styling ( colours, font, etc ) to pull the focus away from the raw error of the browser and towards the simpler FES message.
![image](https://user-images.githubusercontent.com/38867671/86433242-cc6fd500-bd17-11ea-9e39-1092b2e05d0c.png)

From what I could gather, styling of log messages used to be a part of the FES until it was removed three years ago in #2141, to integrate with the web editor, which was new back then. I assume that the console on editor did not support styling of messages back then. But I tried it now, and it seems to work. https://editor.p5js.org/akshay.padte/sketches/8VFX4Fq2v

It would great if someone could give some insight as to exactly why styling was removed in the FES and the current status with the web editor.
#### PR Checklist
<!--
  To check any option, replace the "[ ]" with a "[x]". Be sure to check out how it looks in the Preview tab! Feel free to remove any portion of the template that is not relevant for your issue.
-->

- [x] `npm run lint` passes
- [ ] [Inline documentation] is included / updated
- [ ] [Unit tests] are included / updated

[Inline documentation]: https://github.com/processing/p5.js/blob/main/contributor_docs/inline_documentation.md
[Unit tests]: https://github.com/processing/p5.js/tree/main/contributor_docs#unit-tests