### PR TITLE
Fixed bug were cached colors are not cleared

### DIFF
--- a/src/color/p5.Color.js
+++ b/src/color/p5.Color.js
@@ -365,6 +365,10 @@ p5.Color.prototype._calculateLevels = function() {
   for (let i = array.length - 1; i >= 0; --i) {
     levels[i] = Math.round(array[i] * 255);
   }
+
+  // Clear cached HSL/HSB values
+  this.hsla = null;
+  this.hsba = null;
 };
 
 p5.Color.prototype._getAlpha = function() {

--- a/test/unit/color/setting.js
+++ b/test/unit/color/setting.js
@@ -214,4 +214,76 @@ suite('color/Setting', function() {
       assert.deepEqual(myp5._colorMaxes[myp5.HSB], [360, 100, 100, 1]);
     });
   });
+
+  suite('p5.Color components', function() {
+    test('setRed() correctly sets red component', function() {
+      myp5.colorMode(myp5.RGB, 255);
+      const c = myp5.color(0, 162, 205, 255);
+      c.setRed(100);
+      assert.equal(myp5.red(c), 100);
+      assert.equal(myp5.green(c), 162);
+      assert.equal(myp5.blue(c), 205);
+      assert.equal(myp5.alpha(c), 255);
+    });
+
+    test('setGreen() correctly sets green component', function() {
+      myp5.colorMode(myp5.RGB, 255);
+      const c = myp5.color(0, 162, 205, 255);
+      c.setGreen(100);
+      assert.equal(myp5.red(c), 0);
+      assert.equal(myp5.green(c), 100);
+      assert.equal(myp5.blue(c), 205);
+      assert.equal(myp5.alpha(c), 255);
+    });
+
+    test('setBlue() correctly sets blue component', function() {
+      myp5.colorMode(myp5.RGB, 255);
+      const c = myp5.color(0, 162, 205, 255);
+      c.setBlue(100);
+      assert.equal(myp5.red(c), 0);
+      assert.equal(myp5.green(c), 162);
+      assert.equal(myp5.blue(c), 100);
+      assert.equal(myp5.alpha(c), 255);
+    });
+
+    test('setAlpha correctly sets alpha component', function() {
+      myp5.colorMode(myp5.RGB, 255);
+      const c = myp5.color(0, 162, 205, 255);
+      c.setAlpha(100);
+      assert.equal(myp5.red(c), 0);
+      assert.equal(myp5.green(c), 162);
+      assert.equal(myp5.blue(c), 205);
+      assert.equal(myp5.alpha(c), 100);
+    });
+
+    test('changing the red/green/blue/alpha components should clear the cached HSL/HSB values', function() {
+      myp5.colorMode(myp5.RGB, 255);
+      const c = myp5.color(0, 162, 205, 255);
+
+      // create HSL/HSB values
+      myp5.lightness(c);
+      myp5.brightness(c);
+      c.setRed(100);
+      assert(!c.hsba);
+      assert(!c.hsla);
+
+      myp5.lightness(c);
+      myp5.brightness(c);
+      c.setGreen(100);
+      assert(!c.hsba);
+      assert(!c.hsla);
+
+      myp5.lightness(c);
+      myp5.brightness(c);
+      c.setBlue(100);
+      assert(!c.hsba);
+      assert(!c.hsla);
+
+      myp5.lightness(c);
+      myp5.brightness(c);
+      c.setAlpha(100);
+      assert(!c.hsba);
+      assert(!c.hsla);
+    });
+  });
 });


### PR DESCRIPTION
#### Changes:
When using the `setRed()/setGreen()/setBlue()/setAlpha()` methods of `p5.Color`, cached HSL and HSB values are not cleared properly. This leads to the following bug:

```javascript
const c = color(255, 0, 0);
console.log(lightness(c)) // 50
c.setRed(0);
console.log(lightness(c)); // bug: still 50
```
The first call to `lightness()` computes the HSL values and caches them, the second call retrieves the cached values even though the RGB values have changed. The fix is simple: Clear the `hsba `and `hsla `fields of `p5.Color` when calling `setRed()/setGreen()/setBlue()/setAlpha()`.

#### PR Checklist
<!--
  To check any option, replace the "[ ]" with a "[x]". Be sure to check out how it looks in the Preview tab! Feel free to remove any portion of the template that is not relevant for your issue.
-->

- [x] `npm run lint` passes
- [x] [Inline documentation] is included / updated
- [x] [Unit tests] are included / updated
