### PR TITLE
norender class added to createCapture documentation

### DIFF
--- a/src/dom/dom.js
+++ b/src/dom/dom.js
@@ -1339,7 +1339,7 @@ if (navigator.mediaDevices.getUserMedia === undefined) {
  * </code>
  * </div>
  *
- * <div class='notest'>
+ * <div class='notest norender'>
  * <code>
  * function setup() {
  *   createCanvas(480, 120);
@@ -1359,7 +1359,7 @@ if (navigator.mediaDevices.getUserMedia === undefined) {
  * }
  * </code>
  * </div>
- * <div class='notest'>
+ * <div class='notest norender'>
  * <code>
  * let capture;
  *


### PR DESCRIPTION
<!--
  Thank you for contributing! Please use this pull request (PR) template.


 In the description field of this PR, include "resolves #XXXX" tagging the issue you are fixing. If this PR addresses the issue but doesn't completely resolve it (ie the issue should remain open after your PR is merged), write "addresses #XXXX".-->
Resolves #5166 

 Changes:
`norender` class added to the `div` element of createCapture documentation. As the size of the canvas is greater than 100x100 the indentation of the text was changed. With `norender` class this issue will be resolved. 


 Screenshots of the change:
![image](https://user-images.githubusercontent.com/67458417/116497183-623aa900-a8c4-11eb-9720-ddaf9c24ced7.png)


#### PR Checklist
<!--
  To check any option, replace the "[ ]" with a "[x]". Be sure to check out how it looks in the Preview tab! Feel free to remove any portion of the template that is not relevant for your issue.
-->

- [x] `npm run lint` passes
- [x] [Inline documentation] is included / updated
- [x] [Unit tests] are included / updated

[Inline documentation]: https://github.com/processing/p5.js/blob/main/contributor_docs/inline_documentation.md
[Unit tests]: https://github.com/processing/p5.js/tree/main/contributor_docs#unit-tests
