### PR TITLE
Resolves #4792, randomGaussian(m, sd=0) fix & added corresponding test

### DIFF
--- a/src/math/random.js
+++ b/src/math/random.js
@@ -206,7 +206,7 @@ p5.prototype.random = function(min, max) {
  * 100 horizontal lines from center of canvas. height & side change each render
  * black lines radiate from center of canvas. size determined each render
  */
-p5.prototype.randomGaussian = function(mean, sd) {
+p5.prototype.randomGaussian = function(mean, sd = 1) {
   let y1, x1, x2, w;
   if (this._gaussian_previous) {
     y1 = y2;
@@ -224,8 +224,7 @@ p5.prototype.randomGaussian = function(mean, sd) {
   }
 
   const m = mean || 0;
-  const s = sd || 1;
-  return y1 * s + m;
+  return y1 * sd + m;
 };
 
 export default p5;

--- a/test/unit/math/random.js
+++ b/test/unit/math/random.js
@@ -166,5 +166,12 @@ suite('Random', function() {
         }
       });
     });
+
+    suite('randomGaussian(42, 0)', function() {
+      test('should return 42', function() {
+        result = myp5.randomGaussian(42, 0);
+        assert.isTrue(result === 42);
+      });
+    });
   });
 });


### PR DESCRIPTION
<!--
  Thank you for contributing! Please use this pull request (PR) template.


 In the description field of this PR, include "resolves #XXXX" tagging the issue you are fixing. If this PR addresses the issue but doesn't completely resolve it (ie the issue should remain open after your PR is merged), write "addresses #XXXX".-->
Resolves #4792 

 Changes:
<!-- Add here what changes were made in this pull request and if possible provide links showcasing the changes. -->
As discussed in #4792 , I added a default parameter to function randomGaussian in random.js. I also added a unit test to check `randomGaussian(42, 0) === 42`. The previous code doesn't pass this test and this one does. 

 Screenshots of the change:
<!-- If applicable, add screenshots depicting the changes. -->
[Prev](https://p5js.org/reference/#/p5/randomGaussian):
![image](https://user-images.githubusercontent.com/30195912/94928542-853ae100-04cc-11eb-8d15-a6712eb7a6d9.png)
Now:
![image](https://user-images.githubusercontent.com/30195912/94928519-7b18e280-04cc-11eb-872b-3b0ba5db138e.png)


#### PR Checklist
<!--
  To check any option, replace the "[ ]" with a "[x]". Be sure to check out how it looks in the Preview tab! Feel free to remove any portion of the template that is not relevant for your issue.
-->

- [X] `npm run lint` passes
- [x] [Inline documentation] is included / updated
- [X] [Unit tests] are included / updated

[Inline documentation]: https://github.com/processing/p5.js/blob/main/contributor_docs/inline_documentation.md
[Unit tests]: https://github.com/processing/p5.js/tree/main/contributor_docs#unit-tests
