### PR TITLE
Allow p5.Texture inputs to setUniform

### DIFF
--- a/src/webgl/p5.Shader.js
+++ b/src/webgl/p5.Shader.js
@@ -305,10 +305,10 @@ p5.Shader.prototype.useProgram = function() {
  * @chainable
  * @param {String} uniformName the name of the uniform.
  * Must correspond to the name used in the vertex and fragment shaders
- * @param {Boolean|Number|Number[]|p5.Image|p5.Graphics|p5.MediaElement}
+ * @param {Boolean|Number|Number[]|p5.Image|p5.Graphics|p5.MediaElement|p5.Texture}
  * data the data to associate with the uniform. The type can be
  * a boolean (true/false), a number, an array of numbers, or
- * an image (p5.Image, p5.Graphics, p5.MediaElement)
+ * an image (p5.Image, p5.Graphics, p5.MediaElement, p5.Texture)
  *
  * @example
  * <div modernizr='webgl'>

--- a/src/webgl/p5.Shader.js
+++ b/src/webgl/p5.Shader.js
@@ -461,8 +461,9 @@ p5.Shader.prototype.setUniform = function(uniformName, data) {
       break;
     case gl.SAMPLER_2D:
       gl.activeTexture(gl.TEXTURE0 + uniform.samplerIndex);
-      uniform.texture = this._renderer.getTexture(data);
-      gl.uniform1i(uniform.location, uniform.samplerIndex);
+      uniform.texture =
+        data instanceof p5.Texture ? data : this._renderer.getTexture(data);
+      gl.uniform1i(location, uniform.samplerIndex);
       break;
     //@todo complete all types
   }


### PR DESCRIPTION
Changes: This PR allows you to use your own p5.Texture `const tex = new p5.Texture(canvas,  new p5.Image(256, 256));` as an input to a custom shader. It's a single line change, where we just check if the input is an instance of a p5.Texture, and if so just pass it along to the shader.
 
Currently for sampler2D's the setUniform function can already accept p5.Images, p5.Graphics, and p5.MediaElement. However, the function can't actually accept texture inputs. Instead, it converts the other types of inputs to textures, and then sends them along to the shader. It seems a little silly that the function responsible for sending textures to a shader can't accept those inputs itself.

I think this change will help people extend the library to do more complex things with webGL graphics. For example, after this change is implemented, one could implement framebuffer objects with p5.js. Currently we use the p5.Graphics objects as a stand in for those, but framebuffers should be much more performant, and get around some limitations around the number of webGL contexts allowed by the browser on a single page.

I'm not quite sure how to implement a unit test for this. We don't currently unit test the setUniform function for every type, only for if the arrays are empty. 
 

#### PR Checklist

- [X] `npm run lint` passes
- [X] [Inline documentation] is included / updated
- [ ] [Unit tests] are included / updated

[Inline documentation]: https://github.com/processing/p5.js/blob/main/contributor_docs/inline_documentation.md
[Unit tests]: https://github.com/processing/p5.js/tree/main/contributor_docs#unit-tests
