### PR TITLE
simplify code contributions by automating the dev setup.

### DIFF
--- a/.gitpod.Dockerfile
+++ b/.gitpod.Dockerfile
@@ -1,0 +1,50 @@
+FROM gitpod/workspace-full-vnc
+
+USER gitpod
+
+RUN sudo apt-get update && \
+    sudo apt-get install -y \
+        ca-certificates \
+        fonts-liberation \
+        libappindicator3-1 \
+        libasound2 \
+        libatk-bridge2.0-0 \
+        libatk1.0-0 \
+        libc6 \
+        libcairo2 \
+        libcups2 \
+        libdbus-1-3 \
+        libexpat1 \
+        libfontconfig1 \
+        libgbm1 \
+        libgcc1 \
+        libglib2.0-0 \
+        libgtk-3-0 \
+        libnspr4 \
+        libnss3 \
+        libpango-1.0-0 \
+        libpangocairo-1.0-0 \
+        libstdc++6 \
+        libx11-6 \
+        libx11-xcb1 \
+        libxcb1 \
+        libxcomposite1 \
+        libxcursor1 \
+        libxdamage1 \
+        libxext6 \
+        libxfixes3 \
+        libxi6 \
+        libxrandr2 \
+        libxrender1 \
+        libxss1 \
+        libxtst6 \
+        lsb-release \
+        wget \
+        xdg-utils && \
+    sudo rm -rf /var/lib/apt/lists/*
+
+
+
+RUN sudo apt-get -q update && \
+    sudo apt-get install -yq chromium-browser && \
+    sudo rm -rf /var/lib/apt/lists/*

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -1,0 +1,16 @@
+image:
+  file: .gitpod.Dockerfile
+tasks:
+  - init: | 
+      npm ci 
+      gp sync-done boot
+    command: npm run grunt 
+    
+  - name: Dev
+    command: gp sync-await boot && sleep 10 && npm run dev 
+
+ports:
+  - port: 9001
+    onOpen: open-preview
+  - port: 5900
+    onOpen: ignore

--- a/contributor_docs/README.md
+++ b/contributor_docs/README.md
@@ -68,8 +68,6 @@ We know the development process can be a little tricky at first. You're not alon
 
 This process is also covered [in a video by The Coding Train.](https://youtu.be/Rr3vLyP1Ods) :train::rainbow:
 
-
-
 1. Install [node.js](http://nodejs.org/), which also automatically installs the [npm](https://www.npmjs.org) package manager.
 
 2. [Fork](https://help.github.com/articles/fork-a-repo) the [p5.js repository](https://github.com/processing/p5.js) into your own GitHub account.
@@ -113,6 +111,9 @@ This process is also covered [in a video by The Coding Train.](https://youtu.be/
 9. Once everything is ready, submit your changes as a [pull request](https://help.github.com/articles/creating-a-pull-request).
 
 
+Alternatively you can also use Gitpod for the one-click online setup for contributing with a single click it will launch a workspace and automatically clone the repo, install the dependencies run `npm run grunt` and `npm run dev`.
+
+[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
 
 # Gotchas
 

--- a/tasks/test/mocha-chrome.js
+++ b/tasks/test/mocha-chrome.js
@@ -16,7 +16,7 @@ module.exports = function(grunt) {
     // Launch Chrome in headless mode
     const browser = await puppeteer.launch({
       headless: true,
-      args: ['--no-sandbox']
+      args: ['--no-sandbox', '--disable-setuid-sandbox']
     });
 
     try {


### PR DESCRIPTION
 Changes:
<!-- Add here what changes were made in this pull request and if possible provide links showcasing the changes. -->

Hi. I work for Gitpod(an online IDE which is free for Open Source) and we are currently on a mission to simplify contributors onboarding experience for cool and popular Open Source projects. 

This Pr adds Gitpod config to the repo via which, anyone would be able to launch a workspace where it will automatically:

- clone the `p5.js` repo.
- install all the dependencies i.e via running `npm ci`.
- run `npm run grunt` and `npm run dev` in separate terminals.

All of this can be helpful for newcomers/beginners i.e the can start in just a single click without having to set anything up.

You can give it a try on my fork of the repo via the following link:

https://gitpod.io/#https://github.com/nisarhassan12/p5.js

 Screenshots of the change:
<!-- If applicable, add screenshots depicting the changes. -->

![image](https://user-images.githubusercontent.com/46004116/96327123-12933f00-1050-11eb-88a8-ed34c27170f7.png)

#### PR Checklist
<!--
  To check any option, replace the "[ ]" with a "[x]". Be sure to check out how it looks in the Preview tab! Feel free to remove any portion of the template that is not relevant for your issue.
-->

- [x] `npm run lint` passes
- [ ] [Inline documentation] is included / updated
- [ ] [Unit tests] are included / updated

[Inline documentation]: https://github.com/processing/p5.js/blob/main/contributor_docs/inline_documentation.md
[Unit tests]: https://github.com/processing/p5.js/tree/main/contributor_docs#unit-tests
