### PR TITLE
get version constant from package.json

### DIFF
--- a/src/core/constants.js
+++ b/src/core/constants.js
@@ -11,7 +11,7 @@ const _PI = Math.PI;
  * @property {String} VERSION
  * @final
  */
-export const VERSION = VERSIONCONST;
+export const VERSION = 'VERSIONCONST';
 
 // GRAPHICS RENDERER
 /**

--- a/src/core/constants.js
+++ b/src/core/constants.js
@@ -11,7 +11,7 @@ const _PI = Math.PI;
  * @property {String} VERSION
  * @final
  */
-export const VERSION = require('../../package.json').version;
+export const VERSION = VERSIONCONST;
 
 // GRAPHICS RENDERER
 /**

--- a/src/core/constants.js
+++ b/src/core/constants.js
@@ -11,7 +11,8 @@ const _PI = Math.PI;
  * @property {String} VERSION
  * @final
  */
-export const VERSION = 'VERSIONCONST';
+export const VERSION =
+  'VERSION_CONST_WILL_BE_REPLACED_BY_BROWSERIFY_BUILD_PROCESS';
 
 // GRAPHICS RENDERER
 /**

--- a/src/core/constants.js
+++ b/src/core/constants.js
@@ -6,6 +6,13 @@
 
 const _PI = Math.PI;
 
+/**
+ * Version of this p5.js.
+ * @property {String} VERSION
+ * @final
+ */
+export const VERSION = require('../../package.json').version;
+
 // GRAPHICS RENDERER
 /**
  * The default, two-dimensional renderer.

--- a/tasks/build/browserify.js
+++ b/tasks/build/browserify.js
@@ -78,6 +78,11 @@ module.exports = function(grunt) {
           code += data;
         })
         .on('end', function() {
+          code = code.replace(
+            'VERSIONCONST',
+            grunt.template.process(`'<%= pkg.version %>'`)
+          );
+
           // "code" is complete: create the distributable UMD build by running
           // the bundle through derequire
           // (Derequire changes the bundle's internal "require" function to

--- a/tasks/build/browserify.js
+++ b/tasks/build/browserify.js
@@ -79,7 +79,7 @@ module.exports = function(grunt) {
         })
         .on('end', function() {
           code = code.replace(
-            `'VERSIONCONST'`,
+            `'VERSION_CONST_WILL_BE_REPLACED_BY_BROWSERIFY_BUILD_PROCESS'`,
             grunt.template.process(`'<%= pkg.version %>'`)
           );
 

--- a/tasks/build/browserify.js
+++ b/tasks/build/browserify.js
@@ -79,7 +79,7 @@ module.exports = function(grunt) {
         })
         .on('end', function() {
           code = code.replace(
-            'VERSIONCONST',
+            `'VERSIONCONST'`,
             grunt.template.process(`'<%= pkg.version %>'`)
           );
 


### PR DESCRIPTION
<!--
  Thank you for contributing! Please use this pull request (PR) template.


 In the description field of this PR, include "resolves #XXXX" tagging the issue you are fixing. If this PR addresses the issue but doesn't completely resolve it (ie the issue should remain open after your PR is merged), write "addresses #XXXX".-->
Resolves #2525 continuing from https://github.com/processing/p5.js/pull/5096

 Changes:
<!-- Add here what changes were made in this pull request and if possible provide links showcasing the changes. -->

add version constant taking from `package.json` reflecting @lmccart 's comment https://github.com/processing/p5.js/pull/5096#pullrequestreview-613543846
However the downside is that the whole `package.json` seems to be exposed to the minifined file. This is not a problem as the project is open-source, but I wonder if it causes other issues.

snippets from compiled bundle:

```javascript
      262: [
        function(_dereq_, module, exports) {
          module.exports = {
            name: 'p5',
            repository: 'processing/p5.js',
            scripts: {
              grunt: 'grunt',
              build: 'grunt build',
              dev: 'grunt browserify:dev connect:yui watch:quick',
              docs: 'grunt yui',
              'docs:dev': 'grunt yui:dev',
              test: 'grunt',
              lint: 'grunt lint-no-fix',
              'lint:source': 'grunt lint-no-fix:source',
              'lint:samples': 'grunt lint-no-fix:samples',
              'lint:fix': 'grunt lint-fix',
              'contributors:add': 'all-contributors add',
              'contributors:generate': 'all-contributors generate',
              generate: 'all-contributors generate',
              release: 'grunt release-p5',
              prepublishOnly: 'grunt prerelease'
            },
            'lint-staged': {
              ignore: ['test/js/**/*.js'],
              'Gruntfile.js': 'eslint',
              'docs/preprocessor.js': 'eslint',
              'utils/**/*.js': 'eslint',
              'tasks/**/*.js': 'eslint',
              'test/**/*.js': 'eslint',
              'src/**/*.js': [
                'eslint',
                'node --require @babel/register ./utils/sample-linter.js'
              ]
            },
            version: '1.2.0',
            devDependencies: {
              '@babel/core': '^7.7.7',
              '@babel/preset-env': '^7.10.2',
              '@babel/register': '^7.7.7',
```

```javascript
          /**
           * Version of this p5.js.
           * @property {String} VERSION
           * @final
           */
          var VERSION = _dereq_('../../package.json').version;
```

#### PR Checklist
<!--
  To check any option, replace the "[ ]" with a "[x]". Be sure to check out how it looks in the Preview tab! Feel free to remove any portion of the template that is not relevant for your issue.
-->

- [ ] `npm run lint` passes
- [ ] [Inline documentation] is included / updated
- [ ] [Unit tests] are included / updated

[Inline documentation]: https://github.com/processing/p5.js/blob/main/contributor_docs/inline_documentation.md
[Unit tests]: https://github.com/processing/p5.js/tree/main/contributor_docs#unit-tests
