### PR TITLE
FES: Handle multiple nearest matches for a misspelt symbol

### DIFF
--- a/test/unit/core/error_helpers.js
+++ b/test/unit/core/error_helpers.js
@@ -388,24 +388,43 @@ suite('Error Helpers', function() {
     });
 
     testUnMinified('detects capitalization mistakes', function() {
+      const logMsg = help(new ReferenceError('MouseX is not defined'));
       assert.match(
-        help(new ReferenceError('MouseX is not defined')),
-        /It seems that you may have accidently written MouseX instead of mouseX/
+        logMsg,
+        /It seems that you may have accidently written "MouseX"/
       );
+      assert.match(logMsg, /mouseX/);
     });
 
     testUnMinified('detects spelling mistakes', function() {
+      const logMsg = help(new ReferenceError('colour is not defined'));
       assert.match(
-        help(new ReferenceError('colour is not defined')),
-        /It seems that you may have accidently written colour instead of color/
+        logMsg,
+        /It seems that you may have accidently written "colour"/
       );
+      assert.match(logMsg, /color/);
     });
 
+    testUnMinified(
+      'can give more than one closest matches, if applicable',
+      function() {
+        const logMsg = help(new ReferenceError('strok is not defined'));
+        assert.match(
+          logMsg,
+          /It seems that you may have accidently written "strok"/
+        );
+        assert.match(logMsg, /stroke/);
+        assert.match(logMsg, /STROKE/);
+      }
+    );
+
     testUnMinified('detects spelling + captialization mistakes', function() {
+      const logMsg = help(new ReferenceError('RandomGossian is not defined'));
       assert.match(
-        help(new ReferenceError('RandomGossian is not defined')),
-        /It seems that you may have accidently written RandomGossian instead of randomGaussian/
+        logMsg,
+        /It seems that you may have accidently written "RandomGossian"/
       );
+      assert.match(logMsg, /randomGaussian/);
     });
   });
 

--- a/translations/en/translation.json
+++ b/translations/en/translation.json
@@ -37,7 +37,8 @@
     },
     "libraryError": "An error with message \"{{error}}\" occured inside the p5js library when {{func}} was called {{location}}\n\nIf not stated otherwise, it might be an issue with the arguments passed to {{func}}.",
     "location": "(on line {{line}} in {{file}} [{{location}}])",
-    "misspelling": "It seems that you may have accidently written {{name}} instead of {{actualName}} {{location}}.\n\nPlease correct it to {{actualName}} if you wish to use the {{type}} from p5.js",
+    "misspelling": "It seems that you may have accidently written \"{{name}}\" instead of \"{{actualName}}\" {{location}}.\n\nPlease correct it to {{actualName}} if you wish to use the {{type}} from p5.js",
+    "misspelling_plural": "It seems that you may have accidently written \"{{name}}\" {{location}}.\n\nYou may have meant one of the following:\n{{suggestions}}",
     "misusedTopLevel": "Did you just try to use p5.js's {{symbolName}} {{symbolType}}? If so, you may want to move it into your sketch's setup() function.\n\nFor more details, see: {{link}}",
     "positions": {
       "p_1": "first",

--- a/translations/es/translation.json
+++ b/translations/es/translation.json
@@ -38,6 +38,7 @@
     "libraryError": "",
     "location": "",
     "misspelling": "",
+    "misspelling_plural": "",
     "misusedTopLevel": "",
     "positions": {
       "p_1": "",


### PR DESCRIPTION
<!--
  Thank you for contributing! Please use this pull request (PR) template.


 In the description field of this PR, include "resolves #XXXX" tagging the issue you are fixing. If this PR addresses the issue but doesn't completely resolve it (ie the issue should remain open after your PR is merged), write "addresses #XXXX".-->
Addresses #4637

 ### Changes:
Modify misspelling detection to handle edge cases where the typed symbol closely matches ( is the same distance away from )  two or more p5 functions/members. 
For example, some misspelt symbol like `stoke` could match both `stroke` ( the function ) and `STROKE` ( the constant ). Earlier it would only suggest one. Now it will suggest both as 
```
🌸 p5.js says: It seems that you may have accidently written "stoke" (on line 3 in sketch.js [http://localhost:8000/lib/empty-example/sketch.js:3:3]).

You may have meant one of the following:

▶️ STROKE (http://p5js.org/reference/#/p5/STROKE)
▶️ stroke() (http://p5js.org/reference/#/p5/stroke)
```


#### PR Checklist
<!--
  To check any option, replace the "[ ]" with a "[x]". Be sure to check out how it looks in the Preview tab! Feel free to remove any portion of the template that is not relevant for your issue.
-->

- [x] `npm run lint` passes
- [ ] [Inline documentation] is included / updated
- [x] [Unit tests] are included / updated

[Inline documentation]: https://github.com/processing/p5.js/blob/main/contributor_docs/inline_documentation.md
[Unit tests]: https://github.com/processing/p5.js/tree/main/contributor_docs#unit-tests
