### PR TITLE
docs: fix typos in contributing docs

### DIFF
--- a/contributor_docs/contributing_documentation.md
+++ b/contributor_docs/contributing_documentation.md
@@ -1,17 +1,17 @@
-Documentation is essential for new learners and experienced programmers alike. It helps make our community inclusive by extending a friendly hand to those that are less familiar with p5.js. It also helps us find the bugs and issues with the code itself, because we test and try things out as we document.
+Documentation is essential for new learners and experienced programmers alike. It helps make our community inclusive by extending a friendly hand to those who are less familiar with p5.js. It also helps us find the bugs and issues with the code itself, because we test and try things out as we document.
 
 There are several ways to contribute to documentation:
 
 ## ☝️ Open issues
-If you're just getting started, one really helpful thing way you can contribute is by opening issues for documentation needs. If you notice a typo, a missing or broken example, or a function description that is confusing, [open an issue for it](https://github.com/processing/p5.js/issues)! Please include a link to the page that needs fixing so we can find it easily.
+If you're just getting started, one really helpful way you can contribute is by opening issues for documentation needs. If you notice a typo, a missing or broken example, or a function description that is confusing, [open an issue for it](https://github.com/processing/p5.js/issues)! Please include a link to the page that needs fixing so we can find it easily.
 
 ## 🗯 Contribute to the reference  
