### PR TITLE
dom.js - Make PositionType argument optional

### DIFF
--- a/src/dom/dom.js
+++ b/src/dom/dom.js
@@ -1799,7 +1799,7 @@ p5.Element.prototype.html = function() {
  * @method position
  * @param  {Number} [x] x-position relative to upper left of window (optional)
  * @param  {Number} [y] y-position relative to upper left of window (optional)
- * @param  {String} positionType it can be static, fixed, relative, sticky, initial or inherit (optional)
+ * @param  {String} [positionType] it can be static, fixed, relative, sticky, initial or inherit (optional)
  * @chainable
  */
 p5.Element.prototype.position = function() {


### PR DESCRIPTION
Minor change to mark `[PositionType]` as optional (JSDoc syntax)t.

This is causing issues creating the typescript file using YUIDoc