### PR TITLE
Reference Catmull-Rom in the docs for curvePoint

### DIFF
--- a/src/core/shape/curves.js
+++ b/src/core/shape/curves.js
@@ -454,7 +454,7 @@ p5.prototype.curveTightness = function(t) {
  * @param {Number} c coordinate of second point
  * @param {Number} d coordinate of second control point
  * @param {Number} t value between 0 and 1
- * @return {Number} bezier value at position t
+ * @return {Number} Catmull-Rom value at position t
  * @example
  * <div>
  * <code>

--- a/src/core/shape/curves.js
+++ b/src/core/shape/curves.js
@@ -454,7 +454,7 @@ p5.prototype.curveTightness = function(t) {
  * @param {Number} c coordinate of second point
  * @param {Number} d coordinate of second control point
  * @param {Number} t value between 0 and 1
- * @return {Number} Catmull-Rom value at position t
+ * @return {Number} <a href="#/p5/curve">Curve()</a> value at position t
  * @example
  * <div>
  * <code>

--- a/src/core/shape/curves.js
+++ b/src/core/shape/curves.js
@@ -454,7 +454,7 @@ p5.prototype.curveTightness = function(t) {
  * @param {Number} c coordinate of second point
  * @param {Number} d coordinate of second control point
  * @param {Number} t value between 0 and 1
- * @return {Number} <a href="#/p5/curve">Curve()</a> value at position t
+ * @return {Number} <a href="#/p5/curve">Curve</a> value at position t
  * @example
  * <div>
  * <code>


### PR DESCRIPTION
This is a small documentation change to make it clearer what `curvePoint` is calculating. Right now, `bezierPoint`'s documented return value is a Bezier value, but the docs for `curvePoint` also call its return value a Bezier value. Hopefully this will be clearer if the `curvePoint` docs mention the type of spline it is calculating a point alone.

Changes:
- Mentions that the return value of `curvePoint` is a value on a *Catmull-Rom* spline (which is what `curve` draws) as opposed to a Bezier value (which is what `bezierPoint` draws)

#### PR Checklist


- [x] [Inline documentation] is included / updated

