### PR TITLE
Fix frustum examples

### DIFF
--- a/src/webgl/p5.Camera.js
+++ b/src/webgl/p5.Camera.js
@@ -262,9 +262,7 @@ p5.prototype.ortho = function(...args) {
  * function draw() {
  *   background(200);
  *   orbitControl();
- *   strokeWeight(10);
- *   stroke(0, 0, 255);
- *   noFill();
+ *   normalMaterial();
  *
  *   rotateY(-0.2);
  *   rotateX(-0.3);
@@ -900,9 +898,7 @@ p5.Camera.prototype.ortho = function(left, right, bottom, top, near, far) {
  * function draw() {
  *   background(200);
  *   orbitControl();
- *   strokeWeight(10);
- *   stroke(0, 0, 255);
- *   noFill();
+ *   normalMaterial();
  *
  *   rotateY(-0.2);
  *   rotateX(-0.3);


### PR DESCRIPTION
Mentioned in #5264

**Changes:**

Currently the [frustum][2] examples look like this:  
![stroke2](https://user-images.githubusercontent.com/4354703/120088206-a085dc80-c0ab-11eb-9756-81d13280d584.png)

The stroke's relative size makes it difficult to tell what you are looking at.  
This PR changes the code in the examples to use `normalMaterial()` instead.  
![frustum_normalMaterial2](https://user-images.githubusercontent.com/4354703/120088203-9b289200-c0ab-11eb-9fd1-70e854fb19d0.png)

This is more inline with other examples in the series such as [perspective()][0] and [ortho()][1].

[0]: https://p5js.org/reference/#/p5/perspective
[1]: https://p5js.org/reference/#/p5/ortho
[2]: https://p5js.org/reference/#/p5/frustum
