### PR TITLE
Add textWrap and textHyphens functions

### DIFF
--- a/src/core/constants.js
+++ b/src/core/constants.js
@@ -589,10 +589,10 @@ export const BOLD = 'bold';
  */
 export const BOLDITALIC = 'bold italic';
 /**
- * @property {String} LINE
+ * @property {String} CHAR
  * @final
  */
-export const LINE = 'LINE';
+export const CHAR = 'CHAR';
 /**
  * @property {String} WORD
  * @final

--- a/src/core/constants.js
+++ b/src/core/constants.js
@@ -588,6 +588,16 @@ export const BOLD = 'bold';
  * @final
  */
 export const BOLDITALIC = 'bold italic';
+/**
+ * @property {String} LINE
+ * @final
+ */
+export const LINE = 'LINE';
+/**
+ * @property {String} WORD
+ * @final
+ */
+export const WORD = 'WORD';
 
 // TYPOGRAPHY-INTERNAL
 export const _DEFAULT_TEXT_FILL = '#000000';

--- a/src/core/p5.Renderer.js
+++ b/src/core/p5.Renderer.js
@@ -44,6 +44,8 @@ p5.Renderer = function(elt, pInst, isMainCanvas) {
   this._textDescent = null;
   this._textAlign = constants.LEFT;
   this._textBaseline = constants.BASELINE;
+  this._textHyphens = true;
+  this._textWrap = constants.LINE;
 
   this._rectMode = constants.CORNER;
   this._ellipseMode = constants.CENTER;
@@ -77,7 +79,9 @@ p5.Renderer.prototype.push = function() {
       _textSize: this._textSize,
       _textAlign: this._textAlign,
       _textBaseline: this._textBaseline,
-      _textStyle: this._textStyle
+      _textStyle: this._textStyle,
+      _textHyphens: this._textHyphens,
+      _textWrap: this._textWrap
     }
   };
 };
@@ -206,6 +210,16 @@ p5.Renderer.prototype.textAlign = function(h, v) {
       vertical: this._textBaseline
     };
   }
