### PR TITLE
Detecting redeclaration of p5.js reserved constants and functions

### DIFF
--- a/contributor_docs/friendly_error_system.md
+++ b/contributor_docs/friendly_error_system.md
@@ -245,8 +245,8 @@ line(0, 0, 100, 100, x3, Math.PI);
 * All the colors are checked for being color blind friendly.
 * More elaborate ascii is always welcome! 
 * Extend Global Error catching. This means catching errors that the browser is throwing to the console and matching them with friendly messages. `fesErrorMonitor()` does this for a select few kinds of errors but help in supporting more is welcome :)
-* Improve `sketch_reader.js`'s code reading and variable/function name extracting functionality.
-* `sketch_reader.js` can be extended and new features can be added to it to better aid the user.
+* Improve `sketch_reader.js`'s code reading and variable/function name extracting functionality (which extracts names of the function and variables declared by the user in their code). For example currently `sketch_reader.js` is not able to extract variable/function names properly if all the code is written in a single line.
+* `sketch_reader.js` can be extended and new features (for example: Alerting the user when they have declared a variable in the `draw()` function) can be added to it to better aid the user. 
 
 
 ```javascript

--- a/contributor_docs/friendly_error_system.md
+++ b/contributor_docs/friendly_error_system.md
@@ -27,6 +27,8 @@ The FES can also help the user differentiate between errors that happen inside t
 
 Please also see inline notes in [src/core/friendly_errors/fes_core.js](https://github.com/processing/p5.js/blob/main/src/core/friendly_errors/fes_core.js) for more technical information.
 
+The FES can detect the declaration of reserved p5.js constants (for eg: PI) and functions (for eg: text) by the user. This operation is performed by `fesCodeReader()` in `sketch_reader.js`. You can have a look at the full code [src/core/friendly_errors/sketch_reader.js](https://github.com/processing/p5.js/blob/main/src/core/friendly_errors/sketch_reader.js)
+
 ### `core/friendly_errors/file_errors/friendlyFileLoadError()`: 
 * This function generates and displays friendly error messages if a file fails to load correctly. It also checks if the size of a file might be too large to load and produces a warning. 
 * This can be called through : `p5._friendlyFileLoadError(ERROR_TYPE, FILE_PATH)`.
@@ -137,6 +139,36 @@ Please correct it to color if you wish to use the function from p5.js (http://p5
 */
 ```
 
+### `core/friendly_errors/fes_core/sketch_reader/fesCodeReader()`:
+* This function is executed everytime when the `load` event is triggered. It checks if a p5.js reserved constant or function is redefined by the user.
+
+* Redefining p5.js reserved constant
+```js
+function setup() {
+  //PI is a p5.js reserved constant
+  let PI = 100;
+}
+
+/* 
+FES will show:
+p5.js says: you have used a p5.js reserved variable "PI" make sure you change the variable name to something else.
+(https://p5js.org/reference/#/p5/PI)
+*/
+```
+
+* Redefining p5.js reserved function
+```js
+function setup() {
+  //text is a p5.js reserved function
+  let text = 100;
+}
+
+/* 
+FES will show:
+p5.js says: you have used a p5.js reserved function "text" make sure you change the function name to something else.
+*/
+```
+
 ### `core/friendly_errors/fes_core/checkForUserDefinedFunctions()`:
 * Checks if any user defined function (`setup()`, `draw()`, `mouseMoved()`, etc.) has been used with a capitalization mistake
 * For example
@@ -200,6 +232,8 @@ line(0, 0, 100, 100, x3, Math.PI);
 
  * The functionality described under **`fesErrorMonitor()`** currently only works on the web editor or if running on a local server. For more details see [this](https://github.com/processing/p5.js/pull/4730).
 
+ * The extracting variable/function names feature of FES's `sketch_reader` is not perfect and some cases might go undetected (for eg: when all the code is written in a single line).
+
 ## In The Works
 * Identify more common error types and generalize with FES (e.g. `bezierVertex()`, `quadraticVertex()` - required object not initiated; checking Number parameters positive for `nf()` `nfc()` `nfp()` `nfs()`)
 
@@ -211,6 +245,8 @@ line(0, 0, 100, 100, x3, Math.PI);
 * All the colors are checked for being color blind friendly.
 * More elaborate ascii is always welcome! 
 * Extend Global Error catching. This means catching errors that the browser is throwing to the console and matching them with friendly messages. `fesErrorMonitor()` does this for a select few kinds of errors but help in supporting more is welcome :)
