### PR TITLE
Fix inconsistent single-spaces after periods: 2d_primitives.js - circle

### DIFF
--- a/src/core/shape/2d_primitives.js
+++ b/src/core/shape/2d_primitives.js
@@ -269,9 +269,9 @@ p5.prototype.ellipse = function(x, y, w, h, detailX) {
 };
 
 /**
- * Draws a circle to the screen. A circle is a simple closed shape.It is the set
+ * Draws a circle to the screen. A circle is a simple closed shape. It is the set
  * of all points in a plane that are at a given distance from a given point,
- * the centre.This function is a special case of the ellipse() function, where
+ * the centre. This function is a special case of the ellipse() function, where
  * the width and height of the ellipse are the same. Height and width of the
  * ellipse correspond to the diameter of the circle. By default, the first two
  * parameters set the location of the centre of the circle, the third sets the


### PR DESCRIPTION
Update inline reference for [circle ](https://github.com/processing/p5.js/blob/b15ca7c7ac8ba95ccb0123cf74fc163040090e1b/src/core/shape/2d_primitives.js#L259)so that the use of single-spaces are consistent.

<!--
  Thank you for contributing! Please use this pull request (PR) template.


 In the description field of this PR, include "resolves #XXXX" tagging the issue you are fixing. If this PR addresses the issue but doesn't completely resolve it (ie the issue should remain open after your PR is merged), write "addresses #XXXX".-->
Resolves [#871 (p5.js-website)](https://github.com/processing/p5.js-website/issues/871)

 **Changes:**
Added single-spaces after periods where needed.

 **Screenshots of the change:**
![p5-js-inconsistent-spacing-after-periods-fixed](https://user-images.githubusercontent.com/63413065/92814855-4613e700-f389-11ea-81d4-e4854555adc7.jpg)


#### PR Checklist
<!--
  To check any option, replace the "[ ]" with a "[x]". Be sure to check out how it looks in the Preview tab! Feel free to remove any portion of the template that is not relevant for your issue.
-->

- [x] `npm run lint` passes
- [x] [Inline documentation] is included / updated

[Inline documentation]: https://github.com/processing/p5.js/blob/main/contributor_docs/inline_documentation.md
[Unit tests]: https://github.com/processing/p5.js/tree/main/contributor_docs#unit-tests
