### PR TITLE
Fixes bug introduced by #5483

### DIFF
--- a/src/webgl/p5.Shader.js
+++ b/src/webgl/p5.Shader.js
@@ -178,7 +178,17 @@ p5.Shader.prototype._loadUniforms = function() {
       samplerIndex++;
       this.samplers.push(uniform);
     }
-    uniform.isArray = uniformInfo.size > 1;
+
+    uniform.isArray =
+      uniformInfo.size > 1 ||
+      uniform.type === gl.FLOAT_MAT3 ||
+      uniform.type === gl.FLOAT_MAT4 ||
+      uniform.type === gl.FLOAT_VEC2 ||
+      uniform.type === gl.FLOAT_VEC3 ||
+      uniform.type === gl.FLOAT_VEC4 ||
+      uniform.type === gl.INT_VEC2 ||
+      uniform.type === gl.INT_VEC4 ||
+      uniform.type === gl.INT_VEC3;
 
     this.uniforms[uniformName] = uniform;
   }


### PR DESCRIPTION
Changes:
This pr adds back in a more rigorous type check for array uniform types. I had mistakenly removed the check in #5483 but today I realized that matrix types were being considered false by the isArray boolean. 

This caused a number of problems, most notably, the matrices not being correctly updated when things like screen resolution or viewport changed. 

#### PR Checklist
- [x] `npm run lint` passes

[Inline documentation]: https://github.com/processing/p5.js/blob/main/contributor_docs/inline_documentation.md
[Unit tests]: https://github.com/processing/p5.js/tree/main/contributor_docs#unit-tests