+* Improve `sketch_reader.js`'s code reading and variable/function name extracting functionality.
+* `sketch_reader.js` can be extended and new features can be added to it to better aid the user.
 
 
 ```javascript

--- a/src/app.js
+++ b/src/app.js
@@ -6,6 +6,7 @@ import './core/friendly_errors/stacktrace';
 import './core/friendly_errors/validate_params';
 import './core/friendly_errors/file_errors';
 import './core/friendly_errors/fes_core';
+import './core/friendly_errors/sketch_reader';
 import './core/helpers';
 import './core/legacy';
 import './core/preload';

--- a/src/core/friendly_errors/sketch_reader.js
+++ b/src/core/friendly_errors/sketch_reader.js
@@ -23,11 +23,35 @@ const _checkForConsts = variables => {
   }
 };
 
+const _checkForFuncs = funcs => {
+  const p5Constructors = {};
+  for (let key of Object.keys(p5)) {
+    // Get a list of all constructors in p5. They are functions whose names
+    // start with a capital letter
+    if (typeof p5[key] === 'function' && key[0] !== key[0].toLowerCase()) {
+      p5Constructors[key] = p5[key];
+    }
+  }
+  for (let i = 0; i < funcs.length; i++) {
+    //for every function name obtained check if it matches any p5.js function name
+    const keyArr = Object.keys(p5Constructors);
+    let j = 0;
+    for (; j < keyArr.length; j++) {
+      if (p5Constructors[keyArr[j]].prototype[funcs[i]] !== undefined) {
+        //if a p5.js function is used ie it is in the funcs array
+        p5._friendlyError(
+          translator('fes.sketchReaderErrors.reservedFunc', {
+            symbol: funcs[i]
+          })
+        );
+        break;
+      }
+    }
+    if (j < keyArr.length) break;
+  }
+};
+
 const _extractVariables = arr => {
-  console.log(
-    '%cFrom _extractVariables',
-    'color: black; font-weight: bold; font-size: 16px; background: yellow;'
-  );
   //extract variable names from the user's code
   let matches = [];
   arr.forEach(ele => {
@@ -60,16 +84,12 @@ const _extractVariables = arr => {
 const _extractFuncVariables = arr => {
   let matches = [];
   //extract function names
-  console.log(
-    '%cFrom _extractFuncVariables',
-    'color: black; font-weight: bold; font-size: 16px; background: yellow;'
-  );
   const reg = /(?:(?:let|const)\s+)([\w$]+)/;
   arr.forEach(ele => {
     matches.push(ele.match(reg)[1]);
   });
   //matches array contains the names of the functions
-  console.log(matches);
+  _checkForFuncs(matches);
 };
 
 const _codeToLines = code => {

--- a/src/core/friendly_errors/sketch_reader.js
+++ b/src/core/friendly_errors/sketch_reader.js
@@ -64,7 +64,9 @@ const _extractVariables = arr => {
             match = s.match(/(\w+)\s*(?==)/i);
             return match[1];
           } else if (!s.match(new RegExp('[[]{}]'))) {
-            return s.match(/(?:(?:let|const|var)\s+)?([\w$]+)/)[1];
+            let m = s.match(/(?:(?:let|const|var)\s+)?([\w$]+)/);
+            if (m !== null)
+              return s.match(/(?:(?:let|const|var)\s+)?([\w$,]+)/)[1];
           } else return [];
         })
       );

--- a/src/core/friendly_errors/sketch_reader.js
+++ b/src/core/friendly_errors/sketch_reader.js
@@ -18,10 +18,9 @@ import p5 from '../main';
 import { translator } from '../internationalization';
 import * as constants from '../constants';
 
-if (
-  typeof IS_MINIFIED !== 'undefined' ||
-  document.location.pathname.includes('file://')
-) {
+const IS_LOCAL = document.location.origin.includes('file://');
+
+if (typeof IS_MINIFIED !== 'undefined' || IS_LOCAL) {
   //if p5.min.js or directly running the html file then skip check
   p5._fesCodeReader = () => {};
 } else {
@@ -222,7 +221,7 @@ if (
     return new Promise(resolve => {
       let codeNode = document.querySelector('body'),
         text = '';
-      if (codeNode) {
+      if (codeNode && window.location.href.includes('blob')) {
         //if web editor
         fetch(codeNode.children[0].getAttribute('src')).then(res =>
           res.text().then(txt => {

--- a/src/core/friendly_errors/sketch_reader.js
+++ b/src/core/friendly_errors/sketch_reader.js
@@ -5,7 +5,23 @@
  */
 
 import p5 from '../main';
-// import * as constants from '../constants';
+import * as constants from '../constants';
+import { translator } from '../internationalization';
+
+const _checkForConsts = variables => {
+  for (let i = 0; i < variables.length; i++) {
+    if (constants[variables[i]] !== undefined) {
+      let url = `https://p5js.org/reference/#/p5/${variables[i]}`;
+      p5._friendlyError(
+        translator('fes.sketchReaderErrors.reservedConst', {
+          url: url,
+          symbol: variables[i]
+        })
+      );
+      break;
+    }
+  }
+};
 
 const _extractVariables = arr => {
   console.log(
@@ -41,7 +57,7 @@ const _extractVariables = arr => {
       }
     }
   });
-  console.log(matches);
+  _checkForConsts(matches);
   //now we have to check if the obtained variables are a part of p5.js or not
 };
 

--- a/src/core/friendly_errors/sketch_reader.js
+++ b/src/core/friendly_errors/sketch_reader.js
@@ -28,15 +28,11 @@ const _extractVariables = arr => {
     '%cFrom _extractVariables',
     'color: black; font-weight: bold; font-size: 16px; background: yellow;'
   );
