### PR TITLE
Fix HTML element rendering for inline docs

### DIFF
--- a/src/dom/dom.js
+++ b/src/dom/dom.js
@@ -310,7 +310,7 @@ function addElement(elt, pInst, media) {
 }
 
 /**
- * Creates a &lt;div&gt;&lt;/div&gt; element in the DOM with given inner HTML.
+ * Creates a `&lt;div&gt;&lt;/div&gt;` element in the DOM with given inner HTML.
  *
  * @method createDiv
  * @param  {String} [html] inner HTML for element created
@@ -327,7 +327,7 @@ p5.prototype.createDiv = function(html = '') {
 };
 
 /**
- * Creates a &lt;p&gt;&lt;/p&gt; element in the DOM with given inner HTML. Used
+ * Creates a `&lt;p&gt;&lt;/p&gt;` element in the DOM with given inner HTML. Used
  * for paragraph length text.
  *
  * @method createP
@@ -345,7 +345,7 @@ p5.prototype.createP = function(html = '') {
 };
 
 /**
- * Creates a &lt;span&gt;&lt;/span&gt; element in the DOM with given inner HTML.
+ * Creates a `&lt;span&gt;&lt;/span&gt;` element in the DOM with given inner HTML.
  *
  * @method createSpan
  * @param  {String} [html] inner HTML for element created
@@ -362,7 +362,7 @@ p5.prototype.createSpan = function(html = '') {
 };
 
 /**
- * Creates an &lt;img&gt; element in the DOM with given src and
+ * Creates an `&lt;img&gt;` element in the DOM with given src and
  * alternate text.
  *
  * @method createImg
@@ -408,7 +408,7 @@ p5.prototype.createImg = function() {
 };
 
 /**
- * Creates an &lt;a&gt;&lt;/a&gt; element in the DOM for including a hyperlink.
+ * Creates an `&lt;a&gt;&lt;/a&gt;` element in the DOM for including a hyperlink.
  *
  * @method createA
  * @param  {String} href       url of page to link to
@@ -433,7 +433,7 @@ p5.prototype.createA = function(href, html, target) {
 /** INPUT **/
 
 /**
- * Creates a slider &lt;input&gt;&lt;/input&gt; element in the DOM.
+ * Creates a slider `&lt;input&gt;&lt;/input&gt;` element in the DOM.
  * Use .size() to set the display length of the slider.
  *
  * @method createSlider
@@ -488,7 +488,7 @@ p5.prototype.createSlider = function(min, max, value, step) {
 };
 
 /**
- * Creates a &lt;button&gt;&lt;/button&gt; element in the DOM.
+ * Creates a `&lt;button&gt;&lt;/button&gt;` element in the DOM.
  * Use .size() to set the display size of the button.
  * Use .mousePressed() to specify behavior on press.
  *
@@ -522,7 +522,7 @@ p5.prototype.createButton = function(label, value) {
 };
 
 /**
- * Creates a checkbox &lt;input&gt;&lt;/input&gt; element in the DOM.
+ * Creates a checkbox `&lt;input&gt;&lt;/input&gt;` element in the DOM.
  * Calling .checked() on a checkbox returns if it is checked or not
  *
  * @method createCheckbox
@@ -590,7 +590,7 @@ p5.prototype.createCheckbox = function() {
 };
 
 /**
- * Creates a dropdown menu &lt;select&gt;&lt;/select&gt; element in the DOM.
+ * Creates a dropdown menu `&lt;select&gt;&lt;/select&gt;` element in the DOM.
  * It also helps to assign select-box methods to <a href="#/p5.Element">p5.Element</a> when selecting existing select box.
  * - `.option(name, [value])` can be used to set options for the select after it is created.
  * - `.value()` will return the currently selected option.
@@ -1004,7 +1004,7 @@ p5.prototype.createColorPicker = function(value) {
 };
 
 /**
- * Creates an &lt;input&gt;&lt;/input&gt; element in the DOM for text input.
+ * Creates an `&lt;input&gt;&lt;/input&gt;` element in the DOM for text input.
  * Use .<a href="#/p5.Element/size">size()</a> to set the display length of the box.
  *
  * @method createInput
@@ -1038,7 +1038,7 @@ p5.prototype.createInput = function(value = '', type = 'text') {
 };
 
 /**
- * Creates an &lt;input&gt;&lt;/input&gt; element in the DOM of type 'file'.
+ * Creates an `&lt;input&gt;&lt;/input&gt;` element in the DOM of type 'file'.
  * This allows users to select local files for use in a sketch.
  *
  * @method createFileInput
@@ -1145,7 +1145,7 @@ function createMedia(pInst, type, src, callback) {
 }
 
 /**
- * Creates an HTML5 &lt;video&gt; element in the DOM for simple playback
+ * Creates an HTML5 `&lt;video&gt;` element in the DOM for simple playback
  * of audio/video. Shown by default, can be hidden with .<a href="#/p5.Element/hide">hide()</a>
  * and drawn into canvas using <a href="#/p5/image">image()</a>. The first parameter
  * can be either a single string path to a video file, or an array of string
@@ -1193,7 +1193,7 @@ p5.prototype.createVideo = function(src, callback) {
 /** AUDIO STUFF **/
 
 /**
- * Creates a hidden HTML5 &lt;audio&gt; element in the DOM for simple audio
+ * Creates a hidden HTML5 `&lt;audio&gt;` element in the DOM for simple audio
  * playback. The first parameter can be either a single string path to a
  * audio file, or an array of string paths to different formats of the same
  * audio. This is useful for ensuring that your audio can play across
@@ -1275,7 +1275,7 @@ if (navigator.mediaDevices.getUserMedia === undefined) {
 }
 
 /**
- * Creates a new HTML5 &lt;video&gt; element that contains the audio/video feed
+ * Creates a new HTML5 `&lt;video&gt;` element that contains the audio/video feed
  * from a webcam. The element is separate from the canvas and is displayed by
  * default. The element can be hidden using .<a href="#/p5.Element/hide">hide()</a>.
  * The feed can be drawn onto the canvas using <a href="#/p5/image">image()</a>.


### PR DESCRIPTION
<!--
  Thank you for contributing! Please use this pull request (PR) template.


 In the description field of this PR, include "resolves #XXXX" tagging the issue you are fixing. If this PR addresses the issue but doesn't completely resolve it (ie the issue should remain open after your PR is merged), write "addresses #XXXX".-->
Resolves #4710

 Changes:
<!-- Add here what changes were made in this pull request and if possible provide links showcasing the changes. -->
Changed the HTML tags written in [dom.js](https://github.com/processing/p5.js/blob/main/src/dom/dom.js) file's inline documentation to markdown code syntax (by wrapping the element's tags with \`\`). This prevents rendering of these tags as HTML element in the documentation page (see screenshots for more) by the yuidoc generator.

Code changed from:
<img width="406" alt="oh2" src="https://user-images.githubusercontent.com/34810212/90974683-ffca2580-e54a-11ea-8f16-90310c26407a.png">
to:
<img width="446" alt="oh1" src="https://user-images.githubusercontent.com/34810212/90974689-0789ca00-e54b-11ea-98a3-21bf561c26b5.png">

 Screenshots of the change:
1. createInput() reference docs (similar for createP, createDiv, createSlider and createSpan): 
<img width="608" alt="fix_00" src="https://user-images.githubusercontent.com/34810212/90974281-5f263680-e547-11ea-9775-f60325455358.png">

gets fixed to:
<img width="809" alt="fix" src="https://user-images.githubusercontent.com/34810212/90974296-8250e600-e547-11ea-92b8-1f64938412ae.png">

2. createSelect() reference docs:
<img width="586" alt="fix_003" src="https://user-images.githubusercontent.com/34810212/90974308-9f85b480-e547-11ea-89c2-7df6076ffa11.png">

gets fixed to: 
<img width="740" alt="fix_004" src="https://user-images.githubusercontent.com/34810212/90974313-a6acc280-e547-11ea-9434-0570ad2db4f3.png">

3. createAudio() reference docs (similar for createVideo):
<img width="581" alt="fix_005" src="https://user-images.githubusercontent.com/34810212/90974326-c04e0a00-e547-11ea-99b3-c9f2170785f2.png">

gets fixed to:
<img width="752" alt="fix_006" src="https://user-images.githubusercontent.com/34810212/90974329-ccd26280-e547-11ea-9d17-2d599502489d.png">



#### PR Checklist
<!--
  To check any option, replace the "[ ]" with a "[x]". Be sure to check out how it looks in the Preview tab! Feel free to remove any portion of the template that is not relevant for your issue.
-->

- [x] `npm run lint` passes
- [x] [Inline documentation] is included / updated
- [ ] [Unit tests] are included / updated

[Inline documentation]: https://github.com/processing/p5.js/blob/main/contributor_docs/inline_documentation.md
[Unit tests]: https://github.com/processing/p5.js/tree/main/contributor_docs#unit-tests
