### PR TITLE
Remove reference to p5 instance in p5.Vector objects

### DIFF
--- a/src/math/math.js
+++ b/src/math/math.js
@@ -38,7 +38,11 @@ import p5 from '../core/main';
  */
 p5.prototype.createVector = function(x, y, z) {
   if (this instanceof p5) {
-    return new p5.Vector(this, arguments);
+    return new p5.Vector(
+      this._fromRadians.bind(this),
+      this._toRadians.bind(this),
+      ...arguments
+    );
   } else {
     return new p5.Vector(x, y, z);
   }

--- a/src/math/p5.Vector.js
+++ b/src/math/p5.Vector.js
@@ -49,13 +49,17 @@ import * as constants from '../core/constants';
  */
 p5.Vector = function Vector() {
   let x, y, z;
+
   // This is how it comes in with createVector()
-  if (arguments[0] instanceof p5) {
-    // save reference to p5 if passed in
-    this.p5 = arguments[0];
-    x = arguments[1][0] || 0;
-    y = arguments[1][1] || 0;
-    z = arguments[1][2] || 0;
+  // This check if the first argument is a function
+  if ({}.toString.call(arguments[0]) === '[object Function]') {
+    // In this case the vector have an associated p5 instance
+    this.isPInst = true;
+    this._fromRadians = arguments[0];
+    this._toRadians = arguments[1];
+    x = arguments[2] || 0;
+    y = arguments[3] || 0;
+    z = arguments[4] || 0;
     // This is what we'll get with new p5.Vector()
   } else {
     x = arguments[0] || 0;
@@ -228,8 +232,14 @@ p5.Vector.prototype.set = function set(x, y, z) {
  * </div>
  */
 p5.Vector.prototype.copy = function copy() {
-  if (this.p5) {
-    return new p5.Vector(this.p5, [this.x, this.y, this.z]);
+  if (this.isPInst) {
+    return new p5.Vector(
+      this._fromRadians,
+      this._toRadians,
+      this.x,
+      this.y,
+      this.z
+    );
   } else {
     return new p5.Vector(this.x, this.y, this.z);
   }
@@ -1125,8 +1135,8 @@ p5.Vector.prototype.cross = function cross(v) {
   const x = this.y * v.z - this.z * v.y;
   const y = this.z * v.x - this.x * v.z;
   const z = this.x * v.y - this.y * v.x;
-  if (this.p5) {
-    return new p5.Vector(this.p5, [x, y, z]);
+  if (this.isPInst) {
+    return new p5.Vector(this._fromRadians, this._toRadians, x, y, z);
   } else {
     return new p5.Vector(x, y, z);
   }
@@ -1456,7 +1466,7 @@ p5.Vector.prototype.setMag = function setMag(n) {
  */
 p5.Vector.prototype.heading = function heading() {
   const h = Math.atan2(this.y, this.x);
-  if (this.p5) return this.p5._fromRadians(h);
+  if (this.isPInst) return this._fromRadians(h);
   return h;
 };
 
@@ -1547,7 +1557,7 @@ p5.Vector.prototype.setHeading = function setHeading(a) {
  */
 p5.Vector.prototype.rotate = function rotate(a) {
   let newHeading = this.heading() + a;
-  if (this.p5) newHeading = this.p5._toRadians(newHeading);
+  if (this.isPInst) newHeading = this._toRadians(newHeading);
   const mag = this.mag();
   this.x = Math.cos(newHeading) * mag;
   this.y = Math.sin(newHeading) * mag;
@@ -1629,8 +1639,8 @@ p5.Vector.prototype.angleBetween = function angleBetween(v) {
   let angle;
   angle = Math.acos(Math.min(1, Math.max(-1, dotmagmag)));
   angle = angle * Math.sign(this.cross(v).z || 1);
-  if (this.p5) {
-    angle = this.p5._fromRadians(angle);
+  if (this.isPInst) {
+    angle = this._fromRadians(angle);
   }
   return angle;
 };


### PR DESCRIPTION
<!--
  Thank you for contributing! Please use this pull request (PR) template.


 In the description field of this PR, include "resolves #XXXX" tagging the issue you are fixing. If this PR addresses the issue but doesn't completely resolve it (ie the issue should remain open after your PR is merged), write "addresses #XXXX".-->
Resolves #5367

Changes:
Change constructor signature called by `createVector()` of `p5.Vector` to accept `_fromRadians` and `_toRadians` functions as first two arguments with their `this` value bound to the original p5 instance. This isn't changing any documented public signature so shouldn't be a breaking change.

As a result, test now pass on both node 14 and node 16 because there is no longer cyclic references in p5.Vector.

#### PR Checklist
<!--
  To check any option, replace the "[ ]" with a "[x]". Be sure to check out how it looks in the Preview tab! Feel free to remove any portion of the template that is not relevant for your issue.
-->

- [x] `npm run lint` passes
- [ ] [Inline documentation] is included / updated
- [ ] [Unit tests] are included / updated

[Inline documentation]: https://github.com/processing/p5.js/blob/main/contributor_docs/inline_documentation.md
[Unit tests]: https://github.com/processing/p5.js/tree/main/contributor_docs#unit-tests
