### PR TITLE
Add class method and tests for p5.Vector.toString()

### DIFF
--- a/src/math/p5.Vector.js
+++ b/src/math/p5.Vector.js
@@ -2364,4 +2364,23 @@ p5.Vector.normalize = function normalize(v, target) {
   return target.normalize();
 };
 
+/**
+ * Returns a string representation of a vector v. This method is useful for
+ * logging vectors in the console.
+ * Note that the static method p5.Vector.toString() overrides the existing
+ * inherited method Function.prototype.toString().
+ */
+/**
+ * @method toString
+ * @static
+ * @param  {p5.Vector}    v the vector to stringify
+ * @return {String}       the string representation
+ */
+p5.Vector.toString = function toString(v) {
+  // NOTE: Returning `v.toString()` directly here will cause test cases such as
+  //       `assert.instanceOf(v, p5.Vector)` that check if something is an instance
+  //       of a p5.Vector to fail. Using `String(v)` as a workaround.
+  return String(v);
+};
+
 export default p5.Vector;

--- a/test/unit/math/p5.Vector.js
+++ b/test/unit/math/p5.Vector.js
@@ -58,7 +58,7 @@ suite('p5.Vector', function() {
     setup(function() {
       v = new p5.Vector();
     });
-    test('should set constant to DEGREES', function() {
+    test('should create instance of p5.Vector', function() {
       assert.instanceOf(v, p5.Vector);
     });
 
@@ -1286,6 +1286,31 @@ suite('p5.Vector', function() {
         Math.abs(z_normal.angleBetween(z_bounce_outgoing.mult(-1))),
         0.01
       );
+    });
+  });
+
+  suite('toString', function() {
+    let v, vString;
+
+    setup(function() {
+      v = new p5.Vector(0, -1, 1);
+      vString = 'p5.Vector Object : [0, -1, 1]';
+    });
+
+    suite('p5.Vector.prototype.toString() [INSTANCE]', function() {
+      test('v.toString() should return "p5.Vector Object : [0, -1, 1]"', function() {
+        expect(v.toString()).to.equal(vString);
+      });
+
+      test('String(v) should return "p5.Vector Object : [0, -1, 1]"', function() {
+        expect(String(v)).to.equal(vString);
+      });
+    });
+
+    suite('p5.Vector.toString() [CLASS]', function() {
+      test('p5.Vector.toString(v) should return "p5.Vector Object : [0, -1, 1]"', function() {
+        expect(p5.Vector.toString(v)).to.equal(vString);
+      });
     });
   });
 });


### PR DESCRIPTION
<!--
  Thank you for contributing! Please use this pull request (PR) template.


 In the description field of this PR, include "resolves #XXXX" tagging the issue you are fixing. If this PR addresses the issue but doesn't completely resolve it (ie the issue should remain open after your PR is merged), write "addresses #XXXX".-->
Addresses #4852

####  Changes
Add tests for `p5.Vector.prototype.toString()`
Add class method and tests for `p5.Vector.toString()`

#### Notes
Adding class method `p5.Vector.toString()` for consistency's sake, as per #4852, but noticed that this has the small side effect of overriding the inherited default method from `Function.prototype.toString()`, which returns the code that defines a function. I think it's unlikely anyone depends on that original behaviour, but since it's a breaking change I figured I'd split this particular change off of the rest of the static/class methods in #5044. This way we can discuss it separately.

One weird ramification is that defining `p5.Vector.toString = (v) => v.toString()` caused problems with unit tests for instanceof p5.Vector - I haven't dug in to figure out why, but I did find out that `p5.Vector.toString = (v) => String(v)` seems to work just fine. Strange, right?

#### PR Checklist
<!--
  To check any option, replace the "[ ]" with a "[x]". Be sure to check out how it looks in the Preview tab! Feel free to remove any portion of the template that is not relevant for your issue.
-->

- [x] `npm run lint` passes
- [x] [Inline documentation] is included / updated
- [x] [Unit tests] are included / updated

[Inline documentation]: https://github.com/processing/p5.js/blob/main/contributor_docs/inline_documentation.md
[Unit tests]: https://github.com/processing/p5.js/tree/main/contributor_docs#unit-tests
