### PR TITLE
Implementing p5.Vector setHeading() (Issue #4767)

### DIFF
--- a/src/math/p5.Vector.js
+++ b/src/math/p5.Vector.js
@@ -1441,6 +1441,30 @@ p5.Vector.prototype.heading = function heading() {
 };
 
 /**
+ * Rotate the vector to a specific angle (only 2D vectors), magnitude remains the
+ * same
+ *
+ * @method setHeading
+ * @param  {number}    angle the angle of rotation
+ * @chainable
+ * @example
+ * <div class="norender">
+ * <code>
+ * let v = createVector(10.0, 20.0);
+ * // result of v.heading() is 1.1071487177940904
+ * v.setHeading(Math.PI);
+ * // result of v.heading() is now 3.141592653589793
+ * </code>
+ * </div>
+ */
+
+p5.Vector.prototype.setHeading = function setHeading(a) {
+  this.rotate(-this.heading());
+  this.rotate(a);
+  return this;
+};
+
+/**
  * Rotate the vector by an angle (only 2D vectors), magnitude remains the
  * same
  *

--- a/src/math/p5.Vector.js
+++ b/src/math/p5.Vector.js
@@ -1459,8 +1459,9 @@ p5.Vector.prototype.heading = function heading() {
  */
 
 p5.Vector.prototype.setHeading = function setHeading(a) {
-  this.rotate(-this.heading());
-  this.rotate(a);
+  let m = this.mag();
+  this.x = m * Math.cos(a);
+  this.y = m * Math.sin(a);
   return this;
 };
 

--- a/test/unit/math/p5.Vector.js
+++ b/test/unit/math/p5.Vector.js
@@ -20,10 +20,10 @@ suite('p5.Vector', function() {
 
   suite('setHeading', function() {
     setup(function() {
-      v = createVector(1,1);
+      v = myp5.createVector(1, 1);
       v.setHeading(1);
     });
-    test('should have heading() value of 0', function(){
+    test('should have heading() value of 1', function() {
       assert.closeTo(v.heading(), 1, 0.001);
     });
   });

--- a/test/unit/math/p5.Vector.js
+++ b/test/unit/math/p5.Vector.js
@@ -18,6 +18,15 @@ suite('p5.Vector', function() {
   });
   var v;
 
+  suite('setHeading', function() {
+    setup(function() {
+      v = createVector(1,1);
+      v.setHeading(1);
+    });
+    test('should have heading() value of 0', function(){
+      assert.closeTo(v.heading(), 1, 0.001);
+    });
+  });
   suite('p5.prototype.createVector()', function() {
     setup(function() {
       v = myp5.createVector();


### PR DESCRIPTION
This commit adds the `setHeading()` function to the `p5.Vector` class. There are
some remaining issues here. For example, there are no tests. However, there
is an example of it's use.

<!--
  Thank you for contributing! Please use this pull request (PR) template.


 In the description field of this PR, include "resolves #XXXX" tagging the issue you are fixing. If this PR addresses the issue but doesn't completely resolve it (ie the issue should remain open after your PR is merged), write "addresses #XXXX".-->
Resolves #4767 

#### PR Checklist
<!--
  To check any option, replace the "[ ]" with a "[x]". Be sure to check out how it looks in the Preview tab! Feel free to remove any portion of the template that is not relevant for your issue.
-->

- [x] `npm run lint` passes
- [x] [Inline documentation] is included / updated
- [ ] [Unit tests] are included / updated

[Inline documentation]: https://github.com/processing/p5.js/blob/main/contributor_docs/inline_documentation.md
[Unit tests]: https://github.com/processing/p5.js/tree/main/contributor_docs#unit-tests
