### PR TITLE
Issue radiobutton

### DIFF
--- a/src/dom/dom.js
+++ b/src/dom/dom.js
@@ -943,7 +943,6 @@ p5.prototype.createRadio = function() {
   };
 
   self.selected = function(value) {
-    // console.log('Hello');
     let result = null;
     if (value === undefined) {
       for (const option of self._getOptionsArray()) {

--- a/src/dom/dom.js
+++ b/src/dom/dom.js
@@ -943,6 +943,7 @@ p5.prototype.createRadio = function() {
   };
 
   self.selected = function(value) {
+    // console.log('Hello');
     let result = null;
     if (value === undefined) {
       for (const option of self._getOptionsArray()) {
@@ -952,6 +953,12 @@ p5.prototype.createRadio = function() {
         }
       }
     } else {
+      // forEach loop to uncheck all radio buttons before
+      // setting any one as checked.
+      self
+        ._getOptionsArray()
+        .forEach(option => option.removeAttribute('checked'));
+
       for (const option of self._getOptionsArray()) {
         if (option.value === value) {
           option.setAttribute('checked', true);

--- a/src/events/mouse.js
+++ b/src/events/mouse.js
@@ -984,7 +984,10 @@ p5.prototype._onwheel = function(e) {
  * Note that not all browsers support this feature.
  * This enables you to create experiences that aren't limited by the mouse moving out of the screen
  * even if it is repeatedly moved into one direction.
- * For example, a first person perspective experience.
+ * For example, a first person perspective experience. It is recommended to
+ * use <a href="#/p5/requestPointerLock">requestPointerLock()</a> as a result
+ * of any user interaction, like <a href="#/p5/mouseClicked">mouseClicked()</a>
+ * or <a href="#/p5/keyPressed">keyPressed()</a>
  *
  * @method requestPointerLock
  * @example
@@ -993,7 +996,6 @@ p5.prototype._onwheel = function(e) {
  * let cam;
  * function setup() {
  *   createCanvas(100, 100, WEBGL);
- *   requestPointerLock();
  *   cam = createCamera();
  * }
  *
@@ -1002,6 +1004,10 @@ p5.prototype._onwheel = function(e) {
  *   cam.pan(-movedX * 0.001);
  *   cam.tilt(movedY * 0.001);
  *   sphere(25);
+ * }
+ *
+ * function mouseClicked() {
+ *   requestPointerLock();
  * }
  * </code>
  * </div>
@@ -1024,8 +1030,8 @@ p5.prototype.requestPointerLock = function() {
 
 /**
  * The function <a href="#/p5/exitPointerLock">exitPointerLock()</a>
- * exits a previously triggered <a href="#/p5/requestPointerLock">pointer Lock</a>
- * for example to make ui elements usable etc
+ * exits a previously triggered <a href="#/p5/requestPointerLock">pointer Lock</a>.
+ * For example, it might be used to make UI elements usable once again.
  *
  * @method exitPointerLock
  * @example

--- a/src/events/mouse.js
+++ b/src/events/mouse.js
@@ -984,10 +984,7 @@ p5.prototype._onwheel = function(e) {
  * Note that not all browsers support this feature.
  * This enables you to create experiences that aren't limited by the mouse moving out of the screen
  * even if it is repeatedly moved into one direction.
- * For example, a first person perspective experience. It is recommended to
- * use <a href="#/p5/requestPointerLock">requestPointerLock()</a> as a result
- * of any user interaction, like <a href="#/p5/mouseClicked">mouseClicked()</a>
- * or <a href="#/p5/keyPressed">keyPressed()</a>
+ * For example, a first person perspective experience.
  *
  * @method requestPointerLock
  * @example
@@ -996,6 +993,7 @@ p5.prototype._onwheel = function(e) {
  * let cam;
  * function setup() {
  *   createCanvas(100, 100, WEBGL);
+ *   requestPointerLock();
  *   cam = createCamera();
  * }
  *
@@ -1004,10 +1002,6 @@ p5.prototype._onwheel = function(e) {
  *   cam.pan(-movedX * 0.001);
  *   cam.tilt(movedY * 0.001);
  *   sphere(25);
- * }
- *
- * function mouseClicked() {
- *   requestPointerLock();
  * }
  * </code>
  * </div>
@@ -1030,8 +1024,8 @@ p5.prototype.requestPointerLock = function() {
 
 /**
  * The function <a href="#/p5/exitPointerLock">exitPointerLock()</a>
- * exits a previously triggered <a href="#/p5/requestPointerLock">pointer Lock</a>.
- * For example, it might be used to make UI elements usable once again.
+ * exits a previously triggered <a href="#/p5/requestPointerLock">pointer Lock</a>
+ * for example to make ui elements usable etc
  *
  * @method exitPointerLock
  * @example


### PR DESCRIPTION
Resolves #5603 

####Screenshots of the change:

The issue, as illustrated below, is whenever we cycled through the radio button selections in the code, the `checked=true` option is not removed after each subsequent change. Therefore, after one cycle, all options have `checked=true` and the program malfunctions.

![before](https://user-images.githubusercontent.com/40564575/154317645-d51fd626-a6e2-4bfc-aa5a-02ecc443efec.gif)

The expected behavior: 

![after](https://user-images.githubusercontent.com/40564575/154318245-c48ed7d7-4e87-4dd1-bbdb-ff367f7543aa.gif)
 

#### PR Checklist

- [x] `npm run lint` passes

Acknowledgement: Credit goes to @sflanker for solving the problem in the issue itself, I simply implemented it selectively in the source code.