### PR TITLE
fix: Update the rem instance method to be chainable

### DIFF
--- a/src/math/p5.Vector.js
+++ b/src/math/p5.Vector.js
@@ -399,7 +399,12 @@ p5.Vector.prototype.rem = function rem(x, y, z) {
       const xComponent = parseFloat(x.x);
       const yComponent = parseFloat(x.y);
       const zComponent = parseFloat(x.z);
-      return calculateRemainder3D.call(this, xComponent, yComponent, zComponent);
+      return calculateRemainder3D.call(
+        this,
+        xComponent,
+        yComponent,
+        zComponent
+      );
     }
   } else if (x instanceof Array) {
     if (x.every(element => Number.isFinite(element))) {
@@ -421,7 +426,7 @@ p5.Vector.prototype.rem = function rem(x, y, z) {
     const vectorComponents = [...arguments];
     if (vectorComponents.every(element => Number.isFinite(element))) {
       if (vectorComponents.length === 2) {
-       return calculateRemainder2D.call(
+        return calculateRemainder2D.call(
           this,
           vectorComponents[0],
           vectorComponents[1]

--- a/src/math/p5.Vector.js
+++ b/src/math/p5.Vector.js
@@ -399,15 +399,15 @@ p5.Vector.prototype.rem = function rem(x, y, z) {
       const xComponent = parseFloat(x.x);
       const yComponent = parseFloat(x.y);
       const zComponent = parseFloat(x.z);
-      calculateRemainder3D.call(this, xComponent, yComponent, zComponent);
+      return calculateRemainder3D.call(this, xComponent, yComponent, zComponent);
     }
   } else if (x instanceof Array) {
     if (x.every(element => Number.isFinite(element))) {
       if (x.length === 2) {
-        calculateRemainder2D.call(this, x[0], x[1]);
+        return calculateRemainder2D.call(this, x[0], x[1]);
       }
       if (x.length === 3) {
-        calculateRemainder3D.call(this, x[0], x[1], x[2]);
+        return calculateRemainder3D.call(this, x[0], x[1], x[2]);
       }
     }
   } else if (arguments.length === 1) {
@@ -421,7 +421,7 @@ p5.Vector.prototype.rem = function rem(x, y, z) {
     const vectorComponents = [...arguments];
     if (vectorComponents.every(element => Number.isFinite(element))) {
       if (vectorComponents.length === 2) {
-        calculateRemainder2D.call(
+       return calculateRemainder2D.call(
           this,
           vectorComponents[0],
           vectorComponents[1]
@@ -432,7 +432,7 @@ p5.Vector.prototype.rem = function rem(x, y, z) {
     const vectorComponents = [...arguments];
     if (vectorComponents.every(element => Number.isFinite(element))) {
       if (vectorComponents.length === 3) {
-        calculateRemainder3D.call(
+        return calculateRemainder3D.call(
           this,
           vectorComponents[0],
           vectorComponents[1],


### PR DESCRIPTION
Hello 👋  I was perusing the Vector math methods and notice the `rem` method is not chainable as defined by the JSDoc. See here: https://editor.p5js.org/aaronccasanova/sketches/F-7AVWMCC


Note: I did not pull down the repository and test the changes, but rather made the updates in the github.dev/vscode editor. That being said feel free to close this PR if there is a more formal process for contributing 👍