### PR TITLE
removes the extra space in the reference page under the foundation section.

### DIFF
--- a/src/core/reference.js
+++ b/src/core/reference.js
@@ -1,5 +1,6 @@
 /**
  * @module Foundation
+ * @submodule Foundation
  * @for p5
  */
 


### PR DESCRIPTION
Resolves [#938](https://github.com/processing/p5.js-website/issues/938)

This removes the line break under [Foundation](https://p5js.org/reference/#group-Foundation) section in reference page 
<!--
  Thank you for contributing! Please use this pull request (PR) template.


 In the description field of this PR, include "resolves #XXXX" tagging the issue you are fixing. If this PR addresses the issue but doesn't completely resolve it (ie the issue should remain open after your PR is merged), write "addresses #XXXX".-->

 Changes:added submodule to Foundation section
<!-- Add here what changes were made in this pull request and if possible provide links showcasing the changes. -->



#### PR Checklist
<!--
  To check any option, replace the "[ ]" with a "[x]". Be sure to check out how it looks in the Preview tab! Feel free to remove any portion of the template that is not relevant for your issue.
-->

- [x] `npm run lint` passes
- [x] [Inline documentation] is included / updated
- [x] [Unit tests] are included / updated

[Inline documentation]: https://github.com/processing/p5.js/blob/main/contributor_docs/inline_documentation.md
[Unit tests]: https://github.com/processing/p5.js/tree/main/contributor_docs#unit-tests
