### PR TITLE
Updated strokeWeight() documentation

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3875,12 +3875,6 @@
         "node-releases": "^1.1.71"
       },
       "dependencies": {
-        "caniuse-lite": {
-          "version": "1.0.30001228",
-          "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001228.tgz",
-          "integrity": "sha512-QQmLOGJ3DEgokHbMSA8cj2a+geXqmnpyOFT0lhQV6P3/YOJvGDEwoedcwxEQ30gJIwIIunHIicunJ2rzK5gB2A==",
-          "dev": true
-        },
         "electron-to-chromium": {
           "version": "1.3.736",
           "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.736.tgz",
@@ -4102,6 +4096,12 @@
       "version": "5.3.1",
       "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
       "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==",
+      "dev": true
+    },
+    "caniuse-lite": {
+      "version": "1.0.30001283",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001283.tgz",
+      "integrity": "sha512-9RoKo841j1GQFSJz/nCXOj0sD7tHBtlowjYlrqIUS812x9/emfBLBt6IyMz1zIaYc/eRL8Cs6HPUVi2Hzq4sIg==",
       "dev": true
     },
     "caseless": {

--- a/src/core/shape/attributes.js
+++ b/src/core/shape/attributes.js
@@ -332,6 +332,9 @@ p5.prototype.strokeJoin = function(join) {
  * Sets the width of the stroke used for lines, points and the border around
  * shapes. All widths are set in units of pixels.
  *
+ * Note that it is affected by any transformation or scaling that has
+ * been applied previously.
+ *
  * @method strokeWeight
  * @param  {Number} weight the weight of the stroke (in pixels)
  * @chainable
@@ -348,8 +351,21 @@ p5.prototype.strokeJoin = function(join) {
  * </code>
  * </div>
  *
+ * <div>
+ * <code>
+ * //Example of stroke weights
+ * //after transformations
+ * strokeWeight(1); // Default
+ * line(20, 20, 80, 20);
+ * scale(5); // Adding scale transformation
+ * strokeWeight(1); // Resulting strokeweight is 5
+ * line(4, 8, 16, 8); // Coordinates adjusted for scaling
+ * </code>
+ * </div>
+ *
  * @alt
  * 3 horizontal black lines. Top line: thin, mid: medium, bottom:thick.
+ * 2 horizontal black line. Top line: thin, botton line: 5 times thicker than top
  */
 p5.prototype.strokeWeight = function(w) {
   p5._validateParameters('strokeWeight', arguments);


### PR DESCRIPTION
Resolves #5468 

 Changes:
Updated the strokeWeight() documentation to take in consideration transformations and scaling. Added an example to demonstrate the same.

 Screenshots of the change:
Before:
![image](https://user-images.githubusercontent.com/40564575/143657844-25c30cc4-70cd-45a1-8d14-fc89fa8f8638.png)

After:
![image](https://user-images.githubusercontent.com/40564575/143657878-4a05adb3-653a-4d95-8d1a-6ff855a68244.png)

#### PR Checklist
- [x] `npm run lint` passes
- [x] [Inline documentation] is included / updated
- [x] [Unit tests] are included / updated
