### PR TITLE
Added support for UInt32 vertex indices. addresses #5270

### DIFF
--- a/test/unit/webgl/p5.RendererGL.js
+++ b/test/unit/webgl/p5.RendererGL.js
@@ -449,6 +449,7 @@ suite('p5.RendererGL', function() {
 
       assert.isObject(buffers);
       assert.isDefined(buffers.indexBuffer);
+      assert.isDefined(buffers.indexBufferType);
       assert.isDefined(buffers.vertexBuffer);
       assert.isDefined(buffers.lineNormalBuffer);
       assert.isDefined(buffers.lineVertexBuffer);


### PR DESCRIPTION
Resolves #5270

 Changes:

When creating buffers for vertex indices and drawing triangles with WebGL, uses a UInt32 buffer if necessary based on the maximum vertex index.

_Note: If the browser does not support the OES_element_index_uint and a model with > 65535 vertices is rendered this code throws an error. In theory it might be possible to support this scenario too by breaking up the model into multiple chunks, however that seems pretty onerous for little to no benefit given the broad browser support for the OES_element_index_uint extension._

#### PR Checklist

- [X] `npm run lint` passes
- [ ] [Inline documentation] is included / updated
- [ ] [Unit tests] are included / updated

I don't think any documentation change is warranted.
It's not clear how this change could be unit tested.