-  //we can extract variable names from here and check
-  //there are 2 regex and 2 ways of declaring the variables, we can use them both and do our stuff
-
-  //check if the line contains a , => either let a, b=2,d; or let a = [12,321,342]
+  //extract variable names from the user's code
   let matches = [];
   arr.forEach(ele => {
+    //extract a, b, c from let/const a=10, b=20, c;
     if (ele.includes(',')) {
-      //do the regex 1
-
       matches.push(
         ...ele.split(',').flatMap(s => {
           let match;
@@ -49,7 +45,7 @@ const _extractVariables = arr => {
         })
       );
     } else {
-      //do the regex 2
+      //extract a from let/const a=10;
       const reg = /(?:(?:let|const)\s+)([\w$]+)/g;
       const found = ele.matchAll(reg);
       for (const match of found) {
@@ -57,13 +53,13 @@ const _extractVariables = arr => {
       }
     }
   });
-  _checkForConsts(matches);
-  //now we have to check if the obtained variables are a part of p5.js or not
+  //check if the obtained variables are a part of p5.js or not
+  _checkForConsts(matches); //check if the obtained variables are a p5.js constants
 };
 
 const _extractFuncVariables = arr => {
   let matches = [];
-  //we can extract function names from here and check
+  //extract function names
   console.log(
     '%cFrom _extractFuncVariables',
     'color: black; font-weight: bold; font-size: 16px; background: yellow;'
@@ -72,13 +68,15 @@ const _extractFuncVariables = arr => {
   arr.forEach(ele => {
     matches.push(ele.match(reg)[1]);
   });
+  //matches array contains the names of the functions
   console.log(matches);
 };
 
 const _codeToLines = code => {
+  //convert code to array of code and filter out
+  //unnecessary lines
   let arr = code.split('\n');
-
-  //filter out variable names from all
+  //filter out lines containing variable names
   let arrVars = arr
     .map(line => line.trim())
     .filter(
@@ -89,7 +87,7 @@ const _codeToLines = code => {
         (!line.includes('=>') && !line.includes('function'))
     );
 
-  //filter out function names from all
+  //filter out lines containing function names
   let arrFunc = arr
     .map(line => line.trim())
     .filter(
@@ -100,17 +98,16 @@ const _codeToLines = code => {
         (line.includes('=>') || line.includes('function'))
     );
 
-  //now pass the relevant array to a regexer function which will list all the variables/functions
+  //pass the relevant array to a function which will extract all the variables/functions names
   _extractVariables(arrVars);
   _extractFuncVariables(arrFunc);
 };
 
 const _removeMultilineComments = str => {
-  //get the start index of open multiline comment
   let start = str.indexOf('/*');
   let end = str.indexOf('*/');
 
-  //create a new string which don't have things in comments
+  //create a new string which don't have multiline comments
   while (start !== -1 && end !== -1) {
     if (start === 0) {
       str = str.substr(end + 2);
@@ -123,41 +120,49 @@ const _removeMultilineComments = str => {
   return str;
 };
 
-const _fesCodeReader = async () => {
-  let codeNode = document.querySelector('[data-tag="@fs-sketch.js"]'),
-    text = '';
-  if (codeNode) {
-    //if web editor
-    text = codeNode.innerHTML;
-  } else {
-    //obtain the name of the file in script tag
-    const scripts = [...document.querySelectorAll('script')]
-      .map(file => file.getAttribute('src'))
-      .filter(
-        attr =>
-          attr !== null &&
-          attr !== undefined &&
-          !attr.includes('p5.js') &&
-          !attr.includes('p5.min.js') &&
-          !attr.includes('p5.sounds.min.js') &&
-          !attr.includes('p5.sounds.js') &&
-          attr !== ''
+const _fesCodeReader = () => {
+  return new Promise((resolve, reject) => {
+    let codeNode = document.querySelector('[data-tag="@fs-sketch.js"]'),
+      text = '';
+    if (codeNode) {
+      //if web editor
+      text = codeNode.innerHTML;
+      resolve(text);
+    } else {
+      //obtain the name of the file in script tag
+      //ignore p5.js, p5.min.js, p5.sounds.js, p5.sounds.min.js
+      const scripts = [...document.querySelectorAll('script')]
+        .map(file => file.getAttribute('src'))
+        .filter(
+          attr =>
+            attr !== null &&
+            attr !== undefined &&
+            !attr.includes('p5.js') &&
+            !attr.includes('p5.min.js') &&
+            !attr.includes('p5.sounds.min.js') &&
+            !attr.includes('p5.sounds.js') &&
+            attr !== ''
+        );
+      //obtain the user's code form the JS file
+      fetch(`${scripts[0]}`).then(res =>
+        res.text().then(txt => {
+          text = txt;
+          resolve(text);
+        })
       );
-    //scripts will have all the files which donsen't contains the files in the array: [null, undefined, '', 'p5.js','p5.min.js','p5.sound.min.js', 'p5.sound.js']
-    //there can be multiple files but we will check only 1 file because we assume that user will only use 1 file and not multiple
-    //this can of course be extended to multiple files
-
-    await fetch(`${scripts[0]}`).then(res =>
-      res.text().then(txt => {
-        text = txt;
-      })
-    );
-  }
-  //convert the code to array of lines of code
-  text = _removeMultilineComments(text);
-  _codeToLines(text);
+    }
+  });
 };
 
-window.addEventListener('load', _fesCodeReader);
+window.addEventListener('load', () => {
+  _fesCodeReader()
+    .then(code => {
+      //remove multiline comments
+      code = _removeMultilineComments(code);
+      //convert the code to array of lines of code
+      _codeToLines(code);
+    })
+    .catch(err => console.log(err));
+});
 
 export default p5;

--- a/src/core/friendly_errors/sketch_reader.js
+++ b/src/core/friendly_errors/sketch_reader.js
@@ -144,12 +144,16 @@ const _removeMultilineComments = str => {
 
 const _fesCodeReader = () => {
   return new Promise(resolve => {
-    let codeNode = document.querySelector('[data-tag="@fs-sketch.js"]'),
+    let codeNode = document.querySelector('body'),
       text = '';
     if (codeNode) {
       //if web editor
-      text = codeNode.innerHTML;
-      resolve(text);
+      fetch(codeNode.children[0].getAttribute('src')).then(res =>
+        res.text().then(txt => {
+          text = txt;
+          resolve(text);
+        })
+      );
     } else {
       //obtain the name of the file in script tag
       //ignore p5.js, p5.min.js, p5.sounds.js, p5.sounds.min.js
@@ -163,6 +167,7 @@ const _fesCodeReader = () => {
             !attr.includes('p5.min.js') &&
             !attr.includes('p5.sounds.min.js') &&
             !attr.includes('p5.sounds.js') &&
+            !attr.includes('previewScripts') &&
             attr !== ''
         );
       //obtain the user's code form the JS file

--- a/src/core/friendly_errors/sketch_reader.js
+++ b/src/core/friendly_errors/sketch_reader.js
@@ -121,7 +121,7 @@ const _removeMultilineComments = str => {
 };
 
 const _fesCodeReader = () => {
-  return new Promise((resolve, reject) => {
+  return new Promise(resolve => {
     let codeNode = document.querySelector('[data-tag="@fs-sketch.js"]'),
       text = '';
     if (codeNode) {

--- a/src/core/friendly_errors/sketch_reader.js
+++ b/src/core/friendly_errors/sketch_reader.js
@@ -2,194 +2,272 @@
  * @for p5
  * @requires core
  *
+ * This file contains the code for sketch reader functionality
+ * of the FES.
+ * p5._fesCodeReader() with the help of other helper functions performs the following tasks.
+ *
+ * 1. Extraction of the code written by the user
+ * 2. Conversion of the code to an array of lines of code
+ * 3. Catching variable and function decleration
+ * 4. Checking if the declared function/variable is a reserved p5.js
+ *    constant or function
+ *
  */
 
 import p5 from '../main';
-import * as constants from '../constants';
 import { translator } from '../internationalization';
+import * as constants from '../constants';
 
-const _checkForConsts = variables => {
-  for (let i = 0; i < variables.length; i++) {
-    if (constants[variables[i]] !== undefined) {
-      let url = `https://p5js.org/reference/#/p5/${variables[i]}`;
-      p5._friendlyError(
-        translator('fes.sketchReaderErrors.reservedConst', {
-          url: url,
-          symbol: variables[i]
-        })
-      );
-      break;
-    }
-  }
-};
-
-const _checkForFuncs = funcs => {
-  const p5Constructors = {};
-  for (let key of Object.keys(p5)) {
-    // Get a list of all constructors in p5. They are functions whose names
-    // start with a capital letter
-    if (typeof p5[key] === 'function' && key[0] !== key[0].toLowerCase()) {
-      p5Constructors[key] = p5[key];
-    }
-  }
-  for (let i = 0; i < funcs.length; i++) {
-    //for every function name obtained check if it matches any p5.js function name
-    const keyArr = Object.keys(p5Constructors);
-    let j = 0;
-    for (; j < keyArr.length; j++) {
-      if (p5Constructors[keyArr[j]].prototype[funcs[i]] !== undefined) {
-        //if a p5.js function is used ie it is in the funcs array
+if (
+  typeof IS_MINIFIED !== 'undefined' ||
+  document.location.pathname.includes('file://')
+) {
+  //if p5.min.js or directly running the html file then skip check
+  p5._fesCodeReader = () => {};
+} else {
+  /**
+   * Takes a list of variables defined by the user in the code
+   * as an array and checks if the list contains p5.js constants.
+   * If found then display a friendly error message.
+   *
+   * @method checkForConsts
+   * @private
+   * @param {Array} variables list of variables defined by user
+   */
+  const checkForConsts = variables => {
+    for (let i = 0; i < variables.length; i++) {
+      if (constants[variables[i]] !== undefined) {
+        let url = `https://p5js.org/reference/#/p5/${variables[i]}`;
         p5._friendlyError(
-          translator('fes.sketchReaderErrors.reservedFunc', {
-            symbol: funcs[i]
+          translator('fes.sketchReaderErrors.reservedConst', {
+            url: url,
+            symbol: variables[i]
           })
         );
         break;
       }
     }
-    if (j < keyArr.length) break;
-  }
-};
+  };
 
-const _extractVariables = arr => {
-  //extract variable names from the user's code
-  let matches = [];
-  arr.forEach(ele => {
-    //extract a, b, c from let/const a=10, b=20, c;
-    if (ele.includes(',')) {
-      matches.push(
-        ...ele.split(',').flatMap(s => {
-          let match;
-          if (s.includes('=')) {
-            match = s.match(/(\w+)\s*(?==)/i);
-            return match[1];
-          } else if (!s.match(new RegExp('[[]{}]'))) {
-            let m = s.match(/(?:(?:let|const|var)\s+)?([\w$]+)/);
-            if (m !== null)
-              return s.match(/(?:(?:let|const|var)\s+)?([\w$,]+)/)[1];
-          } else return [];
-        })
-      );
-    } else {
-      //extract a from let/const a=10;
-      const reg = /(?:(?:let|const)\s+)([\w$]+)/g;
-      const found = ele.matchAll(reg);
-      for (const match of found) {
-        matches.push(match[1]);
+  /**
+   * Takes a list of functions defined by the user in the code
+   * as an array and checks if the list contains a reserved p5.js function.
+   * If found then display a friendly error message.
+   *
+   * @method checkForFuncs
+   * @private
+   * @param {Array} funcs list of functions defined by user
+   */
+  const checkForFuncs = funcs => {
+    const p5Constructors = {};
+    for (let key of Object.keys(p5)) {
+      // Get a list of all constructors in p5. They are functions whose names
+      // start with a capital letter
+      if (typeof p5[key] === 'function' && key[0] !== key[0].toLowerCase()) {
+        p5Constructors[key] = p5[key];
       }
     }
-  });
-  //check if the obtained variables are a part of p5.js or not
-  _checkForConsts(matches); //check if the obtained variables are a p5.js constants
-};
-
-const _extractFuncVariables = arr => {
-  let matches = [];
-  //extract function names
-  const reg = /(?:(?:let|const)\s+)([\w$]+)/;
-  arr.forEach(ele => {
-    matches.push(ele.match(reg)[1]);
-  });
-  //matches array contains the names of the functions
-  _checkForFuncs(matches);
-};
-
-const _codeToLines = code => {
-  //convert code to array of code and filter out
-  //unnecessary lines
-  let arr = code.split('\n');
-  //filter out lines containing variable names
-  let arrVars = arr
-    .map(line => line.trim())
-    .filter(
-      line =>
-        line !== '' &&
-        !line.includes('//') &&
-        (line.includes('let') || line.includes('const')) &&
-        (!line.includes('=>') && !line.includes('function'))
-    );
-
-  //filter out lines containing function names
-  let arrFunc = arr
-    .map(line => line.trim())
-    .filter(
-      line =>
-        line !== '' &&
-        !line.includes('//') &&
-        (line.includes('let') || line.includes('const')) &&
-        (line.includes('=>') || line.includes('function'))
-    );
-
-  //pass the relevant array to a function which will extract all the variables/functions names
-  _extractVariables(arrVars);
-  _extractFuncVariables(arrFunc);
-};
-
-const _removeMultilineComments = str => {
-  let start = str.indexOf('/*');
-  let end = str.indexOf('*/');
-
-  //create a new string which don't have multiline comments
-  while (start !== -1 && end !== -1) {
-    if (start === 0) {
-      str = str.substr(end + 2);
-    } else str = str.substr(0, start) + str.substr(end + 2);
-
-    start = str.indexOf('/*');
-    end = str.indexOf('*/');
-  }
-
-  return str;
-};
-
-const _fesCodeReader = () => {
-  return new Promise(resolve => {
-    let codeNode = document.querySelector('body'),
-      text = '';
-    if (codeNode) {
-      //if web editor
-      fetch(codeNode.children[0].getAttribute('src')).then(res =>
-        res.text().then(txt => {
-          text = txt;
-          resolve(text);
-        })
-      );
-    } else {
-      //obtain the name of the file in script tag
-      //ignore p5.js, p5.min.js, p5.sounds.js, p5.sounds.min.js
-      const scripts = [...document.querySelectorAll('script')]
-        .map(file => file.getAttribute('src'))
-        .filter(
-          attr =>
-            attr !== null &&
-            attr !== undefined &&
-            !attr.includes('p5.js') &&
-            !attr.includes('p5.min.js') &&
-            !attr.includes('p5.sounds.min.js') &&
-            !attr.includes('p5.sounds.js') &&
-            !attr.includes('previewScripts') &&
-            attr !== ''
-        );
-      //obtain the user's code form the JS file
-      fetch(`${scripts[0]}`).then(res =>
-        res.text().then(txt => {
-          text = txt;
-          resolve(text);
-        })
-      );
+    for (let i = 0; i < funcs.length; i++) {
+      //for every function name obtained check if it matches any p5.js function name
+      const keyArr = Object.keys(p5Constructors);
+      let j = 0;
+      for (; j < keyArr.length; j++) {
+        if (p5Constructors[keyArr[j]].prototype[funcs[i]] !== undefined) {
+          //if a p5.js function is used ie it is in the funcs array
+          p5._friendlyError(
+            translator('fes.sketchReaderErrors.reservedFunc', {
+              symbol: funcs[i]
+            })
+          );
+          break;
+        }
+      }
+      if (j < keyArr.length) break;
     }
+  };
+
+  /**
+   * Takes an array in which each element is a line of code
+   * containing a variable definition(Eg: arr=['let x = 100', 'const y = 200'])
+   * and extracts the variables defined.
+   *
+   * @method extractVariables
+   * @private
+   * @param {Array} arr array of lines of code
+   */
+  const extractVariables = arr => {
+    //extract variable names from the user's code
+    let matches = [];
+    arr.forEach(ele => {
+      //extract a, b, c from let/const a=10, b=20, c;
+      if (ele.includes(',')) {
+        matches.push(
+          ...ele.split(',').flatMap(s => {
+            let match;
+            if (s.includes('=')) {
+              match = s.match(/(\w+)\s*(?==)/i);
+              return match[1];
+            } else if (!s.match(new RegExp('[[]{}]'))) {
+              let m = s.match(/(?:(?:let|const|var)\s+)?([\w$]+)/);
+              if (m !== null)
+                return s.match(/(?:(?:let|const|var)\s+)?([\w$,]+)/)[1];
+            } else return [];
+          })
+        );
+      } else {
+        //extract a from let/const a=10;
+        const reg = /(?:(?:let|const)\s+)([\w$]+)/g;
+        const found = ele.matchAll(reg);
+        for (const match of found) {
+          matches.push(match[1]);
+        }
+      }
+    });
+    //check if the obtained variables are a part of p5.js or not
+    checkForConsts(matches); //check if the obtained variables are a p5.js constants
+  };
+
+  /**
+   * Takes an array in which each element is a line of code
+   * containing a function definition(arr=['let x = () => {...}'])
+   * and extracts the functions defined.
+   *
+   * @method extractFuncVariables
+   * @private
+   * @param {Array} arr array of lines of code
+   */
+  const extractFuncVariables = arr => {
+    let matches = [];
+    //extract function names
+    const reg = /(?:(?:let|const)\s+)([\w$]+)/;
+    arr.forEach(ele => {
+      matches.push(ele.match(reg)[1]);
+    });
+    //matches array contains the names of the functions
+    checkForFuncs(matches);
+  };
+
+  /**
+   * Converts code written by the user to an array
+   * every element of which is a seperate line of code.
+   *
+   * @method codeToLines
+   * @private
+   * @param {String} code code written by the user
+   */
+  const codeToLines = code => {
+    //convert code to array of code and filter out
+    //unnecessary lines
+    let arr = code.split('\n');
+    //filter out lines containing variable names
+    let arrVars = arr
+      .map(line => line.trim())
+      .filter(
+        line =>
+          line !== '' &&
+          !line.includes('//') &&
+          (line.includes('let') || line.includes('const')) &&
+          (!line.includes('=>') && !line.includes('function'))
+      );
+
+    //filter out lines containing function names
+    let arrFunc = arr
+      .map(line => line.trim())
+      .filter(
+        line =>
+          line !== '' &&
+          !line.includes('//') &&
+          (line.includes('let') || line.includes('const')) &&
+          (line.includes('=>') || line.includes('function'))
+      );
+
+    //pass the relevant array to a function which will extract all the variables/functions names
+    extractVariables(arrVars);
+    extractFuncVariables(arrFunc);
+  };
+
+  /**
+   *  Remove multiline comments and the code written inside it.
+   *
+   * @method removeMultilineComments
+   * @private
+   * @param {String} str code written by the user
+   */
+  const removeMultilineComments = str => {
+    let start = str.indexOf('/*');
+    let end = str.indexOf('*/');
+
+    //create a new string which don't have multiline comments
+    while (start !== -1 && end !== -1) {
+      if (start === 0) {
+        str = str.substr(end + 2);
+      } else str = str.substr(0, start) + str.substr(end + 2);
+
+      start = str.indexOf('/*');
+      end = str.indexOf('*/');
+    }
+
+    return str;
+  };
+
+  /**
+   * Initiates the sketch_reader's processes.
+   * Obtains the user's code and forwards it for further
+   * processing and evaluation.
+   *
+   * @method fesCodeReader
+   * @private
+   */
+  const fesCodeReader = () => {
+    return new Promise(resolve => {
+      let codeNode = document.querySelector('body'),
+        text = '';
+      if (codeNode) {
+        //if web editor
+        fetch(codeNode.children[0].getAttribute('src')).then(res =>
+          res.text().then(txt => {
+            text = txt;
+            resolve(text);
+          })
+        );
+      } else {
+        //obtain the name of the file in script tag
+        //ignore p5.js, p5.min.js, p5.sounds.js, p5.sounds.min.js
+        const scripts = [...document.querySelectorAll('script')]
+          .map(file => file.getAttribute('src'))
+          .filter(
+            attr =>
+              attr !== null &&
+              attr !== undefined &&
+              !attr.includes('p5.js') &&
+              !attr.includes('p5.min.js') &&
+              !attr.includes('p5.sounds.min.js') &&
+              !attr.includes('p5.sounds.js') &&
+              !attr.includes('previewScripts') &&
+              attr !== ''
+          );
+        //obtain the user's code form the JS file
+        fetch(`${scripts[0]}`).then(res =>
+          res.text().then(txt => {
+            text = txt;
+            resolve(text);
+          })
+        );
+      }
+    });
+  };
+
+  p5._fesCodeReader = fesCodeReader;
+
+  window.addEventListener('load', () => {
+    fesCodeReader()
+      .then(code => {
+        //remove multiline comments
+        code = removeMultilineComments(code);
+        //convert the code to array of lines of code
+        codeToLines(code);
+      })
+      .catch(err => console.log(err));
   });
-};
-
-window.addEventListener('load', () => {
-  _fesCodeReader()
-    .then(code => {
-      //remove multiline comments
-      code = _removeMultilineComments(code);
-      //convert the code to array of lines of code
-      _codeToLines(code);
-    })
-    .catch(err => console.log(err));
-});
-
+}
 export default p5;

--- a/src/core/friendly_errors/sketch_reader.js
+++ b/src/core/friendly_errors/sketch_reader.js
@@ -1,0 +1,133 @@
+/**
+ * @for p5
+ * @requires core
+ *
+ */
+
+import p5 from '../main';
+// import * as constants from '../constants';
+
+const _extractVariables = arr => {
+  console.log(
+    '%cFrom _extractVariables',
+    'color: black; font-weight: bold; font-size: 16px; background: yellow;'
+  );
+  //we can extract variable names from here and check
+  //there are 2 regex and 2 ways of declaring the variables, we can use them both and do our stuff
+
+  //check if the line contains a , => either let a, b=2,d; or let a = [12,321,342]
+  let matches = [];
+  arr.forEach(ele => {
+    if (ele.includes(',')) {
+      //do the regex 1
+
+      matches.push(
+        ...ele.split(',').flatMap(s => {
+          let match;
+          if (s.includes('=')) {
+            match = s.match(/(\w+)\s*(?==)/i);
+            return match[1];
+          } else if (!s.match(new RegExp('[[]{}]'))) {
+            return s.match(/(?:(?:let|const|var)\s+)?([\w$]+)/)[1];
+          } else return [];
+        })
+      );
+    } else {
+      //do the regex 2
+      const reg = /(?:(?:let|const)\s+)([\w$]+)/g;
+      const found = ele.matchAll(reg);
+      for (const match of found) {
+        matches.push(match[1]);
+      }
+    }
+  });
+  console.log(matches);
+  //now we have to check if the obtained variables are a part of p5.js or not
+  //problem 1 => if we have comma declaration after a normal declaration then the matches array is overritten prevent that
+};
+
+const _extractFuncVariables = arr => {
+  let matches = [];
+  //we can extract function names from here and check
+  console.log(
+    '%cFrom _extractFuncVariables',
+    'color: black; font-weight: bold; font-size: 16px; background: yellow;'
+  );
+  const reg = /(?:(?:let|const)\s+)([\w$]+)/;
+  arr.forEach(ele => {
+    matches.push(ele.match(reg)[1]);
+  });
+  console.log(matches);
+};
+
+const _codeToLines = code => {
+  let arr = code.split('\n');
+
+  //filter out variable names from all
+  let arrVars = arr
+    .map(line => line.trim())
+    .filter(
+      line =>
+        line !== '' &&
+        !line.includes('//') &&
+        (line.includes('let') || line.includes('const')) &&
+        (!line.includes('=>') && !line.includes('function'))
+    );
+
+  //filter out function names from all
+  let arrFunc = arr
+    .map(line => line.trim())
+    .filter(
+      line =>
+        line !== '' &&
+        !line.includes('//') &&
+        (line.includes('let') || line.includes('const')) &&
+        (line.includes('=>') || line.includes('function'))
+    );
+
+  //now pass the relevant array to a regexer function which will list all the variables/functions
+  _extractVariables(arrVars);
+  _extractFuncVariables(arrFunc);
+};
+
+const _fesCodeReader = async () => {
+  let codeNode = document.querySelector('[data-tag="@fs-sketch.js"]'),
+    text = '';
+  if (codeNode) {
+    //if web editor
+    text = codeNode.innerHTML;
+  } else {
+    //obtain the name of the file in script tag
+    const scripts = [...document.querySelectorAll('script')]
+      .map(file => file.getAttribute('src'))
+      .filter(
+        attr =>
+          ![
+            null,
+            undefined,
+            '',
+            'p5.js',
+            'p5.min.js',
+            'p5.sound.min.js',
+            'p5.sound.js'
+          ].includes(attr)
+      );
+    //scripts will have all the files which donsen't contains the files in the array: [null, undefined, '', 'p5.js','p5.min.js','p5.sound.min.js', 'p5.sound.js']
+    //there can be multiple files but we will check only 1 file because we assume that user will only use 1 file and not multiple
+    //this can of course be extended to multiple files
+
+    await fetch(`${scripts[0]}`)
+      .then(res =>
+        res.text().then(txt => {
+          text = txt;
+        })
+      )
+      .catch(err => console.log(`ERROR: ${err}`));
+  }
+  //convert the code to array of lines of code
+  _codeToLines(text);
+};
+
+window.addEventListener('load', _fesCodeReader);
+
+export default p5;

--- a/test/unit/core/error_helpers.js
+++ b/test/unit/core/error_helpers.js
@@ -826,3 +826,95 @@ suite('Global Error Handling', function() {
     }
   );
 });
+
+suite('Tests for p5.js sketch_reader', function() {
+  const WAIT_AND_RESOLVE = [
+    '<script>',
+    'p5._fesLogger = window.logger',
+    'let flag = false;',
+    'setInterval(() => {',
+    // just because the log has one element doesn't necessarily mean that the
+    // handler has finished its job. The flag allows it to take some more time
+    // after adding the first log message
+    '  if (window.logger.length > 0) {',
+    '    if (flag) window.afterSetup();',
+    '    flag = true;',
+    '  }',
+    '}, 50);',
+    '</script>'
+  ].join('\n');
+
+  let log;
+  const logger = function(err) {
+    log.push(err);
+  };
+
+  const prepSketchReaderTest = (arr, resolve) => {
+    iframe = createP5Iframe(
+      [P5_SCRIPT_TAG, WAIT_AND_RESOLVE, '<script>', ...arr, '</script>'].join(
+        '\n'
+      )
+    );
+    log = [];
+    iframe.elt.contentWindow.logger = logger;
+    iframe.elt.contentWindow.afterSetup = resolve;
+    return iframe;
+  };
+
+  testUnMinified(
+    'detects reassignment of p5.js constant inside setup',
+    function() {
+      return new Promise(function(resolve) {
+        prepSketchReaderTest(
+          ['function setup() {', 'let PI = 100', '}'],
+          resolve
+        );
+      }).then(function() {
+        assert.strictEqual(log.length, 1);
+        assert.match(log[0], /you have used a p5.js reserved variable/);
+      });
+    }
+  );
+
+  testUnMinified(
+    'detects reassignment of p5.js function inside setup',
+    function() {
+      return new Promise(function(resolve) {
+        prepSketchReaderTest(
+          ['function setup() {', 'let text = 100', '}'],
+          resolve
+        );
+      }).then(function() {
+        assert.strictEqual(log.length, 1);
+        assert.match(log[0], /you have used a p5.js reserved function/);
+      });
+    }
+  );
+
+  testUnMinified(
+    'detects reassignment of p5.js constant outside setup',
+    function() {
+      return new Promise(function(resolve) {
+        prepSketchReaderTest(['let PI = 100', 'function setup() {}'], resolve);
+      }).then(function() {
+        assert.strictEqual(log.length, 1);
+        assert.match(log[0], /you have used a p5.js reserved variable/);
+      });
+    }
+  );
+
+  testUnMinified(
+    'detects reassignment of p5.js function outside setup',
+    function() {
+      return new Promise(function(resolve) {
+        prepSketchReaderTest(
+          ['let text = 100', 'function setup() {}'],
+          resolve
+        );
+      }).then(function() {
+        assert.strictEqual(log.length, 1);
+        assert.match(log[0], /you have used a p5.js reserved function/);
+      });
+    }
+  );
+});

--- a/translations/en/translation.json
+++ b/translations/en/translation.json
@@ -55,6 +55,9 @@
       "p_9": "ninth"
     },
     "pre": "\n🌸 p5.js says: {{message}}",
+    "sketchReaderErrors": {
+      "reservedConst": "you have used a p5.js reserved variable \"{{symbol}}\" make sure you change the variable name to something else.\n({{url}})"
+    },
     "welcome": "Welcome! This is your friendly debugger. To turn me off, switch to using p5.min.js.",
     "wrongPreload": "An error with message \"{{error}}\" occured inside the p5js library when \"{{func}}\" was called {{location}}.\n\nIf not stated otherwise, it might be due to \"{{func}}\" being called from preload. Nothing besides load calls (loadImage, loadJSON, loadFont, loadStrings, etc.) should be inside the preload function."
   }

--- a/translations/en/translation.json
+++ b/translations/en/translation.json
@@ -56,7 +56,8 @@
     },
     "pre": "\n🌸 p5.js says: {{message}}",
     "sketchReaderErrors": {
-      "reservedConst": "you have used a p5.js reserved variable \"{{symbol}}\" make sure you change the variable name to something else.\n({{url}})"
+      "reservedConst": "you have used a p5.js reserved variable \"{{symbol}}\" make sure you change the variable name to something else.\n({{url}})",
+      "reservedFunc": "you have used a p5.js reserved function \"{{symbol}}\" make sure you change the function name to something else."
     },
     "welcome": "Welcome! This is your friendly debugger. To turn me off, switch to using p5.min.js.",
     "wrongPreload": "An error with message \"{{error}}\" occured inside the p5js library when \"{{func}}\" was called {{location}}.\n\nIf not stated otherwise, it might be due to \"{{func}}\" being called from preload. Nothing besides load calls (loadImage, loadJSON, loadFont, loadStrings, etc.) should be inside the preload function."

--- a/translations/es/translation.json
+++ b/translations/es/translation.json
@@ -55,6 +55,9 @@
       "p_9": ""
     },
     "pre": "🌸 p5.js dice: {{message}}",
+    "sketchReaderErrors": {
+      "reservedConst": ""
+    },
     "welcome": "",
     "wrongPreload": ""
   }

--- a/translations/es/translation.json
+++ b/translations/es/translation.json
@@ -56,7 +56,8 @@
     },
     "pre": "🌸 p5.js dice: {{message}}",
     "sketchReaderErrors": {
-      "reservedConst": ""
+      "reservedConst": "",
+      "reservedFunc": ""
     },
     "welcome": "",
     "wrongPreload": ""


### PR DESCRIPTION
<!--
  Thank you for contributing! Please use this pull request (PR) template.


 In the description field of this PR, include "resolves #XXXX" tagging the issue you are fixing. If this PR addresses the issue but doesn't completely resolve it (ie the issue should remain open after your PR is merged), write "addresses #XXXX".-->
Resolves #5350

 Changes:
<!-- Add here what changes were made in this pull request and if possible provide links showcasing the changes. -->

- The new file `sketch_reader.js` contains the code that will help the FES detect redeclaration of p5.js constants and functions.
- Inline documentation is included
- Unit tests are included

 Screenshots of the change:
<!-- If applicable, add screenshots depicting the changes. -->
Detection of p5.js reserved function:
![image](https://user-images.githubusercontent.com/54030684/128673985-c28f1edd-e4bd-4e89-9392-3b5ed7abd5e6.png)

Detection of p5.js reserved constant
![image](https://user-images.githubusercontent.com/54030684/128674003-08374768-f606-4d6b-9c09-ea53d2d61ae4.png)


#### PR Checklist
<!--
  To check any option, replace the "[ ]" with a "[x]". Be sure to check out how it looks in the Preview tab! Feel free to remove any portion of the template that is not relevant for your issue.
-->

- [x] `npm run lint` passes
- [x] [Inline documentation] is included / updated
- [x] [Unit tests] are included / updated

[Inline documentation]: https://github.com/processing/p5.js/blob/main/contributor_docs/inline_documentation.md
[Unit tests]: https://github.com/processing/p5.js/tree/main/contributor_docs#unit-tests
