### PR TITLE
Improve clarity of `noLights()` example

### DIFF
--- a/src/webgl/light.js
+++ b/src/webgl/light.js
@@ -861,25 +861,30 @@ p5.prototype.spotLight = function(
  *   createCanvas(100, 100, WEBGL);
  * }
  * function draw() {
- *   background(0);
+ *   background(200);
  *   noStroke();
  *
- *   ambientLight(150, 0, 0);
- *   translate(-25, 0, 0);
- *   ambientMaterial(250);
- *   sphere(20);
+ *   ambientLight(255, 0, 0);
+ *   translate(-30, 0, 0);
+ *   ambientMaterial(255);
+ *   sphere(13);
  *
  *   noLights();
- *   ambientLight(0, 150, 0);
- *   translate(50, 0, 0);
- *   ambientMaterial(250);
- *   sphere(20);
+ *   translate(30, 0, 0);
+ *   ambientMaterial(255);
+ *   sphere(13);
+ *
+ *   ambientLight(0, 255, 0);
+ *   translate(30, 0, 0);
+ *   ambientMaterial(255);
+ *   sphere(13);
  * }
  * </code>
  * </div>
  *
  * @alt
- * Two spheres showing different colors
+ * Three white spheres. Each appears as a different
+ * color due to lighting.
  */
 p5.prototype.noLights = function() {
   this._assert3d('noLights');


### PR DESCRIPTION
In the current example, it is not immediately apparent what `noLights()` does.

_current_
![noLightsExample_current](https://user-images.githubusercontent.com/4354703/121974376-7899a880-cd3c-11eb-89bb-4df780f3f962.png)

_current with `noLights()` commented out_
![noLightsExample_current_commentedOut](https://user-images.githubusercontent.com/4354703/121974387-7d5e5c80-cd3c-11eb-8efb-934803d3e927.png)

I propose adding a third sphere to the example to more readily demonstrate the `light > no light > light` sequence. Live demo [here][0].

_change_
![noLightsExample_proposal](https://user-images.githubusercontent.com/4354703/121974395-82bba700-cd3c-11eb-8bdf-638242422b22.png)

_change with `noLights()` commented out_
![noLightsExample_proposal_commentedOut](https://user-images.githubusercontent.com/4354703/121974407-8818f180-cd3c-11eb-9e5d-cb868497648e.png)

Change rendered as docs:
![noLightsExample_proposal_docs](https://user-images.githubusercontent.com/4354703/121974533-d5955e80-cd3c-11eb-9565-265d6e99b2df.png)



[0]: https://editor.p5js.org/acedean/sketches/V4nfcPqfK