### PR TITLE
added missing requried Distortion.process param

### DIFF
--- a/lib/addons/p5.sound.js
+++ b/lib/addons/p5.sound.js
@@ -11762,6 +11762,7 @@ var __WEBPACK_AMD_DEFINE_RESULT__;
    *
    * @method process
    * @for p5.Distortion
+   * @param  {p5.SoundFile} soundFile p5.SoundFile
    * @param {Number} [amount=0.25] Unbounded distortion amount.
    *                                Normal values range from 0-1.
    * @param {String} [oversample='none'] 'none', '2x', or '4x'.


### PR DESCRIPTION
 Changes:
Adds required parameter to `process` method of `Distortion` object. A `SoundFile` is required but there is no indication in the documents as seen here:
![image](https://user-images.githubusercontent.com/12960453/119267854-5a69de00-bbbe-11eb-9080-80dc3e4ac20f.png)