### PR TITLE
Added p5.Element.prototype.[step | min | max] changed p5.Element.prototype.value

### DIFF
--- a/.all-contributorsrc
+++ b/.all-contributorsrc
@@ -2518,6 +2518,17 @@
         "code",
         "doc"
       ]
+    },
+    {
+      "login": "DavidWeiss2",
+      "name": "David Weiss",
+      "avatar_url": "https://avatars.githubusercontent.com/u/12801099?v=4",
+      "profile": "https://github.com/DavidWeiss2",
+      "contributions": [
+        "example",
+        "code",
+        "doc"
+      ]
     }
   ],
   "repoType": "github",

--- a/src/dom/dom.js
+++ b/src/dom/dom.js
@@ -2076,7 +2076,7 @@ p5.Element.prototype.value = function() {
  * // gets the value
  * let slider;
  * function setup() {
- *  slider = createSlider(0, 10, 1, 0.1);
+ *   slider = createSlider(0, 10, 1, 0.1);
  * }
  *
  * function mousePressed() {
@@ -2084,9 +2084,8 @@ p5.Element.prototype.value = function() {
  * }
  * </code></div>
  * <div class='norender'><code>
- * 
  * // sets the min value
- * let inp;
+ * let slider;
  * function setup() {
  *   slider = createSlider(0, 10, 1, 0.1);
  * }
@@ -2101,9 +2100,10 @@ p5.Element.prototype.value = function() {
  * @param  {Number}     min
  * @chainable
  */
- p5.Element.prototype.min = function() {
+p5.Element.prototype.min = function() {
   if (arguments.length > 0) {
-    this.elt.value = this.elt.value < arguments[0] ?  arguments[0] : this.elt.value;
+    this.elt.value =
+      this.elt.value < arguments[0] ? arguments[0] : this.elt.value;
     this.elt.min = arguments[0];
     return this;
   }
@@ -2122,7 +2122,7 @@ p5.Element.prototype.value = function() {
  * // gets the max value
  * let slider;
  * function setup() {
- *  slider = createSlider(0, 10, 1, 0.1);
+ *   slider = createSlider(0, 10, 1, 0.1);
  * }
  *
  * function mousePressed() {
@@ -2130,9 +2130,8 @@ p5.Element.prototype.value = function() {
  * }
  * </code></div>
  * <div class='norender'><code>
- * 
  * // sets the max value
- * let inp;
+ * let slider;
  * function setup() {
  *   slider = createSlider(0, 10, 1, 0.1);
  * }
@@ -2147,9 +2146,10 @@ p5.Element.prototype.value = function() {
  * @param  {Number}     max
  * @chainable
  */
- p5.Element.prototype.max = function() {
+p5.Element.prototype.max = function() {
   if (arguments.length > 0) {
-    this.elt.value = this.elt.value > arguments[0] ?  arguments[0] : this.elt.value;
+    this.elt.value =
+      this.elt.value > arguments[0] ? arguments[0] : this.elt.value;
     this.elt.max = arguments[0];
     return this;
   }
@@ -2168,7 +2168,7 @@ p5.Element.prototype.value = function() {
  * // gets the step value
  * let slider;
  * function setup() {
- *  slider = createSlider(0, 10, 1, 0.1);
+ *   slider = createSlider(0, 10, 1, 0.1);
  * }
  *
  * function mousePressed() {
@@ -2176,9 +2176,8 @@ p5.Element.prototype.value = function() {
  * }
  * </code></div>
  * <div class='norender'><code>
- * 
  * // sets the step value
- * let inp;
+ * let slider;
  * function setup() {
  *   slider = createSlider(0, 10, 1, 0.1);
  * }
@@ -2193,12 +2192,14 @@ p5.Element.prototype.value = function() {
  * @param  {Number}     step
  * @chainable
  */
- p5.Element.prototype.step = function() {
-  if(arguments.length === 0){
+p5.Element.prototype.step = function() {
+  if (arguments.length === 0) {
     return parseFloat(this.elt.step);
   }
-  this.elt.step = arguments[0] > this.elt.max - this.elt.min ?
-  this.elt.max - this.elt.min : arguments[0];
+  this.elt.step =
+    arguments[0] > this.elt.max - this.elt.min
+      ? this.elt.max - this.elt.min
+      : arguments[0];
   this.elt.step = Math.max(this.elt.step, 0.000000000000000001);
   return this;
 };

--- a/src/dom/dom.js
+++ b/src/dom/dom.js
@@ -495,11 +495,7 @@ p5.prototype.createSlider = function(min, max, value, step) {
   elt.type = 'range';
   elt.min = min;
   elt.max = max;
-  if (step === 0) {
-    elt.step = 0.000000000000000001; // smallest valid step
-  } else if (step) {
-    elt.step = step;
-  }
+  elt.step = Math.max(step, 0.000000000000000001);
   if (typeof value === 'number') elt.value = value;
   return addElement(elt, this);
 };
@@ -2067,6 +2063,144 @@ p5.Element.prototype.value = function() {
       return parseFloat(this.elt.value);
     } else return this.elt.value;
   }
+};
+
+/**
+ * Either returns the min value of the element if no arguments
+ * given, or sets the min value of the element.
+ *
+ * @method min
+ * @return {Number} value of the element
+ * @example
+ * <div class='norender'><code>
+ * // gets the value
+ * let slider;
+ * function setup() {
+ *  slider = createSlider(0, 10, 1, 0.1);
+ * }
+ *
+ * function mousePressed() {
+ *   print(slider.min());
+ * }
+ * </code></div>
+ * <div class='norender'><code>
+ * 
+ * // sets the min value
+ * let inp;
+ * function setup() {
+ *   slider = createSlider(0, 10, 1, 0.1);
+ * }
+ *
+ * function mousePressed() {
+ *   slider.min(3);
+ * }
+ * </code></div>
+ */
+/**
+ * @method min
+ * @param  {Number}     min
+ * @chainable
+ */
+ p5.Element.prototype.min = function() {
+  if (arguments.length > 0) {
+    this.elt.value = this.elt.value < arguments[0] ?  arguments[0] : this.elt.value;
+    this.elt.min = arguments[0];
+    return this;
+  }
+
+  return parseFloat(this.elt.min);
+};
+
+/**
+ * Either returns the max value of the element if no arguments
+ * given, or sets the max value of the element.
+ *
+ * @method max
+ * @return {Number} value of the element
+ * @example
+ * <div class='norender'><code>
+ * // gets the max value
+ * let slider;
+ * function setup() {
+ *  slider = createSlider(0, 10, 1, 0.1);
+ * }
+ *
+ * function mousePressed() {
+ *   print(slider.max());
+ * }
+ * </code></div>
+ * <div class='norender'><code>
+ * 
+ * // sets the max value
+ * let inp;
+ * function setup() {
+ *   slider = createSlider(0, 10, 1, 0.1);
+ * }
+ *
+ * function mousePressed() {
+ *   slider.max(8);
+ * }
+ * </code></div>
+ */
+/**
+ * @method min
+ * @param  {Number}     max
+ * @chainable
+ */
+ p5.Element.prototype.max = function() {
+  if (arguments.length > 0) {
+    this.elt.value = this.elt.value > arguments[0] ?  arguments[0] : this.elt.value;
+    this.elt.max = arguments[0];
+    return this;
+  }
+
+  return parseFloat(this.elt.max);
+};
+
+/**
+ * Either returns the step value of the element if no arguments
+ * given, or sets the step value of the element.
+ *
+ * @method step
+ * @return {Number} value of the element
+ * @example
+ * <div class='norender'><code>
+ * // gets the step value
+ * let slider;
+ * function setup() {
+ *  slider = createSlider(0, 10, 1, 0.1);
+ * }
+ *
+ * function mousePressed() {
+ *   print(slider.step());
+ * }
+ * </code></div>
+ * <div class='norender'><code>
+ * 
+ * // sets the step value
+ * let inp;
+ * function setup() {
+ *   slider = createSlider(0, 10, 1, 0.1);
+ * }
+ *
+ * function mousePressed() {
+ *   slider.step(8);
+ * }
+ * </code></div>
+ */
+/**
+ * @method step
+ * @param  {Number}     step
+ * @chainable
+ */
+ p5.Element.prototype.step = function() {
+  if(arguments.length === 0){
+    return parseFloat(this.elt.step);
+  }
+  this.elt.step = arguments[0] > this.elt.max - this.elt.min ?
+  this.elt.max - this.elt.min : arguments[0];
+  this.elt.step = Math.max(this.elt.step, 0.000000000000000001);
+  return this;
 };
 
 /**


### PR DESCRIPTION
Resolves #5050

 Changes:
I added the following functions:
p5.Element.prototype.step
p5.Element.prototype.min
p5.Element.prototype.max

that have similar behavior to:
p5.Element.prototype.value

And also, change the create slider to have, in all cases, a step size that is not less than the min.


#### PR Checklist

- [x] `npm run lint` passes
- [x] [Inline documentation] is included / updated
- [ ] [Unit tests] are included/updated **I would love to see info about adding test cases for my code. It's a good practice that I would love to practice on.

[Inline documentation]: https://github.com/processing/p5.js/blob/main/contributor_docs/inline_documentation.md
[Unit tests]: https://github.com/processing/p5.js/tree/main/contributor_docs#unit-tests
