### PR TITLE
Revert of PR #4712, restores text wrapping behavior

### DIFF
--- a/src/core/p5.Renderer.js
+++ b/src/core/p5.Renderer.js
@@ -216,10 +216,10 @@ p5.Renderer.prototype.text = function(str, x, y, maxWidth, maxHeight) {
   let jj;
   let line;
   let testLine;
+  let currentLineLength;
   let testWidth;
   let words;
   let totalHeight;
-  let shiftedY;
   let finalMaxHeight = Number.MAX_VALUE;
 
   if (!(this._doFill || this._doStroke)) {
@@ -237,27 +237,20 @@ p5.Renderer.prototype.text = function(str, x, y, maxWidth, maxHeight) {
 
   if (typeof maxWidth !== 'undefined') {
     totalHeight = 0;
+    currentLineLength = 1;
     for (ii = 0; ii < cars.length; ii++) {
       line = '';
       words = cars[ii].split(' ');
       for (n = 0; n < words.length; n++) {
         testLine = `${line + words[n]} `;
         testWidth = this.textWidth(testLine);
-        if (testWidth > maxWidth) {
-          let currentWord = words[n];
-          for (let index = 0; index < currentWord.length; index++) {
-            testLine = `${line + currentWord[index]}`;
-            testWidth = this.textWidth(testLine);
-            if (testWidth > maxWidth && line.length > 0) {
-              line = `${currentWord[index]}`;
-              totalHeight += p.textLeading();
-            } else {
-              line = testLine;
-            }
-          }
-          line = `${line} `;
+        if (testWidth > maxWidth && currentLineLength > 1) {
+          line = `${words[n]} `;
+          totalHeight += p.textLeading();
+          currentLineLength = 1;
         } else {
           line = testLine;
+          currentLineLength += 1;
         }
       }
       if (ii < cars.length - 1) {
@@ -306,25 +299,10 @@ p5.Renderer.prototype.text = function(str, x, y, maxWidth, maxHeight) {
       for (n = 0; n < words.length; n++) {
         testLine = `${line + words[n]} `;
         testWidth = this.textWidth(testLine);
-        if (testWidth > maxWidth) {
-          let currentWord = words[n];
-          for (let index = 0; index < currentWord.length; index++) {
-            testLine = `${line + currentWord[index]}`;
-            testWidth = this.textWidth(testLine);
-            if (testWidth > maxWidth && line.length > 0) {
-              const lastChar = line.slice(-1);
-              const shouldAddHyphen = lastChar !== '\n' && lastChar !== ' ';
-              line = `${line}${shouldAddHyphen ? '-' : ''}`;
-
-              this._renderText(p, line, x, y, finalMaxHeight);
-              y += p.textLeading();
-
-              line = `${currentWord[index]}`;
-            } else {
-              line = testLine;
-            }
-          }
-          line = `${line} `;
+        if (testWidth > maxWidth && line.length > 0) {
+          this._renderText(p, line, x, y, finalMaxHeight);
+          line = `${words[n]} `;
+          y += p.textLeading();
         } else {
           line = testLine;
         }

--- a/src/core/p5.Renderer.js
+++ b/src/core/p5.Renderer.js
@@ -220,6 +220,7 @@ p5.Renderer.prototype.text = function(str, x, y, maxWidth, maxHeight) {
   let testWidth;
   let words;
   let totalHeight;
+  let shiftedY;
   let finalMaxHeight = Number.MAX_VALUE;
 
   if (!(this._doFill || this._doStroke)) {


### PR DESCRIPTION
Resolves #5081

 Changes:
Reverts PR #4712 and restores text wrapping behavior as seen in version 1.1.9.

 Screenshots of the change:
Current rendering of 'Lorem ipsum dolor sit amet, consectetur adipiscing elit' in 100, 100 canvas:
![Screenshot 2021-03-14 at 21 22 32](https://user-images.githubusercontent.com/15334958/111082992-95d79480-850b-11eb-8a91-7f4755bff875.png)
Fixed:
![Screenshot 2021-03-14 at 21 19 50](https://user-images.githubusercontent.com/15334958/111082994-9708c180-850b-11eb-8732-612be973784a.png)

Note this also re-introduces Issue #4652, future improvements should change how single words that exceed the length of a line can be handled by hyphenation or not.  

#### PR Checklist
<!--
  To check any option, replace the "[ ]" with a "[x]". Be sure to check out how it looks in the Preview tab! Feel free to remove any portion of the template that is not relevant for your issue.
-->

- [x] `npm run lint` passes

Inline documentation and unit tests unchanged

[Inline documentation]: https://github.com/processing/p5.js/blob/main/contributor_docs/inline_documentation.md
[Unit tests]: https://github.com/processing/p5.js/tree/main/contributor_docs#unit-tests
