### PR TITLE
Fixed function isTextureShader.

### DIFF
--- a/src/webgl/p5.Shader.js
+++ b/src/webgl/p5.Shader.js
@@ -494,7 +494,7 @@ p5.Shader.prototype.isNormalShader = function() {
 };
 
 p5.Shader.prototype.isTextureShader = function() {
-  return this.samplerIndex > 0;
+  return this.samplers.length > 0;
 };
 
 p5.Shader.prototype.isColorShader = function() {

--- a/test/unit/webgl/p5.Shader.js
+++ b/test/unit/webgl/p5.Shader.js
@@ -261,5 +261,53 @@ suite('p5.Shader', function() {
       var curShader = myp5._renderer.userFillShader;
       assert.isTrue(curShader === null);
     });
+
+    test('isTextureShader returns true if there is a sampler', function() {
+      var s = myp5._renderer._getLightShader();
+      myp5.shader(s);
+      assert.isTrue(s.isTextureShader());
+    });
+
+    test('isTextureShader returns false if there is no sampler', function() {
+      var s = myp5._renderer._getColorShader();
+      myp5.shader(s);
+      assert.isFalse(s.isTextureShader());
+    });
+
+    test('isLightShader returns true if there are lighting uniforms', function() {
+      var s = myp5._renderer._getLightShader();
+      myp5.shader(s);
+      assert.isTrue(s.isLightShader());
+    });
+
+    test('isLightShader returns false if there are no lighting uniforms', function() {
+      var s = myp5._renderer._getPointShader();
+      myp5.shader(s);
+      assert.isFalse(s.isLightShader());
+    });
+
+    test('isNormalShader returns true if there is a normal attribute', function() {
+      var s = myp5._renderer._getNormalShader();
+      myp5.shader(s);
+      assert.isTrue(s.isNormalShader());
+    });
+
+    test('isNormalShader returns false if there is no normal attribute', function() {
+      var s = myp5._renderer._getPointShader();
+      myp5.shader(s);
+      assert.isFalse(s.isNormalShader());
+    });
+
+    test('isStrokeShader returns true if there is a stroke weight uniform', function() {
+      var s = myp5._renderer._getLineShader();
+      myp5.shader(s);
+      assert.isTrue(s.isStrokeShader());
+    });
+
+    test('isStrokeShader returns false if there is no stroke weight uniform', function() {
+      var s = myp5._renderer._getLightShader();
+      myp5.shader(s);
+      assert.isFalse(s.isStrokeShader());
+    });
   });
 });


### PR DESCRIPTION
This allows user defined shaders work with textures.
Previously this function always returned false.

Resolves #5507

#### PR Checklist

- [x] `npm run lint` passes
- [x] [Unit tests] are included / updated

[Unit tests]: https://github.com/processing/p5.js/tree/main/contributor_docs#unit-tests
