### PR TITLE
add VERSION const as p5.VERSION

### DIFF
--- a/src/core/main.js
+++ b/src/core/main.js
@@ -714,6 +714,8 @@ for (const k in constants) {
   p5.prototype[k] = constants[k];
 }
 
+// makes the `VERSION` constant available on the p5 object
+// in instance mode, even if it hasn't been instatiated yet
 p5.VERSION = constants.VERSION;
 
 // functions that cause preload to wait

--- a/src/core/main.js
+++ b/src/core/main.js
@@ -714,6 +714,8 @@ for (const k in constants) {
   p5.prototype[k] = constants[k];
 }
 
+p5.VERSION = constants.VERSION;
+
 // functions that cause preload to wait
 // more can be added by using registerPreloadMethod(func)
 p5.prototype._preloadMethods = {

--- a/test/unit/core/version.js
+++ b/test/unit/core/version.js
@@ -1,0 +1,28 @@
+suite('Version', function() {
+  var myp5;
+
+  setup(function(done) {
+    new p5(function(p) {
+      p.setup = function() {
+        myp5 = p;
+        done();
+      };
+    });
+  });
+
+  teardown(function() {
+    myp5.remove();
+  });
+
+  test('exists on p5 object', function() {
+    assert.isString(p5.VERSION);
+    // ensure the string isn't empty
+    assert.isTrue(p5.VERSION.length > 0);
+  });
+
+  test('exists on instance of p5 sketch', function() {
+    assert.isString(myp5.VERSION);
+    // ensure the string isn't empty
+    assert.isTrue(myp5.VERSION.length > 0);
+  });
+});

--- a/test/unit/spec.js
+++ b/test/unit/spec.js
@@ -14,6 +14,7 @@ var spec = {
     'rendering',
     'structure',
     'transform',
+    'version',
     'vertex'
   ],
   data: ['p5.TypedDict', 'local_storage'],


### PR DESCRIPTION
continues from https://github.com/processing/p5.js/pull/5107 and resolves https://github.com/processing/p5.js/issues/2525

- [x] `npm run lint` passes
- [x] [Inline documentation] is included / updated
- [x] [Unit tests] are included / updated

I kept both `p5.VERSION` and `p5.prototype.VERSION` but not sure if we keep both or we just use the former so that it will never be exposed to global scope (no `sketch=>sketch.VERSION` in case of instance). Whichever it is, the new implementation (`p5.VERSION`) should have the priority as it has an advantage that it can be referenced without instantiation.
