### PR TITLE
fixed FES errors link

### DIFF
--- a/src/core/friendly_errors/fes_core.js
+++ b/src/core/friendly_errors/fes_core.js
@@ -139,7 +139,7 @@ if (typeof IS_MINIFIED !== 'undefined') {
 
       const funcName =
         methodParts.length === 1 ? func : methodParts.slice(2).join('/');
-      msgWithReference = `${message} (http://p5js.org/reference/#/${referenceSection}/${funcName})`;
+      msgWithReference = `${message} (http://p5js.org/reference/#/${referenceSection}.${funcName})`;
     }
     return msgWithReference;
   };


### PR DESCRIPTION
<!--
  Thank you for contributing! Please use this pull request (PR) template.


 In the description field of this PR, include "resolves #XXXX" tagging the issue you are fixing. If this PR addresses the issue but doesn't completely resolve it (ie the issue should remain open after your PR is merged), write "addresses #XXXX".-->
Resolves #5346 

 Changes:
<!-- Add here what changes were made in this pull request and if possible provide links showcasing the changes. -->
Previously, FES was generating wrong links to the p5 errors. Now, it should work just fine.
See screenshots below or follow the issue for more details.

 Screenshots of the change:
<!-- If applicable, add screenshots depicting the changes. -->

#### Example 1
##### Before
![2](https://user-images.githubusercontent.com/87201197/152297295-fcb425d3-f06d-41ef-bd3d-24bf1bf19f8b.png)
> Error URL: http://p5js.org/reference/#/p5/Color

##### After
![111](https://user-images.githubusercontent.com/87201197/152297193-cf10b3f7-f40a-4667-80ec-d920eb699e1d.png)
> Error URL: http://p5js.org/reference/#/p5.Color

#### Example 2
##### Before
![0](https://user-images.githubusercontent.com/87201197/152297683-fbd175b3-20f6-4694-a75a-b7ffc0c4381f.png)
> Error URL: https://p5js.org/reference/#/p5/Graphics

##### After
![9](https://user-images.githubusercontent.com/87201197/152297696-01c4d4df-2395-48e3-b67e-67e41a7c1bb3.png)
> Error URL: https://p5js.org/reference/#/p5.Graphics

##### PR Checklist
<!--
  To check any option, replace the "[ ]" with a "[x]". Be sure to check out how it looks in the Preview tab! Feel free to remove any portion of the template that is not relevant for your issue.
-->

- [x] `npm run lint` passes