### PR TITLE
Fix "it's" in translation.json

### DIFF
--- a/translations/en/translation.json
+++ b/translations/en/translation.json
@@ -27,8 +27,8 @@
       "stackSubseq": "▶️ Called from line {{line}} in \"{{func}}\" in {{file}} ({{location}})\n\n",
       "stackTop": "▶️ Error at line {{line}} in \"{{func}}\" in {{file}} ({{location}})\n\n",
       "syntax": {
-        "invalidToken": "There's a syntax error due to a symbol that JavaScript doesn't recognize or didn't expect at it's place.\nFor more: {{url}}",
-        "unexpectedToken": "There's a syntax error due to a symbol that wasn't expected at it's place.\nUsually this is due to a typo. Check the line number in the error below for anything missing/extra.\nFor more: {{url}}"
+        "invalidToken": "There's a syntax error due to a symbol that JavaScript doesn't recognize or didn't expect at its place.\nFor more: {{url}}",
+        "unexpectedToken": "There's a syntax error due to a symbol that wasn't expected at its place.\nUsually this is due to a typo. Check the line number in the error below for anything missing/extra.\nFor more: {{url}}"
       },
       "type": {
         "notfunc": "There's an error as \"{{symbol}}\" could not be called as a function {{location}}.\nCheck the spelling, letter-casing (JavaScript is case-sensitive) and its type.\nFor more: {{url}}",


### PR DESCRIPTION
In the description field of this PR, include "resolves #XXXX" tagging the issue you are fixing. If this PR addresses the issue but doesn't completely resolve it (ie the issue should remain open after your PR is merged), write "addresses #XXXX".-->
Resolves #[Add issue number here]

Changes:
Fix a couple of "it's" / "its" typos in en/translation.json

- [x] `npm run lint` passes
- [x] [Inline documentation] is included / updated
- [ ] [Unit tests] are included / updated

[Inline documentation]: https://github.com/processing/p5.js/blob/main/contributor_docs/inline_documentation.md
[Unit tests]: https://github.com/processing/p5.js/tree/main/contributor_docs#unit-tests

Before:
<img width="874" alt="image" src="https://user-images.githubusercontent.com/674/122660264-c423da80-d1b2-11eb-9846-cdd27c34ceb8.png">

