### PR TITLE
Fixes offscreen rendering bug

### DIFF
--- a/src/core/main.js
+++ b/src/core/main.js
@@ -166,12 +166,6 @@ class p5 {
     // PRIVATE p5 PROPERTIES AND METHODS
     //////////////////////////////////////////////
 
-    this._accessibleOutputs = {
-      text: false,
-      grid: false,
-      textLabel: false,
-      gridLabel: false
-    };
     this._setupDone = false;
     // for handling hidpi
     this._pixelDensity = Math.ceil(window.devicePixelRatio) || 1;
@@ -583,6 +577,13 @@ class p5 {
   }
 
   _initializeInstanceVariables() {
+    this._accessibleOutputs = {
+      text: false,
+      grid: false,
+      textLabel: false,
+      gridLabel: false
+    };
+
     this._styles = [];
 
     this._bezierDetail = 20;


### PR DESCRIPTION
Resolves #5000 

Changes:
  - p5.Graphics wraps the renderer but doesn't initialize `accessibleOutputs` property
  - This moves the `accessibleOutputs` initialize into `initializeInstanceVariables` since that's applied on the default renderer and p5.Graphics

#### PR Checklist

- [x] `npm run lint` passes
- [x] [Inline documentation] is included / updated
- [x] [Unit tests] are included / updated
