### PR TITLE
checking for pixel array reassignment inside updatePixels

### DIFF
--- a/src/core/p5.Renderer2D.js
+++ b/src/core/p5.Renderer2D.js
@@ -281,7 +281,7 @@ p5.Renderer2D.prototype._getPixel = function(x, y) {
 
 p5.Renderer2D.prototype.loadPixels = function() {
   const pixelsState = this._pixelsState; // if called by p5.Image
-
+  
   const pd = pixelsState._pixelDensity;
   const w = this.width * pd;
   const h = this.height * pd;
@@ -391,18 +391,24 @@ p5.Renderer2D.prototype.updatePixels = function(x, y, w, h) {
     this.gifProperties.frames[this.gifProperties.displayIndex].image =
       pixelsState.imageData;
   }
-
-  if (pixelsState.pixels !== pixelsState.imageData.data) {
+  
+  let pixels = pixelsState.pixels
+  if (this._pInst instanceof p5 &&  
+      this._pInst._isGlobal === true) {
+    pixels = globalThis.pixels;
+  }
+  
+  if (pixels !== pixelsState.imageData.data) {
     let imgData;
-    if (pixelsState.pixels instanceof Uint8ClampedArray) {
-      if (pixelsState.pixels.length === pixelsState.imageData.data.length) {
+    if (pixels instanceof Uint8ClampedArray) {
+      if (pixels.length === pixelsState.imageData.data.length) {
         imgData = new ImageData(
-          pixelsState.pixels,
+          pixels,
           pixelsState.width,
           pixelsState.height
         );
       } else {
-        let imgArr = Array.from(pixelsState.pixels);
+        let imgArr = Array.from(pixels);
         imgArr.length = pixelsState.imageData.data.length;
         imgData = new ImageData(
           Uint8ClampedArray.from(imgArr),
@@ -411,10 +417,10 @@ p5.Renderer2D.prototype.updatePixels = function(x, y, w, h) {
         );
       }
     } else {
-      if (Array.isArray(pixelsState.pixels)) {
-        pixelsState.pixels.length = pixelsState.imageData.data.length;
+      if (Array.isArray(pixels)) {
+        pixels.length = pixelsState.imageData.data.length;
         imgData = new ImageData(
-          Uint8ClampedArray.from(pixelsState.pixels),
+          Uint8ClampedArray.from(pixels),
           pixelsState.imageData.width,
           pixelsState.imageData.height
         );

--- a/src/core/p5.Renderer2D.js
+++ b/src/core/p5.Renderer2D.js
@@ -392,6 +392,39 @@ p5.Renderer2D.prototype.updatePixels = function(x, y, w, h) {
       pixelsState.imageData;
   }
 
+  if (pixelsState.pixels !== pixelsState.imageData.data) {
+    let imgData;
+    if (pixelsState.pixels instanceof Uint8ClampedArray) {
+      if (pixelsState.pixels.length === pixelsState.imageData.data.length) {
+        imgData = new ImageData(
+          pixelsState.pixels,
+          pixelsState.width,
+          pixelsState.height
+        );
+      } else {
+        let imgArr = Array.from(pixelsState.pixels);
+        imgArr.length = pixelsState.imageData.data.length;
+        imgData = new ImageData(
+          Uint8ClampedArray.from(imgArr),
+          pixelsState.width,
+          pixelsState.height
+        );
+      }
+    } else {
+      if (Array.isArray(pixelsState.pixels)) {
+        pixelsState.pixels.length = pixelsState.imageData.data.length;
+        imgData = new ImageData(
+          Uint8ClampedArray.from(pixelsState.pixels),
+          pixelsState.imageData.width,
+          pixelsState.imageData.height
+        );
+      }
+    }
+
+    pixelsState._setProperty('imageData', imgData);
+    pixelsState._setProperty('pixels', imgData.data);
+  }
+
   this.drawingContext.putImageData(pixelsState.imageData, x, y, 0, 0, w, h);
 };
 

--- a/src/core/p5.Renderer2D.js
+++ b/src/core/p5.Renderer2D.js
@@ -281,7 +281,7 @@ p5.Renderer2D.prototype._getPixel = function(x, y) {
 
 p5.Renderer2D.prototype.loadPixels = function() {
   const pixelsState = this._pixelsState; // if called by p5.Image
-  
+
   const pd = pixelsState._pixelDensity;
   const w = this.width * pd;
   const h = this.height * pd;
@@ -391,22 +391,17 @@ p5.Renderer2D.prototype.updatePixels = function(x, y, w, h) {
     this.gifProperties.frames[this.gifProperties.displayIndex].image =
       pixelsState.imageData;
   }
-  
-  let pixels = pixelsState.pixels
-  if (this._pInst instanceof p5 &&  
-      this._pInst._isGlobal === true) {
+
+  let pixels = pixelsState.pixels;
+  if (this._pInst instanceof p5 && this._pInst._isGlobal === true) {
     pixels = globalThis.pixels;
   }
-  
+
   if (pixels !== pixelsState.imageData.data) {
     let imgData;
     if (pixels instanceof Uint8ClampedArray) {
       if (pixels.length === pixelsState.imageData.data.length) {
-        imgData = new ImageData(
-          pixels,
-          pixelsState.width,
-          pixelsState.height
-        );
+        imgData = new ImageData(pixels, pixelsState.width, pixelsState.height);
       } else {
         let imgArr = Array.from(pixels);
         imgArr.length = pixelsState.imageData.data.length;

--- a/src/core/p5.Renderer2D.js
+++ b/src/core/p5.Renderer2D.js
@@ -401,21 +401,26 @@ p5.Renderer2D.prototype.updatePixels = function(x, y, w, h) {
     let imgData;
     if (pixels instanceof Uint8ClampedArray) {
       if (pixels.length === pixelsState.imageData.data.length) {
-        imgData = new ImageData(pixels, pixelsState.width, pixelsState.height);
-      } else {
-        let imgArr = Array.from(pixels);
-        imgArr.length = pixelsState.imageData.data.length;
         imgData = new ImageData(
-          Uint8ClampedArray.from(imgArr),
-          pixelsState.width,
-          pixelsState.height
+          pixels,
+          pixelsState.imageData.width,
+          pixelsState.imageData.height
+        );
+      } else {
+        let imgArr = new Uint8ClampedArray(pixelsState.imageData.data.length);
+        imgArr.set(pixels);
+        imgData = new ImageData(
+          imgArr,
+          pixelsState.imageData.width,
+          pixelsState.imageData.height
         );
       }
     } else {
       if (Array.isArray(pixels)) {
-        pixels.length = pixelsState.imageData.data.length;
+        let imgArr = new Uint8ClampedArray(pixelsState.imageData.data.length);
+        imgArr.set(pixels);
         imgData = new ImageData(
-          Uint8ClampedArray.from(pixels),
+          imgArr,
           pixelsState.imageData.width,
           pixelsState.imageData.height
         );


### PR DESCRIPTION
<!--
  Thank you for contributing! Please use this pull request (PR) template.


 In the description field of this PR, include "resolves #XXXX" tagging the issue you are fixing. If this PR addresses the issue but doesn't completely resolve it (ie the issue should remain open after your PR is merged), write "addresses #XXXX".-->
Resolves #4993

 Changes:
<!-- Add here what changes were made in this pull request and if possible provide links showcasing the changes. -->
checking for pixel array reassignment inside updatePixels and creating new ImageData object accordingly, keeping optimizations related to copying in mind (like if map() is used the resulting UInt8ClampedArray can directly be used by ImageData Constructor and no copying of data will be needed ).

 Screenshots of the change:
<!-- If applicable, add screenshots depicting the changes. -->

#### PR Checklist
<!--
  To check any option, replace the "[ ]" with a "[x]". Be sure to check out how it looks in the Preview tab! Feel free to remove any portion of the template that is not relevant for your issue.
-->

- [x] `npm run lint` passes
- [ ] [Inline documentation] is included / updated
- [ ] [Unit tests] are included / updated

[Inline documentation]: https://github.com/processing/p5.js/blob/main/contributor_docs/inline_documentation.md
[Unit tests]: https://github.com/processing/p5.js/tree/main/contributor_docs#unit-tests
