### PR TITLE
add internal functions for changing translation language in i18next

### DIFF
--- a/src/core/internationalization.js
+++ b/src/core/internationalization.js
@@ -167,3 +167,28 @@ export const initialize = () => {
   // we have the translation files.
   return i18init;
 };
+
+/**
+ * Returns a list of languages we have translations loaded for
+ */
+export const availableTranslatorLanguages = () => {
+  return i18next.languages;
+};
+
+/**
+ * Returns the current language selected for translation
+ */
+export const currentTranslatorLanguage = language => {
+  return i18next.language;
+};
+
+/**
+ * Sets the current language for translation
+ * Returns a promise that resolved when loading is finished,
+ * or rejects if it fails.
+ */
+export const setTranslatorLanguage = language => {
+  return i18next.changeLanguage(language || undefined, e =>
+    console.debug(`Translations failed to load (${e})`)
+  );
+};


### PR DESCRIPTION
This is some foundational work for allowing the web editor to change the translation language used for FES messages in a running p5.js sketch. These changes don't expose any functionality externally, I've just written wrappers around the underlying `i18next` functions that make these changes so its easier for others to work with within p5.js.

cc @almchung

#### PR Checklist
<!--
  To check any option, replace the "[ ]" with a "[x]". Be sure to check out how it looks in the Preview tab! Feel free to remove any portion of the template that is not relevant for your issue.
-->

- [x] `npm run lint` passes
- [x] [Inline documentation] is included / updated
