### PR TITLE
Resolves #4687 : Uncaught TypeError in createColorPicker() 's color() if initialised without parameter

### DIFF
--- a/src/dom/dom.js
+++ b/src/dom/dom.js
@@ -990,11 +990,13 @@ p5.prototype.createColorPicker = function(value) {
   self = addElement(elt, this);
   // Method to return a p5.Color object for the given color.
   self.color = function() {
-    if (value.mode) {
-      p5.prototype._colorMode = value.mode;
-    }
-    if (value.maxes) {
-      p5.prototype._colorMaxes = value.maxes;
+    if(value){
+      if (value.mode) {
+        p5.prototype._colorMode = value.mode;
+      }
+      if (value.maxes) {
+        p5.prototype._colorMaxes = value.maxes;
+      }
     }
     return p5.prototype.color(this.elt.value);
   };

--- a/src/dom/dom.js
+++ b/src/dom/dom.js
@@ -990,7 +990,7 @@ p5.prototype.createColorPicker = function(value) {
   self = addElement(elt, this);
   // Method to return a p5.Color object for the given color.
   self.color = function() {
-    if(value){
+    if (value) {
       if (value.mode) {
         p5.prototype._colorMode = value.mode;
       }


### PR DESCRIPTION
<!--
  Thank you for contributing! Please use this pull request (PR) template.


 In the description field of this PR, include "resolves #XXXX" tagging the issue you are fixing. If this PR addresses the issue but doesn't completely resolve it (ie the issue should remain open after your PR is merged), write "addresses #XXXX".-->
Resolves #4687

 Changes:
<!-- Add here what changes were made in this pull request and if possible provide links showcasing the changes. -->
Adds a check for `value` parameter, and skips accessing it's properties if `value` is undefined.
