### PR TITLE
Improve clarity of `lightFalloff()` example

### DIFF
--- a/src/webgl/light.js
+++ b/src/webgl/light.js
@@ -443,17 +443,26 @@ p5.prototype.lights = function() {
  *   noStroke();
  * }
  * function draw() {
+ *   ortho();
  *   background(0);
+ *
  *   let locX = mouseX - width / 2;
  *   let locY = mouseY - height / 2;
- *   translate(-25, 0, 0);
+ *   locX /= 2; // half scale
+ *
  *   lightFalloff(1, 0, 0);
- *   pointLight(250, 250, 250, locX, locY, 50);
+ *   push();
+ *   translate(-25, 0, 0);
+ *   pointLight(250, 250, 250, locX - 25, locY, 50);
  *   sphere(20);
- *   translate(50, 0, 0);
- *   lightFalloff(0.9, 0.01, 0);
- *   pointLight(250, 250, 250, locX, locY, 50);
+ *   pop();
+ *
+ *   lightFalloff(0.97, 0.03, 0);
+ *   push();
+ *   translate(25, 0, 0);
+ *   pointLight(250, 250, 250, locX + 25, locY, 50);
  *   sphere(20);
+ *   pop();
  * }
  * </code>
  * </div>


### PR DESCRIPTION
In the current example, the translations to place the spheres are done globally (instead of using `push` and `pop`). As a result, the light positions are affected by these translations.

As a consequence of this, the color of the rightmost sphere is affected more by the light position than by falloff.

This is what the two spheres look like in the **current** example if the lines setting `lightFalloff()` are commented out:

![falloffExample_current_commentedOut](https://user-images.githubusercontent.com/4354703/121977224-b7caf800-cd42-11eb-96ce-19b5328cb184.png)

What should happen instead is that both spheres are equally lit. Here is what they look like with `lightFalloff()` commented out in the **proposed** example:

![falloffExample_proposal_commentedOut](https://user-images.githubusercontent.com/4354703/121977235-c0233300-cd42-11eb-829b-dbbd64cb7937.png)

In the proposed changes (live version [here][0]), the difference between the two spheres becomes attributable to falloff only.

Change as docs:
![falloffExample_proposal_docs](https://user-images.githubusercontent.com/4354703/121977240-c6191400-cd42-11eb-8bcd-2ae98ee24068.png)



[0]: https://editor.p5js.org/acedean/sketches/7lkU8Q9cv
