### PR TITLE
Fixing ellipse() and arc detail bug and adding unit test to cover p5.RendererGL.prototype.ellipse and p5.RendererGL.prototype.arc

### DIFF
--- a/src/core/shape/2d_primitives.js
+++ b/src/core/shape/2d_primitives.js
@@ -122,9 +122,10 @@ p5.prototype._normalizeArcAngles = (
  * @param  {Number} stop   angle to stop the arc, specified in radians
  * @param  {Constant} [mode] optional parameter to determine the way of drawing
  *                         the arc. either CHORD, PIE or OPEN
- * @param  {Number} [detail] optional parameter for WebGL mode only. This is to
+ * @param  {Integer} [detail] optional parameter for WebGL mode only. This is to
  *                         specify the number of vertices that makes up the
- *                         perimeter of the arc. Default value is 25.
+ *                         perimeter of the arc. Default value is 25. Won't 
+ *                         draw a stroke for a detail of more than 50.
  * @chainable
  *
  * @example
@@ -261,7 +262,10 @@ p5.prototype.arc = function(x, y, w, h, start, stop, mode, detail) {
  * @param  {Number} y
  * @param  {Number} w
  * @param  {Number} h
- * @param  {Integer} detail number of radial sectors to draw (for WebGL mode)
+ * @param  {Integer} [detail] optional parameter for WebGL mode only. This is to
+ *                         specify the number of vertices that makes up the
+ *                         perimeter of the ellipse. Default value is 25. Won't 
+ *                         draw a stroke for a detail of more than 50.
  */
 p5.prototype.ellipse = function(x, y, w, h, detailX) {
   p5._validateParameters('ellipse', arguments);

--- a/src/core/shape/2d_primitives.js
+++ b/src/core/shape/2d_primitives.js
@@ -124,7 +124,7 @@ p5.prototype._normalizeArcAngles = (
  *                         the arc. either CHORD, PIE or OPEN
  * @param  {Integer} [detail] optional parameter for WebGL mode only. This is to
  *                         specify the number of vertices that makes up the
- *                         perimeter of the arc. Default value is 25. Won't 
+ *                         perimeter of the arc. Default value is 25. Won't
  *                         draw a stroke for a detail of more than 50.
  * @chainable
  *
@@ -264,7 +264,7 @@ p5.prototype.arc = function(x, y, w, h, start, stop, mode, detail) {
  * @param  {Number} h
  * @param  {Integer} [detail] optional parameter for WebGL mode only. This is to
  *                         specify the number of vertices that makes up the
- *                         perimeter of the ellipse. Default value is 25. Won't 
+ *                         perimeter of the ellipse. Default value is 25. Won't
  *                         draw a stroke for a detail of more than 50.
  */
 p5.prototype.ellipse = function(x, y, w, h, detailX) {

--- a/src/webgl/3d_primitives.js
+++ b/src/webgl/3d_primitives.js
@@ -1157,7 +1157,9 @@ p5.RendererGL.prototype.arc = function(args) {
     if (detail <= 50) {
       arcGeom._makeTriangleEdges()._edgesToVertices(arcGeom);
     } else if (this._doStroke) {
-      console.log('Cannot apply a stroke to an ${shape} with more than 50 detail');
+      console.log(
+        `Cannot apply a stroke to an ${shape} with more than 50 detail`
+      );
     }
 
     this.createBuffers(gId, arcGeom);

--- a/src/webgl/3d_primitives.js
+++ b/src/webgl/3d_primitives.js
@@ -1156,8 +1156,8 @@ p5.RendererGL.prototype.arc = function(args) {
 
     if (detail <= 50) {
       arcGeom._makeTriangleEdges()._edgesToVertices(arcGeom);
-    } else if (this._renderer._doStroke) {
-      console.log('Cannot stroke ${shape} with more than 50 detail');
+    } else if (this._doStroke) {
+      console.log('Cannot apply a stroke to an ${shape} with more than 50 detail');
     }
 
     this.createBuffers(gId, arcGeom);

--- a/test/unit/webgl/3d_primitives.js
+++ b/test/unit/webgl/3d_primitives.js
@@ -238,4 +238,89 @@ suite('3D Primitives', function() {
       );
     });
   });
+
+  suite('p5.RendererGL.prototype.ellipse', function() {
+    test('should be a function', function() {
+      assert.ok(myp5._renderer.ellipse);
+      assert.typeOf(myp5._renderer.ellipse, 'function');
+    });
+    test('no friendly-err-msg', function() {
+      assert.doesNotThrow(
+        function() {
+          myp5.ellipse(0, 0, 100);
+        },
+        Error,
+        'got unwanted exception'
+      );
+    });
+    test('missing param #2', function() {
+      assert.validationError(function() {
+        myp5.ellipse(0, 0);
+      });
+    });
+    test('missing param #2', function() {
+      assert.validationError(function() {
+        var size;
+        myp5.ellipse(0, 0, size);
+      });
+    });
+    test('wrong param type at #0', function() {
+      assert.validationError(function() {
+        myp5.ellipse('a', 0, 100, 100);
+      });
+    });
+    test('no friendly-err-msg. detail parameter > 50', function() {
+      assert.doesNotThrow(
+        function() {
+          myp5.ellipse(50, 50, 120, 30, 51);
+        },
+        Error,
+        'got unwanted exception'
+      );
+    });
+  });
+
+  suite('p5.RendererGL.prototype.arc', function() {
+    test('should be a function', function() {
+      assert.ok(myp5._renderer.arc);
+      assert.typeOf(myp5._renderer.arc, 'function');
+    });
+    test('no friendly-err-msg', function() {
+      assert.doesNotThrow(
+        function() {
+          myp5.arc(1, 1, 10.5, 10, 0, Math.PI, 'pie');
+        },
+        Error,
+        'got unwanted exception'
+      );
+    });
+    test('missing param #4, #5', function() {
+      assert.validationError(function() {
+        myp5.arc(1, 1, 10.5, 10);
+      });
+    });
+    test('wrong param type at #0', function() {
+      assert.validationError(function() {
+        myp5.arc('a', 1, 10.5, 10, 0, Math.PI, 'pie');
+      });
+    });
+    test('no friendly-err-msg. detail parameter > 50', function() {
+      assert.doesNotThrow(
+        function() {
+          myp5.arc(1, 1, 100, 100, 0, Math.PI / 2, 'chord', 51);
+        },
+        Error,
+        'got unwanted exception'
+      );
+    });
+    test('no friendly-err-msg. default mode', function() {
+      assert.doesNotThrow(
+        function() {
+          myp5.arc(1, 1, 100, 100, Math.PI / 4, Math.PI / 3);
+        },
+        Error,
+        'got unwanted exception'
+      );
+    });
+  });
 });


### PR DESCRIPTION
<!--
  Thank you for contributing! Please use this pull request (PR) template.


 In the description field of this PR, include "resolves #XXXX" tagging the issue you are fixing. If this PR addresses the issue but doesn't completely resolve it (ie the issue should remain open after your PR is merged), write "addresses #XXXX".-->
Resolves #5102

 Changes:
<!-- Add here what changes were made in this pull request and if possible provide links showcasing the changes. -->
- Fixed bug for when a detail parameter of greater than 50 is passed to ellipse or arc `this._renderer is undefined`.
- Changed wording on no stroke with > 50 detail warning message.
- Updated documentation on ellipse and arc to reflect that they don't render a stroke when detail > 50.
- Added unit tests that cover all lines of p5.RendererGL.prototype.ellipse and p5.RendererGL.prototype.arc. Something that previously was completely uncovered.

 Screenshots of the change: N/A
<!-- If applicable, add screenshots depicting the changes. -->

#### PR Checklist
<!--
  To check any option, replace the "[ ]" with a "[x]". Be sure to check out how it looks in the Preview tab! Feel free to remove any portion of the template that is not relevant for your issue.
-->

- [x] `npm run lint` passes
- [x] [Inline documentation] is included / updated
- [x] [Unit tests] are included / updated

[Inline documentation]: https://github.com/processing/p5.js/blob/main/contributor_docs/inline_documentation.md
[Unit tests]: https://github.com/processing/p5.js/tree/main/contributor_docs#unit-tests

Any suggestions or modifications are very much welcome. 💕