-Read through the [reference](http://p5js.org/reference/), and look for typos, broken examples, confusing documentation. If it's a straightforward fix, go ahead and work on it! If it's a more involved question that requires discussion, create an [issue](https://github.com/processing/p5.js/issues/new).
+Read through the [reference](http://p5js.org/reference/), and look for typos, broken examples, or confusing documentation. If it's a straightforward fix, go ahead and work on it! If it's a more involved question that requires discussion, create an [issue](https://github.com/processing/p5.js/issues/new).
 * Here are instructions for [getting setup for the first time with the p5.js repo](./README.md).
 * The reference is built from the inline documentation in the source code (found in the `src/` folder).
 * Here is information on [how to update or add inline documentation and examples](./inline_documentation.md).
 * If you find errors with the [spanish documentation](http://p5js.org/es), there are instructions to update this [here](https://github.com/processing/p5.js-website#internationalization-i18n-and-structure).
-* Community maintained typescript definitions are [here](https://github.com/p5-types/p5.ts).
+* Community-maintained Typescript definitions are [here](https://github.com/p5-types/p5.ts).
 
 ## ✨ Make examples  
 While the examples in the reference are meant to be very simplistic snippets of code, it is also useful to have longer, more complex examples.

--- a/contributor_docs/inline_documentation.md
+++ b/contributor_docs/inline_documentation.md
@@ -88,7 +88,7 @@ The `@return` is identical to `@params`, but without the name. It should be the 
 @return {type} Description of the data returned.
 ```
 
-If the method returns the parent object, you can skip the @return and add this line instead:
+If the method returns the parent object, you can skip the `@return` and add this line instead:
 
 ```
 @chainable
@@ -96,7 +96,7 @@ If the method returns the parent object, you can skip the @return and add this l
 
 ## Additional signatures
 
-If a method has multiple possible parameter options, you can specify each individually. For example, see the examples for [background](http://p5js.org/reference/#p5/background) under "syntax". To do this, choose one version to list as the first signature using the guidelines above. At the end of the documentation block, you can add additional signatures, each in it's own block, following the example below.
+If a method has multiple possible parameter options, you can specify each individually. For example, see the examples for [background](http://p5js.org/reference/#p5/background) under "syntax". To do this, choose one version to list as the first signature using the guidelines above. At the end of the documentation block, you can add additional signatures, each in its own block, following the example below.
 
 ```
 /**
@@ -116,7 +116,7 @@ If a method has multiple possible parameter options, you can specify each indivi
 
 Notes:
 * If a parameter has been defined previously, like `a` in this case, you do not need to fill in the definition again. 
-* It is not necessary to create a separate signature if the only difference between two signatures is the additional of an optional parameter.
+* It is not necessary to create a separate signature if the only difference between two signatures is the addition of an optional parameter.
 * You can see two examples of this inline in the source code for [background](https://github.com/processing/p5.js/blob/f38f91308fdacc2f1982e0430b620778fff30a5a/src/color/setting.js#L106) and [color](https://github.com/processing/p5.js/blob/f38f91308fdacc2f1982e0430b620778fff30a5a/src/color/creating_reading.js#L241).
 
 ## Specify other tags
@@ -147,7 +147,7 @@ Use `@private` if a property or variable is a private variable (default is `@pub
 
 ## Specify module for files
 
-The top of each *file* should contain a `@module` tag at the top of the file. Modules should correspond to JavaScript files (or require.js modules). They can work as groups in the lists of items. see here: http://p5js.org/api/#methods (the modules are COLOR, IMAGE, PVECTOR, etc.). 
+The top of each *file* should contain a `@module` tag. Modules should correspond to JavaScript files (or require.js modules). They can work as groups in the lists of items. See http://p5js.org/api/#methods (the modules are COLOR, IMAGE, PVECTOR, etc.). 
 
 ```
 /**
@@ -178,7 +178,7 @@ Constructors are defined with `@class`. Each constructor should have the tag `@c
 
 ## Adding example code
 
-Optionally, you can add examples with `@example`. Example code should be placed between `<code></code>` tags with comments included. Unless otherwise specified with a `setup()` function, each `<code>` block is automatically run on a canvas of 100x100 pixels with a gray background. Define all variables with `let` in examples, as the lowest barrier for beginners learning JS. Please see examples in other src files to make sure it is formatted correctly. If your example creates other html elements apart from the canvas, they will be rendered with a width of 100 pixels.
+Optionally, you can add examples with `@example`. Example code should be placed between `<code></code>` tags with comments included. Unless otherwise specified with a `setup()` function, each `<code>` block is automatically run on a canvas of 100x100 pixels with a gray background. Define all variables with `let` in examples, as the lowest barrier for beginners learning JS. Please see examples in other src files to make sure it is formatted correctly. If your example creates other HTML elements apart from the canvas, they will be rendered with a width of 100 pixels.
 
 ```
 @example
@@ -208,7 +208,7 @@ by a line break.
 </div>
 ```
 
-If you do not want the example to execute your code (ie you just want the code to show up), include the class "norender" in the div:
+If you do not want the example to execute your code (i.e. you just want the code to show up), include the class "norender" in the div:
 ```
 @example
 <div class="norender">
@@ -216,8 +216,8 @@ If you do not want the example to execute your code (ie you just want the code t
 </div>
 ```
 
-
 If you do not want the example to be run as part of the build tests (for example, if the example requires user interaction, or uses functionality not supported by the headless-Chrome test framework), include the class "notest" in the div:
+
 ```
 @example
 <div class='norender notest'><code>
@@ -266,7 +266,7 @@ horizontal wave pattern effected by mouse x-position & updating noise values.
 ```
 
 ## Template for methods
-Here is an example for a well documentated method. To create a new method, you can use [this template](https://github.com/processing/p5.js/tree/main/contributor_docs/method.example.js). You can replace the text with your method's variables and remove the remaining ones.
+Here is an example for a well-documentated method. To create a new method, you can use [this template](https://github.com/processing/p5.js/tree/main/contributor_docs/method.example.js). Replace the text with your method's variables and remove the remaining ones.
 ![Image showing inline documentation example for methods](https://raw.githubusercontent.com/processing/p5.js/main/contributor_docs/images/method-template-example.png)
 
 


### PR DESCRIPTION
Hi! First-time p5.js contributor here. 👋🏼 

By day, I work on the docs team at GitHub. We're preparing to [open-source docs.github.com next month](https://github.com/github/roadmap/issues/112), and I've been looking at contributing docs from popular open-source projects for inspiration.

By night, I've been slowly learning p5.js, mostly by watching @shiffman's highly entertaining [Coding Train](https://www.youtube.com/c/TheCodingTrain/playlists?view=50&sort=dd&shelf_id=9) videos.

As I read through this project's [contributor docs](https://github.com/processing/p5.js/tree/main/contributor_docs), I noticed a few typos along the way. This PR fixes the little things I noticed.

Thanks for taking the time to make p5.js such a fun and approachable open-source project. ✨ 