### PR TITLE
remove extra optional text from docs for describe

### DIFF
--- a/src/accessibility/describe.js
+++ b/src/accessibility/describe.js
@@ -37,7 +37,7 @@ const labelTableElId = '_lte_'; //Label Table Element
  *
  * @method describe
  * @param  {String} text      description of the canvas
- * @param  {Constant} [display] either LABEL or FALLBACK (Optional)
+ * @param  {Constant} [display] either LABEL or FALLBACK
  *
  * @example
  * <div>
@@ -137,7 +137,7 @@ p5.prototype.describe = function(text, display) {
  * @method describeElement
  * @param  {String} name      name of the element
  * @param  {String} text      description of the element
- * @param  {Constant} [display] either LABEL or FALLBACK (Optional)
+ * @param  {Constant} [display] either LABEL or FALLBACK
  *
  * @example
  * <div>


### PR DESCRIPTION
I noticed that the text on https://p5js.org/reference/#/p5/describe has a duplicate "Optional" note on the last parameter.

<img width="798" alt="Screen Shot 2021-04-03 at 6 46 32 PM" src="https://user-images.githubusercontent.com/964912/113496322-646c3c00-94ad-11eb-9981-9d38ad420466.png">

I looked at https://github.com/processing/p5.js/blob/main/contributor_docs/inline_documentation.md#specify-parameters and learned that parameter names enclosed in square brackets (`[]`) will have the optional text automatically added to the end for the reference!

## Changes:
removed manual note about optional parameters from `describe.js`

#### PR Checklist
<!--
  To check any option, replace the "[ ]" with a "[x]". Be sure to check out how it looks in the Preview tab! Feel free to remove any portion of the template that is not relevant for your issue.
-->

- [x] `npm run lint` passes
- [x] [Inline documentation] is included / updated
