### PR TITLE
Add example for specularMaterial()

### DIFF
--- a/src/webgl/material.js
+++ b/src/webgl/material.js
@@ -712,6 +712,33 @@ p5.prototype.emissiveMaterial = function(v1, v2, v3, a) {
  * @param  {Number} [alpha] alpha value relative to current color range
  *                                 (default is 0-255)
  * @chainable
+ *
+ * @example
+ * <div>
+ * <code>
+ * function setup() {
+ *   createCanvas(100, 100, WEBGL);
+ *   noStroke();
+ * }
+ *
+ * function draw() {
+ *   background(0);
+ *
+ *   ambientLight(60);
+ *
+ *   // add point light to showcase specular material
+ *   let locX = mouseX - width / 2;
+ *   let locY = mouseY - height / 2;
+ *   pointLight(255, 255, 255, locX, locY, 50);
+ *
+ *   specularMaterial(250);
+ *   shininess(50);
+ *   torus(30, 10, 64, 64);
+ * }
+ * </code>
+ * </div>
+ * @alt
+ * torus with specular material
  */
 
 /**
@@ -724,24 +751,6 @@ p5.prototype.emissiveMaterial = function(v1, v2, v3, a) {
  *                                 relative to the current color range
  * @param  {Number}        [alpha]
  * @chainable
- *
- * @example
- * <div>
- * <code>
- * function setup() {
- *   createCanvas(100, 100, WEBGL);
- * }
- * function draw() {
- *   background(0);
- *   ambientLight(50);
- *   pointLight(250, 250, 250, 100, 100, 30);
- *   specularMaterial(250);
- *   sphere(40);
- * }
- * </code>
- * </div>
- * @alt
- * diffused radiating light source from top right of canvas
  */
 
 /**


### PR DESCRIPTION
Adds an example for [`specularMaterial()`][0]

Live demo [here][1].

**Screenshot of change**
![specularMaterialExample_proposal](https://user-images.githubusercontent.com/4354703/121827347-e2507e80-cc78-11eb-8a32-4d330722c2a5.png)

\---

Note in the current source code, I found that an [example was already present][2]. It fails to render in the generated documentation because of where it is declared. (On the second parameter variant instead of the first). [Here][3] is a live demo of this hidden example, and below a screenshot of what it renders.
![specularMaterialExample_hidden](https://user-images.githubusercontent.com/4354703/121827363-eaa8b980-cc78-11eb-938d-1280f7aa3cec.png)


[0]: https://p5js.org/reference/#/p5/specularMaterial
[1]: https://editor.p5js.org/acedean/sketches/aVTH4VdHd
[2]: https://github.com/processing/p5.js/blob/7375939aa4e4e5ada7381815ace2dcb8a0daa74c/src/webgl/material.js#L728
[3]: https://editor.p5js.org/acedean/sketches/0N81pic7o
