### PR TITLE
getItem() uses parseFloat instead of parseInt

### DIFF
--- a/src/data/local_storage.js
+++ b/src/data/local_storage.js
@@ -150,7 +150,7 @@ p5.prototype.getItem = function(key) {
   } else if (value !== null) {
     switch (type) {
       case 'number':
-        value = parseInt(value);
+        value = parseFloat(value);
         break;
       case 'boolean':
         value = value === 'true';


### PR DESCRIPTION
Resolves #4740

 Changes:
Changed `parseInt()` to `parseFloat()`
