### PR TITLE
Fixes initialization of user-defined stroke shader

### DIFF
--- a/src/webgl/material.js
+++ b/src/webgl/material.js
@@ -255,14 +255,14 @@ p5.prototype.shader = function(s) {
     s._renderer = this._renderer;
   }
 
+  s.init();
+
   if (s.isStrokeShader()) {
     this._renderer.userStrokeShader = s;
   } else {
     this._renderer.userFillShader = s;
     this._renderer._useNormalMaterial = false;
   }
-
-  s.init();
 
   return this;
 };


### PR DESCRIPTION
Resolves #5285

**Changes:**  
Initializes uniforms before using them to perform `isStrokeShader()` check. See linked issue for more details.

