### PR TITLE
fixing links to p5.MediaElement - resolves #5355

### DIFF
--- a/src/dom/dom.js
+++ b/src/dom/dom.js
@@ -1184,7 +1184,7 @@ function createMedia(pInst, type, src, callback) {
  *                             enough data has been loaded to play the media
  *                             up to its end without having to stop for
  *                             further buffering of content
- * @return {p5.MediaElement}   pointer to video <a href="#/p5.Element">p5.Element</a>
+ * @return {p5.MediaElement}   pointer to video <a href="#/p5.MediaElement">p5.MediaElement</a>
  * @example
  * <div><code>
  * let vid;
@@ -1231,7 +1231,7 @@ p5.prototype.createVideo = function(src, callback) {
  *                             enough data has been loaded to play the media
  *                             up to its end without having to stop for
  *                             further buffering of content
- * @return {p5.MediaElement}   pointer to audio <a href="#/p5.Element">p5.Element</a>
+ * @return {p5.MediaElement}   pointer to audio <a href="#/p5.MediaElement">p5.MediaElement</a>
  * @example
  * <div><code>
  * let ele;


### PR DESCRIPTION
Both createVideo and createAudio return p5.MediaElements, so the documentation is updated accordingly.

Resolves #5355 

 Changes:
A simple documentation change that now points to p5.MediaElement in the website pages.


 Screenshots of the change:
...

#### PR Checklist

(removed items that did not apply)
- [X] [Inline documentation] is included / updated


[Inline documentation]: https://github.com/processing/p5.js/blob/main/contributor_docs/inline_documentation.md
[Unit tests]: https://github.com/processing/p5.js/tree/main/contributor_docs#unit-tests
