### PR TITLE
Fixed background transparency with Images

### DIFF
--- a/src/core/p5.Renderer2D.js
+++ b/src/core/p5.Renderer2D.js
@@ -47,7 +47,14 @@ p5.Renderer2D.prototype.background = function(...args) {
   this.resetMatrix();
 
   if (args[0] instanceof p5.Image) {
-    this._pInst.image(args[0], 0, 0, this.width, this.height);
+    if (args[1] >= 0) {
+      // set transparency of background
+      const img = args[0];
+      this.drawingContext.globalAlpha = args[1] / 255;
+      this._pInst.image(img, 0, 0, this.width, this.height);
+    } else {
+      this._pInst.image(args[0], 0, 0, this.width, this.height);
+    }
   } else {
     const curFill = this._getFill();
     // create background rect


### PR DESCRIPTION
Co-authored-by: TwoTicks <adityasiddheshwar.adisid@gmail.com>

Resolves #5175
Continues #5225

@two-ticks suggested the `globalAlpha` implementation in #5225, this PR implements it.

## Changes:

[Example](https://editor.p5js.org/yashlamba/sketches/gFMiuAr45)
Replicated the example from #5225, to demonstrate consistency with the other solution.

- Setting alpha in background now works with images.
- Alpha parameter range is consistent with the docs (0-255), wanted to point this out since `globalAlpha` uses 0-1 range.

 Screenshots of the change:


#### PR Checklist
<img width="1599" alt="image" src="https://user-images.githubusercontent.com/44164398/170814656-febc2167-fcdf-466c-9b25-2c48523eb3ed.png">
<img width="1599" alt="image" src="https://user-images.githubusercontent.com/44164398/170814670-1e97258c-755b-4b1e-9beb-2c2bcd270851.png">

- [ ] `npm run lint` passes
- [ ] [Inline documentation] is included / updated
- [ ] [Unit tests] are included / updated

[Inline documentation]: https://github.com/processing/p5.js/blob/main/contributor_docs/inline_documentation.md
[Unit tests]: https://github.com/processing/p5.js/tree/main/contributor_docs#unit-tests
