### PR TITLE
Improve documetation clarity of material methods

### DIFF
--- a/src/webgl/material.js
+++ b/src/webgl/material.js
@@ -531,11 +531,17 @@ p5.prototype.textureWrap = function(wrapX, wrapY = wrapX) {
 };
 
 /**
- * Normal material for geometry is a material that is not affected by light.
- * It is not reflective and is a placeholder material often used for debugging.
- * Surfaces facing the X-axis, become red, those facing the Y-axis, become green and those facing the Z-axis, become blue.
- * You can view all possible materials in this
+ * Creates a normal material.
+ *
+ * A normal material is not affected by light. It is often used as
+ * a placeholder material when debugging.
+ *
+ * Surfaces facing the X-axis become red, those facing the Y-axis
+ * become green, and those facing the Z-axis become blue.
+ *
+ * You can view more materials in this
  * <a href="https://p5js.org/examples/3d-materials.html">example</a>.
+ *
  * @method normalMaterial
  * @chainable
  * @example
@@ -553,7 +559,7 @@ p5.prototype.textureWrap = function(wrapX, wrapY = wrapX) {
  * </code>
  * </div>
  * @alt
- * Red, green and blue gradient.
+ * Sphere with normal material
  */
 p5.prototype.normalMaterial = function(...args) {
   this._assert3d('normalMaterial');
@@ -569,14 +575,30 @@ p5.prototype.normalMaterial = function(...args) {
 };
 
 /**
- * Ambient material for geometry with a given color. Ambient material defines the color the object reflects under any lighting.
- * For example, if the ambient material of an object is pure red, but the ambient lighting only contains green, the object will not reflect any light.
- * Here's an <a href="https://p5js.org/examples/3d-materials.html">example containing all possible materials</a>.
- * @method  ambientMaterial
- * @param  {Number} v1  gray value, red or hue value
- *                         (depending on the current color mode),
- * @param  {Number} [v2] green or saturation value
- * @param  {Number} [v3] blue or brightness value
+ * Creates an ambient material with the given color.
+ *
+ * The ambientMaterial() color is the color the object will reflect
+ * under **any** lighting.
+ *
+ * Consider an ambientMaterial() with the color yellow (255, 255, 0).
+ * If the light emits the color white (255, 255, 255), then the object
+ * will appear yellow as it will reflect the red and green components
+ * of the light. If the light emits the color red (255, 0, 0), then
+ * the object will appear red as it will reflect the red component
+ * of the light. If the light emits the color blue (0, 0, 255),
+ * then the object will appear black, as there is no component of
+ * the light that it can reflect.
+ *
+ * You can view more materials in this
+ * <a href="https://p5js.org/examples/3d-materials.html">example</a>.
+ *
+ * @method ambientMaterial
+ * @param  {Number} v1  red or hue value relative to the current
+ *                       color range
+ * @param  {Number} v2  green or saturation value relative to the
+ *                       current color range
+ * @param  {Number} v3  blue or brightness value relative to the
+ *                       current color range
  * @chainable
  * @example
  * <div>
@@ -587,12 +609,16 @@ p5.prototype.normalMaterial = function(...args) {
  * function draw() {
  *   background(0);
  *   noStroke();
- *   ambientLight(200);
+ *   ambientLight(255);
  *   ambientMaterial(70, 130, 230);
  *   sphere(40);
  * }
  * </code>
  * </div>
+ * @alt
+ * sphere reflecting red, blue, and green light
+ *
+ * @example
  * <div>
  * <code>
  * // ambientLight is both red and blue (magenta),
@@ -602,12 +628,16 @@ p5.prototype.normalMaterial = function(...args) {
  * }
  * function draw() {
  *   background(70);
- *   ambientLight(100); // white light
- *   ambientMaterial(255, 0, 255); // pink material
+ *   ambientLight(255, 0, 255); // magenta light
+ *   ambientMaterial(255); // white material
  *   box(30);
  * }
  * </code>
  * </div>
+ * @alt
+ * box reflecting only red and blue light
+ *
+ * @example
  * <div>
  * <code>
  * // ambientLight is green. Since object does not contain
@@ -618,19 +648,27 @@ p5.prototype.normalMaterial = function(...args) {
  * function draw() {
  *   background(70);
  *   ambientLight(0, 255, 0); // green light
- *   ambientMaterial(255, 0, 255); // pink material
+ *   ambientMaterial(255, 0, 255); // magenta material
  *   box(30);
  * }
  * </code>
  * </div>
  * @alt
- * radiating light source from top right of canvas
- * box reflecting only red and blue light
  * box reflecting no light
  */
+
 /**
- * @method  ambientMaterial
- * @param  {Number[]|String|p5.Color} color  color, color Array, or CSS color string
+ * @method ambientMaterial
+ * @param  {Number} gray  number specifying value between
+ *                         white and black
+ * @chainable
+ */
+
+/**
+ * @method ambientMaterial
+ * @param  {p5.Color|Number[]|String} color
+ *           color as a <a href="#/p5.Color">p5.Color</a>,
+ *            as an array, or as a CSS string
  * @chainable
  */
 p5.prototype.ambientMaterial = function(v1, v2, v3) {
@@ -649,17 +687,27 @@ p5.prototype.ambientMaterial = function(v1, v2, v3) {
 };
 
 /**
- * Sets the emissive color of the material used for geometry drawn to
- * the screen. This is a misnomer in the sense that the material does not
- * actually emit light that effects surrounding polygons. Instead,
- * it gives the appearance that the object is glowing. An emissive material
- * will display at full strength even if there is no light for it to reflect.
+ * Creates an emissive material with the given color.
+ *
+ * An emissive material will display the emissive color at
+ * full strength regardless of lighting. This can give the
+ * appearance that the object is glowing.
+ *
+ * Note, "emissive" is a misnomer in the sense that the material
+ * does not actually emit light that will affect surrounding objects.
+ *
+ * You can view more materials in this
+ * <a href="https://p5js.org/examples/3d-materials.html">example</a>.
+ *
  * @method emissiveMaterial
- * @param  {Number} v1  gray value, red or hue value
- *                         (depending on the current color mode),
- * @param  {Number} [v2] green or saturation value
- * @param  {Number} [v3] blue or brightness value
- * @param  {Number} [a]  opacity
+ * @param  {Number} v1       red or hue value relative to the current
+ *                            color range
+ * @param  {Number} v2       green or saturation value relative to the
+ *                            current color range
+ * @param  {Number} v3       blue or brightness value relative to the
+ *                            current color range
+ * @param  {Number} [alpha]  alpha value relative to current color
+ *                            range (default is 0-255)
  * @chainable
  * @example
  * <div>
@@ -678,11 +726,21 @@ p5.prototype.ambientMaterial = function(v1, v2, v3) {
  * </div>
  *
  * @alt
- * radiating light source from top right of canvas
+ * sphere with green emissive material
  */
+
 /**
- * @method  emissiveMaterial
- * @param  {Number[]|String|p5.Color} color  color, color Array, or CSS color string
+ * @method emissiveMaterial
+ * @param  {Number} gray  number specifying value between
+ *                         white and black
+ * @chainable
+ */
+
+/**
+ * @method emissiveMaterial
+ * @param  {p5.Color|Number[]|String} color
+ *           color as a <a href="#/p5.Color">p5.Color</a>,
+ *            as an array, or as a CSS string
  * @chainable
  */
 p5.prototype.emissiveMaterial = function(v1, v2, v3, a) {
@@ -701,11 +759,23 @@ p5.prototype.emissiveMaterial = function(v1, v2, v3, a) {
 };
 
 /**
- * Specular material for geometry with a given color. Specular material is a shiny reflective material.
- * Like ambient material it also defines the color the object reflects under ambient lighting.
- * For example, if the specular material of an object is pure red, but the ambient lighting only contains green, the object will not reflect any light.
- * For all other types of light like point and directional light, a specular material will reflect the color of the light source to the viewer.
- * Here's an <a href="https://p5js.org/examples/3d-materials.html">example containing all possible materials</a>.
+ * Creates a specular material with the given color.
+ *
+ * A specular material is reflective (shiny). The shininess can be
+ * controlled by the <a href="#/p5/shininess">shininess()</a> function.
+ *
+ * Like <a href="#/p5/ambientMaterial">ambientMaterial()</a>,
+ * the specularMaterial() color is the color the object will reflect
+ * under <a href="#/p5/ambientLight">ambientLight()</a>.
+ * However unlike ambientMaterial(), for all other types of lights
+ * (<a href="#/p5/directionalLight">directionalLight()</a>,
+ * <a href="#/p5/pointLight">pointLight()</a>,
+ * <a href="#/p5/spotLight">spotLight()</a>),
+ * a specular material will reflect the **color of the light source**.
+ * This is what gives it its "shiny" appearance.
+ *
+ * You can view more materials in this
+ * <a href="https://p5js.org/examples/3d-materials.html">example</a>.
  *
  * @method specularMaterial
  * @param  {Number} gray number specifying value between white and black.
@@ -746,7 +816,9 @@ p5.prototype.emissiveMaterial = function(v1, v2, v3, a) {
 
 /**
  * @method specularMaterial
- * @param  {Number[]|String|p5.Color} color color Array, or CSS color string
+ * @param  {p5.Color|Number[]|String} color
+ *           color as a <a href="#/p5.Color">p5.Color</a>,
+ *            as an array, or as a CSS string
  * @chainable
  */
 p5.prototype.specularMaterial = function(v1, v2, v3, alpha) {
@@ -765,12 +837,13 @@ p5.prototype.specularMaterial = function(v1, v2, v3, alpha) {
 };
 
 /**
- * Sets the amount of gloss in the surface of shapes.
- * Used in combination with specularMaterial() in setting
- * the material properties of shapes. The default and minimum value is 1.
+ * Sets the amount of gloss ("shininess") of a
+ * <a href="#/p5/specularMaterial">specularMaterial()</a>.
+ *
+ * The default and minimum value is 1.
+ *
  * @method shininess
- * @param {Number} shine Degree of Shininess.
- *                       Defaults to 1.
+ * @param {Number} shine  degree of shininess
  * @chainable
  * @example
  * <div>
@@ -796,7 +869,7 @@ p5.prototype.specularMaterial = function(v1, v2, v3, alpha) {
  * </code>
  * </div>
  * @alt
- * Shininess on Camera changes position with mouse
+ * two spheres, one more shiny than the other
  */
 p5.prototype.shininess = function(shine) {
   this._assert3d('shininess');


### PR DESCRIPTION
Minor changes to the wording used in the following material methods, with the goal of improving clarity.

### [normalMaterial()][0]

_1) Reword_

Current:

> Normal material for geometry is a material that is not affected by light. It is not reflective and is a placeholder material often used for debugging. Surfaces facing the X-axis, become red, those facing the Y-axis, become green and those facing the Z-axis, become blue. You can view all possible materials in this example.

Change:

> Creates a normal material.

> A normal material is not affected by light. It is often used as a placeholder material when debugging.

> Surfaces facing the X-axis become red, those facing the Y-axis become green, and those facing the Z-axis become blue.

> You can view more materials in this <a href="https://p5js.org/examples/3d-materials.html">example</a>.


### [ambientMaterial()][1]

_1) Reword_

Current:

> Ambient material for geometry with a given color. Ambient material defines the color the object reflects under any lighting. For example, if the ambient material of an object is pure red, but the ambient lighting only contains green, the object will not reflect any light. Here's an example containing all possible materials.

Change:

> Creates an ambient material with the given color.

> The ambientMaterial() color is the color the object will reflect under **any** lighting.

> Consider an ambientMaterial() with the color yellow (255, 255, 0). If the light emits the color white (255, 255, 255), then the object will appear yellow as it will reflect the red and green components of the light. If the light emits the color red (255, 0, 0), then the object will appear red as it will reflect the red component of the light. If the light emits the color blue (0, 0, 255), then the object will appear black, as there is no component of the light that it can reflect.

> You can view more materials in this <a href="https://p5js.org/examples/3d-materials.html">example</a>.


_2) Add variant to improve clarity_

Use same parameter descriptions as <a href="https://p5js.org/reference/#/p5/color">color()</a> reference.

Current:

> ambientMaterial(v1, [v2], [v3])

> v1
> gray value, red or hue value (depending on the current color mode),

> v2
> green or saturation value (Optional)

> v3
> blue or brightness value (Optional)

Change:

> ambientMaterial(gray)

> ambientMaterial(v1, v2, v3)

> gray
> Number: number specifying value between white and black

> v1
> red or hue value relative to the current color range

> v2
> green or saturation value relative to the current color range

> v3
> blue or brightness value relative to the current color range


_3) Improve clarity_

Current:

> Number[]|String|p5.Color:
> color, color Array, or CSS color string

Change:

> p5.Color|Number[]|String:
> color as a <a href="#/p5.Color">p5.Color</a>, as an array, or as a CSS string


_4) Improve examples_

