### PR TITLE
Fixed typo on atan2() page

### DIFF
--- a/src/math/trigonometry.js
+++ b/src/math/trigonometry.js
@@ -129,7 +129,7 @@ p5.prototype.atan = function(ratio) {
  * to the position of the cursor.
  *
  * Note: The y-coordinate of the point is the first parameter, and the
- * x-coordinate is the second parameter, due the the structure of calculating
+ * x-coordinate is the second parameter, due to the structure of calculating
  * the tangent.
  *
  * @method atan2


### PR DESCRIPTION
Changes:
changed "due the the" to "due to the"


 Screenshots of the change:

<img width="811" alt="Screen Shot 2022-04-04 at 4 53 41 PM" src="https://user-images.githubusercontent.com/95722198/161630462-e03848a4-2de2-4725-a806-4843dd391ef0.png">

