### PR TITLE
FES ko new translation file + en file minor updates

### DIFF
--- a/lib/empty-example/sketch.js
+++ b/lib/empty-example/sketch.js
@@ -4,4 +4,5 @@ function setup() {
 
 function draw() {
   // put drawing code here
+  arc(1, 1, 10.5, 10, b, Math.PI, 'pie');
 }

--- a/lib/empty-example/sketch.js
+++ b/lib/empty-example/sketch.js
@@ -4,5 +4,4 @@ function setup() {
 
 function draw() {
   // put drawing code here
-  arc(1, 1, 10.5, 10, b, Math.PI, 'pie');
 }

--- a/src/core/friendly_errors/fes_core.js
+++ b/src/core/friendly_errors/fes_core.js
@@ -208,7 +208,7 @@ if (typeof IS_MINIFIED !== 'undefined') {
   p5._friendlyAutoplayError = function(src) {
     const message = translator('fes.autoplay', {
       src,
-      link: 'https://developer.mozilla.org/docs/Web/Media/Autoplay_guide'
+      url: 'https://developer.mozilla.org/docs/Web/Media/Autoplay_guide'
     });
     console.log(translator('fes.pre', { message }));
   };
@@ -760,13 +760,10 @@ if (typeof IS_MINIFIED !== 'undefined') {
 
             // if the flow gets this far, this is likely not a misspelling
             // of a p5 property/function
-            let url1 = 'https://p5js.org/examples/data-variable-scope.html';
-            let url2 =
-              'https://developer.mozilla.org/docs/Web/JavaScript/Reference/Errors/Not_Defined#What_went_wrong';
+            let url = 'https://p5js.org/examples/data-variable-scope.html';
             p5._friendlyError(
               translator('fes.globalErrors.reference.notDefined', {
-                url1,
-                url2,
+                url,
                 symbol: errSym,
                 location: locationObj
                   ? translator('fes.location', locationObj)
@@ -842,14 +839,13 @@ if (typeof IS_MINIFIED !== 'undefined') {
             //let a = null;
             //console.log(a.property); -> a is null
             let errSym = matchedError.match[1];
-            let url1 =
+            let url =
               'https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Errors/Cant_access_property#what_went_wrong';
-            let url2 =
-              'https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/null';
+            /*let url2 =
+              'https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/null';*/
             p5._friendlyError(
               translator('fes.globalErrors.type.readFromNull', {
-                url1,
-                url2,
+                url,
                 symbol: errSym,
                 location: locationObj
                   ? translator('fes.location', locationObj)
@@ -865,14 +861,13 @@ if (typeof IS_MINIFIED !== 'undefined') {
             //let a; -> default value of a is undefined
             //console.log(a.property); -> a is undefined
             let errSym = matchedError.match[1];
-            let url1 =
+            let url =
               'https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Errors/Cant_access_property#what_went_wrong';
-            let url2 =
-              'https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/undefined#description';
+            /*let url2 =
+              'https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/undefined#description';*/
             p5._friendlyError(
               translator('fes.globalErrors.type.readFromUndefined', {
-                url1,
-                url2,
+                url,
                 symbol: errSym,
                 location: locationObj
                   ? translator('fes.location', locationObj)
@@ -1063,7 +1058,7 @@ const helpForMisusedAtTopLevelCode = (e, log) => {
           translator('fes.misusedTopLevel', {
             symbolName,
             symbolType: symbol.type,
-            link: FAQ_URL
+            url: FAQ_URL
           })
         );
       }

--- a/src/core/friendly_errors/file_errors.js
+++ b/src/core/friendly_errors/file_errors.js
@@ -12,7 +12,7 @@ if (typeof IS_MINIFIED !== 'undefined') {
   const fileLoadErrorCases = (num, filePath) => {
     const suggestion = translator('fes.fileLoadError.suggestion', {
       filePath,
-      link: 'https://github.com/processing/p5.js/wiki/Local-server'
+      url: 'https://github.com/processing/p5.js/wiki/Local-server'
     });
     switch (num) {
       case 0:

--- a/src/core/friendly_errors/sketch_reader.js
+++ b/src/core/friendly_errors/sketch_reader.js
@@ -100,8 +100,10 @@ if (typeof IS_MINIFIED !== 'undefined') {
             undefined
           ) {
             //if a p5.js function is used ie it is in the funcs array
+            let url = `https://p5js.org/reference/#/p5/${variableArray[i]}`;
             p5._friendlyError(
               translator('fes.sketchReaderErrors.reservedFunc', {
+                url: url,
                 symbol: variableArray[i]
               })
             );
@@ -330,8 +332,10 @@ if (typeof IS_MINIFIED !== 'undefined') {
               p5Constructors[keyArray[k]].prototype[functionArray[i]] !==
               element
             ) {
+              let url = `https://p5js.org/reference/#/p5/${functionArray[i]}`;
               p5._friendlyError(
                 translator('fes.sketchReaderErrors.reservedFunc', {
+                  url: url,
                   symbol: functionArray[i]
                 })
               );

--- a/src/core/friendly_errors/validate_params.js
+++ b/src/core/friendly_errors/validate_params.js
@@ -558,7 +558,7 @@ if (typeof IS_MINIFIED !== 'undefined') {
             context: (errorObj.position + 1).toString(),
             defaultValue: (errorObj.position + 1).toString()
           }),
-          link: '[https://p5js.org/examples/data-variable-scope.html]'
+          url: 'https://p5js.org/examples/data-variable-scope.html'
         };
 
         break;

--- a/src/core/friendly_errors/validate_params.js
+++ b/src/core/friendly_errors/validate_params.js
@@ -652,7 +652,7 @@ if (typeof IS_MINIFIED !== 'undefined') {
       // i18next-extract-mark-context-next-line ["EMPTY_VAR", "TOO_MANY_ARGUMENTS", "TOO_FEW_ARGUMENTS", "WRONG_TYPE"]
       message = translator('fes.friendlyParamError.type', translationObj);
 
-      p5._friendlyError(`${message}.`, func, 3);
+      p5._friendlyError(`${message}`, func, 3);
     }
   };
 

--- a/test/unit/core/error_helpers.js
+++ b/test/unit/core/error_helpers.js
@@ -814,10 +814,10 @@ suite('Global Error Handling', function() {
       temp = temp.filter(e => e.trim().length > 0);
       assert.strictEqual(temp.length, 4);
       assert.match(log[0], /"asdfg" is not defined/);
-      assert.match(temp[0], /Error at/);
-      assert.match(temp[0], /myfun/);
-      assert.match(temp[1], /Called from/);
-      assert.match(temp[1], /setup/);
+      assert.match(temp[1], /Error at/);
+      assert.match(temp[1], /myfun/);
+      assert.match(temp[3], /Called from/);
+      assert.match(temp[3], /setup/);
     });
   });
 

--- a/test/unit/core/error_helpers.js
+++ b/test/unit/core/error_helpers.js
@@ -812,7 +812,7 @@ suite('Global Error Handling', function() {
       assert.strictEqual(log.length, 2);
       let temp = log[1].split('\n');
       temp = temp.filter(e => e.trim().length > 0);
-      assert.strictEqual(temp.length, 2);
+      assert.strictEqual(temp.length, 4);
       assert.match(log[0], /"asdfg" is not defined/);
       assert.match(temp[0], /Error at/);
       assert.match(temp[0], /myfun/);

--- a/translations/dev.js
+++ b/translations/dev.js
@@ -1,7 +1,8 @@
 export { default as en_translation } from './en/translation';
 export { default as es_translation } from './es/translation';
+export { default as ko_translation } from './ko/translation';
 
-/** 
+/**
  * When adding a new language, add a new "export" statement above this.
  * For example, if we were to add fr ( French ), we would write:
  * export { default as fr_translation } from './fr/translation';
@@ -9,7 +10,7 @@ export { default as es_translation } from './es/translation';
  * If the language key has a hypen (-), replace it with an underscore ( _ )
  * e.g. for es-MX we would write:
  * export { default as es_MX_translation } from './es-MX/translation';
- * 
+ *
  * "es_MX" is the language key whereas "translation" is the filename
  * ( translation.json ) or the namespace
 */

--- a/translations/en/translation.json
+++ b/translations/en/translation.json
@@ -25,8 +25,8 @@
         "cannotAccess": "\n{{location}} \"{{symbol}}\" is used before declaration. Make sure you have declared the variable before using it.\n\n+ More info: {{url}}",
         "notDefined": "\n{{location}} \"{{symbol}}\" is not defined in the current scope. If you have defined it in your code, you should check its scope, spelling, and letter-casing (JavaScript is case-sensitive).\n\n+ More info: {{url}}"
       },
-      "stackSubseq": "{{location}} Called from line {{line}} in \"{{func}}\" in {{file}} \n",
-      "stackTop": "{{location}} Error at line {{line}} in \"{{func}}\" in {{file}} \n",
+      "stackSubseq": "└[{{location}}] \n\t Called from line {{line}} in {{func}}()\n",
+      "stackTop": "┌[{{location}}] \n\t Error at line {{line}} in {{func}}()\n",
       "syntax": {
         "badReturnOrYield": "\nSyntax Error - return lies outside of a function. Make sure you’re not missing any brackets, so that return lies inside a function.\n\n+ More info: {{url}}",
         "invalidToken": "\nSyntax Error - Found a symbol that JavaScript doesn't recognize or didn't expect at it's place.\n\n+ More info: {{url}}",
@@ -43,7 +43,7 @@
       }
     },
     "libraryError": "{{location}} An error with message \"{{error}}\" occurred inside the p5js library when {{func}} was called. If not stated otherwise, it might be an issue with the arguments passed to {{func}}.",
-    "location": "[{{file}}: line {{line}}]",
+    "location": "[{{file}}, line {{line}}]",
     "misspelling": "{{location}} It seems that you may have accidentally written \"{{name}}\" instead of \"{{actualName}}\". Please correct it to {{actualName}} if you wish to use the {{type}} from p5.js.",
     "misspelling_plural": "{{location}} It seems that you may have accidentally written \"{{name}}\".\nYou may have meant one of the following: \n{{suggestions}}",
     "misusedTopLevel": "Did you just try to use p5.js's {{symbolName}} {{symbolType}}? If so, you may want to move it into your sketch's setup() function.\n\n+ More info: {{url}}",

--- a/translations/en/translation.json
+++ b/translations/en/translation.json
@@ -1,7 +1,7 @@
 {
   "fes": {
-    "autoplay": "The media that tried to play (with '{{src}}') wasn't allowed to by this browser, most likely due to the browser's autoplay policy. Check out {{link}} for more information about why.",
-    "checkUserDefinedFns": "It seems that you may have accidentally written {{name}} instead of {{actualName}}.\n\nPlease correct it if it's not intentional.",
+    "autoplay": "The media that tried to play (with '{{src}}') wasn't allowed to by this browser, most likely due to the browser's autoplay policy.\n\n+ More info: {{url}}",
+    "checkUserDefinedFns": "It seems that you may have accidentally written {{name}} instead of {{actualName}}. Please correct it if it's not intentional.",
     "fileLoadError": {
       "bytes": "It looks like there was a problem loading your file. {{suggestion}}",
       "font": "It looks like there was a problem loading your font. {{suggestion}}",
@@ -10,43 +10,43 @@
       "json": "It looks like there was a problem loading your JSON file. {{suggestion}}",
       "large": "If your large file isn't fetched successfully, we recommend splitting the file into smaller segments and fetching those.",
       "strings": "It looks like there was a problem loading your text file. {{suggestion}}",
-      "suggestion": "Try checking if the file path ({{filePath}}) is correct, hosting the file online, or running a local server. (More info at {{link}})",
+      "suggestion": "Try checking if the file path ({{filePath}}) is correct, hosting the file online, or running a local server.\n\n+ More info: {{url}}",
       "table": "It looks like there was a problem loading your table file. {{suggestion}}",
       "xml": "It looks like there was a problem loading your XML file. {{suggestion}}"
     },
     "friendlyParamError": {
-      "type_EMPTY_VAR": "{{func}}() was expecting {{formatType}} for the {{position}} parameter, received an empty variable instead. {{location}}\n\nIf not intentional, this is often a problem with scope: {{link}}",
-      "type_TOO_FEW_ARGUMENTS": "{{func}}() was expecting at least {{minParams}} arguments, but received only {{argCount}}. {{location}}",
-      "type_TOO_MANY_ARGUMENTS": "{{func}}() was expecting no more than {{maxParams}} arguments, but received {{argCount}}. {{location}}",
-      "type_WRONG_TYPE": "{{func}}() was expecting {{formatType}} for the {{position}} parameter, received {{argType}} instead. {{location}}"
+      "type_EMPTY_VAR": "{{location}} {{func}}() was expecting {{formatType}} for the {{position}} parameter, received an empty variable instead. If not intentional, this is often a problem with scope.\n\n+ More info: {{url}}",
+      "type_TOO_FEW_ARGUMENTS": "{{location}} {{func}}() was expecting at least {{minParams}} arguments, but received only {{argCount}}.",
+      "type_TOO_MANY_ARGUMENTS": "{{location}} {{func}}() was expecting no more than {{maxParams}} arguments, but received {{argCount}}.",
+      "type_WRONG_TYPE": "{{location}} {{func}}() was expecting {{formatType}} for the {{position}} parameter, received {{argType}} instead."
     },
     "globalErrors": {
       "reference": {
-        "cannotAccess": "\nError ▶️ \"{{symbol}}\" is used before declaration. Make sure you have declared the variable before using it.\n\n{{location}}\n\nFor more: {{url}}",
-        "notDefined": "\nError ▶️ \"{{symbol}}\" is not defined in the current scope {{location}}.\n\nIf you have defined it in your code, you should check its scope, spelling, and letter-casing (JavaScript is case-sensitive). For more:\n{{url1}}\n{{url2}}"
+        "cannotAccess": "\n{{location}} \"{{symbol}}\" is used before declaration. Make sure you have declared the variable before using it.\n\n+ More info: {{url}}",
+        "notDefined": "\n{{location}} \"{{symbol}}\" is not defined in the current scope. If you have defined it in your code, you should check its scope, spelling, and letter-casing (JavaScript is case-sensitive).\n\n+ More info: {{url}}"
       },
-      "stackSubseq": "▶️ Called from line {{line}} in \"{{func}}\" in {{file}} ({{location}})\n\n",
-      "stackTop": "▶️ Error at line {{line}} in \"{{func}}\" in {{file}} ({{location}})\n\n",
+      "stackSubseq": "{{location}} Called from line {{line}} in \"{{func}}\" in {{file}} \n",
+      "stackTop": "{{location}} Error at line {{line}} in \"{{func}}\" in {{file}} \n",
       "syntax": {
-        "badReturnOrYield": "\nSyntax Error ▶️ return lies outside of a function. Make sure you’re not missing any brackets, so that return lies inside a function.\nFor more: {{url}}",
-        "invalidToken": "\nSyntax Error ▶️ Found a symbol that JavaScript doesn't recognize or didn't expect at it's place.\nFor more: {{url}}",
-        "missingInitializer": "\nSyntax Error ▶️ A const variable is declared but not initialized. In JavaScript, an initializer for a const is required. A value must be specified in the same statement in which the variable is declared. Check the line number in the error and assign the const variable a value.\nFor more: {{url}}",
-        "redeclaredVariable": "\nSyntax Error ▶️ \"{{symbol}}\" is being redeclared. JavaScript doesn't allow declaring a variable more than once. Check the line number in error for redeclaration of the variable.\nFor more: {{url}}",
-        "unexpectedToken": "\nSyntax Error ▶️ Symbol present at a place that wasn't expected.\nUsually this is due to a typo. Check the line number in the error for anything missing/extra.\nFor more: {{url}}"
+        "badReturnOrYield": "\nSyntax Error - return lies outside of a function. Make sure you’re not missing any brackets, so that return lies inside a function.\n\n+ More info: {{url}}",
+        "invalidToken": "\nSyntax Error - Found a symbol that JavaScript doesn't recognize or didn't expect at it's place.\n\n+ More info: {{url}}",
+        "missingInitializer": "\nSyntax Error - A const variable is declared but not initialized. In JavaScript, an initializer for a const is required. A value must be specified in the same statement in which the variable is declared. Check the line number in the error and assign the const variable a value.\n\n+ More info: {{url}}",
+        "redeclaredVariable": "\nSyntax Error - \"{{symbol}}\" is being redeclared. JavaScript doesn't allow declaring a variable more than once. Check the line number in error for redeclaration of the variable.\n\n+ More info: {{url}}",
+        "unexpectedToken": "\nSyntax Error - Symbol present at a place that wasn't expected.\nUsually this is due to a typo. Check the line number in the error for anything missing/extra.\n\n+ More info: {{url}}"
       },
       "type": {
-        "constAssign": "\nError ▶️ A const variable is being re-assigned. In javascript, re-assigning a value to a constant is not allowed. If you want to re-assign new values to a variable, make sure it is declared as var or let.\n{{location}}\nFor more: {{url}}",
-        "notfunc": "\nError ▶️ \"{{symbol}}\" could not be called as a function {{location}}.\nCheck the spelling, letter-casing (JavaScript is case-sensitive) and its type.\nFor more: {{url}}",
-        "notfuncObj": "\nError ▶️ \"{{symbol}}\" could not be called as a function {{location}}.\nVerify whether \"{{obj}}\" has \"{{symbol}}\" in it and check the spelling, letter-casing (JavaScript is case-sensitive) and its type.\nFor more: {{url}}",
-        "readFromNull": "\nError ▶️ The property of null can't be read. In javascript the value null indicates that an object has no value.\nFor more: \n{{url1}}\n{{url2}}",
-        "readFromUndefined": "\nError ▶️ Cannot read property of undefined. Check the line number in error and make sure the variable which is being operated is not undefined.\nFor more: \n{{url1}}\n{{url2}}"
+        "constAssign": "\n{{location}} A const variable is being re-assigned. In javascript, re-assigning a value to a constant is not allowed. If you want to re-assign new values to a variable, make sure it is declared as var or let.\n\n+ More info: {{url}}",
+        "notfunc": "\n{{location}} \"{{symbol}}\" could not be called as a function.\nCheck the spelling, letter-casing (JavaScript is case-sensitive) and its type.\n\n+ More info: {{url}}",
+        "notfuncObj": "\n{{location}} \"{{symbol}}\" could not be called as a function.\nVerify whether \"{{obj}}\" has \"{{symbol}}\" in it and check the spelling, letter-casing (JavaScript is case-sensitive) and its type.\n\n+ More info: {{url}}",
+        "readFromNull": "\n{{location}} The property of null can't be read. In javascript the value null indicates that an object has no value.\n\n+ More info: {{url}}",
+        "readFromUndefined": "\n{{location}} Cannot read property of undefined. Check the line number in error and make sure the variable which is being operated is not undefined.\n\n + More info: {{url}}"
       }
     },
-    "libraryError": "An error with message \"{{error}}\" occurred inside the p5js library when {{func}} was called {{location}}\n\nIf not stated otherwise, it might be an issue with the arguments passed to {{func}}.",
-    "location": "(on line {{line}} in {{file}} [{{location}}])",
-    "misspelling": "It seems that you may have accidentally written \"{{name}}\" instead of \"{{actualName}}\" {{location}}.\n\nPlease correct it to {{actualName}} if you wish to use the {{type}} from p5.js",
-    "misspelling_plural": "It seems that you may have accidentally written \"{{name}}\" {{location}}.\n\nYou may have meant one of the following:\n{{suggestions}}",
-    "misusedTopLevel": "Did you just try to use p5.js's {{symbolName}} {{symbolType}}? If so, you may want to move it into your sketch's setup() function.\n\nFor more details, see: {{link}}",
+    "libraryError": "{{location}} An error with message \"{{error}}\" occurred inside the p5js library when {{func}} was called. If not stated otherwise, it might be an issue with the arguments passed to {{func}}.",
+    "location": "[{{file}}: line {{line}}]",
+    "misspelling": "{{location}} It seems that you may have accidentally written \"{{name}}\" instead of \"{{actualName}}\". Please correct it to {{actualName}} if you wish to use the {{type}} from p5.js.",
+    "misspelling_plural": "{{location}} It seems that you may have accidentally written \"{{name}}\".\nYou may have meant one of the following: \n{{suggestions}}",
+    "misusedTopLevel": "Did you just try to use p5.js's {{symbolName}} {{symbolType}}? If so, you may want to move it into your sketch's setup() function.\n\n+ More info: {{url}}",
     "positions": {
       "p_1": "first",
       "p_10": "tenth",
@@ -63,10 +63,10 @@
     },
     "pre": "\n🌸 p5.js says: {{message}}",
     "sketchReaderErrors": {
-      "reservedConst": "you have used a p5.js reserved variable \"{{symbol}}\" make sure you change the variable name to something else.\n({{url}})",
-      "reservedFunc": "you have used a p5.js reserved function \"{{symbol}}\" make sure you change the function name to something else."
+      "reservedConst": "you have used a p5.js reserved variable \"{{symbol}}\" make sure you change the variable name to something else.\n\n+ More info: {{url}}",
+      "reservedFunc": "you have used a p5.js reserved function \"{{symbol}}\" make sure you change the function name to something else.\n\n+ More info: {{url}}"
     },
     "welcome": "Welcome! This is your friendly debugger. To turn me off, switch to using p5.min.js.",
-    "wrongPreload": "An error with message \"{{error}}\" occurred inside the p5js library when \"{{func}}\" was called {{location}}.\n\nIf not stated otherwise, it might be due to \"{{func}}\" being called from preload. Nothing besides load calls (loadImage, loadJSON, loadFont, loadStrings, etc.) should be inside the preload function."
+    "wrongPreload": "{{location}} An error with message \"{{error}}\" occurred inside the p5js library when \"{{func}}\" was called. If not stated otherwise, it might be due to \"{{func}}\" being called from preload. Nothing besides load calls (loadImage, loadJSON, loadFont, loadStrings, etc.) should be inside the preload function."
   }
 }

--- a/translations/index.js
+++ b/translations/index.js
@@ -6,7 +6,7 @@ import en from './en/translation';
 /**
  * Here, we define a default/fallback language which we can use without internet.
  * You won't have to change this when adding a new language.
- * 
+ *
  * `translation` is the namespace we are using for our initial set of strings
  */
 export default {
@@ -18,10 +18,11 @@ export default {
 /**
  * This is a list of languages that we have added so far.
  * If you have just added a new language (yay!), add its key to the list below
- * (`en` is english, `es` es español). Also add its export to 
+ * (`en` is english, `es` es español). Also add its export to
  * dev.js, which is another file in this folder.
  */
 export const languages = [
   'en',
-  'es'
+  'es',
+  'ko'
 ];

--- a/translations/ko/README.md
+++ b/translations/ko/README.md
@@ -1,0 +1,11 @@
+# Welcome to the FES Korean branch!
+안녕하세요, FES 한국어 브랜치에 어서오세요!
+
+## Translation Credits
+2021년 가을부터 공동작업으로 진행된 FES 에러메시지 공동 번역 작업은 아래 분들이 함께하셨습니다.
+* [염인화](https://yinhwa.art/) (Inhwa Yeom): artist/XR researcher based in South Korea. (Take a look at her works on [p5 for 50+](https://p5for50.plus/) ([Processing Foundation Fellows 2020](https://medium.com/processing-foundation/p5-js-for-ages-50-in-korea-50d47b5927fb)) and p5js website Korean translation)
+* 전유진 (Youjin Jeon): artist/organizer based in Seoul, South Korea. [여성을 위한 열린 기술랩(Woman Open Tech Lab.kr)](http://womanopentechlab.kr/) and [Seoul Express](http://seoulexpress.kr/)
+* [정앎](https://www.almichu.com/) (Alm Chung, organizer): Korean-American artist/researcher based in Seattle, WA.
+* 이지현 (Jihyun Lee): Korean publishing editor based in South Korea
+
+질문이나 건의 사항은 @almchung 에게 문의주시길 바랍니다.

--- a/translations/ko/README.md
+++ b/translations/ko/README.md
@@ -2,7 +2,7 @@
 안녕하세요, FES 한국어 브랜치에 어서오세요!
 
 ## Translation Credits
-2021년 가을부터 공동작업으로 진행된 FES 에러메시지 공동 번역 작업은 아래 분들이 함께하셨습니다.
+2021년 가을부터 공동작업으로 진행되어 2022년 1월에 마무리된 FES 에러메시지 공동 번역 작업은 아래 분들이 함께하셨습니다.
 * [염인화](https://yinhwa.art/) (Inhwa Yeom): artist/XR researcher based in South Korea. (Take a look at her works on [p5 for 50+](https://p5for50.plus/) ([Processing Foundation Fellows 2020](https://medium.com/processing-foundation/p5-js-for-ages-50-in-korea-50d47b5927fb)) and p5js website Korean translation)
 * 전유진 (Youjin Jeon): artist/organizer based in Seoul, South Korea. [여성을 위한 열린 기술랩(Woman Open Tech Lab.kr)](http://womanopentechlab.kr/) and [Seoul Express](http://seoulexpress.kr/)
 * [정앎](https://www.almichu.com/) (Alm Chung, organizer): Korean-American artist/researcher based in Seattle, WA.

--- a/translations/ko/README.md
+++ b/translations/ko/README.md
@@ -1,11 +1,15 @@
 # Welcome to the FES Korean branch!
 안녕하세요, FES 한국어 브랜치에 어서오세요!
 
-## Translation Credits
+## 한국어 Translation Credits
 2021년 가을부터 공동작업으로 진행되어 2022년 1월에 마무리된 FES 에러메시지 공동 번역 작업은 아래 분들이 함께하셨습니다.
 * [염인화](https://yinhwa.art/) (Inhwa Yeom): artist/XR researcher based in South Korea. (Take a look at her works on [p5 for 50+](https://p5for50.plus/) ([Processing Foundation Fellows 2020](https://medium.com/processing-foundation/p5-js-for-ages-50-in-korea-50d47b5927fb)) and p5js website Korean translation)
 * 전유진 (Youjin Jeon): artist/organizer based in Seoul, South Korea. [여성을 위한 열린 기술랩(Woman Open Tech Lab.kr)](http://womanopentechlab.kr/) and [Seoul Express](http://seoulexpress.kr/)
 * [정앎](https://www.almichu.com/) (Alm Chung, organizer): Korean-American artist/researcher based in Seattle, WA.
 * 이지현 (Jihyun Lee): Korean publishing editor based in South Korea
+
+## 한국어 Translation Resources
+* 추후 추가될 예정입니다!
+
 
 질문이나 건의 사항은 @almchung 에게 문의주시길 바랍니다.

--- a/translations/ko/translation.json
+++ b/translations/ko/translation.json
@@ -15,18 +15,18 @@
       "xml": "XML 파일을 로드하는 중에 문제가 발생했습니다. {{suggestion}}"
     },
     "friendlyParamError": {
-      "type_EMPTY_VAR": "{{location}} {{formatType}} 타입 값을 받는 {{func}}}()의 {{position}} 매개변수(parameter)에 아무 값도 전달되지 않았습니다. 범위(scope)와 관련된 문제일 수 있습니다.\n\n+ 추가 정보: {{url}}",
+      "type_EMPTY_VAR": "{{location}} {{formatType}} 타입 값을 받는 {{func}}()의 {{position}} 매개변수(parameter)에 아무 값도 전달되지 않았습니다. 범위(scope)와 관련된 문제일 수 있습니다.\n\n+ 추가 정보: {{url}}",
       "type_TOO_FEW_ARGUMENTS": "{{location}} 최소 {{minParams}}개의 인수(argument)를 받는 함수 {{func}}()에 인수가 {{argCount}}개만 입력되었습니다.",
       "type_TOO_MANY_ARGUMENTS": "{{location}} 최대 {{maxParams}}개의 인수(argument)를 받는 함수 {{func}}()에 인수가 {{argCount}}개나 입력되었습니다.",
-      "type_WRONG_TYPE": "{{location}} {{formatType}} 타입의 값을 받는 {{func}}() {{position}} 매개변수(parameter)에 {{argType}} 타입의 값이 입력되었습니다."
+      "type_WRONG_TYPE": "{{location}} {{formatType}} 타입의 값을 받는 {{func}}()의 {{position}} 매개변수(parameter)에 {{argType}} 타입의 값이 입력되었습니다."
     },
     "globalErrors": {
       "reference": {
         "cannotAccess": "\n{{location}} \"{{symbol}}\"가 선언되지 않은 채 사용되었습니다. 변수를 사용하기 전, 먼저 선언했는지 확인해보세요.\n\n+ 추가 정보: {{url}}",
         "notDefined": "\n{{location}} \"{{symbol}}\"은 현재 범위(scope) 안에 정의되지 않았습니다. 만약 정의를 했다면, 해당 범위와 오탈자, 대소문자 등을 확인해보세요 (자바스크립트에서는 대소문자를 구분합니다).\n\n+ 추가 정보: {{url}}"
       },
-      "stackSubseq": "{{location}} {{file}}의 함수 \"{{func}}\"에 있는 {{line}} 줄에서 호출.\n",
-      "stackTop": "{{location}} {{file}}의 함수 \"{{func}}\"에 있는 {{line}} 줄에서 오류 발생.\n",
+      "stackSubseq": "└[{{location}}] \n\t {{func}}()에 있는 줄{{line}}에서 호출\n",
+      "stackTop": "┌[{{location}}] \n\t {{func}}()에 있는 줄{{line}}에서 오류 발생\n",
       "syntax": {
         "badReturnOrYield": "\n구문 오류 - 대괄호가 제대로 쓰였는지 확인해 본 후, return을 함수 안에 넣어주세요.\n\n+ 추가 정보: {{url}}",
         "invalidToken": "\n구문 오류 - 자바스크립트가 인식할 수 없거나, 적합하지 않은 기호나 문구가 입력되었습니다.\n\n+ 추가 정보: {{url}}",
@@ -43,7 +43,7 @@
       }
     },
     "libraryError": "{{location}} 함수 {{func}}가 호출되었을 때,  \"{{error}}\" 오류가 p5js 라이브러리 내에서 발생했습니다. 함수 {{func}}에 전달한 인수(argument)가 문제일 수 있습니다.",
-    "location": "[{{file}}: 줄{{line}}]",
+    "location": "[{{file}}, 줄{{line}}]",
     "misspelling": "{{location}} 혹시 p5.js의 {{type}}를 사용하시려면 \"{{name}}\"를 {{actualName}}로 고쳐 보세요.",
     "misspelling_plural": "{{location}} 혹시 p5.js의 {{type}}를 사용하시려면 \"{{name}}\"를 다음 중 하나로 고쳐보세요: \n{{suggestions}}",
     "misusedTopLevel": "{{location}} 혹시 p5.js의 {{symbolType}} 타입 {{symbolName}}을 사용하셨나요? 그렇다면 {{symbolName}}을 작성 중인 setup() 함수의 대괄호 안으로 옮겨보세요.\n\n+ 추가 정보: {{url}}",

--- a/translations/ko/translation.json
+++ b/translations/ko/translation.json
@@ -1,0 +1,72 @@
+{
+  "fes": {
+    "autoplay": "미디어('{{src}}')[[가]] 이 브라우저에서는 재생되지 않았습니다. 사용하고 계신 브라우저의 자동 재생 정책 때문일 수 있습니다.\n\n+ 추가 정보: {{url}}",
+    "checkUserDefinedFns": "혹시 {{actualName}} 대신 {{name}}[[를]] 쓴 것이 아닌지 살펴보세요.",
+    "fileLoadError": {
+      "bytes": "파일을 로드하는 중에 문제가 발생했습니다. {{suggestion}}",
+      "font": "글꼴을 로드하는 중에 문제가 발생했습니다. {{suggestion}}",
+      "gif": "GIF 파일을 로드하는 중에 문제가 발생했습니다. GIF 파일의 인코딩 방식이 87a이거나 89a인지를 확인해보세요.",
+      "image": "이미지를 로드하는 중에 문제가 발생했습니다. {{suggestion}}",
+      "json": "JSON 파일을 로드하는 중에 문제가 발생했습니다. {{suggestion}}",
+      "large": "용량이 큰 파일을 한꺼번에 로드하는 중에 문제가 발생했습니다. 파일 용량을 줄여 보세요.",
+      "strings": "텍스트 파일을 로드하는 중에 문제가 발생했습니다. {{suggestion}}",
+      "suggestion": "파일 경로({{filePath}})가 올바른지 확인해보세요. 혹은 해당 파일을 호스팅 서비스를 이용하거나 로컬 서버를 구동하여 웹에 올리는 방법을 고려해 보세요.\n\n+ 추가 정보: {{url}}",
+      "table": "테이블 파일을 로드하는 중에 문제가 발생했습니다. {{suggestion}}",
+      "xml": "XML 파일을 로드하는 중에 문제가 발생했습니다. {{suggestion}}"
+    },
+    "friendlyParamError": {
+      "type_EMPTY_VAR": "{{location}} {{formatType}} 타입 값을 받는 {{func}}}()의 {{position}} 매개변수(parameter)에 아무 값도 전달되지 않았습니다. 범위(scope)와 관련된 문제일 수 있습니다.\n\n+ 추가 정보: {{url}}",
+      "type_TOO_FEW_ARGUMENTS": "{{location}} 최소 {{minParams}}개의 인수(argument)를 받는 함수 {{func}}()에 인수가 {{argCount}}개만 입력되었습니다.",
+      "type_TOO_MANY_ARGUMENTS": "{{location}} 최대 {{maxParams}}개의 인수(argument)를 받는 함수 {{func}}()에 인수가 {{argCount}}개나 입력되었습니다.",
+      "type_WRONG_TYPE": "{{location}} {{formatType}} 타입의 값을 받는 {{func}}() {{position}} 매개변수(parameter)에 {{argType}} 타입의 값이 입력되었습니다."
+    },
+    "globalErrors": {
+      "reference": {
+        "cannotAccess": "\n{{location}} \"{{symbol}}\"[[가]] 선언되지 않은 채 사용되었습니다. 변수를 사용하기 전, 먼저 선언했는지 확인해보세요.\n\n+ 추가 정보: {{url}}",
+        "notDefined": "\n{{location}} \"{{symbol}}\"[[은]] 현재 범위(scope) 안에 정의되지 않았습니다. 만약 정의를 했다면, 해당 범위와 오탈자, 대소문자 등을 확인해보세요 (자바스크립트에서는 대소문자를 구분합니다).\n\n+ 추가 정보: {{url}}"
+      },
+      "stackSubseq": "{{location}} {{file}}의 함수 \"{{func}}\"에 있는 {{line}} 줄에서 호출.\n",
+      "stackTop": "{{location}} {{file}}의 함수 \"{{func}}\"에 있는 {{line}} 줄에서 오류 발생.\n",
+      "syntax": {
+        "badReturnOrYield": "\n구문 오류 - 대괄호가 제대로 쓰였는지 확인해 본 후, return을 함수 안에 넣어주세요.\n\n+ 추가 정보: {{url}}",
+        "invalidToken": "\n구문 오류 - 자바스크립트가 인식할 수 없거나, 적합하지 않은 기호나 문구가 입력되었습니다.\n\n+ 추가 정보: {{url}}",
+        "missingInitializer": "\n구문 오류 - const 변수가 선언되었지만 초기화되지 않았습니다. 변수가 선언된 명령문 안에서 값을 지정해주세요.\n\n+ 추가 정보: {{url}}",
+        "redeclaredVariable": "\n구문 오류 - 이미 선언된 \"{{symbol}}\"[[가]] 재선언되었습니다. 자바스크립트에서는 같은 변수를 한 번 이상 선언할 수 없습니다.\n\n+ 추가 정보: {{url}}",
+        "unexpectedToken": "\n구문 오류 - 입력된 문구가 예상하지 못한 위치에 있습니다.보통 이런 상황은 오탈자 때문에 일어나는 경우가 많습니다. 누락되거나 추가된 내용이 없는지 확인하세요.\n\n+ 추가 정보: {{url}}"
+      },
+      "type": {
+        "constAssign": "\n{{location}} const 변수가 재지정되었습니다. 자바스크립트에서는 const 변수에 다른 값을 여러 번 지정할 수 없으므로 새로운 값을 여러 번 지정하시려면, const 대신 var나 let을 써서 변수를 선언해 주세요.\n\n+ 추가 정보: {{url}}",
+        "notfunc": "\n{{location}} \"{{symbol}}\"[[는]] 함수로 호출할 수 없습니다. 타입과 오탈자, 대소문자 등을 확인해주세요.\n\n+ 추가 정보: {{url}}",
+        "notfuncObj": "\n{{location}} \"{{symbol}}\"[[는]] 함수로 호출할 수 없습니다. \"{{obj}}\"[[가]] \"{{symbol}}\"[[를]] 가지고 있는지 살펴보고, 타입과 오탈자, 대소문자 등을 확인해주세요.\n\n+ 추가 정보: {{url}}",
+        "readFromNull": "\n{{location}} null의 속성(property)을 읽을 수 없습니다. 자바스크립트에서 null이란, 객체(object)에 주어진 값이 비어있다는 뜻입니다.\n\n+ 추가 정보: {{url}}",
+        "readFromUndefined": "\n{{location}} undefined의 속성(property)을 읽을 수 없습니다. 혹시 연산 중인 변수가 정의되지 않았는지 확인하세요.\n\n+ 추가 정보: {{url}}"
+      }
+    },
+    "libraryError": "{{location}} 함수 {{func}}[[가]] 호출되었을 때,  \"{{error}}\" 오류가 p5js 라이브러리 내에서 발생했습니다. 함수 {{func}}에 전달한 인수(argument)가 문제일 수 있습니다.",
+    "location": "[{{file}}: 줄{{line}}]",
+    "misspelling": "{{location}} 혹시 p5.js의 {{type}}[[를]] 사용하시려면 \"{{name}}\"를 {{actualName}}[[로]] 고쳐 보세요.",
+    "misspelling_plural": "{{location}} 혹시 p5.js의 {{type}}[[를]] 사용하시려면 \"{{name}}\"를 다음 중 하나로 고쳐보세요: \n{{suggestions}}",
+    "misusedTopLevel": "{{location}} 혹시 p5.js의 {{symbolType}} 타입 {{symbolName}}[[을]] 사용하셨나요? 그렇다면 {{symbolName}}[[을]] 작성 중인 setup() 함수의 대괄호 안으로 옮겨보세요.\n\n+ 추가 정보: {{url}}",
+    "positions": {
+      "p_1": "1번째",
+      "p_10": "10번째",
+      "p_11": "11번째",
+      "p_12": "12번째",
+      "p_2": "2번째",
+      "p_3": "3번째",
+      "p_4": "4번째",
+      "p_5": "5번째",
+      "p_6": "6번째",
+      "p_7": "7번째",
+      "p_8": "8번째",
+      "p_9": "9번째"
+    },
+    "pre": "\n🌸 p5.js says: {{message}}",
+    "sketchReaderErrors": {
+      "reservedConst": "p5.js에서 이미 쓰고 있는 변수 \"{{symbol}}\"[[를]] 사용하셨습니다. 해당 변수를 다른 이름으로 바꾸어 주세요.\n\n+ 추가 정보: {{url}}",
+      "reservedFunc": "p5.js에서 이미 쓰고 있는 함수 \"{{symbol}}\"[[를]] 사용하셨습니다. 해당 함수를 다른 이름으로 바꾸어 주세요.\n\n+ 추가 정보: {{url}}"
+    },
+    "welcome": "{{logo}} 환영합니다, 이 메세지는 에러를 찾는 디버깅 안내문입니다. 안내가 필요없는 경우 p5.js대신 p5.min.js를 사용하세요.",
+    "wrongPreload": "{{location}} \"{{func}}\"[[가]] 호출되며 p5js 라이브러리 내부에서 다음 오류가 발생했습니다: \"{{error}}\".\n\n 함수 \"{{func}}\"[[가]] preload()에서 호출되었기 때문일 수 있습니다. preload() 함수 안에서는 지정된 함수(예: loadImage, loadJSON, loadFont, loadStrings 등)만 호출할 수 있습니다."
+  }
+}

--- a/translations/ko/translation.json
+++ b/translations/ko/translation.json
@@ -1,7 +1,7 @@
 {
   "fes": {
-    "autoplay": "미디어('{{src}}')[[가]] 이 브라우저에서는 재생되지 않았습니다. 사용하고 계신 브라우저의 자동 재생 정책 때문일 수 있습니다.\n\n+ 추가 정보: {{url}}",
-    "checkUserDefinedFns": "혹시 {{actualName}} 대신 {{name}}[[를]] 쓴 것이 아닌지 살펴보세요.",
+    "autoplay": "미디어('{{src}}')가 이 브라우저에서는 재생되지 않았습니다. 사용하고 계신 브라우저의 자동 재생 정책 때문일 수 있습니다.\n\n+ 추가 정보: {{url}}",
+    "checkUserDefinedFns": "혹시 {{actualName}} 대신 {{name}}를 쓴 것이 아닌지 살펴보세요.",
     "fileLoadError": {
       "bytes": "파일을 로드하는 중에 문제가 발생했습니다. {{suggestion}}",
       "font": "글꼴을 로드하는 중에 문제가 발생했습니다. {{suggestion}}",
@@ -22,8 +22,8 @@
     },
     "globalErrors": {
       "reference": {
-        "cannotAccess": "\n{{location}} \"{{symbol}}\"[[가]] 선언되지 않은 채 사용되었습니다. 변수를 사용하기 전, 먼저 선언했는지 확인해보세요.\n\n+ 추가 정보: {{url}}",
-        "notDefined": "\n{{location}} \"{{symbol}}\"[[은]] 현재 범위(scope) 안에 정의되지 않았습니다. 만약 정의를 했다면, 해당 범위와 오탈자, 대소문자 등을 확인해보세요 (자바스크립트에서는 대소문자를 구분합니다).\n\n+ 추가 정보: {{url}}"
+        "cannotAccess": "\n{{location}} \"{{symbol}}\"가 선언되지 않은 채 사용되었습니다. 변수를 사용하기 전, 먼저 선언했는지 확인해보세요.\n\n+ 추가 정보: {{url}}",
+        "notDefined": "\n{{location}} \"{{symbol}}\"은 현재 범위(scope) 안에 정의되지 않았습니다. 만약 정의를 했다면, 해당 범위와 오탈자, 대소문자 등을 확인해보세요 (자바스크립트에서는 대소문자를 구분합니다).\n\n+ 추가 정보: {{url}}"
       },
       "stackSubseq": "{{location}} {{file}}의 함수 \"{{func}}\"에 있는 {{line}} 줄에서 호출.\n",
       "stackTop": "{{location}} {{file}}의 함수 \"{{func}}\"에 있는 {{line}} 줄에서 오류 발생.\n",
@@ -31,22 +31,22 @@
         "badReturnOrYield": "\n구문 오류 - 대괄호가 제대로 쓰였는지 확인해 본 후, return을 함수 안에 넣어주세요.\n\n+ 추가 정보: {{url}}",
         "invalidToken": "\n구문 오류 - 자바스크립트가 인식할 수 없거나, 적합하지 않은 기호나 문구가 입력되었습니다.\n\n+ 추가 정보: {{url}}",
         "missingInitializer": "\n구문 오류 - const 변수가 선언되었지만 초기화되지 않았습니다. 변수가 선언된 명령문 안에서 값을 지정해주세요.\n\n+ 추가 정보: {{url}}",
-        "redeclaredVariable": "\n구문 오류 - 이미 선언된 \"{{symbol}}\"[[가]] 재선언되었습니다. 자바스크립트에서는 같은 변수를 한 번 이상 선언할 수 없습니다.\n\n+ 추가 정보: {{url}}",
+        "redeclaredVariable": "\n구문 오류 - 이미 선언된 \"{{symbol}}\"가 재선언되었습니다. 자바스크립트에서는 같은 변수를 한 번 이상 선언할 수 없습니다.\n\n+ 추가 정보: {{url}}",
         "unexpectedToken": "\n구문 오류 - 입력된 문구가 예상하지 못한 위치에 있습니다.보통 이런 상황은 오탈자 때문에 일어나는 경우가 많습니다. 누락되거나 추가된 내용이 없는지 확인하세요.\n\n+ 추가 정보: {{url}}"
       },
       "type": {
         "constAssign": "\n{{location}} const 변수가 재지정되었습니다. 자바스크립트에서는 const 변수에 다른 값을 여러 번 지정할 수 없으므로 새로운 값을 여러 번 지정하시려면, const 대신 var나 let을 써서 변수를 선언해 주세요.\n\n+ 추가 정보: {{url}}",
-        "notfunc": "\n{{location}} \"{{symbol}}\"[[는]] 함수로 호출할 수 없습니다. 타입과 오탈자, 대소문자 등을 확인해주세요.\n\n+ 추가 정보: {{url}}",
-        "notfuncObj": "\n{{location}} \"{{symbol}}\"[[는]] 함수로 호출할 수 없습니다. \"{{obj}}\"[[가]] \"{{symbol}}\"[[를]] 가지고 있는지 살펴보고, 타입과 오탈자, 대소문자 등을 확인해주세요.\n\n+ 추가 정보: {{url}}",
+        "notfunc": "\n{{location}} \"{{symbol}}\"는 함수로 호출할 수 없습니다. 타입과 오탈자, 대소문자 등을 확인해주세요.\n\n+ 추가 정보: {{url}}",
+        "notfuncObj": "\n{{location}} \"{{symbol}}\"는 함수로 호출할 수 없습니다. \"{{obj}}\"가 \"{{symbol}}\"를 가지고 있는지 살펴보고, 타입과 오탈자, 대소문자 등을 확인해주세요.\n\n+ 추가 정보: {{url}}",
         "readFromNull": "\n{{location}} null의 속성(property)을 읽을 수 없습니다. 자바스크립트에서 null이란, 객체(object)에 주어진 값이 비어있다는 뜻입니다.\n\n+ 추가 정보: {{url}}",
         "readFromUndefined": "\n{{location}} undefined의 속성(property)을 읽을 수 없습니다. 혹시 연산 중인 변수가 정의되지 않았는지 확인하세요.\n\n+ 추가 정보: {{url}}"
       }
     },
-    "libraryError": "{{location}} 함수 {{func}}[[가]] 호출되었을 때,  \"{{error}}\" 오류가 p5js 라이브러리 내에서 발생했습니다. 함수 {{func}}에 전달한 인수(argument)가 문제일 수 있습니다.",
+    "libraryError": "{{location}} 함수 {{func}}가 호출되었을 때,  \"{{error}}\" 오류가 p5js 라이브러리 내에서 발생했습니다. 함수 {{func}}에 전달한 인수(argument)가 문제일 수 있습니다.",
     "location": "[{{file}}: 줄{{line}}]",
-    "misspelling": "{{location}} 혹시 p5.js의 {{type}}[[를]] 사용하시려면 \"{{name}}\"를 {{actualName}}[[로]] 고쳐 보세요.",
-    "misspelling_plural": "{{location}} 혹시 p5.js의 {{type}}[[를]] 사용하시려면 \"{{name}}\"를 다음 중 하나로 고쳐보세요: \n{{suggestions}}",
-    "misusedTopLevel": "{{location}} 혹시 p5.js의 {{symbolType}} 타입 {{symbolName}}[[을]] 사용하셨나요? 그렇다면 {{symbolName}}[[을]] 작성 중인 setup() 함수의 대괄호 안으로 옮겨보세요.\n\n+ 추가 정보: {{url}}",
+    "misspelling": "{{location}} 혹시 p5.js의 {{type}}를 사용하시려면 \"{{name}}\"를 {{actualName}}로 고쳐 보세요.",
+    "misspelling_plural": "{{location}} 혹시 p5.js의 {{type}}를 사용하시려면 \"{{name}}\"를 다음 중 하나로 고쳐보세요: \n{{suggestions}}",
+    "misusedTopLevel": "{{location}} 혹시 p5.js의 {{symbolType}} 타입 {{symbolName}}을 사용하셨나요? 그렇다면 {{symbolName}}을 작성 중인 setup() 함수의 대괄호 안으로 옮겨보세요.\n\n+ 추가 정보: {{url}}",
     "positions": {
       "p_1": "1번째",
       "p_10": "10번째",
@@ -63,10 +63,10 @@
     },
     "pre": "\n🌸 p5.js says: {{message}}",
     "sketchReaderErrors": {
-      "reservedConst": "p5.js에서 이미 쓰고 있는 변수 \"{{symbol}}\"[[를]] 사용하셨습니다. 해당 변수를 다른 이름으로 바꾸어 주세요.\n\n+ 추가 정보: {{url}}",
-      "reservedFunc": "p5.js에서 이미 쓰고 있는 함수 \"{{symbol}}\"[[를]] 사용하셨습니다. 해당 함수를 다른 이름으로 바꾸어 주세요.\n\n+ 추가 정보: {{url}}"
+      "reservedConst": "p5.js에서 이미 쓰고 있는 변수 \"{{symbol}}\"를 사용하셨습니다. 해당 변수를 다른 이름으로 바꾸어 주세요.\n\n+ 추가 정보: {{url}}",
+      "reservedFunc": "p5.js에서 이미 쓰고 있는 함수 \"{{symbol}}\"를 사용하셨습니다. 해당 함수를 다른 이름으로 바꾸어 주세요.\n\n+ 추가 정보: {{url}}"
     },
     "welcome": "{{logo}} 환영합니다, 이 메세지는 에러를 찾는 디버깅 안내문입니다. 안내가 필요없는 경우 p5.js대신 p5.min.js를 사용하세요.",
-    "wrongPreload": "{{location}} \"{{func}}\"[[가]] 호출되며 p5js 라이브러리 내부에서 다음 오류가 발생했습니다: \"{{error}}\".\n\n 함수 \"{{func}}\"[[가]] preload()에서 호출되었기 때문일 수 있습니다. preload() 함수 안에서는 지정된 함수(예: loadImage, loadJSON, loadFont, loadStrings 등)만 호출할 수 있습니다."
+    "wrongPreload": "{{location}} \"{{func}}\"가 호출되며 p5js 라이브러리 내부에서 다음 오류가 발생했습니다: \"{{error}}\".\n\n 함수 \"{{func}}\"가 preload()에서 호출되었기 때문일 수 있습니다. preload() 함수 안에서는 지정된 함수(예: loadImage, loadJSON, loadFont, loadStrings 등)만 호출할 수 있습니다."
   }
 }


### PR DESCRIPTION
This PR includes the Korean translation of FES error messages and minor updates to the English FES.

 Changes:
* Added the FES Korean translation file (`translations/ko/translation.json`)
  * Translation credits: 염인화 (Inhwa Yeom), 전유진 (Youjin Jeon), 이지현 (Jihyun Lee), and 정앎 (Alm Chung).
* Started the FES Korean translation README/credits file (`translations/ko/README.md`)
* Minor design updates to the FES English translation file (`translations/en/translation.json`):
  1. Re-formatted error location information and move it to the beginning of a message
  2. Applied the "one external link per message" rule, condensing multiple URL links into one
  3. Standardized the different keys for web resources (`{{url}}`, `{{url#}}`, and `{{link}}`) into `{{url}}`
  4. Replaced emoji with Unicode symbols.
  5. Shortened messages.

This PR doesn't include the i18next Korean postposition plugin, which I may revisit after releasing the FES Korean translation.  

After this contribution, the Korean FES i18n team wishes to share the internationalization process via our i18n guidelines/design notes and publish the materials somewhere on the p5js website, if possible. What would be the best way to discuss this?


Please let me know if you have any questions or concerns. Thank you!


#### PR Checklist
- [X] `npm run lint` passes