### PR TITLE
Fixed GIF Freezing After Returning to Unfocused Tab

### DIFF
--- a/src/image/p5.Image.js
+++ b/src/image/p5.Image.js
@@ -224,7 +224,7 @@ p5.Image = function(width, height) {
  */
 p5.Image.prototype._animateGif = function(pInst) {
   const props = this.gifProperties;
-  const curTime = pInst._lastFrameTime + pInst.deltaTime;
+  const curTime = pInst._lastFrameTime;
   if (props.lastChangeTime === 0) {
     props.lastChangeTime = curTime;
   }


### PR DESCRIPTION
Resolves #5434 

 Changes:
GIFs now only use `_lastFrameTime` to track when to show the next frame. A sum with `deltaTime` was used before to estimate what the current time was in a way which would keep frames across all GIFs synchronized, but had the side effect of freezing a GIF when returning from a different tab or window, as the estimate would use the large `deltaTime` between the previous frames to estimate a `curTime` which has not yet been reached. Everything is effectively the same, except GIF frames are no longer translated by the running-average of `deltaTime`.


#### PR Checklist

- [x] `npm run lint` passes
- [x] [Inline documentation] is included / updated
- [x] [Unit tests] are included / updated
