### PR TITLE
Fixing ReferenceError: totalHeight is not defined throw by textAlign(…

### DIFF
--- a/src/core/p5.Renderer.js
+++ b/src/core/p5.Renderer.js
@@ -269,11 +269,11 @@ p5.Renderer.prototype.text = function(str, x, y, maxWidth, maxHeight) {
 
       switch (this._textBaseline) {
         case constants.BOTTOM:
-          shiftedY = y + (maxHeight - totalHeight);
+          shiftedY = y + maxHeight;
           y = Math.max(shiftedY, y);
           break;
         case constants.CENTER:
-          shiftedY = y + (maxHeight - totalHeight) / 2;
+          shiftedY = y + maxHeight / 2;
           y = Math.max(shiftedY, y);
           break;
         case constants.BASELINE:


### PR DESCRIPTION
Fixing ReferenceError: totalHeight is not defined throw by textAlign(___, CENTER) and textAlign(___, BOTTOM)
Resolves #5360 

 Changes:
Removed undefine variable ```totalHeight``` from src/core/p5.Renderer.js causing ReferenceError while calling 
textAlign_(___, CENTER) and textAlign(_____, BOTTOM)

#### PR Checklist

- [x] `npm run lint` passes
- [ ] [Inline documentation] is included / updated
- [ ] [Unit tests] are included / updated

[Inline documentation]: https://github.com/processing/p5.js/blob/main/contributor_docs/inline_documentation.md
[Unit tests]: https://github.com/processing/p5.js/tree/main/contributor_docs#unit-tests
