### PR TITLE
Point to wiki in text() reference page

### DIFF
--- a/src/typography/loading_displaying.js
+++ b/src/typography/loading_displaying.js
@@ -162,6 +162,8 @@ p5.prototype.loadFont = function(path, onSuccess, onError) {
  * <b>WEBGL</b>: Only opentype/truetype fonts are supported. You must load a font
  * using the <a href="#/p5/loadFont">loadFont()</a> method (see the example above).
  * <a href="#/p5/stroke">stroke()</a> currently has no effect in webgl mode.
+ * Learn more about working with text in webgl mode
+ * <a href="https://github.com/processing/p5.js/wiki/Getting-started-with-WebGL-in-p5#text">here</a>.
  *
  * @method text
  * @param {String|Object|Array|Number|Boolean} str the alphanumeric

--- a/src/typography/loading_displaying.js
+++ b/src/typography/loading_displaying.js
@@ -162,8 +162,8 @@ p5.prototype.loadFont = function(path, onSuccess, onError) {
  * <b>WEBGL</b>: Only opentype/truetype fonts are supported. You must load a font
  * using the <a href="#/p5/loadFont">loadFont()</a> method (see the example above).
  * <a href="#/p5/stroke">stroke()</a> currently has no effect in webgl mode.
- * Learn more about working with text in webgl mode
- * <a href="https://github.com/processing/p5.js/wiki/Getting-started-with-WebGL-in-p5#text">here</a>.
+ * Learn more about working with text in webgl mode on the
+ * <a href="https://github.com/processing/p5.js/wiki/Getting-started-with-WebGL-in-p5#text">wiki</a>.
  *
  * @method text
  * @param {String|Object|Array|Number|Boolean} str the alphanumeric


### PR DESCRIPTION
Adds a note that points to the [wiki][0] as a resource for learning more about using text in WEBGL mode. There is a fair amount of subtlety that cannot be squeezed onto the [`text()` reference page][1].

![textAddendum](https://user-images.githubusercontent.com/4354703/122310498-b417ac80-cecd-11eb-86b0-caef8f629674.png)


[0]: https://github.com/processing/p5.js/wiki/Getting-started-with-WebGL-in-p5#text
[1]: https://p5js.org/reference/#/p5/text