Changes:

example 1:
- Use white (255) as `ambientLight` color so that output matches expectations. I.e. isolate color effect to just `ambientMaterial`.

example 2:
- color values currently swapped. Un-swapped to match explanation in comments.


### [emissiveMaterial()][2]

_1) Reword_

Current:

> Sets the emissive color of the material used for geometry drawn to the screen. This is a misnomer in the sense that the material does not actually emit light that effects surrounding polygons. Instead, it gives the appearance that the object is glowing. An emissive material will display at full strength even if there is no light for it to reflect.

Change:

> Creates an emissive material with the given color.

> An emissive material will display the emissive color at full strength regardless of lighting. This can give the appearance that the object is glowing.

> Note, "emissive" is a misnomer in the sense that the material does not actually emit light that will affect surrounding objects.


_2) Add link that appears in other materials_

> You can view more materials in this <a href="https://p5js.org/examples/3d-materials.html">example</a>.


_3) Add variant to improve clarity (and rename `a` param to `alpha`)_

Use same parameter descriptions as <a href="https://p5js.org/reference/#/p5/color">color()</a> reference.

Current:

> emissiveMaterial(v1, [v2], [v3], [a])

> v1
> gray value, red or hue value (depending on the current color mode),

> v2
> green or saturation value (Optional)

