### PR TITLE
Add static version of p5.Vector.normalize()

### DIFF
--- a/src/math/p5.Vector.js
+++ b/src/math/p5.Vector.js
@@ -2304,10 +2304,14 @@ p5.Vector.lerp = function lerp(v1, v2, amt, target) {
 };
 
 /**
+ * Calculates the magnitude (length) of the vector and returns the result as
+ * a float (this is simply the equation sqrt(x\*x + y\*y + z\*z).)
+ */
+/**
  * @method mag
+ * @static
  * @param {p5.Vector} vecT the vector to return the magnitude of
  * @return {Number}        the magnitude of vecT
- * @static
  */
 p5.Vector.mag = function mag(vecT) {
   const x = vecT.x,

--- a/src/math/p5.Vector.js
+++ b/src/math/p5.Vector.js
@@ -1213,6 +1213,20 @@ p5.Vector.prototype.dist = function dist(v) {
  * // [0.4454354, 0.8908708, 0.089087084]
  * </code>
  * </div>
+ *
+ * <div class="norender">
+ * <code>
+ * // Static method
+ * let v_initial = createVector(10, 20, 2);
+ * // v_initial has components [10.0, 20.0, 2.0]
+ * let v_normalized = p5.Vector.normalize(v_initial);
+ * print(v_normalized);
+ * // returns a new vector with components set to
+ * // [0.4454354, 0.8908708, 0.089087084]
+ * // v_initial remains unchanged
+ * </code>
+ * </div>
+ *
  * <div>
  * <code>
  * function draw() {
@@ -2319,6 +2333,31 @@ p5.Vector.mag = function mag(vecT) {
     z = vecT.z;
   const magSq = x * x + y * y + z * z;
   return Math.sqrt(magSq);
+};
+
+/**
+ * Normalize the vector to length 1 (make it a unit vector).
+ */
+/**
+ * @method normalize
+ * @static
+ * @param {p5.Vector} v  the vector to normalize
+ * @param {p5.Vector} [target] the vector to receive the result (Optional)
+ * @return {p5.Vector}   v normalized to a length of 1
+ */
+p5.Vector.normalize = function normalize(v, target) {
+  if (arguments.length < 2) {
+    target = v.copy();
+  } else {
+    if (!(target instanceof p5.Vector)) {
+      p5._friendlyError(
+        'The target parameter should be of type p5.Vector',
+        'p5.Vector.normalize'
+      );
+    }
+    target.set(v);
+  }
+  return target.normalize();
 };
 
 export default p5.Vector;

--- a/test/unit/math/p5.Vector.js
+++ b/test/unit/math/p5.Vector.js
@@ -868,18 +868,16 @@ suite('p5.Vector', function() {
   });
 
   suite('normalize', function() {
-    setup(function() {
-      v.x = 1;
-      v.y = 1;
-      v.z = 1;
-    });
+    suite('v.normalize()', function() {
+      setup(function() {
+        v = myp5.createVector(1, 1, 1);
+      });
 
-    test('should return the same object', function() {
-      expect(v.normalize()).to.eql(v);
-    });
+      test('should return the same object', function() {
+        expect(v.normalize()).to.eql(v);
+      });
 
-    suite('with unit vector', function() {
-      test('should not change the vector', function() {
+      test('unit vector should not change values', function() {
         v.x = 1;
         v.y = 0;
         v.z = 0;
@@ -888,10 +886,8 @@ suite('p5.Vector', function() {
         expect(v.y).to.eql(0);
         expect(v.z).to.eql(0);
       });
-    });
 
-    suite('with 2,2,1', function() {
-      test('should normalize to 0.66,0.66,0.33', function() {
+      test('2,2,1 should normalize to ~0.66,0.66,0.33', function() {
         v.x = 2;
         v.y = 2;
         v.z = 1;
@@ -899,6 +895,38 @@ suite('p5.Vector', function() {
         expect(v.x).to.be.closeTo(0.6666, 0.01);
         expect(v.y).to.be.closeTo(0.6666, 0.01);
         expect(v.z).to.be.closeTo(0.3333, 0.01);
+      });
+    });
+
+    suite('p5.Vector.normalize(v)', function() {
+      var res;
+      setup(function() {
+        v = myp5.createVector(1, 0, 0);
+        res = p5.Vector.normalize(v);
+      });
+
+      test('should not be undefined', function() {
+        expect(res).to.not.eql(undefined);
+      });
+
+      test('should not return same object v', function() {
+        expect(res).to.not.equal(v);
+      });
+
+      test('unit vector 1,0,0 should normalize to 1,0,0', function() {
+        expect(res.x).to.eql(1);
+        expect(res.y).to.eql(0);
+        expect(res.z).to.eql(0);
+      });
+
+      test('2,2,1 should normalize to ~0.66,0.66,0.33', function() {
+        v.x = 2;
+        v.y = 2;
+        v.z = 1;
+        res = p5.Vector.normalize(v);
+        expect(res.x).to.be.closeTo(0.6666, 0.01);
+        expect(res.y).to.be.closeTo(0.6666, 0.01);
+        expect(res.z).to.be.closeTo(0.3333, 0.01);
       });
     });
   });


### PR DESCRIPTION
<!--
  Thank you for contributing! Please use this pull request (PR) template.


 In the description field of this PR, include "resolves #XXXX" tagging the issue you are fixing. If this PR addresses the issue but doesn't completely resolve it (ie the issue should remain open after your PR is merged), write "addresses #XXXX".-->
Addresses #4852

#### Changes:
Adds static version of vector function p5.Vector.normalize(), with inline documentation and very basic tests.

#### PR Checklist
<!--
  To check any option, replace the "[ ]" with a "[x]". Be sure to check out how it looks in the Preview tab! Feel free to remove any portion of the template that is not relevant for your issue.
-->

- [x] `npm run lint` passes
- [x] [Inline documentation] is included / updated
- [x] [Unit tests] are included / updated

[Inline documentation]: https://github.com/processing/p5.js/blob/main/contributor_docs/inline_documentation.md
[Unit tests]: https://github.com/processing/p5.js/tree/main/contributor_docs#unit-tests

#### Additional Comments:
The unit tests I have added are a little bit messy and certainly incomplete, but they follow the example/style set by the existing vector tests. It may be worth giving the whole test module a once-over, but I think that merits its own issue.

Please let me know if you have any suggestions for improvements (for any aspect of this), since I will be modelling the rest of the static vector functions after this one.