### PR TITLE
refactor: replace deprecated String.prototype.substr()

### DIFF
--- a/docs/preprocessor.js
+++ b/docs/preprocessor.js
@@ -10,7 +10,7 @@ function smokeTestMethods(data) {
 
       if (
         classitem.access !== 'private' &&
-        classitem.file.substr(0, 3) === 'src' &&
+        classitem.file.slice(0, 3) === 'src' &&
         classitem.name &&
         !classitem.example
       ) {

--- a/src/core/friendly_errors/sketch_reader.js
+++ b/src/core/friendly_errors/sketch_reader.js
@@ -235,8 +235,8 @@ if (typeof IS_MINIFIED !== 'undefined') {
     //create a new string which don't have multiline comments
     while (start !== -1 && end !== -1) {
       if (start === 0) {
-        code = code.substr(end + 2);
-      } else code = code.substr(0, start) + code.substr(end + 2);
+        code = code.slice(end + 2);
+      } else code = code.slice(0, start) + code.slice(end + 2);
 
       start = code.indexOf('/*');
       end = code.indexOf('*/');

--- a/src/core/friendly_errors/validate_params.js
+++ b/src/core/friendly_errors/validate_params.js
@@ -204,8 +204,8 @@ if (typeof IS_MINIFIED !== 'undefined') {
     // look for the docs in the `data.json` datastructure
 
     const ichDot = func.lastIndexOf('.');
-    const funcName = func.substr(ichDot + 1);
-    const funcClass = func.substr(0, ichDot) || 'p5';
+    const funcName = func.slice(ichDot + 1);
+    const funcClass = func.slice(0, ichDot !== -1 ? ichDot : 0) || 'p5';
 
     const classitems = arrDoc;
     let queryResult = classitems[funcClass][funcName];
@@ -247,10 +247,10 @@ if (typeof IS_MINIFIED !== 'undefined') {
         // split this parameter's types
         format.types = format.type.split('|').map(function ct(type) {
           // array
-          if (type.substr(type.length - 2, 2) === '[]') {
+          if (type.slice(-2) === '[]') {
             return {
               name: type,
-              array: ct(type.substr(0, type.length - 2))
+              array: ct(type.slice(0, -2))
             };
           }
 
@@ -298,7 +298,7 @@ if (typeof IS_MINIFIED !== 'undefined') {
           }
 
           // function
-          if (lowerType.substr(0, 'function'.length) === 'function') {
+          if (lowerType.slice(0, 'function'.length) === 'function') {
             lowerType = 'function';
           }
           // builtin

--- a/src/typography/loading_displaying.js
+++ b/src/typography/loading_displaying.js
@@ -119,11 +119,11 @@ p5.prototype.loadFont = function(path, onSuccess, onError) {
     const lastDotIdx = fileNoPath.lastIndexOf('.');
     let fontFamily;
     let newStyle;
-    const fileExt = lastDotIdx < 1 ? null : fileNoPath.substr(lastDotIdx + 1);
+    const fileExt = lastDotIdx < 1 ? null : fileNoPath.slice(lastDotIdx + 1);
 
     // if so, add it to the DOM (name-only) for use with DOM module
     if (validFontTypes.includes(fileExt)) {
-      fontFamily = fileNoPath.substr(0, lastDotIdx);
+      fontFamily = fileNoPath.slice(0, lastDotIdx !== -1 ? lastDotIdx : 0);
       newStyle = document.createElement('style');
       newStyle.appendChild(
         document.createTextNode(

--- a/test/js/sinon.js
+++ b/test/js/sinon.js
@@ -5,13 +5,13 @@
  * @author Contributors: https://github.com/cjohansen/Sinon.JS/blob/master/AUTHORS
  *
  * (The BSD License)
- * 
+ *
  * Copyright (c) 2010-2014, Christian Johansen, christian@cjohansen.no
  * All rights reserved.
- * 
+ *
  * Redistribution and use in source and binary forms, with or without modification,
  * are permitted provided that the following conditions are met:
- * 
+ *
  *     * Redistributions of source code must retain the above copyright notice,
  *       this list of conditions and the following disclaimer.
  *     * Redistributions in binary form must reproduce the above copyright notice,
@@ -20,7 +20,7 @@
  *     * Neither the name of Christian Johansen nor the names of his contributors
  *       may be used to endorse or promote products derived from this software
  *       without specific prior written permission.
- * 
+ *
  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
  * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
  * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
@@ -463,7 +463,7 @@
     module.exports = m(require("samsam"));
 }) || function (m) { this.formatio = m(this.samsam); }
 )(function (samsam) {
-    
+
     var formatio = {
         excludeConstructors: ["Object", /^.$/],
         quoteStrings: true,
@@ -566,7 +566,7 @@
         processed.push(array);
         var pieces = [];
         var i, l;
-        l = (this.limitChildrenCount > 0) ? 
+        l = (this.limitChildrenCount > 0) ?
             Math.min(this.limitChildrenCount, array.length) : array.length;
 
         for (i = 0; i < l; ++i) {
@@ -586,7 +586,7 @@
         var pieces = [], properties = samsam.keys(object).sort();
         var length = 3;
         var prop, str, obj, i, k, l;
-        l = (this.limitChildrenCount > 0) ? 
+        l = (this.limitChildrenCount > 0) ?
             Math.min(this.limitChildrenCount, properties.length) : properties.length;
 
         for (i = 0; i < l; ++i) {
@@ -636,7 +636,7 @@
         var content = element.innerHTML;
 
         if (content.length > 20) {
-            content = content.substr(0, 20) + "[...]";
+            content = content.slice(0, 20) + "[...]";
         }
 
         var res = formatted + pairs.join(" ") + ">" + content +

--- a/test/unit/color/p5.Color.js
+++ b/test/unit/color/p5.Color.js
@@ -986,7 +986,7 @@ suite('p5.Color', function() {
     test('should generate (r,g,b,a) color string with 0-1 normalized alpha', function() {
       // Will not exactly equal 0.5 due to math: test "0.5" substr of
       // 'rgba(128,0,128,0.5...' instead of checking the entire string
-      assert.equal(colorStr.substr(15, 3), '0.5');
+      assert.equal(colorStr.slice(15, 18), '0.5');
     });
 
     test('should consistently generate the same output', function() {


### PR DESCRIPTION
[String.prototype.substr()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/substr) is deprecated so we replace it with [String.prototype.slice()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/slice) which works similarily but isn't deprecated.
.substr() probably isn't going away anytime soon but the change is trivial so it doesn't hurt to do it.

#### PR Checklist

- [x] `npm run lint` passes
- [ ] [Inline documentation] is included / updated
- [ ] [Unit tests] are included / updated

[Inline documentation]: https://github.com/processing/p5.js/blob/main/contributor_docs/inline_documentation.md
[Unit tests]: https://github.com/processing/p5.js/tree/main/contributor_docs#unit-tests
