### PR TITLE
p5.image docs typo fix

### DIFF
--- a/src/image/p5.Image.js
+++ b/src/image/p5.Image.js
@@ -603,7 +603,7 @@ p5.Image.prototype.copy = function(...args) {
 /**
  * Masks part of an image from displaying by loading another
  * image and using its alpha channel as an alpha channel for
- * this image. Masks are cumulative, one applied to an image
+ * this image. Masks are cumulative, once applied to an image
  * object, they cannot be removed.
  *
  * @method mask


### PR DESCRIPTION
 Changes:
"**one** applied to an image object" to "**once** applied to an image object"

For [this page](https://p5js.org/reference/#/p5.Image/mask).

#### PR Checklist
n/a
