### PR TITLE
Fixes Issue #5646 (httpGet() not showing friendly error message)

### DIFF
--- a/src/core/friendly_errors/file_errors.js
+++ b/src/core/friendly_errors/file_errors.js
@@ -74,6 +74,13 @@ if (typeof IS_MINIFIED !== 'undefined') {
           message: translator('fes.fileLoadError.gif'),
           method: 'loadImage'
         };
+      case 9:
+        return {
+          message: translator('fes.fileLoadError.get', {
+            suggestion
+          }),
+          method: 'httpGet'
+        };
     }
   };
   /**

--- a/src/io/files.js
+++ b/src/io/files.js
@@ -823,10 +823,10 @@ p5.prototype.httpGet = function() {
 
   const args = Array.prototype.slice.call(arguments);
   const path = args[0];
-  let datatype; // String
-  let data; // Object|Boolean
-  let callback; // Function
-  let errorCallback; // Function
+  let datatype;
+  let data;
+  let callback;
+  let errorCallback;
 
   for (let i = 1; i < args.length; i++) {
     const arg = args[i];
@@ -842,12 +842,6 @@ p5.prototype.httpGet = function() {
       }
     }
   }
-
-  // args.splice(1, 0, 'GET');
-  // const argsArray = [path, 'GET', datatype];
-  // if (data) argsArray.push(data);
-  // if (callback) argsArray.push(callback);
-  // if (errorCallback) argsArray.push(err);
 
   return this.httpDo(
     path,
@@ -870,8 +864,6 @@ p5.prototype.httpGet = function() {
       }
     }
   );
-
-  // return p5.prototype.httpDo.apply(this, argsArray);
 };
 
 /**

--- a/src/io/files.js
+++ b/src/io/files.js
@@ -822,8 +822,56 @@ p5.prototype.httpGet = function() {
   p5._validateParameters('httpGet', arguments);
 
   const args = Array.prototype.slice.call(arguments);
-  args.splice(1, 0, 'GET');
-  return p5.prototype.httpDo.apply(this, args);
+  const path = args[0];
+  let datatype; // String
+  let data; // Object|Boolean
+  let callback; // Function
+  let errorCallback; // Function
+
+  for (let i = 1; i < args.length; i++) {
+    const arg = args[i];
+    if (typeof arg === 'string') {
+      datatype = arg;
+    } else if (typeof arg === 'object') {
+      data = arg;
+    } else if (typeof arg === 'function') {
+      if (!callback) {
+        callback = arg;
+      } else {
+        errorCallback = arg;
+      }
+    }
+  }
+
+  // args.splice(1, 0, 'GET');
+  // const argsArray = [path, 'GET', datatype];
+  // if (data) argsArray.push(data);
+  // if (callback) argsArray.push(callback);
+  // if (errorCallback) argsArray.push(err);
+
+  return this.httpDo(
+    path,
+    'GET',
+    datatype,
+    data,
+    resp => {
+      if (callback) {
+        callback(resp);
+      } else {
+        return resp;
+      }
+    },
+    err => {
+      p5._friendlyFileLoadError(9, path);
+      if (errorCallback) {
+        errorCallback(err);
+      } else {
+        throw err;
+      }
+    }
+  );
+
+  // return p5.prototype.httpDo.apply(this, argsArray);
 };
 
 /**

--- a/translations/en/translation.json
+++ b/translations/en/translation.json
@@ -5,6 +5,7 @@
     "fileLoadError": {
       "bytes": "It looks like there was a problem loading your file. {{suggestion}}",
       "font": "It looks like there was a problem loading your font. {{suggestion}}",
+      "get": "It looks like there was a problem completing your GET request. {{suggestion}}",
       "gif": "There was some trouble loading your GIF. Make sure that your GIF is using 87a or 89a encoding.",
       "image": "It looks like there was a problem loading your image. {{suggestion}}",
       "json": "It looks like there was a problem loading your JSON file. {{suggestion}}",

--- a/translations/es/translation.json
+++ b/translations/es/translation.json
@@ -5,6 +5,7 @@
     "fileLoadError": {
       "bytes": "",
       "font": "",
+      "get": "",
       "gif": "",
       "image": "",
       "json": "",


### PR DESCRIPTION
Resolves #5646 

 Changes:
Modified the `httpGet()`  method to show Friendly Error Message when an error is thrown


 Screenshots of the change:

Before:
![image](https://user-images.githubusercontent.com/40564575/160285291-1b22e966-3af5-49fa-ac84-b1b3a637d1a8.png)

After:
![image](https://user-images.githubusercontent.com/40564575/160285338-a30e67d6-092d-43f9-844d-66ae16b42754.png)


#### PR Checklist

- [x] `npm run lint` passes
