### PR TITLE
Fixed typos in inline_documentation.md

### DIFF
--- a/contributor_docs/inline_documentation.md
+++ b/contributor_docs/inline_documentation.md
@@ -115,7 +115,7 @@ If a method has multiple possible parameter options, you can specify each indivi
 ```
 
 Notes:
-* If a parameter has been defined previously, like `a` in this case, you do not need to fill in the definition again. 
+* If a parameter was given description previously, like `a` in this case, you do not need to rewrite its description again. 
 * It is not necessary to create a separate signature if the only difference between two signatures is the addition of an optional parameter.
 * You can see two examples of this inline in the source code for [background](https://github.com/processing/p5.js/blob/f38f91308fdacc2f1982e0430b620778fff30a5a/src/color/setting.js#L106) and [color](https://github.com/processing/p5.js/blob/f38f91308fdacc2f1982e0430b620778fff30a5a/src/color/creating_reading.js#L241).
 

--- a/contributor_docs/inline_documentation.md
+++ b/contributor_docs/inline_documentation.md
@@ -147,7 +147,7 @@ Use `@private` if a property or variable is a private variable (default is `@pub
 
 ## Specify module for files
 
-The top of each *file* should contain a `@module` tag. Modules should correspond to JavaScript files (or require.js modules). They can work as groups in the lists of items. See http://p5js.org/api/#methods (the modules are COLOR, IMAGE, PVECTOR, etc.). 
+The top of each *file* should contain a `@module` tag. Modules should correspond to JavaScript files (or require.js modules). They can work as groups in the lists of items. See [here](https://p5js.org/reference/#collection-list-nav) (the modules are COLOR, IMAGE, IO, PVECTOR, etc.). 
 
 ```
 /**

--- a/contributor_docs/inline_documentation.md
+++ b/contributor_docs/inline_documentation.md
@@ -273,7 +273,7 @@ Here is an example for a well-documented method. To create a new method, you can
 
 ## Generating documentation
 
-* Run `grunt yui:build` once first to generate all local files needed, as well as a copy of the reference from the source code. Run it again anytime you make changes to the core JS files behind the yuidoc reference page. These are changes in files located in the yuidoc-p5-theme-src folder, NOT inline documentation changes to src.
+* Run `grunt yui:build` once first to generate all local files needed, as well as a copy of the reference from the source code. Run it again anytime you make changes to the core JS files behind the yuidoc reference page. These are changes in files located in the yuidoc-p5-theme folder, NOT inline documentation changes to src.
 * If you only made changes to the source code, you can just run `grunt yui`, though `grunt yui:build` will also do the trick. 
 * You can run `npm run docs:dev` to launch a live preview of the site that will update each time you make changes. (You will need to refresh the page after making changes to see them appear.)
 

--- a/contributor_docs/inline_documentation.md
+++ b/contributor_docs/inline_documentation.md
@@ -267,6 +267,7 @@ horizontal wave pattern effected by mouse x-position & updating noise values.
 
 ## Template for methods
 Here is an example for a well-documented method. To create a new method, you can use [this template](https://github.com/processing/p5.js/tree/main/contributor_docs/method.example.js). Replace the text with your method's variables and remove the remaining ones.
+
 ![Image showing inline documentation example for methods](https://raw.githubusercontent.com/processing/p5.js/main/contributor_docs/images/method-template-example.png)
 
 

--- a/contributor_docs/inline_documentation.md
+++ b/contributor_docs/inline_documentation.md
@@ -273,11 +273,11 @@ Here is an example for a well-documented method. To create a new method, you can
 
 ## Generating documentation
 
-* Run `grunt yui:build` once first to generate all local files needed, as well as a copy of the reference from the source code. Run it again anytime you make changes to the core JS files behind the yuidoc reference page. These are changes in files located in the yuidoc-p5-theme folder, NOT inline documentation changes to src.
-* If you only made changes to the source code, you can just run `grunt yui`, though `grunt yui:build` will also do the trick. 
+* Run `npm run grunt yui:build` once first to generate all local files needed, as well as a copy of the reference from the source code. Run it again anytime you make changes to the core JS files behind the yuidoc reference page. These are changes in files located in the yuidoc-p5-theme folder, NOT inline documentation changes to src.
+* If you only made changes to the source code, you can just run `npm run grunt yui`, though `npm run grunt yui:build` will also do the trick. 
 * You can run `npm run docs:dev` to launch a live preview of the site that will update each time you make changes. (You will need to refresh the page after making changes to see them appear.)
 
-The build reference can be found in docs/reference. To preview it locally, run `grunt yui:dev` and view it as http://localhost:9001/docs/reference/.
+The build reference can be found in docs/reference. To preview it locally, run `npm run grunt yui:dev` and view it as http://localhost:9001/docs/reference/.
 
 
 ## Spanish language version

--- a/contributor_docs/ko/inline_documentation.md
+++ b/contributor_docs/ko/inline_documentation.md
@@ -271,11 +271,11 @@ horizontal wave pattern effected by mouse x-position & updating noise values.
 
 ## 문서 생성
 
-* 먼저 `grunt yui:build`를 한 번 실행하여 필요한 모든 로컬 파일과 소스 코드의 참조 사본을 생성합니다. yuidoc 레퍼런스 페이지 뒤에서 코어 JS 파일을 변경할 때마다 다시 실행해주세요. 이는 src의 인라인 문서 변경이 아니라 yuidoc-p5-theme-src 폴더에있는 파일에 대한 변경 사항입니다.
-* 소스 코드만 변경했다면 `grunt yui`만 실행할 수 있지만 `grunt yui:build`도 사용할 수 있습니다.
+* 먼저 `npm run grunt yui:build`를 한 번 실행하여 필요한 모든 로컬 파일과 소스 코드의 참조 사본을 생성합니다. yuidoc 레퍼런스 페이지 뒤에서 코어 JS 파일을 변경할 때마다 다시 실행해주세요. 이는 src의 인라인 문서 변경이 아니라 yuidoc-p5-theme-src 폴더에있는 파일에 대한 변경 사항입니다.
+* 소스 코드만 변경했다면 `npm run grunt yui`만 실행할 수 있지만 `npm run grunt yui:build`도 사용할 수 있습니다.
 * `npm run docs:dev`를 실행하여 변경할 때마다 업데이트되는 사이트의 실시간 미리보기를 할 수 있습니다.(변경 한 후 페이지를 새로고침해야 표시됩니다.)
 
-빌드 레퍼런스는 docs/reference에서 찾을 수 있으며. 로컬에서 미리 보려면 `grunt yui:dev`를 실행해 http://localhost:9001/docs/reference/ 에서 살펴보세요.
+빌드 레퍼런스는 docs/reference에서 찾을 수 있으며. 로컬에서 미리 보려면 `npm run grunt yui:dev`를 실행해 http://localhost:9001/docs/reference/ 에서 살펴보세요.
 
 
 ## 스페인어 버전


### PR DESCRIPTION
addresses #2865

All of the changes below are made to the [Inline documentation].

 #### Changes:
- Resolved template image rendering in between the line (under **Template for methods** section [here](https://github.com/processing/p5.js/blob/main/contributor_docs/inline_documentation.md#template-for-methods)).
- Rewrote 'yuidoc-p5-theme-src' to 'yuidoc-p5-theme' (this the latest name see [here](https://github.com/processing/p5.js/tree/main/docs)) in [this section](https://github.com/processing/p5.js/blob/main/contributor_docs/inline_documentation.md#generating-documentation).
- Rewrote 'definition' to 'description' (the first point of 'Notes' under **Additional signatures** section [here](https://github.com/processing/p5.js/blob/main/contributor_docs/inline_documentation.md#additional-signatures)) since, it is referred as 'description' in Specify parameters section.
- The link http://p5js.org/api/#methods (under **Specify modules for files** section [here](https://github.com/processing/p5.js/blob/main/contributor_docs/inline_documentation.md#specify-module-for-files)) is broken. I believe this should redirect to the list of p5.js modules. Hence, I added [this link](https://p5js.org/reference/#collection-list-nav) to the reference page where the modules are mentioned.  
- changed `grunt yui:build` to `npm run grunt yui:build`([this section](https://github.com/processing/p5.js/blob/main/contributor_docs/inline_documentation.md#generating-documentation)). This will be easier for people new to npm like me ;) to run it. This change is also made in the Spanish version of inline documentation [here](https://github.com/processing/p5.js/blob/main/contributor_docs/ko/inline_documentation.md#%EB%AC%B8%EC%84%9C-%EC%83%9D%EC%84%B1).

#### Screenshots of the template image change: (in [this section](https://github.com/processing/p5.js/blob/main/contributor_docs/inline_documentation.md#template-for-methods))
**Before:**
![Screenshot from 2020-12-21 23-17-12](https://user-images.githubusercontent.com/56887198/102807268-54d85400-43e4-11eb-876b-2ed2827ae517.png)

**After:**
![Screenshot from 2020-12-21 23-16-56](https://user-images.githubusercontent.com/56887198/102806987-dc719300-43e3-11eb-843e-d89d058d6bd4.png)



#### PR Checklist
- [x] [Inline documentation] is updated

[Inline documentation]: https://github.com/processing/p5.js/blob/main/contributor_docs/inline_documentation.md
