### PR TITLE
Improve createCamera() example

### DIFF
--- a/src/webgl/p5.Camera.js
+++ b/src/webgl/p5.Camera.js
@@ -309,7 +309,6 @@ p5.prototype.frustum = function(...args) {
  *   createCanvas(100, 100, WEBGL);
  *   background(0);
  *   camera = createCamera();
- *   setCamera(camera);
  * }
  *
  * function draw() {


### PR DESCRIPTION
Removes the unnecessary call to `setCamera()` in the [`createCamera()`][0] example. `createCamera()` [sets][1] the camera it returns as the current/active camera.

Removing it also helps with consistency with the description that appears on the reference page below the example:

> Creates a new p5.Camera object and tells the renderer to use that camera. Returns the p5.Camera object.

[0]: https://p5js.org/reference/#/p5/createCamera
[1]: https://github.com/processing/p5.js/blob/1250864d63e6353233789f0059f62ebe0188a2a5/src/webgl/p5.Camera.js#L334