### PR TITLE
Rename `Lights, Camera` module to `3D`

### DIFF
--- a/src/webgl/interaction.js
+++ b/src/webgl/interaction.js
@@ -1,5 +1,5 @@
 /**
- * @module Lights, Camera
+ * @module 3D
  * @submodule Interaction
  * @for p5
  * @requires core

--- a/src/webgl/light.js
+++ b/src/webgl/light.js
@@ -1,5 +1,5 @@
 /**
- * @module Lights, Camera
+ * @module 3D
  * @submodule Lights
  * @for p5
  * @requires core

--- a/src/webgl/material.js
+++ b/src/webgl/material.js
@@ -1,5 +1,5 @@
 /**
- * @module Lights, Camera
+ * @module 3D
  * @submodule Material
  * @for p5
  * @requires core

--- a/src/webgl/p5.Camera.js
+++ b/src/webgl/p5.Camera.js
@@ -1,5 +1,5 @@
 /**
- * @module Lights, Camera
+ * @module 3D
  * @submodule Camera
  * @requires core
  */

--- a/src/webgl/p5.Shader.js
+++ b/src/webgl/p5.Shader.js
@@ -1,6 +1,6 @@
 /**
  * This module defines the p5.Shader class
- * @module Lights, Camera
+ * @module 3D
  * @submodule Material
  * @for p5
  * @requires core

--- a/src/webgl/p5.Texture.js
+++ b/src/webgl/p5.Texture.js
@@ -1,6 +1,6 @@
 /**
  * This module defines the p5.Texture class
- * @module Lights, Camera
+ * @module 3D
  * @submodule Material
  * @for p5
  * @requires core


### PR DESCRIPTION
Resolves #5294

**Changes:**

See linked issue. Renames `Lights, Camera` module to `3D`

Note, does not propagate change to [p5.Geometry][0] (to avoid conflict with this [separate PR][1]).

**Screenshots of the change:**

_top menu_
![lightsCamera2_change1](https://user-images.githubusercontent.com/4354703/120907833-147f3200-c622-11eb-8d77-67f521874896.png)

_renamed section_
![lightsCamera2_change2](https://user-images.githubusercontent.com/4354703/120907837-1ba64000-c622-11eb-83fa-a421dcd94903.png)


[0]: https://github.com/processing/p5.js/blob/main/src/webgl/p5.Geometry.js
[1]: https://github.com/processing/p5.js/pull/5291
