### PR TITLE
Fix grammar in the p5.sound documentation

### DIFF
--- a/.all-contributorsrc
+++ b/.all-contributorsrc
@@ -3023,10 +3023,20 @@
         "code",
         "tool"
       ]
+    },
+    {
+      "login": "Dmkk01",
+      "name": "Dominik Łasiński",
+      "avatar_url": "https://avatars.githubusercontent.com/u/76247450?v=4",
+      "profile": "https://www.dominik-lasinski.com/",
+      "contributions": [
+        "doc"
+      ]
     }
   ],
   "repoType": "github",
   "repoHost": "https://github.com",
   "contributorsPerLine": 7,
-  "skipCi": true
+  "skipCi": true,
+  "commitConvention": "none"
 }

--- a/README.md
+++ b/README.md
@@ -556,6 +556,7 @@ We recognize all types of contributions. This project follows the [all-contribut
     <td align="center"><a href="https://www.zhdk.ch/weiterbildung/weiterbildung-design/cas-coding-for-the-arts"><img src="https://avatars.githubusercontent.com/u/88927553?v=4?s=100" width="100px;" alt=""/><br /><sub><b>Coding for the Arts</b></sub></a><br /><a href="https://github.com/processing/p5.js/issues?q=author%3Acas-c4ta" title="Bug reports">🐛</a></td>
     <td align="center"><a href="http://danieljamesross.github.io"><img src="https://avatars.githubusercontent.com/u/28922296?v=4?s=100" width="100px;" alt=""/><br /><sub><b>Dan</b></sub></a><br /><a href="https://github.com/processing/p5.js/issues?q=author%3Adanieljamesross" title="Bug reports">🐛</a></td>
     <td align="center"><a href="https://github.com/liz-peng"><img src="https://avatars.githubusercontent.com/u/8376256?v=4?s=100" width="100px;" alt=""/><br /><sub><b>Liz Peng</b></sub></a><br /><a href="#design-liz-peng" title="Design">🎨</a> <a href="https://github.com/processing/p5.js/commits?author=liz-peng" title="Code">💻</a> <a href="#tool-liz-peng" title="Tools">🔧</a></td>
+    <td align="center"><a href="https://www.dominik-lasinski.com/"><img src="https://avatars.githubusercontent.com/u/76247450?v=4?s=100" width="100px;" alt=""/><br /><sub><b>Dominik Łasiński</b></sub></a><br /><a href="https://github.com/processing/p5.js/commits?author=Dmkk01" title="Documentation">📖</a></td>
   </tr>
 </table>
 

--- a/lib/addons/p5.sound.js
+++ b/lib/addons/p5.sound.js
@@ -816,7 +816,7 @@ function _typeof(obj) { if (typeof Symbol === "function" && typeof Symbol.iterat
  * It is often 44100, or twice the range of human hearing.
  *
  * @method sampleRate
- * @return {Number} samplerate samples per second
+ * @return {Number} Sample rate samples per second
  */
 
 function sampleRate() {
@@ -1151,7 +1151,7 @@ function safeBufferSize(idealBufferSize) {
  *  @for p5
  *  @method saveSound
  *  @param  {p5.SoundFile} soundFile p5.SoundFile that you wish to save
- *  @param  {String} fileName      name of the resulting .wav file.
+ *  @param  {String} fileName      Name of the resulting .wav file.
  */
 
 
@@ -1419,7 +1419,7 @@ function _clearOnEnd(e) {
  *
  *  @class p5.SoundFile
  *  @constructor
- *  @param {String|Array} path   path to a sound file (String). Optionally,
+ *  @param {String|Array} path   Path to a sound file (String). Optionally,
  *                               you may include multiple file formats in
  *                               an array. Alternately, accepts an object
  *                               from the HTML5 File API, or a p5.File.
@@ -1681,12 +1681,11 @@ function () {
      *
      * @method play
      * @for p5.SoundFile
-     * @param {Number} [startTime]            (optional) schedule playback to start (in seconds from now).
-     * @param {Number} [rate]             (optional) playback rate
-     * @param {Number} [amp]              (optional) amplitude (volume)
-     *                                     of playback
-     * @param {Number} [cueStart]        (optional) cue start time in seconds
-     * @param {Number} [duration]          (optional) duration of playback in seconds
+     * @param {Number} [startTime]             schedule playback to start (in seconds from now).
+     * @param {Number} [rate]             playback rate
+     * @param {Number} [amp]              amplitude (volume) of playback
+     * @param {Number} [cueStart]             cue start time in seconds
+     * @param {Number} [duration]             duration of playback in seconds
      */
 
   }, {
@@ -1855,7 +1854,7 @@ function () {
      *
      *  @method pause
      *  @for p5.SoundFile
-     *  @param {Number} [startTime] (optional) schedule event to occur
+     *  @param {Number} [startTime]             schedule event to occur
      *                               seconds from now
      *  @example
      *  <div><code>
@@ -1908,12 +1907,12 @@ function () {
      *
      * @method loop
      * @for p5.SoundFile
-     * @param {Number} [startTime] (optional) schedule event to occur
+     * @param {Number} [startTime]  schedule event to occur
      *                             seconds from now
-     * @param {Number} [rate]        (optional) playback rate
-     * @param {Number} [amp]         (optional) playback volume
-     * @param {Number} [cueLoopStart] (optional) startTime in seconds
-     * @param {Number} [duration]  (optional) loop duration in seconds
+     * @param {Number} [rate]         playback rate
+     * @param {Number} [amp]          playback volume
+     * @param {Number} [cueLoopStart]  startTime in seconds
+     * @param {Number} [duration]   loop duration in seconds
      * @example
      *  <div><code>
      *  let soundFile;
@@ -2027,7 +2026,7 @@ function () {
      *
      * @method stop
      * @for p5.SoundFile
-     * @param {Number} [startTime] (optional) schedule event to occur
+     * @param {Number} [startTime]  schedule event to occur
      *                             in seconds from now
      */
 
@@ -2092,7 +2091,7 @@ function () {
      * @method pan
      * @for p5.SoundFile
      * @param {Number} [panValue]     Set the stereo panner
-     * @param {Number} [timeFromNow]  schedule this event to happen
+     * @param {Number} [timeFromNow]  Schedule this event to happen
      *                                 seconds from now
      * @example
      * <div><code>
@@ -2854,7 +2853,7 @@ function () {
      *
      * @method save
      * @for p5.SoundFile
-     * @param  {String} [fileName]      name of the resulting .wav file.
+     * @param  {String} [fileName]      Name of the resulting .wav file.
      * @example
      *  <div><code>
      *  let mySound;
@@ -3120,10 +3119,10 @@ function () {
    *
    *  @method setInput
    *  @for p5.Amplitude
-   *  @param {soundObject|undefined} [snd] set the sound source
-   *                                       (optional, defaults to
+   *  @param {soundObject|undefined} [snd] Set the sound source
+   *                                       (defaults to
    *                                       main output)
-   *  @param {Number|undefined} [smoothing] a range between 0.0 and 1.0
+   *  @param {Number|undefined} [smoothing] A range between 0.0 and 1.0
    *                                        to smooth amplitude readings
    *  @example
    *  <div><code>
@@ -3212,7 +3211,7 @@ function () {
      *
      *  @method getLevel
      *  @for p5.Amplitude
-     *  @param {Number} [channel] Optionally return only channel 0 (left) or 1 (right)
+     *  @param {Number} [channel] Return only channel 0 (left) or 1 (right)
      *  @return {Number}       Amplitude as a number between 0.0 and 1.0
      *  @example
      *  <div><code>
@@ -3273,7 +3272,7 @@ function () {
      *
      * @method toggleNormalize
      * @for p5.Amplitude
-     * @param {boolean} [boolean] set normalize to true (1) or false (0)
+     * @param {boolean} [boolean] Set normalize to true (1) or false (0)
      */
 
   }, {
@@ -3296,7 +3295,7 @@ function () {
      *
      *  @method smooth
      *  @for p5.Amplitude
-     *  @param {Number} set smoothing from 0.0 <= 1
+     *  @param {Number} [set] Smoothing from 0.0 <= 1
      */
 
   }, {
@@ -3861,7 +3860,7 @@ function () {
      *  @method  linAverages
      *  @for p5.FFT
      *  @param  {Number}  N                Number of returned frequency groups
-     *  @return {Array}   linearAverages   Array of average amplitude values for each group
+     *  @return {Array}      Array of average amplitude values for each group
      */
 
   }, {
@@ -3897,7 +3896,7 @@ function () {
      *  @method  logAverages
      *  @for p5.FFT
      *  @param  {Array}   octaveBands    Array of Octave Bands objects for grouping
-     *  @return {Array}   logAverages    Array of average amplitude values for each group
+     *  @return {Array}       Array of average amplitude values for each group
      */
 
   }, {
@@ -3934,7 +3933,7 @@ function () {
      *  @for p5.FFT
      *  @param  {Number}  N             Specifies the 1/N type of generated octave bands
      *  @param  {Number}  fCtr0         Minimum central frequency for the lowest band
-     *  @return {Array}   octaveBands   Array of octave band objects with their bounds
+     *  @return {Array}      Array of octave band objects with their bounds
      */
 
   }, {
@@ -4174,8 +4173,8 @@ function () {
    *
    *  @method  start
    *  @for p5.Oscillator
-   *  @param  {Number} [time] startTime in seconds from now.
-   *  @param  {Number} [frequency] frequency in Hz.
+   *  @param  {Number} [time] Start time in seconds from now.
+   *  @param  {Number} [frequency] Frequency in Hertz.
    */
 
 
@@ -4241,12 +4240,12 @@ function () {
      *
      *  @method  amp
      *  @for p5.Oscillator
-     *  @param  {Number|Object} vol between 0 and 1.0
+     *  @param  {Number|Object} [vol] Between 0 and 1.0
      *                              or a modulating signal/oscillator
-     *  @param {Number} [rampTime] create a fade that lasts rampTime
-     *  @param {Number} [timeFromNow] schedule this event to happen
+     *  @param {Number} [rampTime] Create a fade that lasts rampTime
+     *  @param {Number} [timeFromNow] Schedule this event to happen
      *                                seconds from now
-     *  @return  {AudioParam} gain  If no value is provided,
+     *  @return  {AudioParam}  If no value is provided,
      *                              returns the Web Audio API
      *                              AudioParam that controls
      *                              this oscillator's
@@ -4293,7 +4292,7 @@ function () {
      *  @param  {Number} [rampTime] Ramp time (in seconds)
      *  @param  {Number} [timeFromNow] Schedule this event to happen
      *                                   at x seconds from now
-     *  @return  {AudioParam} Frequency If no value is provided,
+     *  @return  {AudioParam} Frequency if no value is provided,
      *                                  returns the Web Audio API
      *                                  AudioParam that controls
      *                                  this oscillator's frequency
@@ -4388,7 +4387,7 @@ function () {
      *
      *  @method  getType
      *  @for p5.Oscillator
-     *  @returns {String} type of oscillator  eg . 'sine', 'triangle', 'sawtooth' or 'square'.
+     *  @returns {String} Type of oscillator  eg . 'sine', 'triangle', 'sawtooth' or 'square'.
      */
 
   }, {
@@ -4447,7 +4446,7 @@ function () {
      *  @method  pan
      *  @for p5.Oscillator
      *  @param  {Number} panning Number between -1 and 1
-     *  @param  {Number} timeFromNow schedule this event to happen
+     *  @param  {Number} timeFromNow Schedule this event to happen
      *                                seconds from now
      */
 
@@ -4463,7 +4462,7 @@ function () {
      *  @method  getPan
      *  @for p5.Oscillator
      *
-     *  @returns {number} panPosition of oscillator , between Left (-1) and Right (1)
+     *  @returns {number} panPosition of oscillator, a value between Left (-1) and Right (1)
      */
 
   }, {
@@ -4498,7 +4497,7 @@ function () {
      *
      *  @method  phase
      *  @for p5.Oscillator
-     *  @param  {Number} phase float between 0.0 and 1.0
+     *  @param  {Number} phase Float between 0.0 and 1.0
      */
 
   }, {
@@ -4527,7 +4526,7 @@ function () {
      *  @method  add
      *  @for p5.Oscillator
      *  @param {Number} number Constant number to add
-     *  @return {p5.Oscillator} Oscillator Returns this oscillator
+     *  @return {p5.Oscillator} Returns this oscillator
      *                                     with scaled output
      *
      */
@@ -4548,7 +4547,7 @@ function () {
      *  @method  mult
      *  @for p5.Oscillator
      *  @param {Number} number Constant number to multiply
-     *  @return {p5.Oscillator} Oscillator Returns this oscillator
+     *  @return {p5.Oscillator} Returns this oscillator
      *                                     with multiplied output
      */
 
@@ -4567,11 +4566,11 @@ function () {
      *
      *  @method  scale
      *  @for p5.Oscillator
-     *  @param  {Number} inMin  input range minumum
-     *  @param  {Number} inMax  input range maximum
-     *  @param  {Number} outMin input range minumum
-     *  @param  {Number} outMax input range maximum
-     *  @return {p5.Oscillator} Oscillator Returns this oscillator
+     *  @param  {Number} inMin  Input range minumum
+     *  @param  {Number} inMax  Input range maximum
+     *  @param  {Number} outMin Input range minumum
+     *  @param  {Number} outMax Input range maximum
+     *  @return {p5.Oscillator} Returns this oscillator
      *                                     with scaled output
      */
 
@@ -4966,8 +4965,8 @@ p5.Envelope.prototype.setADSR = function (aTime, dTime, sPercent, rTime) {
  *
  *  @method  setRange
  *  @for p5.Envelope
- *  @param {Number} aLevel attack level (defaults to 1)
- *  @param {Number} rLevel release level (defaults to 0)
+ *  @param {Number} aLevel Attack level (defaults to 1)
+ *  @param {Number} rLevel Release level (defaults to 0)
  *  @example
  *  <div><code>
  *  let attackLevel = 1.0;
@@ -5087,8 +5086,8 @@ p5.Envelope.prototype.checkExpInput = function (value) {
  *  @for p5.Envelope
  *  @param  {Object} unit         A p5.sound object or
  *                                Web Audio Param.
- *  @param  {Number} [startTime]  time from now (in seconds) at which to play
- *  @param  {Number} [sustainTime] time to sustain before releasing the envelope
+ *  @param  {Number} [startTime]  Time from now (in seconds) at which to play
+ *  @param  {Number} [sustainTime] Time to sustain before releasing the envelope
  *  @example
  *  <div><code>
  *  let attackLevel = 1.0;
@@ -5261,7 +5260,7 @@ p5.Envelope.prototype.triggerAttack = function (unit, secondsFromNow) {
  *  @method  triggerRelease
  *  @for p5.Envelope
  *  @param  {Object} unit p5.sound Object or Web Audio Param
- *  @param  {Number} secondsFromNow time to trigger the release
+ *  @param  {Number} secondsFromNow Time to trigger the release
  *  @example
  *  <div><code>
  *  let attackTime = 0.001;
@@ -5465,7 +5464,7 @@ p5.Envelope.prototype.disconnect = function () {
  *  @method  add
  *  @for p5.Envelope
  *  @param {Number} number Constant number to add
- *  @return {p5.Envelope} Envelope Returns this envelope
+ *  @return {p5.Envelope}  Returns this envelope
  *                                     with scaled output
  */
 
@@ -5484,7 +5483,7 @@ p5.Envelope.prototype.add = function (num) {
  *  @method  mult
  *  @for p5.Envelope
  *  @param {Number} number Constant number to multiply
- *  @return {p5.Envelope} Envelope Returns this envelope
+ *  @return {p5.Envelope}  Returns this envelope
  *                                     with scaled output
  */
 
@@ -5502,11 +5501,11 @@ p5.Envelope.prototype.mult = function (num) {
  *
  *  @method  scale
  *  @for p5.Envelope
- *  @param  {Number} inMin  input range minumum
- *  @param  {Number} inMax  input range maximum
- *  @param  {Number} outMin input range minumum
- *  @param  {Number} outMax input range maximum
- *  @return {p5.Envelope} Envelope Returns this envelope
+ *  @param  {Number} inMin  Input range minumum
+ *  @param  {Number} inMax  Input range maximum
+ *  @param  {Number} outMin Input range minumum
+ *  @param  {Number} outMax Input range maximum
+ *  @return {p5.Envelope}  Returns this envelope
  *                                     with scaled output
  */
 
@@ -6259,8 +6258,8 @@ function () {
      *
      *  @method  amp
      *  @for p5.AudioIn
-     *  @param  {Number} vol between 0 and 1.0
-     *  @param {Number} [time] ramp time (optional)
+     *  @param  {Number} vol Between 0 and 1.0
+     *  @param {Number} [time] Ramp time 
      */
 
   }, {
@@ -6347,7 +6346,7 @@ function () {
      *
      *  @method setSource
      *  @for p5.AudioIn
-     *  @param {number} num position of input source in the array
+     *  @param {number} num Position of input source in the array
      *  @example
      *  <div><code>
      *  let audioIn;
@@ -6480,9 +6479,9 @@ function () {
    *
    *  @method  amp
    *  @for p5.Effect
-   *  @param {Number} [vol] amplitude between 0 and 1.0
-   *  @param {Number} [rampTime] create a fade that lasts until rampTime
-   *  @param {Number} [tFromNow] schedule this event to happen in tFromNow seconds
+   *  @param {Number} [vol] Amplitude between 0 and 1.0
+   *  @param {Number} [rampTime] Create a fade that lasts until rampTime
+   *  @param {Number} [tFromNow] Schedule this event to happen in tFromNow seconds
    */
 
 
@@ -6763,7 +6762,7 @@ function (_Effect) {
      *  @method  set
      *  @param {Number} [freq] Frequency in Hz, from 10 to 22050
      *  @param {Number} [res]  Resonance (Q) from 0.001 to 1000
-     *  @param {Number} [timeFromNow] schedule this event to happen
+     *  @param {Number} [timeFromNow] Schedule this event to happen
      *                                seconds from now
      */
 
@@ -6785,7 +6784,7 @@ function (_Effect) {
      *
      *  @method  freq
      *  @param  {Number} freq Filter Frequency
-     *  @param {Number} [timeFromNow] schedule this event to happen
+     *  @param {Number} [timeFromNow] Schedule this event to happen
      *                                seconds from now
      *  @return {Number} value  Returns the current frequency value
      */
@@ -6815,9 +6814,9 @@ function (_Effect) {
      *  @method  res
      *  @param {Number} res  Resonance/Width of filter freq
      *                       from 0.001 to 1000
-     *  @param {Number} [timeFromNow] schedule this event to happen
+     *  @param {Number} [timeFromNow] Schedule this event to happen
      *                                seconds from now
-     *  @return {Number} value Returns the current res value
+     *  @return {Number} Returns the current res value
      */
 
   }, {
@@ -6865,7 +6864,7 @@ function (_Effect) {
      * Toggle function. Switches between the specified type and allpass
      *
      * @method toggle
-     * @return {boolean} [Toggle value]
+     * @return {boolean} Toggle value
      */
 
   }, {
@@ -7688,21 +7687,21 @@ function (_Effect) {
      * Getter and setter methods for position coordinates
      * @method positionX
      * @for p5.Panner3D
-     * @return {Number}      updated coordinate value
+     * @return {Number}      Updated coordinate value
      */
 
     /**
      * Getter and setter methods for position coordinates
      * @method positionY
      * @for p5.Panner3D
-     * @return {Number}      updated coordinate value
+     * @return {Number}      Updated coordinate value
      */
 
     /**
      * Getter and setter methods for position coordinates
      * @method positionZ
      * @for p5.Panner3D
-     * @return {Number}      updated coordinate value
+     * @return {Number}      Updated coordinate value
      */
 
   }, {
@@ -7773,21 +7772,21 @@ function (_Effect) {
      * Getter and setter methods for orient coordinates
      * @method orientX
      * @for p5.Panner3D
-     * @return {Number}      updated coordinate value
+     * @return {Number}      Updated coordinate value
      */
 
     /**
      * Getter and setter methods for orient coordinates
      * @method orientY
      * @for p5.Panner3D
-     * @return {Number}      updated coordinate value
+     * @return {Number}      Updated coordinate value
      */
 
     /**
      * Getter and setter methods for orient coordinates
      * @method orientZ
      * @for p5.Panner3D
-     * @return {Number}      updated coordinate value
+     * @return {Number}      Updated coordinate value
      */
 
   }, {
@@ -7854,7 +7853,7 @@ function (_Effect) {
      * @method  maxDist
      * @for p5.Panner3D
      * @param  {Number} maxDistance
-     * @return {Number} updated value
+     * @return {Number} Updated value
      */
 
   }, {
@@ -7871,7 +7870,7 @@ function (_Effect) {
      * @method  rollof
      * @for p5.Panner3D
      * @param  {Number} rolloffFactor
-     * @return {Number} updated value
+     * @return {Number} Updated value
      */
 
   }, {
@@ -8056,7 +8055,7 @@ function (_Effect) {
    *  @param  {Number} [delayTime] Time (in seconds) of the delay/echo.
    *                               Some browsers limit delayTime to
    *                               1 second.
-   *  @param  {Number} [feedback]  sends the delay back through itself
+   *  @param  {Number} [feedback]  Sends the delay back through itself
    *                               in a loop that decreases in volume
    *                               each time.
    *  @param  {Number} [lowPass]   Cutoff frequency. Only frequencies
@@ -8225,9 +8224,9 @@ function (_Effect) {
      *
      *  @method  amp
      *  @for p5.Delay
-     *  @param  {Number} volume amplitude between 0 and 1.0
-     *  @param {Number} [rampTime] create a fade that lasts rampTime
-     *  @param {Number} [timeFromNow] schedule this event to happen
+     *  @param  {Number} volume Amplitude between 0 and 1.0
+     *  @param {Number} [rampTime] Create a fade that lasts rampTime
+     *  @param {Number} [timeFromNow] Schedule this event to happen
      *                                seconds from now
      */
 
@@ -8484,9 +8483,9 @@ function (_Effect) {
      *
      *  @method  amp
      *  @for p5.Reverb
-     *  @param  {Number} volume amplitude between 0 and 1.0
-     *  @param  {Number} [rampTime] create a fade that lasts rampTime
-     *  @param  {Number} [timeFromNow] schedule this event to happen
+     *  @param  {Number} volume Amplitude between 0 and 1.0
+     *  @param  {Number} [rampTime] Create a fade that lasts rampTime
+     *  @param  {Number} [timeFromNow] Schedule this event to happen
      *                                seconds from now
      */
 
@@ -8565,9 +8564,9 @@ function (_Effect) {
  *  @class p5.Convolver
  *  @extends p5.Effect
  *  @constructor
- *  @param  {String}   path     path to a sound file
- *  @param  {Function} [callback] function to call when loading succeeds
- *  @param  {Function} [errorCallback] function to call if loading fails.
+ *  @param  {String}   path     Path to a sound file
+ *  @param  {Function} [callback] Function to call when loading succeeds
+ *  @param  {Function} [errorCallback] Function to call if loading fails.
  *                                     This function will receive an error or
  *                                     XMLHttpRequest object with information
  *                                     about what went wrong.
@@ -8791,9 +8790,9 @@ function (_Reverb) {
      *
      *  @method  addImpulse
      *  @for p5.Convolver
-     *  @param  {String}   path     path to a sound file
-     *  @param  {Function} callback function (optional)
-     *  @param  {Function} errorCallback function (optional)
+     *  @param  {String}   path     Path to a sound file
+     *  @param  {Function} callback Function to call when loading succeeds (Optional)
+     *  @param  {Function} errorCallback Function to call when loading fails (Optional)
      */
 
   }, {
@@ -8812,9 +8811,9 @@ function (_Reverb) {
      *
      *  @method  resetImpulse
      *  @for p5.Convolver
-     *  @param  {String}   path     path to a sound file
-     *  @param  {Function} callback function (optional)
-     *  @param  {Function} errorCallback function (optional)
+     *  @param  {String}   path     Path to a sound file
+     *  @param  {Function} callback Function to call when loading succeeds (Optional)
+     *  @param  {Function} errorCallback Function to call when loading fails (Optional)
      */
 
   }, {
@@ -8888,11 +8887,11 @@ function (_Reverb) {
  *
  *  @method  createConvolver
  *  @for p5
- *  @param  {String}   path     path to a sound file
- *  @param  {Function} [callback] function to call if loading is successful.
+ *  @param  {String}   path     Path to a sound file
+ *  @param  {Function} [callback] Function to call if loading is successful.
  *                                The object will be passed in as the argument
  *                                to the callback function.
- *  @param  {Function} [errorCallback] function to call if loading is not successful.
+ *  @param  {Function} [errorCallback] Function to call if loading is not successful.
  *                                A custom error will be passed in as the argument
  *                                to the callback function.
  *  @return {p5.Convolver}
@@ -9295,7 +9294,7 @@ function () {
      *
      *  @method  start
      *  @for p5.Part
-     *  @param  {Number} [time] seconds from now
+     *  @param  {Number} [time] Seconds from now
      */
 
   }, {
@@ -9315,7 +9314,7 @@ function () {
      *
      *  @method  loop
      *  @for p5.Part
-     *  @param  {Number} [time] seconds from now
+     *  @param  {Number} [time] Seconds from now
      */
 
   }, {
@@ -9351,7 +9350,7 @@ function () {
      *
      *  @method  stop
      *  @for p5.Part
-     *  @param  {Number} [time] seconds from now
+     *  @param  {Number} [time] Seconds from now
      */
 
   }, {
@@ -9366,7 +9365,7 @@ function () {
      *
      *  @method  pause
      *  @for p5.Part
-     *  @param  {Number} time seconds from now
+     *  @param  {Number} time Seconds from now
      */
 
   }, {
@@ -9381,7 +9380,7 @@ function () {
      *
      *  @method  addPhrase
      *  @for p5.Part
-     *  @param {p5.Phrase}   phrase   reference to a p5.Phrase
+     *  @param {p5.Phrase}   phrase   Reference to a p5.Phrase
      */
 
   }, {
@@ -9842,7 +9841,7 @@ function () {
    * Start the loop
    * @method  start
    * @for p5.SoundLoop
-   * @param  {Number} [timeFromNow] schedule a starting time
+   * @param  {Number} [timeFromNow] Schedule a starting time
    */
 
 
@@ -9861,7 +9860,7 @@ function () {
      * Stop the loop
      * @method  stop
      * @for p5.SoundLoop
-     * @param  {Number} [timeFromNow] schedule a stopping time
+     * @param  {Number} [timeFromNow] Schedule a stopping time
      */
 
   }, {
@@ -9879,7 +9878,7 @@ function () {
      * Pause the loop
      * @method pause
      * @for p5.SoundLoop
-     * @param  {Number} [timeFromNow] schedule a pausing time
+     * @param  {Number} [timeFromNow] Schedule a pausing time
      */
 
   }, {
@@ -9901,7 +9900,7 @@ function () {
      *
      * @method  syncedStart
      * @for p5.SoundLoop
-     * @param  {Object} otherLoop   a p5.SoundLoop to sync with
+     * @param  {Object} otherLoop   A p5.SoundLoop to sync with
      * @param  {Number} [timeFromNow] Start the loops in sync after timeFromNow seconds
      */
 
@@ -11100,9 +11099,9 @@ function () {
      *
      *  @method  amp
      *  @for p5.Gain
-     *  @param  {Number} volume amplitude between 0 and 1.0
-     *  @param  {Number} [rampTime] create a fade that lasts rampTime
-     *  @param  {Number} [timeFromNow] schedule this event to happen
+     *  @param  {Number} volume Amplitude between 0 and 1.0
+     *  @param  {Number} [rampTime] Create a fade that lasts rampTime
+     *  @param  {Number} [timeFromNow] Schedule this event to happen
      *                                seconds from now
      */
 
@@ -11382,14 +11381,14 @@ function (_AudioVoice) {
    *
    *  @method play
    *  @for p5.MonoSynth
-   *  @param {String | Number} note the note you want to play, specified as a
+   *  @param {String | Number} note The note you want to play, specified as a
    *                                 frequency in Hertz (Number) or as a midi
    *                                 value in Note/Octave format ("C4", "Eb3"...etc")
    *                                 See <a href = "https://github.com/Tonejs/Tone.js/wiki/Instruments">
    *                                 Tone</a>. Defaults to 440 hz.
-   *  @param  {Number} [velocity] velocity of the note to play (ranging from 0 to 1)
-   *  @param  {Number} [secondsFromNow]  time from now (in seconds) at which to play
-   *  @param  {Number} [sustainTime] time to sustain before releasing the envelope. Defaults to 0.15 seconds.
+   *  @param  {Number} [velocity] Velocity of the note to play (ranging from 0 to 1)
+   *  @param  {Number} [secondsFromNow]  Time from now (in seconds) at which to play
+   *  @param  {Number} [sustainTime] Time to sustain before releasing the envelope. Defaults to 0.15 seconds.
    *  @example
    *  <div><code>
    *  let monoSynth;
@@ -11433,13 +11432,13 @@ function (_AudioVoice) {
      *  Similar to holding down a key on a piano, but it will
      *  hold the sustain level until you let go.
      *
-     *  @param {String | Number} note the note you want to play, specified as a
+     *  @param {String | Number} note The note you want to play, specified as a
      *                                 frequency in Hertz (Number) or as a midi
      *                                 value in Note/Octave format ("C4", "Eb3"...etc")
      *                                 See <a href = "https://github.com/Tonejs/Tone.js/wiki/Instruments">
      *                                 Tone</a>. Defaults to 440 hz
-     *  @param  {Number} [velocity] velocity of the note to play (ranging from 0 to 1)
-     *  @param  {Number} [secondsFromNow]  time from now (in seconds) at which to play
+     *  @param  {Number} [velocity] Velocity of the note to play (ranging from 0 to 1)
+     *  @param  {Number} [secondsFromNow]  Time from now (in seconds) at which to play
      *  @method  triggerAttack
      *  @for p5.MonoSynth
      *  @example
@@ -11480,7 +11479,7 @@ function (_AudioVoice) {
      *  the key on a piano and letting the sound fade according to the
      *  release level and release time.
      *
-     *  @param  {Number} secondsFromNow time to trigger the release
+     *  @param  {Number} secondsFromNow Time to trigger the release
      *  @method  triggerRelease
      *  @for p5.MonoSynth
      *  @example
@@ -11545,9 +11544,9 @@ function (_AudioVoice) {
      * MonoSynth amp
      * @method  amp
      * @for p5.MonoSynth
-     * @param  {Number} vol      desired volume
+     * @param  {Number} vol      Desired volume
      * @param  {Number} [rampTime] Time to reach new volume
-     * @return {Number}          new volume value
+     * @return {Number}          New volume value
      */
 
   }, {
@@ -11802,10 +11801,10 @@ function () {
      *
      *  @method  play
      *  @for p5.PolySynth
-     *  @param  {Number} [note] midi note to play (ranging from 0 to 127 - 60 being a middle C)
-     *  @param  {Number} [velocity] velocity of the note to play (ranging from 0 to 1)
-     *  @param  {Number} [secondsFromNow]  time from now (in seconds) at which to play
-     *  @param  {Number} [sustainTime] time to sustain before releasing the envelope
+     *  @param  {Number} [note] Midi note to play (ranging from 0 to 127 - 60 being a middle C)
+     *  @param  {Number} [velocity] Velocity of the note to play (ranging from 0 to 1)
+     *  @param  {Number} [secondsFromNow]  Time from now (in seconds) at which to play
+     *  @param  {Number} [sustainTime] Time to sustain before releasing the envelope
      *  @example
      *  <div><code>
      *  let polySynth;
@@ -11913,9 +11912,9 @@ function () {
      *
      *  @method  noteAttack
      *  @for p5.PolySynth
-     *  @param  {Number} [note]           midi note on which attack should be triggered.
-     *  @param  {Number} [velocity]       velocity of the note to play (ranging from 0 to 1)/
-     *  @param  {Number} [secondsFromNow] time from now (in seconds)
+     *  @param  {Number} [note]           Midi note on which attack should be triggered.
+     *  @param  {Number} [velocity]       Velocity of the note to play (ranging from 0 to 1)/
+     *  @param  {Number} [secondsFromNow] Time from now (in seconds)
      *  @example
      *  <div><code>
      *  let polySynth = new p5.PolySynth();
@@ -12025,9 +12024,9 @@ function () {
      *
      *  @method  noteRelease
      *  @for p5.PolySynth
-     *  @param  {Number} [note]           midi note on which attack should be triggered.
+     *  @param  {Number} [note]           Midi note on which attack should be triggered.
      *                                    If no value is provided, all notes will be released.
-     *  @param  {Number} [secondsFromNow] time to trigger the release
+     *  @param  {Number} [secondsFromNow] Time to trigger the release
      *  @example
      *  <div><code>
      *  let polySynth = new p5.PolySynth();


### PR DESCRIPTION
 Changes:
- Mostly adding a capital letter to the start of the sentence.
- Adding some extra information to params and/or return values.
- Remove additional 'optional' texts
- Remove repeated words in the same sentence


- [x] `npm run lint` passes
- [x] [Inline documentation] is included / updated
- [x] [Unit tests] are included / updated
