### PR TITLE
fix: #4993 user-reassigned pixel data

### DIFF
--- a/src/core/p5.Renderer2D.js
+++ b/src/core/p5.Renderer2D.js
@@ -387,6 +387,18 @@ p5.Renderer2D.prototype.updatePixels = function(x, y, w, h) {
   w *= pd;
   h *= pd;
 
+  // checking if user assigned pixel array is appropriate for this object
+  if (pixelsState.pixels.length !== pixelsState.imageData.data.length) {
+    throw new Error(`
+      User assigned pixel array does not match image/canvas dimensions.
+    `);
+  }
+
+  // assigning the pixels to imageData.data (given the above check passes)
+  for (let i = 0; i < pixelsState.pixels.length; i++) {
+    pixelsState.imageData.data[i] = pixelsState.pixels[i];
+  }
+
   if (this.gifProperties) {
     this.gifProperties.frames[this.gifProperties.displayIndex].image =
       pixelsState.imageData;


### PR DESCRIPTION
<!--
  Thank you for contributing! Please use this pull request (PR) template.


 In the description field of this PR, include "resolves #XXXX" tagging the issue you are fixing. If this PR addresses the issue but doesn't completely resolve it (ie the issue should remain open after your PR is merged), write "addresses #XXXX".-->
Resolves #4993 
###  Issue:
Updating the `pixels` property of objects does not affect the inherent data/pixels used to draw on the canvas.

###  Changes:
- Check if `pixels` property (available to the user for change, with documentation) is sized appropriately for the object.
- Assign this pixel data to `imageData.data`.


#### PR Checklist
<!--
  To check any option, replace the "[ ]" with a "[x]". Be sure to check out how it looks in the Preview tab! Feel free to remove any portion of the template that is not relevant for your issue.
-->

- [x] `npm run lint` passes

[Inline documentation]: https://github.com/processing/p5.js/blob/main/contributor_docs/inline_documentation.md
[Unit tests]: https://github.com/processing/p5.js/tree/main/contributor_docs#unit-tests
