### PR TITLE
Update `saveFrames` documentation

### DIFF
--- a/src/image/image.js
+++ b/src/image/image.js
@@ -69,7 +69,7 @@ import omggif from 'omggif';
  * let img = createImage(66, 66);
  * img.loadPixels();
  * let d = pixelDensity();
- * let halfImage = 4 * (img.width * d) * (img.height / 2 * d);
+ * let halfImage = 4 * (img.width * d) * ((img.height / 2) * d);
  * for (let i = 0; i < halfImage; i += 4) {
  *   img.pixels[i] = red(pink);
  *   img.pixels[i + 1] = green(pink);

--- a/src/image/image.js
+++ b/src/image/image.js
@@ -69,7 +69,7 @@ import omggif from 'omggif';
  * let img = createImage(66, 66);
  * img.loadPixels();
  * let d = pixelDensity();
- * let halfImage = 4 * (img.width * d) * ((img.height / 2) * d);
+ * let halfImage = 4 * (img.width * d) * (img.height / 2 * d);
  * for (let i = 0; i < halfImage; i += 4) {
  *   img.pixels[i] = red(pink);
  *   img.pixels[i + 1] = green(pink);

--- a/src/image/image.js
+++ b/src/image/image.js
@@ -420,15 +420,20 @@ p5.prototype.saveGif = function(pImg, filename) {
  *  as an argument to the callback function as an array of objects, with the
  *  size of array equal to the total number of frames.
  *
- *  Note that <a href="#/p5.Image/saveFrames">saveFrames()</a> will only save the first 15 frames of an animation.
+ *  Note that <a href="#/p5.Image/saveFrames">saveFrames()</a> will only save the first 15 seconds of an animation.
+ *  The arguments `duration` and `framerate` are constrained to be less or equal 15 and 22, respectively, which means you
+ *  can only download a maximum of 15 seconds worth of frames at 22 frames per second, adding up to 330 frames.
+ *  This is done in order to avoid memory problems since a large enough canvas can fill up the memory in your computer
+ *  very easily and crash your program or even your browser.
+ * 
  *  To export longer animations, you might look into a library like
  *  <a href="https://github.com/spite/ccapture.js/">ccapture.js</a>.
  *
  *  @method saveFrames
  *  @param  {String}   filename
  *  @param  {String}   extension 'jpg' or 'png'
- *  @param  {Number}   duration  Duration in seconds to save the frames for.
- *  @param  {Number}   framerate  Framerate to save the frames in.
+ *  @param  {Number}   duration  Duration in seconds to save the frames for. This parameter will be constrained to be less or equal to 15.
+ *  @param  {Number}   framerate  Framerate to save the frames in. This parameter will be constrained to be less or equal to 22.
  *  @param  {function(Array)} [callback] A callback function that will be executed
                                   to handle the image data. This function
                                   should accept an array as argument. The

--- a/src/image/image.js
+++ b/src/image/image.js
@@ -420,8 +420,7 @@ p5.prototype.saveGif = function(pImg, filename) {
  *  as an argument to the callback function as an array of objects, with the
  *  size of array equal to the total number of frames.
  *
- *  Note that <a href="#/p5.Image/saveFrames">saveFrames()</a> will only save the first 15 seconds of an animation.
- *  The arguments `duration` and `framerate` are constrained to be less or equal 15 and 22, respectively, which means you
+ *  The arguments `duration` and `framerate` are constrained to be less or equal to 15 and 22, respectively, which means you
  *  can only download a maximum of 15 seconds worth of frames at 22 frames per second, adding up to 330 frames.
  *  This is done in order to avoid memory problems since a large enough canvas can fill up the memory in your computer
  *  very easily and crash your program or even your browser.


### PR DESCRIPTION
<!--
  Thank you for contributing! Please use this pull request (PR) template.


 In the description field of this PR, include "resolves #XXXX" tagging the issue you are fixing. If this PR addresses the issue but doesn't completely resolve it (ie the issue should remain open after your PR is merged), write "addresses #XXXX".-->
## Issue
Resolves #5685, in which some discussion was made regarding the behaviour of the `saveFrames` function. @endurance21 and I were inspecting the code and thought it was not working properly, but @limzykenneth went ahead and clarified why the arguments are set up like that, but stated that there was no proper explanation for that within the docs. So that is what this change is aiming to solve! 

I tried to be explicit enough in my explanation for the reason to be clear, but not too technical so newcomers can properly understand the problem. Let me know if I it needs change for it to be either clearer and more explicit or less technical and more friendly!

## Changes
<!-- Add here what changes were made in this pull request and if possible provide links showcasing the changes. -->
1. https://github.com/jesi-rgb/p5.js/blob/21f5e3db573cad9ef4a00821a5468b31549656a6/src/image/image.js#L72
	1. Fixes an issue with the linter (adding parentheses to the division)
2. https://github.com/jesi-rgb/p5.js/blob/21f5e3db573cad9ef4a00821a5468b31549656a6/src/image/image.js#L424
	3. Adds further explanation as to why the function works like this
4. https://github.com/jesi-rgb/p5.js/blob/21f5e3db573cad9ef4a00821a5468b31549656a6/src/image/image.js#L435
	5. Adds further explanation in the arguments description to make sure people know what to expect.

## Screenshots of the change:
<!-- If applicable, add screenshots depicting the changes. -->
The changes I added are highlighted.

<img width="1136" alt="image" src="https://user-images.githubusercontent.com/50735312/174475463-7d753842-90f5-4be0-b0d3-623378380bf5.png">

<img width="1256" alt="image" src="https://user-images.githubusercontent.com/50735312/174475477-d3a28d22-fbc0-4099-9660-f11d04f54419.png">


#### PR Checklist
<!--
  To check any option, replace the "[ ]" with a "[x]". Be sure to check out how it looks in the Preview tab! Feel free to remove any portion of the template that is not relevant for your issue.
-->

- [x] `npm run lint` passes
- [x] [Inline documentation] is included / updated
- [x] [Unit tests] are included / updated

[Inline documentation]: https://github.com/processing/p5.js/blob/main/contributor_docs/inline_documentation.md
[Unit tests]: https://github.com/processing/p5.js/tree/main/contributor_docs#unit-tests
