### PR TITLE
Allow clear colors to propagate to the webGL clear method.

### DIFF
--- a/src/color/setting.js
+++ b/src/color/setting.js
@@ -186,6 +186,11 @@ p5.prototype.background = function(...args) {
  * or partially transparent. This function clears everything to make all of
  * the pixels 100% transparent.
  *
+ * Note: In WebGL mode, this function can be passed normalized RGBA color values in
+ * order to clear the screen to a specific color. In addition to color, it will also
+ * clear the depth buffer. If you are not using the webGL renderer
+ * these color values will have no effect.
+ *
  * @method clear
  * @chainable
  * @example
@@ -204,10 +209,19 @@ p5.prototype.background = function(...args) {
  *
  * @alt
  * small white ellipses are continually drawn at mouse's x and y coordinates.
+ *
+ * @param {Number} r normalized red val.
+ * @param {Number} g normalized green val.
+ * @param {Number} b normalized blue val.
+ * @param {Number} a normalized alpha val.
  */
+p5.prototype.clear = function(...args) {
+  const _r = args[0] || 0;
+  const _g = args[1] || 0;
+  const _b = args[2] || 0;
+  const _a = args[3] || 0;
 
-p5.prototype.clear = function() {
-  this._renderer.clear();
+  this._renderer.clear(_r, _g, _b, _a);
   return this;
 };
 

--- a/src/webgl/p5.RendererGL.js
+++ b/src/webgl/p5.RendererGL.js
@@ -901,7 +901,9 @@ p5.RendererGL.prototype.clear = function(...args) {
   const _g = args[1] || 0;
   const _b = args[2] || 0;
   const _a = args[3] || 0;
+
   this.GL.clearColor(_r, _g, _b, _a);
+  this.GL.clearDepth(1);
   this.GL.clear(this.GL.COLOR_BUFFER_BIT | this.GL.DEPTH_BUFFER_BIT);
 };
 

--- a/test/unit/webgl/p5.RendererGL.js
+++ b/test/unit/webgl/p5.RendererGL.js
@@ -337,6 +337,18 @@ suite('p5.RendererGL', function() {
       done();
     });
 
+    test('clear color with rgba arguments', function(done) {
+      myp5.createCanvas(50, 50);
+      myp5.clear(1, 0, 0, 1);
+      pixel = myp5.get(0, 0);
+      assert.deepEqual(pixel, [255, 0, 0, 255]);
+      pg = myp5.createGraphics(50, 50, myp5.WEBGL);
+      pg.clear(1, 0, 0, 1);
+      pixel = pg.get(0, 0);
+      assert.deepEqual(pixel, [255, 0, 0, 255]);
+      done();
+    });
+
     test('semi-transparent GL graphics with GL canvas', function(done) {
       myp5.createCanvas(50, 50, myp5.WEBGL);
       pg = myp5.createGraphics(25, 50, myp5.WEBGL);

--- a/test/unit/webgl/p5.RendererGL.js
+++ b/test/unit/webgl/p5.RendererGL.js
@@ -338,7 +338,7 @@ suite('p5.RendererGL', function() {
     });
 
     test('clear color with rgba arguments', function(done) {
-      myp5.createCanvas(50, 50);
+      myp5.createCanvas(50, 50, myp5.WEBGL);
       myp5.clear(1, 0, 0, 1);
       pixel = myp5.get(0, 0);
       assert.deepEqual(pixel, [255, 0, 0, 255]);


### PR DESCRIPTION
Resolves #5513 

 Changes:
Allows RGBA values to propagate to the clear method in the webGL renderer. The webGL clear method was implemented to accept color values, but previously, those values were never actually passed to the method. 

This PR also updates the clear method documentation to reflect this change, as well as a unit test.


#### PR Checklist
- [X] `npm run lint` passes
- [X] [Inline documentation] is included / updated
- [X] [Unit tests] are included / updated

[Inline documentation]: https://github.com/processing/p5.js/blob/main/contributor_docs/inline_documentation.md
[Unit tests]: https://github.com/processing/p5.js/tree/main/contributor_docs#unit-tests
