### PR TITLE
Fix the texture() example

### DIFF
--- a/src/webgl/material.js
+++ b/src/webgl/material.js
@@ -344,7 +344,7 @@ p5.prototype.normalMaterial = function(...args) {
  *   rotateY(frameCount * 0.01);
  *   //pass image as texture
  *   texture(img);
- *   box(200, 200, 200);
+ *   box(width / 2);
  * }
  * </code>
  * </div>


### PR DESCRIPTION
Currently, the size of the box used in the first [`texture()`][0] example is `200`. The canvas however is `100`. The net effect is that we see the interior of the box, which is likely not the intended behaviour.

![texture_cur](https://user-images.githubusercontent.com/4354703/120398937-56de0180-c2f8-11eb-8945-5b689e4eec63.png)

If the box is scaled down, then we can see the entirety of it on the canvas (from the outisde). Which gives a better example of what a texture looks like when applied to a box.

![texture_change](https://user-images.githubusercontent.com/4354703/120398956-61000000-c2f8-11eb-9c26-7cff47e0a75e.png)


[0]: https://p5js.org/reference/#/p5/texture
