### PR TITLE
Fix alignment of radio buttons in the second example of createRadio() reference 

### DIFF
--- a/src/dom/dom.js
+++ b/src/dom/dom.js
@@ -784,7 +784,7 @@ p5.prototype.createSelect = function() {
  *   radio.option('apple', 1);
  *   radio.option('bread', 2);
  *   radio.option('juice', 3);
- *   radio.style('width', '60px');
+ *   radio.style('width', '30px');
  *   textAlign(CENTER);
  * }
  *


### PR DESCRIPTION

Resolves #4912 

 Changes:

**Earlier:**

![Screenshot (67)_LI](https://user-images.githubusercontent.com/58628586/99961118-dfad3b00-2db3-11eb-870e-53ba2b88cc2f.jpg)

**Now:**

![Screenshot (69)_LI](https://user-images.githubusercontent.com/58628586/99961301-2b5fe480-2db4-11eb-8433-5d4d13541d9d.jpg)

#### PR Checklist

- [X] `npm run lint` passes
- [ ] [Inline documentation] is included / updated
- [ ] [Unit tests] are included / updated

[Inline documentation]: https://github.com/processing/p5.js/blob/main/contributor_docs/inline_documentation.md
[Unit tests]: https://github.com/processing/p5.js/tree/main/contributor_docs#unit-tests
