### PR TITLE
Prevent i18next from using browser storage

### DIFF
--- a/src/core/internationalization.js
+++ b/src/core/internationalization.js
@@ -140,7 +140,12 @@ export const initialize = () => {
         escapeValue: false
       },
       detection: {
-        checkWhitelist: false
+        checkWhitelist: false,
+
+        // prevent storing or locating language from cookie or localStorage
+        // more info on https://github.com/processing/p5.js/issues/4862
+        order: ['querystring', 'navigator', 'htmlTag', 'path', 'subdomain'],
+        caches: []
       },
       backend: {
         fallback: 'en',


### PR DESCRIPTION
<!--
  Thank you for contributing! Please use this pull request (PR) template.


 In the description field of this PR, include "resolves #XXXX" tagging the issue you are fixing. If this PR addresses the issue but doesn't completely resolve it (ie the issue should remain open after your PR is merged), write "addresses #XXXX".-->
Resolves #4862
### Changes:
Stop i18next language detector from using browser storage to cache language names. 

#### PR Checklist
- [x] `npm run lint` passes
- [ ] [Inline documentation] is included / updated
- [ ] [Unit tests] are included / updated

[Inline documentation]: https://github.com/processing/p5.js/blob/main/contributor_docs/inline_documentation.md
[Unit tests]: https://github.com/processing/p5.js/tree/main/contributor_docs#unit-tests
