### PR TITLE
docs(reference): Copy-edits to reference docs

### DIFF
--- a/src/accessibility/describe.js
+++ b/src/accessibility/describe.js
@@ -113,8 +113,8 @@ p5.prototype.describe = function(text, display) {
 
 /**
  * This function creates a screen-reader accessible
- * description for elements —shapes or groups of shapes that create
- * meaning together— in the canvas. The first paramater should
+ * description for elements&mdash;shapes or groups of shapes that create
+ * meaning together&mdash;in the canvas. The first paramater should
  * be the name of the element. The second parameter should be a string
  * with a description of the element. The third parameter is optional.
  * If specified, it determines how the element description is displayed.
@@ -211,7 +211,7 @@ p5.prototype.describeElement = function(name, text, display) {
 
 /*
  *
- * Helper functions for describe() and describeElement().
+ * Helper functions for `describe()` and `describeElement()`.
  *
  */
 
@@ -235,7 +235,7 @@ function _descriptionText(text) {
 }
 
 /*
- * Helper functions for describe()
+ * Helper functions for `describe()`.
  */
 
 //creates HTML structure for canvas descriptions
@@ -306,7 +306,7 @@ p5.prototype._describeHTML = function(type, text) {
 };
 
 /*
- * Helper functions for describeElement().
+ * Helper functions for `describeElement()`.
  */
 
 //check that name is not LABEL or FALLBACK and ensure text ends with colon

--- a/src/accessibility/outputs.js
+++ b/src/accessibility/outputs.js
@@ -11,24 +11,24 @@ import p5 from '../core/main';
  * <code class="language-javascript">textOutput()</code> creates a screenreader
  * accessible output that describes the shapes present on the canvas.
  * The general description of the canvas includes canvas size,
- * canvas color, and number of elements in the canvas
- * (example: 'Your output is a, 400 by 400 pixels, lavender blue
- * canvas containing the following 4 shapes:'). This description
+ * canvas color, and number of elements in the canvas.
+ * (Example: "Your output is a, 400 by 400 pixels, lavender blue
+ * canvas containing the following 4 shapes: ".) This description
  * is followed by a list of shapes where the color, position, and area
- * of each shape are described (example: "orange ellipse at top left
- * covering 1% of the canvas"). Each element can be selected to get
+ * of each shape are described. (Example: "orange ellipse at top left
+ * covering 1% of the canvas".) Each element can be selected to get
  * more details. A table of elements is also provided. In this table,
- * shape, color, location, coordinates and area are described
- * (example: "orange ellipse location=top left area=2").
+ * shape, color, location, coordinates, and area are described.
+ * (Example: "orange ellipse location=top left area=2".)
  *
  * <code class="language-javascript">textOutput()</code> and <code class="language-javascript">textOutput(FALLBACK)</code>
  * make the output available in <a href="https://developer.mozilla.org/en-US/docs/Web/API/Canvas_API/Tutorial/Hit_regions_and_accessibility" target="_blank">
  * a sub DOM inside the canvas element</a> which is accessible to screen readers.
  * <code class="language-javascript">textOutput(LABEL)</code> creates an
- * additional div with the output adjacent to the canvas, this is useful
+ * additional `div` with the output adjacent to the canvas, this is useful
  * for non-screen reader users that might want to display the output outside
- * of the canvas' sub DOM as they code. However, using LABEL will create
- * unnecessary redundancy for screen reader users. We recommend using LABEL
+ * of the canvas' sub DOM as they code. However, using `LABEL` will create
+ * unnecessary redundancy for screen reader users. We recommend using `LABEL`
  * only as part of the development process of a sketch and removing it before
  * publishing or sharing with screen reader users.
  *
@@ -87,18 +87,18 @@ p5.prototype.textOutput = function(display) {
 
 /**
  * <code class="language-javascript">gridOutput()</code> lays out the
- * content of the canvas in the form of a grid (html table) based
+ * content of the canvas in the form of a grid (HTML table) based
  * on the spatial location of each shape. A brief
  * description of the canvas is available before the table output.
  * This description includes: color of the background, size of the canvas,
- * number of objects, and object types (example: "lavender blue canvas is
- * 200 by 200 and contains 4 objects - 3 ellipses 1 rectangle"). The grid
+ * number of objects, and object types. (Example: "lavender blue canvas is
+ * 200 by 200 and contains 4 objects - 3 ellipses 1 rectangle".) The grid
  * describes the content spatially, each element is placed on a cell of the
  * table depending on its position. Within each cell an element the color
- * and type of shape of that element are available (example: "orange ellipse").
+ * and type of shape of that element are available. (Example: "orange ellipse".)
  * These descriptions can be selected individually to get more details.
  * A list of elements where shape, color, location, and area are described
- * (example: "orange ellipse location=top left area=1%") is also available.
+ * (Example: "orange ellipse location=top left area=1%") is also available.
  *
  * <code class="language-javascript">gridOutput()</code> and <code class="language-javascript">gridOutput(FALLBACK)</code>
  * make the output available in <a href="https://developer.mozilla.org/en-US/docs/Web/API/Canvas_API/Tutorial/Hit_regions_and_accessibility" target="_blank">
@@ -106,8 +106,8 @@ p5.prototype.textOutput = function(display) {
  * <code class="language-javascript">gridOutput(LABEL)</code> creates an
  * additional div with the output adjacent to the canvas, this is useful
  * for non-screen reader users that might want to display the output outside
- * of the canvas' sub DOM as they code. However, using LABEL will create
- * unnecessary redundancy for screen reader users. We recommend using LABEL
+ * of the canvas' sub DOM as they code. However, using `LABEL` will create
+ * unnecessary redundancy for screen reader users. We recommend using `LABEL`
  * only as part of the development process of a sketch and removing it before
  * publishing or sharing with screen reader users.
  *

--- a/src/color/creating_reading.js
+++ b/src/color/creating_reading.js
@@ -117,7 +117,7 @@ p5.prototype.brightness = function(c) {
  * Creates colors for storing in variables of the color datatype. The
  * parameters are interpreted as RGB or HSB values depending on the
  * current <a href="#/p5/colorMode">colorMode()</a>. The default mode is RGB values from 0 to 255
- * and, therefore, the function call color(255, 204, 0) will return a
+ * and, therefore, the function call `color(255, 204, 0)` will return a
  * bright yellow color.
  *
  * Note that if only one value is provided to <a href="#/p5/color">color()</a>, it will be interpreted
@@ -126,7 +126,7 @@ p5.prototype.brightness = function(c) {
  * either RGB or HSB values. Adding a fourth value applies alpha
  * transparency.
  *
- * If a single string argument is provided, RGB, RGBA and Hex CSS color
+ * If a single string argument is provided, RGB, RGBA,and Hex CSS color
  * strings and all named color strings are supported. In this case, an alpha
  * number value as a second argument is not supported, the RGBA form should be
  * used.
@@ -274,7 +274,7 @@ p5.prototype.brightness = function(c) {
 
 /**
  * @method color
- * @param  {Number[]}      values  an array containing the red,green,blue &
+ * @param  {Number[]}      values  an array containing the red, green, blue,
  *                                 and alpha components of the color
  * @return {p5.Color}
  */
@@ -359,7 +359,7 @@ p5.prototype.hue = function(c) {
 };
 
 /**
- * Blends two colors to find a third color somewhere between them. The amt
+ * Blends two colors to find a third color somewhere between them. The `amt`
  * parameter is the amount to interpolate between the two values where 0.0
  * is equal to the first color, 0.1 is very near the first color, 0.5 is halfway
  * in between, etc. An amount below 0 will be treated as 0. Likewise, amounts

--- a/src/color/p5.Color.js
+++ b/src/color/p5.Color.js
@@ -54,7 +54,7 @@ p5.Color = function(pInst, vals) {
  *
  * @method toString
  * @param {String} [format] How the color string will be formatted.
- * Leaving this empty formats the string as rgba(r, g, b, a).
+ * Leaving this empty formats the string as `rgba(r, g, b, a)`.
  * '#rgb' '#rgba' '#rrggbb' and '#rrggbbaa' format as hexadecimal color codes.
  * 'rgb' 'hsb' and 'hsl' return the color formatted in the specified color mode.
  * 'rgba' 'hsba' and 'hsla' are the same as above but with alpha channels.
@@ -254,8 +254,8 @@ p5.Color.prototype.toString = function(format) {
 };
 
 /**
- * The setRed function sets the red component of a color.
- * The range depends on your color mode, in the default RGB mode it's between 0 and 255.
+ * The `setRed()` function sets the red component of a color.
+ * The range depends on your color mode. In the default RGB mode, it's between `0` and `255`.
  * @method setRed
  * @param {Number} red the new red value
  * @example
@@ -283,8 +283,8 @@ p5.Color.prototype.setRed = function(new_red) {
 };
 
 /**
- * The setGreen function sets the green component of a color.
- * The range depends on your color mode, in the default RGB mode it's between 0 and 255.
+ * The `setGreen()` function sets the green component of a color.
+ * The range depends on your color mode. In the default RGB mode, it's between `0` and `255`.
  * @method setGreen
  * @param {Number} green the new green value
  * @example
@@ -307,8 +307,8 @@ p5.Color.prototype.setGreen = function(new_green) {
 };
 
 /**
- * The setBlue function sets the blue component of a color.
- * The range depends on your color mode, in the default RGB mode it's between 0 and 255.
+ * The `setBlue()` function sets the blue component of a color.
+ * The range depends on your color mode. In the default RGB mode, it's between `0` and `255`.
  * @method setBlue
  * @param {Number} blue the new blue value
  * @example
@@ -331,8 +331,8 @@ p5.Color.prototype.setBlue = function(new_blue) {
 };
 
 /**
- * The setAlpha function sets the transparency (alpha) value of a color.
- * The range depends on your color mode, in the default RGB mode it's between 0 and 255.
+ * The `setAlpha()` function sets the transparency (alpha) value of a color.
+ * The range depends on your color mode. In the default RGB mode, it's between `0` and `255`.
  * @method setAlpha
  * @param {Number} alpha the new alpha value
  * @example
@@ -610,7 +610,7 @@ const namedColors = {
  * viable CSS color strings: fragmenting the regexes in this way increases the
  * legibility and comprehensibility of the code.
  *
- * Note that RGB values of .9 are not parsed by IE, but are supported here for
+ * Note that RGB values of `.9` are not parsed by IE, but are supported here for
  * color string consistency.
  */
 const WHITESPACE = /\s*/; // Match zero or more whitespace characters.
@@ -756,8 +756,8 @@ const colorPatterns = {
 };
 
 /**
- * For a number of different inputs, returns a color formatted as [r, g, b, a]
- * arrays, with each component normalized between 0 and 1.
+ * For a number of different inputs, returns a color formatted as `[r, g, b, a]`
+ * arrays, with each component normalized between `0` and `1`.
  *
  * @private
  * @param {Array} [...args] An 'array-like' object that represents a list of

--- a/src/color/setting.js
+++ b/src/color/setting.js
@@ -21,9 +21,9 @@ import './p5.Color';
  * The color is either specified in terms of the RGB, HSB, or HSL color depending
  * on the current <a href="#/p5/colorMode">colorMode</a>. (The default color space
  * is RGB, with each value in the range from 0 to 255). The alpha range by default
- * is also 0 to 255.<br><br>
+ * is also 0 to 255.
  *
- * If a single string argument is provided, RGB, RGBA and Hex CSS color strings
+ * If a single string argument is provided, RGB, RGBA, and Hex CSS color strings
  * and all named color strings are supported. In this case, an alpha number
  * value as a second argument is not supported, the RGBA form should be used.
  *
@@ -179,7 +179,7 @@ p5.prototype.background = function(...args) {
 
 /**
  * Clears the pixels within a buffer. This function only clears the canvas.
- * It will not clear objects created by createX() methods such as
+ * It will not clear objects created by `create*()` methods such as
  * <a href="#/p5/createVideo">createVideo()</a> or <a href="#/p5/createDiv">createDiv()</a>.
  * Unlike the main graphics context, pixels in additional graphics areas created
  * with <a href="#/p5/createGraphics">createGraphics()</a> can be entirely
@@ -216,17 +216,17 @@ p5.prototype.clear = function() {
  * color data. By default, the parameters for <a href="#/p5/fill">fill()</a>,
  * <a href="#/p5/stroke">stroke()</a>, <a href="#/p5/background">background()</a>,
  * and <a href="#/p5/color">color()</a> are defined by values between 0 and 255
- * using the RGB color model. This is equivalent to setting colorMode(RGB, 255).
- * Setting colorMode(HSB) lets you use the HSB system instead. By default, this
- * is colorMode(HSB, 360, 100, 100, 1). You can also use HSL.
+ * using the RGB color model. This is equivalent to setting `colorMode(RGB, 255)`.
+ * Setting `colorMode(HSB)` lets you use the HSB system instead. By default, this
+ * is `colorMode(HSB, 360, 100, 100, 1)`. You can also use HSL.
  *
  * Note: existing color objects remember the mode that they were created in,
  * so you can change modes as you like without affecting their appearance.
  *
  * @method colorMode
- * @param {Constant} mode   either RGB, HSB or HSL, corresponding to
- *                          Red/Green/Blue and Hue/Saturation/Brightness
- *                          (or Lightness)
+ * @param {Constant} mode   either RGB, HSB, or HSL, corresponding to
+ *                          Red/Green/Blue, Hue/Saturation/Brightness, or
+ *                          Hue/Saturation/Lightness
  * @param {Number}  [max]  range for all values
  * @chainable
  *
@@ -331,14 +331,14 @@ p5.prototype.colorMode = function(mode, max1, max2, max3, maxA) {
 };
 
 /**
- * Sets the color used to fill shapes. For example, if you run fill(204, 102, 0),
+ * Sets the color used to fill shapes. For example, if you run `fill(204, 102, 0)`,
  * all shapes drawn after the fill command will be filled with the color orange.
  * This color is either specified in terms of the RGB or HSB color depending on
  * the current <a href="#/p5/colorMode">colorMode()</a>. (The default color space
  * is RGB, with each value in the range from 0 to 255). The alpha range by default
  * is also 0 to 255.
  *
- * If a single string argument is provided, RGB, RGBA and Hex CSS color strings
+ * If a single string argument is provided, RGB, RGBA, and Hex CSS color strings
  * and all named color strings are supported. In this case, an alpha number
  * value as a second argument is not supported, the RGBA form should be used.
  *
@@ -472,7 +472,7 @@ p5.prototype.colorMode = function(mode, max1, max2, max3, maxA) {
 
 /**
  * @method fill
- * @param  {Number[]}      values  an array containing the red,green,blue &
+ * @param  {Number[]}      values  an array containing the red, green, blue,
  *                                 and alpha components of the color
  * @chainable
  */
@@ -572,12 +572,12 @@ p5.prototype.noStroke = function() {
 
 /**
  * Sets the color used to draw lines and borders around shapes. This color
- * is either specified in terms of the RGB or HSB color depending on the
- * current <a href="#/p5/colorMode">colorMode()</a> (the default color space
- * is RGB, with each value in the range from 0 to 255). The alpha range by
+ * is either specified in terms of the RGB or HSB color, depending on the
+ * current <a href="#/p5/colorMode">colorMode()</a>. (The default color space
+ * is RGB, with each value in the range from 0 to 255.) The alpha range by
  * default is also 0 to 255.
  *
- * If a single string argument is provided, RGB, RGBA and Hex CSS color
+ * If a single string argument is provided, RGB, RGBA, and Hex CSS color
  * strings and all named color strings are supported. In this case, an alpha
  * number value as a second argument is not supported, the RGBA form should be
  * used.
@@ -724,7 +724,7 @@ p5.prototype.noStroke = function() {
 
 /**
  * @method stroke
- * @param  {Number[]}      values  an array containing the red,green,blue &
+ * @param  {Number[]}      values  an array containing the red, green, blue,
  *                                 and alpha components of the color
  * @chainable
  */
@@ -744,12 +744,12 @@ p5.prototype.stroke = function(...args) {
 
 /**
  * All drawing that follows <a href="#/p5/erase">erase()</a> will subtract from
- * the canvas.Erased areas will reveal the web page underneath the canvas.Erasing
+ * the canvas. Erased areas will reveal the web page underneath the canvas. Erasing
  * can be canceled with <a href="#/p5/noErase">noErase()</a>.
  *
  * Drawing done with <a href="#/p5/image">image()</a> and <a href="#/p5/background">
  * background()</a> in between <a href="#/p5/erase">erase()</a> and
- * <a href="#/p5/noErase">noErase()</a> will not erase the canvas but works as usual.
+ * <a href="#/p5/noErase">noErase()</a> will not erase the canvas, but works as usual.
  *
  * @method erase
  * @param  {Number}   [strengthFill]      A number (0-255) for the strength of erasing for a shape's fill.

--- a/src/core/constants.js
+++ b/src/core/constants.js
@@ -64,8 +64,8 @@ export const WAIT = 'wait';
 // TRIGONOMETRY
 
 /**
- * HALF_PI is a mathematical constant with the value
- * 1.57079632679489661923. It is half the ratio of the
+ * `HALF_PI` is a mathematical constant with the value
+ * `1.57079632679489661923`. It is half the ratio of the
  * circumference of a circle to its diameter. It is useful in
  * combination with the trigonometric functions <a href="#/p5/sin">sin()</a> and <a href="#/p5/cos">cos()</a>.
  *
@@ -82,8 +82,8 @@ export const WAIT = 'wait';
  */
 export const HALF_PI = _PI / 2;
 /**
- * PI is a mathematical constant with the value
- * 3.14159265358979323846. It is the ratio of the circumference
+ * `PI` is a mathematical constant with the value
+ * `3.14159265358979323846`. It is the ratio of the circumference
  * of a circle to its diameter. It is useful in combination with
  * the trigonometric functions <a href="#/p5/sin">sin()</a> and <a href="#/p5/cos">cos()</a>.
  *
@@ -100,7 +100,7 @@ export const HALF_PI = _PI / 2;
  */
 export const PI = _PI;
 /**
- * QUARTER_PI is a mathematical constant with the value 0.7853982.
+ * `QUARTER_PI` is a mathematical constant with the value `0.7853982`.
  * It is one quarter the ratio of the circumference of a circle to
  * its diameter. It is useful in combination with the trigonometric
  * functions <a href="#/p5/sin">sin()</a> and <a href="#/p5/cos">cos()</a>.
@@ -118,8 +118,8 @@ export const PI = _PI;
  */
 export const QUARTER_PI = _PI / 4;
 /**
- * TAU is an alias for TWO_PI, a mathematical constant with the
- * value 6.28318530717958647693. It is twice the ratio of the
+ * `TAU` is an alias for `TWO_PI`, a mathematical constant with the
+ * value `6.28318530717958647693`. It is twice the ratio of the
  * circumference of a circle to its diameter. It is useful in
  * combination with the trigonometric functions <a href="#/p5/sin">sin()</a> and <a href="#/p5/cos">cos()</a>.
  *
@@ -136,8 +136,8 @@ export const QUARTER_PI = _PI / 4;
  */
 export const TAU = _PI * 2;
 /**
- * TWO_PI is a mathematical constant with the value
- * 6.28318530717958647693. It is twice the ratio of the
+ * `TWO_PI` is a mathematical constant with the value
+ * `6.28318530717958647693`. It is twice the ratio of the
  * circumference of a circle to its diameter. It is useful in
  * combination with the trigonometric functions <a href="#/p5/sin">sin()</a> and <a href="#/p5/cos">cos()</a>.
  *

--- a/src/core/environment.js
+++ b/src/core/environment.js
@@ -21,12 +21,12 @@ const _windowPrint = window.print;
  * The <a href="#/p5/print">print()</a> function writes to the console area of
  * your browser. This function is often helpful for looking at the data a program
  * is producing. This function creates a new line of text for each call to
- * the function. Individual elements can be separated with quotes ("") and joined
- * with the addition operator (+).
+ * the function. Individual elements can be separated with quotes (`""`) and joined
+ * with the addition operator (`+`).
  *
- * Note that calling print() without any arguments invokes the window.print()
- * function which opens the browser's print dialog. To print a blank line
- * to console you can write print('\n').
+ * Note that calling `print()` without any arguments invokes the `window.print()`
+ * function, which opens the browser's print dialog. To print a blank line
+ * to console you can write `print('\n')`.
  *
  * @method print
  * @param {Any} contents any combination of Number, String, Object, Boolean,
@@ -129,7 +129,7 @@ p5.prototype.deltaTime = 0;
 /**
  * Confirms if the window a p5.js program is in is "focused," meaning that
  * the sketch will accept mouse or keyboard input. This variable is
- * "true" if the window is focused and "false" if not.
+ * `true` if the window is focused and `false` if not.
  *
  * @property {Boolean} focused
  * @readOnly
@@ -160,14 +160,14 @@ p5.prototype.focused = document.hasFocus();
 /**
  * Sets the cursor to a predefined symbol or an image, or makes it visible
  * if already hidden. If you are trying to set an image as the cursor, the
- * recommended size is 16x16 or 32x32 pixels. The values for parameters x and y
+ * recommended size is 16x16 or 32x32 pixels. The values for parameters `x` and `y`
  * must be less than the dimensions of the image.
  *
  * @method cursor
- * @param {String|Constant} type Built-In: either ARROW, CROSS, HAND, MOVE, TEXT and WAIT
+ * @param {String|Constant} type Built-In: either ARROW, CROSS, HAND, MOVE, TEXT, and WAIT
  *                               Native CSS properties: 'grab', 'progress', 'cell' etc.
  *                               External: path for cursor's images
- *                               (Allowed File extensions: .cur, .gif, .jpg, .jpeg, .png)
+ *                               (Allowed File extensions: `.cur`, `.gif`, `.jpg`, `.jpeg`, `.png`)
  *                               For more information on Native CSS cursors and url visit:
  *                               https://developer.mozilla.org/en-US/docs/Web/CSS/cursor
  * @param {Number}          [x]  the horizontal active spot of the cursor (must be less than 32)
@@ -227,17 +227,17 @@ p5.prototype.cursor = function(type, x, y) {
 
 /**
  * Specifies the number of frames to be displayed every second. For example,
- * the function call frameRate(30) will attempt to refresh 30 times a second.
+ * the function call `frameRate(30)` will attempt to refresh 30 times a second.
  * If the processor is not fast enough to maintain the specified rate, the
- * frame rate will not be achieved. Setting the frame rate within 
+ * frame rate will not be achieved. Setting the frame rate within
  * <a href="#/p5/setup">setup()</a> is recommended. The default frame rate is
- * based on the frame rate of the display (here also called "refresh rate"), 
+ * based on the frame rate of the display (here also called "refresh rate"),
  * which is set to 60 frames per second on most computers. A frame rate of 24
- * frames per second (usual for movies) or above will be enough for smooth 
- * animations. This is the same as setFrameRate(val).
- * 
+ * frames per second (usual for movies) or above will be enough for smooth
+ * animations. This is the same as `setFrameRate(val)`.
+ *
  * Calling <a href="#/p5/frameRate">frameRate()</a> with no arguments returns
- * the current framerate. The draw function must run at least once before it will
+ * the current framerate. The `draw()` function must run at least once before it will
  * return a value. This is the same as <a href="#/p5/getFrameRate">getFrameRate()</a>.
  *
  * Calling <a href="#/p5/frameRate">frameRate()</a> with arguments that are not
@@ -314,7 +314,7 @@ p5.prototype.getFrameRate = function() {
 
 /**
  * Specifies the number of frames to be displayed every second. For example,
- * the function call frameRate(30) will attempt to refresh 30 times a second.
+ * the function call `frameRate(30)` will attempt to refresh 30 times a second.
  * If the processor is not fast enough to maintain the specified rate, the
  * frame rate will not be achieved. Setting the frame rate within <a href="#/p5/setup">setup()</a> is
  * recommended. The default rate is 60 frames per second.
@@ -373,7 +373,7 @@ p5.prototype.displayWidth = screen.width;
  * System variable that stores the height of the screen display according to The
  * default <a href="#/p5/pixelDensity">pixelDensity</a>. This is used to run a
  * full-screen program on any display size. To return actual screen size,
- * multiply this by pixelDensity.
+ * multiply this by `pixelDensity`.
  *
  * @property {Number} displayHeight
  * @readOnly
@@ -388,8 +388,8 @@ p5.prototype.displayWidth = screen.width;
 p5.prototype.displayHeight = screen.height;
 
 /**
- * System variable that stores the width of the inner window, it maps to
- * window.innerWidth.
+ * System variable that stores the width of the inner window. This maps to
+ * `window.innerWidth`.
  *
  * @property {Number} windowWidth
  * @readOnly
@@ -403,8 +403,8 @@ p5.prototype.displayHeight = screen.height;
  */
 p5.prototype.windowWidth = getWindowWidth();
 /**
- * System variable that stores the height of the inner window, it maps to
- * window.innerHeight.
+ * System variable that stores the height of the inner window. This maps to
+ * `window.innerHeight`.
  *
  * @property {Number} windowHeight
  * @readOnly
@@ -476,9 +476,11 @@ function getWindowHeight() {
 /**
  * System variable that stores the width of the drawing canvas. This value
  * is set by the first parameter of the <a href="#/p5/createCanvas">createCanvas()</a> function.
- * For example, the function call createCanvas(320, 240) sets the width
- * variable to the value 320. The value of width defaults to 100 if
- * <a href="#/p5/createCanvas">createCanvas()</a> is not used in a program.
+ * For example, the function call `createCanvas(320, 240)` sets the `width`
+ * variable to the value `320`.
+ *
+ * The value of `width` defaults to 100 if <a href="#/p5/createCanvas">createCanvas()</a>
+ * is not used in a program.
  *
  * @property {Number} width
  * @readOnly
@@ -488,9 +490,11 @@ p5.prototype.width = 0;
 /**
  * System variable that stores the height of the drawing canvas. This value
  * is set by the second parameter of the <a href="#/p5/createCanvas">createCanvas()</a> function. For
- * example, the function call createCanvas(320, 240) sets the height
- * variable to the value 240. The value of height defaults to 100 if
- * <a href="#/p5/createCanvas">createCanvas()</a> is not used in a program.
+ * example, the function call `createCanvas(320, 240)` sets the `height`
+ * variable to the value `240`.
+ *
+ * The value of `height` defaults to 100 if <a href="#/p5/createCanvas">createCanvas()</a>
+ * is not used in a program.
  *
  * @property {Number} height
  * @readOnly
@@ -549,7 +553,7 @@ p5.prototype.fullscreen = function(val) {
 
 /**
  * Sets the pixel scaling for high pixel density displays. By default
- * pixel density is set to match display density, call pixelDensity(1)
+ * pixel density is set to match display density, call `pixelDensity(1)`
  * to turn this off. Calling <a href="#/p5/pixelDensity">pixelDensity()</a> with no arguments returns
  * the current pixel density of the sketch.
  *
@@ -661,7 +665,7 @@ function exitFullscreen() {
  * Gets the current URL. Note: when using the
  * p5 Editor, this will return an empty object because the sketch
  * is embedded in an iframe. It will work correctly if you view the
- * sketch using the editor's present or share URLs.
+ * sketch using the editor's "present" or "share" URLs.
  * @method getURL
  * @return {String} url
  * @example
@@ -692,7 +696,7 @@ p5.prototype.getURL = () => location.href;
  * Gets the current URL path as an array. Note: when using the
  * p5 Editor, this will return an empty object because the sketch
  * is embedded in an iframe. It will work correctly if you view the
- * sketch using the editor's present or share URLs.
+ * sketch using the editor's "present" or "share" URLs.
  * @method getURLPath
  * @return {String[]} path components
  * @example
@@ -714,7 +718,7 @@ p5.prototype.getURLPath = () =>
  * Gets the current URL params as an Object. Note: when using the
  * p5 Editor, this will return an empty object because the sketch
  * is embedded in an iframe. It will work correctly if you view the
- * sketch using the editor's present or share URLs.
+ * sketch using the editor's "present" or "share" URLs.
  * @method getURLParams
  * @return {Object} URL params
  * @example

--- a/src/core/main.js
+++ b/src/core/main.js
@@ -44,12 +44,12 @@ class p5 {
      * asynchronous loading of external files in a blocking way. If a preload
      * function is defined, <a href="#/p5/setup">setup()</a> will wait until any load calls within have
      * finished. Nothing besides load calls (<a href="#/p5/loadImage">loadImage</a>, <a href="#/p5/loadJSON">loadJSON</a>, <a href="#/p5/loadFont">loadFont</a>,
-     * <a href="#/p5/loadStrings">loadStrings</a>, etc.) should be inside the preload function. If asynchronous
+     * <a href="#/p5/loadStrings">loadStrings</a>, etc.) should be inside the `preload()` function. If asynchronous
      * loading is preferred, the load methods can instead be called in <a href="#/p5/setup">setup()</a>
      * or anywhere else with the use of a callback parameter.
      *
      * By default the text "loading..." will be displayed. To make your own
-     * loading page, include an HTML element with id "p5_loading" in your
+     * loading page, include an HTML element with id `p5_loading` in your
      * page. More information <a href="http://bit.ly/2kQ6Nio">here</a>.
      *
      * @method preload
@@ -416,8 +416,8 @@ class p5 {
      * Removes the entire p5 sketch. This will remove the canvas and any
      * elements created by p5.js. It will also stop the draw loop and unbind
      * any properties or methods from the window global scope. It will
-     * leave a variable p5 in case you wanted to create a new p5 sketch.
-     * If you like, you can set p5 = null to erase it. While all functions and
+     * leave a variable `p5`, in case you wanted to create a new p5 sketch.
+     * If you like, you can set `p5 = null` to erase it. While all functions and
      * variables and objects created by the p5 library will be removed, any
      * other global variables created by your code will remain.
      *

--- a/src/core/p5.Element.js
+++ b/src/core/p5.Element.js
@@ -9,8 +9,8 @@ import p5 from './main';
 /**
  * Base class for all elements added to a sketch, including canvas,
  * graphics buffers, and other HTML elements. It is not called directly, but <a href="#/p5.Element">p5.Element</a>
- * objects are created by calling <a href="#/p5/createCanvas">createCanvas</a>, <a href="#/p5/createGraphics">createGraphics</a>,
- * <a href="#/p5/createDiv">createDiv</a>, <a href="#/p5/createImg">createImg</a>, <a href="#/p5/createInput">createInput</a>, etc.
+ * objects are created by calling <a href="#/p5/createCanvas">createCanvas()</a>, <a href="#/p5/createGraphics">createGraphics()</a>,
+ * <a href="#/p5/createDiv">createDiv</a>, <a href="#/p5/createImg">createImg()</a>, <a href="#/p5/createInput">createInput()</a>, etc.
  *
  * @class p5.Element
  * @constructor
@@ -46,9 +46,10 @@ p5.Element = function(elt, pInst) {
 
 /**
  *
- * Attaches the element to the parent specified. A way of setting
+ * Attaches the element to the `parent` specified. A way of setting
  * the container for the element. Accepts either a string ID, DOM
  * node, or <a href="#/p5.Element">p5.Element</a>. If no arguments given, parent node is returned.
+ *
  * For more ways to position the canvas, see the
  * <a href='https://github.com/processing/p5.js/wiki/Positioning-your-canvas'>
  * positioning the canvas</a> wiki page.
@@ -115,6 +116,7 @@ p5.Element.prototype.parent = function(p) {
  *
  * Sets the ID of the element. If no ID argument is passed in, it instead
  * returns the current ID of the element.
+ *
  * Note that only one element can have a particular id in a page.
  * The <a href="#/p5.Element/class">.class()</a> function can be used
  * to identify multiple elements with the same class name.
@@ -153,7 +155,7 @@ p5.Element.prototype.id = function(id) {
 
 /**
  *
- * Adds given class to the element. If no class argument is passed in, it
+ * Adds given `class` to the element. If no class argument is passed in, it
  * instead returns a string containing the current class(es) of the element.
  *
  * @method class
@@ -190,12 +192,12 @@ p5.Element.prototype.class = function(c) {
  * The .<a href="#/p5.Element/mousePressed">mousePressed()</a> function is called
  * once after every time a mouse button is pressed over the element. Some mobile
  * browsers may also trigger this event on a touch screen, if the user performs
- * a quick tap. This can be used to attach element specific event listeners.
+ * a quick tap. This can be used to attach element-specific event listeners.
  *
  * @method mousePressed
- * @param  {Function|Boolean} fxn function to be fired when mouse is
+ * @param  {Function|Boolean} fxn Function to be fired when mouse is
  *                                pressed over the element.
- *                                if `false` is passed instead, the previously
+ *                                If `false` is passed instead, the previously
  *                                firing function will no longer fire.
  * @chainable
  * @example
@@ -251,7 +253,7 @@ p5.Element.prototype.mousePressed = function(fxn) {
  * @method doubleClicked
  * @param  {Function|Boolean} fxn function to be fired when mouse is
  *                                double clicked over the element.
- *                                if `false` is passed instead, the previously
+ *                                If `false` is passed instead, the previously
  *                                firing function will no longer fire.
  * @return {p5.Element}
  * @example
@@ -292,7 +294,7 @@ p5.Element.prototype.doubleClicked = function(fxn) {
 /**
  * The <a href="#/p5.Element/mouseWheel">mouseWheel()</a> function is called
  * once after every time a mouse wheel is scrolled over the element. This can
- * be used to attach element specific event listeners.
+ * be used to attach element-specific event listeners.
  *
  * The function accepts a callback function as argument which will be executed
  * when the `wheel` event is triggered on the element, the callback function is
@@ -307,7 +309,7 @@ p5.Element.prototype.doubleClicked = function(fxn) {
  * @method mouseWheel
  * @param  {Function|Boolean} fxn function to be fired when mouse is
  *                                scrolled over the element.
- *                                if `false` is passed instead, the previously
+ *                                If `false` is passed instead, the previously
  *                                firing function will no longer fire.
  * @chainable
  * @example
@@ -355,12 +357,12 @@ p5.Element.prototype.mouseWheel = function(fxn) {
  * The <a href="#/p5.Element/mouseReleased">mouseReleased()</a> function is
  * called once after every time a mouse button is released over the element.
  * Some mobile browsers may also trigger this event on a touch screen, if the
- * user performs a quick tap. This can be used to attach element specific event listeners.
+ * user performs a quick tap. This can be used to attach element-specific event listeners.
  *
  * @method mouseReleased
  * @param  {Function|Boolean} fxn function to be fired when mouse is
  *                                released over the element.
- *                                if `false` is passed instead, the previously
+ *                                If `false` is passed instead, the previously
  *                                firing function will no longer fire.
  * @chainable
  * @example
@@ -404,12 +406,12 @@ p5.Element.prototype.mouseReleased = function(fxn) {
  * The .<a href="#/p5.Element/mouseClicked">mouseClicked()</a> function is
  * called once after a mouse button is pressed and released over the element.
  * Some mobile browsers may also trigger this event on a touch screen, if the
- * user performs a quick tap.This can be used to attach element specific event listeners.
+ * user performs a quick tap. This can be used to attach element-specific event listeners.
  *
  * @method mouseClicked
  * @param  {Function|Boolean} fxn function to be fired when mouse is
  *                                clicked over the element.
- *                                if `false` is passed instead, the previously
+ *                                If `false` is passed instead, the previously
  *                                firing function will no longer fire.
  * @chainable
  * @example
@@ -454,12 +456,12 @@ p5.Element.prototype.mouseClicked = function(fxn) {
 /**
  * The .<a href="#/p5.Element/mouseMoved">mouseMoved()</a> function is called once every time a
  * mouse moves over the element. This can be used to attach an
- * element specific event listener.
+ * element-specific event listener.
  *
  * @method mouseMoved
  * @param  {Function|Boolean} fxn function to be fired when a mouse moves
  *                                over the element.
- *                                if `false` is passed instead, the previously
+ *                                If `false` is passed instead, the previously
  *                                firing function will no longer fire.
  * @chainable
  * @example
@@ -510,12 +512,12 @@ p5.Element.prototype.mouseMoved = function(fxn) {
 /**
  * The .<a href="#/p5.Element/mouseOver">mouseOver()</a> function is called once after every time a
  * mouse moves onto the element. This can be used to attach an
- * element specific event listener.
+ * element-specific event listener.
  *
  * @method mouseOver
  * @param  {Function|Boolean} fxn function to be fired when a mouse moves
  *                                onto the element.
- *                                if `false` is passed instead, the previously
+ *                                If `false` is passed instead, the previously
  *                                firing function will no longer fire.
  * @chainable
  * @example
@@ -551,12 +553,12 @@ p5.Element.prototype.mouseOver = function(fxn) {
 /**
  * The .<a href="#/p5.Element/mouseOut">mouseOut()</a> function is called once after every time a
  * mouse moves off the element. This can be used to attach an
- * element specific event listener.
+ * element-specific event listener.
  *
  * @method mouseOut
  * @param  {Function|Boolean} fxn function to be fired when a mouse
  *                                moves off of an element.
- *                                if `false` is passed instead, the previously
+ *                                If `false` is passed instead, the previously
  *                                firing function will no longer fire.
  * @chainable
  * @example
@@ -591,12 +593,12 @@ p5.Element.prototype.mouseOut = function(fxn) {
 
 /**
  * The .<a href="#/p5.Element/touchStarted">touchStarted()</a> function is called once after every time a touch is
- * registered. This can be used to attach element specific event listeners.
+ * registered. This can be used to attach element-specific event listeners.
  *
  * @method touchStarted
  * @param  {Function|Boolean} fxn function to be fired when a touch
  *                                starts over the element.
- *                                if `false` is passed instead, the previously
+ *                                If `false` is passed instead, the previously
  *                                firing function will no longer fire.
  * @chainable
  * @example
@@ -638,12 +640,12 @@ p5.Element.prototype.touchStarted = function(fxn) {
 
 /**
  * The .<a href="#/p5.Element/touchMoved">touchMoved()</a> function is called once after every time a touch move is
- * registered. This can be used to attach element specific event listeners.
+ * registered. This can be used to attach element-specific event listeners.
  *
  * @method touchMoved
  * @param  {Function|Boolean} fxn function to be fired when a touch moves over
  *                                the element.
- *                                if `false` is passed instead, the previously
+ *                                If `false` is passed instead, the previously
  *                                firing function will no longer fire.
  * @chainable
  * @example
@@ -677,12 +679,12 @@ p5.Element.prototype.touchMoved = function(fxn) {
 
 /**
  * The .<a href="#/p5.Element/touchEnded">touchEnded()</a> function is called once after every time a touch is
- * registered. This can be used to attach element specific event listeners.
+ * registered. This can be used to attach element-specific event listeners.
  *
  * @method touchEnded
  * @param  {Function|Boolean} fxn function to be fired when a touch ends
  *                                over the element.
- *                                if `false` is passed instead, the previously
+ *                                If `false` is passed instead, the previously
  *                                firing function will no longer fire.
  * @chainable
  * @example
@@ -725,12 +727,12 @@ p5.Element.prototype.touchEnded = function(fxn) {
 /**
  * The .<a href="#/p5.Element/dragOver">dragOver()</a> function is called once after every time a
  * file is dragged over the element. This can be used to attach an
- * element specific event listener.
+ * element-specific event listener.
  *
  * @method dragOver
  * @param  {Function|Boolean} fxn function to be fired when a file is
  *                                dragged over the element.
- *                                if `false` is passed instead, the previously
+ *                                If `false` is passed instead, the previously
  *                                firing function will no longer fire.
  * @chainable
  * @example
@@ -761,14 +763,14 @@ p5.Element.prototype.dragOver = function(fxn) {
 };
 
 /**
- * The .dragLeave() function is called once after every time a
+ * The .<a href="#/p5.Element/dragLeave">dragLeave()</a> function is called once after every time a
  * dragged file leaves the element area. This can be used to attach an
- * element specific event listener.
+ * element-specific event listener.
  *
  * @method dragLeave
  * @param  {Function|Boolean} fxn function to be fired when a file is
  *                                dragged off the element.
- *                                if `false` is passed instead, the previously
+ *                                If `false` is passed instead, the previously
  *                                firing function will no longer fire.
  * @chainable
  * @example

--- a/src/core/p5.Renderer.js
+++ b/src/core/p5.Renderer.js
@@ -10,7 +10,7 @@ import * as constants from '../core/constants';
 /**
  * Main graphics and rendering context, as well as the base API
  * implementation for p5.js "core". To be used as the superclass for
- * Renderer2D and Renderer3D classes, respectively.
+ * `Renderer2D` and `Renderer3D` classes, respectively.
  *
  * @class p5.Renderer
  * @constructor

--- a/src/core/p5.Renderer2D.js
+++ b/src/core/p5.Renderer2D.js
@@ -5,9 +5,9 @@ import filters from '../image/filters';
 import './p5.Renderer';
 
 /**
- * p5.Renderer2D
+ * `p5.Renderer2D`
  * The 2D graphics canvas renderer class.
- * extends p5.Renderer
+ * Extends `p5.Renderer`.
  */
 const styleEmpty = 'rgba(0,0,0,0)';
 // const alphaThreshold = 0.00125; // minimum visible

--- a/src/core/reference.js
+++ b/src/core/reference.js
@@ -39,7 +39,7 @@
  * elements can still be changeable. So if a variable is assigned an array, you
  * can still add or remove elements from the array but cannot reassign another
  * array to it. Also unlike `let`, you cannot declare variables without value
- * using const.
+ * using `const`.
  *
  * Constants have block-scope. This means that the constant only exists within
  * the <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/block">
@@ -48,7 +48,7 @@
  *
  * From <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/const">the MDN entry</a>:
  * Declares a read-only named constant.
- * Constants are block-scoped, much like variables defined using the 'let' statement.
+ * Constants are block-scoped, much like variables defined using the `let` statement.
  * The value of a constant can't be changed through reassignment, and it can't be redeclared.
  * @property const
  *
@@ -93,7 +93,7 @@
  * From <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Comparison_Operators">the MDN entry</a>:
  * The non-identity operator returns true if the operands are not equal and/or not of the same type.
  *
- * Note: In some examples around the web you may see a double-equals-sign
+ * Note: In some examples around the web, you may see a double-equals-sign
  * <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Comparison_Operators#Equality">==</a>,
  * used for comparison instead. This is the non-strict equality operator in Javascript.
  * This will convert the two values being compared to the same type before comparing them.
@@ -113,8 +113,8 @@
  */
 
 /**
- * The greater than operator <a href="#/p5/>">></a>
- * evaluates to true if the left value is greater than
+ * The greater than operator <a href="#/p5/>">&gt;</a>
+ * evaluates to `true` if the left value is greater than
  * the right value.
  *
  * <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Comparison_Operators">
@@ -135,8 +135,8 @@
  */
 
 /**
- * The greater than or equal to operator <a href="#/p5/>=">>=</a>
- * evaluates to true if the left value is greater than or equal to
+ * The greater than or equal to operator <a href="#/p5/>=">&gt;=</a>
+ * evaluates to `true` if the left value is greater than or equal to
  * the right value.
  *
  * <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Comparison_Operators">There is more info on comparison operators on MDN.</a>
@@ -156,8 +156,8 @@
  */
 
 /**
- * The less than operator <a href="#/p5/<"><</a>
- * evaluates to true if the left value is less than
+ * The less than operator <a href="#/p5/<">&lt;</a>
+ * evaluates to `true` if the left value is less than
  * the right value.
  *
  * <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Comparison_Operators">There is more info on comparison operators on MDN.</a>
@@ -177,8 +177,8 @@
  */
 
 /**
- * The less than or equal to operator <a href="#/p5/<="><=</a>
- * evaluates to true if the left value is less than or equal to
+ * The less than or equal to operator <a href="#/p5/<=">&lt;=</a>
+ * evaluates to `true` if the left value is less than or equal to
  * the right value.
  *
  * <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Comparison_Operators">There is more info on comparison operators on MDN.</a>
@@ -200,16 +200,16 @@
 /**
  * The <a href="#/p5/if-else">if-else</a> statement helps control the flow of your code.
  *
- * A condition is placed between the parenthesis following 'if',
- * when that condition evalues to <a href="https://developer.mozilla.org/en-US/docs/Glossary/truthy">truthy</a>,
+ * A condition is placed between the parenthesis following `if`.
+ * When that condition evalues to <a href="https://developer.mozilla.org/en-US/docs/Glossary/truthy">truthy</a>,
  * the code between the following curly braces is run.
  * Alternatively, when the condition evaluates to <a href="https://developer.mozilla.org/en-US/docs/Glossary/Falsy">falsy</a>,
- * the code between the curly braces of 'else' block is run instead. Writing an
- * else block is optional.
+ * the code between the curly braces of `else` block is run instead. Writing an
+ * `else` block is optional.
  *
  * From <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/if...else">the MDN entry</a>:
  * The 'if' statement executes a statement if a specified condition is truthy.
- * If the condition is falsy, another statement can be executed
+ * If the condition is falsy, another statement can be executed.
  * @property if-else
  *
  * @example
@@ -234,7 +234,7 @@
  *
  * Optionally, functions can have parameters. <a href="https://developer.mozilla.org/en-US/docs/Glossary/Parameter">Parameters</a>
  * are variables that are scoped to the function, that can be assigned a value
- * when calling the function.Multiple parameters can be given by seperating them
+ * when calling the function. Multiple parameters can be given by seperating them
  * with commmas.
  *
  * From <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function">the MDN entry</a>:
@@ -290,7 +290,7 @@
  * A boolean can only be `true` or `false`.
  *
  * From <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Data_structures#Boolean_type">the MDN entry</a>:
- * Boolean represents a logical entity and can have two values: true, and false.
+ * Boolean represents a logical entity and can have two values: `true`, and `false`.
  *
  * @property boolean
  *
@@ -309,7 +309,7 @@
 /**
  * A <a href="#/p5/string">string</a> is one of the 7 <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Data_structures#Primitive_values">primitive data types</a> in Javascript.
  * A string is a series of text characters. In Javascript, a string value must
- * be surrounded by either single-quotation marks(') or double-quotation marks(").
+ * be surrounded by either single-quotation marks(`) or double-quotation marks(`"`).
  *
  * From <a href="https://developer.mozilla.org/en-US/docs/Glossary/string">the MDN entry</a>:
  * A string is a sequence of characters used to represent text.
@@ -410,25 +410,25 @@
  * section of code multiple times.
  *
  * A 'for loop' consists of three different expressions inside of a parenthesis,
- * all of which are optional.These expressions are used to control the number of
- * times the loop is run.The first expression is a statement that is used to set
- * the initial state for the loop.The second expression is a condition that you
- * would like to check before each loop. If this expression returns false then
- * the loop will exit.The third expression is executed at the end of each loop.
- * These expression are separated by ; (semi-colon).In case of an empty expression,
+ * all of which are optional. These expressions are used to control the number of
+ * times the loop is run. The first expression is a statement that is used to set
+ * the initial state for the loop. The second expression is a condition that you
+ * would like to check before each loop. If this expression returns `false`, then
+ * the loop will exit. The third expression is executed at the end of each loop.
+ * These expression are separated by `;` (semi-colons). In case of an empty expression,
  * only a semi-colon is written.
  *
  * The code inside of the loop body (in between the curly braces) is executed between the evaluation of the second
  * and third expression.
  *
  * As with any loop, it is important to ensure that the loop can 'exit', or that
- * the test condition will eventually evaluate to false. The test condition with a <a href="#/p5/for">for</a> loop
+ * the test condition will eventually evaluate to `false`. The test condition with a <a href="#/p5/for">for</a> loop
  * is the second expression detailed above. Ensuring that this expression can eventually
- * become false ensures that your loop doesn't attempt to run an infinite amount of times,
+ * become `false` ensures that your loop doesn't attempt to run an infinite amount of times,
  * which can crash your browser.
  *
  * From <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/for">the MDN entry</a>:
- * Creates a loop that executes a specified statement until the test condition evaluates to false.
+ * Creates a loop that executes a specified statement until the test condition evaluates to `false`.
  * The condition is evaluated after executing the statement, resulting in the specified statement executing at least once.
  * @property for
  *
@@ -451,12 +451,12 @@
  *
  * With a 'while loop', the code inside of the loop body (between the curly
  * braces) is run repeatedly until the test condition (inside of the parenthesis)
- * evaluates to false. The condition is tested before executing the code body
+ * evaluates to `false`. The condition is tested before executing the code body
  * with <a href="#/p5/while">while</a>, so if the condition is initially false
  * the loop body, or statement, will never execute.
  *
  * As with any loop, it is important to ensure that the loop can 'exit', or that
- * the test condition will eventually evaluate to false. This is to keep your loop
+ * the test condition will eventually evaluate to `false`. This is to keep your loop
  * from trying to run an infinite amount of times, which can crash your browser.
  *
  * From <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/while">the MDN entry</a>:
@@ -489,7 +489,7 @@
 
 /**
  * From <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/JSON/stringify">the MDN entry</a>:
- * The JSON.stringify() method converts a JavaScript object or value to a JSON <a href="#/p5/string">string</a>.
+ * The `JSON.stringify()` method converts a JavaScript object or value to a JSON <a href="#/p5/string">string</a>.
  * @method stringify
  * @static
  * @for JSON

--- a/src/core/rendering.js
+++ b/src/core/rendering.js
@@ -15,9 +15,9 @@ const defaultClass = 'p5Canvas';
 /**
  * Creates a canvas element in the document, and sets the dimensions of it
  * in pixels. This method should be called only once at the start of setup.
- * Calling <a href="#/p5/createCanvas">createCanvas</a> more than once in a
+ * Calling <a href="#/p5/createCanvas">createCanvas()</a> more than once in a
  * sketch will result in very unpredictable behavior. If you want more than
- * one drawing canvas you could use <a href="#/p5/createGraphics">createGraphics</a>
+ * one drawing canvas you could use <a href="#/p5/createGraphics">createGraphics()</a>
  * (hidden by default but it can be shown).
  *
  * Important note: in 2D mode (i.e. when `p5.Renderer` is not set) the origin (0,0)
@@ -181,7 +181,7 @@ p5.prototype.resizeCanvas = function(w, h, noRedraw) {
 };
 
 /**
- * Removes the default canvas for a p5 sketch that doesn't require a canvas
+ * Removes the default canvas for a p5 sketch that doesn't require a canvas.
  * @method noCanvas
  * @example
  * <div>
@@ -202,7 +202,7 @@ p5.prototype.noCanvas = function() {
 };
 
 /**
- * Creates and returns a new p5.Renderer object. Use this class if you need
+ * Creates and returns a new `p5.Renderer` object. Use this class if you need
  * to draw into an off-screen graphics buffer. The two parameters define the
  * width and height in pixels.
  *
@@ -244,36 +244,53 @@ p5.prototype.createGraphics = function(w, h, renderer) {
  * Blends the pixels in the display window according to the defined mode.
  * There is a choice of the following modes to blend the source pixels (A)
  * with the ones of pixels already in the display window (B):
+ *
  * <ul>
  * <li><code>BLEND</code> - linear interpolation of colours: C =
  * A*factor + B. <b>This is the default blending mode.</b></li>
+ *
  * <li><code>ADD</code> - sum of A and B</li>
+ *
  * <li><code>DARKEST</code> - only the darkest colour succeeds: C =
  * min(A*factor, B).</li>
+ *
  * <li><code>LIGHTEST</code> - only the lightest colour succeeds: C =
  * max(A*factor, B).</li>
+ *
  * <li><code>DIFFERENCE</code> - subtract colors from underlying image.</li>
+ *
  * <li><code>EXCLUSION</code> - similar to <code>DIFFERENCE</code>, but less
  * extreme.</li>
+ *
  * <li><code>MULTIPLY</code> - multiply the colors, result will always be
  * darker.</li>
+ *
  * <li><code>SCREEN</code> - opposite multiply, uses inverse values of the
  * colors.</li>
+ *
  * <li><code>REPLACE</code> - the pixels entirely replace the others and
  * don't utilize alpha (transparency) values.</li>
+ *
  * <li><code>REMOVE</code> - removes pixels from B with the alpha strength of A.</li>
+ *
  * <li><code>OVERLAY</code> - mix of <code>MULTIPLY</code> and <code>SCREEN
  * </code>. Multiplies dark values, and screens light values. <em>(2D)</em></li>
+ *
  * <li><code>HARD_LIGHT</code> - <code>SCREEN</code> when greater than 50%
  * gray, <code>MULTIPLY</code> when lower. <em>(2D)</em></li>
+ *
  * <li><code>SOFT_LIGHT</code> - mix of <code>DARKEST</code> and
  * <code>LIGHTEST</code>. Works like <code>OVERLAY</code>, but not as harsh. <em>(2D)</em>
  * </li>
+ *
  * <li><code>DODGE</code> - lightens light tones and increases contrast,
  * ignores darks. <em>(2D)</em></li>
+ *
  * <li><code>BURN</code> - darker areas are applied, increasing contrast,
  * ignores lights. <em>(2D)</em></li>
+ *
  * <li><code>SUBTRACT</code> - remainder of A and B <em>(3D)</em></li>
+ *
  * </ul>
  *
  * <em>(2D)</em> indicates that this blend mode <b>only</b> works in the 2D renderer.<br>
@@ -283,7 +300,7 @@ p5.prototype.createGraphics = function(w, h, renderer) {
  * @param  {Constant} mode blend mode to set for canvas.
  *                either BLEND, DARKEST, LIGHTEST, DIFFERENCE, MULTIPLY,
  *                EXCLUSION, SCREEN, REPLACE, OVERLAY, HARD_LIGHT,
- *                SOFT_LIGHT, DODGE, BURN, ADD, REMOVE or SUBTRACT
+ *                SOFT_LIGHT, DODGE, BURN, ADD, REMOVE, or SUBTRACT
  * @example
  * <div>
  * <code>

--- a/src/core/shape/2d_primitives.js
+++ b/src/core/shape/2d_primitives.js
@@ -21,17 +21,17 @@ import '../friendly_errors/validate_params';
  *          0 <= start < TWO_PI ;    start <= stop < start + TWO_PI
  *
  *      This means that the arc rendering functions don't have to be concerned
- *      with what happens if stop is smaller than start, or if the arc 'goes
- *      round more than once', etc.: they can just start at start and increase
- *      until stop and the correct arc will be drawn.
+ *      with what happens if `stop` is smaller than `start`, or if the arc 'goes
+ *      round more than once', etc.: they can just start at `start` and increase
+ *      until `stop`, and the correct arc will be drawn.
  *
  *   2. Optionally adjusts the angles within each quadrant to counter the naive
  *      scaling of the underlying ellipse up from the unit circle.  Without
- *      this, the angles become arbitrary when width != height: 45 degrees
+ *      this, the angles become arbitrary when `width != height`: 45 degrees
  *      might be drawn at 5 degrees on a 'wide' ellipse, or at 85 degrees on
  *      a 'tall' ellipse.
  *
- *   3. Flags up when start and stop correspond to the same place on the
+ *   3. Flags up when `start` and `stop` correspond to the same place on the
  *      underlying ellipse.  This is useful if you want to do something special
  *      there (like rendering a whole ellipse instead).
  */
@@ -100,16 +100,21 @@ p5.prototype._normalizeArcAngles = (
 };
 
 /**
- * Draw an arc to the screen. If called with only x, y, w, h, start and stop,
- * the arc will be drawn and filled as an open pie segment. If a mode parameter
- * is provided, the arc will be filled like an open semi-circle (OPEN), a closed
- * semi-circle (CHORD), or as a closed pie segment (PIE). The origin may be changed
- * with the <a href="#/p5/ellipseMode">ellipseMode()</a> function.
+ * Draw an arc to the screen.
  *
- * The arc is always drawn clockwise from wherever start falls to wherever stop
- * falls on the ellipse. Adding or subtracting TWO_PI to either angle does not
- * change where they fall. If both start and stop fall at the same place, a full
- * ellipse will be drawn. Be aware that the y-axis increases in the downward
+ * If called with only `x`, `y`, `w`, `h`, `start`, and `stop`, the arc will be
+ * drawn and filled as an open pie segment.
+ *
+ * If a `mode` parameter is provided, the arc will be filled like an open
+ * semi-circle (OPEN), a closed semi-circle (CHORD), or as a closed pie segment (PIE).
+ * The origin may be changed with the <a href="#/p5/ellipseMode">ellipseMode()</a> function.
+ *
+ * The arc is always drawn clockwise from wherever `start` falls to wherever `stop`
+ * falls on the ellipse. Adding or subtracting `TWO_PI` to either angle does not
+ * change where they fall. If both `start` and `stop` fall at the same place, a full
+ * ellipse will be drawn.
+ *
+ * Be aware that the y-axis increases in the downward
  * direction, therefore angles are measured clockwise from the positive
  * x-direction ("3 o'clock").
  *
@@ -121,7 +126,7 @@ p5.prototype._normalizeArcAngles = (
  * @param  {Number} start  angle to start the arc, specified in radians
  * @param  {Number} stop   angle to stop the arc, specified in radians
  * @param  {Constant} [mode] optional parameter to determine the way of drawing
- *                         the arc. either CHORD, PIE or OPEN
+ *                         the arc. either CHORD, PIE, or OPEN
  * @param  {Integer} [detail] optional parameter for WebGL mode only. This is to
  *                         specify the number of vertices that makes up the
  *                         perimeter of the arc. Default value is 25. Won't
@@ -232,9 +237,10 @@ p5.prototype.arc = function(x, y, w, h, start, stop, mode, detail) {
 /**
  * Draws an ellipse (oval) to the screen. By default, the first two parameters
  * set the location of the center of the ellipse, and the third and fourth
- * parameters set the shape's width and height. If no height is specified, the
- * value of width is used for both the width and height. If a negative height or
- * width is specified, the absolute value is taken.
+ * parameters set the shape's width and height.
+ *
+ * If no height is specified, the value of width is used for both the width and height.
+ * If a negative height or width is specified, the absolute value is taken.
  *
  * An ellipse with equal width and height is a circle. The origin may be changed
  * with the <a href="#/p5/ellipseMode">ellipseMode()</a> function.
@@ -275,7 +281,7 @@ p5.prototype.ellipse = function(x, y, w, h, detailX) {
 /**
  * Draws a circle to the screen. A circle is a simple closed shape. It is the set
  * of all points in a plane that are at a given distance from a given point,
- * the centre. This function is a special case of the ellipse() function, where
+ * the centre. This function is a special case of the `ellipse()` function, where
  * the width and height of the ellipse are the same. Height and width of the
  * ellipse correspond to the diameter of the circle. By default, the first two
  * parameters set the location of the centre of the circle, the third sets the
@@ -340,9 +346,11 @@ p5.prototype._renderEllipse = function(x, y, w, h, detailX) {
  * Draws a line (a direct path between two points) to the screen. If called with
  * only 4 parameters, it will draw a line in 2D with a default width of 1 pixel.
  * This width can be modified by using the <a href="#/p5/strokeWeight">
- * strokeWeight()</a> function. A line cannot be filled, therefore the <a
- * href="#/p5/fill">fill()</a> function will not affect the color of a line. So to
- * color a line, use the <a href="#/p5/stroke">stroke()</a> function.
+ * strokeWeight()</a> function.
+ *
+ * A line cannot be filled; therefore the <a href="#/p5/fill">fill()</a> function
+ * will not affect the color of a line. To color a line, use the
+ * <a href="#/p5/stroke">stroke()</a> function.
  *
  * @method line
  * @param  {Number} x1 the x-coordinate of the first point
@@ -478,10 +486,10 @@ p5.prototype.point = function(...args) {
 /**
  * Draws a quad on the canvas. A quad is a quadrilateral, a four sided polygon. It is
  * similar to a rectangle, but the angles between its edges are not
- * constrained to ninety degrees. The first pair of parameters (x1,y1)
- * sets the first vertex and the subsequent pairs should proceed
+ * constrained to ninety degrees. The first pair of parameters (`x1`,`y1`)
+ * sets the first vertex, and the subsequent pairs should proceed
  * clockwise or counter-clockwise around the defined shape.
- * z-arguments only work when quad() is used in WEBGL mode.
+ * z-arguments only work when `quad()` is used in WEBGL mode.
  *
  * @method quad
  * @param {Number} x1 the x-coordinate of the first point
@@ -553,11 +561,11 @@ p5.prototype.quad = function(...args) {
  * Draws a rectangle on the canvas. A rectangle is a four-sided closed shape with
  * every angle at ninety degrees. By default, the first two parameters set
  * the location of the upper-left corner, the third sets the width, and the
- * fourth sets the height. The way these parameters are interpreted, may be
+ * fourth sets the height. The way these parameters are interpreted may be
  * changed with the <a href="#/p5/rectMode">rectMode()</a> function.
  *
- * The fifth, sixth, seventh and eighth parameters, if specified,
- * determine corner radius for the top-left, top-right, lower-right and
+ * The fifth, sixth, seventh, and eighth parameters, if specified,
+ * determine corner radius for the top-left, top-right, lower-right, and
  * lower-left corners, respectively. An omitted corner radius parameter is set
  * to the value of the previously specified radius value in the parameter list.
  *
@@ -618,13 +626,13 @@ p5.prototype.rect = function() {
 /**
  * Draws a square to the screen. A square is a four-sided shape with every angle
  * at ninety degrees, and equal side size. This function is a special case of the
- * rect() function, where the width and height are the same, and the parameter
- * is called "s" for side size. By default, the first two parameters set the
+ * `rect()` function, where the width and height are the same, and the parameter
+ * is called `s`" for side size. By default, the first two parameters set the
  * location of the upper-left corner, the third sets the side size of the square.
  * The way these parameters are interpreted, may be changed with the <a
  * href="#/p5/rectMode">rectMode()</a> function.
  *
- * The fourth, fifth, sixth and seventh parameters, if specified,
+ * The fourth, fifth, sixth, and seventh parameters, if specified,
  * determine corner radius for the top-left, top-right, lower-right and
  * lower-left corners, respectively. An omitted corner radius parameter is set
  * to the value of the previously specified radius value in the parameter list.

--- a/src/core/shape/attributes.js
+++ b/src/core/shape/attributes.js
@@ -18,15 +18,15 @@ import * as constants from '../constants';
  * as the shape's center point's x and y coordinates respectively, while the third
  * and fourth parameters are its width and height.
  *
- * ellipseMode(RADIUS) also uses the first two parameters as the shape's center
+ * `ellipseMode(RADIUS)` also uses the first two parameters as the shape's center
  * point's x and y coordinates, but uses the third and fourth parameters to
  * specify half of the shapes's width and height.
  *
- * ellipseMode(CORNER) interprets the first two parameters as the upper-left
+ * `ellipseMode(CORNER)` interprets the first two parameters as the upper-left
  * corner of the shape, while the third and fourth parameters are its width
  * and height.
  *
- * ellipseMode(CORNERS) interprets the first two parameters as the location of
+ * `ellipseMode(CORNERS)` interprets the first two parameters as the location of
  * one corner of the ellipse's bounding box, and the third and fourth parameters
  * as the location of the opposite corner.
  *
@@ -120,16 +120,16 @@ p5.prototype.noSmooth = function() {
  * upper-left corner of the shape, while the third and fourth parameters are its
  * width and height.
  *
- * rectMode(CORNERS) interprets the first two parameters as the location of
+ * `rectMode(CORNERS)` interprets the first two parameters as the location of
  * one of the corners, and the third and fourth parameters as the location of
  * the diagonally opposite corner. Note, the rectangle is drawn between the
  * coordinates, so it is not neccesary that the first corner be the upper left
  * corner.
  *
- * rectMode(CENTER) interprets the first two parameters as the shape's center
+ * `rectMode(CENTER)` interprets the first two parameters as the shape's center
  * point, while the third and fourth parameters are its width and height.
  *
- * rectMode(RADIUS) also uses the first two parameters as the shape's center
+ * `rectMode(RADIUS)` also uses the first two parameters as the shape's center
  * point, but uses the third and fourth parameters to specify half of the shape's
  * width and height respectively.
  *
@@ -218,14 +218,14 @@ p5.prototype.smooth = function() {
 
 /**
  * Sets the style for rendering line endings. These ends are either rounded,
- * squared or extended, each of which specified with the corresponding
- * parameters: ROUND, SQUARE and PROJECT. The default cap is ROUND.
+ * squared, or extended, each of which specified with the corresponding
+ * parameters: ROUND, SQUARE, and PROJECT. The default cap is ROUND.
  *
  * The parameter to this method must be written in ALL CAPS because they are
  * predefined as constants in ALL CAPS and Javascript is a case-sensitive language.
  *
  * @method strokeCap
- * @param  {Constant} cap either ROUND, SQUARE or PROJECT
+ * @param  {Constant} cap either ROUND, SQUARE, or PROJECT
  * @chainable
  * @example
  * <div>
@@ -258,15 +258,15 @@ p5.prototype.strokeCap = function(cap) {
 
 /**
  * Sets the style of the joints which connect line segments. These joints
- * are either mitered, beveled or rounded and specified with the
- * corresponding parameters MITER, BEVEL and ROUND. The default joint is
+ * are either mitered, beveled, or rounded, and specified with the
+ * corresponding parameters MITER, BEVEL, and ROUND. The default joint is
  * MITER.
  *
  * The parameter to this method must be written in ALL CAPS because they are
  * predefined as constants in ALL CAPS and Javascript is a case-sensitive language.
  *
  * @method strokeJoin
- * @param  {Constant} join either MITER, BEVEL, ROUND
+ * @param  {Constant} join either MITER, BEVEL, or ROUND
  * @chainable
  * @example
  * <div>

--- a/src/core/shape/curves.js
+++ b/src/core/shape/curves.js
@@ -92,7 +92,7 @@ p5.prototype.bezier = function(...args) {
 /**
  * Sets the resolution at which Bezier's curve is displayed. The default value is 20.
  *
- * Note, This function is only useful when using the WEBGL renderer
+ * Note: This function is only useful when using the WEBGL renderer
  * as the default canvas renderer does not use this information.
  *
  * @method bezierDetail
@@ -129,12 +129,12 @@ p5.prototype.bezierDetail = function(d) {
 
 /**
  * Given the x or y co-ordinate values of control and anchor points of a bezier
- * curve, it evaluates the x or y coordinate of the bezier at position t. The
- * parameters a and d are the x or y coordinates of first and last points on the
- * curve while b and c are of the control points.The final parameter t is the
- * position of the resultant point which is given between 0 and 1.
+ * curve, it evaluates the x or y coordinate of the bezier at position `t`. The
+ * parameters `a` and `d` are the x or y coordinates of first and last points on the
+ * curve, while `b` and `c` are the control points. The final parameter `t` is the
+ * position of the resulting point, which is given between 0 and 1.
  * This can be done once with the x coordinates and a second time
- * with the y coordinates to get the location of a bezier curve at t.
+ * with the y coordinates to get the location of a bezier curve at `t`.
  *
  * @method bezierPoint
  * @param {Number} a coordinate of first point on the curve
@@ -183,10 +183,10 @@ p5.prototype.bezierPoint = function(a, b, c, d, t) {
 };
 
 /**
- * Evaluates the tangent to the Bezier at position t for points a, b, c, d.
- * The parameters a and d are the first and last points
- * on the curve, and b and c are the control points.
- * The final parameter t varies between 0 and 1.
+ * Evaluates the tangent to the Bezier at position `t` for points `a`, `b`, `c`, `d`.
+ * The parameters `a` and `d` are the first and last points
+ * on the curve, and `b` and `c` are the control points.
+ * The final parameter `t` varies between 0 and 1.
  *
  * @method bezierTangent
  * @param {Number} a coordinate of first point on the curve
@@ -397,7 +397,7 @@ p5.prototype.curveDetail = function(d) {
 
 /**
  * Modifies the quality of forms created with <a href="#/p5/curve">curve()</a>
- * and <a href="#/p5/curveVertex">curveVertex()</a>.The parameter tightness
+ * and <a href="#/p5/curveVertex">curveVertex()</a>. The parameter `amount`
  * determines how the curve fits to the vertex points. The value 0.0 is the
  * default value for tightness (this value defines the curves to be Catmull-Rom
  * splines) and the value 1.0 connects all the points with straight lines.
@@ -442,11 +442,11 @@ p5.prototype.curveTightness = function(t) {
 };
 
 /**
- * Evaluates the curve at position t for points a, b, c, d.
- * The parameter t varies between 0 and 1, a and d are control points
- * of the curve, and b and c are the start and end points of the curve.
+ * Evaluates the curve at position `t` for points `a`, `b`, `c`, `d`.
+ * The parameter `t` varies between 0 and 1, `a` and `d` are control points
+ * of the curve, and `b` and `c` are the start and end points of the curve.
  * This can be done once with the x coordinates and a second time
- * with the y coordinates to get the location of a curve at t.
+ * with the y coordinates to get the location of a curve at `t`.
  *
  * @method curvePoint
  * @param {Number} a coordinate of first control point of the curve
@@ -491,9 +491,9 @@ p5.prototype.curvePoint = function(a, b, c, d, t) {
 };
 
 /**
- * Evaluates the tangent to the curve at position t for points a, b, c, d.
- * The parameter t varies between 0 and 1, a and d are points on the curve,
- * and b and c are the control points.
+ * Evaluates the tangent to the curve at position `t` for points `a`, `b`, `c`, `d`.
+ * The parameter `t` varies between 0 and 1, `a` and `d` are points on the curve,
+ * and `b` and `c` are the control points.
  *
  * @method curveTangent
  * @param {Number} a coordinate of first control point

--- a/src/core/shape/vertex.js
+++ b/src/core/shape/vertex.js
@@ -107,7 +107,7 @@ p5.prototype.beginContour = function() {
  *
  * @method beginShape
  * @param  {Constant} [kind] either POINTS, LINES, TRIANGLES, TRIANGLE_FAN
- *                                TRIANGLE_STRIP, QUADS, QUAD_STRIP or TESS
+ *                                TRIANGLE_STRIP, QUADS, QUAD_STRIP, or TESS
  * @chainable
  * @example
  * <div>
@@ -292,13 +292,13 @@ p5.prototype.beginShape = function(kind) {
 
 /**
  * Specifies vertex coordinates for Bezier curves. Each call to
- * bezierVertex() defines the position of two control points and
+ * `bezierVertex()` defines the position of two control points and
  * one anchor point of a Bezier curve, adding a new segment to a
- * line or shape. For WebGL mode bezierVertex() can be used in 2D
+ * line or shape. For WebGL mode `bezierVertex()` can be used in 2D
  * as well as 3D mode. 2D mode expects 6 parameters, while 3D mode
  * expects 9 parameters (including z coordinates).
  *
- * The first time bezierVertex() is used within a <a href="#/p5/beginShape">beginShape()</a>
+ * The first time `bezierVertex()` is used within a <a href="#/p5/beginShape">beginShape()</a>
  * call, it must be prefaced with a call to <a href="#/p5/vertex">vertex()</a> to set the first anchor
  * point. This function must be used between <a href="#/p5/beginShape">beginShape()</a> and <a href="#/p5/endShape">endShape()</a>
  * and only when there is no MODE or POINTS parameter specified to
@@ -416,15 +416,15 @@ p5.prototype.bezierVertex = function(...args) {
  * Specifies vertex coordinates for curves. This function may only
  * be used between <a href="#/p5/beginShape">beginShape()</a> and <a href="#/p5/endShape">endShape()</a> and only when there
  * is no MODE parameter specified to <a href="#/p5/beginShape">beginShape()</a>.
- * For WebGL mode curveVertex() can be used in 2D as well as 3D mode.
+ * For WebGL mode `curveVertex()` can be used in 2D as well as 3D mode.
  * 2D mode expects 2 parameters, while 3D mode expects 3 parameters.
  *
- * The first and last points in a series of curveVertex() lines will be used to
+ * The first and last points in a series of `curveVertex()` lines will be used to
  * guide the beginning and end of a the curve. A minimum of four
  * points is required to draw a tiny curve between the second and
- * third points. Adding a fifth point with curveVertex() will draw
+ * third points. Adding a fifth point with `curveVertex()` will draw
  * the curve between the second, third, and fourth points. The
- * curveVertex() function is an implementation of Catmull-Rom
+ * `curveVertex()` function is an implementation of Catmull-Rom
  * splines.
  *
  * @method curveVertex
@@ -523,7 +523,7 @@ p5.prototype.curveVertex = function(...args) {
 
 /**
  * Use the <a href="#/p5/beginContour">beginContour()</a> and <a href="#/p5/endContour">endContour()</a> functions to create negative
- * shapes within shapes such as the center of the letter 'O'. <a href="#/p5/beginContour">beginContour()</a>
+ * shapes within shapes (such as the center of the letter `O`). <a href="#/p5/beginContour">beginContour()</a>
  * begins recording vertices for the shape and <a href="#/p5/endContour">endContour()</a> stops recording.
  * The vertices that define a negative shape must "wind" in the opposite
  * direction from the exterior shape. First draw vertices for the exterior
@@ -667,11 +667,11 @@ p5.prototype.endShape = function(mode) {
 
 /**
  * Specifies vertex coordinates for quadratic Bezier curves. Each call to
- * quadraticVertex() defines the position of one control points and one
+ * `quadraticVertex()` defines the position of one control points and one
  * anchor point of a Bezier curve, adding a new segment to a line or shape.
- * The first time quadraticVertex() is used within a <a href="#/p5/beginShape">beginShape()</a> call, it
+ * The first time `quadraticVertex()` is used within a <a href="#/p5/beginShape">beginShape()</a> call, it
  * must be prefaced with a call to <a href="#/p5/vertex">vertex()</a> to set the first anchor point.
- * For WebGL mode quadraticVertex() can be used in 2D as well as 3D mode.
+ * For WebGL mode `quadraticVertex()` can be used in 2D as well as 3D mode.
  * 2D mode expects 4 parameters, while 3D mode expects 6 parameters
  * (including z coordinates).
  *
@@ -1003,7 +1003,7 @@ p5.prototype.vertex = function(x, y, moveTo, u, v) {
 /**
  * Sets the 3d vertex normal to use for subsequent vertices drawn with
  * <a href="#/p5/vertex">vertex()</a>. A normal is a vector that is generally
- * nearly perpendicular to a shape's surface which controls how much light will
+ * nearly perpendicular to a shape's surface, which controls how much light will
  * be reflected from that part of the surface.
  *
  * @method normal

--- a/src/core/structure.js
+++ b/src/core/structure.js
@@ -28,7 +28,7 @@ import p5 from './main';
  * has been specified. Otherwise, the sketch would enter an odd state until
  * <a href="#/p5/loop">loop()</a> was called.
  *
- * Use <a href="#/p5/isLooping">isLooping()</a> to check current state of loop().
+ * Use <a href="#/p5/isLooping">isLooping()</a> to check current state of `loop()`.
  *
  * @method noLoop
  * @example
@@ -81,14 +81,14 @@ p5.prototype.noLoop = function() {
 };
 
 /**
- * By default, p5.js loops through draw() continuously, executing the code within
+ * By default, p5.js loops through `draw()` continuously, executing the code within
  * it. However, the <a href="#/p5/draw">draw()</a> loop may be stopped by calling
  * <a href="#/p5/noLoop">noLoop()</a>. In that case, the <a href="#/p5/draw">draw()</a>
- * loop can be resumed with loop().
+ * loop can be resumed with `loop()`.
  *
- * Avoid calling loop() from inside setup().
+ * Avoid calling `loop()` from inside `setup()`.
  *
- * Use <a href="#/p5/isLooping">isLooping()</a> to check current state of loop().
+ * Use <a href="#/p5/isLooping">isLooping()</a> to check current state of `loop()`.
  *
  * @method loop
  * @example
@@ -192,8 +192,11 @@ p5.prototype.isLooping = function() {
 /**
  * The <a href="#/p5/push">push()</a> function saves the current drawing style
  * settings and transformations, while <a href="#/p5/pop">pop()</a> restores these
- * settings. Note that these functions are always used together. They allow you to
+ * settings.
+ *
+ * Note that these functions are always used together. They allow you to
  * change the style and transformation settings and later return to what you had.
+ *
  * When a new state is started with <a href="#/p5/push">push()</a>, it builds on
  * the current style and transform information. The <a href="#/p5/push">push()</a>
  * and <a href="#/p5/pop">pop()</a> functions can be embedded to provide more
@@ -227,7 +230,7 @@ p5.prototype.isLooping = function() {
  * <a href="#/p5/translate">translate()</a>,
  * <a href="#/p5/noiseSeed">noiseSeed()</a>.
  *
- * In WEBGL mode additional style settings are stored. These are controlled by the
+ * In WEBGL mode, additional style settings are stored. These are controlled by the
  * following functions: <a href="#/p5/setCamera">setCamera()</a>,
  * <a href="#/p5/ambientLight">ambientLight()</a>,
  * <a href="#/p5/directionalLight">directionalLight()</a>,
@@ -290,9 +293,13 @@ p5.prototype.push = function() {
 /**
  * The <a href="#/p5/push">push()</a> function saves the current drawing style
  * settings and transformations, while <a href="#/p5/pop">pop()</a> restores
- * these settings. Note that these functions are always used together. They allow
+ * these settings.
+ *
+ * Note that these functions are always used together. They allow
  * you to change the style and transformation settings and later return to what
- * you had. When a new state is started with <a href="#/p5/push">push()</a>, it
+ * you had.
+ *
+ * When a new state is started with <a href="#/p5/push">push()</a>, it
  * builds on the current style and transform information. The <a href="#/p5/push">push()</a>
  * and <a href="#/p5/pop">pop()</a> functions can be embedded to provide more
  * control. (See the second example for a demonstration.)
@@ -325,7 +332,7 @@ p5.prototype.push = function() {
  * <a href="#/p5/translate">translate()</a>,
  * <a href="#/p5/noiseSeed">noiseSeed()</a>.
  *
- * In WEBGL mode additional style settings are stored. These are controlled by
+ * In WEBGL, mode additional style settings are stored. These are controlled by
  * the following functions:
  * <a href="#/p5/setCamera">setCamera()</a>,
  * <a href="#/p5/ambientLight">ambientLight()</a>,
@@ -511,12 +518,12 @@ p5.prototype.redraw = function(n) {
  * are bound up in a single variable instead of polluting your global namespace.
  *
  * Optionally, you can specify a default container for the canvas and any other elements
- * to append to with a second argument. You can give the ID of an element in your html,
- * or an html node itself.
+ * to append to with a second argument. You can give the ID of an element in your HTML,
+ * or an HTML node itself.
  *
- * Note that creating instances like this also allows you to have more than one p5 sketch on
- * a single web page, as they will each be wrapped up with their own set up variables. Of
- * course, you could also use iframes to have multiple sketches in global mode.
+ * Note: Creating instances like this also allows you to have more than one p5 sketch on
+ * a single web page, as they will each be wrapped up with their own set up variables.
+ * Alternatively, you could also use `iframe` elements to have multiple sketches in global mode.
  *
  * @method p5
  * @param {Object} sketch a function containing a p5.js sketch

--- a/src/core/transform.js
+++ b/src/core/transform.js
@@ -199,7 +199,7 @@ p5.prototype.resetMatrix = function() {
  * origin and positive numbers rotate objects in a clockwise direction.
  * Transformations apply to everything that happens after and subsequent
  * calls to the function accumulates the effect. For example, calling
- * rotate(HALF_PI) and then rotate(HALF_PI) is the same as rotate(PI).
+ * `rotate(HALF_PI)` and then `rotate(HALF_PI)` is the same as `rotate(PI)`.
  * All transformations are reset when <a href="#/p5/draw">draw()</a> begins again.
  *
  * Technically, <a href="#/p5/rotate">rotate()</a> multiplies the current transformation matrix
@@ -208,7 +208,7 @@ p5.prototype.resetMatrix = function() {
  *
  * @method rotate
  * @param  {Number} angle the angle of rotation, specified in radians
- *                        or degrees, depending on current angleMode
+ *                        or degrees, depending on current `angleMode`
  * @param  {p5.Vector|Number[]} [axis] (in 3d) the axis to rotate around
  * @chainable
  * @example
@@ -239,7 +239,7 @@ p5.prototype.rotate = function(angle, axis) {
  *
  * @method  rotateX
  * @param  {Number} angle the angle of rotation, specified in radians
- *                        or degrees, depending on current angleMode
+ *                        or degrees, depending on current `angleMode`
  * @chainable
  * @example
  * <div modernizr='webgl'>
@@ -275,7 +275,7 @@ p5.prototype.rotateX = function(angle) {
  *
  * @method rotateY
  * @param  {Number} angle the angle of rotation, specified in radians
- *                        or degrees, depending on current angleMode
+ *                        or degrees, depending on current `angleMode`
  * @chainable
  * @example
  * <div modernizr='webgl'>
@@ -313,7 +313,7 @@ p5.prototype.rotateY = function(angle) {
  *
  * @method rotateZ
  * @param  {Number} angle the angle of rotation, specified in radians
- *                        or degrees, depending on current angleMode
+ *                        or degrees, depending on current `angleMode`
  * @chainable
  * @example
  * <div modernizr='webgl'>
@@ -343,12 +343,12 @@ p5.prototype.rotateZ = function(angle) {
  * Increases or decreases the size of a shape by expanding or contracting
  * vertices. Objects always scale from their relative origin to the
  * coordinate system. Scale values are specified as decimal percentages.
- * For example, the function call scale(2.0) increases the dimension of a
+ * For example, the function call `scale(2.0)` increases the dimension of a
  * shape by 200%.
  *
  * Transformations apply to everything that happens after and subsequent
- * calls to the function multiply the effect. For example, calling scale(2.0)
- * and then scale(1.5) is the same as scale(3.0). If <a href="#/p5/scale">scale()</a> is called
+ * calls to the function multiply the effect. For example, calling `scale(2.0)`
+ * and then `scale(1.5)` is the same as scale(3.0). If <a href="#/p5/scale">scale()</a> is called
  * within <a href="#/p5/draw">draw()</a>, the transformation is reset when the loop begins again.
  *
  * Using this function with the z parameter is only available in WEBGL mode.
@@ -415,13 +415,13 @@ p5.prototype.scale = function(x, y, z) {
 
 /**
  * Shears a shape around the x-axis by the amount specified by the angle
- * parameter. Angles should be specified in the current angleMode.
+ * parameter. Angles should be specified in the current `angleMode`.
  * Objects are always sheared around their relative position to the origin
  * and positive numbers shear objects in a clockwise direction.
  *
  * Transformations apply to everything that happens after and subsequent
  * calls to the function accumulates the effect. For example, calling
- * shearX(PI/2) and then shearX(PI/2) is the same as shearX(PI).
+ * `shearX(PI/2)` and then `shearX(PI/2)` is the same as `shearX(PI)`.
  * If <a href="#/p5/shearX">shearX()</a> is called within the <a href="#/p5/draw">draw()</a>,
  * the transformation is reset when the loop begins again.
  *
@@ -431,7 +431,7 @@ p5.prototype.scale = function(x, y, z) {
  *
  * @method shearX
  * @param  {Number} angle angle of shear specified in radians or degrees,
- *                        depending on current angleMode
+ *                        depending on current `angleMode`
  * @chainable
  * @example
  * <div>
@@ -454,13 +454,13 @@ p5.prototype.shearX = function(angle) {
 
 /**
  * Shears a shape around the y-axis the amount specified by the angle
- * parameter. Angles should be specified in the current angleMode. Objects
+ * parameter. Angles should be specified in the current `angleMode`. Objects
  * are always sheared around their relative position to the origin and
  * positive numbers shear objects in a clockwise direction.
  *
  * Transformations apply to everything that happens after and subsequent
  * calls to the function accumulates the effect. For example, calling
- * shearY(PI/2) and then shearY(PI/2) is the same as shearY(PI). If
+ * `shearY(PI/2)` and then `shearY(PI/2)` is the same as `shearY(PI)`. If
  * <a href="#/p5/shearY">shearY()</a> is called within the <a href="#/p5/draw">draw()</a>, the transformation is reset when
  * the loop begins again.
  *
@@ -470,7 +470,7 @@ p5.prototype.shearX = function(angle) {
  *
  * @method shearY
  * @param  {Number} angle angle of shear specified in radians or degrees,
- *                        depending on current angleMode
+ *                        depending on current `angleMode`
  * @chainable
  * @example
  * <div>
@@ -493,13 +493,13 @@ p5.prototype.shearY = function(angle) {
 
 /**
  * Specifies an amount to displace objects within the display window.
- * The x parameter specifies left/right translation, the y parameter
+ * The `x` parameter specifies left/right translation, the `y` parameter
  * specifies up/down translation.
  *
  * Transformations are cumulative and apply to everything that happens after
  * and subsequent calls to the function accumulates the effect. For example,
- * calling translate(50, 0) and then translate(20, 0) is the same as
- * translate(70, 0). If <a href="#/p5/translate">translate()</a> is called within <a href="#/p5/draw">draw()</a>, the
+ * calling `translate(50, 0)` and then `translate(20, 0)` is the same as
+ * `translate(70, 0)`. If <a href="#/p5/translate">translate()</a> is called within <a href="#/p5/draw">draw()</a>, the
  * transformation is reset when the loop begins again. This function can be
  * further controlled by using <a href="#/p5/push">push()</a> and <a href="#/p5/pop">pop()</a>.
  *

--- a/src/data/local_storage.js
+++ b/src/data/local_storage.js
@@ -14,7 +14,7 @@ import p5 from '../core/main';
  * between browsing sessions and page reloads.
  * The key can be the name of the variable but doesn't
  * have to be. To retrieve stored items
- * see <a href="#/p5/getItem">getItem</a>.
+ * see <a href="#/p5/getItem">getItem()</a>.
  *
  * Sensitive data such as passwords or personal information
  * should not be stored in local storage.
@@ -101,7 +101,7 @@ p5.prototype.storeItem = function(key, value) {
 /**
  *
  * Returns the value of an item that was stored in local storage
- * using storeItem()
+ * using `storeItem()`.
  *
  * @method getItem
  * @for p5
@@ -176,7 +176,7 @@ p5.prototype.getItem = function(key) {
 
 /**
  *
- * Clears all local storage items set with storeItem()
+ * Clears all local storage items set with `storeItem()`
  * for the current domain.
  *
  * @method clearStorage
@@ -204,7 +204,7 @@ p5.prototype.clearStorage = function() {
 
 /**
  *
- * Removes an item that was stored with storeItem()
+ * Removes an item that was stored with `storeItem()`.
  *
  * @method removeItem
  * @param {String} key

--- a/src/data/p5.TypedDict.js
+++ b/src/data/p5.TypedDict.js
@@ -5,7 +5,7 @@
  * @requires core
  *
  * This module defines the p5 methods for the p5 Dictionary classes.
- * The classes StringDict and NumberDict are for storing and working
+ * The classes <a href="#/p5.StringDict">StringDict</a> and <a href="#/p5.NumberDict">NumberDict</a> are for storing and working
  * with key-value pairs.
  */
 
@@ -13,7 +13,7 @@ import p5 from '../core/main';
 
 /**
  *
- * Creates a new instance of p5.StringDict using the key-value pair
+ * Creates a new instance of `p5.StringDict` using the key-value pair
  * or the object you provide.
  *
  * @method createStringDict
@@ -81,7 +81,7 @@ p5.prototype.createNumberDict = function(key, value) {
 
 /**
  *
- * Base class for all p5.Dictionary types. Specifically
+ * Base class for all `p5.Dictionary` types. Specifically,
  * typed Dictionary classes inherit from this class.
  *
  * @class p5.TypedDict
@@ -120,8 +120,8 @@ p5.TypedDict.prototype.size = function() {
 };
 
 /**
- * Returns true if the given key exists in the Dictionary,
- * otherwise returns false.
+ * Returns `true` if the given `key` exists in the Dictionary,
+ * otherwise returns `false`.
  *
  * @method hasKey
  * @param {Number|String} key that you want to look up
@@ -142,7 +142,7 @@ p5.TypedDict.prototype.hasKey = function(key) {
 };
 
 /**
- * Returns the value stored at the given key.
+ * Returns the value stored at the given `key`.
  *
  * @method get
  * @param {Number|String} the key you want to access
@@ -168,8 +168,8 @@ p5.TypedDict.prototype.get = function(key) {
 };
 
 /**
- * Updates the value associated with the given key in case it already exists
- * in the Dictionary. Otherwise a new key-value pair is added.
+ * Updates the `value` associated with the given `key`, if it already exists
+ * in the Dictionary. Otherwise, a new key-value pair is added.
  *
  * @method set
  * @param {Number|String} key
@@ -263,7 +263,7 @@ p5.TypedDict.prototype.clear = function() {
 };
 
 /**
- * Removes the key-value pair stored at the given key from the Dictionary.
+ * Removes the key-value pair stored at the given `key` from the Dictionary.
  *
  * @method remove
  * @param {Number|String} key for the pair to remove

--- a/src/dom/dom.js
+++ b/src/dom/dom.js
@@ -20,9 +20,9 @@ import p5 from '../core/main';
 
 /**
  * Searches the page for the first element that matches the given CSS selector string (can be an
- * ID, class, tag name or a combination) and returns it as a <a href="#/p5.Element">p5.Element</a>.
- * The DOM node itself can be accessed with .elt.
- * Returns null if none found. You can also specify a container to search within.
+ * ID, class, tag name, or a combination) and returns it as a <a href="#/p5.Element">p5.Element</a>.
+ * The DOM node itself can be accessed with `.elt`.
+ * Returns `null` if none found. You can also specify a `container` to search within.
  *
  * @method select
  * @param  {String} selectors CSS selector string of element to search for
@@ -67,11 +67,11 @@ p5.prototype.select = function(e, p) {
 
 /**
  * Searches the page for elements that match the given CSS selector string (can be an ID a class,
- * tag name or a combination) and returns them as <a href="#/p5.Element">p5.Element</a>s in
+ * tag name, or a combination) and returns them as <a href="#/p5.Element">p5.Element</a>s in
  * an array.
- * The DOM node itself can be accessed with .elt.
+ * The DOM node itself can be accessed with `.elt`.
  * Returns an empty array if none found.
- * You can also specify a container to search within.
+ * You can also specify a `container` to search within.
  *
  * @method selectAll
  * @param  {String} selectors CSS selector string of elements to search for
@@ -175,7 +175,7 @@ p5.prototype._wrapElement = function(elt) {
 
 /**
  * Removes all elements created by p5, except any canvas / graphics
- * elements created by <a href="#/p5/createCanvas">createCanvas</a> or <a href="#/p5/createGraphics">createGraphics</a>.
+ * elements created by <a href="#/p5/createCanvas">createCanvas()</a> or <a href="#/p5/createGraphics">createGraphics()</a>.
  * Event handlers are removed, and element is removed from the DOM.
  * @method removeElements
  * @example
@@ -377,11 +377,11 @@ p5.prototype.createSpan = function(html = '') {
 };
 
 /**
- * Creates an `&lt;img&gt;` element in the DOM with given src and
+ * Creates an `&lt;img&gt;` element in the DOM with given `src` and
  * alternate text.
  *
  * @method createImg
- * @param  {String} src src path or url for image
+ * @param  {String} src src path or URL for image
  * @param  {String} alt <a href="https://developer.mozilla.org/en-US/docs/Web/HTML/Element/Img#Attributes">alternate text</a> to be used if image does not load. You can use also an empty string (`""`) if that an image is not intended to be viewed.
  * @return {p5.Element} pointer to <a href="#/p5.Element">p5.Element</a> holding created node
  * @example
@@ -427,10 +427,10 @@ p5.prototype.createImg = function() {
  * Creates an `&lt;a&gt;&lt;/a&gt;` element in the DOM for including a hyperlink.
  *
  * @method createA
- * @param  {String} href       url of page to link to
- * @param  {String} html       inner html of link element to display
+ * @param  {String} href       URL of page to link to
+ * @param  {String} html       inner HTML of link element to display
  * @param  {String} [target]   target where new link should open,
- *                             could be _blank, _self, _parent, _top.
+ *                             could be `'_blank'`, `'_self'`, `'_parent'`, or `'_top'`.
  * @return {p5.Element} pointer to <a href="#/p5.Element">p5.Element</a> holding created node
  * @example
  * <div><code>
@@ -451,13 +451,13 @@ p5.prototype.createA = function(href, html, target) {
 
 /**
  * Creates a slider `&lt;input&gt;&lt;/input&gt;` element in the DOM.
- * Use .size() to set the display length of the slider.
+ * Use `.size()` to set the display length of the slider.
  *
  * @method createSlider
  * @param  {Number} min minimum value of the slider
  * @param  {Number} max maximum value of the slider
  * @param  {Number} [value] default value of the slider
- * @param  {Number} [step] step size for each tick of the slider (if step is set to 0, the slider will move continuously from the minimum to the maximum value)
+ * @param  {Number} [step] step size for each tick of the slider (if step is set to `0`, the slider will move continuously from the minimum to the maximum value)
  * @return {p5.Element} pointer to <a href="#/p5.Element">p5.Element</a> holding created node
  * @example
  * <div><code>
@@ -506,8 +506,8 @@ p5.prototype.createSlider = function(min, max, value, step) {
 
 /**
  * Creates a `&lt;button&gt;&lt;/button&gt;` element in the DOM.
- * Use .size() to set the display size of the button.
- * Use .mousePressed() to specify behavior on press.
+ * Use `.size()` to set the display size of the button.
+ * Use `.mousePressed()` to specify behavior on press.
  *
  * @method createButton
  * @param  {String} label label displayed on the button
@@ -540,11 +540,11 @@ p5.prototype.createButton = function(label, value) {
 
 /**
  * Creates a checkbox `&lt;input&gt;&lt;/input&gt;` element in the DOM.
- * Calling .checked() on a checkbox returns if it is checked or not
+ * Calling `.checked()` on a checkbox returns if it is checked or not.
  *
  * @method createCheckbox
  * @param  {String} [label] label displayed after checkbox
- * @param  {boolean} [value] value of the checkbox; checked is true, unchecked is false
+ * @param  {boolean} [value] value of the checkbox; checked is `true`, unchecked is `false`
  * @return {p5.Element} pointer to <a href="#/p5.Element">p5.Element</a> holding created node
  * @example
  * <div><code>
@@ -609,6 +609,7 @@ p5.prototype.createCheckbox = function() {
 /**
  * Creates a dropdown menu `&lt;select&gt;&lt;/select&gt;` element in the DOM.
  * It also helps to assign select-box methods to <a href="#/p5.Element">p5.Element</a> when selecting existing select box.
+ *
  * - `.option(name, [value])` can be used to set options for the select after it is created.
  * - `.value()` will return the currently selected option.
  * - `.selected()` will return current dropdown element which is an instance of <a href="#/p5.Element">p5.Element</a>
@@ -755,8 +756,9 @@ p5.prototype.createSelect = function() {
 };
 
 /**
- * Creates a radio button element in the DOM.It also helps existing radio buttons
+ * Creates a radio button element in the DOM. It also helps existing radio buttons
  * assign methods of <a href="#/p5.Element/">p5.Element</a>.
+ *
  * - `.option(value, [label])` can be used to create a new option for the
  *   element. If an option with a value already exists, it will be returned.
  *   Optionally, a label can be provided as second argument for the option.
@@ -767,9 +769,9 @@ p5.prototype.createSelect = function() {
  * - `.disable(Boolean)` method will enable/disable the whole radio button element.
  *
  * @method createRadio
- * @param  {Object} containerElement An container HTML Element either a div
- * or span inside which all existing radio inputs will be considered as options.
- * @param {string} [name] A name parameter for each Input Element.
+ * @param  {Object} containerElement An container HTML Element (either a `div`
+ * or `span`) inside which all existing radio inputs will be considered as options.
+ * @param {string} [name] A `name` parameter for each Input Element.
  * @return {p5.Element} pointer to <a href="#/p5.Element">p5.Element</a> holding created node
  * @example
  * <div><code>
@@ -934,8 +936,8 @@ p5.prototype.createRadio = function() {
 
 /**
  * Creates a colorPicker element in the DOM for color input.
- * The .value() method will return a hex string (#rrggbb) of the color.
- * The .color() method will return a p5.Color object with the current chosen color.
+ * The `.value()` method will return a hex string (`#rrggbb`) of the color.
+ * The `.color()` method will return a <a href="#/p5.Color">p5.Color</a> object with the current chosen color.
  *
  * @method createColorPicker
  * @param {String|p5.Color} [value] default color of element
@@ -1026,7 +1028,7 @@ p5.prototype.createColorPicker = function(value) {
  *
  * @method createInput
  * @param {String} value default value of the input box
- * @param {String} [type] type of text, ie text, password etc. Defaults to text.
+ * @param {String} [type] type of text (i.e. `'text'`, `'password'`, etc.). Defaults to `'text'`.
  *   Needs a value to be specified first.
  * @return {p5.Element} pointer to <a href="#/p5.Element">p5.Element</a> holding created node
  * @example
@@ -1300,7 +1302,7 @@ if (navigator.mediaDevices.getUserMedia === undefined) {
  * from a webcam. The element is separate from the canvas and is displayed by
  * default. The element can be hidden using .<a href="#/p5.Element/hide">hide()</a>.
  * The feed can be drawn onto the canvas using <a href="#/p5/image">image()</a>.
- * The loadedmetadata property can be used to detect when the element has fully
+ * The `loadedmetadata` property can be used to detect when the element has fully
  * loaded (see second example).
  *
  * More specific properties of the feed can be passing in a Constraints object.
@@ -1309,14 +1311,14 @@ if (navigator.mediaDevices.getUserMedia === undefined) {
  * by all browsers.
  *
  * <em>Security note</em>: A new browser security specification requires that
- * getUserMedia, which is behind <a href="#/p5/createCapture">createCapture()</a>,
+ * `getUserMedia()`, which is behind <a href="#/p5/createCapture">createCapture()</a>,
  * only works when you're running the code locally, or on HTTPS. Learn more
  * <a href='http://stackoverflow.com/questions/34197653/getusermedia-in-chrome-47-without-using-https'>here</a>
  * and <a href='https://developer.mozilla.org/en-US/docs/Web/API/MediaDevices/getUserMedia'>here</a>.
  *
  * @method createCapture
  * @param  {String|Constant|Object}   type type of capture, either VIDEO or
- *                                   AUDIO if none specified, default both,
+ *                                   AUDIO if none specified (default both),
  *                                   or a Constraints object
  * @param  {Function}                 [callback] function to be called once
  *                                   stream has loaded
@@ -1516,7 +1518,7 @@ p5.Element.prototype.removeClass = function(c) {
 
 /**
  *
- * Checks if specified class already set to element
+ * Checks if specified class already set to element.
  *
  * @method hasClass
  * @returns {boolean} a boolean value if element has specified class
@@ -1683,8 +1685,8 @@ p5.Element.prototype.center = function(align) {
 /**
  *
  * If an argument is given, sets the inner HTML of the element,
- * replacing any existing html. If true is included as a second
- * argument, html is appended instead of replacing existing html.
+ * replacing any existing HTML. If `true` is included as a second
+ * argument, `html` is appended instead of replacing existing HTML.
  * If no arguments are given, returns
  * the inner HTML of the element.
  *
@@ -1721,13 +1723,13 @@ p5.Element.prototype.html = function() {
 
 /**
  *
- * Sets the position of the element. If no position type argument is given, the
+ * Sets the position of the element. If no `position` type argument is given, the
  * position will be relative to (0, 0) of the window.
- * Essentially, this sets position:absolute and left and top
+ * Essentially, this sets `position:absolute` and `left` and `top`
  * properties of style. If an optional third argument specifying position type is given,
- * the x and y coordinates will be interpreted based on the <a target="_blank"
+ * the `x` and `y` coordinates will be interpreted based on the <a target="_blank"
  * href="https://developer.mozilla.org/en-US/docs/Web/CSS/position">positioning scheme</a>.
- * If no arguments given, the function returns the x and y position of the element.
+ * If no arguments given, the function returns the `x` and `y` position of the element.
  *
  * found documentation on how to be more specific with object type
  * https://stackoverflow.com/questions/14714314/how-do-i-comment-object-literals-in-yuidoc
@@ -1840,10 +1842,10 @@ p5.Element.prototype._rotate = function() {
 };
 
 /**
- * Sets the given style (css) property (1st arg) of the element with the
- * given value (2nd arg). If a single argument is given, .style()
+ * Sets the given style (CSS) `property` of the element with the
+ * given `value`. If a single argument is given, `.style()`
  * returns the value of the given property; however, if the single argument
- * is given in css syntax ('text-align:center'), .style() sets the css
+ * is given in CSS syntax (e.g., `text-align:center`), `.style()` sets the CSS
  * appropriately.
  *
  * @method style
@@ -1938,7 +1940,7 @@ p5.Element.prototype.style = function(prop, val) {
  *
  * Adds a new attribute or changes the value of an existing attribute
  * on the specified element. If no value is specified, returns the
- * value of the given attribute, or null if attribute is not set.
+ * value of the given attribute, or `null` if attribute is not set.
  *
  * @method attribute
  * @return {String} value of attribute
@@ -2071,7 +2073,7 @@ p5.Element.prototype.value = function() {
 
 /**
  *
- * Shows the current element. Essentially, setting display:block for the style.
+ * Shows the current element. Essentially, setting `display:block` for the style.
  *
  * @method show
  * @chainable
@@ -2088,7 +2090,7 @@ p5.Element.prototype.show = function() {
 };
 
 /**
- * Hides the current element. Essentially, setting display:none for the style.
+ * Hides the current element. Essentially, setting `display:none` for the style.
  *
  * @method hide
  * @chainable
@@ -2107,7 +2109,7 @@ p5.Element.prototype.hide = function() {
  *
  * Sets the width and height of the element. AUTO can be used to
  * only adjust one dimension at a time. If no arguments are given, it
- * returns the width and height of the element in an object. In case of
+ * returns the `width` and `height` of the element in an object. In case of
  * elements which need to be loaded, such as images, it is recommended
  * to call the function after the element has finished loading.
  *
@@ -2225,7 +2227,7 @@ p5.Element.prototype.remove = function() {
 /**
  * Registers a callback that gets called every time a file that is
  * dropped on the element has been loaded.
- * p5 will load every dropped file into memory and pass it as a p5.File object to the callback.
+ * p5 will load every dropped file into memory and pass it as a <a href="#/p5.File">p5.File</a> object to the callback.
  * Multiple files dropped at the same time will result in multiple calls to the callback.
  *
  * You can optionally pass a second callback which will be registered to the raw
@@ -2334,8 +2336,8 @@ p5.Element.prototype.drop = function(callback, fxn) {
 /**
  * Extends <a href="#/p5.Element">p5.Element</a> to handle audio and video. In addition to the methods
  * of <a href="#/p5.Element">p5.Element</a>, it also contains methods for controlling media. It is not
- * called directly, but <a href="#/p5.MediaElement">p5.MediaElement</a>s are created by calling <a href="#/p5/createVideo">createVideo</a>,
- * <a href="#/p5/createAudio">createAudio</a>, and <a href="#/p5/createCapture">createCapture</a>.
+ * called directly, but <a href="#/p5.MediaElement">p5.MediaElement</a>s are created by calling <a href="#/p5/createVideo">createVideo()</a>,
+ * <a href="#/p5/createAudio">createAudio()</a>, and <a href="#/p5/createCapture">createCapture()</a>.
  *
  * @class p5.MediaElement
  * @constructor
@@ -2887,10 +2889,10 @@ p5.MediaElement.prototype.volume = function(val) {
 
 /**
  * If no arguments are given, returns the current playback speed of the
- * element. The speed parameter sets the speed where 2.0 will play the
- * element twice as fast, 0.5 will play at half the speed, and -1 will play
- * the element in normal speed in reverse.(Note that not all browsers support
- * backward playback and even if they do, playback might not be smooth.)
+ * element. The speed parameter sets the speed where `2.0` will play the
+ * element twice as fast, `0.5` will play at half the speed, and `-1` will play
+ * the element in normal speed in reverse. (Note that not all browsers support
+ * backward playback; and even if they do, playback might not be smooth.)
  *
  * @method speed
  * @return {Number} current playback speed of the element
@@ -2976,7 +2978,7 @@ p5.MediaElement.prototype.speed = function(val) {
 
 /**
  * If no arguments are given, returns the current time of the element.
- * If an argument is given the current time of the element is set to it.
+ * If an argument is given, the current time of the element is set to it.
  *
  * @method time
  * @return {Number} current time (in seconds)
@@ -3189,10 +3191,10 @@ p5.MediaElement.prototype.onended = function(callback) {
 /*** CONNECT TO WEB AUDIO API / p5.sound.js ***/
 
 /**
- * Send the audio output of this element to a specified audioNode or
- * p5.sound object. If no element is provided, connects to p5's main
+ * Send the audio output of this element to a specified `audioNode` or
+ * <a href="#/p5.sound">p5.sound</a> object. If no element is provided, connects to p5's main
  * output. That connection is established when this method is first called.
- * All connections are removed by the .disconnect() method.
+ * All connections are removed by the `.disconnect()` method.
  *
  * This method is meant to be used with the p5.sound.js addon library.
  *
@@ -3339,7 +3341,7 @@ const Cue = function(callback, time, id, val) {
  * @param {Number}   time     Time in seconds, relative to this media
  *                             element's playback. For example, to trigger
  *                             an event every time playback reaches two
- *                             seconds, pass in the number 2. This will be
+ *                             seconds, pass in the number `2`. This will be
  *                             passed as the first parameter to
  *                             the callback function.
  * @param {Function} callback Name of a function that will be
@@ -3350,7 +3352,7 @@ const Cue = function(callback, time, id, val) {
  *                             second parameter to the
  *                             callback function.
  * @return {Number} id ID of this cue,
- *                     useful for removeCue(id)
+ *                     useful for `removeCue(id)`
  * @example
  * <div><code>
  * //
@@ -3390,9 +3392,9 @@ p5.MediaElement.prototype.addCue = function(time, callback, val) {
 
 /**
  * Remove a callback based on its ID. The ID is returned by the
- * addCue method.
+ * `addCue()` method.
  * @method removeCue
- * @param  {Number} id ID of the cue, as returned by addCue
+ * @param  {Number} id ID of the cue, as returned by `addCue()`
  * @example
  * <div><code>
  * let audioEl, id1, id2;
@@ -3432,9 +3434,9 @@ p5.MediaElement.prototype.removeCue = function(id) {
 
 /**
  * Remove all of the callbacks that had originally been scheduled
- * via the addCue method.
+ * via the `addCue()` method.
  * @method  clearCues
- * @param  {Number} id ID of the cue, as returned by addCue
+ * @param  {Number} id ID of the cue, as returned by `addCue()`
  * @example
  * <div><code>
  * let audioEl;
@@ -3489,7 +3491,7 @@ p5.MediaElement.prototype._onTimeUpdate = function() {
 
 /**
  * Base class for a file.
- * Used for Element.drop and createFileInput.
+ * Used for <a href="#/p5.Element/drop">Element.drop()</a> and <a href="#/p5/createFileInput">createFileInput</a>.
  *
  * @class p5.File
  * @constructor

--- a/src/events/acceleration.js
+++ b/src/events/acceleration.js
@@ -9,9 +9,9 @@ import p5 from '../core/main';
 import * as constants from '../core/constants';
 
 /**
- * The system variable deviceOrientation always contains the orientation of
- * the device. The value of this variable will either be set 'landscape'
- * or 'portrait'. If no data is available it will be set to 'undefined'.
+ * The system variable `deviceOrientation` always contains the orientation of
+ * the device. The value of this variable will either be set `'landscape'`
+ * or `'portrait'`. If no data is available, it will be set to `undefined`.
  * either LANDSCAPE or PORTRAIT.
  *
  * @property {Constant} deviceOrientation
@@ -21,7 +21,7 @@ p5.prototype.deviceOrientation =
   window.innerWidth / window.innerHeight > 1.0 ? 'landscape' : 'portrait';
 
 /**
- * The system variable accelerationX always contains the acceleration of the
+ * The system variable `accelerationX` always contains the acceleration of the
  * device along the x axis. Value is represented as meters per second squared.
  *
  * @property {Number} accelerationX
@@ -44,7 +44,7 @@ p5.prototype.deviceOrientation =
 p5.prototype.accelerationX = 0;
 
 /**
- * The system variable accelerationY always contains the acceleration of the
+ * The system variable `accelerationY` always contains the acceleration of the
  * device along the y axis. Value is represented as meters per second squared.
  *
  * @property {Number} accelerationY
@@ -67,7 +67,7 @@ p5.prototype.accelerationX = 0;
 p5.prototype.accelerationY = 0;
 
 /**
- * The system variable accelerationZ always contains the acceleration of the
+ * The system variable `accelerationZ` always contains the acceleration of the
  * device along the z axis. Value is represented as meters per second squared.
  *
  * @property {Number} accelerationZ
@@ -92,7 +92,7 @@ p5.prototype.accelerationY = 0;
 p5.prototype.accelerationZ = 0;
 
 /**
- * The system variable pAccelerationX always contains the acceleration of the
+ * The system variable `pAccelerationX` always contains the acceleration of the
  * device along the x axis in the frame previous to the current frame. Value
  * is represented as meters per second squared.
  *
@@ -102,7 +102,7 @@ p5.prototype.accelerationZ = 0;
 p5.prototype.pAccelerationX = 0;
 
 /**
- * The system variable pAccelerationY always contains the acceleration of the
+ * The system variable `pAccelerationY` always contains the acceleration of the
  * device along the y axis in the frame previous to the current frame. Value
  * is represented as meters per second squared.
  *
@@ -112,7 +112,7 @@ p5.prototype.pAccelerationX = 0;
 p5.prototype.pAccelerationY = 0;
 
 /**
- * The system variable pAccelerationZ always contains the acceleration of the
+ * The system variable `pAccelerationZ` always contains the acceleration of the
  * device along the z axis in the frame previous to the current frame. Value
  * is represented as meters per second squared.
  *
@@ -133,13 +133,14 @@ p5.prototype._updatePAccelerations = function() {
 };
 
 /**
- * The system variable rotationX always contains the rotation of the
+ * The system variable `rotationX` always contains the rotation of the
  * device along the x axis. If the sketch <a href="#/p5/angleMode">
- * angleMode()</a> is set to DEGREES, the value will be -180 to 180. If
- * it is set to RADIANS, the value will be -PI to PI.
+ * angleMode()</a> is set to <a href="#/p5/DEGREES">DEGREES</a>, the
+ * value will be `-180` to `180`. If it is set to <a href="#/p5/RADIANS">RADIANS</a>,
+ * the value will be `-PI` to `PI`.
  *
- * Note: The order the rotations are called is important, ie. if used
- * together, it must be called in the order Z-X-Y or there might be
+ * Note: The order the rotations are called is important. i.e. if used
+ * together, it must be called in the order Z-X-Y, or there might be
  * unexpected behaviour.
  *
  * @property {Number} rotationX
@@ -166,13 +167,14 @@ p5.prototype._updatePAccelerations = function() {
 p5.prototype.rotationX = 0;
 
 /**
- * The system variable rotationY always contains the rotation of the
+ * The system variable `rotationY` always contains the rotation of the
  * device along the y axis. If the sketch <a href="#/p5/angleMode">
- * angleMode()</a> is set to DEGREES, the value will be -90 to 90. If
- * it is set to RADIANS, the value will be -PI/2 to PI/2.
+ * angleMode()</a> is set to <a href="#/p5/DEGREES">DEGREES</a>, the
+ * value will be `-90` to `90`. If it is set to <a href="#/p5/RADIANS">RADIANS</a>,
+ * the value will be `-PI/2` to `PI/2`.
  *
- * Note: The order the rotations are called is important, ie. if used
- * together, it must be called in the order Z-X-Y or there might be
+ * Note: The order the rotations are called is important. i.e. if used
+ * together, it must be called in the order Z-X-Y, or there might be
  * unexpected behaviour.
  *
  * @property {Number} rotationY
@@ -199,16 +201,17 @@ p5.prototype.rotationX = 0;
 p5.prototype.rotationY = 0;
 
 /**
- * The system variable rotationZ always contains the rotation of the
+ * The system variable `rotationZ` always contains the rotation of the
  * device along the z axis. If the sketch <a href="#/p5/angleMode">
- * angleMode()</a> is set to DEGREES, the value will be 0 to 360. If
- * it is set to RADIANS, the value will be 0 to 2*PI.
+ * angleMode()</a> is set to <a href="#/p5/DEGREES">DEGREES</a>, the value
+ * will be `0` to `360`. If it is set to <a href="#/p5/RADIANS">RADIANS</a>,
+ * the value will be `0` to `2*PI`.
  *
- * Unlike rotationX and rotationY, this variable is available for devices
+ * Unlike `rotationX` and `rotationY`, this variable is available for devices
  * with a built-in compass only.
  *
- * Note: The order the rotations are called is important, ie. if used
- * together, it must be called in the order Z-X-Y or there might be
+ * Note: The order the rotations are called is important. i.e. if used
+ * together, it must be called in the order Z-X-Y, or there might be
  * unexpected behaviour.
  *
  * @example
@@ -237,13 +240,13 @@ p5.prototype.rotationY = 0;
 p5.prototype.rotationZ = 0;
 
 /**
- * The system variable pRotationX always contains the rotation of the
+ * The system variable `pRotationX` always contains the rotation of the
  * device along the x axis in the frame previous to the current frame.
- * If the sketch <a href="#/p5/angleMode"> angleMode()</a> is set to DEGREES,
- * the value will be -180 to 180. If it is set to RADIANS, the value will
- * be -PI to PI.
+ * If the sketch <a href="#/p5/angleMode">angleMode()</a> is set to <a href="#/p5/DEGREES">DEGREES</a>,
+ * the value will be `-180` to `180`. If it is set to <a href="#/p5/RADIANS">RADIANS</a>, the value will
+ * be `-PI` to `PI`.
  *
- * pRotationX can also be used with rotationX to determine the rotate
+ * `pRotationX` can also be used with `rotationX` to determine the rotate
  * direction of the device along the X-axis.
  * @example
  * <div class='norender'>
@@ -283,13 +286,13 @@ p5.prototype.rotationZ = 0;
 p5.prototype.pRotationX = 0;
 
 /**
- * The system variable pRotationY always contains the rotation of the
+ * The system variable `pRotationY` always contains the rotation of the
  * device along the y axis in the frame previous to the current frame.
- * If the sketch <a href="#/p5/angleMode"> angleMode()</a> is set to DEGREES,
- * the value will be -90 to 90. If it is set to RADIANS, the value will
- * be -PI/2 to PI/2.
+ * If the sketch <a href="#/p5/angleMode">angleMode()</a> is set to <a href="#/p5/DEGREES">DEGREES</a>,
+ * the value will be `-90` to `90`. If it is set to <a href="#/p5/RADIANS">RADIANS</a>, the value will
+ * be `-PI/2` to `PI/2`.
  *
- * pRotationY can also be used with rotationY to determine the rotate
+ * `pRotationY` can also be used with `rotationY` to determine the rotate
  * direction of the device along the Y-axis.
  * @example
  * <div class='norender'>
@@ -328,13 +331,14 @@ p5.prototype.pRotationX = 0;
 p5.prototype.pRotationY = 0;
 
 /**
- * The system variable pRotationZ always contains the rotation of the
+ * The system variable `pRotationZ` always contains the rotation of the
  * device along the z axis in the frame previous to the current frame.
- * If the sketch <a href="#/p5/angleMode"> angleMode()</a> is set to DEGREES,
- * the value will be 0 to 360. If it is set to RADIANS, the value will
- * be 0 to 2*PI.
+ * If the sketch <a href="#/p5/angleMode">angleMode()</a> is set to
+ * <a href="#/p5/DEGREES">DEGREES</a>, the value will be `0` to `360`.
+ * If it is set to <a href="#/p5/RADIANS">RADIANS</a>, the value will
+ * be `0` to `2*PI`.
  *
- * pRotationZ can also be used with rotationZ to determine the rotate
+ * `pRotationZ` can also be used with `rotationZ` to determine the rotate
  * direction of the device along the Z-axis.
  * @example
  * <div class='norender'>
@@ -388,8 +392,8 @@ p5.prototype._updatePRotations = function() {
 
 /**
  * When a device is rotated, the axis that triggers the <a href="#/p5/deviceTurned">deviceTurned()</a>
- * method is stored in the turnAxis variable. The turnAxis variable is only defined within
- * the scope of deviceTurned().
+ * method is stored in the `turnAxis` variable. The `turnAxis` variable is only defined within
+ * the scope of `deviceTurned()`.
  * @property {String} turnAxis
  * @readOnly
  * @example
@@ -514,7 +518,7 @@ p5.prototype.setShakeThreshold = function(val) {
 
 /**
  * The <a href="#/p5/deviceMoved">deviceMoved()</a> function is called when the device is moved by more than
- * the threshold value along X, Y or Z axis. The default threshold is set to 0.5.
+ * the threshold value along X, Y, or Z axis. The default threshold is set to 0.5.
  * The threshold value can be changed using <a href="https://p5js.org/reference/#/p5/setMoveThreshold">setMoveThreshold()</a>.
  *
  * @method deviceMoved
@@ -547,9 +551,9 @@ p5.prototype.setShakeThreshold = function(val) {
  * The <a href="#/p5/deviceTurned">deviceTurned()</a> function is called when the device rotates by
  * more than 90 degrees continuously.
  *
- * The axis that triggers the <a href="#/p5/deviceTurned">deviceTurned()</a> method is stored in the turnAxis
+ * The axis that triggers the <a href="#/p5/deviceTurned">deviceTurned()</a> method is stored in the `turnAxis`
  * variable. The <a href="#/p5/deviceTurned">deviceTurned()</a> method can be locked to trigger on any axis:
- * X, Y or Z by comparing the turnAxis variable to 'X', 'Y' or 'Z'.
+ * `X`, `Y`, or `Z`, by comparing the `turnAxis` variable to `X`, `Y`, or `Z`.
  *
  * @method deviceTurned
  * @example
@@ -603,7 +607,7 @@ p5.prototype.setShakeThreshold = function(val) {
 
 /**
  * The <a href="#/p5/deviceShaken">deviceShaken()</a> function is called when the device total acceleration
- * changes of accelerationX and accelerationY values is more than
+ * changes of `accelerationX` and `accelerationY` values is more than
  * the threshold value. The default threshold is set to 30.
  * The threshold value can be changed using <a href="https://p5js.org/reference/#/p5/setShakeThreshold">setShakeThreshold()</a>.
  *

--- a/src/events/keyboard.js
+++ b/src/events/keyboard.js
@@ -104,7 +104,7 @@ p5.prototype.keyCode = 0;
  * The <a href="#/p5/keyPressed">keyPressed()</a> function is called once every time a key is pressed. The
  * keyCode for the key that was pressed is stored in the <a href="#/p5/keyCode">keyCode</a> variable.
  *
- * For non-ASCII keys, use the keyCode variable. You can check if the keyCode
+ * For non-ASCII keys, use the `keyCode` variable. You can check if the `keyCode`
  * equals BACKSPACE, DELETE, ENTER, RETURN, TAB, ESCAPE, SHIFT, CONTROL,
  * OPTION, ALT, UP_ARROW, DOWN_ARROW, LEFT_ARROW, RIGHT_ARROW.
  *
@@ -116,10 +116,11 @@ p5.prototype.keyCode = 0;
  * Because of how operating systems handle key repeats, holding down a key
  * may cause multiple calls to <a href="#/p5/keyTyped">keyTyped()</a> (and <a href="#/p5/keyReleased">keyReleased()</a> as well). The
  * rate of repeat is set by the operating system and how each computer is
- * configured.<br><br>
+ * configured.
+ *
  * Browsers may have different default
  * behaviors attached to various key events. To prevent any default
- * behavior for this event, add "return false" to the end of the method.
+ * behavior for this event, add `return false` to the end of the method.
  *
  * @method keyPressed
  * @param  {Object} [event] optional KeyboardEvent callback argument.
@@ -189,10 +190,10 @@ p5.prototype._onkeydown = function(e) {
 };
 /**
  * The <a href="#/p5/keyReleased">keyReleased()</a> function is called once every time a key is released.
- * See <a href="#/p5/key">key</a> and <a href="#/p5/keyCode">keyCode</a> for more information.<br><br>
- * Browsers may have different default
- * behaviors attached to various key events. To prevent any default
- * behavior for this event, add "return false" to the end of the method.
+ * See <a href="#/p5/key">key</a> and <a href="#/p5/keyCode">keyCode</a> for more information.
+ *
+ * Browsers may have different default behaviors attached to various key events.
+ * To prevent any default behavior for this event, add `return false` to the end of the method.
  *
  * @method keyReleased
  * @param  {Object} [event] optional KeyboardEvent callback argument.
@@ -249,10 +250,10 @@ p5.prototype._onkeyup = function(e) {
  * Because of how operating systems handle key repeats, holding down a key
  * will cause multiple calls to <a href="#/p5/keyTyped">keyTyped()</a> (and <a href="#/p5/keyReleased">keyReleased()</a> as well). The
  * rate of repeat is set by the operating system and how each computer is
- * configured.<br><br>
- * Browsers may have different default behaviors attached to various key
- * events. To prevent any default behavior for this event, add "return false"
- * to the end of the method.
+ * configured.
+ *
+ * Browsers may have different default behaviors attached to various key events.
+ * To prevent any default behavior for this event, add `return false` to the end of the method.
  *
  * @method keyTyped
  * @param  {Object} [event] optional KeyboardEvent callback argument.
@@ -309,7 +310,7 @@ p5.prototype._onblur = function(e) {
  * The <a href="#/p5/keyIsDown">keyIsDown()</a> function checks if the key is currently down, i.e. pressed.
  * It can be used if you have an object that moves, and you want several keys
  * to be able to affect its behaviour simultaneously, such as moving a
- * sprite diagonally. You can put in any number representing the keyCode of
+ * sprite diagonally. You can put in any number representing the `keyCode` of
  * the key, or use any of the variable <a href="#/p5/keyCode">keyCode</a> names listed
  * <a href="http://p5js.org/reference/#p5/keyCode">here</a>.
  *

--- a/src/events/mouse.js
+++ b/src/events/mouse.js
@@ -11,7 +11,7 @@ import * as constants from '../core/constants';
 
 /**
  *
- * The variable movedX contains the horizontal movement of the mouse since the last frame
+ * The variable `movedX` contains the horizontal movement of the mouse since the last frame.
  * @property {Number} movedX
  * @readOnly
  * @example
@@ -41,7 +41,7 @@ import * as constants from '../core/constants';
 p5.prototype.movedX = 0;
 
 /**
- * The variable movedY contains the vertical movement of the mouse since the last frame
+ * The variable `movedY` contains the vertical movement of the mouse since the last frame.
  * @property {Number} movedY
  * @readOnly
  * @example
@@ -71,17 +71,18 @@ p5.prototype.movedX = 0;
 p5.prototype.movedY = 0;
 /*
  * This is a flag which is false until the first time
- * we receive a mouse event. The pmouseX and pmouseY
- * values will match the mouseX and mouseY values until
+ * we receive a mouse event. The `pmouseX` and `pmouseY`
+ * values will match the `mouseX` and `mouseY` values until
  * this interaction takes place.
  */
 p5.prototype._hasMouseInteracted = false;
 
 /**
- * The system variable mouseX always contains the current horizontal
+ * The system variable `mouseX` always contains the current horizontal
  * position of the mouse, relative to (0, 0) of the canvas. The value at
  * the top-left corner is (0, 0) for 2-D and (-width/2, -height/2) for WebGL.
- * If touch is used instead of mouse input, mouseX will hold the x value
+ *
+ * If touch is used instead of mouse input, `mouseX` will hold the x value
  * of the most recent touch point.
  *
  * @property {Number} mouseX
@@ -104,10 +105,11 @@ p5.prototype._hasMouseInteracted = false;
 p5.prototype.mouseX = 0;
 
 /**
- * The system variable mouseY always contains the current vertical
+ * The system variable `mouseY` always contains the current vertical
  * position of the mouse, relative to (0, 0) of the canvas. The value at
  * the top-left corner is (0, 0) for 2-D and (-width/2, -height/2) for WebGL.
- * If touch is used instead of mouse input, mouseY will hold the y value
+ *
+ * If touch is used instead of mouse input, `mouseY` will hold the y value
  * of the most recent touch point.
  *
  * @property {Number} mouseY
@@ -130,10 +132,10 @@ p5.prototype.mouseX = 0;
 p5.prototype.mouseY = 0;
 
 /**
- * The system variable pmouseX always contains the horizontal position of
+ * The system variable `pmouseX` always contains the horizontal position of
  * the mouse or finger in the frame previous to the current frame, relative to
  * (0, 0) of the canvas. The value at the top-left corner is (0, 0) for 2-D and
- * (-width/2, -height/2) for WebGL. Note: pmouseX will be reset to the current mouseX
+ * (-width/2, -height/2) for WebGL. Note: `pmouseX` will be reset to the current `mouseX`
  * value at the start of each touch event.
  *
  * @property {Number} pmouseX
@@ -162,10 +164,10 @@ p5.prototype.mouseY = 0;
 p5.prototype.pmouseX = 0;
 
 /**
- * The system variable pmouseY always contains the vertical position of
+ * The system variable `pmouseY` always contains the vertical position of
  * the mouse or finger in the frame previous to the current frame, relative to
  * (0, 0) of the canvas. The value at the top-left corner is (0, 0) for 2-D and
- * (-width/2, -height/2) for WebGL. Note: pmouseY will be reset to the current mouseY
+ * (-width/2, -height/2) for WebGL. Note: `pmouseY` will be reset to the current `mouseY`
  * value at the start of each touch event.
  *
  * @property {Number} pmouseY
@@ -193,7 +195,7 @@ p5.prototype.pmouseX = 0;
 p5.prototype.pmouseY = 0;
 
 /**
- * The system variable winMouseX always contains the current horizontal
+ * The system variable `winMouseX` always contains the current horizontal
  * position of the mouse, relative to (0, 0) of the window.
  *
  * @property {Number} winMouseX
@@ -231,7 +233,7 @@ p5.prototype.pmouseY = 0;
 p5.prototype.winMouseX = 0;
 
 /**
- * The system variable winMouseY always contains the current vertical
+ * The system variable `winMouseY` always contains the current vertical
  * position of the mouse, relative to (0, 0) of the window.
  *
  * @property {Number} winMouseY
@@ -269,9 +271,9 @@ p5.prototype.winMouseX = 0;
 p5.prototype.winMouseY = 0;
 
 /**
- * The system variable pwinMouseX always contains the horizontal position
+ * The system variable `pwinMouseX` always contains the horizontal position
  * of the mouse in the frame previous to the current frame, relative to
- * (0, 0) of the window. Note: pwinMouseX will be reset to the current winMouseX
+ * (0, 0) of the window. Note: `pwinMouseX` will be reset to the current `winMouseX`
  * value at the start of each touch event.
  *
  * @property {Number} pwinMouseX
@@ -309,9 +311,9 @@ p5.prototype.winMouseY = 0;
 p5.prototype.pwinMouseX = 0;
 
 /**
- * The system variable pwinMouseY always contains the vertical position of
+ * The system variable `pwinMouseY` always contains the vertical position of
  * the mouse in the frame previous to the current frame, relative to (0, 0)
- * of the window. Note: pwinMouseY will be reset to the current winMouseY
+ * of the window. Note: `pwinMouseY` will be reset to the current `winMouseY`
  * value at the start of each touch event.
  *
  * @property {Number} pwinMouseY
@@ -350,9 +352,9 @@ p5.prototype.pwinMouseY = 0;
 
 /**
  * p5 automatically tracks if the mouse button is pressed and which
- * button is pressed. The value of the system variable mouseButton is either
+ * button is pressed. The value of the system variable `mouseButton` is either
  * LEFT, RIGHT, or CENTER depending on which button was pressed last.
- * Warning: different browsers may track mouseButton differently.
+ * Warning: different browsers may track `mouseButton` differently.
  *
  * @property {Constant} mouseButton
  * @readOnly
@@ -387,8 +389,8 @@ p5.prototype.pwinMouseY = 0;
 p5.prototype.mouseButton = 0;
 
 /**
- * The boolean system variable mouseIsPressed is true if the mouse is pressed
- * and false if not.
+ * The boolean system variable `mouseIsPressed` is `true` if the mouse is pressed
+ * and `false` if not.
  *
  * @property {Boolean} mouseIsPressed
  * @readOnly
@@ -480,10 +482,10 @@ p5.prototype._setMouseButton = function(e) {
 
 /**
  * The <a href="#/p5/mouseMoved">mouseMoved()</a> function is called every time the mouse moves and a mouse
- * button is not pressed.<br><br>
- * Browsers may have different default
- * behaviors attached to various mouse events. To prevent any default
- * behavior for this event, add "return false" to the end of the method.
+ * button is not pressed.
+ *
+ * Browsers may have different default behaviors attached to various mouse events.
+ * To prevent any default behavior for this event, add `return false` to the end of the method.
  *
  * @method mouseMoved
  * @param  {Object} [event] optional MouseEvent callback argument.
@@ -535,10 +537,10 @@ p5.prototype._setMouseButton = function(e) {
 /**
  * The <a href="#/p5/mouseDragged">mouseDragged()</a> function is called once every time the mouse moves and
  * a mouse button is pressed. If no <a href="#/p5/mouseDragged">mouseDragged()</a> function is defined, the
- * <a href="#/p5/touchMoved">touchMoved()</a> function will be called instead if it is defined.<br><br>
- * Browsers may have different default
- * behaviors attached to various mouse events. To prevent any default
- * behavior for this event, add "return false" to the end of the method.
+ * <a href="#/p5/touchMoved">touchMoved()</a> function will be called instead if it is defined.
+ *
+ * Browsers may have different default behaviors attached to various mouse events.
+ * To prevent any default behavior for this event, add `return false` to the end of the method.
  *
  * @method mouseDragged
  * @param  {Object} [event] optional MouseEvent callback argument.
@@ -614,13 +616,13 @@ p5.prototype._onmousemove = function(e) {
 
 /**
  * The <a href="#/p5/mousePressed">mousePressed()</a> function is called once after every time a mouse button
- * is pressed. The mouseButton variable (see the related reference entry)
+ * is pressed. The `mouseButton` variable (see the related reference entry)
  * can be used to determine which button has been pressed. If no
  * <a href="#/p5/mousePressed">mousePressed()</a> function is defined, the <a href="#/p5/touchStarted">touchStarted()</a> function will be
- * called instead if it is defined.<br><br>
- * Browsers may have different default
- * behaviors attached to various mouse events. To prevent any default
- * behavior for this event, add "return false" to the end of the method.
+ * called instead if it is defined.
+ *
+ * Browsers may have different default behaviors attached to various mouse events.
+ * To prevent any default behavior for this event, add `return false` to the end of the method.
  *
  * @method mousePressed
  * @param  {Object} [event] optional MouseEvent callback argument.
@@ -696,10 +698,10 @@ p5.prototype._onmousedown = function(e) {
 /**
  * The <a href="#/p5/mouseReleased">mouseReleased()</a> function is called every time a mouse button is
  * released. If no <a href="#/p5/mouseReleased">mouseReleased()</a> function is defined, the <a href="#/p5/touchEnded">touchEnded()</a>
- * function will be called instead if it is defined.<br><br>
- * Browsers may have different default
- * behaviors attached to various mouse events. To prevent any default
- * behavior for this event, add "return false" to the end of the method.
+ * function will be called instead if it is defined.
+ *
+ * Browsers may have different default behaviors attached to various mouse events.
+ * To prevent any default behavior for this event, add `return false` to the end of the method.
  *
  * @method mouseReleased
  * @param  {Object} [event] optional MouseEvent callback argument.
@@ -771,13 +773,14 @@ p5.prototype._ondragover = p5.prototype._onmousemove;
 
 /**
  * The <a href="#/p5/mouseClicked">mouseClicked()</a> function is called once after a mouse button has been
- * pressed and then released.<br><br>
+ * pressed and then released.
+ *
  * Browsers handle clicks differently, so this function is only guaranteed to be
  * run when the left mouse button is clicked. To handle other mouse buttons
- * being pressed or released, see <a href="#/p5/mousePressed">mousePressed()</a> or <a href="#/p5/mouseReleased">mouseReleased()</a>.<br><br>
- * Browsers may have different default
- * behaviors attached to various mouse events. To prevent any default
- * behavior for this event, add "return false" to the end of the method.
+ * being pressed or released, see <a href="#/p5/mousePressed">mousePressed()</a> or <a href="#/p5/mouseReleased">mouseReleased()</a>.
+ *
+ * Browsers may have different default behaviors attached to various mouse events.
+ * To prevent any default behavior for this event, add `return false` to the end of the method.
  *
  * @method mouseClicked
  * @param  {Object} [event] optional MouseEvent callback argument.
@@ -840,11 +843,12 @@ p5.prototype._onclick = function(e) {
 
 /**
  * The <a href="#/p5/doubleClicked">doubleClicked()</a> function is executed every time a event
- * listener has detected a dblclick event which is a part of the
- * DOM L3 specification. The doubleClicked event is fired when a
+ * listener has detected a `dblclick` event which is a part of the
+ * DOM L3 specification. The `doubleClicked` event is fired when a
  * pointing device button (usually a mouse's primary button)
- * is clicked twice on a single element. For more info on the
- * dblclick event refer to mozilla's documentation here:
+ * is clicked twice on a single element.
+ *
+ * For more info on the `dblclick` event, refer to Mozilla's documentation here:
  * https://developer.mozilla.org/en-US/docs/Web/Events/dblclick
  *
  * @method doubleClicked
@@ -926,16 +930,18 @@ p5.prototype._pmouseWheelDeltaY = 0;
 /**
  * The function <a href="#/p5/mouseWheel">mouseWheel()</a> is executed every time a vertical mouse wheel
  * event is detected either triggered by an actual mouse wheel or by a
- * touchpad.<br><br>
- * The event.delta property returns the amount the mouse wheel
- * have scrolled. The values can be positive or negative depending on the
+ * touchpad.
+ *
+ * The `event.delta` property returns the amount the mouse wheel
+ * have scrolled. The values can be positive or negative, depending on the
  * scroll direction (on OS X with "natural" scrolling enabled, the signs
- * are inverted).<br><br>
- * Browsers may have different default behaviors attached to various
- * mouse events. To prevent any default behavior for this event, add
- * "return false" to the end of the method.<br><br>
+ * are inverted).
+ *
+ * Browsers may have different default behaviors attached to various mouse events.
+ * To prevent any default behavior for this event, add `return false` to the end of the method.
+ *
  * Due to the current support of the "wheel" event on Safari, the function
- * may only work as expected if "return false" is included while using Safari.
+ * may only work as expected if `return false` is included while using Safari.
  *
  * @method mouseWheel
  * @param  {Object} [event] optional WheelEvent callback argument.
@@ -981,7 +987,9 @@ p5.prototype._onwheel = function(e) {
  * locks the pointer to its current position and makes it invisible.
  * Use <a href="#/p5/movedX">movedX</a> and <a href="#/p5/movedY">movedY</a> to get the difference the mouse was moved since
  * the last call of draw.
+ *
  * Note that not all browsers support this feature.
+ *
  * This enables you to create experiences that aren't limited by the mouse moving out of the screen
  * even if it is repeatedly moved into one direction.
  * For example, a first person perspective experience.
@@ -1024,8 +1032,8 @@ p5.prototype.requestPointerLock = function() {
 
 /**
  * The function <a href="#/p5/exitPointerLock">exitPointerLock()</a>
- * exits a previously triggered <a href="#/p5/requestPointerLock">pointer Lock</a>
- * for example to make ui elements usable etc
+ * exits a previously triggered <a href="#/p5/requestPointerLock">pointer lock</a>
+ * for example to make UI elements usable, etc.
  *
  * @method exitPointerLock
  * @example

--- a/src/events/touch.js
+++ b/src/events/touch.js
@@ -8,12 +8,12 @@
 import p5 from '../core/main';
 
 /**
- * The system variable touches[] contains an array of the positions of all
+ * The system variable `touches[]` contains an array of the positions of all
  * current touch points, relative to (0, 0) of the canvas, and IDs identifying a
- * unique touch as it moves. Each element in the array is an object with x, y,
- * and id properties.
+ * unique touch as it moves. Each element in the array is an object with `x`, `y`,
+ * and `id` properties.
  *
- * The touches[] array is not supported on Safari and IE on touch-based
+ * The `touches[]` array is not supported on Safari and IE on touch-based
  * desktops (laptops).
  *
  * @property {Object[]} touches
@@ -69,12 +69,12 @@ function getTouchInfo(canvas, w, h, e, i = 0) {
 }
 
 /**
- * The touchStarted() function is called once after every time a touch is
+ * The `touchStarted()` function is called once after every time a touch is
  * registered. If no <a href="#/p5/touchStarted">touchStarted()</a> function is defined, the <a href="#/p5/mousePressed">mousePressed()</a>
- * function will be called instead if it is defined.<br><br>
- * Browsers may have different default behaviors attached to various touch
- * events. To prevent any default behavior for this event, add "return false"
- * to the end of the method.
+ * function will be called instead if it is defined.
+ *
+ * Browsers may have different default behaviors attached to various touch events.
+ * To prevent any default behavior for this event, add `return false` to the end of the method.
  *
  * @method touchStarted
  * @param  {Object} [event] optional TouchEvent callback argument.
@@ -151,10 +151,10 @@ p5.prototype._ontouchstart = function(e) {
 /**
  * The <a href="#/p5/touchMoved">touchMoved()</a> function is called every time a touch move is registered.
  * If no <a href="#/p5/touchMoved">touchMoved()</a> function is defined, the <a href="#/p5/mouseDragged">mouseDragged()</a> function will
- * be called instead if it is defined.<br><br>
- * Browsers may have different default behaviors attached to various touch
- * events. To prevent any default behavior for this event, add "return false"
- * to the end of the method.
+ * be called instead if it is defined.
+ *
+ * Browsers may have different default behaviors attached to various touch events.
+ * To prevent any default behavior for this event, add `return false` to the end of the method.
  *
  * @method touchMoved
  * @param  {Object} [event] optional TouchEvent callback argument.
@@ -223,10 +223,10 @@ p5.prototype._ontouchmove = function(e) {
 /**
  * The <a href="#/p5/touchEnded">touchEnded()</a> function is called every time a touch ends. If no
  * <a href="#/p5/touchEnded">touchEnded()</a> function is defined, the <a href="#/p5/mouseReleased">mouseReleased()</a> function will be
- * called instead if it is defined.<br><br>
- * Browsers may have different default behaviors attached to various touch
- * events. To prevent any default behavior for this event, add "return false"
- * to the end of the method.
+ * called instead if it is defined.
+ *
+ * Browsers may have different default behaviors attached to various touch events.
+ * To prevent any default behavior for this event, add `return false` to the end of the method.
  *
  * @method touchEnded
  * @param  {Object} [event] optional TouchEvent callback argument.

--- a/src/image/filters.js
+++ b/src/image/filters.js
@@ -7,7 +7,7 @@
  * as opposed to modules. The functions are destructive, modifying
  * the passed in canvas rather than creating a copy.
  *
- * Generally speaking users of this module will use the Filters.apply method
+ * Generally speaking users of this module will use the `Filters.apply()` method
  * on a canvas to create an effect.
  *
  * A number of functions are borrowed/adapted from
@@ -189,7 +189,7 @@ Filters.apply = function(canvas, func, filterParam) {
 /**
  * Converts the image to black and white pixels depending if they are above or
  * below the threshold defined by the level parameter. The parameter must be
- * between 0.0 (black) and 1.0 (white). If no level is specified, 0.5 is used.
+ * between 0.0 (black) and 1.0 (white). If no `level` is specified, 0.5 is used.
  *
  * Borrowed from http://www.html5rocks.com/en/tutorials/canvas/imagefilters/
  *
@@ -279,7 +279,7 @@ Filters.invert = function(canvas) {
  * the parameter. The parameter can be set to values between 2 and 255, but
  * results are most noticeable in the lower ranges.
  *
- * Adapted from java based processing implementation
+ * Adapted from Java-based processing implementation
  *
  * @private
  * @param  {Canvas} canvas
@@ -307,7 +307,7 @@ Filters.posterize = function(canvas, level) {
 };
 
 /**
- * reduces the bright areas in an image
+ * Reduces the bright areas in an image
  * @private
  * @param  {Canvas} canvas
  */
@@ -394,7 +394,7 @@ Filters.dilate = function(canvas) {
 };
 
 /**
- * increases the bright areas in an image
+ * Increases the bright areas in an image
  * @private
  * @param  {Canvas} canvas
  */

--- a/src/image/image.js
+++ b/src/image/image.js
@@ -97,9 +97,9 @@ p5.prototype.createImage = function(width, height) {
  *
  *  @method saveCanvas
  *  @param  {p5.Element|HTMLCanvasElement} selectedCanvas   a variable
- *                                  representing a specific html5 canvas (optional)
+ *                                  representing a specific HTML5 canvas (optional)
  *  @param  {String} [filename]
- *  @param  {String} [extension]      'jpg' or 'png'
+ *  @param  {String} [extension]      `'jpg'` or `'png'`
  *
  *  @example
  * <div class='norender notest'><code>

--- a/src/image/loading_displaying.js
+++ b/src/image/loading_displaying.js
@@ -29,7 +29,7 @@ import '../core/friendly_errors/fes_core';
  * security.
 
  * You can also pass in a string of a base64 encoded image as an alternative to the file path.
- * Remember to add "data:image/png;base64," in front of the string.
+ * Remember to add `"data:image/png;base64,"` in front of the string.
  *
  * @method loadImage
  * @param  {String} path Path of the image to be loaded

--- a/src/image/p5.Image.js
+++ b/src/image/p5.Image.js
@@ -22,7 +22,7 @@ import Filters from './filters';
  * Creates a new <a href="#/p5.Image">p5.Image</a>. A <a href="#/p5.Image">p5.Image</a> is a canvas backed representation of an
  * image.
  *
- * p5 can display .gif, .jpg and .png images. Images may be displayed
+ * p5 can display `.gif`, `.jpg`, and `.png` images. Images may be displayed
  * in 2D and 3D space. Before an image is used, it must be loaded with the
  * <a href="#/p5/loadImage">loadImage()</a> function. The <a href="#/p5.Image">p5.Image</a> class contains fields for the width and
  * height of the image, as well as an array called <a href="#/p5.Image/pixels">pixels[]</a> that contains the
@@ -347,8 +347,8 @@ p5.Image.prototype.updatePixels = function(x, y, w, h) {
  * Get a region of pixels from an image.
  *
  * If no params are passed, the whole image is returned.
- * If x and y are the only params passed a single pixel is extracted.
- * If all params are passed a rectangle region is extracted and a <a href="#/p5.Image">p5.Image</a>
+ * If `x` and `y` are the only params passed, a single pixel is extracted.
+ * If all params are passed, a rectangle region is extracted and a <a href="#/p5.Image">p5.Image</a>
  * is returned.
  *
  * @method get
@@ -436,9 +436,9 @@ p5.Image.prototype.set = function(x, y, imgOrCol) {
 
 /**
  * Resize the image to a new width and height. To make the image scale
- * proportionally, use 0 as the value for the wide or high parameter.
+ * proportionally, use `0` as the value for the `width` or `height` parameter.
  * For instance, to make the width of an image 150 pixels, and change
- * the height using the same proportion, use resize(150, 0).
+ * the height using the same proportion, use `resize(150, 0)`.
  *
  * @method resize
  * @param {Number} width the resized image width
@@ -603,8 +603,9 @@ p5.Image.prototype.copy = function(...args) {
 /**
  * Masks part of an image from displaying by loading another
  * image and using its alpha channel as an alpha channel for
- * this image. Masks are cumulative, one applied to an image
- * object, they cannot be removed.
+ * this image.
+ *
+ * Masks are cumulative. Once applied to an image object, they cannot be removed.
  *
  * @method mask
  * @param {p5.Image} srcImage source image
@@ -696,7 +697,7 @@ p5.Image.prototype.mask = function(p5Image) {
  * DILATE
  * Increases the light areas. No parameter is used.
  *
- * filter() does not work in WEBGL mode.
+ * `filter()` does not work in WEBGL mode.
  * A similar effect can be achieved in WEBGL mode using custom
  * shaders. Adam Ferriss has written
  * a <a href="https://github.com/aferriss/p5jsShaderExamples"
@@ -859,13 +860,13 @@ p5.Image.prototype.isModified = function() {
 /**
  * Saves the image to a file and force the browser to download it.
  * Accepts two strings for filename and file extension
- * Supports png (default), jpg, and gif
- *<br><br>
+ * Supports `png` (default), `jpg`, and `gif`.
+ *
  * Note that the file will only be downloaded as an animated GIF
- * if the p5.Image was loaded from a GIF file.
+ * if the `p5.Image` was loaded from a GIF file.
  * @method save
  * @param {String} filename give your file a name
- * @param  {String} extension 'png' or 'jpg'
+ * @param  {String} extension `'png'` or `'jpg'`
  * @example
  * <div><code>
  * let photo;

--- a/src/image/pixels.js
+++ b/src/image/pixels.js
@@ -17,7 +17,7 @@ import '../color/p5.Color';
  * factor for <a href="#/p5/pixelDensity">pixelDensity</a>) of the display window x4,
  * representing the R, G, B, A values in order for each pixel, moving from
  * left to right across each row, then down each column. Retina and other
- * high density displays will have more pixels[] (by a factor of
+ * high density displays will have more `pixels[]` (by a factor of
  * pixelDensity^2).
  * For example, if the image is 100x100 pixels, there will be 40,000. On a
  * retina display, there will be 160,000.
@@ -94,7 +94,7 @@ p5.prototype.pixels = [];
  * @param  {Constant} blendMode the blend mode. either
  *     BLEND, DARKEST, LIGHTEST, DIFFERENCE,
  *     MULTIPLY, EXCLUSION, SCREEN, REPLACE, OVERLAY, HARD_LIGHT,
- *     SOFT_LIGHT, DODGE, BURN, ADD or NORMAL.
+ *     SOFT_LIGHT, DODGE, BURN, ADD, or NORMAL.
  *
  * @example
  * <div><code>
@@ -172,8 +172,8 @@ p5.prototype.blend = function(...args) {
 
 /**
  * Copies a region of the canvas to another region of the canvas
- * and copies a region of pixels from an image used as the srcImg parameter
- * into the canvas srcImage is specified this is used as the source. If
+ * and copies a region of pixels from an image used as the `srcImg` parameter
+ * into the canvas `srcImage` is specified this is used as the source. If
  * the source and destination regions aren't the same size, it will
  * automatically resize source pixels to fit the specified
  * target region.
@@ -309,8 +309,8 @@ p5.prototype._copyHelper = (
  *
  * THRESHOLD
  * Converts the image to black and white pixels depending if they are above or
- * below the threshold defined by the level parameter. The parameter must be
- * between 0.0 (black) and 1.0 (white). If no level is specified, 0.5 is used.
+ * below the threshold defined by the `level` parameter. The parameter must be
+ * between 0.0 (black) and 1.0 (white). If no `level` is specified, 0.5 is used.
  *
  * GRAY
  * Converts any colors in the image to grayscale equivalents. No parameter
@@ -328,7 +328,7 @@ p5.prototype._copyHelper = (
  * results are most noticeable in the lower ranges.
  *
  * BLUR
- * Executes a Gaussian blur with the level parameter specifying the extent
+ * Executes a Gaussian blur with the `level` parameter specifying the extent
  * of the blurring. If no parameter is used, the blur is equivalent to
  * Gaussian blur of radius 1. Larger values increase the blur.
  *
@@ -338,7 +338,7 @@ p5.prototype._copyHelper = (
  * DILATE
  * Increases the light areas. No parameter is used.
  *
- * filter() does not work in WEBGL mode.
+ * `filter()` does not work in WEBGL mode.
  * A similar effect can be achieved in WEBGL mode using custom
  * shaders. Adam Ferriss has written
  * a <a href="https://github.com/aferriss/p5jsShaderExamples"
@@ -347,7 +347,7 @@ p5.prototype._copyHelper = (
  *
  * @method filter
  * @param  {Constant} filterType  either THRESHOLD, GRAY, OPAQUE, INVERT,
- *                                POSTERIZE, BLUR, ERODE, DILATE or BLUR.
+ *                                POSTERIZE, BLUR, ERODE, DILATE, or BLUR.
  *                                See Filters.js for docs on
  *                                each available filter
  * @param  {Number} [filterParam] an optional parameter unique
@@ -483,14 +483,14 @@ p5.prototype.filter = function(operation, value) {
  *
  * Returns an array of [R,G,B,A] values for any pixel or grabs a section of
  * an image. If no parameters are specified, the entire image is returned.
- * Use the x and y parameters to get the value of one pixel. Get a section of
- * the display window by specifying additional w and h parameters. When
- * getting an image, the x and y parameters define the coordinates for the
+ * Use the `x` and `y` parameters to get the value of one pixel. Get a section of
+ * the display window by specifying additional `w` and `h` parameters. When
+ * getting an image, the `x` and `y` parameters define the coordinates for the
  * upper-left corner of the image, regardless of the current <a href="#/p5/imageMode">imageMode()</a>.
  *
- * Getting the color of a single pixel with get(x, y) is easy, but not as fast
+ * Getting the color of a single pixel with `get(x, y)` is easy, but not as fast
  * as grabbing the data directly from <a href="#/p5/pixels">pixels[]</a>. The equivalent statement to
- * get(x, y) using <a href="#/p5/pixels">pixels[]</a> with pixel density d is
+ * `get(x, y)` using <a href="#/p5/pixels">pixels[]</a> with pixel density `d` is:
  * ```javascript
  * let x, y, d; // set these to the coordinates
  * let off = (y * width + x) * d * 4;
@@ -504,7 +504,7 @@ p5.prototype.filter = function(operation, value) {
  * ```
  * See the reference for <a href="#/p5/pixels">pixels[]</a> for more information.
  *
- * If you want to extract an array of colors or a subimage from an p5.Image object,
+ * If you want to extract an array of colors or a subimage from an `p5.Image` object,
  * take a look at <a href="#/p5.Image/get">p5.Image.get()</a>
  *
  * @method get
@@ -556,7 +556,7 @@ p5.prototype.filter = function(operation, value) {
  * @method get
  * @param  {Number}        x
  * @param  {Number}        y
- * @return {Number[]}      color of pixel at x,y in array format [R, G, B, A]
+ * @return {Number[]}      color of pixel at `x`,`y` in array format [R, G, B, A]
  */
 p5.prototype.get = function(x, y, w, h) {
   p5._validateParameters('get', arguments);
@@ -602,17 +602,18 @@ p5.prototype.loadPixels = function(...args) {
 /**
  * Changes the color of any pixel, or writes an image directly to the
  * display window.
- * The x and y parameters specify the pixel to change and the c parameter
+ *
+ * The `x` and `y` parameters specify the pixel to change and the `c` parameter
  * specifies the color value. This can be a <a href="#/p5.Color">p5.Color</a> object, or [R, G, B, A]
  * pixel array. It can also be a single grayscale value.
- * When setting an image, the x and y parameters define the coordinates for
+ * When setting an image, the `x` and `y` parameters define the coordinates for
  * the upper-left corner of the image, regardless of the current <a href="#/p5/imageMode">imageMode()</a>.
  *
  * After using <a href="#/p5/set">set()</a>, you must call <a href="#/p5/updatePixels">updatePixels()</a> for your changes to appear.
  * This should be called once all pixels have been set, and must be called before
  * calling .<a href="#/p5/get">get()</a> or drawing the image.
  *
- * Setting the color of a single pixel with set(x, y) is easy, but not as
+ * Setting the color of a single pixel with `set(x, y)` is easy, but not as
  * fast as putting the data directly into <a href="#/p5/pixels">pixels[]</a>. Setting the <a href="#/p5/pixels">pixels[]</a>
  * values directly may be complicated when working with a retina display,
  * but will perform better when lots of pixels need to be set directly on

--- a/src/io/files.js
+++ b/src/io/files.js
@@ -30,9 +30,9 @@ import '../core/friendly_errors/fes_core';
  *
  * This method is suitable for fetching files up to size of 64MB.
  * @method loadJSON
- * @param  {String}        path       name of the file or url to load
+ * @param  {String}        path       name of the file or URL to load
  * @param  {Object}        [jsonpOptions] options object for jsonp related settings
- * @param  {String}        [datatype] "json" or "jsonp"
+ * @param  {String}        [datatype] `"json"` or `"jsonp"`
  * @param  {function}      [callback] function to be executed after
  *                                    <a href="#/p5/loadJSON">loadJSON()</a> completes, data is passed
  *                                    in as first argument
@@ -186,7 +186,7 @@ p5.prototype.loadJSON = function(...args) {
  * example, the file must be located in the sketch directory/folder.
  *
  * Alternatively, the file maybe be loaded from anywhere on the local
- * computer using an absolute path (something that starts with / on Unix and
+ * computer using an absolute path (something that starts with `/` on Unix and
  * Linux, or a drive letter on Windows), or the filename parameter can be a
  * URL for a file found on a network.
  *
@@ -205,7 +205,7 @@ p5.prototype.loadJSON = function(...args) {
  * @return {String[]}            Array of Strings
  * @example
  *
- * Calling loadStrings() inside <a href="#/p5/preload">preload()</a> guarantees to complete the
+ * Calling `loadStrings()` inside <a href="#/p5/preload">preload()</a> guarantees to complete the
  * operation before <a href="#/p5/setup">setup()</a> and <a href="#/p5/draw">draw()</a> are called.
  *
  * <div><code>
@@ -317,9 +317,9 @@ p5.prototype.loadStrings = function(...args) {
  * All files loaded and saved use UTF-8 encoding. This method is suitable for fetching files up to size of 64MB.
  * @method loadTable
  * @param  {String}         filename    name of the file or URL to load
- * @param  {String}         [extension] parse the table by comma-separated values "csv", semicolon-separated
- *                                      values "ssv", or tab-separated values "tsv"
- * @param  {String}         [header]    "header" to indicate table has header row
+ * @param  {String}         [extension] parse the table by comma-separated values `"csv"`, semicolon-separated
+ *                                      values `"ssv"`, or tab-separated values `"tsv"`
+ * @param  {String}         [header]    `"header"` to indicate table has header row
  * @param  {function}       [callback]  function to be executed after
  *                                      <a href="#/p5/loadTable">loadTable()</a> completes. On success, the
  *                                      <a href="#/p5.Table">Table</a> object is passed in as the
@@ -586,7 +586,7 @@ function makeObject(row, headers) {
  * the file must be located in the sketch directory/folder.
  *
  * Alternatively, the file maybe be loaded from anywhere on the local
- * computer using an absolute path (something that starts with / on Unix and
+ * computer using an absolute path (something that starts with `/` on Unix and
  * Linux, or a drive letter on Windows), or the filename parameter can be a
  * URL for a file found on a network.
  *
@@ -698,7 +698,7 @@ p5.prototype.loadXML = function(...args) {
  *                                    completes
  * @param {function} [errorCallback] function to be executed if there
  *                                    is an error
- * @returns {Object} an object whose 'bytes' property will be the loaded buffer
+ * @returns {Object} an object whose `bytes` property will be the loaded buffer
  *
  * @example
  * <div class='norender'><code>
@@ -750,16 +750,16 @@ p5.prototype.loadBytes = function(file, callback, errorCallback) {
 };
 
 /**
- * Method for executing an HTTP GET request. If data type is not specified,
- * p5 will try to guess based on the URL, defaulting to text. This is equivalent to
- * calling <code>httpDo(path, 'GET')</code>. The 'binary' datatype will return
- * a Blob object, and the 'arrayBuffer' datatype will return an ArrayBuffer
+ * Method for executing an HTTP GET request. If `datatype` is not specified,
+ * p5 will try to guess based on the URL, defaulting to `"text"`. This is equivalent to
+ * calling `httpDo(path, 'GET')`. The `"binary"` datatype will return
+ * a Blob object, and the `"arrayBuffer"` datatype will return an ArrayBuffer
  * which can be used to initialize typed arrays (such as Uint8Array).
  *
  * @method httpGet
- * @param  {String}        path       name of the file or url to load
- * @param  {String}        [datatype] "json", "jsonp", "binary", "arrayBuffer",
- *                                    "xml", or "text"
+ * @param  {String}        path       name of the file or URL to load
+ * @param  {String}        [datatype] `"json"`, `"jsonp"`, `"binary"`, `"arrayBuffer"`,
+ *                                    `"xml"`, or `"text"`
  * @param  {Object|Boolean} [data]    param data passed sent with request
  * @param  {function}      [callback] function to be executed after
  *                                    <a href="#/p5/httpGet">httpGet()</a> completes, data is passed in
@@ -827,13 +827,13 @@ p5.prototype.httpGet = function() {
 };
 
 /**
- * Method for executing an HTTP POST request. If data type is not specified,
- * p5 will try to guess based on the URL, defaulting to text. This is equivalent to
- * calling <code>httpDo(path, 'POST')</code>.
+ * Method for executing an HTTP POST request. If `datatype` is not specified,
+ * p5 will try to guess based on the URL, defaulting to `"text"`. This is equivalent to
+ * calling `httpDo(path, 'POST')`.
  *
  * @method httpPost
- * @param  {String}        path       name of the file or url to load
- * @param  {String}        [datatype] "json", "jsonp", "xml", or "text".
+ * @param  {String}        path       name of the file or URL to load
+ * @param  {String}        [datatype] `"json"`, `"jsonp"`, `"xml"`, or `"text"`.
  *                                    If omitted, <a href="#/p5/httpPost">httpPost()</a> will guess.
  * @param  {Object|Boolean} [data]    param data passed sent with request
  * @param  {function}      [callback] function to be executed after
@@ -917,11 +917,13 @@ p5.prototype.httpPost = function() {
 };
 
 /**
- * Method for executing an HTTP request. If data type is not specified,
- * p5 will try to guess based on the URL, defaulting to text.<br><br>
- * For more advanced use, you may also pass in the path as the first argument
- * and a object as the second argument, the signature follows the one specified
- * in the Fetch API specification.
+ * Method for executing an HTTP request. If `datatype` is not specified,
+ * p5 will try to guess based on the URL, defaulting to `"text"`.
+ *
+ * For more advanced use, you may also pass in the `path` as the first argument
+ * and a object as the second argument (such that signature follows the one specified
+ * in the Fetch API specification).
+ *
  * This method is suitable for fetching files up to size of 64MB when "GET" is used.
  *
  * @method httpDo
@@ -1391,25 +1393,32 @@ p5.PrintWriter = function(filename, extension) {
 // filename, [extension] [canvas] --> saveImage
 
 /**
- *  Saves a given element(image, text, json, csv, wav, or html) to the client's
- *  computer. The first parameter can be a pointer to element we want to save.
- *  The element can be one of <a href="#/p5.Element">p5.Element</a>,an Array of
- *  Strings, an Array of JSON, a JSON object, a <a href="#/p5.Table">p5.Table
- *  </a>, a <a href="#/p5.Image">p5.Image</a>, or a p5.SoundFile (requires
- *  p5.sound). The second parameter is a filename (including extension).The
- *  third parameter is for options specific to this type of object. This method
+ *  Saves a given element (image, text, json, csv, wav, or html) to the client's
+ *  computer.
+ *
+ *  The first parameter can be a pointer to element we want to save.
+ *  The element can be one of <a href="#/p5.Element">p5.Element</a>, an Array of
+ *  Strings, an Array of JSON, a JSON object, a <a href="#/p5.Table">p5.Table</a>,
+ *  a <a href="#/p5.Image">p5.Image</a>, or a `p5.SoundFile` (requires
+ *  `p5.sound`).
+ *
+ *  The second parameter is a filename (including extension).
+ *
+ *  The third parameter is for options specific to this type of object. This method
  *  will save a file that fits the given parameters.
+ *
  *  If it is called without specifying an element, by default it will save the
  *  whole canvas as an image file. You can optionally specify a filename as
  *  the first parameter in such a case.
+ *
  *  **Note that it is not recommended to
- *  call this method within draw, as it will open a new save dialog on every
+ *  call this method within `draw()`, as it will open a new save dialog on every
  *  render.**
  *
  * @method save
  * @param  {Object|String} [objectOrFilename]  If filename is provided, will
  *                                             save canvas as an image with
- *                                             either png or jpg extension
+ *                                             either `png` or `jpg` extension,
  *                                             depending on the filename.
  *                                             If object is provided, will
  *                                             save depending on the object
@@ -1422,7 +1431,7 @@ p5.PrintWriter = function(filename, extension) {
  *                               file extension (see examples above).
  * @param  {Boolean|String} [options]  Additional options depend on
  *                            filetype. For example, when saving JSON,
- *                            <code>true</code> indicates that the
+ *                            `true` indicates that the
  *                            output will be optimized for filesize,
  *                            rather than readability.
  *
@@ -1533,7 +1542,7 @@ p5.prototype.save = function(object, _filename, _options) {
 };
 
 /**
- *  Writes the contents of an Array or a JSON object to a .json file.
+ *  Writes the contents of an Array or a JSON object to a `.json` file.
  *  The file saving process and location of the saved file will
  *  vary between web browsers.
  *
@@ -1655,15 +1664,15 @@ function escapeHelper(content) {
 
 /**
  *  Writes the contents of a <a href="#/p5.Table">Table</a> object to a file. Defaults to a
- *  text file with comma-separated-values ('csv') but can also
- *  use tab separation ('tsv'), or generate an HTML table ('html').
+ *  text file with comma-separated-values (`'csv'`) but can also
+ *  use tab separation (`'tsv'`), or generate an HTML table (`'html'`).
  *  The file saving process and location of the saved file will
  *  vary between web browsers.
  *
  *  @method saveTable
  *  @param  {p5.Table} Table  the <a href="#/p5.Table">Table</a> object to save to a file
  *  @param  {String} filename the filename to which the Table should be saved
- *  @param  {String} [options]  can be one of "tsv", "csv", or "html"
+ *  @param  {String} [options]  can be one of `"tsv"`, `"csv"`, or `"html"`
  *  @example
  *  <div><code>
  * let table;
@@ -1787,10 +1796,10 @@ p5.prototype.saveTable = function(table, filename, options) {
 }; // end saveTable()
 
 /**
- *  Generate a blob of file data as a url to prepare for download.
+ *  Generate a blob of file data as a URL to prepare for download.
  *  Accepts an array of data, a filename, and an extension (optional).
  *  This is a private function because it does not do any formatting,
- *  but it is used by <a href="#/p5/saveStrings">saveStrings</a>, <a href="#/p5/saveJSON">saveJSON</a>, <a href="#/p5/saveTable">saveTable</a> etc.
+ *  but it is used by <a href="#/p5/saveStrings">saveStrings</a>, <a href="#/p5/saveJSON">saveJSON</a>, <a href="#/p5/saveTable">saveTable</a>, etc.
  *
  *  @param  {Array} dataToDownload
  *  @param  {String} filename
@@ -1809,7 +1818,7 @@ p5.prototype.writeFile = function(dataToDownload, filename, extension) {
 };
 
 /**
- *  Forces download. Accepts a url to filedata/blob, a filename,
+ *  Forces download. Accepts a URL to filedata/blob, a filename,
  *  and an extension (optional).
  *  This is a private function because it does not do any formatting,
  *  but it is used by <a href="#/p5/saveStrings">saveStrings</a>, <a href="#/p5/saveJSON">saveJSON</a>, <a href="#/p5/saveTable">saveTable</a> etc.

--- a/src/io/p5.Table.js
+++ b/src/io/p5.Table.js
@@ -37,12 +37,12 @@ import p5 from '../core/main';
  *
  *  @class p5.Table
  *  @constructor
- *  @param  {p5.TableRow[]}     [rows] An array of p5.TableRow objects
+ *  @param  {p5.TableRow[]}     [rows] An array of <a href="#/p5.TableRow">p5.TableRow</a> objects
  */
 p5.Table = function(rows) {
   /**
    * An array containing the names of the columns in the table, if the "header" the table is
-   * loaded with the "header" parameter.
+   * loaded with the `header` parameter.
    * @property columns {String[]}
    * @example
    * <div class="norender">
@@ -85,7 +85,7 @@ p5.Table = function(rows) {
 /**
  *  Use <a href="#/p5/addRow">addRow()</a> to add a new row of data to a <a href="#/p5.Table">p5.Table</a> object. By default,
  *  an empty row is created. Typically, you would store a reference to
- *  the new row in a TableRow object (see newRow in the example above),
+ *  the new row in a <a href="#/p5.TableRow">p5.TableRow</a> object (see newRow in the example above),
  *  and then set individual values using <a href="#/p5/set">set()</a>.
  *
  *  If a <a href="#/p5.TableRow">p5.TableRow</a> object is included as a parameter, then that row is
@@ -360,7 +360,7 @@ p5.Table.prototype.findRow = function(value, column) {
  *  @param  {String} value  The value to match
  *  @param  {Integer|String} column ID number or title of the
  *                                 column to search
- *  @return {p5.TableRow[]}        An Array of TableRow objects
+ *  @return {p5.TableRow[]}        An Array of <a href="#/p5.TableRow">p5.TableRow</a> objects
  *
  * @example
  * <div class="norender">
@@ -428,7 +428,7 @@ p5.Table.prototype.findRows = function(value, column) {
  * @param  {String|RegExp} regexp The regular expression to match
  * @param  {String|Integer} column The column ID (number) or
  *                                  title (string)
- * @return {p5.TableRow}        TableRow object
+ * @return {p5.TableRow}        <a href="#/p5.TableRow">p5.TableRow</a> object
  *
  * @example
  * <div class="norender">
@@ -485,7 +485,7 @@ p5.Table.prototype.matchRow = function(regexp, column) {
  * @param  {String} regexp The regular expression to match
  * @param  {String|Integer} [column] The column ID (number) or
  *                                  title (string)
- * @return {p5.TableRow[]}          An Array of TableRow objects
+ * @return {p5.TableRow[]}          An Array of <a href="#/p5.TableRow">p5.TableRow</a> objects
  * @example
  * <div class="norender">
  * <code>
@@ -637,9 +637,9 @@ p5.Table.prototype.clearRows = function() {
 
 /**
  *  Use <a href="#/p5/addColumn">addColumn()</a> to add a new column to a <a href="#/p5.Table">Table</a> object.
- *  Typically, you will want to specify a title, so the column
- *  may be easily referenced later by name. (If no title is
- *  specified, the new column's title will be null.)
+ *  Typically, you will want to specify a `title`, so the column
+ *  may be easily referenced later by name. (If no `title` is
+ *  specified, the new column's `title` will be `null`.)
  *
  *  @method  addColumn
  *  @param {String} [title] title of the given column
@@ -896,8 +896,8 @@ p5.Table.prototype.trim = function(column) {
 /**
  *  Use <a href="#/p5/removeColumn">removeColumn()</a> to remove an existing column from a Table
  *  object. The column to be removed may be identified by either
- *  its title (a String) or its index value (an int).
- *  removeColumn(0) would remove the first column, removeColumn(1)
+ *  its `title` (a String) or its index value (an int).
+ *  `removeColumn(0)` would remove the first column, `removeColumn(1)`
  *  would remove the second column, and so on.
  *
  *  @method  removeColumn

--- a/src/io/p5.TableRow.js
+++ b/src/io/p5.TableRow.js
@@ -10,12 +10,12 @@ import p5 from '../core/main';
  *  A TableRow object represents a single row of data values,
  *  stored in columns, from a table.
  *
- *  A Table Row contains both an ordered array, and an unordered
+ *  A TableRow contains both an ordered array, and an unordered
  *  JSON object.
  *
  *  @class p5.TableRow
  *  @constructor
- *  @param {String} [str]       optional: populate the row with a
+ *  @param {String} [str]       (optional) populate the row with a
  *                              string of values, separated by the
  *                              separator
  *  @param {String} [separator] comma separated values (csv) by default

--- a/src/io/p5.XML.js
+++ b/src/io/p5.XML.js
@@ -312,8 +312,8 @@ function elementsToP5XML(elements) {
 }
 
 /**
- * Returns the first of the element's children that matches the name parameter
- * or the child of the given index.It returns undefined if no matching
+ * Returns the first of the element's children that matches the `name` parameter
+ * or the child of the given index. It returns `undefined` if no matching
  * child is found.
  *
  * @method getChild
@@ -620,10 +620,10 @@ p5.XML.prototype.hasAttribute = function(name) {
 };
 
 /**
- * Returns an attribute value of the element as an Number. If the defaultValue
- * parameter is specified and the attribute doesn't exist, then defaultValue
- * is returned. If no defaultValue is specified and the attribute doesn't
- * exist, the value 0 is returned.
+ * Returns an attribute value of the element as an Number. If the `defaultValue`
+ * parameter is specified and the attribute doesn't exist, then `defaultValue`
+ * is returned. If no `defaultValue` is specified and the attribute doesn't
+ * exist, the value `0` is returned.
  *
  * @method getNum
  * @param {String} name            the non-null full name of the attribute
@@ -667,10 +667,10 @@ p5.XML.prototype.getNum = function(name, defaultValue) {
 };
 
 /**
- * Returns an attribute value of the element as an String. If the defaultValue
- * parameter is specified and the attribute doesn't exist, then defaultValue
- * is returned. If no defaultValue is specified and the attribute doesn't
- * exist, null is returned.
+ * Returns an attribute value of the element as an String. If the `defaultValue`
+ * parameter is specified and the attribute doesn't exist, then `defaultValue`
+ * is returned. If no `defaultValue` is specified and the attribute doesn't
+ * exist, `null` is returned.
  *
  * @method getString
  * @param {String} name            the non-null full name of the attribute
@@ -756,7 +756,7 @@ p5.XML.prototype.setAttribute = function(name, value) {
 
 /**
  * Returns the content of an element. If there is no such content,
- * defaultValue is returned if specified, otherwise null is returned.
+ * `defaultValue` is returned if specified, otherwise `null` is returned.
  *
  * @method getContent
  * @param {String} [defaultValue] value returned if no content is found

--- a/src/math/calculation.js
+++ b/src/math/calculation.js
@@ -8,7 +8,7 @@
 import p5 from '../core/main';
 
 /**
- * Calculates the absolute value (magnitude) of a number. Maps to Math.abs().
+ * Calculates the absolute value (magnitude) of a number. Maps to `Math.abs()`.
  * The absolute value of a number is always positive.
  *
  * @method abs
@@ -32,8 +32,8 @@ p5.prototype.abs = Math.abs;
 
 /**
  * Calculates the closest int value that is greater than or equal to the
- * value of the parameter. Maps to Math.ceil(). For example, ceil(9.03)
- * returns the value 10.
+ * value of the parameter. Maps to `Math.ceil()`. For example, `ceil(9.03)`
+ * returns the value `10`.
  *
  * @method ceil
  * @param  {Number} n number to round up
@@ -162,10 +162,10 @@ p5.prototype.constrain = function(n, low, high) {
  * @method dist
  * @param  {Number} x1
  * @param  {Number} y1
- * @param  {Number} z1 z-coordinate of the first point
+ * @param  {Number} z1 `z`-coordinate of the first point
  * @param  {Number} x2
  * @param  {Number} y2
- * @param  {Number} z2 z-coordinate of the second point
+ * @param  {Number} z2 `z`-coordinate of the second point
  * @return {Number}    distance between the two points
  */
 p5.prototype.dist = function(...args) {
@@ -180,8 +180,8 @@ p5.prototype.dist = function(...args) {
 };
 
 /**
- * Returns Euler's number e (2.71828...) raised to the power of the n
- * parameter. Maps to Math.exp().
+ * Returns Euler's number `e` (2.71828...) raised to the power of the `n`
+ * parameter. Maps to `Math.exp()`.
  *
  * @method exp
  * @param  {Number} n exponent to raise
@@ -230,7 +230,7 @@ p5.prototype.exp = Math.exp;
 
 /**
  * Calculates the closest int value that is less than or equal to the
- * value of the parameter. Maps to Math.floor().
+ * value of the parameter. Maps to `Math.floor()`.
  *
  * @method floor
  * @param  {Number} n number to round down
@@ -267,13 +267,15 @@ p5.prototype.exp = Math.exp;
 p5.prototype.floor = Math.floor;
 
 /**
- * Calculates a number between two numbers at a specific increment. The amt
- * parameter is the amount to interpolate between the two values where 0.0
+ * Calculates a number between two numbers at a specific increment. The `amt`
+ * parameter is the amount to interpolate between the two values (where 0.0
  * equal to the first point, 0.1 is very near the first point, 0.5 is
- * half-way in between, and 1.0 is equal to the second point. If the
- * value of amt is more than 1.0 or less than 0.0, the number will be
- * calculated accordingly in the ratio of the two given numbers. The lerp
- * function is convenient for creating motion along a straight
+ * half-way in between, and 1.0 is equal to the second point).
+ *
+ * If the value of `amt` is more than 1.0 or less than 0.0, the number will be
+ * calculated accordingly in the ratio of the two given numbers.
+ *
+ * The `lerp()` function is convenient for creating motion along a straight
  * path and for drawing dotted lines.
  *
  * @method lerp
@@ -315,12 +317,12 @@ p5.prototype.lerp = function(start, stop, amt) {
 
 /**
  * Calculates the natural logarithm (the base-e logarithm) of a number. This
- * function expects the n parameter to be a value greater than 0.0. Maps to
- * Math.log().
+ * function expects the `n` parameter to be a value greater than `0.0`. Maps to
+ * `Math.log()`.
  *
  * @method log
  * @param  {Number} n number greater than 0
- * @return {Number}   natural logarithm of n
+ * @return {Number}   natural logarithm of `n`
  * @example
  * <div><code>
  * function draw() {
@@ -369,11 +371,12 @@ p5.prototype.lerp = function(start, stop, amt) {
 p5.prototype.log = Math.log;
 
 /**
- * Calculates the magnitude (or length) of a vector. A vector is a direction
- * in space commonly used in computer graphics and linear algebra. Because it
- * has no "start" position, the magnitude of a vector can be thought of as
- * the distance from the coordinate 0,0 to its x,y value. Therefore, <a href="#/p5/mag">mag()</a> is
- * a shortcut for writing dist(0, 0, x, y).
+ * Calculates the magnitude (or length) of a vector.
+ *
+ * A vector is a direction in space commonly used in computer graphics and linear algebra.
+ * Because it has no "start" position, the magnitude of a vector can be thought of as
+ * the distance from the coordinate `0,0` to its `x,y` value. Therefore,
+ * <a href="#/p5/mag">mag()</a> is a shortcut for writing `dist(0, 0, x, y)`.
  *
  * @method mag
  * @param  {Number} a first value
@@ -410,8 +413,8 @@ p5.prototype.mag = function(x, y) {
  * Re-maps a number from one range to another.
  *
  * In the first example above, the number 25 is converted from a value in the
- * range of 0 to 100 into a value that ranges from the left edge of the
- * window (0) to the right edge (width).
+ * range of `0` to `100` into a value that ranges from the left edge of the
+ * window (`0`) to the right edge (`width`).
  *
  * @method map
  * @param  {Number} value  the incoming value to be converted
@@ -558,8 +561,9 @@ p5.prototype.min = function(...args) {
 };
 
 /**
- * Normalizes a number from another range into a value between 0 and 1.
- * Identical to map(value, low, high, 0, 1).
+ * Normalizes a number from another range into a value between `0` and `1`.
+ * Identical to `map(value, low, high, 0, 1)`.
+ *
  * Numbers outside of the range are not clamped to 0 and 1, because
  * out-of-range values are often intentional and useful. (See the example above.)
  *
@@ -612,10 +616,10 @@ p5.prototype.norm = function(n, start, stop) {
 /**
  * Facilitates exponential expressions. The <a href="#/p5/pow">pow()</a> function is an efficient
  * way of multiplying numbers by themselves (or their reciprocals) in large
- * quantities. For example, pow(3, 5) is equivalent to the expression
- * 3 &times; 3 &times; 3 &times; 3 &times; 3 and pow(3, -5) is equivalent to 1 /
- * 3 &times; 3 &times; 3 &times; 3 &times; 3. Maps to
- * Math.pow().
+ * quantities. For example, `pow(3, 5)` is equivalent to the expression
+ * `3 &times; 3 &times; 3 &times; 3 &times; 3` and `pow(3, -5)` is equivalent to `1 /
+ * 3 &times; 3 &times; 3 &times; 3 &times; 3`.
+ * Maps to `Math.pow()`.
  *
  * @method pow
  * @param  {Number} n base of the exponential expression
@@ -645,7 +649,7 @@ p5.prototype.pow = Math.pow;
 
 /**
  * Calculates the integer closest to the n parameter. For example,
- * round(133.8) returns the value 134. Maps to Math.round().
+ * `round(133.8)` returns the value `134`. Maps to `Math.round()`.
  *
  * @method round
  * @param  {Number} n number to round
@@ -701,7 +705,7 @@ p5.prototype.round = function(n, decimals) {
 /**
  * Squares a number (multiplies a number by itself). The result is always a
  * positive number, as multiplying two negative numbers always yields a
- * positive result. For example, -1 * -1 = 1.
+ * positive result. For example: `-1 * -1 = 1`.
  *
  * @method sq
  * @param  {Number} n number to square
@@ -745,8 +749,8 @@ p5.prototype.sq = n => n * n;
 /**
  * Calculates the square root of a number. The square root of a number is
  * always positive, even though there may be a valid negative root. The
- * square root s of number a is such that s*s = a. It is the opposite of
- * squaring. Maps to Math.sqrt().
+ * square root `s` of number `a` is such that `s*s = a`. It is the opposite of
+ * squaring. Maps to `Math.sqrt()`.
  *
  * @method sqrt
  * @param  {Number} n non-negative number to square root
@@ -834,7 +838,7 @@ function hypot(x, y, z) {
  *
  * @method fract
  * @param {Number} num Number whose fractional part needs to be found out
- * @returns {Number} fractional part of x, i.e, {x}
+ * @returns {Number} fractional part of `num`.
  * @example
  * <div><code>
  * text(7345.73472742, 10, 25);

--- a/src/math/math.js
+++ b/src/math/math.js
@@ -14,9 +14,9 @@ import p5 from '../core/main';
  * direction.
  *
  * @method createVector
- * @param {Number} [x] x component of the vector
- * @param {Number} [y] y component of the vector
- * @param {Number} [z] z component of the vector
+ * @param {Number} [x] `x` component of the vector
+ * @param {Number} [y] `y` component of the vector
+ * @param {Number} [z] `z` component of the vector
  * @return {p5.Vector}
  * @example
  * <div><code>

--- a/src/math/noise.js
+++ b/src/math/noise.js
@@ -36,26 +36,31 @@ let perlin; // will be initialized lazily by noise() or noiseSeed()
 /**
  * Returns the Perlin noise value at specified coordinates. Perlin noise is
  * a random sequence generator producing a more naturally ordered, harmonic
- * succession of numbers compared to the standard <b>random()</b> function.
+ * succession of numbers compared to the standard `random()` function.
  * It was invented by Ken Perlin in the 1980s and been used since in
  * graphical applications to produce procedural textures, natural motion,
- * shapes, terrains etc.<br /><br /> The main difference to the
- * <b>random()</b> function is that Perlin noise is defined in an infinite
- * n-dimensional space where each pair of coordinates corresponds to a
- * fixed semi-random value (fixed only for the lifespan of the program; see
- * the <a href="#/p5/noiseSeed">noiseSeed()</a> function). p5.js can compute 1D, 2D and 3D noise,
+ * shapes, terrains, etc.
+ *
+ * The main difference to the `random()` function is that Perlin noise is
+ * defined in an infinite n-dimensional space, where each pair of coordinates
+ * corresponds to a fixed semi-random value (fixed only for the lifespan of the program;
+ * see the <a href="#/p5/noiseSeed">noiseSeed()</a> function).
+ *
+ * p5.js can compute 1D, 2D, and 3D noise,
  * depending on the number of coordinates given. The resulting value will
  * always be between 0.0 and 1.0. The noise value can be animated by moving
  * through the noise space as demonstrated in the example above. The 2nd
- * and 3rd dimension can also be interpreted as time.<br /><br />The actual
- * noise is structured similar to an audio signal, in respect to the
+ * and 3rd dimension can also be interpreted as time.
+ *
+ * The actual noise is structured similar to an audio signal, in respect to the
  * function's use of frequencies. Similar to the concept of harmonics in
  * physics, perlin noise is computed over several octaves which are added
- * together for the final result. <br /><br />Another way to adjust the
- * character of the resulting sequence is the scale of the input
+ * together for the final result.
+ *
+ * Another way to adjust the character of the resulting sequence is the scale of the input
  * coordinates. As the function works within an infinite space the value of
  * the coordinates doesn't matter as such, only the distance between
- * successive coordinates does (eg. when using <b>noise()</b> within a
+ * successive coordinates does (e.g., when using `noise()` within a
  * loop). As a general rule the smaller the difference between coordinates,
  * the smoother the resulting noise sequence will be. Steps of 0.005-0.03
  * work best for most applications, but this will differ depending on use.
@@ -186,12 +191,12 @@ p5.prototype.noise = function(x, y = 0, z = 0) {
  * By default, noise is computed over 4 octaves with each octave contributing
  * exactly half than its predecessor, starting at 50% strength for the 1st
  * octave. This falloff amount can be changed by adding an additional function
- * parameter. Eg. a falloff factor of 0.75 means each octave will now have
- * 75% impact (25% less) of the previous lower octave. Any value between
+ * parameter. For example, a falloff factor of 0.75 means each octave will now
+ * have 75% impact (25% less) of the previous lower octave. Any value between
  * 0.0 and 1.0 is valid, however note that values greater than 0.5 might
- * result in greater than 1.0 values returned by <b>noise()</b>.
+ * result in greater than 1.0 values returned by `noise()`.
  *
- * By changing these parameters, the signal created by the <b>noise()</b>
+ * By changing these parameters, the signal created by the `noise()`
  * function can be adapted to fit very specific needs and characteristics.
  *
  * @method noiseDetail
@@ -241,9 +246,9 @@ p5.prototype.noiseDetail = function(lod, falloff) {
 };
 
 /**
- * Sets the seed value for <b>noise()</b>. By default, <b>noise()</b>
+ * Sets the seed value for `noise()`. By default, `noise()`
  * produces different results each time the program is run. Set the
- * <b>value</b> parameter to a constant to return the same pseudo-random
+ * `value` parameter to a constant to return the same pseudo-random
  * numbers each time the software is run.
  *
  * @method noiseSeed

--- a/src/math/p5.Vector.js
+++ b/src/math/p5.Vector.js
@@ -11,8 +11,8 @@ import * as constants from '../core/constants';
  * A class to describe a two or three dimensional vector, specifically
  * a Euclidean (also known as geometric) vector. A vector is an entity
  * that has both magnitude and direction. The datatype, however, stores
- * the components of the vector (x, y for 2D, and x, y, z for 3D). The magnitude
- * and direction can be accessed via the methods <a href="#/p5.Vector/mag">mag()</a> and <a href="#/p5.Vector/heading">heading()</a>.
+ * the components of the vector (`x`, `y` for 2D, and `x`, `y`, `z` for 3D).
+ * The magnitude and direction can be accessed via the methods <a href="#/p5.Vector/mag">mag()</a> and <a href="#/p5.Vector/heading">heading()</a>.
  *
  * In many of the p5.js examples, you will see <a href="#/p5.Vector">p5.Vector</a> used to describe a
  * position, velocity, or acceleration. For example, if you consider a rectangle
@@ -28,9 +28,9 @@ import * as constants from '../core/constants';
  *
  * @class p5.Vector
  * @constructor
- * @param {Number} [x] x component of the vector
- * @param {Number} [y] y component of the vector
- * @param {Number} [z] z component of the vector
+ * @param {Number} [x] `x` component of the vector
+ * @param {Number} [y] `y` component of the vector
+ * @param {Number} [z] `z` component of the vector
  * @example
  * <div>
  * <code>
@@ -63,25 +63,25 @@ p5.Vector = function Vector() {
     z = arguments[2] || 0;
   }
   /**
-   * The x component of the vector
+   * The `x` component of the vector
    * @property x {Number}
    */
   this.x = x;
   /**
-   * The y component of the vector
+   * The `y` component of the vector
    * @property y {Number}
    */
   this.y = y;
   /**
-   * The z component of the vector
+   * The `z` component of the vector
    * @property z {Number}
    */
   this.z = z;
 };
 
 /**
- * Returns a string representation of a vector v by calling String(v)
- * or v.toString(). This method is useful for logging vectors in the
+ * Returns a string representation of a vector `v` by calling `String(v)`
+ * or `v.toString()`. This method is useful for logging vectors in the
  * console.
  * @method  toString
  * @return {String}
@@ -130,12 +130,12 @@ p5.Vector.prototype.toString = function p5VectorToString() {
 };
 
 /**
- * Sets the x, y, and z component of the vector using two or three separate
+ * Sets the `x`, `y`, and `z` component of the vector using two or three separate
  * variables, the data from a <a href="#/p5.Vector">p5.Vector</a>, or the values from a float array.
  * @method set
- * @param {Number} [x] the x component of the vector
- * @param {Number} [y] the y component of the vector
- * @param {Number} [z] the z component of the vector
+ * @param {Number} [x] the `x` component of the vector
+ * @param {Number} [y] the `y` component of the vector
+ * @param {Number} [z] the `z` component of the vector
  * @chainable
  * @example
  * <div class="norender">
@@ -190,7 +190,7 @@ p5.Vector.prototype.toString = function p5VectorToString() {
  */
 /**
  * @method set
- * @param {p5.Vector|Number[]} value the vector to set
+ * @param {p5.Vector|Number[]} value The vector to set
  * @chainable
  */
 p5.Vector.prototype.set = function set(x, y, z) {
@@ -236,16 +236,16 @@ p5.Vector.prototype.copy = function copy() {
 };
 
 /**
- * Adds x, y, and z components to a vector, adds one vector to another, or
+ * Adds `x`, `y`, and `z` components to a vector; or, adds one vector to another; or
  * adds two independent vectors together. The version of the method that adds
  * two vectors together is a static method and returns a <a href="#/p5.Vector">p5.Vector</a>, the others
  * acts directly on the vector. Additionally, you may provide arguments to this function as an array.
  * See the examples for more context.
  *
  * @method add
- * @param  {Number} x   the x component of the vector to be added
- * @param  {Number} [y] the y component of the vector to be added
- * @param  {Number} [z] the z component of the vector to be added
+ * @param  {Number} x   the `x` component of the vector to be added
+ * @param  {Number} [y] the `y` component of the vector to be added
+ * @param  {Number} [z] the `z` component of the vector to be added
  * @chainable
  * @example
  * <div class="norender">
@@ -444,16 +444,16 @@ p5.Vector.prototype.rem = function rem(x, y, z) {
 };
 
 /**
- * Subtracts x, y, and z components from a vector, subtracts one vector from
- * another, or subtracts two independent vectors. The version of the method
+ * Subtracts `x`, `y`, and `z` components from a vector; or, subtracts one vector from
+ * another; or, subtracts two independent vectors. The version of the method
  * that subtracts two vectors is a static method and returns a <a href="#/p5.Vector">p5.Vector</a>, the
  * other acts directly on the vector. Additionally, you may provide arguments to this function as an array.
  * See the examples for more context.
  *
  * @method sub
- * @param  {Number} x   the x component of the vector to subtract
- * @param  {Number} [y] the y component of the vector to subtract
- * @param  {Number} [z] the z component of the vector to subtract
+ * @param  {Number} x   the `x` component of the vector to subtract
+ * @param  {Number} [y] the `y` component of the vector to subtract
+ * @param  {Number} [z] the `z` component of the vector to subtract
  * @chainable
  * @example
  * <div class="norender">
@@ -545,11 +545,11 @@ p5.Vector.prototype.sub = function sub(x, y, z) {
 };
 
 /**
- * Multiplies the vector by a scalar, multiplies the x, y, and z components from a vector, or multiplies
- * the x, y, and z components of two independent vectors. When multiplying a vector by a scalar, the x, y,
- * and z components of the vector are all multiplied by the scalar. When multiplying a vector by a vector,
- * the x, y, z components of both vectors are multiplied by each other
- * (for example, with two vectors a and b: a.x * b.x, a.y * b.y, a.z * b.z). The static version of this method
+ * Multiplies the vector by a scalar; or, multiplies the `x`, `y`, and `z` components from a vector; or, multiplies
+ * the `x`, `y`, and `z` components of two independent vectors. When multiplying a vector by a scalar, the `x`, `y`,
+ * and `z` components of the vector are all multiplied by the scalar. When multiplying a vector by a vector,
+ * the `x`, `y`, and `z` components of both vectors are multiplied by each other
+ * (for example, with two vectors `a` and `b`: `a.x * b.x`, `a.y * b.y`, `a.z * b.z`). The static version of this method
  * creates a new <a href="#/p5.Vector">p5.Vector</a> while the non static version acts on the vector
  * directly. Additionally, you may provide arguments to this function as an array.
  * See the examples for more context.
@@ -639,9 +639,9 @@ p5.Vector.prototype.sub = function sub(x, y, z) {
 
 /**
  * @method mult
- * @param  {Number} x The number to multiply with the x component of the vector
- * @param  {Number} y The number to multiply with the y component of the vector
- * @param  {Number} [z] The number to multiply with the z component of the vector
+ * @param  {Number} x The number to multiply with the `x` component of the vector
+ * @param  {Number} y The number to multiply with the `y` component of the vector
+ * @param  {Number} [z] The number to multiply with the `z` component of the vector
  * @chainable
  */
 
@@ -737,11 +737,11 @@ p5.Vector.prototype.mult = function mult(x, y, z) {
 };
 
 /**
- * Divides the vector by a scalar, divides a vector by the x, y, and z arguments, or divides the x, y, and
- * z components of two vectors against each other. When dividing a vector by a scalar, the x, y,
- * and z components of the vector are all divided by the scalar. When dividing a vector by a vector,
- * the x, y, z components of the source vector are treated as the dividend, and the x, y, z components
- * of the argument is treated as the divisor (for example with two vectors a and b: a.x / b.x, a.y / b.y, a.z / b.z).
+ * Divides the vector by a scalar; or, divides a vector by the `x`, `y`, and `z` arguments; or, divides the `x`, `y`, and
+ * `z` components of two vectors against each other. When dividing a vector by a scalar, the `x`, `y`,
+ * and `z` components of the vector are all divided by the scalar. When dividing a vector by a vector,
+ * the `x`, `y`, and `z` components of the source vector are treated as the dividend, and the `x`, `y`, and `z` components
+ * of the argument is treated as the divisor. (For example, with the vectors `a` and `b`: `a.x / b.x`, `a.y / b.y`, `a.z / b.z`.)
  * The static version of this method creates a
  * new <a href="#/p5.Vector">p5.Vector</a> while the non static version acts on the vector directly.
  * Additionally, you may provide arguments to this function as an array.
@@ -831,9 +831,9 @@ p5.Vector.prototype.mult = function mult(x, y, z) {
 
 /**
  * @method div
- * @param  {Number} x The number to divide with the x component of the vector
- * @param  {Number} y The number to divide with the y component of the vector
- * @param  {Number} [z] The number to divide with the z component of the vector
+ * @param  {Number} x The number to divide with the `x` component of the vector
+ * @param  {Number} y The number to divide with the `y` component of the vector
+ * @param  {Number} [z] The number to divide with the `z` component of the vector
  * @chainable
  */
 
@@ -943,7 +943,7 @@ p5.Vector.prototype.div = function div(x, y, z) {
 };
 /**
  * Calculates the magnitude (length) of the vector and returns the result as
- * a float (this is simply the equation sqrt(x\*x + y\*y + z\*z).)
+ * a float. (This is simply the equation `sqrt(x*x + y*y + z*z)`.)
  *
  * @method mag
  * @return {Number} magnitude of the vector
@@ -991,7 +991,7 @@ p5.Vector.prototype.mag = function mag() {
 
 /**
  * Calculates the squared magnitude of the vector and returns the result
- * as a float (this is simply the equation <em>(x\*x + y\*y + z\*z)</em>.)
+ * as a float (this is simply the equation `(x*x + y*y + z*z)`.)
  * Faster if the real length is not required in the
  * case of comparing vectors, etc.
  *
@@ -1049,9 +1049,9 @@ p5.Vector.prototype.magSq = function magSq() {
  * method. See the examples for more context.
  *
  * @method dot
- * @param  {Number} x   x component of the vector
- * @param  {Number} [y] y component of the vector
- * @param  {Number} [z] z component of the vector
+ * @param  {Number} x   `x` component of the vector
+ * @param  {Number} [y] `y` component of the vector
+ * @param  {Number} [z] `z` component of the vector
  * @return {Number}       the dot product
  *
  * @example
@@ -1128,12 +1128,11 @@ p5.Vector.prototype.cross = function cross(v) {
 };
 
 /**
- * Calculates the Euclidean distance between two points (considering a
- * point as a vector object).
- * If you are looking to calculate distance with 2 points see <a href="#/p5/dist">dist()</a>
+ * Calculates the Euclidean distance between two points (considering a point as a vector object).
+ * If you are looking to calculate distance with 2 points, see <a href="#/p5/dist">dist()</a>.
  *
  * @method dist
- * @param  {p5.Vector} v the x, y, and z coordinates of a <a href="#/p5.Vector">p5.Vector</a>
+ * @param  {p5.Vector} v the `x`, `y`, and `z` coordinates of a <a href="#/p5.Vector">p5.Vector</a>
  * @return {Number}      the distance
  * @example
  * <div class="norender">
@@ -1200,7 +1199,7 @@ p5.Vector.prototype.dist = function dist(v) {
 };
 
 /**
- * Normalize the vector to length 1 (make it a unit vector).
+ * Normalize the vector to length `1` (make it a unit vector).
  *
  * @method normalize
  * @return {p5.Vector} normalized <a href="#/p5.Vector">p5.Vector</a>
@@ -1270,8 +1269,7 @@ p5.Vector.prototype.normalize = function normalize() {
 };
 
 /**
- * Limit the magnitude of this vector to the value used for the <b>max</b>
- * parameter.
+ * Limit the magnitude of this vector to the value of the `max` parameter.
  *
  * @method limit
  * @param  {Number}    max the maximum magnitude for the vector
@@ -1328,8 +1326,7 @@ p5.Vector.prototype.limit = function limit(max) {
 };
 
 /**
- * Set the magnitude of this vector to the value used for the <b>len</b>
- * parameter.
+ * Set the magnitude of this vector to the value of the `len` parameter.
  *
  * @method setMag
  * @param  {number}    len the new length for this vector
@@ -1384,8 +1381,8 @@ p5.Vector.prototype.setMag = function setMag(n) {
 };
 
 /**
- * Calculate the angle of rotation for this vector(only 2D vectors).
- * p5.Vectors created using <a href="#/p5/createVector">createVector()</a>
+ * Calculate the angle of rotation for this vector (only 2D vectors).
+ * Vectors created using <a href="#/p5/createVector">createVector()</a>
  * will take the current <a href="#/p5/angleMode">angleMode</a> into
  * consideration, and give the angle in radians or degree accordingly.
  *
@@ -1456,8 +1453,8 @@ p5.Vector.prototype.heading = function heading() {
 };
 
 /**
- * Rotate the vector to a specific angle (only 2D vectors), magnitude remains the
- * same
+ * Rotate the vector to a specific angle (only 2D vectors).
+ * Magnitude remains the same.
  *
  * @method setHeading
  * @param  {number}    angle the angle of rotation
@@ -1481,8 +1478,8 @@ p5.Vector.prototype.setHeading = function setHeading(a) {
 };
 
 /**
- * Rotate the vector by an angle (only 2D vectors), magnitude remains the
- * same
+ * Rotate the vector by an angle (only 2D vectors).
+ * Magnitude remains the same.
  *
  * @method rotate
  * @param  {number}    angle the angle of rotation
@@ -1555,7 +1552,7 @@ p5.Vector.prototype.rotate = function rotate(a) {
  * give the angle in radians or degree accordingly.
  *
  * @method angleBetween
- * @param  {p5.Vector}    value the x, y, and z components of a <a href="#/p5.Vector">p5.Vector</a>
+ * @param  {p5.Vector}    value the `x`, `y`, and `z` components of a <a href="#/p5.Vector">p5.Vector</a>
  * @return {Number}       the angle between (in radians)
  * @example
  * <div class="norender">
@@ -1630,15 +1627,15 @@ p5.Vector.prototype.angleBetween = function angleBetween(v) {
   return angle;
 };
 /**
- * Linear interpolate the vector to another vector
+ * Linear interpolate the vector to another vector.
  *
  * @method lerp
- * @param  {Number}    x   the x component
- * @param  {Number}    y   the y component
- * @param  {Number}    z   the z component
- * @param  {Number}    amt the amount of interpolation; some value between 0.0
- *                         (old vector) and 1.0 (new vector). 0.9 is very near
- *                         the new vector. 0.5 is halfway in between.
+ * @param  {Number}    x   the `x` component
+ * @param  {Number}    y   the `y` component
+ * @param  {Number}    z   the `z` component
+ * @param  {Number}    amt the amount of interpolation; some value between `0.0`
+ *                         (old vector) and `1.0` (new vector). `0.9` is very near
+ *                         the new vector. `0.5` is halfway in between.
  * @chainable
  *
  * @example
@@ -1720,7 +1717,7 @@ p5.Vector.prototype.lerp = function lerp(x, y, z, amt) {
 
 /**
  * Reflect the incoming vector about a normal to a line in 2D, or about a normal to a plane in 3D
- * This method acts on the vector directly
+ * This method acts on the vector directly.
  *
  * @method reflect
  * @param  {p5.Vector} surfaceNormal   the <a href="#/p5.Vector">p5.Vector</a> to reflect about, will be normalized by this method
@@ -1806,12 +1803,12 @@ p5.Vector.prototype.array = function array() {
 };
 
 /**
- * Equality check against a <a href="#/p5.Vector">p5.Vector</a>
+ * Equality check against a <a href="#/p5.Vector">p5.Vector</a>.
  *
  * @method equals
- * @param {Number} [x] the x component of the vector
- * @param {Number} [y] the y component of the vector
- * @param {Number} [z] the z component of the vector
+ * @param {Number} [x] the `x` component of the vector
+ * @param {Number} [y] the `y` component of the vector
+ * @param {Number} [z] the `z` component of the vector
  * @return {Boolean} whether the vectors are equals
  * @example
  * <div class = "norender">
@@ -1861,12 +1858,12 @@ p5.Vector.prototype.equals = function equals(x, y, z) {
 // Static Methods
 
 /**
- * Make a new 2D vector from an angle
+ * Make a new 2D vector from an `angle`.
  *
  * @method fromAngle
  * @static
  * @param {Number}     angle the desired angle, in radians (unaffected by <a href="#/p5/angleMode">angleMode</a>)
- * @param {Number}     [length] the length of the new vector (defaults to 1)
+ * @param {Number}     [length] the length of the new vector (defaults to `1`)
  * @return {p5.Vector}       the new <a href="#/p5.Vector">p5.Vector</a> object
  * @example
  * <div>
@@ -1912,14 +1909,14 @@ p5.Vector.fromAngle = function fromAngle(angle, length) {
 };
 
 /**
- * Make a new 3D vector from a pair of ISO spherical angles
+ * Make a new 3D vector from a pair of ISO spherical angles.
  *
  * @method fromAngles
  * @static
- * @param {Number}     theta    the polar angle, in radians (zero is up)
+ * @param {Number}     theta    the polar angle, in radians (`0` is up)
  * @param {Number}     phi      the azimuthal angle, in radians
- *                               (zero is out of the screen)
- * @param {Number}     [length] the length of the new vector (defaults to 1)
+ *                               (`0` is out of the screen)
+ * @param {Number}     [length] the length of the new vector (defaults to `1`)
  * @return {p5.Vector}          the new <a href="#/p5.Vector">p5.Vector</a> object
  * @example
  * <div modernizr='webgl'>
@@ -1961,7 +1958,7 @@ p5.Vector.fromAngles = function(theta, phi, length) {
 };
 
 /**
- * Make a new 2D unit vector from a random angle
+ * Make a new 2D unit vector from a random angle.
  *
  * @method random2D
  * @static
@@ -2089,8 +2086,8 @@ p5.Vector.rem = function rem(v1, v2) {
 };
 
 /*
- * Subtracts one <a href="#/p5.Vector">p5.Vector</a> from another and returns a new one.  The second
- * vector (v2) is subtracted from the first (v1), resulting in v1-v2.
+ * Subtracts one <a href="#/p5.Vector">p5.Vector</a> from another and returns a new one.
+ * The second vector (`v2`) is subtracted from the first (`v1`), resulting in `v1-v2`.
  */
 /**
  * @method sub
@@ -2170,7 +2167,8 @@ p5.Vector.mult = function mult(v, n, target) {
 };
 
 /**
- * Rotates the vector (only 2D vectors) by the given angle, magnitude remains the same and returns a new vector.
+ * Rotates the vector (only 2D vectors) by the given angle.
+ * Magnitude remains the same. This returns a new vector.
  */
 
 /**
@@ -2323,13 +2321,13 @@ p5.Vector.lerp = function lerp(v1, v2, amt, target) {
 
 /**
  * Calculates the magnitude (length) of the vector and returns the result as
- * a float (this is simply the equation sqrt(x\*x + y\*y + z\*z).)
+ * a float. (This is simply the equation `sqrt(x*x + y*y + z*z)`.)
  */
 /**
  * @method mag
  * @static
  * @param {p5.Vector} vecT the vector to return the magnitude of
- * @return {Number}        the magnitude of vecT
+ * @return {Number}        the magnitude of `vecT`
  */
 p5.Vector.mag = function mag(vecT) {
   const x = vecT.x,
@@ -2340,14 +2338,14 @@ p5.Vector.mag = function mag(vecT) {
 };
 
 /**
- * Normalize the vector to length 1 (make it a unit vector).
+ * Normalize the vector to length `1` (make it a unit vector).
  */
 /**
  * @method normalize
  * @static
  * @param {p5.Vector} v  the vector to normalize
  * @param {p5.Vector} [target] the vector to receive the result
- * @return {p5.Vector}   v normalized to a length of 1
+ * @return {p5.Vector}   `v` normalized to a length of `1`
  */
 p5.Vector.normalize = function normalize(v, target) {
   if (arguments.length < 2) {

--- a/src/math/random.js
+++ b/src/math/random.js
@@ -66,7 +66,7 @@ p5.prototype.randomSeed = function(seed) {
 /**
  * Return a random floating-point number.
  *
- * Takes either 0, 1 or 2 arguments.
+ * Takes either 0, 1, or 2 arguments.
  *
  * If no argument is given, returns a random number from 0
  * up to (but not including) 1.
@@ -159,7 +159,7 @@ p5.prototype.random = function(min, max) {
  * returned; and a higher probability that numbers near the mean will
  * be returned.
  *
- * Takes either 0, 1 or 2 arguments.<br>
+ * Takes either 0, 1, or 2 arguments.<br>
  * If no args, returns a mean of 0 and standard deviation of 1.<br>
  * If one arg, that arg is the mean (standard deviation is 1).<br>
  * If two args, first is mean, second is standard deviation.

--- a/src/math/trigonometry.js
+++ b/src/math/trigonometry.js
@@ -16,10 +16,10 @@ import * as constants from '../core/constants';
 p5.prototype._angleMode = constants.RADIANS;
 
 /**
- * The inverse of <a href="#/p5/cos">cos()</a>, returns the arc cosine of a value.
- * This function expects the values in the range of -1 to 1 and values are returned in
- * the range 0 to PI (3.1415927) if the angleMode is RADIANS or 0 to 180 if the
- * angle mode is DEGREES.
+ * The inverse of <a href="#/p5/cos">cos()</a>; returns the arc cosine of a value.
+ * This function expects the values in the range of -1 to 1, and values are returned in
+ * the range 0 to PI (3.1415927) if the <a href="#/p5/angleMode">angleMode</a> is RADIANS, or 0 to 180 if the
+ * <a href="#/p5/angleMode">angleMode</a> is DEGREES.
  *
  * @method acos
  * @param  {Number} value the value whose arc cosine is to be returned
@@ -51,10 +51,10 @@ p5.prototype.acos = function(ratio) {
 };
 
 /**
- * The inverse of <a href="#/p5/sin">sin()</a>, returns the arc sine of a value.
+ * The inverse of <a href="#/p5/sin">sin()</a>; returns the arc sine of a value.
  * This function expects the values in the range of -1 to 1 and values are returned
- * in the range -PI/2 to PI/2 if the angleMode is RADIANS or -90 to 90 if the angle
- * mode is DEGREES.
+ * in the range -PI/2 to PI/2 if the <a href="#/p5/angleMode">angleMode</a> is RADIANS,
+ * or -90 to 90 if the <a href="#/p5/angleMode">angleMode</a> is DEGREES.
  *
  * @method asin
  * @param  {Number} value the value whose arc sine is to be returned
@@ -86,10 +86,10 @@ p5.prototype.asin = function(ratio) {
 };
 
 /**
- * The inverse of <a href="#/p5/tan">tan()</a>, returns the arc tangent of a value.
+ * The inverse of <a href="#/p5/tan">tan()</a>; returns the arc tangent of a value.
  * This function expects the values in the range of -Infinity to Infinity (exclusive) and
- * values are returned in the range -PI/2 to PI/2 if the angleMode is RADIANS or
- * -90 to 90 if the angle mode is DEGREES.
+ * values are returned in the range -PI/2 to PI/2 if the <a href="#/p5/angleMode">angleMode</a>
+ * is RADIANS or -90 to 90 if the <a href="#/p5/angleMode">angleMode</a> is DEGREES.
  *
  * @method atan
  * @param  {Number} value the value whose arc tangent is to be returned
@@ -123,9 +123,10 @@ p5.prototype.atan = function(ratio) {
 /**
  * Calculates the angle (in radians) from a specified point to the coordinate
  * origin as measured from the positive x-axis. Values are returned as a
- * float in the range from PI to -PI if the angleMode is RADIANS or 180 to
- * -180 if the angleMode is DEGREES. The atan2<a href="#/p5/">()</a> function is
- * most often used for orienting geometry to the position of the cursor.
+ * float in the range from PI to -PI if the <a href="#/p5/angleMode">angleMode</a>
+ * is RADIANS or 180 to -180 if the <a href="#/p5/angleMode">angleMode</a> is DEGREES.
+ * The atan2<a href="#/p5/">()</a> function is most often used for orienting geometry
+ * to the position of the cursor.
  *
  * Note: The y-coordinate of the point is the first parameter, and the
  * x-coordinate is the second parameter, due the the structure of calculating
@@ -238,10 +239,13 @@ p5.prototype.tan = function(angle) {
 
 /**
  * Converts a radian measurement to its corresponding value in degrees.
+ *
  * Radians and degrees are two ways of measuring the same thing. There are
  * 360 degrees in a circle and 2*PI radians in a circle. For example,
- * 90° = PI/2 = 1.5707964. This function does not take into account the
- * current <a href="#/p5/angleMode">angleMode</a>.
+ * 90° = PI/2 = 1.5707964.
+ *
+ * This function does not take into account the current
+ * <a href="#/p5/angleMode">angleMode</a>.
  *
  * @method degrees
  * @param  {Number} radians the radians value to convert to degrees
@@ -261,10 +265,13 @@ p5.prototype.degrees = angle => angle * constants.RAD_TO_DEG;
 
 /**
  * Converts a degree measurement to its corresponding value in radians.
+ *
  * Radians and degrees are two ways of measuring the same thing. There are
  * 360 degrees in a circle and 2*PI radians in a circle. For example,
- * 90° = PI/2 = 1.5707964. This function does not take into account the
- * current <a href="#/p5/angleMode">angleMode</a>.
+ * 90° = PI/2 = 1.5707964.
+ *
+ * This function does not take into account the current
+ * <a href="#/p5/angleMode">angleMode</a>.
  *
  * @method radians
  * @param  {Number} degrees the degree value to convert to radians

--- a/src/typography/attributes.js
+++ b/src/typography/attributes.js
@@ -10,18 +10,18 @@ import p5 from '../core/main';
 
 /**
  * Sets the current alignment for drawing text. Accepts two
- * arguments: horizAlign (LEFT, CENTER, or RIGHT) and
- * vertAlign (TOP, BOTTOM, CENTER, or BASELINE).
+ * arguments: `horizAlign` (LEFT, CENTER, or RIGHT) and
+ * `vertAlign` (TOP, BOTTOM, CENTER, or BASELINE).
  *
- * The horizAlign parameter is in reference to the x value
- * of the <a href="#/p5/text">text()</a> function, while the vertAlign parameter
- * is in reference to the y value.
+ * The `horizAlign` parameter is in reference to the `x` value
+ * of the <a href="#/p5/text">text()</a> function, while the `vertAlign` parameter
+ * is in reference to the `y` value.
  *
- * So if you write textAlign(LEFT), you are aligning the left
- * edge of your text to the x value you give in <a href="#/p5/text">text()</a>.
- * If you write textAlign(RIGHT, TOP), you are aligning the right edge
- * of your text to the x value and the top of edge of the text
- * to the y value.
+ * So if you write `textAlign(LEFT)`, you are aligning the left
+ * edge of your text to the `x` value you give in <a href="#/p5/text">text()</a>.
+ * If you write `textAlign(RIGHT, TOP)`, you are aligning the right edge
+ * of your text to the `x` value and the top of edge of the text
+ * to the `y` value.
  *
  * @method textAlign
  * @param {Constant} horizAlign horizontal alignment, either LEFT,
@@ -148,13 +148,14 @@ p5.prototype.textSize = function(theSize) {
 };
 
 /**
- * Sets/gets the style of the text for system fonts to NORMAL, ITALIC, BOLD or BOLDITALIC.
- * Note: this may be is overridden by CSS styling. For non-system fonts
- * (opentype, truetype, etc.) please load styled fonts instead.
+ * Sets/gets the style of the text for system fonts to NORMAL, ITALIC, BOLD, or BOLDITALIC.
+ *
+ * Note: This may be overridden by CSS styling. For non-system fonts
+ * (opentype, truetype, etc.), please load styled fonts instead.
  *
  * @method textStyle
  * @param {Constant} theStyle styling for text, either NORMAL,
- *                            ITALIC, BOLD or BOLDITALIC
+ *                            ITALIC, BOLD, or BOLDITALIC
  * @chainable
  * @example
  * <div>
@@ -285,13 +286,20 @@ p5.prototype._updateTextMetrics = function() {
 };
 
 /**
- * Specifies how lines of text are wrapped within a text box. This requires a max-width set on the text area, specified in <a href="#/p5/text">text()</a> as parameter `x2`.
+ * Specifies how lines of text are wrapped within a text box. This requires a
+ * `max-width` set on the text area, specified in <a href="#/p5/text">text()</a>
+ * as parameter `x2`.
  *
- * WORD wrap style only breaks lines at spaces. A single string without spaces that exceeds the boundaries of the canvas or text area is not truncated, and will overflow the desired area, disappearing at the canvas edge.
+ * WORD wrap style only breaks lines at spaces. A single string without spaces
+ * that exceeds the boundaries of the canvas or text area is not truncated, and
+ * will overflow the desired area, disappearing at the canvas edge.
  *
  * CHAR wrap style breaks lines wherever needed to stay within the text box.
  *
- * WORD is the default wrap style, and both styles will still break lines at any line breaks (`\n`) specified in the original text. The text area max-height parameter (`y2`) also still applies to wrapped text in both styles, lines of text that do not fit within the text area will not be drawn to the screen.
+ * WORD is the default wrap style, and both styles will still break lines at any
+ * line breaks (`\n`) specified in the original text. The text area `max-height`
+ * parameter (`y2`) also still applies to wrapped text in both styles, lines of
+ * text that do not fit within the text area will not be drawn to the screen.
  *
  * @method textWrap
  * @param {Constant} wrapStyle text wrapping style, either WORD or CHAR

--- a/src/typography/loading_displaying.js
+++ b/src/typography/loading_displaying.js
@@ -15,7 +15,7 @@ import '../core/friendly_errors/fes_core';
 
 /**
  * Loads an opentype font file (.otf, .ttf) from a file or a URL,
- * and returns a PFont Object. This method is asynchronous,
+ * and returns a `PFont` Object. This method is asynchronous,
  * meaning it may not finish before the next line in your sketch
  * is executed.
  *
@@ -25,7 +25,7 @@ import '../core/friendly_errors/fes_core';
  * security.
  *
  * @method loadFont
- * @param  {String}        path       name of the file or url to load
+ * @param  {String}        path       name of the file or URL to load
  * @param  {Function}      [callback] function to be executed after
  *                                    <a href="#/p5/loadFont">loadFont()</a> completes
  * @param  {Function}      [onError]  function to be executed if
@@ -33,7 +33,7 @@ import '../core/friendly_errors/fes_core';
  * @return {p5.Font}                  <a href="#/p5.Font">p5.Font</a> object
  * @example
  *
- * Calling loadFont() inside <a href="#/p5/preload">preload()</a> guarantees
+ * Calling` loadFont()` inside <a href="#/p5/preload">preload()</a> guarantees
  * that the load operation will have completed before <a href="#/p5/setup">setup()</a>
  * and <a href="#/p5/draw">draw()</a> are called.
  *
@@ -151,18 +151,18 @@ p5.prototype.loadFont = function(path, onSuccess, onError) {
  * function, which gives the option to draw to the left, right, and center of the
  * coordinates.
  *
- * The x2 and y2 parameters define a rectangular area to display within and
+ * The `x2` and `y2` parameters define a rectangular area to display within and
  * may only be used with string data. When these parameters are specified,
  * they are interpreted based on the current <a href="#/p5/rectMode">rectMode()</a>
  * setting. Text that does not fit completely within the rectangle specified will
- * not be drawn to the screen. If x2 and y2 are not specified, the baseline
+ * not be drawn to the screen. If `x2` and `y2` are not specified, the baseline
  * alignment is the default, which means that the text will be drawn upwards
- * from x and y.
+ * from `x` and `y`.
  *
  * <b>WEBGL</b>: Only opentype/truetype fonts are supported. You must load a font
  * using the <a href="#/p5/loadFont">loadFont()</a> method (see the example above).
- * <a href="#/p5/stroke">stroke()</a> currently has no effect in webgl mode.
- * Learn more about working with text in webgl mode on the
+ * <a href="#/p5/stroke">stroke()</a> currently has no effect in WebGL mode.
+ * Learn more about working with text in WebGL mode on the
  * <a href="https://github.com/processing/p5.js/wiki/Getting-started-with-WebGL-in-p5#text">wiki</a>.
  *
  * @method text
@@ -230,9 +230,9 @@ p5.prototype.text = function(str, x, y, maxWidth, maxHeight) {
 
 /**
  * Sets the current font that will be drawn with the <a href="#/p5/text">text()</a> function.
- * If textFont() is called without any argument, it will return the current font if one has
+ * If `textFont()` is called without any argument, it will return the current font if one has
  * been set already. If not, it will return the name of the default font as a string.
- * If textFont() is called with a font to use, it will return the p5 object.
+ * If `textFont()` is called with a font to use, it will return the p5 object.
  *
  * <b>WEBGL</b>: Only fonts loaded via <a href="#/p5/loadFont">loadFont()</a> are supported.
  *

--- a/src/typography/p5.Font.js
+++ b/src/typography/p5.Font.js
@@ -41,7 +41,7 @@ p5.Font = function(p) {
  *                            opentype fonts contains alignment and baseline options.
  *                            Default is 'LEFT' and 'alphabetic'
  *
- * @return {Object}          a rectangle object with properties: x, y, w, h
+ * @return {Object}          a rectangle object with properties: `x`, `y`, `w`, `h`
  *
  * @example
  * <div>
@@ -190,7 +190,7 @@ p5.Font.prototype.textBounds = function(str, x = 0, y = 0, fontSize, opts) {
  * be removed from the polygon; the value represents the threshold angle to use
  * when determining whether two edges are collinear
  *
- * @return {Array}  an array of points, each with x, y, alpha (the path angle)
+ * @return {Array}  an array of points, each with `x`, `y`, and `alpha` (the path angle)
  * @example
  * <div>
  * <code>

--- a/src/utilities/array_functions.js
+++ b/src/utilities/array_functions.js
@@ -9,7 +9,7 @@ import p5 from '../core/main';
 
 /**
  * Adds a value to the end of an array. Extends the length of
- * the array by one. Maps to Array.push().
+ * the array by one. Maps to `Array.push()`.
  *
  * @method append
  * @deprecated Use <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/push">array.push(value)</a> instead.
@@ -40,12 +40,12 @@ p5.prototype.append = function(array, value) {
  * overwrites existing values in the destination array. To append values
  * instead of overwriting them, use <a href="#/p5/concat">concat()</a>.
  *
- * The simplified version with only two arguments, arrayCopy(src, dst),
+ * The simplified version with only two arguments, `arrayCopy(src, dst)`,
  * copies an entire array to another of the same size. It is equivalent to
- * arrayCopy(src, 0, dst, 0, src.length).
+ * `arrayCopy(src, 0, dst, 0, src.length)`.
  *
  * Using this function is far more efficient for copying array data than
- * iterating through a for() loop and copying each element individually.
+ * iterating through a `for()` loop and copying each element individually.
  *
  * @method arrayCopy
  * @deprecated Use <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/copyWithin">arr1.copyWithin(arr2)</a> instead.
@@ -110,7 +110,7 @@ p5.prototype.arrayCopy = function(src, srcPosition, dst, dstPosition, length) {
 };
 
 /**
- * Concatenates two arrays, maps to Array.concat(). Does not modify the
+ * Concatenates two arrays. Maps to `Array.concat()`. Does not modify the
  * input arrays.
  *
  * @method concat
@@ -139,7 +139,7 @@ p5.prototype.arrayCopy = function(src, srcPosition, dst, dstPosition, length) {
 p5.prototype.concat = (list0, list1) => list0.concat(list1);
 
 /**
- * Reverses the order of an array, maps to Array.reverse()
+ * Reverses the order of an array. Maps to `Array.reverse()`.
  *
  * @method reverse
  * @deprecated Use <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/reverse">array.reverse()</a> instead.
@@ -159,8 +159,8 @@ p5.prototype.concat = (list0, list1) => list0.concat(list1);
 p5.prototype.reverse = list => list.reverse();
 
 /**
- * Decreases an array by one element and returns the shortened array,
- * maps to Array.pop().
+ * Decreases an array by one element and returns the shortened array.
+ * Maps to `Array.pop()`.
  *
  * @method shorten
  * @deprecated Use <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/pop">array.pop()</a> instead.
@@ -227,7 +227,7 @@ p5.prototype.shuffle = function(arr, bool) {
 /**
  * Sorts an array of numbers from smallest to largest, or puts an array of
  * words in alphabetical order. The original array is not modified; a
- * re-ordered array is returned. The count parameter states the number of
+ * re-ordered array is returned. The `count` parameter states the number of
  * elements to sort. For example, if there are 12 elements in an array and
  * count is set to 5, only the first 5 elements in the array will be sorted.
  *
@@ -306,11 +306,11 @@ p5.prototype.splice = function(list, value, index) {
 };
 
 /**
- * Extracts an array of elements from an existing array. The list parameter
- * defines the array from which the elements will be copied, and the start
- * and count parameters specify which elements to extract. If no count is
- * given, elements will be extracted from the start to the end of the array.
- * When specifying the start, remember that the first array element is 0.
+ * Extracts an array of elements from an existing array. The `list` parameter
+ * defines the array from which the elements will be copied, and the `start`
+ * and `count` parameters specify which elements to extract. If no `count` is
+ * given, elements will be extracted from the `start` to the end of the array.
+ * When specifying the `start`, remember that the first array element is 0.
  * This function does not change the source array.
  *
  * @method subset

--- a/src/utilities/conversion.js
+++ b/src/utilities/conversion.js
@@ -9,9 +9,9 @@ import p5 from '../core/main';
 
 /**
  * Converts a string to its floating point representation. The contents of a
- * string must resemble a number, or NaN (not a number) will be returned.
- * For example, float("1234.56") evaluates to 1234.56, but float("giraffe")
- * will return NaN.
+ * string must resemble a number, or `NaN` (not a number) will be returned.
+ * For example, `float("1234.56")` evaluates to `1234.56`, but `float("giraffe")`
+ * will return `NaN`.
  *
  * When an array of values is passed in, then an array of floats of the same
  * length is returned.
@@ -86,7 +86,7 @@ p5.prototype.int = function(n, radix = 10) {
 };
 
 /**
- * Converts a boolean, string or number to its string representation.
+ * Converts a boolean, string, or number to its string representation.
  * When an array of values is passed in, then an array of strings of the same
  * length is returned.
  *
@@ -113,9 +113,9 @@ p5.prototype.str = function(n) {
 
 /**
  * Converts a number or string to its boolean representation.
- * For a number, any non-zero value (positive or negative) evaluates to true,
- * while zero evaluates to false. For a string, the value "true" evaluates to
- * true, while any other value evaluates to false. When an array of number or
+ * For a number, any non-zero value (positive or negative) evaluates to `true`,
+ * while zero evaluates to `false`. For a string, the value `"true"` evaluates to
+ * `true`, while any other value evaluates to `false`. When an array of number or
  * string values is passed in, then a array of booleans of the same length is
  * returned.
  *

--- a/src/utilities/string_functions.js
+++ b/src/utilities/string_functions.js
@@ -14,9 +14,9 @@ import '../core/friendly_errors/fes_core';
 
 /**
  * Combines an array of Strings into one String, each separated by the
- * character(s) used for the separator parameter. To join arrays of ints or
+ * character(s) used for the `separator` parameter. To join arrays of ints or
  * floats, it's necessary to first convert them to Strings using <a href="#/p5/nf">nf()</a> or
- * nfs().
+ * <a href="#/p5/nfs">nfs()</a>.
  *
  * @method join
  * @param  {Array}  list      array of Strings to be joined
@@ -43,20 +43,20 @@ p5.prototype.join = function(list, separator) {
 /**
  * This function is used to apply a regular expression to a piece of text,
  * and return matching groups (elements found inside parentheses) as a
- * String array. If there are no matches, a null value will be returned.
+ * String array. If there are no matches, a `null` value will be returned.
  * If no groups are specified in the regular expression, but the sequence
  * matches, an array of length 1 (with the matched text as the first element
  * of the array) will be returned.
  *
- * To use the function, first check to see if the result is null. If the
- * result is null, then the sequence did not match at all. If the sequence
+ * To use the function, first check to see if the result is `null`. If the
+ * result is `null`, then the sequence did not match at all. If the sequence
  * did match, an array is returned.
  *
  * If there are groups (specified by sets of parentheses) in the regular
  * expression, then the contents of each will be returned in the array.
- * Element [0] of a regular expression match returns the entire matching
- * string, and the match groups start at element [1] (the first group is [1],
- * the second [2], and so on).
+ * Element `[0]` of a regular expression match returns the entire matching
+ * string, and the match groups start at element `[1]` (the first group is `[1]`,
+ * the second `[2]`, and so on).
  *
  * @method match
  * @param  {String} str    the String to be searched
@@ -83,20 +83,20 @@ p5.prototype.match = function(str, reg) {
 /**
  * This function is used to apply a regular expression to a piece of text,
  * and return a list of matching groups (elements found inside parentheses)
- * as a two-dimensional String array. If there are no matches, a null value
+ * as a two-dimensional String array. If there are no matches, a `null` value
  * will be returned. If no groups are specified in the regular expression,
  * but the sequence matches, a two dimensional array is still returned, but
  * the second dimension is only of length one.
  *
- * To use the function, first check to see if the result is null. If the
- * result is null, then the sequence did not match at all. If the sequence
+ * To use the function, first check to see if the result is `null`. If the
+ * result is `null`, then the sequence did not match at all. If the sequence
  * did match, a 2D array is returned.
  *
  * If there are groups (specified by sets of parentheses) in the regular
  * expression, then the contents of each will be returned in the array.
- * Assuming a loop with counter variable i, element [i][0] of a regular
+ * Assuming a loop with counter variable `i`, element `[i][0]` of a regular
  * expression match returns the entire matching string, and the match groups
- * start at element [i][1] (the first group is [i][1], the second [i][2],
+ * start at element `[i][1]` (the first group is `[i][1]`, the second `[i][2]`,
  * and so on).
  *
  * @method matchAll
@@ -130,13 +130,14 @@ p5.prototype.matchAll = function(str, reg) {
 /**
  * Utility function for formatting numbers into strings. There are two
  * versions: one for formatting floats, and one for formatting ints.
- * The values for the digits, left, and right parameters should always
+ * The values for the `digits`, `left`, and `right` parameters should always
  * be positive integers.
- * (NOTE): Be cautious when using left and right parameters as it prepends numbers of 0's if the parameter
- * if greater than the current length of the number.
- * For example if number is 123.2 and left parameter passed is 4 which is greater than length of 123
- * (integer part) i.e 3 than result will be 0123.2. Same case for right parameter i.e. if right is 3 than
- * the result will be 123.200.
+ *
+ * (NOTE): Be cautious when using left and right parameters as it prepends numbers of 0's
+ * if the parameter is greater than the current length of the number.
+ * For example, if `number` is `123.2` and `left` parameter passed is `4`, which is greater than length of `123`
+ the integer part) i.e. 3, then the result will be `0123.2`. The same is true for the `right` parameter (i.e. if `right` is 3, then
+ * the result will be `123.200`).
  *
  * @method nf
  * @param {Number|String}       num      the Number to format
@@ -240,7 +241,7 @@ function doNf(num, left, right) {
  * Utility function for formatting numbers into strings and placing
  * appropriate commas to mark units of 1000. There are two versions: one
  * for formatting ints, and one for formatting an array of ints. The value
- * for the right parameter should always be a positive integer.
+ * for the `right` parameter should always be a positive integer.
  *
  * @method nfc
  * @param  {Number|String}   num     the Number to format
@@ -312,9 +313,9 @@ function doNfc(num, right) {
 
 /**
  * Utility function for formatting numbers into strings. Similar to <a href="#/p5/nf">nf()</a> but
- * puts a "+" in front of positive numbers and a "-" in front of negative
+ * puts a `"+"` in front of positive numbers and a `"-"` in front of negative
  * numbers. There are two versions: one for formatting floats, and one for
- * formatting ints. The values for left, and right parameters
+ * formatting ints. The values for the `left` and `right` parameters
  * should always be positive integers.
  *
  * @method nfp
@@ -374,18 +375,20 @@ function addNfp(num) {
 
 /**
  * Utility function for formatting numbers into strings. Similar to <a href="#/p5/nf">nf()</a> but
- * puts an additional "_" (space) in front of positive numbers just in case to align it with negative
- * numbers which includes "-" (minus) sign.
- * The main usecase of nfs() can be seen when one wants to align the digits (place values) of a non-negative
- * number with some negative number (See the example to get a clear picture).
+ * puts an additional `" "` (space) in front of positive numbers just in case to align it with negative
+ * numbers which includes `"-"` (minus) sign.
+ *
+ * The main usecase of `nfs()` can be seen when one wants to align the digits (place values) of a non-negative
+ * number with some negative number. (See the example to get a clear picture.)
+ *
  * There are two versions: one for formatting float, and one for formatting int.
- * The values for the digits, left, and right parameters should always be positive integers.
- * (IMP): The result on the canvas basically the expected alignment can vary based on the typeface you are using.
- * (NOTE): Be cautious when using left and right parameters as it prepends numbers of 0's if the parameter
+ * The values for the `digits`, `left`, and `right` parameters should always be positive integers.
+ * (IMP): The result on the canvas (basically, the expected alignment) can vary based on the typeface you are using.
+ * (NOTE): Be cautious when using `left` and `right`, parameters as it prepends numbers of 0's if the parameter
  * if greater than the current length of the number.
- * For example if number is 123.2 and left parameter passed is 4 which is greater than length of 123
- * (integer part) i.e 3 than result will be 0123.2. Same case for right parameter i.e. if right is 3 than
- * the result will be 123.200.
+ * For example if number is `123.2` and the `left` parameter is 4, which is greater than length of `123`
+ * (the integer part) i.e. 3, then the result will be `0123.2`. (The same is true for the `right` parameter (i.e. if `right` is 3, then
+ * the result will be `123.200`).
  *
  * @method nfs
  * @param {Number}       num      the Number to format
@@ -451,8 +454,8 @@ function addNfs(num) {
 }
 
 /**
- * The <a href="#/p5/split">split()</a> function maps to String.split(), it breaks a String into
- * pieces using a character or string as the delimiter. The delim parameter
+ * The <a href="#/p5/split">split()</a> function maps to `String.split()`. It breaks a String into
+ * pieces using a character or string as the delimiter. The `delim` parameter
  * specifies the character or characters that mark the boundaries between
  * each piece. A String[] array is returned that contains each of the pieces.
  *
@@ -485,12 +488,12 @@ p5.prototype.split = function(str, delim) {
 
 /**
  * The <a href="#/p5/splitTokens">splitTokens()</a> function splits a String at one or many character
- * delimiters or "tokens." The delim parameter specifies the character or
+ * delimiters (or "tokens"). The `delim` parameter specifies the character or
  * characters to be used as a boundary.
  *
- * If no delim characters are specified, any whitespace character is used to
- * split. Whitespace characters include tab (\t), line feed (\n), carriage
- * return (\r), form feed (\f), and space.
+ * If no `delim` characters are specified, any whitespace character is used to
+ * split. Whitespace characters include tab (`\t`), line feed (`\n`), carriage
+ * return (`\r`), form feed (`\f`), and space.
  *
  * @method splitTokens
  * @param  {String} value   the String to be split
@@ -539,7 +542,8 @@ p5.prototype.splitTokens = function(value, delims) {
 /**
  * Removes whitespace characters from the beginning and end of a String. In
  * addition to standard whitespace characters such as space, carriage return,
- * and tab, this function also removes the Unicode "nbsp" character.
+ * and tab, this function also removes the Unicode "nbsp" (non-breaking space)
+ * character.
  *
  * @method trim
  * @param  {String} str a String to be trimmed

--- a/src/utilities/time_date.js
+++ b/src/utilities/time_date.js
@@ -142,7 +142,7 @@ p5.prototype.second = function() {
 
 /**
  * p5.js communicates with the clock on your computer. The <a href="#/p5/year">year()</a> function
- * returns the current year as an integer (2014, 2015, 2016, etc).
+ * returns the current year as an integer (2014, 2015, 2016, etc.).
  *
  * @method year
  * @return {Integer} the current year

--- a/src/webgl/3d_primitives.js
+++ b/src/webgl/3d_primitives.js
@@ -11,7 +11,7 @@ import './p5.Geometry';
 import * as constants from '../core/constants';
 
 /**
- * Draw a plane with given a width and height
+ * Draw a plane with a given `width` and `height`.
  * @method plane
  * @param  {Number} [width]    width of the plane
  * @param  {Number} [height]   height of the plane
@@ -95,7 +95,7 @@ p5.prototype.plane = function(width, height, detailX, detailY) {
 };
 
 /**
- * Draw a box with given width, height and depth
+ * Draw a box with given `width`, `height`, and `depth`.
  * @method  box
  * @param  {Number} [width]     width of the box
  * @param  {Number} [Height]    height of the box
@@ -215,7 +215,7 @@ p5.prototype.box = function(width, height, depth, detailX, detailY) {
 /**
  * Draw a sphere with given radius.
  *
- * DetailX and detailY determines the number of subdivisions in the x-dimension
+ * `detailX` and `detailY` determines the number of subdivisions in the x-dimension
  * and the y-dimension of a sphere. More subdivisions make the sphere seem
  * smoother. The recommended maximum values are both 24. Using a value greater
  * than 24 may cause a warning or slow down the browser.
@@ -419,9 +419,9 @@ const _truncatedCone = function(
 /**
  * Draw a cylinder with given radius and height
  *
- * DetailX and detailY determines the number of subdivisions in the x-dimension
+ * `detailX` and `detailY` determines the number of subdivisions in the x-dimension
  * and the y-dimension of a cylinder. More subdivisions make the cylinder seem smoother.
- * The recommended maximum value for detailX is 24. Using a value greater than 24
+ * The recommended maximum value for `detailX` is 24. Using a value greater than 24
  * may cause a warning or slow down the browser.
  *
  * @method cylinder
@@ -552,11 +552,11 @@ p5.prototype.cylinder = function(
 };
 
 /**
- * Draw a cone with given radius and height
+ * Draw a cone with a given `radius` and `height`.
  *
- * DetailX and detailY determine the number of subdivisions in the x-dimension and
+ * `detailX` and `detailY` determine the number of subdivisions in the x-dimension and
  * the y-dimension of a cone. More subdivisions make the cone seem smoother. The
- * recommended maximum value for detailX is 24. Using a value greater than 24
+ * recommended maximum value for `detailX` is 24. Using a value greater than 24
  * may cause a warning or slow down the browser.
  * @method cone
  * @param  {Number}  [radius]  radius of the bottom surface
@@ -667,9 +667,9 @@ p5.prototype.cone = function(radius, height, detailX, detailY, cap) {
 };
 
 /**
- * Draw an ellipsoid with given radius
+ * Draw an ellipsoid with given `radius`.
  *
- * DetailX and detailY determine the number of subdivisions in the x-dimension and
+ * `detailX` and `detailY` determine the number of subdivisions in the x-dimension and
  * the y-dimension of a cone. More subdivisions make the ellipsoid appear to be smoother.
  * Avoid detail number above 150, it may crash the browser.
  * @method ellipsoid
@@ -802,11 +802,11 @@ p5.prototype.ellipsoid = function(radiusX, radiusY, radiusZ, detailX, detailY) {
 };
 
 /**
- * Draw a torus with given radius and tube radius
+ * Draw a torus with given `radius` and `tubeRadius`.
  *
- * DetailX and detailY determine the number of subdivisions in the x-dimension and
+ * `detailX` and `detailY` determine the number of subdivisions in the x-dimension and
  * the y-dimension of a torus. More subdivisions make the torus appear to be smoother.
- * The default and maximum values for detailX and detailY are 24 and 16, respectively.
+ * The default and maximum values for `detailX` and `detailY` are 24 and 16, respectively.
  * Setting them to relatively small values like 4 and 6 allows you to create new
  * shapes other than a torus.
  * @method torus
@@ -954,7 +954,7 @@ p5.prototype.torus = function(radius, tubeRadius, detailX, detailY) {
 
 /**
  * Draws a point, a coordinate in space at the dimension of one pixel,
- * given x, y and z coordinates. The color of the point is determined
+ * given `x`, `y`, and `z` coordinates. The color of the point is determined
  * by the current stroke, while the point size is determined by current
  * stroke weight.
  * @private
@@ -1245,7 +1245,7 @@ p5.RendererGL.prototype.quad = function(x1, y1, z1, x2, y2, z2, x3, y3, z3, x4, 
 
   const gId =
     `quad|${x1}|${y1}|${z1}|${x2}|${y2}|${z2}|${x3}|${y3}|${z3}|${x4}|${y4}|${z4}|${detailX}|${detailY}`;
-  
+
   if (!this.geometryInHash(gId)) {
     const quadGeom = new p5.Geometry(detailX, detailY, function() {
       //algorithm adapted from c++ to js
@@ -1273,7 +1273,7 @@ p5.RendererGL.prototype.quad = function(x1, y1, z1, x2, y2, z2, x3, y3, z3, x4, 
         }
       }
     });
-    
+
     quadGeom.faces = [];
     for(let y = 0; y < detailY-1; y++){
       for(let x = 0; x < detailX-1; x++){
@@ -1391,7 +1391,7 @@ p5.RendererGL.prototype.curve = function(
 };
 
 /**
- * Draw a line given two points
+ * Draw a line given two points.
  * @private
  * @param {Number} x0 x-coordinate of first vertex
  * @param {Number} y0 y-coordinate of first vertex

--- a/src/webgl/interaction.js
+++ b/src/webgl/interaction.js
@@ -15,7 +15,7 @@ import * as constants from '../core/constants';
  * and using the mouse wheel (scrolling) will move the camera closer or further
  * from the center of the sketch. This function can be called with parameters
  * dictating sensitivity to mouse movement along the X and Y axes.  Calling
- * this function without parameters is equivalent to calling orbitControl(1,1).
+ * this function without parameters is equivalent to calling `orbitControl(1,1)`.
  * To reverse direction of movement in either axis, enter a negative number
  * for sensitivity.
  * @method orbitControl
@@ -143,21 +143,22 @@ p5.prototype.orbitControl = function(sensitivityX, sensitivityY, sensitivityZ) {
 };
 
 /**
- * debugMode() helps visualize 3D space by adding a grid to indicate where the
+ * `debugMode()` helps visualize 3D space by adding a grid to indicate where the
  * ‘ground’ is in a sketch and an axes icon which indicates the +X, +Y, and +Z
  * directions. This function can be called without parameters to create a
  * default grid and axes icon, or it can be called according to the examples
  * above to customize the size and position of the grid and/or axes icon.  The
  * grid is drawn using the most recently set stroke color and weight.  To
- * specify these parameters, add a call to stroke() and strokeWeight()
- * just before the end of the draw() loop.
+ * specify these parameters, add a call to <a href="#/p5/stroke">stroke()</a>
+ * and <a href="#/p5/strokeWeight">strokeWeight()</a> just before the end of the
+ * <a href="#/p5/draw">draw()</a> loop.
  *
- * By default, the grid will run through the origin (0,0,0) of the sketch
- * along the XZ plane
- * and the axes icon will be offset from the origin.  Both the grid and axes
- * icon will be sized according to the current canvas size.  Note that because the
- * grid runs parallel to the default camera view, it is often helpful to use
- * debugMode along with orbitControl to allow full view of the grid.
+ * By default, the grid will run through the origin `(0,0,0)` of the sketch
+ * along the XZ plane and the axes icon will be offset from the origin.  Both
+ * the grid and axes icon will be sized according to the current canvas size.
+ * Note that because the grid runs parallel to the default camera view, it is
+ * often helpful to use `debugMode()` along with `orbitControl` to allow full
+ * view of the grid.
  * @method debugMode
  * @example
  * <div>
@@ -351,7 +352,7 @@ p5.prototype.debugMode = function(...args) {
 };
 
 /**
- * Turns off debugMode() in a 3D sketch.
+ * Turns off `debugMode()` in a 3D sketch.
  * @method noDebugMode
  * @example
  * <div>
@@ -396,7 +397,7 @@ p5.prototype.noDebugMode = function() {
 };
 
 /**
- * For use with debugMode
+ * For use with `debugMode`.
  * @private
  * @method _grid
  * @param {Number} [size] size of grid sides
@@ -473,7 +474,7 @@ p5.prototype._grid = function(size, numDivs, xOff, yOff, zOff) {
 };
 
 /**
- * For use with debugMode
+ * For use with `debugMode`.
  * @private
  * @method _axesIcon
  * @param {Number} [size] size of axes icon lines

--- a/src/webgl/light.js
+++ b/src/webgl/light.js
@@ -63,7 +63,7 @@ import * as constants from '../core/constants';
 
 /**
  * @method ambientLight
- * @param  {Number[]}      values  an array containing the red,green,blue &
+ * @param  {Number[]}      values  an array containing the red, green, blue,
  *                                 and alpha components of the color
  * @chainable
  */
@@ -90,17 +90,17 @@ p5.prototype.ambientLight = function(v1, v2, v3, a) {
 };
 
 /**
- * Set's the color of the specular highlight when using a specular material and
+ * Sets the color of the specular highlight when using a specular material and
  * specular light.
  *
- * This method can be combined with specularMaterial() and shininess()
- * functions to set specular highlights. The default color is white, ie
- * (255, 255, 255), which is used if this method is not called before
- * specularMaterial(). If this method is called without specularMaterial(),
+ * This method can be combined with `specularMaterial()` and `shininess()`
+ * functions to set specular highlights. The default color is white (i.e.
+ * `(255, 255, 255)`), which is used if this method is not called before
+ * `specularMaterial()`. If this method is called without `specularMaterial()`,
  * There will be no effect.
  *
- * Note: specularColor is equivalent to the processing function
- * <a href="https://processing.org/reference/lightSpecular_.html">lightSpecular</a>.
+ * Note: `specularColor()` is equivalent to the processing function
+ * <a href="https://processing.org/reference/lightSpecular_.html">lightSpecular()</a>.
  *
  * @method specularColor
  * @param  {Number}        v1      red or hue value relative to
@@ -150,7 +150,7 @@ p5.prototype.ambientLight = function(v1, v2, v3, a) {
 
 /**
  * @method specularColor
- * @param  {Number[]}      values  an array containing the red,green,blue &
+ * @param  {Number[]}      values  an array containing the red, green, blue,
  *                                 and alpha components of the color
  * @chainable
  */
@@ -180,7 +180,7 @@ p5.prototype.specularColor = function(v1, v2, v3) {
  * A maximum of 5 directionalLight can be active at one time
  * @method directionalLight
  * @param  {Number}    v1       red or hue value (depending on the current
- * color mode),
+ *                              color mode)
  * @param  {Number}    v2       green or saturation value
  * @param  {Number}    v3       blue or brightness value
  * @param  {p5.Vector} position the direction of the light
@@ -278,12 +278,12 @@ p5.prototype.directionalLight = function(v1, v2, v3, x, y, z) {
 };
 
 /**
- * Creates a point light with a color and a light position
+ * Creates a point light with a color and a light position.
  *
- * A maximum of 5 pointLight can be active at one time
+ * A maximum of 5 pointLight can be active at one time.
  * @method pointLight
  * @param  {Number}    v1       red or hue value (depending on the current
- * color mode),
+ *                              color mode)
  * @param  {Number}    v2       green or saturation value
  * @param  {Number}    v3       blue or brightness value
  * @param  {Number}    x        x axis position
@@ -331,7 +331,7 @@ p5.prototype.directionalLight = function(v1, v2, v3, x, y, z) {
 /**
  * @method pointLight
  * @param  {Number[]|String|p5.Color} color   color Array, CSS color string,
- * or <a href="#/p5.Color">p5.Color</a> value
+ *                                            or <a href="#/p5.Color">p5.Color</a> value
  * @param  {Number}                   x
  * @param  {Number}                   y
  * @param  {Number}                   z
@@ -385,7 +385,13 @@ p5.prototype.pointLight = function(v1, v2, v3, x, y, z) {
 };
 
 /**
- * Sets the default ambient and directional light. The defaults are <a href="#/p5/ambientLight">ambientLight(128, 128, 128)</a> and <a href="#/p5/directionalLight">directionalLight(128, 128, 128, 0, 0, -1)</a>. Lights need to be included in the <a href="#/p5/draw">draw()</a> to remain persistent in a looping program. Placing them in the <a href="#/p5/setup">setup()</a> of a looping program will cause them to only have an effect the first time through the loop.
+ * Sets the default ambient and directional light.
+ * The defaults are <a href="#/p5/ambientLight">ambientLight(128, 128, 128)</a> and
+ * <a href="#/p5/directionalLight">directionalLight(128, 128, 128, 0, 0, -1)</a>.
+ *
+ * Lights need to be included in the <a href="#/p5/draw">draw()</a> function to remain
+ * persistent in a looping program. Placing them in the <a href="#/p5/setup">setup()</a>
+ * of a looping program will cause them to only have an effect the first time through the loop.
  * @method lights
  * @chainable
  * @example
@@ -424,11 +430,13 @@ p5.prototype.lights = function() {
 
 /**
  * Sets the falloff rates for point lights. It affects only the elements which are created after it in the code.
- * The default value is lightFalloff(1.0, 0.0, 0.0), and the parameters are used to calculate the falloff with the following equation:
+ * The default value is `lightFalloff(1.0, 0.0, 0.0)`, and the parameters are used to calculate the falloff with the following equation:
  *
+ * <code><pre>
  * d = distance from light position to vertex position
  *
- * falloff = 1 / (CONSTANT + d \* LINEAR + ( d \* d ) \* QUADRATIC)
+ * falloff = 1 / (CONSTANT + d * LINEAR + ( d * d ) * QUADRATIC)
+ * </pre></code>
  *
  * @method lightFalloff
  * @param {Number} constant   constant value for determining falloff
@@ -518,12 +526,14 @@ p5.prototype.lightFalloff = function(
 
 /**
  * Creates a spotlight with a given color, position, direction of light,
- * angle and concentration. Here, angle refers to the opening or aperture
- * of the cone of the spotlight, and concentration is used to focus the
- * light towards the center. Both angle and concentration are optional, but if
- * you want to provide concentration, you will also have to specify the angle.
+ * angle, and concentration.
  *
- * A maximum of 5 spotLight can be active at one time
+ * Here, `angle` refers to the opening or aperture of the cone of the spotlight,
+ * and `concentration` is used to focus the light towards the center.
+ * Both `angle` and `concentration` are optional, but if you want to provide
+ * `concentration`, you will also have to specify the `angle`.
+ *
+ * A maximum of 5 `spotLight` can be active at one time.
  * @method spotLight
  * @param  {Number}    v1       red or hue value (depending on the current
  * color mode),
@@ -571,7 +581,7 @@ p5.prototype.lightFalloff = function(
 /**
  * @method spotLight
  * @param  {Number[]|String|p5.Color} color color Array, CSS color string,
- * or <a href="#/p5.Color">p5.Color</a> value
+ *                                          or <a href="#/p5.Color">p5.Color</a> value
  * @param  {p5.Vector}                position the position of the light
  * @param  {p5.Vector}                direction the direction of the light
  * @param  {Number}                   [angle]
@@ -859,7 +869,7 @@ p5.prototype.spotLight = function(
 /**
  * This function will remove all the lights from the sketch for the
  * subsequent materials rendered. It affects all the subsequent methods.
- * Calls to lighting methods made after noLights() will re-enable lights
+ * Calls to lighting methods made after `noLights()` will re-enable lights
  * in the sketch.
  * @method noLights
  * @chainable

--- a/src/webgl/loading.js
+++ b/src/webgl/loading.js
@@ -180,12 +180,14 @@ p5.prototype.loadModel = function(path) {
  * Parse OBJ lines into model. For reference, this is what a simple model of a
  * square might look like:
  *
+ * <code><pre>
  * v -0.5 -0.5 0.5
  * v -0.5 -0.5 -0.5
  * v -0.5 0.5 -0.5
  * v -0.5 0.5 0.5
  *
  * f 4 3 2 1
+ * </pre></code>
  */
 function parseObj(model, lines) {
   // OBJ allows a face to specify an index for a vertex (in the above example),
@@ -288,9 +290,9 @@ function parseObj(model, lines) {
 }
 
 /**
- * STL files can be of two types, ASCII and Binary,
+ * STL files can be of two types: ASCII and Binary.
  *
- * We need to convert the arrayBuffer to an array of strings,
+ * We need to convert the arrayBuffer to an array of strings
  * to parse it as an ASCII file.
  */
 function parseSTL(model, buffer) {
@@ -315,7 +317,7 @@ function parseSTL(model, buffer) {
 }
 
 /**
- * This function checks if the file is in ASCII format or in Binary format
+ * This function checks if the file is in ASCII format or in Binary format.
  *
  * It is done by searching keyword `solid` at the start of the file.
  *
@@ -342,7 +344,7 @@ function isBinary(data) {
 }
 
 /**
- * This function matches the `query` at the provided `offset`
+ * This function matches the `query` at the provided `offset`.
  */
 function matchDataViewAt(query, reader, offset) {
   // Check if each byte in query matches the corresponding byte from the current offset
@@ -442,14 +444,14 @@ function parseBinarySTL(model, buffer) {
 }
 
 /**
- * ASCII STL file starts with `solid 'nameOfFile'`
- * Then contain the normal of the face, starting with `facet normal`
- * Next contain a keyword indicating the start of face vertex, `outer loop`
- * Next comes the three vertex, starting with `vertex x y z`
- * Vertices ends with `endloop`
- * Face ends with `endfacet`
- * Next face starts with `facet normal`
- * The end of the file is indicated by `endsolid`
+ * ASCII STL file starts with `solid 'nameOfFile'`.
+ * Then contain the normal of the face, starting with `facet normal`.
+ * Next, contain a keyword indicating the start of face vertex, `outer loop`.
+ * Next comes the three vertex, starting with `vertex x y z`.
+ * Vertices ends with `endloop`.
+ * Face ends with `endfacet`.
+ * Next face starts with `facet normal`.
+ * The end of the file is indicated by `endsolid`.
  */
 function parseASCIISTL(model, lines) {
   let state = '';

--- a/src/webgl/material.js
+++ b/src/webgl/material.js
@@ -16,7 +16,7 @@ import './p5.Texture';
  * The shader files are loaded asynchronously in the
  * background, so this method should be used in <a href="#/p5/preload">preload()</a>.
  *
- * Note, shaders can only be used in WEBGL mode.
+ * Note: Shaders can only be used in WEBGL mode.
  *
  * @method loadShader
  * @param {String} vertFilename path to file containing vertex shader
@@ -112,7 +112,7 @@ p5.prototype.loadShader = function(
  * Creates a new <a href="#/p5.Shader">p5.Shader</a> object
  * from the provided vertex and fragment shader code.
  *
- * Note, shaders can only be used in WEBGL mode.
+ * Note: Shaders can only be used in WEBGL mode.
  *
  * @method createShader
  * @param {String} vertSrc source code for the vertex shader
@@ -192,7 +192,7 @@ p5.prototype.createShader = function(vertSrc, fragSrc) {
  * Use <a href="#/p5/resetShader">resetShader()</a> to
  * restore the default shaders.
  *
- * Note, shaders can only be used in WEBGL mode.
+ * Note: Shaders can only be used in WEBGL mode.
  *
  * @method shader
  * @chainable
@@ -280,9 +280,9 @@ p5.prototype.shader = function(s) {
 };
 
 /**
- * Restores the default shaders. Code that runs after resetShader()
+ * Restores the default shaders. Code that runs after `resetShader()`
  * will not be affected by the shader previously set by
- * <a href="#/p5/shader">shader()</a>
+ * <a href="#/p5/shader">shader()</a>.
  *
  * @method resetShader
  * @chainable
@@ -301,7 +301,7 @@ p5.prototype.resetShader = function() {
  * To texture a geometry created with <a href="#/p5/beginShape">beginShape()</a>,
  * you will need to specify uv coordinates in <a href="#/p5/vertex">vertex()</a>.
  *
- * Note, texture() can only be used in WEBGL mode.
+ * Note: `texture()` can only be used in WEBGL mode.
  *
  * You can view more materials in this
  * <a href="https://p5js.org/examples/3d-materials.html">example</a>.
@@ -436,13 +436,15 @@ p5.prototype.texture = function(tex) {
 };
 
 /**
- * Sets the coordinate space for texture mapping. The default mode is IMAGE
- * which refers to the actual coordinates of the image.
- * NORMAL refers to a normalized space of values ranging from 0 to 1.
+ * Sets the coordinate space for texture mapping. The default mode is
+ * <a href="#/p5/IMAGE">IMAGE</a>, which refers to the actual coordinates
+ * of the image.
+ * <a href="#/p5/NORMAL">NORMAL</a> refers to a normalized space of values
+ * ranging from 0 to 1.
  *
- * With IMAGE, if an image is 100 x 200 pixels, mapping the image onto the entire
+ * With `IMAGE`, if an image is 100×200 pixels, mapping the image onto the entire
  * size of a quad would require the points (0,0) (100, 0) (100,200) (0,200).
- * The same mapping in NORMAL is (0,0) (1,0) (1,1) (0,1).
+ * The same mapping in `NORMAL` is (0,0) (1,0) (1,1) (0,1).
  * @method  textureMode
  * @param {Constant} mode either IMAGE or NORMAL
  * @example
@@ -514,17 +516,21 @@ p5.prototype.textureMode = function(mode) {
 /**
  * Sets the global texture wrapping mode. This controls how textures behave
  * when their uv's go outside of the 0 to 1 range. There are three options:
- * CLAMP, REPEAT, and MIRROR.
+ * <a href="#/p5/CLAMP">CLAMP</a>, <a href="#/p5/REPEAT">REPEAT</a>, and
+ * <a href="#/p5/MIRROR">MIRROR</a>.
  *
- * CLAMP causes the pixels at the edge of the texture to extend to the bounds.
- * REPEAT causes the texture to tile repeatedly until reaching the bounds.
- * MIRROR works similarly to REPEAT but it flips the texture with every new tile.
+ * <a href="#/p5/CLAMP">CLAMP</a> causes the pixels at the edge of the
+ * texture to extend to the bounds.
+ * <a href="#/p5/REPEAT">REPEAT</a> causes the texture to tile repeatedly
+ * until reaching the bounds.
+ * <a href="#/p5/MIRROR">MIRROR</a> works similarly to `REPEAT`, but it
+ * flips the texture with every new tile.
  *
- * REPEAT & MIRROR are only available if the texture
+ * `REPEAT` & `MIRROR` are only available if the texture
  * is a power of two size (128, 256, 512, 1024, etc.).
  *
  * This method will affect all textures in your sketch until a subsequent
- * textureWrap() call is made.
+ * `textureWrap()` call is made.
  *
  * If only one argument is provided, it will be applied to both the
  * horizontal and vertical axes.
@@ -586,7 +592,10 @@ p5.prototype.textureWrap = function(wrapX, wrapY = wrapX) {
 /**
  * Normal material for geometry is a material that is not affected by light.
  * It is not reflective and is a placeholder material often used for debugging.
- * Surfaces facing the X-axis, become red, those facing the Y-axis, become green and those facing the Z-axis, become blue.
+ * Surfaces facing the X-axis become red;
+ * those facing the Y-axis become green;
+ * and those facing the Z-axis become blue.
+ *
  * You can view all possible materials in this
  * <a href="https://p5js.org/examples/3d-materials.html">example</a>.
  * @method normalMaterial
@@ -828,8 +837,8 @@ p5.prototype.specularMaterial = function(v1, v2, v3, alpha) {
 
 /**
  * Sets the amount of gloss in the surface of shapes.
- * Used in combination with specularMaterial() in setting
- * the material properties of shapes. The default and minimum value is 1.
+ * Used in combination with <a href="#/p5/specularMaterial">specularMaterial()</a> in setting
+ * the material properties of shapes. The default (and minimum) value is 1.
  * @method shininess
  * @param {Number} shine Degree of Shininess.
  *                       Defaults to 1.

--- a/src/webgl/p5.Camera.js
+++ b/src/webgl/p5.Camera.js
@@ -26,7 +26,7 @@ import p5 from '../core/main';
  * to view the position of your camera.
  *
  * If no parameters are given, the following default is used:
- * camera(0, 0, (height/2) / tan(PI/6), 0, 0, 0, 0, 1, 0)
+ * `camera(0, 0, (height/2) / tan(PI/6), 0, 0, 0, 0, 1, 0)`
  * @method camera
  * @constructor
  * @for p5
@@ -103,7 +103,7 @@ import p5 from '../core/main';
  * @alt
  * White square repeatedly grows to fill canvas and then shrinks.
  * An interactive example of a red cube with 3 sliders for moving it across x, y,
- * z axis and 3 sliders for shifting it's center.
+ * z axis and 3 sliders for shifting its center.
  */
 p5.prototype.camera = function(...args) {
   this._assert3d('camera');
@@ -124,8 +124,8 @@ p5.prototype.camera = function(...args) {
  * clipping planes.
  *
  * If no parameters are given, the following default is used:
- * perspective(PI/3, width/height, eyeZ/10, eyeZ*10),
- * where eyeZ is equal to ((height/2) / tan(PI/6)).
+ * `perspective(PI/3, width/height, eyeZ/10, eyeZ*10)`,
+ * where `eyeZ` is equal to `((height/2) / tan(PI/6))`.
  * @method  perspective
  * @for p5
  * @param  {Number} [fovy]   camera frustum vertical field of view,
@@ -185,7 +185,7 @@ p5.prototype.perspective = function(...args) {
  * maximum z values.
  *
  * If no parameters are given, the following default is used:
- * ortho(-width/2, width/2, -height/2, height/2).
+ * `ortho(-width/2, width/2, -height/2, height/2)`.
  * @method  ortho
  * @for p5
  * @param  {Number} [left]   camera frustum left plane
@@ -249,7 +249,7 @@ p5.prototype.ortho = function(...args) {
  * <a href="https://p5js.org/reference/#/p5/perspective">perspective()</a>.
  *
  * If no parameters are given, the following default is used:
- * frustum(-width/2, width/2, -height/2, height/2, 0, max(width, height)).
+ * `frustum(-width/2, width/2, -height/2, height/2, 0, max(width, height))`.
  * @method frustum
  * @for p5
  * @param  {Number} [left]   camera frustum left plane
@@ -360,7 +360,7 @@ p5.prototype.createCamera = function() {
  * WebGL mode</a>. It contains camera position, orientation, and projection
  * information necessary for rendering a 3D scene.
  *
- * New p5.Camera objects can be made through the
+ * New `p5.Camera` objects can be made through the
  * <a href="#/p5/createCamera">createCamera()</a> function and controlled through
  * the methods described below. A camera created in this way will use a default
  * position in the scene and a default perspective projection until these
@@ -371,16 +371,16 @@ p5.prototype.createCamera = function() {
  * Note:
  * The methods below operate in two coordinate systems: the 'world' coordinate
  * system describe positions in terms of their relationship to the origin along
- * the X, Y and Z axes whereas the camera's 'local' coordinate system
+ * the X, Y, and Z axes, whereas the camera's 'local' coordinate system
  * describes positions from the camera's point of view: left-right, up-down,
  * and forward-backward. The <a href="#/p5.Camera/move">move()</a> method,
  * for instance, moves the camera along its own axes, whereas the
  * <a href="#/p5.Camera/setPosition">setPosition()</a>
  * method sets the camera's position in world-space.
  *
- * The camera object propreties
+ * The camera object properties
  * <code>eyeX, eyeY, eyeZ, centerX, centerY, centerZ, upX, upY, upZ</code>
- * which describes camera position, orientation, and projection
+ * which describe camera position, orientation, and projection
  * are also accessible via the camera object generated using
  * <a href="#/p5/createCamera">createCamera()</a>
  *
@@ -442,7 +442,7 @@ p5.Camera = function(renderer) {
   this.projMatrix = new p5.Matrix();
 };
 /**
- * camera position value on x axis
+ * Camera position value on x axis
  * @property {Number} eyeX
  * @readonly
  * @example
@@ -470,7 +470,7 @@ p5.Camera = function(renderer) {
  */
 
 /**
- * camera position value on y axis
+ * Camera position value on y axis
  * @property {Number} eyeY
  * @readonly
  * @example
@@ -497,7 +497,7 @@ p5.Camera = function(renderer) {
  */
 
 /**
- * camera position value on z axis
+ * Camera position value on z axis
  * @property {Number} eyeZ
  * @readonly
  * @example
@@ -524,7 +524,7 @@ p5.Camera = function(renderer) {
  */
 
 /**
- * x coordinate representing center of the sketch
+ * X coordinate representing center of the sketch
  * @property {Number} centerX
  * @readonly
  * @example
@@ -552,7 +552,7 @@ p5.Camera = function(renderer) {
  */
 
 /**
- * y coordinate representing center of the sketch
+ * Y coordinate representing center of the sketch
  * @property {Number} centerY
  * @readonly
  * @example
@@ -580,7 +580,7 @@ p5.Camera = function(renderer) {
  */
 
 /**
- * z coordinate representing center of the sketch
+ * Z coordinate representing center of the sketch
  * @property {Number} centerZ
  * @readonly
  * @example
@@ -608,7 +608,7 @@ p5.Camera = function(renderer) {
  */
 
 /**
- * x component of direction 'up' from camera
+ * X component of direction 'up' from camera
  * @property {Number} upX
  * @readonly
  * @example
@@ -631,7 +631,7 @@ p5.Camera = function(renderer) {
  */
 
 /**
- * y component of direction 'up' from camera
+ * Y component of direction 'up' from camera
  * @property {Number} upY
  * @readonly
  * @example
@@ -654,7 +654,7 @@ p5.Camera = function(renderer) {
  */
 
 /**
- * z component of direction 'up' from camera
+ * Z component of direction 'up' from camera
  * @property {Number} upZ
  * @readonly
  * @example
@@ -994,7 +994,7 @@ p5.Camera.prototype.frustum = function(left, right, bottom, top, near, far) {
 ////////////////////////////////////////////////////////////////////////////////
 
 /**
- * Rotate camera view about arbitrary axis defined by x,y,z
+ * Rotate camera view about arbitrary axis defined by `x`,`y`,`z`
  * based on http://learnwebgl.brown37.net/07_cameras/camera_rotating_motion.html
  * @method _rotateView
  * @private
@@ -1658,7 +1658,7 @@ p5.Camera.prototype._getLocalAxes = function() {
 };
 
 /**
- * Orbits the camera about center point. For use with orbitControl().
+ * Orbits the camera about center point. For use with `orbitControl()`.
  * @method _orbit
  * @private
  * @param {Number} dTheta change in spherical coordinate theta
@@ -1712,7 +1712,7 @@ p5.Camera.prototype._orbit = function(dTheta, dPhi, dRadius) {
 };
 
 /**
- * Returns true if camera is currently attached to renderer.
+ * Returns `true` if camera is currently attached to renderer.
  * @method _isActive
  * @private
  */

--- a/src/webgl/p5.Geometry.js
+++ b/src/webgl/p5.Geometry.js
@@ -69,7 +69,7 @@ p5.Geometry.prototype.reset = function() {
 };
 
 /**
- * computes faces for geometry objects based on the vertices.
+ * Computes faces for geometry objects based on the vertices.
  * @method computeFaces
  * @chainable
  */
@@ -112,8 +112,7 @@ p5.Geometry.prototype._getFaceNormal = function(faceId) {
   return n.mult(Math.asin(sinAlpha) / ln);
 };
 /**
- * computes smooth normals per vertex as an average of each
- * face.
+ * Computes smooth normals per vertex as an average of each face.
  * @method computeNormals
  * @chainable
  */
@@ -151,8 +150,7 @@ p5.Geometry.prototype.computeNormals = function() {
 };
 
 /**
- * Averages the vertex normals. Used in curved
- * surfaces
+ * Averages the vertex normals. Used in curved surfaces.
  * @method averageNormals
  * @chainable
  */
@@ -172,7 +170,7 @@ p5.Geometry.prototype.averageNormals = function() {
 };
 
 /**
- * Averages pole normals.  Used in spherical primitives
+ * Averages pole normals.  Used in spherical primitives.
  * @method averagePoleNormals
  * @chainable
  */
@@ -210,7 +208,7 @@ p5.Geometry.prototype.averagePoleNormals = function() {
 };
 
 /**
- * Create a 2D array for establishing stroke connections
+ * Create a 2D array for establishing stroke connections.
  * @private
  * @chainable
  */
@@ -231,9 +229,9 @@ p5.Geometry.prototype._makeTriangleEdges = function() {
 };
 
 /**
- * Create 4 vertices for each stroke line, two at the beginning position
+ * Create 4 vertices for each stroke line: two at the beginning position
  * and two at the end position. These vertices are displaced relative to
- * that line's normal on the GPU
+ * that line's normal on the GPU.
  * @private
  * @chainable
  */
@@ -265,7 +263,7 @@ p5.Geometry.prototype._edgesToVertices = function() {
 };
 
 /**
- * Modifies all vertices to be centered within the range -100 to 100.
+ * Modifies all vertices to be centered within the range `-100` to `100`.
  * @method normalize
  * @chainable
  */

--- a/src/webgl/p5.Matrix.js
+++ b/src/webgl/p5.Matrix.js
@@ -50,11 +50,11 @@ p5.Matrix = function() {
 };
 
 /**
- * Sets the x, y, and z component of the vector using two or three separate
- * variables, the data from a p5.Matrix, or the values from a float array.
+ * Sets the `x`, `y`, and `z` component of the vector using two or three separate
+ * variables, the data from a `p5.Matrix`, or the values from a float array.
  *
  * @method set
- * @param {p5.Matrix|Float32Array|Number[]} [inMatrix] the input p5.Matrix or
+ * @param {p5.Matrix|Float32Array|Number[]} [inMatrix] the input `p5.Matrix` or
  *                                     an Array of length 16
  * @chainable
  */
@@ -93,7 +93,7 @@ p5.Matrix.prototype.set = function(inMatrix) {
 };
 
 /**
- * Gets a copy of the vector, returns a p5.Matrix object.
+ * Gets a copy of the vector, and returns a `p5.Matrix` object.
  *
  * @method get
  * @return {p5.Matrix} the copy of the p5.Matrix object
@@ -103,7 +103,7 @@ p5.Matrix.prototype.get = function() {
 };
 
 /**
- * return a copy of a matrix
+ * Return a copy of a matrix.
  * @method copy
  * @return {p5.Matrix}   the result matrix
  */
@@ -136,7 +136,7 @@ p5.Matrix.prototype.copy = function() {
 p5.Matrix.identity = pInst => new p5.Matrix(pInst);
 
 /**
- * transpose according to a given matrix
+ * Transpose according to a given matrix.
  * @method transpose
  * @param  {p5.Matrix|Float32Array|Number[]} a  the matrix to be
  *                                               based on to transpose
@@ -197,7 +197,7 @@ p5.Matrix.prototype.transpose = function(a) {
 };
 
 /**
- * invert  matrix according to a give matrix
+ * Invert a matrix according to the given matrix.
  * @method invert
  * @param  {p5.Matrix|Float32Array|Number[]} a   the matrix to be
  *                                                based on to invert
@@ -284,7 +284,7 @@ p5.Matrix.prototype.invert = function(a) {
 };
 
 /**
- * Inverts a 3x3 matrix
+ * Inverts a 3x3 matrix.
  * @method invert3x3
  * @chainable
  */
@@ -321,7 +321,7 @@ p5.Matrix.prototype.invert3x3 = function() {
 };
 
 /**
- * transposes a 3x3 p5.Matrix by a mat3
+ * Transposes a 3x3 `p5.Matrix` by a mat3.
  * @method transpose3x3
  * @param  {Number[]} mat3 1-dimensional array
  * @chainable
@@ -340,8 +340,8 @@ p5.Matrix.prototype.transpose3x3 = function(mat3) {
 };
 
 /**
- * converts a 4x4 matrix to its 3x3 inverse transform
- * commonly used in MVMatrix to NMatrix conversions.
+ * Converts a 4x4 matrix to its 3x3 inverse transform.
+ * Commonly used in `MVMatrix` to `NMatrix` conversions.
  * @method invertTranspose
  * @param  {p5.Matrix} mat4 the matrix to be based on to invert
  * @chainable
@@ -377,7 +377,7 @@ p5.Matrix.prototype.inverseTranspose = function(matrix) {
 };
 
 /**
- * inspired by Toji's mat4 determinant
+ * Inspired by Toji's mat4 determinant.
  * @method determinant
  * @return {Number} Determinant of our 4x4 matrix
  */
@@ -400,7 +400,7 @@ p5.Matrix.prototype.determinant = function() {
 };
 
 /**
- * multiply two mat4s
+ * Multiply two mat4s.
  * @method mult
  * @param {p5.Matrix|Float32Array|Number[]} multMatrix The matrix
  *                                                we want to multiply by
@@ -519,7 +519,7 @@ p5.Matrix.prototype.apply = function(multMatrix) {
 };
 
 /**
- * scales a p5.Matrix by scalars or a vector
+ * Scales a `p5.Matrix` by scalars or a vector
  * @method scale
  * @param  {p5.Vector|Float32Array|Number[]} s vector to scale by
  * @chainable
@@ -554,7 +554,7 @@ p5.Matrix.prototype.scale = function(x, y, z) {
 };
 
 /**
- * rotate our Matrix around an axis by the given angle.
+ * Rotate a Matrix around an axis by the given angle `a`.
  * @method rotate
  * @param  {Number} a The angle of rotation in radians
  * @param  {p5.Vector|Number[]} axis  the axis(es) to rotate around
@@ -652,7 +652,7 @@ p5.Matrix.prototype.rotateZ = function(a) {
 };
 
 /**
- * sets the perspective matrix
+ * Sets the perspective matrix.
  * @method perspective
  * @param  {Number} fovy   [description]
  * @param  {Number} aspect [description]
@@ -685,7 +685,7 @@ p5.Matrix.prototype.perspective = function(fovy, aspect, near, far) {
 };
 
 /**
- * sets the ortho matrix
+ * Sets the orthogonal matrix.
  * @method ortho
  * @param  {Number} left   [description]
  * @param  {Number} right  [description]

--- a/src/webgl/p5.RendererGL.Immediate.js
+++ b/src/webgl/p5.RendererGL.Immediate.js
@@ -1,15 +1,15 @@
 /**
  * Welcome to RendererGL Immediate Mode.
- * Immediate mode is used for drawing custom shapes
- * from a set of vertices.  Immediate Mode is activated
- * when you call <a href="#/p5/beginShape">beginShape()</a> & de-activated when you call <a href="#/p5/endShape">endShape()</a>.
- * Immediate mode is a style of programming borrowed
- * from OpenGL's (now-deprecated) immediate mode.
- * It differs from p5.js' default, Retained Mode, which caches
- * geometries and buffers on the CPU to reduce the number of webgl
- * draw calls. Retained mode is more efficient & performative,
- * however, Immediate Mode is useful for sketching quick
- * geometric ideas.
+ *
+ * Immediate mode is used for drawing custom shapes from a set of vertices.
+ * Immediate Mode is activated when you call <a href="#/p5/beginShape">beginShape()</a>
+ * and de-activated when you call <a href="#/p5/endShape">endShape()</a>.
+ *
+ * Immediate mode is a style of programming borrowed from OpenGL's (now-deprecated) immediate mode.
+ * It differs from p5.js' default, Retained Mode, which caches geometries and buffers on the CPU
+ * to reduce the number of WebGL draw calls.
+ * Retained mode is more efficient & performative; however,
+ * Immediate Mode is useful for sketching quick geometric ideas.
  */
 import p5 from '../core/main';
 import * as constants from '../core/constants';
@@ -19,8 +19,8 @@ import './p5.RenderBuffer';
  * Begin shape drawing.  This is a helpful way of generating
  * custom shapes quickly.  However in WEBGL mode, application
  * performance will likely drop as a result of too many calls to
- * <a href="#/p5/beginShape">beginShape()</a> / <a href="#/p5/endShape">endShape()</a>.  As a high performance alternative,
- * please use p5.js geometry primitives.
+ * <a href="#/p5/beginShape">beginShape()</a> / <a href="#/p5/endShape">endShape()</a>.
+ * As a high performance alternative, please use p5.js geometry primitives.
  * @private
  * @method beginShape
  * @param  {Number} mode webgl primitives mode.  beginShape supports the
@@ -37,7 +37,7 @@ p5.RendererGL.prototype.beginShape = function(mode) {
 };
 
 /**
- * adds a vertex to be drawn in a custom Shape.
+ * Adds a vertex to be drawn in a custom Shape.
  * @private
  * @method vertex
  * @param  {Number} x x-coordinate of vertex
@@ -167,13 +167,13 @@ p5.RendererGL.prototype.endShape = function(
 };
 
 /**
- * Called from endShape(). This function calculates the stroke vertices for custom shapes and
+ * Called from `endShape()`. This function calculates the stroke vertices for custom shapes and
  * tesselates shapes when applicable.
  * @private
  * @param  {Number} mode webgl primitives mode.  beginShape supports the
  *                       following modes:
- *                       POINTS,LINES,LINE_STRIP,LINE_LOOP,TRIANGLES,
- *                       TRIANGLE_STRIP, TRIANGLE_FAN and TESS(WEBGL only)
+ *                       POINTS, LINES, LINE_STRIP, LINE_LOOP, TRIANGLES,
+ *                       TRIANGLE_STRIP, TRIANGLE_FAN, and TESS (WEBGL only)
  */
 p5.RendererGL.prototype._processVertices = function(mode) {
   if (this.immediateMode.geometry.vertices.length === 0) return;
@@ -201,7 +201,7 @@ p5.RendererGL.prototype._processVertices = function(mode) {
 };
 
 /**
- * Called from _processVertices(). This function calculates the stroke vertices for custom shapes and
+ * Called from `_processVertices()`. This function calculates the stroke vertices for custom shapes and
  * tesselates shapes when applicable.
  * @private
  * @returns  {Array[Number]} indices for custom shape vertices indicating edges.
@@ -246,7 +246,7 @@ p5.RendererGL.prototype._calculateEdges = function(
 };
 
 /**
- * Called from _processVertices() when applicable. This function tesselates immediateMode.geometry.
+ * Called from `_processVertices()` when applicable. This function tesselates `immediateMode.geometry`.
  * @private
  */
 p5.RendererGL.prototype._tesselateShape = function() {
@@ -266,7 +266,7 @@ p5.RendererGL.prototype._tesselateShape = function() {
 };
 
 /**
- * Called from endShape(). Responsible for calculating normals, setting shader uniforms,
+ * Called from `endShape()`. Responsible for calculating normals, setting shader uniforms,
  * enabling all appropriate buffers, applying color blend, and drawing the fill geometry.
  * @private
  */
@@ -300,7 +300,7 @@ p5.RendererGL.prototype._drawImmediateFill = function() {
 };
 
 /**
- * Called from endShape(). Responsible for calculating normals, setting shader uniforms,
+ * Called from `endShape()`. Responsible for calculating normals, setting shader uniforms,
  * enabling all appropriate buffers, applying color blend, and drawing the stroke geometry.
  * @private
  */

--- a/src/webgl/p5.RendererGL.Retained.js
+++ b/src/webgl/p5.RendererGL.Retained.js
@@ -146,9 +146,9 @@ p5.RendererGL.prototype.drawBuffers = function(gId) {
 };
 
 /**
- * Calls drawBuffers() with a scaled model/view matrix.
+ * Calls `drawBuffers()` with a scaled model/view matrix.
  *
- * This is used by various 3d primitive methods (in primitives.js, eg. plane,
+ * This is used by various 3d primitive methods (in `primitives.js`, eg. plane,
  * box, torus, etc...) to allow caching of un-scaled geometries. Those
  * geometries are generally created with unit-length dimensions, cached as
  * such, and then scaled appropriately in this method prior to rendering.

--- a/src/webgl/p5.RendererGL.js
+++ b/src/webgl/p5.RendererGL.js
@@ -343,31 +343,31 @@ p5.RendererGL.prototype._resetContext = function(options, callback) {
  * not declared in the object will be set to defaults.
  *
  * The available attributes are:
- * <br>
- * alpha - indicates if the canvas contains an alpha buffer
- * default is true
  *
- * depth - indicates whether the drawing buffer has a depth buffer
- * of at least 16 bits - default is true
+ * `alpha` - indicates if the canvas contains an alpha buffer
+ * default is `true`
  *
- * stencil - indicates whether the drawing buffer has a stencil buffer
+ * `depth` - indicates whether the drawing buffer has a depth buffer
+ * of at least 16 bits - default is `true`
+ *
+ * `stencil` - indicates whether the drawing buffer has a stencil buffer
  * of at least 8 bits
  *
- * antialias - indicates whether or not to perform anti-aliasing
- * default is false (true in Safari)
+ * `antialias` - indicates whether or not to perform anti-aliasing
+ * default is `false` (`true` in Safari)
  *
- * premultipliedAlpha - indicates that the page compositor will assume
+ * `premultipliedAlpha` - indicates that the page compositor will assume
  * the drawing buffer contains colors with pre-multiplied alpha
- * default is false
+ * default is `false`
  *
- * preserveDrawingBuffer - if true the buffers will not be cleared and
+ * `preserveDrawingBuffer` - indicates that the buffers will not be cleared and
  * and will preserve their values until cleared or overwritten by author
  * (note that p5 clears automatically on draw loop)
- * default is true
+ * default is `true`
  *
- * perPixelLighting - if true, per-pixel lighting will be used in the
- * lighting shader otherwise per-vertex lighting is used.
- * default is true.
+ * `perPixelLighting` - indicates that per-pixel lighting will be used in the
+ * lighting shader; otherwise, per-vertex lighting is used.
+ * default is `true`.
  *
  * @method setAttributes
  * @for p5
@@ -812,9 +812,9 @@ p5.RendererGL.prototype._getPixel = function(x, y) {
 };
 
 /**
- * Loads the pixels data for this canvas into the pixels[] attribute.
- * Note that updatePixels() and set() do not work.
- * Any pixel manipulation must be done directly to the pixels[] array.
+ * Loads the pixels data for this canvas into the `pixels[]` attribute.
+ * Note that `updatePixels()` and `set()` do not work.
+ * Any pixel manipulation must be done directly to the `pixels[]` array.
  *
  * @private
  * @method loadPixels
@@ -1362,7 +1362,7 @@ p5.RendererGL.prototype._isTypedArray = function(arr) {
   return res;
 };
 /**
- * turn a two dimensional array into one dimensional array
+ * Turn a two dimensional array into one dimensional array
  * @private
  * @param  {Array} arr 2-dimensional array
  * @return {Array}     1-dimensional array
@@ -1399,9 +1399,9 @@ p5.RendererGL.prototype._flatten = function(arr) {
 };
 
 /**
- * turn a p5.Vector Array into a one dimensional number array
+ * Turn a `p5.Vector` Array into a one dimensional number array
  * @private
- * @param  {p5.Vector[]} arr  an array of p5.Vector
+ * @param  {p5.Vector[]} arr  an array of `p5.Vector`
  * @return {Number[]}     a one dimensional array of numbers
  * [p5.Vector(1, 2, 3), p5.Vector(4, 5, 6)] ->
  * [1, 2, 3, 4, 5, 6]

--- a/src/webgl/p5.Shader.js
+++ b/src/webgl/p5.Shader.js
@@ -1,5 +1,5 @@
 /**
- * This module defines the p5.Shader class
+ * This module defines the `p5.Shader` class.
  * @module 3D
  * @submodule Material
  * @for p5
@@ -12,8 +12,8 @@ import p5 from '../core/main';
  * Shader class for WEBGL Mode
  * @class p5.Shader
  * @constructor
- * @param {p5.RendererGL} renderer an instance of p5.RendererGL that
- * will provide the GL context for this new p5.Shader
+ * @param {p5.RendererGL} renderer an instance of `p5.RendererGL` that
+ * will provide the GL context for this new `p5.Shader`
  * @param {String} vertSrc source code for the vertex shader (as a string)
  * @param {String} fragSrc source code for the fragment shader (as a string)
  */
@@ -198,7 +198,7 @@ p5.Shader.prototype.compile = function() {
 };
 
 /**
- * initializes (if needed) and binds the shader program.
+ * Initializes (if needed) and binds the shader program.
  * @method bindShader
  * @private
  */
@@ -308,7 +308,7 @@ p5.Shader.prototype.useProgram = function() {
  * @param {Boolean|Number|Number[]|p5.Image|p5.Graphics|p5.MediaElement}
  * data the data to associate with the uniform. The type can be
  * a boolean (true/false), a number, an array of numbers, or
- * an image (p5.Image, p5.Graphics, p5.MediaElement)
+ * an image (`p5.Image`, `p5.Graphics`, `p5.MediaElement`)
  *
  * @example
  * <div modernizr='webgl'>

--- a/src/webgl/p5.Texture.js
+++ b/src/webgl/p5.Texture.js
@@ -1,5 +1,5 @@
 /**
- * This module defines the p5.Texture class
+ * This module defines the `p5.Texture` class
  * @module 3D
  * @submodule Material
  * @for p5
@@ -13,8 +13,8 @@ import * as constants from '../core/constants';
  * Texture class for WEBGL Mode
  * @private
  * @class p5.Texture
- * @param {p5.RendererGL} renderer an instance of p5.RendererGL that
- * will provide the GL context for this new p5.Texture
+ * @param {p5.RendererGL} renderer an instance of `p5.RendererGL` that
+ * will provide the GL context for this new `p5.Texture`
  * @param {p5.Image|p5.Graphics|p5.Element|p5.MediaElement|ImageData} [obj] the
  * object containing the image data to store in the texture.
  */
@@ -74,7 +74,7 @@ p5.Texture.prototype._getTextureDataFromSource = function() {
 };
 
 /**
- * Initializes common texture parameters, creates a gl texture,
+ * Initializes common texture parameters, creates a GL texture,
  * tries to upload the texture for the first time if data is
  * already available.
  * @private
@@ -277,7 +277,7 @@ p5.Texture.prototype.setInterpolation = function(downScale, upScale) {
 /**
  * Sets the texture wrapping mode. This controls how textures behave
  * when their uv's go outside of the 0 - 1 range. There are three options:
- * CLAMP, REPEAT, and MIRROR. REPEAT & MIRROR are only available if the texture
+ * CLAMP, REPEAT, and MIRROR. REPEAT an MIRROR are only available if the texture
  * is a power of two size (128, 256, 512, 1024, etc.).
  * @method setWrapMode
  * @param {String} wrapX Controls the horizontal texture wrapping behavior


### PR DESCRIPTION
 Changes:

Lots of copy-edits to the source (docstrings) used to generate the p5.js Reference.

Though numerous, the edits are individually minor.  Most are related to formatting or grammar.  A few are for phrasing or clarity.  I also added a few links to other areas of the reference where appropriate.


#### PR Checklist
<!--
  To check any option, replace the "[ ]" with a "[x]". Be sure to check out how it looks in the Preview tab! Feel free to remove any portion of the template that is not relevant for your issue.
-->

- [x] `npm run lint` passes†
- [x] [Inline documentation] is included / updated
- [x] [Unit tests] are included / updated


†: Although the lint task completed successfully, the `yuidoc:prod` task noted that several methods were missing examples.  I didn’t remove any examples at all, so I hope this won’t cause an issue with any automated PR testing.



[Inline documentation]: https://github.com/processing/p5.js/blob/main/contributor_docs/inline_documentation.md
[Unit tests]: https://github.com/processing/p5.js/tree/main/contributor_docs#unit-tests
