### PR TITLE
Prevent setup from running twice 

### DIFF
--- a/src/core/main.js
+++ b/src/core/main.js
@@ -283,9 +283,11 @@ class p5 {
         if (loadingScreen) {
           loadingScreen.parentNode.removeChild(loadingScreen);
         }
-        this._lastFrameTime = window.performance.now();
-        context._setup();
-        context._draw();
+        if (!this._setupDone) {
+          this._lastFrameTime = window.performance.now();
+          context._setup();
+          context._draw();
+        }
       }
     };
 


### PR DESCRIPTION
<!--
  Thank you for contributing! Please use this pull request (PR) template.


 In the description field of this PR, include "resolves #XXXX" tagging the issue you are fixing. If this PR addresses the issue but doesn't completely resolve it (ie the issue should remain open after your PR is merged), write "addresses #XXXX".-->
Resolves #4669

### Changes:
Before calling `_setup` ( which in turn calls user-defined `setup` ), check if it has already run before. Quite a simple fix but seems to work.


#### PR Checklist
<!--
  To check any option, replace the "[ ]" with a "[x]". Be sure to check out how it looks in the Preview tab! Feel free to remove any portion of the template that is not relevant for your issue.
-->

- [x] `npm run lint` passes
- [ ] [Inline documentation] is included / updated
- [ ] [Unit tests] are included / updated

[Inline documentation]: https://github.com/processing/p5.js/blob/main/contributor_docs/inline_documentation.md
[Unit tests]: https://github.com/processing/p5.js/tree/main/contributor_docs#unit-tests
