### PR TITLE
Improve documentation clarity of shader methods

### DIFF
--- a/src/webgl/material.js
+++ b/src/webgl/material.js
@@ -10,13 +10,13 @@ import * as constants from '../core/constants';
 import './p5.Texture';
 
 /**
- * Loads a custom shader from the provided vertex and fragment
- * shader paths. The shader files are loaded asynchronously in the
+ * Creates a new <a href="#/p5.Shader">p5.Shader</a> object
+ * from the provided vertex and fragment shader files.
+ *
+ * The shader files are loaded asynchronously in the
  * background, so this method should be used in <a href="#/p5/preload">preload()</a>.
  *
- * For now, there are three main types of shaders. p5 will automatically
- * supply appropriate vertices, normals, colors, and lighting attributes
- * if the parameters defined in the shader match the names.
+ * Note, shaders can only be used in WEBGL mode.
  *
  * @method loadShader
  * @param {String} vertFilename path to file containing vertex shader
@@ -24,7 +24,7 @@ import './p5.Texture';
  * @param {String} fragFilename path to file containing fragment shader
  * source code
  * @param {function} [callback] callback to be executed after loadShader
- * completes. On success, the Shader object is passed as the first argument.
+ * completes. On success, the p5.Shader object is passed as the first argument.
  * @param {function} [errorCallback] callback to be executed when an error
  * occurs inside loadShader. On error, the error is passed as the first
  * argument.
@@ -109,6 +109,11 @@ p5.prototype.loadShader = function(
 };
 
 /**
+ * Creates a new <a href="#/p5.Shader">p5.Shader</a> object
+ * from the provided vertex and fragment shader code.
+ *
+ * Note, shaders can only be used in WEBGL mode.
+ *
  * @method createShader
  * @param {String} vertSrc source code for the vertex shader
  * @param {String} fragSrc source code for the fragment shader
@@ -177,15 +182,22 @@ p5.prototype.createShader = function(vertSrc, fragSrc) {
 };
 
 /**
- * The <a href="#/p5/shader">shader()</a> function lets the user provide a custom shader
- * to fill in shapes in WEBGL mode. Users can create their
- * own shaders by loading vertex and fragment shaders with
- * <a href="#/p5/loadShader">loadShader()</a>.
+ * Sets the <a href="#/p5.Shader">p5.Shader</a> object to
+ * be used to render subsequent shapes.
+ *
+ * Custom shaders can be created using the
+ * <a href="#/p5/createShader">createShader()</a> and
+ * <a href="#/p5/loadShader">loadShader()</a> functions.
+ *
+ * Use <a href="#/p5/resetShader">resetShader()</a> to
+ * restore the default shaders.
+ *
+ * Note, shaders can only be used in WEBGL mode.
  *
  * @method shader
  * @chainable
- * @param {p5.Shader} [s] the desired <a href="#/p5.Shader">p5.Shader</a> to use for rendering
- * shapes.
+ * @param {p5.Shader} s the <a href="#/p5.Shader">p5.Shader</a> object
+ * to use for rendering shapes.
  *
  * @example
  * <div modernizr='webgl'>
@@ -268,9 +280,9 @@ p5.prototype.shader = function(s) {
 };
 
 /**
- * This function restores the default shaders in WEBGL mode. Code that runs
- * after resetShader() will not be affected by previously defined
- * shaders. Should be run after <a href="#/p5/shader">shader()</a>.
+ * Restores the default shaders. Code that runs after resetShader()
+ * will not be affected by the shader previously set by
+ * <a href="#/p5/shader">shader()</a>
  *
  * @method resetShader
  * @chainable

--- a/src/webgl/p5.Shader.js
+++ b/src/webgl/p5.Shader.js
@@ -294,17 +294,21 @@ p5.Shader.prototype.useProgram = function() {
 };
 
 /**
- * Wrapper around gl.uniform functions.
- * As we store uniform info in the shader we can use that
- * to do type checking on the supplied data and call
- * the appropriate function.
+ * Used to set the uniforms of a
+ * <a href="#/p5.Shader">p5.Shader</a> object.
+ *
+ * Uniforms are used as a way to provide shader programs
+ * (which run on the GPU) with values from a sketch
+ * (which runs on the CPU).
+ *
  * @method setUniform
  * @chainable
- * @param {String} uniformName the name of the uniform in the
- * shader program
- * @param {Object|Number|Boolean|Number[]} data the data to be associated
- * with that uniform; type varies (could be a single numerical value, array,
- * matrix, or texture / sampler reference)
+ * @param {String} uniformName the name of the uniform.
+ * Must correspond to the name used in the vertex and fragment shaders
+ * @param {Boolean|Number|Number[]|p5.Image|p5.Graphics|p5.MediaElement}
+ * data the data to associate with the uniform. The type can be
+ * a boolean (true/false), a number, an array of numbers, or
+ * an image (p5.Image, p5.Graphics, p5.MediaElement)
  *
  * @example
  * <div modernizr='webgl'>


### PR DESCRIPTION
Minor changes to the wording used in the following shader methods, with the goal of improving clarity.

### [loadShader()][0]

_1) Reword_

Current:

> Loads a custom shader from the provided vertex and fragment shader paths.

Change:

> Creates a new <a href="#/p5.Shader">p5.Shader</a> object from the provided vertex and fragment shader files.


_2) Omit this statement_

Current:

> For now, there are three main types of shaders. p5 will automatically supply appropriate vertices, normals, colors, and lighting attributes if the parameters defined in the shader match the names.


_3) Be consistent_

Current:

> On success, the Shader object is passed as the first argument. (Optional)

Change:

> p5.Shader object


_4) Add disclaimer_

> Note, shaders can only be used in WEBGL mode.


### [createShader()][1]

_1) Reword_

Change:

> Creates a new <a href="#/p5.Shader">p5.Shader</a> object from the provided vertex and fragment shader code.


_2) Add disclaimer_

> Note, shaders can only be used in WEBGL mode.


### [shader()][2]

_0) Just a thought_

I think in hindsight, `setShader()` would have been a better name for this function. Because the shader program created by `createShader()` or `loadShader()` is what people think of as **the shader**.


_1) Reword_

Current:

> The <a href="#/p5/shader">shader()</a> function lets the user provide a custom shader to fill in shapes in WEBGL mode.

> Users can create their own shaders by loading vertex and fragment shaders with <a href="#/p5/loadShader">loadShader()</a>.

Change:

> Sets the <a href="#/p5.Shader">p5.Shader</a> object to be used to render subsequent shapes.

> Custom shaders can be created using the <a href="#/p5/createShader">createShader()</a> and <a href="#/p5/loadShader">loadShader()</a> functions.

> Use <a href="#/p5/resetShader">resetShader()</a> to restore the default shaders.


_2) Parameter is not optional_

Current:

> shader([s])

> p5.Shader: the desired p5.Shader to use for rendering shapes. (Optional) 

Change:

> shader(s)

> the p5.Shader object to use for rendering shapes.


_3) Add disclaimer_

> Note, shaders can only be used in WEBGL mode.


### [resetShader()][3]

_1) Reword_

Current:

> This function restores the default shaders in WEBGL mode. Code that runs after resetShader() will not be affected by previously defined shaders.

Change:

> Restores the default shaders. Code that runs after resetShader() will not be affected by the shader previously set by <a href="#/p5/shader">shader()</a>


### [setUniform()][4]

_1) Replace with user-friendly description_

Current:

> Wrapper around gl.uniform functions. As we store uniform info in the shader we can use that to do type checking on the supplied data and call the appropriate function.

Change:

> Used to set the uniforms of a <a href="#/p5.Shader">p5.Shader</a> object.

> Uniforms are used as a way to provide shader programs (which run on the GPU) with values from a sketch (which runs on the CPU).


_2) Improve description_

Current:

> the name of the uniform in the shader program

Change:

> the name of the uniform. Must correspond to the name used in the vertex and fragment shaders


_3) `Object` not a valid data type_

Current:

> Object|Number|Boolean|Number[]

Change:

> Boolean|Number|Number[]|p5.Image|p5.Graphics|p5.MediaElement


_4) Replace with user-friendly description_

Current:

> the data to be associated with that uniform; type varies (could be a single numerical value, array, matrix, or texture / sampler reference) 

Change:

> the data to associate with the uniform.

> The type can be:
> - boolean (true/false)
> - a number
> - an array of numbers
> - an image (p5.Image, p5.Graphics, p5.MediaElement)


## Screenshots of the change

_loadShader_
![d1_loadShader](https://user-images.githubusercontent.com/4354703/121761360-89ec7600-caec-11eb-8f85-8454765b720c.png)

_createShader_
![d2_createShader](https://user-images.githubusercontent.com/4354703/121761364-8d7ffd00-caec-11eb-8235-292ff231b268.png)

_shader_
![d3_shader](https://user-images.githubusercontent.com/4354703/121761365-91ac1a80-caec-11eb-9450-55e06df41552.png)

_resetShader_
![d4_resetShader](https://user-images.githubusercontent.com/4354703/121761369-953fa180-caec-11eb-913d-95939f2dce11.png)

_setUniform_
![d5_setUniform](https://user-images.githubusercontent.com/4354703/121761374-9a045580-caec-11eb-8011-c4ab85cf3da9.png)


[0]: https://p5js.org/reference/#/p5/loadShader
[1]: https://p5js.org/reference/#/p5/createShader
[2]: https://p5js.org/reference/#/p5/shader
[3]: https://p5js.org/reference/#/p5/resetShader
[4]: https://p5js.org/reference/#/p5.Shader/setUniform

