### PR TITLE
Remove console.log() at Line 414 of /src/io/files.js

### DIFF
--- a/src/io/files.js
+++ b/src/io/files.js
@@ -411,8 +411,6 @@ p5.prototype.loadTable = function(path) {
     }
   }
 
-  console.log('SEP IS ' + sep);
-
   const t = new p5.Table();
 
   const self = this;


### PR DESCRIPTION

Resolves #4918 

 Changes:
This PR removes `console.log()` from `loadTable()` function of `/src/io/files.js`.

#### PR Checklist
- [X] `npm run lint` passes
- [ ] [Inline documentation] is included / updated
- [ ] [Unit tests] are included / updated

[Inline documentation]: https://github.com/processing/p5.js/blob/main/contributor_docs/inline_documentation.md
[Unit tests]: https://github.com/processing/p5.js/tree/main/contributor_docs#unit-tests
