### PR TITLE
Inline examples updated to remove "Object reference chain is too long" error

### DIFF
--- a/src/math/p5.Vector.js
+++ b/src/math/p5.Vector.js
@@ -274,7 +274,7 @@ p5.Vector.prototype.copy = function copy() {
  *
  * let v3 = p5.Vector.add(v1, v2);
  * // v3 has components [3, 5, 7]
- * print(v3);
+ * print(String(v3));
  * </code>
  * </div>
  *
@@ -384,7 +384,7 @@ const calculateRemainder3D = function(xComponent, yComponent, zComponent) {
  *
  * let v3 = p5.Vector.rem(v1, v2);
  * // v3 has components [1, 1, 1]
- * print(v3);
+ * print(String(v3));
  * </code>
  * </div>
  */
@@ -482,7 +482,7 @@ p5.Vector.prototype.rem = function rem(x, y, z) {
  *
  * let v3 = p5.Vector.sub(v1, v2);
  * // v3 has components [1, 1, 1]
- * print(v3);
+ * print(String(v3));
  * </code>
  * </div>
  *
@@ -588,7 +588,7 @@ p5.Vector.prototype.sub = function sub(x, y, z) {
  * let v0 = createVector(1, 2, 3);
  * let v1 = createVector(2, 3, 4);
  * const result = p5.Vector.mult(v0, v1);
- * print(result); // result's components are set to [2, 6, 12]
+ * print(String(result)); // result's components are set to [2, 6, 12]
  * </code>
  * </div>
  *
@@ -598,7 +598,7 @@ p5.Vector.prototype.sub = function sub(x, y, z) {
  * let v1 = createVector(1, 2, 3);
  * let v2 = p5.Vector.mult(v1, 2);
  * // v2 has components [2, 4, 6]
- * print(v2);
+ * print(String(v2));
  * </code>
  * </div>
  *
@@ -780,7 +780,7 @@ p5.Vector.prototype.mult = function mult(x, y, z) {
  * let v0 = createVector(9, 4, 2);
  * let v1 = createVector(3, 2, 4);
  * let result = p5.Vector.div(v0, v1);
- * print(result); // result's components are set to [3, 2, 0.5]
+ * print(String(result)); // result's components are set to [3, 2, 0.5]
  * </code>
  * </div>
  *
@@ -790,7 +790,7 @@ p5.Vector.prototype.mult = function mult(x, y, z) {
  * let v1 = createVector(6, 4, 2);
  * let v2 = p5.Vector.div(v1, 2);
  * // v2 has components [3, 2, 1]
- * print(v2);
+ * print(String(v2));
  * </code>
  * </div>
  *
@@ -1100,7 +1100,7 @@ p5.Vector.prototype.dot = function dot(x, y, z) {
  * let v2 = createVector(1, 2, 3);
  *
  * let v = v1.cross(v2); // v's components are [0, 0, 0]
- * print(v);
+ * print(String(v));
  * </code>
  * </div>
  *
@@ -1112,7 +1112,7 @@ p5.Vector.prototype.dot = function dot(x, y, z) {
  *
  * let crossProduct = p5.Vector.cross(v1, v2);
  * // crossProduct has components [0, 0, 1]
- * print(crossProduct);
+ * print(String(crossProduct));
  * </code>
  * </div>
  */
@@ -1221,7 +1221,7 @@ p5.Vector.prototype.dist = function dist(v) {
  * let v_initial = createVector(10, 20, 2);
  * // v_initial has components [10.0, 20.0, 2.0]
  * let v_normalized = p5.Vector.normalize(v_initial);
- * print(v_normalized);
+ * print(String(v_normalized));
  * // returns a new vector with components set to
  * // [0.4454354, 0.8908708, 0.089087084]
  * // v_initial remains unchanged
@@ -1503,9 +1503,9 @@ p5.Vector.prototype.setHeading = function setHeading(a) {
  * let v = createVector(10.0, 20.0);
  * // v has components [10.0, 20.0, 0.0]
  * let rotated_v = p5.Vector.rotate(v, HALF_PI);
- * console.log(rotated_v);
+ * print(String(rotated_v));
  * // rotated_v's components are set to [-20.0, 9.999999, 0.0]
- * console.log(v);
+ * print(String(v));
  * // v's components remains the same (i.e, [10.0, 20.0, 0.0])
  * </code>
  * </div>
@@ -1657,7 +1657,7 @@ p5.Vector.prototype.angleBetween = function angleBetween(v) {
  *
  * let v3 = p5.Vector.lerp(v1, v2, 0.5);
  * // v3 has components [50,50,0]
- * print(v3);
+ * print(String(v3));
  * </code>
  * </div>
  *
@@ -1974,7 +1974,7 @@ p5.Vector.fromAngles = function(theta, phi, length) {
  * // [0.61554617, -0.51195765, 0.0] or
  * // [-0.4695841, -0.14366731, 0.0] or
  * // [0.6091097, -0.22805278, 0.0]
- * print(v);
+ * print(String(v));
  * </code>
  * </div>
  *
@@ -2027,7 +2027,7 @@ p5.Vector.random2D = function random2D() {
  * // [0.61554617, -0.51195765, 0.599168] or
  * // [-0.4695841, -0.14366731, -0.8711202] or
  * // [0.6091097, -0.22805278, -0.7595902]
- * print(v);
+ * print(String(v));
  * </code>
  * </div>
  */

--- a/src/math/p5.Vector.js
+++ b/src/math/p5.Vector.js
@@ -90,7 +90,7 @@ p5.Vector = function Vector() {
  * <code>
  * function setup() {
  *   let v = createVector(20, 30);
- *   print(String(v)); // prints "p5.Vector Object : [20, 30, 0]"
+ *   print(v.toString()); // prints "p5.Vector Object : [20, 30, 0]"
  * }
  * </code>
  * </div>
@@ -274,7 +274,7 @@ p5.Vector.prototype.copy = function copy() {
  *
  * let v3 = p5.Vector.add(v1, v2);
  * // v3 has components [3, 5, 7]
- * print(String(v3));
+ * print(v3.toString());
  * </code>
  * </div>
  *
@@ -384,7 +384,7 @@ const calculateRemainder3D = function(xComponent, yComponent, zComponent) {
  *
  * let v3 = p5.Vector.rem(v1, v2);
  * // v3 has components [1, 1, 1]
- * print(String(v3));
+ * print(v3.toString());
  * </code>
  * </div>
  */
@@ -482,7 +482,7 @@ p5.Vector.prototype.rem = function rem(x, y, z) {
  *
  * let v3 = p5.Vector.sub(v1, v2);
  * // v3 has components [1, 1, 1]
- * print(String(v3));
+ * print(v3.toString());
  * </code>
  * </div>
  *
@@ -588,7 +588,7 @@ p5.Vector.prototype.sub = function sub(x, y, z) {
  * let v0 = createVector(1, 2, 3);
  * let v1 = createVector(2, 3, 4);
  * const result = p5.Vector.mult(v0, v1);
- * print(String(result)); // result's components are set to [2, 6, 12]
+ * print(result.toString()); // result's components are set to [2, 6, 12]
  * </code>
  * </div>
  *
@@ -598,7 +598,7 @@ p5.Vector.prototype.sub = function sub(x, y, z) {
  * let v1 = createVector(1, 2, 3);
  * let v2 = p5.Vector.mult(v1, 2);
  * // v2 has components [2, 4, 6]
- * print(String(v2));
+ * print(v2.toString());
  * </code>
  * </div>
  *
@@ -780,7 +780,7 @@ p5.Vector.prototype.mult = function mult(x, y, z) {
  * let v0 = createVector(9, 4, 2);
  * let v1 = createVector(3, 2, 4);
  * let result = p5.Vector.div(v0, v1);
- * print(String(result)); // result's components are set to [3, 2, 0.5]
+ * print(result.toString()); // result's components are set to [3, 2, 0.5]
  * </code>
  * </div>
  *
@@ -790,7 +790,7 @@ p5.Vector.prototype.mult = function mult(x, y, z) {
  * let v1 = createVector(6, 4, 2);
  * let v2 = p5.Vector.div(v1, 2);
  * // v2 has components [3, 2, 1]
- * print(String(v2));
+ * print(v2.toString());
  * </code>
  * </div>
  *
@@ -1100,7 +1100,7 @@ p5.Vector.prototype.dot = function dot(x, y, z) {
  * let v2 = createVector(1, 2, 3);
  *
  * let v = v1.cross(v2); // v's components are [0, 0, 0]
- * print(String(v));
+ * print(v.toString());
  * </code>
  * </div>
  *
@@ -1112,7 +1112,7 @@ p5.Vector.prototype.dot = function dot(x, y, z) {
  *
  * let crossProduct = p5.Vector.cross(v1, v2);
  * // crossProduct has components [0, 0, 1]
- * print(String(crossProduct));
+ * print(crossProduct.toString());
  * </code>
  * </div>
  */
@@ -1221,7 +1221,7 @@ p5.Vector.prototype.dist = function dist(v) {
  * let v_initial = createVector(10, 20, 2);
  * // v_initial has components [10.0, 20.0, 2.0]
  * let v_normalized = p5.Vector.normalize(v_initial);
- * print(String(v_normalized));
+ * print(v_normalized.toString());
  * // returns a new vector with components set to
  * // [0.4454354, 0.8908708, 0.089087084]
  * // v_initial remains unchanged
@@ -1503,9 +1503,9 @@ p5.Vector.prototype.setHeading = function setHeading(a) {
  * let v = createVector(10.0, 20.0);
  * // v has components [10.0, 20.0, 0.0]
  * let rotated_v = p5.Vector.rotate(v, HALF_PI);
- * print(String(rotated_v));
+ * print(rotated_v.toString());
  * // rotated_v's components are set to [-20.0, 9.999999, 0.0]
- * print(String(v));
+ * print(v.toString());
  * // v's components remains the same (i.e, [10.0, 20.0, 0.0])
  * </code>
  * </div>
@@ -1657,7 +1657,7 @@ p5.Vector.prototype.angleBetween = function angleBetween(v) {
  *
  * let v3 = p5.Vector.lerp(v1, v2, 0.5);
  * // v3 has components [50,50,0]
- * print(String(v3));
+ * print(v3.toString());
  * </code>
  * </div>
  *
@@ -1974,7 +1974,7 @@ p5.Vector.fromAngles = function(theta, phi, length) {
  * // [0.61554617, -0.51195765, 0.0] or
  * // [-0.4695841, -0.14366731, 0.0] or
  * // [0.6091097, -0.22805278, 0.0]
- * print(String(v));
+ * print(v.toString());
  * </code>
  * </div>
  *
@@ -2027,7 +2027,7 @@ p5.Vector.random2D = function random2D() {
  * // [0.61554617, -0.51195765, 0.599168] or
  * // [-0.4695841, -0.14366731, -0.8711202] or
  * // [0.6091097, -0.22805278, -0.7595902]
- * print(String(v));
+ * print(v.toString());
  * </code>
  * </div>
  */

--- a/src/utilities/array_functions.js
+++ b/src/utilities/array_functions.js
@@ -195,14 +195,14 @@ p5.prototype.shorten = function(list) {
  * <div><code>
  * function setup() {
  *   let regularArr = ['ABC', 'def', createVector(), TAU, Math.E];
- *   print(String(regularArr));
+ *   print(regularArr.toString());
  *   shuffle(regularArr, true); // force modifications to passed array
- *   print(String(regularArr));
+ *   print(regularArr.toString());
  *
  *   // By default shuffle() returns a shuffled cloned array:
  *   let newArr = shuffle(regularArr);
- *   print(String(regularArr));
- *   print(String(newArr));
+ *   print(regularArr.toString());
+ *   print(newArr.toString());
  * }
  * </code></div>
  */

--- a/src/utilities/array_functions.js
+++ b/src/utilities/array_functions.js
@@ -195,14 +195,14 @@ p5.prototype.shorten = function(list) {
  * <div><code>
  * function setup() {
  *   let regularArr = ['ABC', 'def', createVector(), TAU, Math.E];
- *   print(regularArr);
+ *   print(String(regularArr));
  *   shuffle(regularArr, true); // force modifications to passed array
- *   print(regularArr);
+ *   print(String(regularArr));
  *
  *   // By default shuffle() returns a shuffled cloned array:
  *   let newArr = shuffle(regularArr);
- *   print(regularArr);
- *   print(newArr);
+ *   print(String(regularArr));
+ *   print(String(newArr));
  * }
  * </code></div>
  */

--- a/tasks/test/mocha-chrome.js
+++ b/tasks/test/mocha-chrome.js
@@ -16,7 +16,8 @@ module.exports = function(grunt) {
     // Launch Chrome in headless mode
     const browser = await puppeteer.launch({
       headless: true,
-      args: ['--no-sandbox', '--disable-setuid-sandbox']
+      args: ['--no-sandbox', '--disable-setuid-sandbox'],
+      executablePath: '/Applications/Chromium.app/Contents/MacOS/Chromium'
     });
 
     try {

--- a/tasks/test/mocha-chrome.js
+++ b/tasks/test/mocha-chrome.js
@@ -16,8 +16,7 @@ module.exports = function(grunt) {
     // Launch Chrome in headless mode
     const browser = await puppeteer.launch({
       headless: true,
-      args: ['--no-sandbox', '--disable-setuid-sandbox'],
-      executablePath: '/Applications/Chromium.app/Contents/MacOS/Chromium'
+      args: ['--no-sandbox', '--disable-setuid-sandbox']
     });
 
     try {


### PR DESCRIPTION
Resolves #5367 (maybe 😅)

 Changes:
Some examples from `math/p5.Vector` and `utilities/array_functions` used `print([Object]);`. 
Changed the lines to print simple string instead: `print([Object].toString());`

This now runs without the `Object reference chain is too long` error (using puppeteer v10.2.0).


#### PR Checklist
<!--
  To check any option, replace the "[ ]" with a "[x]". Be sure to check out how it looks in the Preview tab! Feel free to remove any portion of the template that is not relevant for your issue.
-->

- [x] `npm run lint` passes
- [x] [Inline documentation] is included / updated

[Inline documentation]: https://github.com/processing/p5.js/blob/main/contributor_docs/inline_documentation.md
[Unit tests]: https://github.com/processing/p5.js/tree/main/contributor_docs#unit-tests
