### PR TITLE
FES + i18n: Load translations from a CDN

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -189,7 +189,7 @@ module.exports = grunt => {
           'src/**/*.vert',
           'src/**/*.glsl'
         ],
-        tasks: ['browserify'],
+        tasks: ['browserify:dev'],
         options: {
           livereload: true
         }

--- a/contributor_docs/internationalization.md
+++ b/contributor_docs/internationalization.md
@@ -82,7 +82,12 @@ The easiest way to do this is to add your language code (like "de" for German, "
 
 This will generate you a fresh translations file in `translations/{LANGUAGE_CODE}/`! Now you can begin populating it with your fresh translations! 🥖
 
-You'll also need to add an entry for it in `translations/index.js`. You can follow the pattern used in that file for `en` and `es`.
+You'll also need to add an entry for it in [`translations/index.js`](../translations/index.js) and [`translations/dev.js`](../translations/dev.js). You can follow the pattern used in that file for `en` and `es`.
+
+### Testing changes
+The bulk of translations are not included in the final library, but are hosted online and are automatically downloaded by p5.js when it needs them. Updates to these only happen whenever a new version of p5.js is released. 
+
+However, if you want to see your changes (or any other changes which aren't released yet), you can simply run `npm run dev` which will build p5.js configured to use the translation files present locally on your computer, instead of the ones on the internet.
 
 ### Further Reading
 

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "scripts": {
     "grunt": "grunt",
     "build": "grunt build",
-    "dev": "grunt browserify connect:yui watch:quick",
+    "dev": "grunt browserify:dev connect:yui watch:quick",
     "docs": "grunt yui",
     "docs:dev": "grunt yui:dev",
     "test": "grunt",

--- a/package.json
+++ b/package.json
@@ -94,7 +94,8 @@
     "lib/p5.min.js",
     "lib/p5.js",
     "lib/addons/p5.sound.js",
-    "lib/addons/p5.sound.min.js"
+    "lib/addons/p5.sound.min.js",
+    "translations/**"
   ],
   "description": "[![npm version](https://badge.fury.io/js/p5.svg)](https://www.npmjs.com/package/p5)",
   "bugs": {

--- a/src/core/internationalization.js
+++ b/src/core/internationalization.js
@@ -1,11 +1,72 @@
 import i18next from 'i18next';
 import LanguageDetector from 'i18next-browser-languagedetector';
 
-let resources;
-// Do not include translations in the minified js
+// let resources;
+// // Do not include translations in the minified js
+let fallbackResources, languages;
 if (typeof IS_MINIFIED === 'undefined') {
-  resources = require('../../translations').default;
+  fallbackResources = require('../../translations').default;
+  languages = require('../../translations').languages;
 }
+
+class FetchResources {
+  constructor(services, options) {
+    this.init(services, options);
+  }
+
+  fetchWithTimeout(url, options, timeout = 2000) {
+    return Promise.race([
+      fetch(url, options),
+      new Promise((_, reject) =>
+        setTimeout(() => reject(new Error('timeout')), timeout)
+      )
+    ]);
+  }
+
+  init(services, options = {}) {
+    this.services = services;
+    this.options = options;
+  }
+
+  read(language, namespace, callback) {
+    const loadPath = this.options.loadPath;
+    const url = this.services.interpolator.interpolate(loadPath, {
+      lng: language,
+      ns: namespace
+    });
+
+    // if the default language of the user is the same as our inbuilt fallback,
+    // there's no need to fetch resources.
+    if (language === this.options.fallback) {
+      callback(null, fallbackResources[language][namespace]);
+    } else if (languages.includes(language)) {
+      this.loadUrl(url, callback);
+    } else {
+      callback('Not found', false);
+    }
+  }
+
+  loadUrl(url, callback) {
+    this.fetchWithTimeout(url)
+      .then(
+        response => {
+          const ok = response.ok;
+          if (!ok) {
+            throw new Error(`failed loading ${url}`);
+          }
+          return response.json();
+        },
+        () => {
+          throw new Error(`failed loading ${url}`);
+        }
+      )
+      .then(data => {
+        return callback(null, data);
+      })
+      .catch(callback);
+  }
+}
+FetchResources.type = 'backend';
 
 /**
  * This is our translation function. Give it a key and
@@ -18,38 +79,52 @@ if (typeof IS_MINIFIED === 'undefined') {
  * @returns {String} message (with values inserted) in the user's browser language
  * @private
  */
-export let translator = () => {
+export let translator = (key, values) => {
   console.debug('p5.js translator called before translations were loaded');
-  return '';
+
+  // Certain FES functionality may trigger before translations are downloaded.
+  // Due to the "partialBundledLanguages" option during initialization, we can
+  // still use our fallback language
+  i18next.t(key, values); /* i18next-extract-disable-line */
 };
 // (We'll set this to a real value in the init function below!)
 
 /**
  * Set up our translation function, with loaded languages
  */
-export const initialize = () =>
-  new Promise((resolve, reject) => {
-    i18next
-      .use(LanguageDetector)
-      .init({
-        fallbackLng: 'en',
-        nestingPrefix: '$tr(',
-        nestingSuffix: ')',
-        defaultNS: 'translation',
-        returnEmptyString: false,
-        interpolation: {
-          escapeValue: false
-        },
-        detection: {
-          checkWhitelist: false
-        },
-        resources
-      })
-      .then(
-        translateFn => {
-          translator = translateFn;
-          resolve();
-        },
-        e => reject(`Translations failed to load (${e})`)
-      );
-  });
+export const initialize = () => {
+  let i18init = i18next
+    .use(LanguageDetector)
+    .use(FetchResources)
+    .init({
+      fallbackLng: 'en',
+      nestingPrefix: '$tr(',
+      nestingSuffix: ')',
+      defaultNS: 'translation',
+      returnEmptyString: false,
+      interpolation: {
+        escapeValue: false
+      },
+      detection: {
+        checkWhitelist: false
+      },
+      backend: {
+        fallback: 'en',
+        loadPath:
+          'https://cdn.jsdelivr.net/npm/@akshay-99/p5-test/translations/{{lng}}/{{ns}}.json'
+      },
+      partialBundledLanguages: true,
+      resources: fallbackResources
+    })
+    .then(
+      translateFn => {
+        translator = translateFn;
+      },
+      e => console.debug(`Translations failed to load (${e})`)
+    );
+
+  // i18next.init() returns a promise that resolves when the translations
+  // are loaded. We use this in core/init.js to hold p5 initialization until
+  // we have the translation files.
+  return i18init;
+};

--- a/src/core/internationalization.js
+++ b/src/core/internationalization.js
@@ -1,19 +1,43 @@
 import i18next from 'i18next';
 import LanguageDetector from 'i18next-browser-languagedetector';
 
-// let resources;
-// // Do not include translations in the minified js
 let fallbackResources, languages;
 if (typeof IS_MINIFIED === 'undefined') {
-  fallbackResources = require('../../translations').default;
-  languages = require('../../translations').languages;
+  // internationalization is only for the unminified build
+
+  const translationsModule = require('../../translations');
+  fallbackResources = translationsModule.default;
+  languages = translationsModule.languages;
+
+  if (typeof P5_DEV_BUILD !== 'undefined') {
+    // When the library is built in development mode ( using npm run dev )
+    // we want to use the current translation files on the disk, which may have
+    // been updated but not yet pushed to the CDN.
+    let completeResources = require('../../translations/dev');
+    for (const language of Object.keys(completeResources)) {
+      // In es_translation, language is es and namespace is translation
+      // In es_MX_translation, language is es-MX and namespace is translation
+      const parts = language.split('_');
+      const lng = parts.slice(0, parts.length - 1).join('-');
+      const ns = parts[parts.length - 1];
+
+      fallbackResources[lng] = fallbackResources[lng] || {};
+      fallbackResources[lng][ns] = completeResources[language];
+    }
+  }
 }
 
+/**
+ * This is our i18next "backend" plugin. It tries to fetch languages
+ * from a CDN.
+ */
 class FetchResources {
   constructor(services, options) {
     this.init(services, options);
   }
 
+  // run fetch with a timeout. Automatically rejects on timeout
+  // default timeout = 2000 ms
   fetchWithTimeout(url, options, timeout = 2000) {
     return Promise.race([
       fetch(url, options),
@@ -30,18 +54,25 @@ class FetchResources {
 
   read(language, namespace, callback) {
     const loadPath = this.options.loadPath;
-    const url = this.services.interpolator.interpolate(loadPath, {
-      lng: language,
-      ns: namespace
-    });
 
-    // if the default language of the user is the same as our inbuilt fallback,
-    // there's no need to fetch resources.
     if (language === this.options.fallback) {
+      // if the default language of the user is the same as our inbuilt fallback,
+      // there's no need to fetch resources from the cdn. This won't actually
+      // need to run when we use "partialBundledLanguages" in the init
+      // function.
       callback(null, fallbackResources[language][namespace]);
     } else if (languages.includes(language)) {
+      // The user's language is included in the list of languages
+      // that we so far added translations for.
+
+      const url = this.services.interpolator.interpolate(loadPath, {
+        lng: language,
+        ns: namespace
+      });
       this.loadUrl(url, callback);
     } else {
+      // We don't have translations for this language. i18next will use
+      // the default language instead.
       callback('Not found', false);
     }
   }
@@ -51,12 +82,15 @@ class FetchResources {
       .then(
         response => {
           const ok = response.ok;
+
           if (!ok) {
+            // caught in the catch() below
             throw new Error(`failed loading ${url}`);
           }
           return response.json();
         },
         () => {
+          // caught in the catch() below
           throw new Error(`failed loading ${url}`);
         }
       )
@@ -83,8 +117,8 @@ export let translator = (key, values) => {
   console.debug('p5.js translator called before translations were loaded');
 
   // Certain FES functionality may trigger before translations are downloaded.
-  // Due to the "partialBundledLanguages" option during initialization, we can
-  // still use our fallback language
+  // Using "partialBundledLanguages" option during initialization, we can
+  // still use our fallback language to display messages
   i18next.t(key, values); /* i18next-extract-disable-line */
 };
 // (We'll set this to a real value in the init function below!)
@@ -111,7 +145,7 @@ export const initialize = () => {
       backend: {
         fallback: 'en',
         loadPath:
-          'https://cdn.jsdelivr.net/npm/@akshay-99/p5-test/translations/{{lng}}/{{ns}}.json'
+          'https://cdn.jsdelivr.net/npm/p5/translations/{{lng}}/{{ns}}.json'
       },
       partialBundledLanguages: true,
       resources: fallbackResources

--- a/tasks/build/browserify.js
+++ b/tasks/build/browserify.js
@@ -19,6 +19,8 @@ module.exports = function(grunt) {
     function(param) {
       const isMin = param === 'min';
       const isTest = param === 'test';
+      const isDev = param === 'dev';
+
       const filename = isMin
         ? 'p5.pre-min.js'
         : isTest ? 'p5-test.js' : 'p5.js';
@@ -32,9 +34,14 @@ module.exports = function(grunt) {
       // Render the banner for the top of the file
       const banner = grunt.template.process(bannerTemplate);
 
+      let globalsVars = {};
+      if (isDev) {
+        globalsVars['P5_DEV_BUILD'] = () => true;
+      }
       // Invoke Browserify programatically to bundle the code
       let browseified = browserify(srcFilePath, {
-        standalone: 'p5'
+        standalone: 'p5',
+        insertGlobalVars: globalsVars
       });
 
       if (isMin) {
@@ -48,6 +55,10 @@ module.exports = function(grunt) {
           .exclude('./browser_errors')
           .ignore('i18next')
           .ignore('i18next-browser-languagedetector');
+      }
+
+      if (!isDev) {
+        browseified = browseified.exclude('../../translations/dev');
       }
 
       const babelifyOpts = { plugins: ['static-fs'] };

--- a/tasks/build/browserify.js
+++ b/tasks/build/browserify.js
@@ -34,21 +34,21 @@ module.exports = function(grunt) {
       // Render the banner for the top of the file
       const banner = grunt.template.process(bannerTemplate);
 
-      let globalsVars = {};
+      let globalVars = {};
       if (isDev) {
-        globalsVars['P5_DEV_BUILD'] = () => true;
+        globalVars['P5_DEV_BUILD'] = () => true;
       }
       // Invoke Browserify programatically to bundle the code
-      let browseified = browserify(srcFilePath, {
+      let browserified = browserify(srcFilePath, {
         standalone: 'p5',
-        insertGlobalVars: globalsVars
+        insertGlobalVars: globalVars
       });
 
       if (isMin) {
         // These paths should be the exact same as what are used in the import
         // statements in the source. They are not relative to this file. It's
         // just how browserify works apparently.
-        browseified = browseified
+        browserified = browserified
           .exclude('../../docs/reference/data.json')
           .exclude('../../../docs/parameterData.json')
           .exclude('../../translations')
@@ -58,7 +58,7 @@ module.exports = function(grunt) {
       }
 
       if (!isDev) {
-        browseified = browseified.exclude('../../translations/dev');
+        browserified = browserified.exclude('../../translations/dev');
       }
 
       const babelifyOpts = { plugins: ['static-fs'] };
@@ -67,7 +67,7 @@ module.exports = function(grunt) {
         babelifyOpts.envName = 'test';
       }
 
-      const bundle = browseified.transform('babelify', babelifyOpts).bundle();
+      const bundle = browserified.transform('babelify', babelifyOpts).bundle();
 
       // Start the generated output with the banner comment,
       let code = banner + '\n';

--- a/translations/dev.js
+++ b/translations/dev.js
@@ -1,0 +1,15 @@
+export { default as en_translation } from './en/translation';
+export { default as es_translation } from './es/translation';
+
+/** 
+ * When adding a new language, add a new "export" statement above this.
+ * For example, if we were to add fr ( French ), we would write:
+ * export { default as fr_translation } from './fr/translation';
+ *
+ * If the language key has a hypen (-), replace it with an underscore ( _ )
+ * e.g. for es-MX we would write:
+ * export { default as es_MX_translation } from './es-MX/translation';
+ * 
+ * "es_MX" is the language key whereas "translation" is the filename
+ * ( translation.json ) or the namespace
+*/

--- a/translations/index.js
+++ b/translations/index.js
@@ -1,11 +1,13 @@
 import en from './en/translation';
 
+// Only one language is imported above. This is intentional as other languages
+// will be hosted online and then downloaded whenever needed
+
 /**
- * Maps our translations to their language key
- * (`en` is english, `es` es español)
- *
- * `translation` is the namespace we're using for
- * our initial set of translation strings.
+ * Here, we define a default/fallback language which we can use without internet.
+ * You won't have to change this when adding a new language.
+ * 
+ * `translation` is the namespace we are using for our initial set of strings
  */
 export default {
   en: {
@@ -13,7 +15,12 @@ export default {
   }
 };
 
-// List of languages added so far
+/**
+ * This is a list of languages that we have added so far.
+ * If you have just added a new language (yay!), add its key to the list below
+ * (`en` is english, `es` es español). Also add its export to 
+ * dev.js, which is another file in this folder.
+ */
 export const languages = [
   'en',
   'es'

--- a/translations/index.js
+++ b/translations/index.js
@@ -1,5 +1,4 @@
 import en from './en/translation';
-import es from './es/translation';
 
 /**
  * Maps our translations to their language key
@@ -11,8 +10,11 @@ import es from './es/translation';
 export default {
   en: {
     translation: en
-  },
-  es: {
-    translation: es
   }
 };
+
+// List of languages added so far
+export const languages = [
+  'en',
+  'es'
+];


### PR DESCRIPTION
<!--
  Thank you for contributing! Please use this pull request (PR) template.


 In the description field of this PR, include "resolves #XXXX" tagging the issue you are fixing. If this PR addresses the issue but doesn't completely resolve it (ie the issue should remain open after your PR is merged), write "addresses #XXXX".-->
Resolves #4694

 Changes:
- [x] Publish translation files to a CDN with every release. I have set it up so that the contents under the path `translations/**` get published to NPM. From there, jsDelivr can cache it to their CDN.
I published a namespaced version to test this out and it seems to work
https://cdn.jsdelivr.net/npm/@akshay-99/p5-test@1.0.1/translations/es/translation.json
https://cdn.jsdelivr.net/npm/@akshay-99/p5-test@1.0.1/translations/en/translation.json

These changes would take effect from the next release. Before then, the configured path ( https://cdn.jsdelivr.net/npm/p5/translations/ ) would give us a 404. This wouldn't be a problem for contributors because of the next point below.

- [x] Use local translation files in `dev` mode. Whenever someone is adding/updating something, they should be able to test it out. Fetching from the CDN will not be helpful as these changes wouldn't have been published yet. I configured grunt and browserify to pack all the translation files in the library when running `browserify:dev` ( i.e with `npm run dev` but not with `npm run build` )

Also, since we have updated our default branch name to `main`, we may have to change something with `np` to let it know this. Otherwise it complains that we aren't on the correct branch and would stop the release. For testing out this PR, I just manually passed in `--any-branch`. But there must be some other way to let `np` know the name of the default branch. 

#### PR Checklist
<!--
  To check any option, replace the "[ ]" with a "[x]". Be sure to check out how it looks in the Preview tab! Feel free to remove any portion of the template that is not relevant for your issue.
-->

- [x] `npm run lint` passes
- [ ] [Inline documentation] is included / updated
- [ ] [Unit tests] are included / updated

[Inline documentation]: https://github.com/processing/p5.js/blob/main/contributor_docs/inline_documentation.md
[Unit tests]: https://github.com/processing/p5.js/tree/main/contributor_docs#unit-tests
