### PR TITLE
Rename `aMaterialColor` attribute to `aVertexColor`

### DIFF
--- a/src/webgl/p5.RendererGL.js
+++ b/src/webgl/p5.RendererGL.js
@@ -151,7 +151,7 @@ p5.RendererGL = function(elt, pInst, isMainCanvas, attr) {
       fill: [
         new p5.RenderBuffer(3, 'vertices', 'vertexBuffer', 'aPosition', this, this._vToNArray),
         new p5.RenderBuffer(3, 'vertexNormals', 'normalBuffer', 'aNormal', this, this._vToNArray),
-        new p5.RenderBuffer(4, 'vertexColors', 'colorBuffer', 'aMaterialColor', this),
+        new p5.RenderBuffer(4, 'vertexColors', 'colorBuffer', 'aVertexColor', this),
         new p5.RenderBuffer(3, 'vertexAmbients', 'ambientBuffer', 'aAmbientColor', this),
         //new BufferDef(3, 'vertexSpeculars', 'specularBuffer', 'aSpecularColor'),
         new p5.RenderBuffer(2, 'uvs', 'uvBuffer', 'aTexCoord', this, this._flatten)


### PR DESCRIPTION
Renames the `aMaterialColor` attribute to `aVertexColor`.

This rename better reflects what the attribute contains, which is the color associated with a vertex.

The attribute is currently not used in the source code, hence only one file is affected.

[Related issue][0]

[0]: https://github.com/processing/p5.js-website/issues/1017