### PR TITLE
Removed redundant string "(Optional)" everywhere in the inline documentation

### DIFF
--- a/src/accessibility/outputs.js
+++ b/src/accessibility/outputs.js
@@ -33,7 +33,7 @@ import p5 from '../core/main';
  * publishing or sharing with screen reader users.
  *
  * @method textOutput
- * @param  {Constant} [display] either FALLBACK or LABEL (Optional)
+ * @param  {Constant} [display] either FALLBACK or LABEL
  *
  * @example
  * <div>
@@ -112,7 +112,7 @@ p5.prototype.textOutput = function(display) {
  * publishing or sharing with screen reader users.
  *
  * @method gridOutput
- * @param  {Constant} [display] either FALLBACK or LABEL (Optional)
+ * @param  {Constant} [display] either FALLBACK or LABEL
  *
  * @example
  * <div>

--- a/src/core/friendly_errors/fes_core.js
+++ b/src/core/friendly_errors/fes_core.js
@@ -244,7 +244,7 @@ if (typeof IS_MINIFIED !== 'undefined') {
    * @private
    * @param  {Number} message message to be printed
    * @param  {String} [method] name of method
-   * @param  {Number|String} [color]   CSS color string or error type (Optional)
+   * @param  {Number|String} [color]   CSS color string or error type
    */
   p5._friendlyError = function(message, method, color) {
     report(message, method, color);

--- a/src/math/p5.Vector.js
+++ b/src/math/p5.Vector.js
@@ -2042,7 +2042,7 @@ p5.Vector.random3D = function random3D() {
  * @static
  * @param  {p5.Vector} v1 a <a href="#/p5.Vector">p5.Vector</a> to add
  * @param  {p5.Vector} v2 a <a href="#/p5.Vector">p5.Vector</a> to add
- * @param  {p5.Vector} [target] the vector to receive the result (Optional)
+ * @param  {p5.Vector} [target] the vector to receive the result
  * @return {p5.Vector} the resulting <a href="#/p5.Vector">p5.Vector</a>
  */
 
@@ -2093,7 +2093,7 @@ p5.Vector.rem = function rem(v1, v2) {
  * @static
  * @param  {p5.Vector} v1 a <a href="#/p5.Vector">p5.Vector</a> to subtract from
  * @param  {p5.Vector} v2 a <a href="#/p5.Vector">p5.Vector</a> to subtract
- * @param  {p5.Vector} [target] the vector to receive the result (Optional)
+ * @param  {p5.Vector} [target] the vector to receive the result
  * @return {p5.Vector} the resulting <a href="#/p5.Vector">p5.Vector</a>
  */
 
@@ -2131,7 +2131,7 @@ p5.Vector.sub = function sub(v1, v2, target) {
  * @static
  * @param  {p5.Vector} v
  * @param  {Number}  n
- * @param  {p5.Vector} [target] the vector to receive the result (Optional)
+ * @param  {p5.Vector} [target] the vector to receive the result
  */
 
 /**
@@ -2174,7 +2174,7 @@ p5.Vector.mult = function mult(v, n, target) {
  * @static
  * @param  {p5.Vector} v
  * @param  {Number} angle
- * @param  {p5.Vector} [target] the vector to receive the result (Optional)
+ * @param  {p5.Vector} [target] the vector to receive the result
  */
 p5.Vector.rotate = function rotate(v, a, target) {
   if (arguments.length === 2) {
@@ -2210,7 +2210,7 @@ p5.Vector.rotate = function rotate(v, a, target) {
  * @static
  * @param  {p5.Vector} v
  * @param  {Number}  n
- * @param  {p5.Vector} [target] the vector to receive the result (Optional)
+ * @param  {p5.Vector} [target] the vector to receive the result
  */
 
 /**
@@ -2298,7 +2298,7 @@ p5.Vector.dist = function dist(v1, v2) {
  * @param {p5.Vector} v1
  * @param {p5.Vector} v2
  * @param {Number} amt
- * @param {p5.Vector} [target] the vector to receive the result (Optional)
+ * @param {p5.Vector} [target] the vector to receive the result
  * @return {p5.Vector}      the lerped value
  */
 p5.Vector.lerp = function lerp(v1, v2, amt, target) {
@@ -2342,7 +2342,7 @@ p5.Vector.mag = function mag(vecT) {
  * @method normalize
  * @static
  * @param {p5.Vector} v  the vector to normalize
- * @param {p5.Vector} [target] the vector to receive the result (Optional)
+ * @param {p5.Vector} [target] the vector to receive the result
  * @return {p5.Vector}   v normalized to a length of 1
  */
 p5.Vector.normalize = function normalize(v, target) {


### PR DESCRIPTION
The string was written in the documentation description of parameters that were also indicated as optional by being written as "[param]". This was causing duplicates, as YUIDoc was adding another "(Optional)".

This PR generalizes the improvement from PR #5157 by @outofambit.

#### PR Checklist

- [ ] `npm run lint` passes
- [x] [Inline documentation] is included / updated
- [ ] [Unit tests] are included / updated
