### PR TITLE
docs(src/utilities): Use `describe()` instead of `@alt`

### DIFF
--- a/src/utilities/conversion.js
+++ b/src/utilities/conversion.js
@@ -24,7 +24,7 @@ import p5 from '../core/main';
  * let str = '20';
  * let diameter = float(str);
  * ellipse(width / 2, height / 2, diameter, diameter);
- * describe(`20-by-20 white ellipse in the center of the canvas`);
+ * describe('20-by-20 white ellipse in the center of the canvas');
  * </code></div>
  * <div class='norender'><code>
  * print(float('10.31')); // 10.31

--- a/src/utilities/conversion.js
+++ b/src/utilities/conversion.js
@@ -24,15 +24,13 @@ import p5 from '../core/main';
  * let str = '20';
  * let diameter = float(str);
  * ellipse(width / 2, height / 2, diameter, diameter);
+ * describe(`20×20 white ellipse in the center of the canvas`);
  * </code></div>
  * <div class='norender'><code>
  * print(float('10.31')); // 10.31
  * print(float('Infinity')); // Infinity
  * print(float('-Infinity')); // -Infinity
  * </code></div>
- *
- * @alt
- * 20 by 20 white ellipse in the center of the canvas
  */
 p5.prototype.float = function(str) {
   if (str instanceof Array) {

--- a/src/utilities/conversion.js
+++ b/src/utilities/conversion.js
@@ -24,7 +24,7 @@ import p5 from '../core/main';
  * let str = '20';
  * let diameter = float(str);
  * ellipse(width / 2, height / 2, diameter, diameter);
- * describe(`20×20 white ellipse in the center of the canvas`);
+ * describe(`20-by-20 white ellipse in the center of the canvas`);
  * </code></div>
  * <div class='norender'><code>
  * print(float('10.31')); // 10.31

--- a/src/utilities/string_functions.js
+++ b/src/utilities/string_functions.js
@@ -29,7 +29,7 @@ import '../core/friendly_errors/fes_core';
  * let separator = ' ';
  * let message = join(array, separator);
  * text(message, 5, 50);
- * describe(`“Hello world!” displayed middle left of canvas.`);
+ * describe(`'Hello world!' displayed middle left of canvas.`);
  * </code>
  * </div>
  */
@@ -67,7 +67,7 @@ p5.prototype.join = function(list, separator) {
  * let regexp = 'p5js\\*';
  * let m = match(string, regexp);
  * text(m, 5, 50);
- * describe(`“p5js*” displayed middle left of canvas.`);
+ * describe(`'p5js*' displayed middle left of canvas.`);
  * </code>
  * </div>
  */
@@ -163,7 +163,7 @@ p5.prototype.matchAll = function(str, reg) {
  *   stroke(120);
  *   line(0, 50, width, 50);
  *
- *   describe(`“0321.00” middle top, “-1321.00” middle bottom canvas`);
+ *   describe(`'0321.00' middle top, '-1321.00' middle bottom canvas`);
  * }
  * </code>
  * </div>
@@ -261,8 +261,8 @@ function doNf(num, left, right) {
  *   stroke(120);
  *   line(0, 50, width, 50);
  *
- *   describe(`“11,253,106.115” top middle and
- *     “1.00,1.00,2.00” displayed bottom mid`);
+ *   describe(`'11,253,106.115' top middle and
+ *     '1.00,1.00,2.00' displayed bottom mid`);
  * }
  * </code>
  * </div>
@@ -338,8 +338,8 @@ function doNfc(num, right) {
  *   stroke(120);
  *   line(0, 50, width, 50);
  *
- *   describe(`“+11253106.11” top middle and
- *     “-11253106.11” displayed bottom middle`);
+ *   describe(`'+11253106.11' top middle and
+ *     '-11253106.11' displayed bottom middle`);
  * }
  * </code>
  * </div>
@@ -416,7 +416,7 @@ function addNfp(num) {
  *   stroke(120);
  *   line(0, 50, width, 50);
  *
- *   describe(`“0321.00” top middle and “-1321.00” displayed bottom middle`);
+ *   describe(`'0321.00' top middle and '-1321.00' displayed bottom middle`);
  * }
  * </code>
  * </div>
@@ -464,7 +464,7 @@ function addNfs(num) {
  * text(splitString[0], 5, 30);
  * text(splitString[1], 5, 50);
  * text(splitString[2], 5, 70);
- * describe(`“pat” top left, “Xio” mid left, and
+ * describe(`'pat' top left, 'Xio' mid left, and
  *   “Alex” displayed bottom left`);
  * </code>
  * </div>
@@ -541,7 +541,7 @@ p5.prototype.splitTokens = function(value, delims) {
  * <code>
  * let string = trim('  No new lines\n   ');
  * text(string + ' here', 2, 50);
- * describe(`“No new lines here” displayed center canvas`);
+ * describe(`'No new lines here' displayed center canvas`);
  * </code>
  * </div>
  */

--- a/src/utilities/string_functions.js
+++ b/src/utilities/string_functions.js
@@ -29,7 +29,7 @@ import '../core/friendly_errors/fes_core';
  * let separator = ' ';
  * let message = join(array, separator);
  * text(message, 5, 50);
- * describe(`“hello world!” displayed middle left of canvas.`);
+ * describe(`“Hello world!” displayed middle left of canvas.`);
  * </code>
  * </div>
  */

--- a/src/utilities/string_functions.js
+++ b/src/utilities/string_functions.js
@@ -29,7 +29,7 @@ import '../core/friendly_errors/fes_core';
  * let separator = ' ';
  * let message = join(array, separator);
  * text(message, 5, 50);
- * describe(''Hello world!' displayed middle left of canvas.');
+ * describe('“Hello world!” displayed middle left of canvas.');
  * </code>
  * </div>
  */
@@ -67,7 +67,7 @@ p5.prototype.join = function(list, separator) {
  * let regexp = 'p5js\\*';
  * let m = match(string, regexp);
  * text(m, 5, 50);
- * describe(''p5js*' displayed middle left of canvas.');
+ * describe('“p5js*” displayed middle left of canvas.');
  * </code>
  * </div>
  */
@@ -163,7 +163,7 @@ p5.prototype.matchAll = function(str, reg) {
  *   stroke(120);
  *   line(0, 50, width, 50);
  *
- *   describe(''0321.00' middle top, '-1321.00' middle bottom canvas');
+ *   describe('“0321.00” middle top, “-1321.00” middle bottom canvas');
  * }
  * </code>
  * </div>
@@ -261,8 +261,8 @@ function doNf(num, left, right) {
  *   stroke(120);
  *   line(0, 50, width, 50);
  *
- *   describe(''11,253,106.115' top middle and
- *     '1.00,1.00,2.00' displayed bottom mid');
+ *   describe('“11,253,106.115” top middle and
+ *     “1.00,1.00,2.00” displayed bottom mid');
  * }
  * </code>
  * </div>
@@ -338,8 +338,8 @@ function doNfc(num, right) {
  *   stroke(120);
  *   line(0, 50, width, 50);
  *
- *   describe(''+11253106.11' top middle and
- *     '-11253106.11' displayed bottom middle');
+ *   describe('“+11253106.11” top middle and
+ *     “-11253106.11” displayed bottom middle');
  * }
  * </code>
  * </div>
@@ -416,7 +416,7 @@ function addNfp(num) {
  *   stroke(120);
  *   line(0, 50, width, 50);
  *
- *   describe(''0321.00' top middle and '-1321.00' displayed bottom middle');
+ *   describe('“0321.00” top middle and “-1321.00” displayed bottom middle');
  * }
  * </code>
  * </div>
@@ -464,7 +464,7 @@ function addNfs(num) {
  * text(splitString[0], 5, 30);
  * text(splitString[1], 5, 50);
  * text(splitString[2], 5, 70);
- * describe(''pat' top left, 'Xio' mid left, and
+ * describe('“pat” top left, “Xio” mid left, and
  *   “Alex” displayed bottom left');
  * </code>
  * </div>
@@ -541,7 +541,7 @@ p5.prototype.splitTokens = function(value, delims) {
  * <code>
  * let string = trim('  No new lines\n   ');
  * text(string + ' here', 2, 50);
- * describe(''No new lines here' displayed center canvas');
+ * describe('“No new lines here” displayed center canvas');
  * </code>
  * </div>
  */

--- a/src/utilities/string_functions.js
+++ b/src/utilities/string_functions.js
@@ -261,8 +261,7 @@ function doNf(num, left, right) {
  *   stroke(120);
  *   line(0, 50, width, 50);
  *
- *   describe('“11,253,106.115” top middle and
- *     “1.00,1.00,2.00” displayed bottom mid');
+ *   describe('“11,253,106.115” top middle and “1.00,1.00,2.00” displayed bottom mid');
  * }
  * </code>
  * </div>
@@ -338,8 +337,7 @@ function doNfc(num, right) {
  *   stroke(120);
  *   line(0, 50, width, 50);
  *
- *   describe('“+11253106.11” top middle and
- *     “-11253106.11” displayed bottom middle');
+ *   describe('“+11253106.11” top middle and “-11253106.11” displayed bottom middle');
  * }
  * </code>
  * </div>
@@ -464,8 +462,7 @@ function addNfs(num) {
  * text(splitString[0], 5, 30);
  * text(splitString[1], 5, 50);
  * text(splitString[2], 5, 70);
- * describe('“pat” top left, “Xio” mid left, and
- *   “Alex” displayed bottom left');
+ * describe('“Pat” top left, “Xio” mid left, and “Alex” displayed bottom left');
  * </code>
  * </div>
  */

--- a/src/utilities/string_functions.js
+++ b/src/utilities/string_functions.js
@@ -29,7 +29,7 @@ import '../core/friendly_errors/fes_core';
  * let separator = ' ';
  * let message = join(array, separator);
  * text(message, 5, 50);
- * describe(`'Hello world!' displayed middle left of canvas.`);
+ * describe(''Hello world!' displayed middle left of canvas.');
  * </code>
  * </div>
  */
@@ -67,7 +67,7 @@ p5.prototype.join = function(list, separator) {
  * let regexp = 'p5js\\*';
  * let m = match(string, regexp);
  * text(m, 5, 50);
- * describe(`'p5js*' displayed middle left of canvas.`);
+ * describe(''p5js*' displayed middle left of canvas.');
  * </code>
  * </div>
  */
@@ -163,7 +163,7 @@ p5.prototype.matchAll = function(str, reg) {
  *   stroke(120);
  *   line(0, 50, width, 50);
  *
- *   describe(`'0321.00' middle top, '-1321.00' middle bottom canvas`);
+ *   describe(''0321.00' middle top, '-1321.00' middle bottom canvas');
  * }
  * </code>
  * </div>
@@ -261,8 +261,8 @@ function doNf(num, left, right) {
  *   stroke(120);
  *   line(0, 50, width, 50);
  *
- *   describe(`'11,253,106.115' top middle and
- *     '1.00,1.00,2.00' displayed bottom mid`);
+ *   describe(''11,253,106.115' top middle and
+ *     '1.00,1.00,2.00' displayed bottom mid');
  * }
  * </code>
  * </div>
@@ -338,8 +338,8 @@ function doNfc(num, right) {
  *   stroke(120);
  *   line(0, 50, width, 50);
  *
- *   describe(`'+11253106.11' top middle and
- *     '-11253106.11' displayed bottom middle`);
+ *   describe(''+11253106.11' top middle and
+ *     '-11253106.11' displayed bottom middle');
  * }
  * </code>
  * </div>
@@ -416,7 +416,7 @@ function addNfp(num) {
  *   stroke(120);
  *   line(0, 50, width, 50);
  *
- *   describe(`'0321.00' top middle and '-1321.00' displayed bottom middle`);
+ *   describe(''0321.00' top middle and '-1321.00' displayed bottom middle');
  * }
  * </code>
  * </div>
@@ -464,8 +464,8 @@ function addNfs(num) {
  * text(splitString[0], 5, 30);
  * text(splitString[1], 5, 50);
  * text(splitString[2], 5, 70);
- * describe(`'pat' top left, 'Xio' mid left, and
- *   “Alex” displayed bottom left`);
+ * describe(''pat' top left, 'Xio' mid left, and
+ *   “Alex” displayed bottom left');
  * </code>
  * </div>
  */
@@ -541,7 +541,7 @@ p5.prototype.splitTokens = function(value, delims) {
  * <code>
  * let string = trim('  No new lines\n   ');
  * text(string + ' here', 2, 50);
- * describe(`'No new lines here' displayed center canvas`);
+ * describe(''No new lines here' displayed center canvas');
  * </code>
  * </div>
  */

--- a/src/utilities/string_functions.js
+++ b/src/utilities/string_functions.js
@@ -29,11 +29,9 @@ import '../core/friendly_errors/fes_core';
  * let separator = ' ';
  * let message = join(array, separator);
  * text(message, 5, 50);
+ * describe(`“hello world!” displayed middle left of canvas.`);
  * </code>
  * </div>
- *
- * @alt
- * "hello world!" displayed middle left of canvas.
  */
 p5.prototype.join = function(list, separator) {
   p5._validateParameters('join', arguments);
@@ -69,11 +67,9 @@ p5.prototype.join = function(list, separator) {
  * let regexp = 'p5js\\*';
  * let m = match(string, regexp);
  * text(m, 5, 50);
+ * describe(`“p5js*” displayed middle left of canvas.`);
  * </code>
  * </div>
- *
- * @alt
- * "p5js*" displayed middle left of canvas.
  */
 p5.prototype.match = function(str, reg) {
   p5._validateParameters('match', arguments);
@@ -166,12 +162,11 @@ p5.prototype.matchAll = function(str, reg) {
  *   // Draw dividing line
  *   stroke(120);
  *   line(0, 50, width, 50);
+ *
+ *   describe(`“0321.00” middle top, “-1321.00” middle bottom canvas`);
  * }
  * </code>
  * </div>
- *
- * @alt
- * "0321.00" middle top, -1321.00" middle bottom canvas
  */
 /**
  * @method nf
@@ -265,12 +260,12 @@ function doNf(num, left, right) {
  *   // Draw dividing line
  *   stroke(120);
  *   line(0, 50, width, 50);
+ *
+ *   describe(`“11,253,106.115” top middle and
+ *     “1.00,1.00,2.00” displayed bottom mid`);
  * }
  * </code>
  * </div>
- *
- * @alt
- * "11,253,106.115" top middle and "1.00,1.00,2.00" displayed bottom mid
  */
 /**
  * @method nfc
@@ -342,12 +337,12 @@ function doNfc(num, right) {
  *   // Draw dividing line
  *   stroke(120);
  *   line(0, 50, width, 50);
+ *
+ *   describe(`“+11253106.11” top middle and
+ *     “-11253106.11” displayed bottom middle`);
  * }
  * </code>
  * </div>
- *
- * @alt
- * "+11253106.11" top middle and "-11253106.11" displayed bottom middle
  */
 /**
  * @method nfp
@@ -420,12 +415,11 @@ function addNfp(num) {
  *   // Draw dividing line
  *   stroke(120);
  *   line(0, 50, width, 50);
+ *
+ *   describe(`“0321.00” top middle and “-1321.00” displayed bottom middle`);
  * }
  * </code>
  * </div>
- *
- * @alt
- * "0321.00" top middle and "-1321.00" displayed bottom middle
  */
 /**
  * @method nfs
@@ -470,11 +464,10 @@ function addNfs(num) {
  * text(splitString[0], 5, 30);
  * text(splitString[1], 5, 50);
  * text(splitString[2], 5, 70);
+ * describe(`“pat” top left, “Xio” mid left, and
+ *   “Alex” displayed bottom left`);
  * </code>
  * </div>
- *
- * @alt
- * "pat" top left, "Xio" mid left and "Alex" displayed bottom left
  */
 p5.prototype.split = function(str, delim) {
   p5._validateParameters('split', arguments);
@@ -548,11 +541,9 @@ p5.prototype.splitTokens = function(value, delims) {
  * <code>
  * let string = trim('  No new lines\n   ');
  * text(string + ' here', 2, 50);
+ * describe(`“No new lines here” displayed center canvas`);
  * </code>
  * </div>
- *
- * @alt
- * "No new lines here" displayed center canvas
  */
 /**
  * @method trim

--- a/src/utilities/time_date.js
+++ b/src/utilities/time_date.js
@@ -18,7 +18,7 @@ import p5 from '../core/main';
  * <code>
  * let d = day();
  * text('Current day: \n' + d, 5, 50);
- * describe(`Current day is displayed`);
+ * describe('Current day is displayed');
  * </code>
  * </div>
  */
@@ -37,7 +37,7 @@ p5.prototype.day = function() {
  * <code>
  * let h = hour();
  * text('Current hour:\n' + h, 5, 50);
- * describe(`Current hour is displayed`);
+ * describe('Current hour is displayed');
  * </code>
  * </div>
  */
@@ -56,7 +56,7 @@ p5.prototype.hour = function() {
  * <code>
  * let m = minute();
  * text('Current minute: \n' + m, 5, 50);
- * describe(`Current minute is displayed`);
+ * describe('Current minute is displayed');
  * </code>
  * </div>
  */
@@ -76,8 +76,8 @@ p5.prototype.minute = function() {
  * <code>
  * let millisecond = millis();
  * text('Milliseconds \nrunning: \n' + millisecond, 5, 40);
- * describe(`number of milliseconds since sketch has started
- *   displayed`);
+ * describe('number of milliseconds since sketch has started
+ *   displayed');
  * </code>
  * </div>
  */
@@ -101,7 +101,7 @@ p5.prototype.millis = function() {
  * <code>
  * let m = month();
  * text('Current month: \n' + m, 5, 50);
- * describe(`Current month is displayed`);
+ * describe('Current month is displayed');
  * </code>
  * </div>
  */
@@ -121,7 +121,7 @@ p5.prototype.month = function() {
  * <code>
  * let s = second();
  * text('Current second: \n' + s, 5, 50);
- * describe(`Current second is displayed`);
+ * describe('Current second is displayed');
  * </code>
  * </div>
  */
@@ -140,7 +140,7 @@ p5.prototype.second = function() {
  * <code>
  * let y = year();
  * text('Current year: \n' + y, 5, 50);
- * describe(`Current year is displayed`);
+ * describe('Current year is displayed');
  * </code>
  * </div>
  */

--- a/src/utilities/time_date.js
+++ b/src/utilities/time_date.js
@@ -18,11 +18,9 @@ import p5 from '../core/main';
  * <code>
  * let d = day();
  * text('Current day: \n' + d, 5, 50);
+ * describe(`Current day is displayed`);
  * </code>
  * </div>
- *
- * @alt
- * Current day is displayed
  */
 p5.prototype.day = function() {
   return new Date().getDate();
@@ -39,11 +37,9 @@ p5.prototype.day = function() {
  * <code>
  * let h = hour();
  * text('Current hour:\n' + h, 5, 50);
+ * describe(`Current hour is displayed`);
  * </code>
  * </div>
- *
- * @alt
- * Current hour is displayed
  */
 p5.prototype.hour = function() {
   return new Date().getHours();
@@ -60,11 +56,9 @@ p5.prototype.hour = function() {
  * <code>
  * let m = minute();
  * text('Current minute: \n' + m, 5, 50);
+ * describe(`Current minute is displayed`);
  * </code>
  * </div>
- *
- * @alt
- * Current minute is displayed
  */
 p5.prototype.minute = function() {
   return new Date().getMinutes();
@@ -82,11 +76,10 @@ p5.prototype.minute = function() {
  * <code>
  * let millisecond = millis();
  * text('Milliseconds \nrunning: \n' + millisecond, 5, 40);
+ * describe(`number of milliseconds since sketch has started
+ *   displayed`);
  * </code>
  * </div>
- *
- * @alt
- * number of milliseconds since sketch has started displayed
  */
 p5.prototype.millis = function() {
   if (this._millisStart === -1) {
@@ -108,11 +101,9 @@ p5.prototype.millis = function() {
  * <code>
  * let m = month();
  * text('Current month: \n' + m, 5, 50);
+ * describe(`Current month is displayed`);
  * </code>
  * </div>
- *
- * @alt
- * Current month is displayed
  */
 p5.prototype.month = function() {
   //January is 0!
@@ -130,11 +121,9 @@ p5.prototype.month = function() {
  * <code>
  * let s = second();
  * text('Current second: \n' + s, 5, 50);
+ * describe(`Current second is displayed`);
  * </code>
  * </div>
- *
- * @alt
- * Current second is displayed
  */
 p5.prototype.second = function() {
   return new Date().getSeconds();
@@ -151,11 +140,9 @@ p5.prototype.second = function() {
  * <code>
  * let y = year();
  * text('Current year: \n' + y, 5, 50);
+ * describe(`Current year is displayed`);
  * </code>
  * </div>
- *
- * @alt
- * Current year is displayed
  */
 p5.prototype.year = function() {
   return new Date().getFullYear();

--- a/src/utilities/time_date.js
+++ b/src/utilities/time_date.js
@@ -76,8 +76,7 @@ p5.prototype.minute = function() {
  * <code>
  * let millisecond = millis();
  * text('Milliseconds \nrunning: \n' + millisecond, 5, 40);
- * describe('number of milliseconds since sketch has started
- *   displayed');
+ * describe('number of milliseconds since sketch has started displayed');
  * </code>
  * </div>
  */


### PR DESCRIPTION
Addresses https://github.com/processing/p5.js/issues/5139. Attention @lm-n. ;-)

Changes:
Use `describe()` over `@alt` in inline docs within 📁 src/utilities/.


#### PR Checklist

- [x] `npm run lint` passes
- [x] [Inline documentation] is included / updated

[Inline documentation]: https://github.com/processing/p5.js/blob/main/contributor_docs/inline_documentation.md
