### PR TITLE
Swap order of arguments to radio.option()

### DIFF
--- a/src/dom/dom.js
+++ b/src/dom/dom.js
@@ -770,10 +770,10 @@ p5.prototype.createSelect = function() {
 /**
  * Creates a radio button element in the DOM.It also helps existing radio buttons
  * assign methods of <a href="#/p5.Element/">p5.Element</a>.
- * - `.option(value, [label])` can be used to create a new option for the
- *   element. If an option with a value already exists, it will be returned.
+ * - `.option(label, [value])` can be used to create a new option for the
+ *   element. If an option with a label already exists, it will be returned.
+ *   Optionally, a value can be provided as second argument for the option.
  *   It is recommended to use string values as input for `value`.
- *   Optionally, a label can be provided as second argument for the option.
  * - `.remove(value)` can be used to remove an option for the element. String
  *   values recommended as input for `value`.
  * - `.value()` method will return the currently selected value.
@@ -812,9 +812,9 @@ p5.prototype.createSelect = function() {
  *
  * function setup() {
  *   radio = createRadio();
- *   radio.option('1', 'apple');
- *   radio.option('2', 'bread');
- *   radio.option('3', 'juice');
+ *   radio.option('apple', '1');
+ *   radio.option('bread', '2');
+ *   radio.option('juice', '3');
  *   radio.style('width', '30px');
  *   radio.selected('2');
  *   textAlign(CENTER);


### PR DESCRIPTION



<!--
  Thank you for contributing! Please use this pull request (PR) template.


 In the description field of this PR, include "resolves #XXXX" tagging the issue you are fixing. If this PR addresses the issue but doesn't completely resolve it (ie the issue should remain open after your PR is merged), write "addresses #XXXX".-->
resolves #[4948](https://github.com/processing/p5.js/issues/4948)

 Changes:
<!-- Add here what changes were made in this pull request and if possible provide links showcasing the changes. -->
I changed the order of the label and value parameters in the 2nd example and updated the Description.

The label and the value parameters are swapped in the latest implementation of radio() #[4430](https://github.com/processing/p5.js/pull/4430)

 Screenshots of the change:
<!-- If applicable, add screenshots depicting the changes. -->

#### PR Checklist
<!--
  To check any option, replace the "[ ]" with a "[x]". Be sure to check out how it looks in the Preview tab! Feel free to remove any portion of the template that is not relevant for your issue.
-->

- [x] `npm run lint` passes
- [x] [Inline documentation] is included / updated
- [x ] [Unit tests] are included / updated

[Inline documentation]: https://github.com/processing/p5.js/blob/main/contributor_docs/inline_documentation.md
[Unit tests]: https://github.com/processing/p5.js/tree/main/contributor_docs#unit-tests

