### PR TITLE
make it possible to call "npm run dev" per docs without having called "npm grunt" first

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "scripts": {
     "grunt": "grunt",
     "build": "grunt build",
-    "dev": "grunt browserify:dev connect:yui watch:quick",
+    "dev": "grunt yui browserify:dev connect:yui watch:quick",
     "docs": "grunt yui",
     "docs:dev": "grunt yui:dev",
     "test": "grunt",


### PR DESCRIPTION
Resolves #5388 

 Changes:
- adds `yui` build step as part of `npm run dev`, allowing developers to call `npm run dev` without having called `npm grunt` first. 

The documentation [states](https://p5js.org/contributor-docs/#/?id=development-process): "If you're continuously changing files in the library, you may want to run npm run dev to automatically rebuild the library ...", implying that you may call `npm run dev` instead of `npm run grunt`. This fix makes that possible.

#### PR Checklist

- [X] `npm run lint` passes