### PR TITLE
Resolves #5181

### DIFF
--- a/src/core/p5.Renderer.js
+++ b/src/core/p5.Renderer.js
@@ -56,6 +56,7 @@ p5.Renderer = function(elt, pInst, isMainCanvas) {
   this._doFill = true;
   this._strokeSet = false;
   this._fillSet = false;
+  this._leadingSet = false;
 };
 
 p5.Renderer.prototype = Object.create(p5.Element.prototype);
@@ -75,6 +76,7 @@ p5.Renderer.prototype.push = function() {
       _ellipseMode: this._ellipseMode,
       _textFont: this._textFont,
       _textLeading: this._textLeading,
+      _leadingSet: this._leadingSet,
       _textSize: this._textSize,
       _textAlign: this._textAlign,
       _textBaseline: this._textBaseline,
@@ -145,6 +147,7 @@ p5.Renderer.prototype.get = function(x, y, w, h) {
 
 p5.Renderer.prototype.textLeading = function(l) {
   if (typeof l === 'number') {
+    this._setProperty('_leadingSet', true);
     this._setProperty('_textLeading', l);
     return this._pInst;
   }
@@ -155,7 +158,10 @@ p5.Renderer.prototype.textLeading = function(l) {
 p5.Renderer.prototype.textSize = function(s) {
   if (typeof s === 'number') {
     this._setProperty('_textSize', s);
-    this._setProperty('_textLeading', s * constants._DEFAULT_LEADMULT);
+    if (!this._leadingSet) {
+      // only use a default value if not previously set (#5181)
+      this._setProperty('_textLeading', s * constants._DEFAULT_LEADMULT);
+    }
     return this._applyTextProperties();
   }
 

--- a/src/typography/loading_displaying.js
+++ b/src/typography/loading_displaying.js
@@ -294,10 +294,13 @@ p5.prototype.textFont = function(theFont, theSize) {
 
     if (theSize) {
       this._renderer._setProperty('_textSize', theSize);
-      this._renderer._setProperty(
-        '_textLeading',
-        theSize * constants._DEFAULT_LEADMULT
-      );
+      if (!this._renderer._leadingSet) {
+        // only use a default value if not previously set (#5181)
+        this._renderer._setProperty(
+          '_textLeading',
+          theSize * constants._DEFAULT_LEADMULT
+        );
+      }
     }
 
     return this._renderer._applyTextProperties();

--- a/test/manual-test-examples/p5.Font/simple/index.html
+++ b/test/manual-test-examples/p5.Font/simple/index.html
@@ -11,7 +11,9 @@
   Note: (tight) bounds for a text string <i>may</i> start to the right of the its x-position (blue line)<br />
   <div id='textSketchMono'></div><br />&nbsp;<br />
   Issue #1958:
-  <div id='textSketch1958'></div>
+  <div id='textSketch1958'></div><br />&nbsp;<br />
   <!--div id='textSketch1957'></div-->
+  Issue #5181:
+  <div id='textSketch5181'></div><br />&nbsp;<br />
 </body>
 </html>

--- a/test/manual-test-examples/p5.Font/simple/sketch.js
+++ b/test/manual-test-examples/p5.Font/simple/sketch.js
@@ -155,6 +155,44 @@ var textSketch1958 = function(p) {
 }
 new p5(textSketch1957, "textSketch1957");*/
 
+var textSketch5181 = function(p) {
+  // issue #5181
+  var font,
+    txt =
+      "Lorem Ipsum has been the industry's standard dummy text ever since the 1500s, when an unknown printer took a galley of type and scrambled it to make a type specimen book. It has survived not only five centuries, but also the leap into electronic typesetting, remaining essentially unchanged.";
+
+  p.preload = function() {
+    font = p.loadFont('../OpenSans-Regular.ttf');
+  };
+
+  p.setup = function() {
+    p.createCanvas(300, 700);
+    p.background(255);
+
+    let bounds = [20, 10, 250, 130];
+    p.textFont(font, 12);
+    p.rect(...bounds);
+    p.text('Default Size/Lead (12/15): ' + txt, ...bounds);
+
+    bounds = [20, 150, 250, 230];
+    p.textFont(font, 16);
+    p.rect(...bounds);
+    p.text('Default Size/Lead (16/20): ' + txt, ...bounds);
+
+    bounds = [20, 390, 250, 105];
+    p.textLeading(12);
+    p.textFont(font, 12);
+    p.rect(...bounds);
+    p.text('User-set Size/Lead (12/12): ' + txt, ...bounds);
+
+    bounds = [20, 505, 250, 185];
+    p.textFont(font, 20);
+    p.rect(...bounds);
+    p.text('Maintain Custom Leading (20/12): ' + txt, ...bounds);
+  };
+};
+
 new p5(textSketch, 'textSketch');
 new p5(textSketchMono, 'textSketchMono');
 new p5(textSketch1958, 'textSketch1958');
+new p5(textSketch5181, 'textSketch5181');


### PR DESCRIPTION
Resolves #5181 (test img below)

- [x] `npm run lint` passes
- [x] [Manual test](./test/manual-test-examples/p5.Font/simple/index.html) included / updated

<img width="367" alt="image" src="https://user-images.githubusercontent.com/737638/115003894-d34b8b00-9ed8-11eb-8bbf-09264a04eceb.png">

