### PR TITLE
docs: Fix typos (its/it’s)

### DIFF
--- a/src/color/creating_reading.js
+++ b/src/color/creating_reading.js
@@ -105,8 +105,8 @@ p5.prototype.blue = function(c) {
  * </div>
  *
  * @alt
- * Left half of canvas salmon pink and the right half with it's brightness colored white.
- * Left half of canvas olive colored and the right half with it's brightness color gray.
+ * Left half of canvas salmon pink and the right half with its brightness colored white.
+ * Left half of canvas olive colored and the right half with its brightness color gray.
  */
 p5.prototype.brightness = function(c) {
   p5._validateParameters('brightness', arguments);

--- a/src/dom/dom.js
+++ b/src/dom/dom.js
@@ -261,7 +261,7 @@ p5.prototype.removeElements = function(e) {
  * </code></div>
  *
  * @alt
- * dropdown: pear, kiwi, grape. When selected text "its a" + selection shown.
+ * dropdown: pear, kiwi, grape. When selected text "it's a" + selection shown.
  */
 p5.Element.prototype.changed = function(fxn) {
   p5.Element._adjustListener('change', fxn, this);

--- a/src/webgl/p5.Camera.js
+++ b/src/webgl/p5.Camera.js
@@ -103,7 +103,7 @@ import p5 from '../core/main';
  * @alt
  * White square repeatedly grows to fill canvas and then shrinks.
  * An interactive example of a red cube with 3 sliders for moving it across x, y,
- * z axis and 3 sliders for shifting it's center.
+ * z axis and 3 sliders for shifting its center.
  */
 p5.prototype.camera = function(...args) {
   this._assert3d('camera');
@@ -1302,7 +1302,7 @@ p5.Camera.prototype.lookAt = function(x, y, z) {
  * </div>
  * @alt
  * An interactive example of a red cube with 3 sliders for moving it across x, y,
- * z axis and 3 sliders for shifting it's center.
+ * z axis and 3 sliders for shifting its center.
  */
 p5.Camera.prototype.camera = function(
   eyeX,


### PR DESCRIPTION
Okay.  I thought that my documentation edits in #5482 were simpler, but I thought of an even simpler edit I could make to the reference docs: correcting the use of _its_ vs _it’s_.  :)

Changes:
 * Fix reference docs usage of _its_ vs _it’s_


#### PR Checklist
- [x] `npm run lint` passes
- [x] [Inline documentation] is included / updated
