### PR TITLE
Add `vertex()` variant to documentation

### DIFF
--- a/src/core/shape/vertex.js
+++ b/src/core/shape/vertex.js
@@ -958,9 +958,17 @@ p5.prototype.quadraticVertex = function(...args) {
  * @method vertex
  * @param  {Number} x
  * @param  {Number} y
- * @param  {Number} z   z-coordinate of the vertex
- * @param  {Number} [u] the vertex's texture u-coordinate
- * @param  {Number} [v] the vertex's texture v-coordinate
+ * @param  {Number} z   z-coordinate of the vertex.
+ *                       Defaults to 0 if not specified.
+ * @chainable
+ */
+/**
+ * @method vertex
+ * @param  {Number} x
+ * @param  {Number} y
+ * @param  {Number} [z]
+ * @param  {Number} u   the vertex's texture u-coordinate
+ * @param  {Number} v   the vertex's texture v-coordinate
  * @chainable
  */
 p5.prototype.vertex = function(x, y, moveTo, u, v) {


### PR DESCRIPTION
# Add `vertex()` variant in documentation

The `vertex(x, y, u, v)` variant is currently missing from the [`vertex()` reference page][0]. In this variant, the omitted `z` defaults to `0`. It can be seen in use on the [`textureMode()` reference page][1].

_variants before change_
![vertex_before](https://user-images.githubusercontent.com/4354703/122313280-28a11a00-ced3-11eb-883d-de729a3c8799.png)

_variants after change_
![vertex_proposal](https://user-images.githubusercontent.com/4354703/122313294-2d65ce00-ced3-11eb-9cc1-83d3a8d29b4a.png)


[0]: https://p5js.org/reference/#/p5/vertex
[1]: https://p5js.org/reference/#/p5/textureMode
