### PR TITLE
Change distance example to be more reasonable (addresses #2865)

### DIFF
--- a/src/math/calculation.js
+++ b/src/math/calculation.js
@@ -142,7 +142,7 @@ p5.prototype.constrain = function(n, low, high) {
  *
  *   // d is the length of the line
  *   // the distance from point 1 to point 2.
- *   let d = int(dist(x1, y1, x2, y2));
+ *   let d = dist(x1, y1, x2, y2);
  *
  *   // Let's write d along the line we are drawing!
  *   push();


### PR DESCRIPTION
**Changes:**
Previously the example converted float to integer, thus removing all decimal places. However, the text displaying distance has exactly one decimal place. It makes more sense to me to use that decimal place instead of having it be zero all the time. This way the nature of distance function is also better demonstrated (it returns a float instead of an integer).

**Screenshots of the change:**
Before:
![Screenshot_20201001_004621](https://user-images.githubusercontent.com/35733458/94743139-8f9b9480-037f-11eb-8197-30a9bcfef26c.png)
(Notice the .0)
After:
![Screenshot_20201001_004320](https://user-images.githubusercontent.com/35733458/94743038-5fec8c80-037f-11eb-8198-2d48dc3849a5.png)

#### PR Checklist

- [x] `npm run lint` passes
- [x] [Inline documentation] is updated

[Inline documentation]: https://github.com/processing/p5.js/blob/main/contributor_docs/inline_documentation.md
[Unit tests]: https://github.com/processing/p5.js/tree/main/contributor_docs#unit-tests
