### PR TITLE
Changes webGL alpha buffer to false.

### DIFF
--- a/src/webgl/p5.RendererGL.js
+++ b/src/webgl/p5.RendererGL.js
@@ -235,7 +235,7 @@ p5.RendererGL.prototype._setAttributeDefaults = function(pInst) {
   // See issue #3850, safer to enable AA in Safari
   const applyAA = navigator.userAgent.toLowerCase().includes('safari');
   const defaults = {
-    alpha: true,
+    alpha: false,
     depth: true,
     stencil: true,
     antialias: applyAA,
@@ -345,7 +345,7 @@ p5.RendererGL.prototype._resetContext = function(options, callback) {
  * The available attributes are:
  * <br>
  * alpha - indicates if the canvas contains an alpha buffer
- * default is true
+ * default is false
  *
  * depth - indicates whether the drawing buffer has a depth buffer
  * of at least 16 bits - default is true

--- a/test/unit/webgl/p5.RendererGL.js
+++ b/test/unit/webgl/p5.RendererGL.js
@@ -333,7 +333,7 @@ suite('p5.RendererGL', function() {
       pg.clear();
       myp5.image(pg, -myp5.width / 2, -myp5.height / 2);
       pixel = myp5.get(0, 0);
-      assert.deepEqual(pixel, [0, 255, 255, 255]);
+      assert.deepEqual(pixel, [0, 0, 0, 255]);
       done();
     });
 
@@ -356,7 +356,7 @@ suite('p5.RendererGL', function() {
       pg.background(100, 100, 100, 100);
       myp5.image(pg, -myp5.width / 2, -myp5.height / 2);
       pixel = myp5.get(0, 0);
-      assert.deepEqual(pixel, [39, 194, 194, 194]);
+      assert.deepEqual(pixel, [100, 100, 100, 255]);
       done();
     });
 
@@ -378,7 +378,7 @@ suite('p5.RendererGL', function() {
       pg.clear();
       myp5.image(pg, 0, 0);
       pixel = myp5.get(0, 0);
-      assert.deepEqual(pixel, [0, 255, 255, 255]);
+      assert.deepEqual(pixel, [0, 0, 0, 255]);
       done();
     });
 
@@ -389,7 +389,7 @@ suite('p5.RendererGL', function() {
       pg.background(100, 100, 100, 100);
       myp5.image(pg, 0, 0);
       pixel = myp5.get(0, 0);
-      assert.deepEqual(pixel, [39, 194, 194, 255]);
+      assert.deepEqual(pixel, [100, 100, 100, 255]);
       done();
     });
   });
@@ -437,8 +437,8 @@ suite('p5.RendererGL', function() {
     test('blendModes change pixel colors as expected', function(done) {
       myp5.createCanvas(10, 10, myp5.WEBGL);
       myp5.noStroke();
-      assert.deepEqual([133, 69, 191, 158], mixAndReturn(myp5.ADD, 255));
-      assert.deepEqual([0, 0, 255, 122], mixAndReturn(myp5.REPLACE, 255));
+      assert.deepEqual([133, 69, 191, 255], mixAndReturn(myp5.ADD, 255));
+      assert.deepEqual([0, 0, 255, 255], mixAndReturn(myp5.REPLACE, 255));
       assert.deepEqual([133, 255, 133, 255], mixAndReturn(myp5.SUBTRACT, 255));
       assert.deepEqual([255, 0, 255, 255], mixAndReturn(myp5.SCREEN, 0));
       assert.deepEqual([0, 255, 0, 255], mixAndReturn(myp5.EXCLUSION, 255));


### PR DESCRIPTION
Resolves #5552

 Changes:
Changes the default for the webGL renderer to not have an alpha buffer.



#### PR Checklist


- [X] `npm run lint` passes
- [X] [Inline documentation] is included / updated
- [X] [Unit tests] are included / updated

[Inline documentation]: https://github.com/processing/p5.js/blob/main/contributor_docs/inline_documentation.md
[Unit tests]: https://github.com/processing/p5.js/tree/main/contributor_docs#unit-tests
