### PR TITLE
Unit test fix to resolve #5367

### DIFF
--- a/src/core/friendly_errors/browser_errors.js
+++ b/src/core/friendly_errors/browser_errors.js
@@ -91,7 +91,7 @@ const strings = {
       browser: 'all'
     },
     {
-      msg: 'Cannot read {{.}} of null',
+      msg: 'Cannot read {{.}} null',
       type: 'READNULL',
       browser: 'Chrome'
     },

--- a/src/core/friendly_errors/browser_errors.js
+++ b/src/core/friendly_errors/browser_errors.js
@@ -91,7 +91,7 @@ const strings = {
       browser: 'all'
     },
     {
-      msg: 'Cannot read properties of null',
+      msg: 'Cannot read {{.}} of null',
       type: 'READNULL',
       browser: 'Chrome'
     },
@@ -101,7 +101,7 @@ const strings = {
       browser: 'Firefox'
     },
     {
-      msg: 'Cannot read properties of undefined',
+      msg: 'Cannot read {{.}} undefined',
       type: 'READUDEFINED',
       browser: 'Chrome'
     },

--- a/src/core/friendly_errors/browser_errors.js
+++ b/src/core/friendly_errors/browser_errors.js
@@ -91,7 +91,7 @@ const strings = {
       browser: 'all'
     },
     {
-      msg: "Cannot read property '{{.}}' of null",
+      msg: 'Cannot read property of null',
       type: 'READNULL',
       browser: 'Chrome'
     },
@@ -101,7 +101,7 @@ const strings = {
       browser: 'Firefox'
     },
     {
-      msg: "Cannot read property '{{.}}' of undefined",
+      msg: 'Cannot read property of undefined',
       type: 'READUDEFINED',
       browser: 'Chrome'
     },

--- a/src/core/friendly_errors/browser_errors.js
+++ b/src/core/friendly_errors/browser_errors.js
@@ -91,7 +91,7 @@ const strings = {
       browser: 'all'
     },
     {
-      msg: 'Cannot read property of null',
+      msg: 'Cannot read properties of null',
       type: 'READNULL',
       browser: 'Chrome'
     },
@@ -101,7 +101,7 @@ const strings = {
       browser: 'Firefox'
     },
     {
-      msg: 'Cannot read property of undefined',
+      msg: 'Cannot read properties of undefined',
       type: 'READUDEFINED',
       browser: 'Chrome'
     },

--- a/test/unit/utilities/time_date.js
+++ b/test/unit/utilities/time_date.js
@@ -110,7 +110,7 @@ suite('time and date', function() {
       var runningTime = 50;
       var init_date = window.performance.now();
       // wait :\
-      while (window.performance.now() - init_date < runningTime) {
+      while (window.performance.now() - init_date <= runningTime) {
         /* no-op */
       }
       assert.operator(myp5.millis(), '>', runningTime, 'everything is ok');
@@ -121,7 +121,7 @@ suite('time and date', function() {
       var init_date = Date.now();
       var result = myp5.millis();
       // wait :\
-      while (Date.now() - init_date < runningTime) {
+      while (Date.now() - init_date <= runningTime) {
         /* no-op */
       }
       var newResult = myp5.millis();


### PR DESCRIPTION
Addresses #5367 

 Changes:
- Updated strings in `core/friendly_errors/browser_errors.js` to match Chrome browser's error messages.
- Minor change in `millis()` unit test from `utilities/time_data` to include an edge case.

It seems to pass all lint + unit tests, but I'm not confident about my `millis()` unit test fix. Feedback from anyone would be appreciated!

#### PR Checklist
<!--
  To check any option, replace the "[ ]" with a "[x]". Be sure to check out how it looks in the Preview tab! Feel free to remove any portion of the template that is not relevant for your issue.
-->

- [ ] `npm run lint` passes
- [ ] [Inline documentation] is included / updated
- [ ] [Unit tests] are included / updated

[Inline documentation]: https://github.com/processing/p5.js/blob/main/contributor_docs/inline_documentation.md
[Unit tests]: https://github.com/processing/p5.js/tree/main/contributor_docs#unit-tests
