### PR TITLE
Enter key fix for _onkeypress

### DIFF
--- a/src/events/keyboard.js
+++ b/src/events/keyboard.js
@@ -282,7 +282,7 @@ p5.prototype._onkeypress = function(e) {
     return;
   }
   this._setProperty('_lastKeyCodeTyped', e.which); // track last keyCode
-  this._setProperty('key', String.fromCharCode(e.which));
+  this._setProperty('key', e.key || String.fromCharCode(e.which) || e.which);
 
   const context = this._isGlobal ? window : this;
   if (typeof context.keyTyped === 'function') {


### PR DESCRIPTION
Resolves #4871.

Changes:
Updates _onkeypress to match _onkeydown and _onkeyup setting the global key property.  Fixes a bug where the Enter key is saved as empty string in the global key property when pressed and before released.

#### PR Checklist
<!--
  To check any option, replace the "[ ]" with a "[x]". Be sure to check out how it looks in the Preview tab! Feel free to remove any portion of the template that is not relevant for your issue.
-->

- [x] `npm run lint` passes
- [ ] [Inline documentation] is included / updated
- [ ] [Unit tests] are included / updated

[Inline documentation]: https://github.com/processing/p5.js/blob/main/contributor_docs/inline_documentation.md
[Unit tests]: https://github.com/processing/p5.js/tree/main/contributor_docs#unit-tests
