### PR TITLE
Fixes tint in 2d canvas with webgl p5.Graphics

### DIFF
--- a/src/image/filters.js
+++ b/src/image/filters.js
@@ -35,9 +35,25 @@ Filters._toPixels = function(canvas) {
   if (canvas instanceof ImageData) {
     return canvas.data;
   } else {
-    return canvas
-      .getContext('2d')
-      .getImageData(0, 0, canvas.width, canvas.height).data;
+    if (canvas.getContext('2d')) {
+      return canvas
+        .getContext('2d')
+        .getImageData(0, 0, canvas.width, canvas.height).data;
+    } else if (canvas.getContext('webgl')) {
+      const gl = canvas.getContext('webgl');
+      const len = gl.drawingBufferWidth * gl.drawingBufferHeight * 4;
+      const data = new Uint8Array(len);
+      gl.readPixels(
+        0,
+        0,
+        canvas.width,
+        canvas.height,
+        gl.RGBA,
+        gl.UNSIGNED_BYTE,
+        data
+      );
+      return data;
+    }
   }
 };
 

--- a/src/image/filters.js
+++ b/src/image/filters.js
@@ -40,12 +40,19 @@ Filters._toPixels = function(canvas) {
         .getContext('2d')
         .getImageData(0, 0, canvas.width, canvas.height).data;
     } else if (canvas.getContext('webgl')) {
-      const offCanvas = document.createElement('canvas');
-      offCanvas.width = canvas.width;
-      offCanvas.height = canvas.height;
-      const gl = offCanvas.getContext('2d');
-      gl.drawImage(canvas, 0, 0);
-      return gl.getImageData(0, 0, offCanvas.width, offCanvas.height).data;
+      const gl = canvas.getContext('webgl');
+      const len = gl.drawingBufferWidth * gl.drawingBufferHeight * 4;
+      const data = new Uint8Array(len);
+      gl.readPixels(
+        0,
+        0,
+        canvas.width,
+        canvas.height,
+        gl.RGBA,
+        gl.UNSIGNED_BYTE,
+        data
+      );
+      return data;
     }
   }
 };

--- a/src/image/filters.js
+++ b/src/image/filters.js
@@ -40,19 +40,12 @@ Filters._toPixels = function(canvas) {
         .getContext('2d')
         .getImageData(0, 0, canvas.width, canvas.height).data;
     } else if (canvas.getContext('webgl')) {
-      const gl = canvas.getContext('webgl');
-      const len = gl.drawingBufferWidth * gl.drawingBufferHeight * 4;
-      const data = new Uint8Array(len);
-      gl.readPixels(
-        0,
-        0,
-        canvas.width,
-        canvas.height,
-        gl.RGBA,
-        gl.UNSIGNED_BYTE,
-        data
-      );
-      return data;
+      const offCanvas = document.createElement('canvas');
+      offCanvas.width = canvas.width;
+      offCanvas.height = canvas.height;
+      const gl = offCanvas.getContext('2d');
+      gl.drawImage(canvas, 0, 0);
+      return gl.getImageData(0, 0, offCanvas.width, offCanvas.height).data;
     }
   }
 };


### PR DESCRIPTION
Resolves #5046

 Changes:
Added condition while rendering webgl such that it reads a block of pixels from a specified shape of the current color framebuffer into an ArrayBufferView object.

 Screenshots of the change:
After change:
![image](https://user-images.githubusercontent.com/47415702/109315236-57d24380-7870-11eb-8a16-ef05f97ad9d1.png)


#### PR Checklist
<!--
  To check any option, replace the "[ ]" with a "[x]". Be sure to check out how it looks in the Preview tab! Feel free to remove any portion of the template that is not relevant for your issue.
-->

- [x] `npm run lint` passes
- [ ] [Inline documentation] is included / updated
- [ ] [Unit tests] are included / updated

[Inline documentation]: https://github.com/processing/p5.js/blob/main/contributor_docs/inline_documentation.md
[Unit tests]: https://github.com/processing/p5.js/tree/main/contributor_docs#unit-tests
