### PR TITLE
Fixed round implementation support for numbers that have string representations that use exponential notation.

### DIFF
--- a/src/math/calculation.js
+++ b/src/math/calculation.js
@@ -694,7 +694,8 @@ p5.prototype.round = function(n, decimals) {
   if (!decimals) {
     return Math.round(n);
   }
-  return Number(Math.round(n + 'e' + decimals) + 'e-' + decimals);
+  const multiplier = Math.pow(10, decimals);
+  return Math.round(n * multiplier) / multiplier;
 };
 
 /**

--- a/test/unit/math/calculation.js
+++ b/test/unit/math/calculation.js
@@ -425,6 +425,16 @@ suite('Calculation', function() {
       result = myp5.round(12.31833, 2);
       assert.equal(result, 12.32);
     });
+
+    test('should round very small numbers to zero', function() {
+      result = myp5.round(1.234567e-14);
+      assert.equal(result, 0);
+    });
+
+    test('should round very small numbers to zero when decimal places are specified', function() {
+      result = myp5.round(1.234567e-14, 2);
+      assert.equal(result, 0);
+    });
   });
 
   suite('p5.prototype.sqrt', function() {


### PR DESCRIPTION
Resolves #5340

#### Changes:

The `round()` function now uses multiplication and division by powers of 10 to implement rounding to a fixed number of decimal places instead of using string concatenation with exponent notation.

#### PR Checklist

- [X] `npm run lint` passes
- [X] [Unit tests] are included / update
