### PR TITLE
Allow texture() to accept p5.Texture argument without throwing a warning.

### DIFF
--- a/src/image/loading_displaying.js
+++ b/src/image/loading_displaying.js
@@ -316,7 +316,7 @@ function _sAssign(sVal, iVal) {
  * <img src="assets/drawImage.png"></img>
  *
  * @method image
- * @param  {p5.Image|p5.Element} img    the image to display
+ * @param  {p5.Image|p5.Element|p5.Texture} img    the image to display
  * @param  {Number}   x     the x-coordinate of the top-left corner of the image
  * @param  {Number}   y     the y-coordinate of the top-left corner of the image
  * @param  {Number}   [width]  the width to draw the image
@@ -387,7 +387,7 @@ function _sAssign(sVal, iVal) {
  */
 /**
  * @method image
- * @param  {p5.Image|p5.Element} img
+ * @param  {p5.Image|p5.Element|p5.Texture} img
  * @param  {Number}   dx     the x-coordinate of the destination
  *                           rectangle in which to draw the source image
  * @param  {Number}   dy     the y-coordinate of the destination

--- a/src/webgl/material.js
+++ b/src/webgl/material.js
@@ -380,7 +380,7 @@ p5.prototype.resetShader = function() {
  * <a href="https://p5js.org/examples/3d-materials.html">example</a>.
  *
  * @method texture
- * @param {p5.Image|p5.MediaElement|p5.Graphics} tex  image to use as texture
+ * @param {p5.Image|p5.MediaElement|p5.Graphics|p5.Texture} tex  image to use as texture
  * @chainable
  * @example
  * <div>


### PR DESCRIPTION
 Changes:
 Small changes to the inline docs to allow `texture()` and `image()` to accept p5.Texture objects as arguments without throwing a warning when the arguments get validated. This PR depends on #5517 since `texture()` & `image()` in webGL mode call `setUniform()` under the hood. 

We don't currently have any unit tests for `texture()`, so I haven't added any new ones, but I could probably try and cook something up if we think it is important here. I like wise didn't see much in the way of tests for drawing images.

#### PR Checklist
<!--
  To check any option, replace the "[ ]" with a "[x]". Be sure to check out how it looks in the Preview tab! Feel free to remove any portion of the template that is not relevant for your issue.
-->

- [X] `npm run lint` passes
- [X] [Inline documentation] is included / updated
- [ ] [Unit tests] are included / updated

[Inline documentation]: https://github.com/processing/p5.js/blob/main/contributor_docs/inline_documentation.md
[Unit tests]: https://github.com/processing/p5.js/tree/main/contributor_docs#unit-tests
