### PR TITLE
Enable deploying from 'main' branch

### DIFF
--- a/tasks/release/release-p5.js
+++ b/tasks/release/release-p5.js
@@ -3,16 +3,34 @@
 
 const open = require('open');
 const spawn = require('child_process').spawnSync;
+const simpleGit = require('simple-git/promise');
 
 module.exports = function(grunt) {
   // Register the Release Task
   grunt.registerTask(
     'release-p5',
     'Drafts and Publishes a fresh release of p5.js',
-    function(args) {
+    async function(args) {
+      const done = this.async();
+
+      // Check we are currently on the 'main' branch, refuse to continue
+      // if not and preview is not true.
+      // This section should be removed once support for 'main' branch
+      // is added to np
+      const git = simpleGit();
+      const branches = await git.branchLocal();
+      if (branches.current !== 'main' && !grunt.option('preview')) {
+        console.log('Not on "main" branch, refusing to deploy.');
+        console.log('Preview the release step with the "--preview" flag.');
+        done();
+        return;
+      }
+
       spawn(
         'npx np',
-        grunt.option('preview') ? ['--any-branch', '--preview'] : [],
+        grunt.option('preview')
+          ? ['--any-branch', '--preview']
+          : ['--any-branch'],
         {
           stdio: 'inherit',
           shell: true
@@ -45,6 +63,8 @@ module.exports = function(grunt) {
       // 3. Push the docs out to the website
       grunt.task.run('yui');
       grunt.task.run('release-docs');
+
+      done();
     }
   );
 };


### PR DESCRIPTION
Mentioned in #4701

 Changes:
Enabling `np` to deploy from the `main` branch and adding a check to make sure git is currently at the `main` branch. Usage of the release step is still the same. The `--preview` flag can still be used to preview release from any branch.

#### PR Checklist
<!--
  To check any option, replace the "[ ]" with a "[x]". Be sure to check out how it looks in the Preview tab! Feel free to remove any portion of the template that is not relevant for your issue.
-->

- [ ] `npm run lint` passes
- [ ] [Inline documentation] is included / updated
- [ ] [Unit tests] are included / updated

[Inline documentation]: https://github.com/processing/p5.js/blob/main/contributor_docs/inline_documentation.md
[Unit tests]: https://github.com/processing/p5.js/tree/main/contributor_docs#unit-tests
