### PR TITLE
docs: Use “×” for dimensions

### DIFF
--- a/src/color/creating_reading.js
+++ b/src/color/creating_reading.js
@@ -248,7 +248,7 @@ p5.prototype.brightness = function(c) {
  * Yellow ellipse in top left of canvas, black ellipse in bottom right,both 80×80.
  * Bright fuchsia rect in middle of canvas, 60 pixel width and height.
  * Two bright green rects on opposite sides of the canvas, both 45×80.
- * Four blue rects in each corner of the canvas, each are 35×x35.
+ * Four blue rects in each corner of the canvas, each are 35×35.
  * Bright sea green rect on left and darker rect on right of canvas, both 45×80.
  * Dark green rect on left and lighter green rect on right of canvas, both 45×80.
  * Dark blue rect on left and light teal rect on right of canvas, both 45×80.

--- a/src/color/creating_reading.js
+++ b/src/color/creating_reading.js
@@ -245,13 +245,13 @@ p5.prototype.brightness = function(c) {
  *
  * @alt
  * Yellow rect in middle right of canvas, with 55 pixel width and height.
- * Yellow ellipse in top left of canvas, black ellipse in bottom right,both 80x80.
+ * Yellow ellipse in top left of canvas, black ellipse in bottom right,both 80×80.
  * Bright fuchsia rect in middle of canvas, 60 pixel width and height.
- * Two bright green rects on opposite sides of the canvas, both 45x80.
- * Four blue rects in each corner of the canvas, each are 35x35.
- * Bright sea green rect on left and darker rect on right of canvas, both 45x80.
- * Dark green rect on left and lighter green rect on right of canvas, both 45x80.
- * Dark blue rect on left and light teal rect on right of canvas, both 45x80.
+ * Two bright green rects on opposite sides of the canvas, both 45×80.
+ * Four blue rects in each corner of the canvas, each are 35×x35.
+ * Bright sea green rect on left and darker rect on right of canvas, both 45×80.
+ * Dark green rect on left and lighter green rect on right of canvas, both 45×80.
+ * Dark blue rect on left and light teal rect on right of canvas, both 45×80.
  */
 
 /**
@@ -316,7 +316,7 @@ p5.prototype.color = function() {
  * </div>
  *
  * @alt
- * blue rect on left and green on right, both with black outlines & 35x60.
+ * blue rect on left and green on right, both with black outlines & 35×60.
  */
 p5.prototype.green = function(c) {
   p5._validateParameters('green', arguments);
@@ -351,7 +351,7 @@ p5.prototype.green = function(c) {
  * </div>
  *
  * @alt
- * salmon pink rect on left and black on right, both 35x60.
+ * salmon pink rect on left and black on right, both 35×60.
  */
 p5.prototype.hue = function(c) {
   p5._validateParameters('hue', arguments);
@@ -398,7 +398,7 @@ p5.prototype.hue = function(c) {
  * </div>
  *
  * @alt
- * 4 rects one tan, brown, brownish purple, purple, with white outlines & 20x60
+ * 4 rects one tan, brown, brownish purple, purple, with white outlines & 20×60
  */
 
 p5.prototype.lerpColor = function(c1, c2, amt) {
@@ -472,7 +472,7 @@ p5.prototype.lerpColor = function(c1, c2, amt) {
  * </div>
  *
  * @alt
- * light pastel green rect on left and dark grey rect on right, both 35x60.
+ * light pastel green rect on left and dark grey rect on right, both 35×60.
  */
 p5.prototype.lightness = function(c) {
   p5._validateParameters('lightness', arguments);
@@ -511,7 +511,7 @@ p5.prototype.lightness = function(c) {
  * </div>
  *
  * @alt
- * yellow rect on left and red rect on right, both with black outlines and 35x60.
+ * yellow rect on left and red rect on right, both with black outlines and 35×60.
  * grey canvas
  */
 p5.prototype.red = function(c) {
@@ -546,7 +546,7 @@ p5.prototype.red = function(c) {
  * </div>
  *
  * @alt
- *deep pink rect on left and grey rect on right, both 35x60.
+ *deep pink rect on left and grey rect on right, both 35×60.
  */
 p5.prototype.saturation = function(c) {
   p5._validateParameters('saturation', arguments);

--- a/src/color/setting.js
+++ b/src/color/setting.js
@@ -283,7 +283,7 @@ p5.prototype.clear = function() {
  *Green to red gradient from bottom L to top R. shading originates from top left.
  *Rainbow gradient from left to right. Brightness increasing to white at top.
  *unknown image.
- *50x50 ellipse at middle L & 40x40 ellipse at center. Translucent pink outlines.
+ *50×50 ellipse at middle L & 40×40 ellipse at center. Translucent pink outlines.
  */
 
 /**
@@ -444,17 +444,17 @@ p5.prototype.colorMode = function(mode, max1, max2, max3, maxA) {
  * </div>
  *
  * @alt
- * 60x60 dark charcoal grey rect with black outline in center of canvas.
- * 60x60 yellow rect with black outline in center of canvas.
- * 60x60 royal blue rect with black outline in center of canvas.
- * 60x60 red rect with black outline in center of canvas.
- * 60x60 pink rect with black outline in center of canvas.
- * 60x60 black rect with black outline in center of canvas.
- * 60x60 light green rect with black outline in center of canvas.
- * 60x60 soft green rect with black outline in center of canvas.
- * 60x60 red rect with black outline in center of canvas.
- * 60x60 dark fuchsia rect with black outline in center of canvas.
- * 60x60 blue rect with black outline in center of canvas.
+ * 60×60 dark charcoal grey rect with black outline in center of canvas.
+ * 60×60 yellow rect with black outline in center of canvas.
+ * 60×60 royal blue rect with black outline in center of canvas.
+ * 60×60 red rect with black outline in center of canvas.
+ * 60×60 pink rect with black outline in center of canvas.
+ * 60×60 black rect with black outline in center of canvas.
+ * 60×60 light green rect with black outline in center of canvas.
+ * 60×60 soft green rect with black outline in center of canvas.
+ * 60×60 red rect with black outline in center of canvas.
+ * 60×60 dark fuchsia rect with black outline in center of canvas.
+ * 60×60 blue rect with black outline in center of canvas.
  */
 
 /**
@@ -522,7 +522,7 @@ p5.prototype.fill = function(...args) {
  * </div>
  *
  * @alt
- * white rect top middle and noFill rect center. Both 60x60 with black outlines.
+ * white rect top middle and noFill rect center. Both 60×60 with black outlines.
  * black canvas with purple cube wireframe spinning
  */
 p5.prototype.noFill = function() {
@@ -562,7 +562,7 @@ p5.prototype.noFill = function() {
  * </div>
  *
  * @alt
- * 60x60 white rect at center. no outline.
+ * 60×60 white rect at center. no outline.
  * black canvas with pink cube spinning
  */
 p5.prototype.noStroke = function() {
@@ -696,17 +696,17 @@ p5.prototype.noStroke = function() {
  * </div>
  *
  * @alt
- * 60x60 white rect at center. Dark charcoal grey outline.
- * 60x60 white rect at center. Yellow outline.
- * 60x60 white rect at center. Royal blue outline.
- * 60x60 white rect at center. Red outline.
- * 60x60 white rect at center. Pink outline.
- * 60x60 white rect at center. Black outline.
- * 60x60 white rect at center. Bright green outline.
- * 60x60 white rect at center. Soft green outline.
- * 60x60 white rect at center. Red outline.
- * 60x60 white rect at center. Dark fuchsia outline.
- * 60x60 white rect at center. Blue outline.
+ * 60×60 white rect at center. Dark charcoal grey outline.
+ * 60×60 white rect at center. Yellow outline.
+ * 60×60 white rect at center. Royal blue outline.
+ * 60×60 white rect at center. Red outline.
+ * 60×60 white rect at center. Pink outline.
+ * 60×60 white rect at center. Black outline.
+ * 60×60 white rect at center. Bright green outline.
+ * 60×60 white rect at center. Soft green outline.
+ * 60×60 white rect at center. Red outline.
+ * 60×60 white rect at center. Dark fuchsia outline.
+ * 60×60 white rect at center. Blue outline.
  */
 
 /**
@@ -812,9 +812,9 @@ p5.prototype.stroke = function(...args) {
  * </div>
  *
  * @alt
- * 60x60 centered pink rect, purple background. Elliptical area in top-left of rect is erased white.
- * 60x60 centered purple rect, mint green background. Triangle in top-right is partially erased with fully erased outline.
- * 60x60 centered teal sphere, yellow background. Torus rotating around sphere erases to reveal black text underneath.
+ * 60×60 centered pink rect, purple background. Elliptical area in top-left of rect is erased white.
+ * 60×60 centered purple rect, mint green background. Triangle in top-right is partially erased with fully erased outline.
+ * 60×60 centered teal sphere, yellow background. Torus rotating around sphere erases to reveal black text underneath.
  */
 p5.prototype.erase = function(opacityFill = 255, opacityStroke = 255) {
   this._renderer.erase(opacityFill, opacityStroke);

--- a/src/core/constants.js
+++ b/src/core/constants.js
@@ -78,7 +78,7 @@ export const WAIT = 'wait';
  * </code></div>
  *
  * @alt
- * 80x80 white quarter-circle with curve toward bottom right of canvas.
+ * 80×80 white quarter-circle with curve toward bottom right of canvas.
  */
 export const HALF_PI = _PI / 2;
 /**
@@ -132,7 +132,7 @@ export const QUARTER_PI = _PI / 4;
  * </code></div>
  *
  * @alt
- * 80x80 white ellipse shape in center of canvas.
+ * 80×80 white ellipse shape in center of canvas.
  */
 export const TAU = _PI * 2;
 /**
@@ -150,7 +150,7 @@ export const TAU = _PI * 2;
  * </code></div>
  *
  * @alt
- * 80x80 white ellipse shape in center of canvas.
+ * 80×80 white ellipse shape in center of canvas.
  */
 export const TWO_PI = _PI * 2;
 /**

--- a/src/core/environment.js
+++ b/src/core/environment.js
@@ -153,14 +153,14 @@ p5.prototype.deltaTime = 0;
  * </code></div>
  *
  * @alt
- * green 50x50 ellipse at top left. Red X covers canvas when page focus changes
+ * green 50×50 ellipse at top left. Red X covers canvas when page focus changes
  */
 p5.prototype.focused = document.hasFocus();
 
 /**
  * Sets the cursor to a predefined symbol or an image, or makes it visible
  * if already hidden. If you are trying to set an image as the cursor, the
- * recommended size is 16x16 or 32x32 pixels. The values for parameters x and y
+ * recommended size is 16×16 or 32×32 pixels. The values for parameters x and y
  * must be less than the dimensions of the image.
  *
  * @method cursor
@@ -229,13 +229,13 @@ p5.prototype.cursor = function(type, x, y) {
  * Specifies the number of frames to be displayed every second. For example,
  * the function call frameRate(30) will attempt to refresh 30 times a second.
  * If the processor is not fast enough to maintain the specified rate, the
- * frame rate will not be achieved. Setting the frame rate within 
+ * frame rate will not be achieved. Setting the frame rate within
  * <a href="#/p5/setup">setup()</a> is recommended. The default frame rate is
- * based on the frame rate of the display (here also called "refresh rate"), 
+ * based on the frame rate of the display (here also called "refresh rate"),
  * which is set to 60 frames per second on most computers. A frame rate of 24
- * frames per second (usual for movies) or above will be enough for smooth 
+ * frames per second (usual for movies) or above will be enough for smooth
  * animations. This is the same as setFrameRate(val).
- * 
+ *
  * Calling <a href="#/p5/frameRate">frameRate()</a> with no arguments returns
  * the current framerate. The draw function must run at least once before it will
  * return a value. This is the same as <a href="#/p5/getFrameRate">getFrameRate()</a>.
@@ -345,7 +345,7 @@ p5.prototype.setFrameRate = function(fps) {
  * </code></div>
  *
  * @alt
- * cursor becomes 10x 10 white ellipse the moves with mouse x and y.
+ * cursor becomes 10×10 white ellipse the moves with mouse x and y.
  */
 p5.prototype.noCursor = function() {
   this._curElement.elt.style.cursor = 'none';
@@ -580,8 +580,8 @@ p5.prototype.fullscreen = function(val) {
  * </div>
  *
  * @alt
- * fuzzy 50x50 white ellipse with black outline in center of canvas.
- * sharp 50x50 white ellipse with black outline in center of canvas.
+ * fuzzy 50×50 white ellipse with black outline in center of canvas.
+ * sharp 50×50 white ellipse with black outline in center of canvas.
  */
 /**
  * @method pixelDensity
@@ -621,7 +621,7 @@ p5.prototype.pixelDensity = function(val) {
  * </div>
  *
  * @alt
- * 50x50 white ellipse with black outline in center of canvas.
+ * 50×50 white ellipse with black outline in center of canvas.
  */
 p5.prototype.displayDensity = () => window.devicePixelRatio;
 

--- a/src/core/rendering.js
+++ b/src/core/rendering.js
@@ -27,7 +27,7 @@ const defaultClass = 'p5Canvas';
  *
  * The system variables width and height are set by the parameters passed to this
  * function. If <a href="#/p5/createCanvas">createCanvas()</a> is not used, the
- * window will be given a default size of 100x100 pixels.
+ * window will be given a default size of 100×100 pixels.
  *
  * For more ways to position the canvas, see the
  * <a href='https://github.com/processing/p5.js/wiki/Positioning-your-canvas'>

--- a/src/core/shape/2d_primitives.js
+++ b/src/core/shape/2d_primitives.js
@@ -253,7 +253,7 @@ p5.prototype.arc = function(x, y, w, h, start, stop, mode, detail) {
  * </div>
  *
  * @alt
- *white ellipse with black outline in middle-right of canvas that is 55x55
+ *white ellipse with black outline in middle-right of canvas that is 55×55
  */
 
 /**
@@ -295,7 +295,7 @@ p5.prototype.ellipse = function(x, y, w, h, detailX) {
  * </div>
  *
  * @alt
- * white circle with black outline in mid of canvas that is 55x55.
+ * white circle with black outline in mid of canvas that is 55×55.
  */
 p5.prototype.circle = function() {
   p5._validateParameters('circle', arguments);
@@ -595,9 +595,9 @@ p5.prototype.quad = function(...args) {
  * </div>
  *
  * @alt
- * 55x55 white rect with black outline in mid-right of canvas.
- * 55x55 white rect with black outline and rounded edges in mid-right of canvas.
- * 55x55 white rect with black outline and rounded edges of different radii.
+ * 55×55 white rect with black outline in mid-right of canvas.
+ * 55×55 white rect with black outline and rounded edges in mid-right of canvas.
+ * 55×55 white rect with black outline and rounded edges of different radii.
  */
 
 /**
@@ -662,9 +662,9 @@ p5.prototype.rect = function() {
  * </div>
  *
  * @alt
- * 55x55 white square with black outline in mid-right of canvas.
- * 55x55 white square with black outline and rounded edges in mid-right of canvas.
- * 55x55 white square with black outline and rounded edges of different radii.
+ * 55×55 white square with black outline in mid-right of canvas.
+ * 55×55 white square with black outline and rounded edges in mid-right of canvas.
+ * 55×55 white square with black outline and rounded edges of different radii.
  */
 p5.prototype.square = function(x, y, s, tl, tr, br, bl) {
   p5._validateParameters('square', arguments);

--- a/src/core/shape/attributes.js
+++ b/src/core/shape/attributes.js
@@ -62,8 +62,8 @@ import * as constants from '../constants';
  * </div>
  *
  * @alt
- * 60x60 white ellipse and 30x30 grey ellipse with black outlines at center.
- * 60x60 white ellipse and 30x30 grey ellipse top-right with black outlines.
+ * 60×60 white ellipse and 30×30 grey ellipse with black outlines at center.
+ * 60×60 white ellipse and 30×30 grey ellipse top-right with black outlines.
  */
 p5.prototype.ellipseMode = function(m) {
   p5._validateParameters('ellipseMode', arguments);
@@ -100,7 +100,7 @@ p5.prototype.ellipseMode = function(m) {
  * </div>
  *
  * @alt
- * 2 pixelated 36x36 white ellipses to left & right of center, black background
+ * 2 pixelated 36×36 white ellipses to left & right of center, black background
  */
 p5.prototype.noSmooth = function() {
   this.setAttributes('antialias', false);
@@ -165,8 +165,8 @@ p5.prototype.noSmooth = function() {
  * </div>
  *
  * @alt
- * 50x50 white rect at center and 25x25 grey rect in the top left of the other.
- * 50x50 white rect at center and 25x25 grey rect in the center of the other.
+ * 50×50 white rect at center and 25×25 grey rect in the top left of the other.
+ * 50×50 white rect at center and 25×25 grey rect in the center of the other.
  */
 p5.prototype.rectMode = function(m) {
   p5._validateParameters('rectMode', arguments);
@@ -204,7 +204,7 @@ p5.prototype.rectMode = function(m) {
  * </div>
  *
  * @alt
- * 2 pixelated 36x36 white ellipses one left one right of center. On black.
+ * 2 pixelated 36×36 white ellipses one left one right of center. On black.
  */
 p5.prototype.smooth = function() {
   this.setAttributes('antialias', true);

--- a/src/core/shape/curves.js
+++ b/src/core/shape/curves.js
@@ -476,7 +476,7 @@ p5.prototype.curveTightness = function(t) {
  * </code>
  * </div>
  *
- *line hooking down to right-bottom with 13 5x5 white ellipse points
+ *line hooking down to right-bottom with 13 5×5 white ellipse points
  */
 p5.prototype.curvePoint = function(a, b, c, d, t) {
   p5._validateParameters('curvePoint', arguments);

--- a/src/core/shape/vertex.js
+++ b/src/core/shape/vertex.js
@@ -261,7 +261,7 @@ p5.prototype.beginContour = function() {
  * 2 white triangle shapes mid-right canvas. left one pointing up and right down.
  * 5 horizontal interlocking and alternating white triangles in mid-right canvas.
  * 4 interlocking white triangles in 45 degree rotated square-shape.
- * 2 white rectangle shapes in mid-right canvas. Both 20x55.
+ * 2 white rectangle shapes in mid-right canvas. Both 20×55.
  * 3 side-by-side white rectangles center rect is smaller in mid-right canvas.
  * Thick white l-shape with black outline mid-top-left of canvas.
  */

--- a/src/core/transform.js
+++ b/src/core/transform.js
@@ -25,12 +25,12 @@ import p5 from './main';
  * alt="The transformation matrix used when applyMatrix is called"/>
  *
  * @method applyMatrix
- * @param  {Number|Array} a numbers which define the 2x3 matrix to be multiplied, or an array of numbers
- * @param  {Number} b numbers which define the 2x3 matrix to be multiplied
- * @param  {Number} c numbers which define the 2x3 matrix to be multiplied
- * @param  {Number} d numbers which define the 2x3 matrix to be multiplied
- * @param  {Number} e numbers which define the 2x3 matrix to be multiplied
- * @param  {Number} f numbers which define the 2x3 matrix to be multiplied
+ * @param  {Number|Array} a numbers which define the 2×3 matrix to be multiplied, or an array of numbers
+ * @param  {Number} b numbers which define the 2×3 matrix to be multiplied
+ * @param  {Number} c numbers which define the 2×3 matrix to be multiplied
+ * @param  {Number} d numbers which define the 2×3 matrix to be multiplied
+ * @param  {Number} e numbers which define the 2×3 matrix to be multiplied
+ * @param  {Number} f numbers which define the 2×3 matrix to be multiplied
  * @chainable
  * @example
  * <div>
@@ -221,7 +221,7 @@ p5.prototype.resetMatrix = function() {
  * </div>
  *
  * @alt
- * white 52x52 rect with black outline at center rotated counter 45 degrees
+ * white 52×52 rect with black outline at center rotated counter 45 degrees
  */
 p5.prototype.rotate = function(angle, axis) {
   p5._validateParameters('rotate', arguments);
@@ -380,8 +380,8 @@ p5.prototype.rotateZ = function(angle) {
  * </div>
  *
  * @alt
- * white 52x52 rect with black outline at center rotated counter 45 degrees
- * 2 white rects with black outline- 1 50x50 at center. other 25x65 bottom left
+ * white 52×52 rect with black outline at center rotated counter 45 degrees
+ * 2 white rects with black outline- 1 50×50 at center. other 25×65 bottom left
  */
 /**
  * @method scale
@@ -540,9 +540,9 @@ p5.prototype.shearY = function(angle) {
  * </div>
  *
  * @alt
- * white 55x55 rect with black outline at center right.
- * 3 white 55x55 rects with black outlines at top-l, center-r and bottom-r.
- * a 20x20 white rect moving in a circle around the canvas
+ * white 55×55 rect with black outline at center right.
+ * 3 white 55×55 rects with black outlines at top-l, center-r and bottom-r.
+ * a 20×20 white rect moving in a circle around the canvas
  */
 /**
  * @method translate

--- a/src/events/acceleration.js
+++ b/src/events/acceleration.js
@@ -417,8 +417,8 @@ p5.prototype._updatePRotations = function() {
  * </div>
  *
  * @alt
- * 50x50 black rect in center of canvas. turns white on mobile when device turns
- * 50x50 black rect in center of canvas. turns white on mobile when x-axis turns
+ * 50×50 black rect in center of canvas. turns white on mobile when device turns
+ * 50×50 black rect in center of canvas. turns white on mobile when x-axis turns
  */
 p5.prototype.turnAxis = undefined;
 
@@ -460,7 +460,7 @@ let shake_threshold = 30;
  * </div>
  *
  * @alt
- * 50x50 black rect in center of canvas. turns white on mobile when device moves
+ * 50×50 black rect in center of canvas. turns white on mobile when device moves
  */
 
 p5.prototype.setMoveThreshold = function(val) {
@@ -503,7 +503,7 @@ p5.prototype.setMoveThreshold = function(val) {
  * </div>
  *
  * @alt
- * 50x50 black rect in center of canvas. turns white on mobile when device
+ * 50×50 black rect in center of canvas. turns white on mobile when device
  * is being shaked
  */
 
@@ -540,7 +540,7 @@ p5.prototype.setShakeThreshold = function(val) {
  * </div>
  *
  * @alt
- * 50x50 black rect in center of canvas. turns white on mobile when device moves
+ * 50×50 black rect in center of canvas. turns white on mobile when device moves
  */
 
 /**
@@ -597,8 +597,8 @@ p5.prototype.setShakeThreshold = function(val) {
  * </div>
  *
  * @alt
- * 50x50 black rect in center of canvas. turns white on mobile when device turns
- * 50x50 black rect in center of canvas. turns white on mobile when x-axis turns
+ * 50×50 black rect in center of canvas. turns white on mobile when device turns
+ * 50×50 black rect in center of canvas. turns white on mobile when x-axis turns
  */
 
 /**
@@ -629,7 +629,7 @@ p5.prototype.setShakeThreshold = function(val) {
  * </div>
  *
  * @alt
- * 50x50 black rect in center of canvas. turns white on mobile when device shakes
+ * 50×50 black rect in center of canvas. turns white on mobile when device shakes
  */
 
 p5.prototype._ondeviceorientation = function(e) {

--- a/src/events/keyboard.js
+++ b/src/events/keyboard.js
@@ -28,7 +28,7 @@ import p5 from '../core/main';
  * </div>
  *
  * @alt
- * 50x50 white rect that turns black on keypress.
+ * 50×50 white rect that turns black on keypress.
  */
 p5.prototype.isKeyPressed = false;
 p5.prototype.keyIsPressed = false; // khan
@@ -373,8 +373,8 @@ p5.prototype._onblur = function(e) {
  * </code></div>
  *
  * @alt
- * 50x50 red ellipse moves left, right, up and down with arrow presses.
- * 50x50 red ellipse gets bigger or smaller when + or - are pressed.
+ * 50×50 red ellipse moves left, right, up and down with arrow presses.
+ * 50×50 red ellipse gets bigger or smaller when + or - are pressed.
  */
 p5.prototype.keyIsDown = function(code) {
   p5._validateParameters('keyIsDown', arguments);

--- a/src/events/mouse.js
+++ b/src/events/mouse.js
@@ -188,7 +188,7 @@ p5.prototype.pmouseX = 0;
  * </div>
  *
  * @alt
- * 60x60 black rect center, fuchsia background. rect flickers on mouse movement
+ * 60×60 black rect center, fuchsia background. rect flickers on mouse movement
  */
 p5.prototype.pmouseY = 0;
 
@@ -226,7 +226,7 @@ p5.prototype.pmouseY = 0;
  * </div>
  *
  * @alt
- * 60x60 black rect y moves with mouse y and fuchsia canvas moves with mouse x
+ * 60×60 black rect y moves with mouse y and fuchsia canvas moves with mouse x
  */
 p5.prototype.winMouseX = 0;
 
@@ -264,7 +264,7 @@ p5.prototype.winMouseX = 0;
  * </div>
  *
  * @alt
- * 60x60 black rect x moves with mouse x and fuchsia canvas y moves with mouse y
+ * 60×60 black rect x moves with mouse x and fuchsia canvas y moves with mouse y
  */
 p5.prototype.winMouseY = 0;
 
@@ -382,7 +382,7 @@ p5.prototype.pwinMouseY = 0;
  * </div>
  *
  * @alt
- * 50x50 black ellipse appears on center of fuchsia canvas on mouse click/press.
+ * 50×50 black ellipse appears on center of fuchsia canvas on mouse click/press.
  */
 p5.prototype.mouseButton = 0;
 
@@ -412,7 +412,7 @@ p5.prototype.mouseButton = 0;
  * </div>
  *
  * @alt
- * black 50x50 rect becomes ellipse with mouse click/press. fuchsia background.
+ * black 50×50 rect becomes ellipse with mouse click/press. fuchsia background.
  */
 p5.prototype.mouseIsPressed = false;
 
@@ -528,7 +528,7 @@ p5.prototype._setMouseButton = function(e) {
  * </div>
  *
  * @alt
- * black 50x50 rect becomes lighter with mouse movements until white then resets
+ * black 50×50 rect becomes lighter with mouse movements until white then resets
  * no image displayed
  */
 
@@ -583,7 +583,7 @@ p5.prototype._setMouseButton = function(e) {
  * </div>
  *
  * @alt
- * black 50x50 rect turns lighter with mouse click and drag until white, resets
+ * black 50×50 rect turns lighter with mouse click and drag until white, resets
  * no image displayed
  */
 p5.prototype._onmousemove = function(e) {
@@ -666,7 +666,7 @@ p5.prototype._onmousemove = function(e) {
  * </div>
  *
  * @alt
- * black 50x50 rect turns white with mouse click/press.
+ * black 50×50 rect turns white with mouse click/press.
  * no image displayed
  */
 p5.prototype._onmousedown = function(e) {
@@ -746,7 +746,7 @@ p5.prototype._onmousedown = function(e) {
  * </div>
  *
  * @alt
- * black 50x50 rect turns white with mouse click/press.
+ * black 50×50 rect turns white with mouse click/press.
  * no image displayed
  */
 p5.prototype._onmouseup = function(e) {
@@ -825,7 +825,7 @@ p5.prototype._ondragover = p5.prototype._onmousemove;
  * </div>
  *
  * @alt
- * black 50x50 rect turns white with mouse click/press.
+ * black 50×50 rect turns white with mouse click/press.
  * no image displayed
  */
 p5.prototype._onclick = function(e) {
@@ -893,7 +893,7 @@ p5.prototype._onclick = function(e) {
  * </div>
  *
  * @alt
- * black 50x50 rect turns white with mouse doubleClick/press.
+ * black 50×50 rect turns white with mouse doubleClick/press.
  * no image displayed
  */
 
@@ -962,7 +962,7 @@ p5.prototype._pmouseWheelDeltaY = 0;
  * </div>
  *
  * @alt
- * black 50x50 rect moves up and down with vertical scroll. fuchsia background
+ * black 50×50 rect moves up and down with vertical scroll. fuchsia background
  */
 p5.prototype._onwheel = function(e) {
   const context = this._isGlobal ? window : this;

--- a/src/events/touch.js
+++ b/src/events/touch.js
@@ -120,7 +120,7 @@ function getTouchInfo(canvas, w, h, e, i = 0) {
  * </div>
  *
  * @alt
- * 50x50 black rect turns white with touch event.
+ * 50×50 black rect turns white with touch event.
  * no image displayed
  */
 p5.prototype._ontouchstart = function(e) {
@@ -199,7 +199,7 @@ p5.prototype._ontouchstart = function(e) {
  * </div>
  *
  * @alt
- * 50x50 black rect turns lighter with touch until white. resets
+ * 50×50 black rect turns lighter with touch until white. resets
  * no image displayed
  */
 p5.prototype._ontouchmove = function(e) {
@@ -272,7 +272,7 @@ p5.prototype._ontouchmove = function(e) {
  * </div>
  *
  * @alt
- * 50x50 black rect turns white with touch.
+ * 50×50 black rect turns white with touch.
  * no image displayed
  */
 p5.prototype._ontouchend = function(e) {

--- a/src/image/image.js
+++ b/src/image/image.js
@@ -82,7 +82,7 @@ import omggif from 'omggif';
  * </div>
  *
  * @alt
- * 66x66 dark turquoise rect in center of canvas.
+ * 66×66 dark turquoise rect in center of canvas.
  * 2 gradated dark turquoise rects fade left. 1 center 1 bottom right of canvas
  * no image displayed
  */

--- a/src/image/loading_displaying.js
+++ b/src/image/loading_displaying.js
@@ -344,7 +344,7 @@ function _sAssign(sVal, iVal) {
  * function setup() {
  *   background(50);
  *   // Top-left corner of the img is at (10, 10)
- *   // Width and height are 50 x 50
+ *   // Width and height are 50×50
  *   image(img, 10, 10, 50, 50);
  * }
  * </code>
@@ -368,13 +368,13 @@ function _sAssign(sVal, iVal) {
  * function setup() {
  *   // 1. Background image
  *   // Top-left corner of the img is at (0, 0)
- *   // Width and height are the img's original width and height, 100 x 100
+ *   // Width and height are the img's original width and height, 100×100
  *   image(img, 0, 0);
  *   // 2. Top right image
  *   // Top-left corner of destination rectangle is at (50, 0)
- *   // Destination rectangle width and height are 40 x 20
+ *   // Destination rectangle width and height are 40×20
  *   // The next parameters are relative to the source image:
- *   // - Starting at position (50, 50) on the source image, capture a 50 x 50
+ *   // - Starting at position (50, 50) on the source image, capture a 50×50
  *   // subsection
  *   // - Draw this subsection to fill the dimensions of the destination rectangle
  *   image(img, 50, 0, 40, 20, 50, 50, 50, 50);

--- a/src/image/p5.Image.js
+++ b/src/image/p5.Image.js
@@ -157,7 +157,7 @@ p5.Image = function(width, height) {
    * left to right across each row, then down each column. Retina and other
    * high density displays may have more pixels (by a factor of
    * pixelDensity^2).
-   * For example, if the image is 100x100 pixels, there will be 40,000. With
+   * For example, if the image is 100×100 pixels, there will be 40,000. With
    * pixelDensity = 2, there will be 160,000. The first four values
    * (indices 0-3) in the array will be the R, G, B, A values of the pixel at
    * (0, 0). The second four values (indices 4-7) will contain the R, G, B, A
@@ -212,8 +212,8 @@ p5.Image = function(width, height) {
    * </div>
    *
    * @alt
-   * 66x66 turquoise rect in center of canvas
-   * 66x66 pink rect in center of canvas
+   * 66×66 turquoise rect in center of canvas
+   * 66×66 pink rect in center of canvas
    *
    */
   this.pixels = [];
@@ -378,7 +378,7 @@ p5.Image.prototype.updatePixels = function(x, y, w, h) {
  * </code></div>
  *
  * @alt
- * image of rocky mountains with 50x50 green rect in front
+ * image of rocky mountains with 50×50 green rect in front
  */
 /**
  * @method get

--- a/src/image/pixels.js
+++ b/src/image/pixels.js
@@ -19,7 +19,7 @@ import '../color/p5.Color';
  * left to right across each row, then down each column. Retina and other
  * high density displays will have more pixels[] (by a factor of
  * pixelDensity^2).
- * For example, if the image is 100x100 pixels, there will be 40,000. On a
+ * For example, if the image is 100×100 pixels, there will be 40,000. On a
  * retina display, there will be 160,000.
  *
  * The first four values (indices 0-3) in the array will be the R, G, B, A
@@ -546,7 +546,7 @@ p5.prototype.filter = function(operation, value) {
  *
  * @alt
  * 2 images of the rocky mountains, side-by-side
- * Image of the rocky mountains with 50x50 green rect in center of canvas
+ * Image of the rocky mountains with 50×50 green rect in center of canvas
  */
 /**
  * @method get

--- a/src/io/files.js
+++ b/src/io/files.js
@@ -98,8 +98,8 @@ import '../core/friendly_errors/fes_core';
  * </code></div>
  *
  * @alt
- * 50x50 ellipse that changes from black to white depending on the current humidity
- * 50x50 ellipse that changes from black to white depending on the current humidity
+ * 50×50 ellipse that changes from black to white depending on the current humidity
+ * 50×50 ellipse that changes from black to white depending on the current humidity
  */
 /**
  * @method loadJSON

--- a/src/webgl/material.js
+++ b/src/webgl/material.js
@@ -440,7 +440,7 @@ p5.prototype.texture = function(tex) {
  * which refers to the actual coordinates of the image.
  * NORMAL refers to a normalized space of values ranging from 0 to 1.
  *
- * With IMAGE, if an image is 100 x 200 pixels, mapping the image onto the entire
+ * With IMAGE, if an image is 100×200 pixels, mapping the image onto the entire
  * size of a quad would require the points (0,0) (100, 0) (100,200) (0,200).
  * The same mapping in NORMAL is (0,0) (1,0) (1,1) (0,1).
  * @method  textureMode

--- a/src/webgl/p5.Matrix.js
+++ b/src/webgl/p5.Matrix.js
@@ -17,12 +17,12 @@ if (typeof Float32Array !== 'undefined') {
 }
 
 /**
- * A class to describe a 4x4 matrix
+ * A class to describe a 4×4 matrix
  * for model and view matrix manipulation in the p5js webgl renderer.
  * @class p5.Matrix
  * @private
  * @constructor
- * @param {Array} [mat4] array literal of our 4x4 matrix
+ * @param {Array} [mat4] array literal of our 4×4 matrix
  */
 p5.Matrix = function() {
   const args = new Array(arguments.length);
@@ -284,7 +284,7 @@ p5.Matrix.prototype.invert = function(a) {
 };
 
 /**
- * Inverts a 3x3 matrix
+ * Inverts a 3×3 matrix
  * @method invert3x3
  * @chainable
  */
@@ -321,7 +321,7 @@ p5.Matrix.prototype.invert3x3 = function() {
 };
 
 /**
- * transposes a 3x3 p5.Matrix by a mat3
+ * transposes a 3×3 p5.Matrix by a mat3
  * @method transpose3x3
  * @param  {Number[]} mat3 1-dimensional array
  * @chainable
@@ -340,7 +340,7 @@ p5.Matrix.prototype.transpose3x3 = function(mat3) {
 };
 
 /**
- * converts a 4x4 matrix to its 3x3 inverse transform
+ * converts a 4×4 matrix to its 3×3 inverse transform
  * commonly used in MVMatrix to NMatrix conversions.
  * @method invertTranspose
  * @param  {p5.Matrix} mat4 the matrix to be based on to invert
@@ -379,7 +379,7 @@ p5.Matrix.prototype.inverseTranspose = function(matrix) {
 /**
  * inspired by Toji's mat4 determinant
  * @method determinant
- * @return {Number} Determinant of our 4x4 matrix
+ * @return {Number} Determinant of our 4×4 matrix
  */
 p5.Matrix.prototype.determinant = function() {
   const d00 = this.mat4[0] * this.mat4[5] - this.mat4[1] * this.mat4[4],

--- a/src/webgl/p5.Texture.js
+++ b/src/webgl/p5.Texture.js
@@ -99,7 +99,7 @@ p5.Texture.prototype.init = function(data) {
     this.height === 0 ||
     (this.isSrcMediaElement && !this.src.loadedmetadata)
   ) {
-    // assign a 1x1 empty texture initially, because data is not yet ready,
+    // assign a 1×1 empty texture initially, because data is not yet ready,
     // so that no errors occur in gl console!
     const tmpdata = new Uint8Array([1, 1, 1, 1]);
     gl.texImage2D(


### PR DESCRIPTION
Typographically, `"x" !== "×"`. ☻

**Changes:**
In comments, when referencing pixel dimensions or matrices, use “×” instead of “x”.

This does _not_ include methods like `p5.Matrix.prototype.invert3x3`, where “x” is part of the API and cannot change.  It’s only for “prose”.  

#### PR Checklist

- [x] `npm run lint` passes
- [x] [Inline documentation] is included / updated

[Inline documentation]: https://github.com/processing/p5.js/blob/main/contributor_docs/inline_documentation.md
