### PR TITLE
mark randomGaussian jsdoc params as optional

### DIFF
--- a/src/math/random.js
+++ b/src/math/random.js
@@ -165,8 +165,8 @@ p5.prototype.random = function(min, max) {
  * If two args, first is mean, second is standard deviation.
  *
  * @method randomGaussian
- * @param  {Number} mean  the mean
- * @param  {Number} sd    the standard deviation
+ * @param  {Number} [mean]  the mean
+ * @param  {Number} [sd]    the standard deviation
  * @return {Number} the random number
  * @example
  * <div>


### PR DESCRIPTION
According to the [reference](https://p5js.org/reference/#/p5/randomGaussian) this function can be called with no arguments but TypeScript is showing a type error. 

<img width="604" alt="Screen Shot 2020-07-28 at 8 36 38 pm" src="https://user-images.githubusercontent.com/13985/88655406-0d3dec80-d112-11ea-9e2e-df5da7fe71b1.png">

 Changes:

* Updated the `@params` section of `randomGaussian`



