### PR TITLE
Change p5.Geometry's module/submodule

### DIFF
--- a/src/webgl/p5.Geometry.js
+++ b/src/webgl/p5.Geometry.js
@@ -1,6 +1,6 @@
 /**
- * @module Lights, Camera
- * @submodule Material
+ * @module Shape
+ * @submodule 3D Primitives
  * @for p5
  * @requires core
  * @requires p5.Geometry


### PR DESCRIPTION
Moves the p5.Geometry class from the current `module > submodule` of `Lights, Camera > Material` to `Shape > 3D Primitives`.

This seems a better location for it, especially considering that all 3D Primitives are instances of p5.Geometry.

**Screenshots of the change:**

_current location on [Reference][0] page_
![p5Geometry_current](https://user-images.githubusercontent.com/4354703/120547395-49834e80-c3ae-11eb-953c-2b4a2d2c696a.png)

_new location on Reference page_
![p5Geometry_change](https://user-images.githubusercontent.com/4354703/120547421-53a54d00-c3ae-11eb-9d99-ee7088dd82b5.png)


[0]: https://p5js.org/reference/
