### PR TITLE
changes in saveTable of files.js

### DIFF
--- a/src/io/files.js
+++ b/src/io/files.js
@@ -1718,11 +1718,19 @@ p5.prototype.saveTable = function(table, filename, options) {
       let j;
       for (j = 0; j < table.rows[i].arr.length; j++) {
         if (j < table.rows[i].arr.length - 1) {
-          pWriter.write(table.rows[i].arr[j] + sep);
-        } else if (i < table.rows.length - 1) {
-          pWriter.write(table.rows[i].arr[j]);
+          //double quotes should be inserted in csv only if contains comma separated single value
+          if (ext === 'csv' && table.rows[i].arr[j].includes(',')) {
+            pWriter.write('"' + table.rows[i].arr[j] + '"' + sep);
+          } else {
+            pWriter.write(table.rows[i].arr[j] + sep);
+          }
         } else {
-          pWriter.write(table.rows[i].arr[j]);
+          //double quotes should be inserted in csv only if contains comma separated single value
+          if (ext === 'csv' && table.rows[i].arr[j].includes(',')) {
+            pWriter.write('"' + table.rows[i].arr[j] + '"');
+          } else {
+            pWriter.write(table.rows[i].arr[j]);
+          }
         }
       }
       pWriter.write('\n');


### PR DESCRIPTION
<!--
  Thank you for contributing! Please use this pull request (PR) template.


 In the description field of this PR, include "resolves #XXXX" tagging the issue you are fixing. If this PR addresses the issue but doesn't completely resolve it (ie the issue should remain open after your PR is merged), write "addresses #XXXX".-->
Resolves #4766 

 Changes:
<!-- Add here what changes were made in this pull request and if possible provide links showcasing the changes. -->
- comma separated value for a single cell in csv is now stored in a single cell.

Example: 

```
function setup() {

  const table = new p5.Table();
  table.addColumn('name');
  table.addColumn('species');

  let row1 = table.addRow();
  row1.setString('name', 'Lion');
  row1.setString('species', 'Panthera leo');

  let row2 = table.addRow();
  row2.setString('name', 'Woodpecker, Greater Spotted')
  row2.setString('species', 'Dendrocopos major')

  saveTable(table, 'new.csv');

}
```
For the above code the previous output was:
![image](https://user-images.githubusercontent.com/45002201/91658354-2ce77c80-eae5-11ea-8d7e-f3e07e026cf8.png)

Output after change is:
![image](https://user-images.githubusercontent.com/45002201/91658383-5ef8de80-eae5-11ea-8638-dc04eaa4d02d.png)

#### PR Checklist
<!--
  To check any option, replace the "[ ]" with a "[x]". Be sure to check out how it looks in the Preview tab! Feel free to remove any portion of the template that is not relevant for your issue.
-->

- [x] `npm run lint` passes
- [ ] [Inline documentation] is included / updated
- [ ] [Unit tests] are included / updated

[Inline documentation]: https://github.com/processing/p5.js/blob/main/contributor_docs/inline_documentation.md
[Unit tests]: https://github.com/processing/p5.js/tree/main/contributor_docs#unit-tests
