### PR TITLE
Fix error when handling error in MediaElement.play

### DIFF
--- a/src/dom/dom.js
+++ b/src/dom/dom.js
@@ -2440,7 +2440,7 @@ p5.MediaElement.prototype.play = function() {
     promise = this.elt.play();
   }
   if (promise && promise.catch) {
-    promise.catch(function(e) {
+    promise.catch(e => {
       // if it's an autoplay failure error
       if (e.name === 'NotAllowedError') {
         p5._friendlyAutoplayError(this.src);


### PR DESCRIPTION
Because of the anonymous callback function passed to `promise.catch` `this` was undefined in the function and thus threw the error: `Uncaught (in promise) TypeError: Cannot read property 'src' of undefined`.

 Changes:

I converted the function into an arrow function so `this` keeps the value from outside the function.

#### PR Checklist

- [ ] `npm run lint` passes
- [ ] [Unit tests] are included / updated

[Inline documentation]: https://github.com/processing/p5.js/blob/main/contributor_docs/inline_documentation.md
[Unit tests]: https://github.com/processing/p5.js/tree/main/contributor_docs#unit-tests