### PR TITLE
Small typo in p5.Renderer.js

### DIFF
--- a/src/core/p5.Renderer.js
+++ b/src/core/p5.Renderer.js
@@ -10,7 +10,7 @@ import * as constants from '../core/constants';
 /**
  * Main graphics and rendering context, as well as the base API
  * implementation for p5.js "core". To be used as the superclass for
- * Renderer2D and Renderer3D classes, respecitvely.
+ * Renderer2D and Renderer3D classes, respectively.
  *
  * @class p5.Renderer
  * @constructor


### PR DESCRIPTION
Sorry that this PR is not a great contribution lol but just noticed a typo in p5.Renderer.js when reading docs and figured it could be easily fixed.

**Changes:**
Fix typo in https://p5js.org/reference/#/p5.Renderer
