### PR TITLE
Make camera() parameters optional

### DIFF
--- a/src/webgl/p5.Camera.js
+++ b/src/webgl/p5.Camera.js
@@ -882,13 +882,17 @@ p5.Camera.prototype.camera = function(
   this.eyeY = eyeY;
   this.eyeZ = eyeZ;
 
-  this.centerX = centerX;
-  this.centerY = centerY;
-  this.centerZ = centerZ;
+  if (typeof centerX !== 'undefined') {
+    this.centerX = centerX;
+    this.centerY = centerY;
+    this.centerZ = centerZ;
+  }
 
-  this.upX = upX;
-  this.upY = upY;
-  this.upZ = upZ;
+  if (typeof upX !== 'undefined') {
+    this.upX = upX;
+    this.upY = upY;
+    this.upZ = upZ;
+  }
 
   const local = this._getLocalAxes();
 


### PR DESCRIPTION
Changes:
The documentation for camera() suggests that all 9 parameters are optional, but passing some - but not all - does break currently. This proposed change lets you call camera() with three parameters for changing only the camera position, or six parameters for camera position & target (without having to specify the not-so-intuitive up vector also). Shouldn't affect current behavior inadvertently (e.g. when calling camera() w/o params).


- [x] `npm run lint` passes
- [ ] Inline documentation is included / updated
- [ ] Unit tests are included / updated (_unit tests all seem to pass_)