### PR TITLE
Add text wrapping function

### DIFF
--- a/src/core/constants.js
+++ b/src/core/constants.js
@@ -588,6 +588,16 @@ export const BOLD = 'bold';
  * @final
  */
 export const BOLDITALIC = 'bold italic';
+/**
+ * @property {String} CHAR
+ * @final
+ */
+export const CHAR = 'CHAR';
+/**
+ * @property {String} WORD
+ * @final
+ */
+export const WORD = 'WORD';
 
 // TYPOGRAPHY-INTERNAL
 export const _DEFAULT_TEXT_FILL = '#000000';

--- a/src/typography/attributes.js
+++ b/src/typography/attributes.js
@@ -284,4 +284,73 @@ p5.prototype._updateTextMetrics = function() {
   return this._renderer._updateTextMetrics();
 };
 
+/**
+ * Specifies how lines of text are wrapped within a text box. This requires a max-width set on the text area, specified in <a href="#/p5/text">text()</a> as parameter `x2`.
+ *
+ * WORD wrap style only breaks lines at spaces. A single string without spaces that exceeds the boundaries of the canvas or text area is not truncated, and will overflow the desired area, disappearing at the canvas edge.
+ *
+ * CHAR wrap style breaks lines wherever needed to stay within the text box.
+ *
+ * WORD is the default wrap style, and both styles will still break lines at any line breaks (`\n`) specified in the original text. The text area max-height parameter (`y2`) also still applies to wrapped text in both styles, lines of text that do not fit within the text area will not be drawn to the screen.
+ *
+ * @method textWrap
+ * @param {Constant} wrapStyle text wrapping style, either WORD or CHAR
+ * @return {String} wrapStyle
+ * @example
+ * <div>
+ * <code>
+ * textSize(20);
+ * textWrap(WORD);
+ * text('Have a wonderful day', 0, 10, 100);
+ * </code>
+ * </div>
+ * <div>
+ * <code>
+ * textSize(20);
+ * textWrap(CHAR);
+ * text('Have a wonderful day', 0, 10, 100);
+ * </code>
+ * </div>
+ * <div>
+ * <code>
+ * textSize(20);
+ * textWrap(CHAR);
+ * text('祝你有美好的一天', 0, 10, 100);
+ * </code>
+ * </div>
+ * <div>
+ * <code>
+ * const scream = 'AAAAAAAAAAAAAAAAAAAAAAAAAAAAA';
+ * textSize(20);
+ * textWrap(WORD);
+ * text(scream, 0, 0, 100);
+ * fill(0, 0, 0, 75);
+ * text(scream, 0, 20, 100);
+ * fill(0, 0, 0, 50);
+ * text(scream, 0, 40, 100);
+ * fill(0, 0, 0, 25);
+ * text(scream, 0, 60, 100);
+ * strokeWeight(2);
+ * ellipseMode(CENTER);
+ * fill(255);
+ * ellipse(15, 50, 15, 15);
+ * fill(0);
+ * ellipse(11, 47, 1, 1);
+ * ellipse(19, 47, 1, 1);
+ * ellipse(15, 52, 5, 5);
+ * line(15, 60, 15, 70);
+ * line(15, 65, 5, 55);
+ * line(15, 65, 25, 55);
+ * line(15, 70, 10, 80);
+ * line(15, 70, 20, 80);
+ * </code>
+ * </div>
+ */
+p5.prototype.textWrap = function(wrapStyle) {
+  if (wrapStyle !== 'WORD' && wrapStyle !== 'CHAR') {
+    throw 'Error: textWrap accepts only WORD or CHAR';
+  }
+  return this._renderer.textWrap(wrapStyle);
+};
+
 export default p5;

--- a/test/unit/typography/attributes.js
+++ b/test/unit/typography/attributes.js
@@ -111,4 +111,15 @@ suite('Typography Attributes', function() {
       assert.isNumber(myp5.textDescent());
     });
   });
+
+  suite('p5.prototype.textWrap', function() {
+    test('should throw error for non-constant input', function() {
+      expect(function() {
+        myp5.textWrap('NO-WRAP');
+      }).to.throw('Error: textWrap accepts only WORD or CHAR');
+    });
+    test('returns textWrap text attribute', function() {
+      assert.strictEqual(myp5.textWrap(myp5.WORD), myp5.WORD);
+    });
+  });
 });


### PR DESCRIPTION
Resolves #5081
Addresses #4652 
Follow-up to #5108 

Changes:

Adds **textWrap** function to specify how lines of text are wrapped within a text box. This requires a max-width set on the text area, specified in [text()](https://p5js.org/reference/#/p5/text) as parameter `x2`.
* WORD wrap style only breaks lines at spaces. A single string without spaces that exceeds the boundaries of the canvas or text area is not truncated, and will overflow the desired area, disappearing at the canvas edge.
* CHAR wrap style breaks lines wherever needed to stay within the text box.

WORD is the default wrap style, and both styles will still break lines at any line breaks (\n) specified in the original text. The text area max-height parameter (y2) also still applies to wrapped text in both styles, lines of text that do not fit within the text area will not be drawn to the screen.

I may have gone a little overboard adding documentation and examples, specifically the last one with the little screaming stick-man demonstrating the current lack of truncation. He should be removed if additional functionality is added in the future to deal with truncation and hyphenation, but for now I think he shows kind of a fun way to work with #4652.

I also added an example using Chinese characters, since as @dhowe mentioned in discussion, textWrap(CHAR) is essential for displaying text in character-based languages nicely.

 Screenshots of the change:
![Screenshot 2021-03-31 at 21 56 56](https://user-images.githubusercontent.com/15334958/113204055-14069b80-926d-11eb-93b7-d1fe8ad988b7.png)


#### PR Checklist
- [x] `npm run lint` passes
- [x] [Inline documentation] is included / updated
- [x] [Unit tests] are included / updated
