### PR TITLE
Fix keyCode example causing search box to not function

### DIFF
--- a/src/events/keyboard.js
+++ b/src/events/keyboard.js
@@ -84,7 +84,6 @@ p5.prototype.key = '';
  *   } else if (keyCode === DOWN_ARROW) {
  *     fillVal = 0;
  *   }
- *   return false; // prevent default
  * }
  * </code></div>
  * <div><code>
@@ -93,7 +92,6 @@ p5.prototype.key = '';
  *   background('yellow');
  *   text(`${key} ${keyCode}`, 10, 40);
  *   print(key, ' ', keyCode);
- *   return false; // prevent default
  * }
  * </code></div>
  * @alt


### PR DESCRIPTION
<!--
  Thank you for contributing! Please use this pull request (PR) template.


 In the description field of this PR, include "resolves #XXXX" tagging the issue you are fixing. If this PR addresses the issue but doesn't completely resolve it (ie the issue should remain open after your PR is merged), write "addresses #XXXX".-->
Resolves https://github.com/processing/p5.js-website/issues/800

 Changes:
<!-- Add here what changes were made in this pull request and if possible provide links showcasing the changes. -->
Removed `return false` from examples as they capture the keyboard events and stops all default behaviour including typing into the search box.

#### PR Checklist
<!--
  To check any option, replace the "[ ]" with a "[x]". Be sure to check out how it looks in the Preview tab! Feel free to remove any portion of the template that is not relevant for your issue.
-->

- [x] `npm run lint` passes
- [x] [Inline documentation] is included / updated
- [ ] [Unit tests] are included / updated

[Inline documentation]: https://github.com/processing/p5.js/blob/main/contributor_docs/inline_documentation.md
[Unit tests]: https://github.com/processing/p5.js/tree/main/contributor_docs#unit-tests
