### PR TITLE
Made changes for min() and max() parameter validation

### DIFF
--- a/src/math/calculation.js
+++ b/src/math/calculation.js
@@ -501,7 +501,6 @@ p5.prototype.map = function(n, start1, stop1, start2, stop2, withinBounds) {
  * @return {Number}
  */
 p5.prototype.max = function(...args) {
-  p5._validateParameters('max', args);
   if (args[0] instanceof Array) {
     return Math.max.apply(null, args[0]);
   } else {
@@ -550,7 +549,6 @@ p5.prototype.max = function(...args) {
  * @return {Number}
  */
 p5.prototype.min = function(...args) {
-  p5._validateParameters('min', args);
   if (args[0] instanceof Array) {
     return Math.min.apply(null, args[0]);
   } else {


### PR DESCRIPTION
Resolves #4890

Changes:
The _validateParameters() function was removed from both p5.prototype.max and p5.prototype.min function definitions


#### PR Checklist
<!--
  To check any option, replace the "[ ]" with a "[x]". Be sure to check out how it looks in the Preview tab! Feel free to remove any portion of the template that is not relevant for your issue.
-->

- [x] `npm run lint` passes
- [ ] [Inline documentation] is included / updated
- [ ] [Unit tests] are included / updated

[Inline documentation]: https://github.com/processing/p5.js/blob/main/contributor_docs/inline_documentation.md
[Unit tests]: https://github.com/processing/p5.js/tree/main/contributor_docs#unit-tests
