### PR TITLE
Add anchor tag to web safe font

### DIFF
--- a/src/typography/loading_displaying.js
+++ b/src/typography/loading_displaying.js
@@ -280,7 +280,7 @@ p5.prototype.text = function(str, x, y, maxWidth, maxHeight) {
 /**
  * @method textFont
  * @param {Object|String} font a font loaded via <a href="#/p5/loadFont">loadFont()</a>,
- * or a String representing a <a href="https://mzl.la/2dOw8WD">web safe font</a>
+ * or a String representing a <a href="https://developer.mozilla.org/en-US/docs/Learn/CSS/Styling_text/Fundamentals#web_safe_fonts">web safe font</a>
  * (a font that is generally available across all systems)
  * @param {Number} [size] the font size to use
  * @chainable


### PR DESCRIPTION
Add anchor tag to web safe font, so users don't have to scroll on the page and are directly taken to the list of available fonts.
I came across this minor issue and just fixed it, without opening an issue so no issue number. 
<!--
  Thank you for contributing! Please use this pull request (PR) template.


 In the description field of this PR, include "resolves #XXXX" tagging the issue you are fixing. If this PR addresses the issue but doesn't completely resolve it (ie the issue should remain open after your PR is merged), write "addresses #XXXX".-->
Resolves #[Add issue number here]

 Changes:
<!-- Add here what changes were made in this pull request and if possible provide links showcasing the changes. -->
Minor change, to direct users to web safe fonts using an anchor tag. 

 Screenshots of the change:
<!-- If applicable, add screenshots depicting the changes. -->

#### PR Checklist
<!--
  To check any option, replace the "[ ]" with a "[x]". Be sure to check out how it looks in the Preview tab! Feel free to remove any portion of the template that is not relevant for your issue.
-->

- [ ] `npm run lint` passes
- [ ] [Inline documentation] is included / updated
- [ ] [Unit tests] are included / updated

[Inline documentation]: https://github.com/processing/p5.js/blob/main/contributor_docs/inline_documentation.md
[Unit tests]: https://github.com/processing/p5.js/tree/main/contributor_docs#unit-tests
