### PR TITLE
Decode HTML entities in the documentation file (parameterData.json)

### DIFF
--- a/docs/preprocessor.js
+++ b/docs/preprocessor.js
@@ -1,4 +1,5 @@
 const marked = require('marked');
+const Entities = require('html-entities').AllHtmlEntities;
 
 const DocumentedMethod = require('./documented-method');
 
@@ -269,7 +270,8 @@ function buildParamDocs(docs) {
 
 function renderItemDescriptionsAsMarkdown(item) {
   if (item.description) {
-    item.description = marked(item.description);
+    const entities = new Entities();
+    item.description = entities.decode(marked(item.description));
   }
   if (item.params) {
     item.params.forEach(renderItemDescriptionsAsMarkdown);

--- a/package-lock.json
+++ b/package-lock.json
@@ -7047,6 +7047,11 @@
       "integrity": "sha512-pNgbURSuab90KbTqvRPsseaTxOJCZBD0a7t+haSN33piP9cCM4l0CqdzAif2hUqm716UovKB2ROmiabGAKVXyg==",
       "dev": true
     },
+    "html-entities": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/html-entities/-/html-entities-1.3.1.tgz",
+      "integrity": "sha512-rhE/4Z3hIhzHAUKbW8jVcCyuT5oJCXXqhN/6mXXVCpzTmvJnoH2HL/bt3EZ6p55jbFJBeAe1ZNpL5BugLujxNA=="
+    },
     "htmlescape": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/htmlescape/-/htmlescape-1.1.1.tgz",

--- a/package-lock.json
+++ b/package-lock.json
@@ -7050,7 +7050,8 @@
     "html-entities": {
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/html-entities/-/html-entities-1.3.1.tgz",
-      "integrity": "sha512-rhE/4Z3hIhzHAUKbW8jVcCyuT5oJCXXqhN/6mXXVCpzTmvJnoH2HL/bt3EZ6p55jbFJBeAe1ZNpL5BugLujxNA=="
+      "integrity": "sha512-rhE/4Z3hIhzHAUKbW8jVcCyuT5oJCXXqhN/6mXXVCpzTmvJnoH2HL/bt3EZ6p55jbFJBeAe1ZNpL5BugLujxNA==",
+      "dev": true
     },
     "htmlescape": {
       "version": "1.1.1",

--- a/package.json
+++ b/package.json
@@ -65,6 +65,7 @@
     "grunt-mocha-test": "^0.13.3",
     "grunt-newer": "^1.1.0",
     "grunt-simple-nyc": "^3.0.1",
+    "html-entities": "^1.3.1",
     "husky": "^4.2.3",
     "i18next": "^19.0.2",
     "i18next-browser-languagedetector": "^4.0.1",
@@ -145,9 +146,7 @@
     "not dead"
   ],
   "author": "",
-  "dependencies": {
-    "html-entities": "^1.3.1"
-  },
+  "dependencies": {},
   "husky": {
     "hooks": {
       "pre-commit": "lint-staged"

--- a/package.json
+++ b/package.json
@@ -145,7 +145,9 @@
     "not dead"
   ],
   "author": "",
-  "dependencies": {},
+  "dependencies": {
+    "html-entities": "^1.3.1"
+  },
   "husky": {
     "hooks": {
       "pre-commit": "lint-staged"


### PR DESCRIPTION
**Changes:**
Modified the renderItemDescriptionsAsMarkdown() function in the preprocessor.js so the HTML entities (like "&amp;" for "&") in the class/method/field descriptions are decoded. I used the node-html-entities library to decode the text.

The documentation file (data.json in the p5.js-website repository) is used to create the Reference translation files, so I'm trying to make it as readable as possible.

