### PR TITLE
p5.renderer: allow default renderer to be temporarily replaced

### DIFF
--- a/src/core/rendering.js
+++ b/src/core/rendering.js
@@ -351,4 +351,45 @@ p5.prototype.blendMode = function(mode) {
  * white ellipse with shadow blur effect around edges
  */
 
+/**
+ * Temporarily override the default p5 renderer.
+ *
+ * @method renderer
+ * @param  {p5.Renderer} new default renderer
+ * @return {p5.Renderer} the current default renderer
+ *
+ * @example
+ * <div>
+ * <code>
+ * function setup() {
+ *   createCanvas(windowWidth, windowHeight, WEBGL);
+ *   background(0);
+ *
+ *   const pg = createGraphics(1920, 1080);
+ *   const og = renderer(pg._renderer);
+ *
+ *   // draw into pg by default
+ *   background(80);
+ *   fill(255, 0, 0);
+ *   rect(100, 100, 200, 200);
+ *   rect(300, 300, 200, 200);
+ *
+ *   // reset the canvas renderer
+ *   // and draw a small version of the pg
+ *   renderer(og);
+ *   image(pg, 100, 100, 160, 90);
+ * }
+ * </code>
+ * </div>
+ *
+ * @alt
+ * Small red rectangles on a light gray background.
+ */
+p5.prototype.renderer = function(pg) {
+  p5._validateParameters('renderer', arguments);
+  const og = this._renderer;
+  this._renderer = pg;
+  return og;
+};
+
 export default p5;


### PR DESCRIPTION
Changes:
This patch adds the `p5.renderer()` method to make it easier to replace the default renderer with a `p5.Graphics` object.  When the default renderer is replaced with an off-screen `p5.Renderer` object, the normal drawing calls will render into the off screen object instead of the canvas. The method returns the original renderer, which can be restored later and the off screen renderers can then be combined into a single image.

The intended use is for combining multiple sketches that call methods like `rect()` or `line()` directly instead of through a `p5.Graphics` argument.

#### PR Checklist
- [X] `npm run lint` passes
- [X] [Inline documentation] is included / updated
- [ ] [Unit tests] are included / updated
