### PR TITLE
Add reference to 2D vs. 3D canvas origin location

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12153,7 +12153,7 @@
         },
         "find-up": {
           "version": "3.0.0",
-          "resolved": "",
+          "resolved": false,
           "integrity": "sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==",
           "dev": true,
           "requires": {
@@ -12168,7 +12168,7 @@
         },
         "is-fullwidth-code-point": {
           "version": "2.0.0",
-          "resolved": "",
+          "resolved": false,
           "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
           "dev": true
         },
@@ -12196,7 +12196,7 @@
         },
         "resolve-from": {
           "version": "4.0.0",
-          "resolved": "",
+          "resolved": false,
           "integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==",
           "dev": true
         },
@@ -12234,7 +12234,7 @@
         },
         "which-module": {
           "version": "2.0.0",
-          "resolved": "",
+          "resolved": false,
           "integrity": "sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho=",
           "dev": true
         },
@@ -12251,7 +12251,7 @@
         },
         "y18n": {
           "version": "4.0.0",
-          "resolved": "",
+          "resolved": false,
           "integrity": "sha512-r9S/ZyXu/Xu9q1tYlpsLIsa3EeLXXk0VwlxqTcFRfg9EhMW+17kbt9G0NrgCmhGb5vT2hyhJZLfDGx+7+5Uj/w==",
           "dev": true
         },

--- a/src/core/rendering.js
+++ b/src/core/rendering.js
@@ -24,7 +24,7 @@ const defaultClass = 'p5Canvas';
  * is positioned at the top left of the screen. In 3D mode (i.e. when `p5.Renderer`
  * is set to `WEBGL`), the origin is positioned at the center of the canvas.
  * See [this issue](https://github.com/processing/p5.js/issues/1545) for more information.
- * 
+ *
  * The system variables width and height are set by the parameters passed to this
  * function. If <a href="#/p5/createCanvas">createCanvas()</a> is not used, the
  * window will be given a default size of 100x100 pixels.

--- a/src/core/rendering.js
+++ b/src/core/rendering.js
@@ -20,6 +20,11 @@ const defaultClass = 'p5Canvas';
  * one drawing canvas you could use <a href="#/p5/createGraphics">createGraphics</a>
  * (hidden by default but it can be shown).
  *
+ * Important note: in 2D mode (i.e. when `p5.Renderer` is not set) the origin (0,0)
+ * is positioned at the top left of the screen. In 3D mode (i.e. when `p5.Renderer`
+ * is set to `WEBGL`), the origin is positioned at the center of the canvas.
+ * See [this issue](https://github.com/processing/p5.js/issues/1545) for more information.
+ * 
  * The system variables width and height are set by the parameters passed to this
  * function. If <a href="#/p5/createCanvas">createCanvas()</a> is not used, the
  * window will be given a default size of 100x100 pixels.


### PR DESCRIPTION
<!--
  Thank you for contributing! Please use this pull request (PR) template.


 In the description field of this PR, include "resolves #XXXX" tagging the issue you are fixing. If this PR addresses the issue but doesn't completely resolve it (ie the issue should remain open after your PR is merged), write "addresses #XXXX".-->
Resolves #[Add issue number here]

 Changes:
Documentation change - made the fact that the origin is different in 2D vs. 3D more apparent (kinda self explanatory). See https://github.com/processing/p5.js/issues/1545 for more information - did this via the web editor, so no checks ran.
<!-- Add here what changes were made in this pull request and if possible provide links showcasing the changes. -->


 Screenshots of the change:
<!-- If applicable, add screenshots depicting the changes. -->

#### PR Checklist
<!--
  To check any option, replace the "[ ]" with a "[x]". Be sure to check out how it looks in the Preview tab! Feel free to remove any portion of the template that is not relevant for your issue.
-->

- [x] `npm run lint` passes
- [x] [Inline documentation] is included / updated
- [ ] [Unit tests] are included / updated

[Inline documentation]: https://github.com/processing/p5.js/blob/main/contributor_docs/inline_documentation.md
[Unit tests]: https://github.com/processing/p5.js/tree/main/contributor_docs#unit-tests
