### PR TITLE
Changed frameInfo.delay value when it is equal to 0

### DIFF
--- a/src/image/loading_displaying.js
+++ b/src/image/loading_displaying.js
@@ -193,9 +193,13 @@ function _createGif(
       loadGIFFrameIntoImage(j, gifReader);
       const imageData = new ImageData(framePixels, pImg.width, pImg.height);
       pImg.drawingContext.putImageData(imageData, 0, 0);
+      let frameDelay = frameInfo.delay;
+      if (frameDelay === 0) {
+        frameDelay = 10;
+      }
       frames.push({
         image: pImg.drawingContext.getImageData(0, 0, pImg.width, pImg.height),
-        delay: frameInfo.delay * 10 //GIF stores delay in one-hundredth of a second, shift to ms
+        delay: frameDelay * 10 //GIF stores delay in one-hundredth of a second, shift to ms
       });
     }
 

--- a/src/image/loading_displaying.js
+++ b/src/image/loading_displaying.js
@@ -194,6 +194,7 @@ function _createGif(
       const imageData = new ImageData(framePixels, pImg.width, pImg.height);
       pImg.drawingContext.putImageData(imageData, 0, 0);
       let frameDelay = frameInfo.delay;
+      // To maintain the default of 10FPS when frameInfo.delay equals to 0
       if (frameDelay === 0) {
         frameDelay = 10;
       }


### PR DESCRIPTION

Resolves #5014 

 Changes:

Changes the`frameInfo.delay` value went it is equal to 0 such that delay becomes 100 to maintain the standard of 10 fps.

#### PR Checklist
<!--
  To check any option, replace the "[ ]" with a "[x]". Be sure to check out how it looks in the Preview tab! Feel free to remove any portion of the template that is not relevant for your issue.
-->

- [x] `npm run lint` passes
- [ ] [Inline documentation] is included / updated
- [ ] [Unit tests] are included / updated

[Inline documentation]: https://github.com/processing/p5.js/blob/main/contributor_docs/inline_documentation.md
[Unit tests]: https://github.com/processing/p5.js/tree/main/contributor_docs#unit-tests