+};
+
+p5.Renderer.prototype.textHyphens = function(bool) {
+  this._setProperty('_textHyphens', bool);
+  return this._textHyphens;
+};
+
+p5.Renderer.prototype.textWrap = function(wrapStyle) {
+  this._setProperty('_textWrap', wrapStyle);
+  return this._textWrap;
 };
 
 p5.Renderer.prototype.text = function(str, x, y, maxWidth, maxHeight) {

--- a/src/core/p5.Renderer.js
+++ b/src/core/p5.Renderer.js
@@ -45,7 +45,7 @@ p5.Renderer = function(elt, pInst, isMainCanvas) {
   this._textAlign = constants.LEFT;
   this._textBaseline = constants.BASELINE;
   this._textHyphens = true;
-  this._textWrap = constants.LINE;
+  this._textWrap = constants.WORD;
 
   this._rectMode = constants.CORNER;
   this._ellipseMode = constants.CENTER;
@@ -289,7 +289,7 @@ p5.Renderer.prototype.text = function(str, x, y, maxWidth, maxHeight) {
 
     // Render lines of text according to settings of textWrap and textHyphens
     // Splits lines at spaces, for loop adds one word + space at a time and tests length with next word added. If line + next word is too long, print currents line
-    if (textWrapStyle === constants.LINE) {
+    if (textWrapStyle === constants.WORD) {
       for (let lineIndex = 0; lineIndex < lines.length; lineIndex++) {
         line = '';
         words = lines[lineIndex].split(' ');

--- a/src/typography/attributes.js
+++ b/src/typography/attributes.js
@@ -285,7 +285,7 @@ p5.prototype._updateTextMetrics = function() {
 };
 
 /**
- * Specifies if words should be hyphenated when text wrapped across multiple lines breaks mid-word. Setting textHyphens to true inserts hyphens when a word is broken, false does not. Default is true.
+ * Specifies if words should be hyphenated when text wrapped across multiple lines breaks mid-word. Setting textHyphens to true inserts a hyphen whenever a line is broken at a non-space character, false does not. Default is true.
  *
  * @method textHyphens
  * @param {Boolean} hyphenation true or false
@@ -295,8 +295,8 @@ p5.prototype._updateTextMetrics = function() {
  * <code>
  * let longWord = 'Supercalifragilistic';
  * function draw() {
- *   textSize(14);
- *   textLeading(14);
+ *   textSize(18);
+ *   textLeading(20);
  *   textWrap(WORD);
  *   textHyphens(true);
  *   text(longWord, 0, 10, 100, 50);
@@ -322,10 +322,10 @@ p5.prototype.textHyphens = function(bool) {
  * @example
  * <div>
  * <code>
- * let longText = 'Sphinx of black quartz, judge my vow';
+ * let longText = 'Have a wonderful day';
  * function draw() {
- *   textSize(14);
- *   textLeading(12);
+ *   textSize(16);
+ *   textLeading(14);
  *   textWrap(LINE);
  *   text(longText, 0, 10, 100);
  *   textWrap(WORD);

--- a/src/typography/attributes.js
+++ b/src/typography/attributes.js
@@ -294,15 +294,13 @@ p5.prototype._updateTextMetrics = function() {
  * <div>
  * <code>
  * let longWord = 'Supercalifragilistic';
- * function draw() {
- *   textSize(18);
- *   textLeading(20);
- *   textWrap(WORD);
- *   textHyphens(true);
- *   text(longWord, 0, 10, 100, 50);
- *   textHyphens(false);
- *   text(longWord, 0, 60, 100, 50);
- * }
+ * textSize(18);
+ * textLeading(20);
+ * textWrap(WORD);
+ * textHyphens(true);
+ * text(longWord, 0, 10, 100, 50);
+ * textHyphens(false);
+ * text(longWord, 0, 60, 100, 50);
  * </code>
  * </div>
  */
@@ -323,14 +321,12 @@ p5.prototype.textHyphens = function(bool) {
  * <div>
  * <code>
  * let longText = 'Have a wonderful day';
- * function draw() {
- *   textSize(16);
- *   textLeading(14);
- *   textWrap(LINE);
- *   text(longText, 0, 10, 100);
- *   textWrap(WORD);
- *   text(longText, 0, 60, 100);
- * }
+ * textSize(16);
+ * textLeading(14);
+ * textWrap(LINE);
+ * text(longText, 0, 10, 100);
+ * textWrap(WORD);
+ * text(longText, 0, 60, 100);
  * </code>
  * </div>
  */

--- a/src/typography/attributes.js
+++ b/src/typography/attributes.js
@@ -289,14 +289,14 @@ p5.prototype._updateTextMetrics = function() {
  *
  * @method textHyphens
  * @param {Boolean} hyphenation true or false
- * @return {Boolean}
+ * @return {Boolean} true or false
  * @example
  * <div>
  * <code>
  * let longWord = 'Supercalifragilistic';
  * textSize(18);
  * textLeading(20);
- * textWrap(WORD);
+ * textWrap(CHAR);
  * textHyphens(true);
  * text(longWord, 0, 10, 100, 50);
  * textHyphens(false);
@@ -312,27 +312,27 @@ p5.prototype.textHyphens = function(bool) {
 };
 
 /**
- * Specifies how lines of text are wrapped within the canvas. LINE (default) sets line breaks only at new lines ('\n') and spaces. WORD sets line breaks mid-word if necessary. Set textHyphens to true if you would like a hyphen injected when the word is broken, or false if the word should wrap without hyphenation.
+ * Specifies how lines of text are wrapped within the canvas. WORD (default) sets line breaks only at new lines ('\n') and spaces. CHAR sets line breaks mid-word if necessary. Set textHyphens to true if you would like a hyphen injected when the word is broken, or false if the word should wrap without hyphenation.
  *
  * @method textWrap
- * @param {Constant} wrapStyle text wrapping style, either LINE or WORD
- * @return {String}
+ * @param {Constant} wrapStyle text wrapping style, either WORD or CHAR
+ * @return {String} the text wrapping style
  * @example
  * <div>
  * <code>
  * let longText = 'Have a wonderful day';
  * textSize(16);
  * textLeading(14);
- * textWrap(LINE);
- * text(longText, 0, 10, 100);
  * textWrap(WORD);
+ * text(longText, 0, 10, 100);
+ * textWrap(CHAR);
  * text(longText, 0, 60, 100);
  * </code>
  * </div>
  */
 p5.prototype.textWrap = function(wrapStyle) {
-  if (wrapStyle !== 'LINE' && wrapStyle !== 'WORD') {
-    throw 'Error: textWrap accepts only LINE or WORD';
+  if (wrapStyle !== 'WORD' && wrapStyle !== 'CHAR') {
+    throw 'Error: textWrap accepts only WORD or CHAR';
   }
   return this._renderer.textWrap(wrapStyle);
 };

--- a/src/typography/attributes.js
+++ b/src/typography/attributes.js
@@ -284,4 +284,74 @@ p5.prototype._updateTextMetrics = function() {
   return this._renderer._updateTextMetrics();
 };
 
+/**
+ * Specifies if words should be hyphenated when text wrapped across multiple lines breaks mid-word. Setting textHyphens to true inserts hyphens when a word is broken, false does not. Default is true.
+ *
+ * @method textHyphens
+ * @param {Boolean} hyphenation true or false
+ * @return {Boolean}
+ * @example
+ * <div>
+ * <code>
+ * let longText = 'Lorem ipsum dolor sit amet, consectetur adipiscing elit';
+ * let font;
+ * function preload() {
+ *   font = loadFont('./assets/Regular.otf');
+ * }
+ * function setup() {
+ *   createCanvas(100, 400);
+ * }
+ * function draw() {
+ *   textFont(font);
+ *   textSize(12);
+ *   textWrap(WORD);
+ *   textHyphens(true);
+ *   text(longText, 0, 0, 100, 50);
+ *   textHyphens(false);
+ *   text(longText, 0, 51, 100, 50);
+ * }
+ * </code>
+ * </div>
+ */
+p5.prototype.textHyphens = function(bool) {
+  if (typeof bool !== 'boolean') {
+    throw 'Error: textHyphens accepts true or false';
+  }
+  return this._renderer.textHyphens(bool);
+};
+
+/**
+ * Specifies how lines of text are wrapped within the canvas. LINE (default) sets line breaks only at new lines ('\n') and spaces. WORD sets line breaks mid-word if necessary. Set textHyphens to true if you would like a hyphen injected when the word is broken, or false if the word should wrap without hyphenation.
+ *
+ * @method textWrap
+ * @param {Constant} wrapStyle text wrapping style, either LINE or WORD
+ * @return {String}
+ * @example
+ * <div>
+ * <code>
+ * let longText = 'Blorem blipsum dolor sit amet, consectetur adipiscing elit';
+ * let font;
+ * function preload() {
+ *   font = loadFont('./assets/Regular.otf');
+ * }
+ * function setup() {
+ *   createCanvas(100, 400);
+ * }
+ * function draw() {
+ *   textFont(font);
+ *   textWrap(LINE);
+ *   text(longText, 0, 0, 100, 50);
+ *   textWrap(WORD);
+ *   text(longText, 0, 51, 100, 50);
+ * }
+ * </code>
+ * </div>
+ */
+p5.prototype.textWrap = function(wrapStyle) {
+  if (wrapStyle !== 'LINE' && wrapStyle !== 'WORD') {
+    throw 'Error: textWrap accepts only LINE or WORD';
+  }
+  return this._renderer.textWrap(wrapStyle);
+};
+
 export default p5;

--- a/src/typography/attributes.js
+++ b/src/typography/attributes.js
@@ -293,22 +293,15 @@ p5.prototype._updateTextMetrics = function() {
  * @example
  * <div>
  * <code>
- * let longText = 'Lorem ipsum dolor sit amet, consectetur adipiscing elit';
- * let font;
- * function preload() {
- *   font = loadFont('./assets/Regular.otf');
- * }
- * function setup() {
- *   createCanvas(100, 400);
- * }
+ * let longWord = 'Supercalifragilistic';
  * function draw() {
- *   textFont(font);
- *   textSize(12);
+ *   textSize(14);
+ *   textLeading(14);
  *   textWrap(WORD);
  *   textHyphens(true);
- *   text(longText, 0, 0, 100, 50);
+ *   text(longWord, 0, 10, 100, 50);
  *   textHyphens(false);
- *   text(longText, 0, 51, 100, 50);
+ *   text(longWord, 0, 60, 100, 50);
  * }
  * </code>
  * </div>
@@ -329,20 +322,14 @@ p5.prototype.textHyphens = function(bool) {
  * @example
  * <div>
  * <code>
- * let longText = 'Blorem blipsum dolor sit amet, consectetur adipiscing elit';
- * let font;
- * function preload() {
- *   font = loadFont('./assets/Regular.otf');
- * }
- * function setup() {
- *   createCanvas(100, 400);
- * }
+ * let longText = 'Sphinx of black quartz, judge my vow';
  * function draw() {
- *   textFont(font);
+ *   textSize(14);
+ *   textLeading(12);
  *   textWrap(LINE);
- *   text(longText, 0, 0, 100, 50);
+ *   text(longText, 0, 10, 100);
  *   textWrap(WORD);
- *   text(longText, 0, 51, 100, 50);
+ *   text(longText, 0, 60, 100);
  * }
  * </code>
  * </div>

--- a/test/unit/typography/attributes.js
+++ b/test/unit/typography/attributes.js
@@ -111,4 +111,26 @@ suite('Typography Attributes', function() {
       assert.isNumber(myp5.textDescent());
     });
   });
+
+  suite('p5.prototype.textHyphens', function() {
+    test('should throw error for non-bool input', function() {
+      expect(function() {
+        myp5.textHyphens('true');
+      }).to.throw('Error: textHyphens accepts true or false');
+    });
+    test('returns textHyphens text attribute', function() {
+      assert.strictEqual(myp5.textHyphens(false), false);
+    });
+  });
+
+  suite('p5.prototype.textWrap', function() {
+    test('should throw error for non-constant input', function() {
+      expect(function() {
+        myp5.textWrap('NO-WRAP');
+      }).to.throw('Error: textWrap accepts only LINE or WORD');
+    });
+    test('returns textWrap text attribute', function() {
+      assert.strictEqual(myp5.textWrap(myp5.LINE), myp5.LINE);
+    });
+  });
 });

--- a/test/unit/typography/attributes.js
+++ b/test/unit/typography/attributes.js
@@ -127,10 +127,10 @@ suite('Typography Attributes', function() {
     test('should throw error for non-constant input', function() {
       expect(function() {
         myp5.textWrap('NO-WRAP');
-      }).to.throw('Error: textWrap accepts only LINE or WORD');
+      }).to.throw('Error: textWrap accepts only WORD or CHAR');
     });
     test('returns textWrap text attribute', function() {
-      assert.strictEqual(myp5.textWrap(myp5.LINE), myp5.LINE);
+      assert.strictEqual(myp5.textWrap(myp5.WORD), myp5.WORD);
     });
   });
 });


### PR DESCRIPTION
Resolves #5081
Addresses #4652 (somewhat)

 Changes:
* Adds **textWrap** function which lets the user choose, if they have set a max-width on their text, whether the text should conform to that width by wrapping with or without word-breaks. 
     * Setting `textWrap(LINE)` does not break words and retains the functionality restored in PR #5093, with strings only breaking at spaces as seen in version 1.1.9.
     * Setting `textWrap(WORD)` allows for the functionality seen in version 1.2.0 and version 1.3.0, with strings broken whenever they reach the max-width.

* Adds **textHyphens** function which lets the user choose, if they have set textWrap(WORD), if a hyphen should be inserted when a word is broken. Versions 1.2.0 and 1.3.0 added hyphens to strings not broken at spaces by default, but this can be a problem for other languages and artistic choices (some of us just love a wall of text :P ).
     * Setting `textHyphens(true)` allows for the functionality seen in version 1.2.0 and version 1.3.0, a hyphen is inserted when a line is broken at any non-space character.
     * Setting `textHyphens(false)` allows for strings that exceed the max-width to be broken without hyphen insertion.

If the max-width on text() is not set, the text still breaks only at line breaks included in the original string.

The issue in #4652 is only somewhat addressed with the textWrap and textHyphens functions. If a user sets textWrap(LINE) and still expects a string longer than the max-width to be truncated in some way, there may need to be an additional text attribute for truncation. 

I did a considerable amount of refactoring within the text() function in `p5.Renderer.js` to clarify what was going on, there seemed to be some confusing duplication. My code there is definitely not the DRYest I've written in my life, but hopefully the refactor and comments make it a little easier to understand.

 Screenshots of the change:
![Screenshot 2021-03-19 at 14 45 58](https://user-images.githubusercontent.com/15334958/111790016-10b0fe80-88c2-11eb-859a-ac8e70cb2284.png)
![Screenshot 2021-03-19 at 14 46 13](https://user-images.githubusercontent.com/15334958/111790024-11e22b80-88c2-11eb-88a5-eab8b26dfe64.png)




#### PR Checklist

- [x] `npm run lint` passes
- [x] [Inline documentation] is included / updated
- [x] [Unit tests] are included / updated

[Inline documentation]: https://github.com/processing/p5.js/blob/main/contributor_docs/inline_documentation.md
[Unit tests]: https://github.com/processing/p5.js/tree/main/contributor_docs#unit-tests