> v3
> blue or brightness value (Optional)

> a
> opacity (Optional)

Change:

> emissiveMaterial(gray, [alpha])

> emissiveMaterial(v1, v2, v3, [alpha])

> gray
> Number: number specifying value between white and black

> v1
> red or hue value relative to the current color range

> v2
> green or saturation value relative to the current color range

> v3
> blue or brightness value relative to the current color range

> alpha
> alpha value relative to current color range (default is 0-255) (Optional)


_4) Improve clarity_

Current:

> Number[]|String|p5.Color:
> color, color Array, or CSS color string

Change:

> p5.Color|Number[]|String:
> color as a <a href="#/p5.Color">p5.Color</a>, as an array, or as a CSS string


### [specularMaterial()][3]

_1) Reword_

Current:

> Specular material for geometry with a given color. Specular material is a shiny reflective material. Like ambient material it also defines the color the object reflects under ambient lighting. For example, if the specular material of an object is pure red, but the ambient lighting only contains green, the object will not reflect any light. For all other types of light like point and directional light, a specular material will reflect the color of the light source to the viewer. Here's an example containing all possible materials.

Change:

> Creates a specular material with the given color.

> A specular material is reflective (shiny). The shininess can be controlled by the <a href="#/p5/shininess">shininess()</a> function.

