### PR TITLE
Overlap of code and canvas in the p5 website.

### DIFF
--- a/src/io/files.js
+++ b/src/io/files.js
@@ -844,23 +844,16 @@ p5.prototype.httpGet = function() {
  * // Examples use jsonplaceholder.typicode.com for a Mock Data API
  *
  * let url = 'https://jsonplaceholder.typicode.com/posts';
- * let postData = { userId: 1, title: 'p5 Clicked!', body: 'p5.js is way cool.' };
+ * let postData = { userId: 1, title: 'p5 Clicked!', body: 'p5.js is very cool.' };
  *
  * function setup() {
- *   createCanvas(800, 800);
+ *   createCanvas(100, 100);
+ *	 background(200);
  * }
  *
  * function mousePressed() {
- *   // Pick new random color values
- *   let r = random(255);
- *   let g = random(255);
- *   let b = random(255);
- *
- *   httpPost(url, 'json', postData, function(result) {
+ *     httpPost(url, 'json', postData, function(result) {
  *     strokeWeight(2);
- *     stroke(r, g, b);
- *     fill(r, g, b, 127);
- *     ellipse(mouseX, mouseY, 200, 200);
  *     text(result.body, mouseX, mouseY);
  *   });
  * }
@@ -869,18 +862,14 @@ p5.prototype.httpGet = function() {
  *
  * <div><code>
  * let url = 'ttps://invalidURL'; // A bad URL that will cause errors
- * let postData = { title: 'p5 Clicked!', body: 'p5.js is way cool.' };
+ * let postData = { title: 'p5 Clicked!', body: 'p5.js is very cool.' };
  *
  * function setup() {
- *   createCanvas(800, 800);
+ *   createCanvas(100, 100);
+ *	 background(200);
  * }
  *
  * function mousePressed() {
- *   // Pick new random color values
- *   let r = random(255);
- *   let g = random(255);
- *   let b = random(255);
- *
  *   httpPost(
  *     url,
  *     'json',
@@ -890,8 +879,6 @@ p5.prototype.httpGet = function() {
  *     },
  *     function(error) {
  *       strokeWeight(2);
- *       stroke(r, g, b);
- *       fill(r, g, b, 127);
  *       text(error.toString(), mouseX, mouseY);
  *     }
  *   );

--- a/src/io/files.js
+++ b/src/io/files.js
@@ -848,11 +848,11 @@ p5.prototype.httpGet = function() {
  *
  * function setup() {
  *   createCanvas(100, 100);
- *	 background(200);
+ *   background(200);
  * }
  *
  * function mousePressed() {
- *     httpPost(url, 'json', postData, function(result) {
+ *   httpPost(url, 'json', postData, function(result) {
  *     strokeWeight(2);
  *     text(result.body, mouseX, mouseY);
  *   });
@@ -866,7 +866,7 @@ p5.prototype.httpGet = function() {
  *
  * function setup() {
  *   createCanvas(100, 100);
- *	 background(200);
+ *   background(200);
  * }
  *
  * function mousePressed() {


### PR DESCRIPTION
<!--
  Thank you for contributing! Please use this pull request (PR) template.


 In the description field of this PR, include "resolves #XXXX" tagging the issue you are fixing. If this PR addresses the issue but doesn't completely resolve it (ie the issue should remain open after your PR is merged), write "addresses #XXXX".-->
Resolves [#815](https://github.com/processing/p5.js-website/issues/815)

 Changes:
<!-- Add here what changes were made in this pull request and if possible provide links showcasing the changes. -->Edited httppost() section in 
**src/io/files.js**
1. Changed canvas size to 100x100
2. Simplified the example by removing colouring and circle drawing sections. 

 Screenshots of the change:
<!-- If applicable, add screenshots depicting the changes. -->
![Screenshot from 2020-08-22 15-11-44](https://user-images.githubusercontent.com/43999912/90960641-bb924300-e4c0-11ea-9261-c0a691c468ae.png)

#### PR Checklist
<!--
  To check any option, replace the "[ ]" with a "[x]". Be sure to check out how it looks in the Preview tab! Feel free to remove any portion of the template that is not relevant for your issue.
-->

- [x] `npm run lint` passes
- [x] [Inline documentation] is included / updated
- [x] [Unit tests] are included / updated

[Inline documentation]: https://github.com/processing/p5.js/blob/main/contributor_docs/inline_documentation.md
[Unit tests]: https://github.com/processing/p5.js/tree/main/contributor_docs#unit-tests
