### PR TITLE
Update p5.Font.js in typography to ES6

### DIFF
--- a/src/typography/p5.Font.js
+++ b/src/typography/p5.Font.js
@@ -130,17 +130,17 @@ p5.Font.prototype.textBounds = function(str, x = 0, y = 0, fontSize, opts) {
       maxX[lineCount] = Math.max.apply(null, xCoords[lineCount]);
     }
 
-    var finalMaxX = 0;
-    for (var i = 0; i <= lineCount; i++) {
+    let finalMaxX = 0;
+    for (let i = 0; i <= lineCount; i++) {
       minX[i] = Math.min.apply(null, xCoords[i]);
       maxX[i] = Math.max.apply(null, xCoords[i]);
-      var lineLength = maxX[i] - minX[i];
+      const lineLength = maxX[i] - minX[i];
       if (lineLength > finalMaxX) {
         finalMaxX = lineLength;
       }
     }
 
-    var finalMinX = Math.min.apply(null, minX);
+    const finalMinX = Math.min.apply(null, minX);
     minY = Math.min.apply(null, yCoords);
     maxY = Math.max.apply(null, yCoords);
 


### PR DESCRIPTION
Resolves #4915 

 Changes:
Update [src/typography/p5.Font.js](https://github.com/processing/p5.js/blob/main/src/typography/p5.Font.js) from ES5 to ES6.


#### PR Checklist
- [x] `npm run lint` passes
- [x] [Inline documentation] is included / updated
- [x] [Unit tests] are included / updated

[Inline documentation]: https://github.com/processing/p5.js/blob/main/contributor_docs/inline_documentation.md
[Unit tests]: https://github.com/processing/p5.js/tree/main/contributor_docs#unit-tests