> Like <a href="#/p5/ambientMaterial">ambientMaterial()</a>, the specularMaterial() color is the color the object will reflect under <a href="#/p5/ambientLight">ambientLight()</a>. However unlike ambientMaterial(), for all other types of lights (<a href="#/p5/directionalLight">directionalLight()</a>, <a href="#/p5/pointLight">pointLight()</a>, <a href="#/p5/spotLight">spotLight()</a>), a specular material will reflect the **color of the light source**. This is what gives it its "shiny" appearance.

> You can view more materials in this <a href="https://p5js.org/examples/3d-materials.html">example</a>.


_2) Improve clarity_

Current:

> Number[]|String|p5.Color:
> color, color Array, or CSS color string

Change:

> p5.Color|Number[]|String:
> color as a <a href="#/p5.Color">p5.Color</a>, as an array, or as a CSS string


_3) Add an example_

Change:

Separate PR [over here][].


### [shininess()][4]

_1) Reword_

Current:

> Sets the amount of gloss in the surface of shapes. Used in combination with specularMaterial() in setting the material properties of shapes. The default and minimum value is 1.

Change:

> Sets the amount of gloss ("shininess") of a <a href="#/p5/specularMaterial">specularMaterial()</a>.

> The default and minimum value is 1.


### Screenshots of the change

_normalMaterial_
![e1_normalMaterial](https://user-images.githubusercontent.com/4354703/121826498-28a3de80-cc75-11eb-982b-52b9153440d6.png)

_ambientMaterial_
![e2_ambientMaterial](https://user-images.githubusercontent.com/4354703/121826529-5852e680-cc75-11eb-9484-f4133a1dcd1f.png)

_emissiveMaterial_
![e3_emissiveMaterial](https://user-images.githubusercontent.com/4354703/121826533-61dc4e80-cc75-11eb-8445-c5b276d21d70.png)

_specularMaterial_
![e4_specularMaterial](https://user-images.githubusercontent.com/4354703/121826543-6b65b680-cc75-11eb-8f39-775f9e06d6ff.png)

_shininess_
![e5_shininess](https://user-images.githubusercontent.com/4354703/121826545-70c30100-cc75-11eb-9b9f-e2c4a1c2b7c6.png)




[0]: https://p5js.org/reference/#/p5/normalMaterial
[1]: https://p5js.org/reference/#/p5/ambientMaterial
[2]: https://p5js.org/reference/#/p5/emissiveMaterial
[3]: https://p5js.org/reference/#/p5/specularMaterial
[4]: https://p5js.org/reference/#/p5/shininess
