### PR TITLE
explicitly check if mouseIsPressed is true for documentation

### DIFF
--- a/src/events/mouse.js
+++ b/src/events/mouse.js
@@ -364,7 +364,7 @@ p5.prototype.pwinMouseY = 0;
  *   background(237, 34, 93);
  *   fill(0);
  *
- *   if (mouseIsPressed) {
+ *   if (mouseIsPressed === true) {
  *     if (mouseButton === LEFT) {
  *       ellipse(50, 50, 50, 50);
  *     }
@@ -400,7 +400,7 @@ p5.prototype.mouseButton = 0;
  *   background(237, 34, 93);
  *   fill(0);
  *
- *   if (mouseIsPressed) {
+ *   if (mouseIsPressed === true) {
  *     ellipse(50, 50, 50, 50);
  *   } else {
  *     rect(25, 25, 50, 50);


### PR DESCRIPTION
<!--
  Thank you for contributing! Please use this pull request (PR) template.


 In the description field of this PR, include "resolves #XXXX" tagging the issue you are fixing. If this PR addresses the issue but doesn't completely resolve it (ie the issue should remain open after your PR is merged), write "addresses #XXXX".-->
Resolves #5430 

 Changes:
In the documentation examples for mouseIsPressed, the variable is not explicitly checked against true. keyIsDown, however, does this already. I think it would be good to have the documentation consistent in that.


[Inline documentation]: https://github.com/processing/p5.js/blob/main/contributor_docs/inline_documentation.md
[Unit tests]: https://github.com/processing/p5.js/tree/main/contributor_docs#unit-tests
