### PR TITLE
Add check for TypedArrays in applyMatrix()

### DIFF
--- a/src/core/transform.js
+++ b/src/core/transform.js
@@ -156,7 +156,8 @@ import p5 from './main';
  * A rectangle in the upper left corner
  */
 p5.prototype.applyMatrix = function() {
-  if (Array.isArray(arguments[0])) {
+  let isTypedArray = arguments[0] instanceof Object.getPrototypeOf(Uint8Array);
+  if (Array.isArray(arguments[0]) || isTypedArray) {
     this._renderer.applyMatrix(...arguments[0]);
   } else {
     this._renderer.applyMatrix(...arguments);


### PR DESCRIPTION
<!--
  Thank you for contributing! Please use this pull request (PR) template.


 In the description field of this PR, include "resolves #XXXX" tagging the issue you are fixing. If this PR addresses the issue but doesn't completely resolve it (ie the issue should remain open after your PR is merged), write "addresses #XXXX".-->
Addendum to previous PR #5072 

 Changes:
<!-- Add here what changes were made in this pull request and if possible provide links showcasing the changes. -->
This is a small addendum to the previous PR, as it currently won't recognize input from TypedArrays like Uint8Array or Float32Array.

#### PR Checklist
<!--
  To check any option, replace the "[ ]" with a "[x]". Be sure to check out how it looks in the Preview tab! Feel free to remove any portion of the template that is not relevant for your issue.
-->

- [x] `npm run lint` passes

[Inline documentation]: https://github.com/processing/p5.js/blob/main/contributor_docs/inline_documentation.md
[Unit tests]: https://github.com/processing/p5.js/tree/main/contributor_docs#unit-tests
