### PR TITLE
Add alternative for arrayCopy

### DIFF
--- a/src/utilities/array_functions.js
+++ b/src/utilities/array_functions.js
@@ -48,7 +48,7 @@ p5.prototype.append = function(array, value) {
  * iterating through a for() loop and copying each element individually.
  *
  * @method arrayCopy
- * @deprecated
+ * @deprecated Use <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/copyWithin">arr1.copyWithin(arr2)</a> instead.
  * @param {Array}  src           the source Array
  * @param {Integer} srcPosition  starting position in the source Array
  * @param {Array}  dst           the destination Array


### PR DESCRIPTION
Resolves #4796 

 Changes:
Add `arr1.copyWithin(arr2)` as an alternative for the depreciated `arrayCopy()`

#### PR Checklist

- [x] `npm run lint` passes
- [x] [Inline documentation] is included / updated

[Inline documentation]: https://github.com/processing/p5.js/blob/main/contributor_docs/inline_documentation.md
