### PR TITLE
Static version of p5.Vector.rotate

### DIFF
--- a/src/math/p5.Vector.js
+++ b/src/math/p5.Vector.js
@@ -2139,6 +2139,34 @@ p5.Vector.mult = function mult(v, n, target) {
 };
 
 /**
+ * Rotates the vector (only 2D vectors) by the given angle, magnitude remains the same and returns a new vector.
+ */
+
+/**
+ * @method rotate
+ * @static
+ * @param  {p5.Vector} v
+ * @param  {Number} angle angle of rotation
+ * @param  {p5.Vector} [target] the vector to receive the result (Optional)
+ */
+
+p5.Vector.rotate = function rotate(v, a, target) {
+  if (!target) {
+    target = v.copy();
+    if (arguments.length === 3) {
+      p5._friendlyError(
+        'The target parameter is undefined, it should be of type p5.Vector',
+        'p5.Vector.rotate'
+      );
+    }
+  } else {
+    target.set(v);
+  }
+  target.rotate(a);
+  return target;
+};
+
+/**
  * Divides a vector by a scalar and returns a new vector.
  */
 

--- a/src/math/p5.Vector.js
+++ b/src/math/p5.Vector.js
@@ -1482,6 +1482,19 @@ p5.Vector.prototype.setHeading = function setHeading(a) {
  * </code>
  * </div>
  *
+ * <div class="norender">
+ * <code>
+ * // static function implementation
+ * let v = createVector(10.0, 20.0);
+ * // v has components [10.0, 20.0, 0.0]
+ * let rotated_v = p5.Vector.rotate(v, HALF_PI);
+ * console.log(rotated_v);
+ * // rotated_v's components are set to [-20.0, 9.999999, 0.0]
+ * console.log(v);
+ * // v's components remains the same (i.e, [10.0, 20.0, 0.0])
+ * </code>
+ * </div>
+ *
  * <div>
  * <code>
  * let angle = 0;

--- a/src/math/p5.Vector.js
+++ b/src/math/p5.Vector.js
@@ -2165,14 +2165,14 @@ p5.Vector.mult = function mult(v, n, target) {
 p5.Vector.rotate = function rotate(v, a, target) {
   if (arguments.length === 2) {
     target = v.copy();
-  } else if (target instanceof p5.Vector) {
-    target.set(v);
   } else {
-    target = v.copy();
-    p5._friendlyError(
-      'The target parameter should be of type p5.Vector',
-      'p5.Vector.rotate'
-    );
+    if (!(target instanceof p5.Vector)) {
+      p5._friendlyError(
+        'The target parameter should be of type p5.Vector',
+        'p5.Vector.rotate'
+      );
+    }
+    target.set(v);
   }
   target.rotate(a);
   return target;

--- a/src/math/p5.Vector.js
+++ b/src/math/p5.Vector.js
@@ -2162,18 +2162,17 @@ p5.Vector.mult = function mult(v, n, target) {
  * @param  {Number} angle
  * @param  {p5.Vector} [target] the vector to receive the result (Optional)
  */
-
 p5.Vector.rotate = function rotate(v, a, target) {
-  if (!target) {
+  if (arguments.length === 2) {
     target = v.copy();
-    if (arguments.length === 3) {
-      p5._friendlyError(
-        'The target parameter is undefined, it should be of type p5.Vector',
-        'p5.Vector.rotate'
-      );
-    }
-  } else {
+  } else if (target instanceof p5.Vector) {
     target.set(v);
+  } else {
+    target = v.copy();
+    p5._friendlyError(
+      'The target parameter should be of type p5.Vector',
+      'p5.Vector.rotate'
+    );
   }
   target.rotate(a);
   return target;

--- a/src/math/p5.Vector.js
+++ b/src/math/p5.Vector.js
@@ -2146,7 +2146,7 @@ p5.Vector.mult = function mult(v, n, target) {
  * @method rotate
  * @static
  * @param  {p5.Vector} v
- * @param  {Number} angle angle of rotation
+ * @param  {Number} angle
  * @param  {p5.Vector} [target] the vector to receive the result (Optional)
  */
 


### PR DESCRIPTION
Addresses #4852

 **Changes:**
- added static function counterpart of [`rotate()`]
- added example of static implementation of [`rotate()`]


**Changes need to implemented:**
- [ ] start readme file for `src/math`
- [ ] add other static functions (name of those functions will be added here)

#### PR Checklist
- [x] `npm run lint` passes
- [ ] [Unit tests] are included / updated

@limzykenneth @lmccart I have updated the examples of the [`rotate()`] function in the reference page for its static implementation. Is there anything else that should be done for [`rotate()`]?

Once static implementation of `rotate()` looks good. I will start adding the same for other functions. Hopefully, collaborate with @weslord and @covalentbond if they are interested. Finally, start a readme for `src/math`.  

[Unit tests]: https://github.com/processing/p5.js/tree/main/contributor_docs#unit-tests
[`rotate()`]: https://p5js.org/reference/#/p5.Vector/rotate 