### PR TITLE
added describe() to all 3d reference examples

### DIFF
--- a/src/webgl/3d_primitives.js
+++ b/src/webgl/3d_primitives.js
@@ -33,6 +33,8 @@ import * as constants from '../core/constants';
  *   background(200);
  *   plane(50, 50);
  * }
+ *
+ * describe('a white plane with black wireframe lines');
  * </code>
  * </div>
  *
@@ -120,6 +122,8 @@ p5.prototype.plane = function(width, height, detailX, detailY) {
  *   rotateY(frameCount * 0.01);
  *   box(50);
  * }
+ *
+ * describe('a white box rotating in 3D space');
  * </code>
  * </div>
  */
@@ -237,6 +241,8 @@ p5.prototype.box = function(width, height, depth, detailX, detailY) {
  *   background(205, 102, 94);
  *   sphere(40);
  * }
+ *
+ * describe('a white sphere with black wireframe lines');
  * </code>
  * </div>
  *
@@ -257,6 +263,10 @@ p5.prototype.box = function(width, height, depth, detailX, detailY) {
  *   rotateY(millis() / 1000);
  *   sphere(40, detailX.value(), 16);
  * }
+ *
+ * describe(
+ *   'a white sphere with low detail on the x-axis, including a slider to adjust detailX'
+ * );
  * </code>
  * </div>
  *
@@ -277,6 +287,10 @@ p5.prototype.box = function(width, height, depth, detailX, detailY) {
  *   rotateY(millis() / 1000);
  *   sphere(40, 16, detailY.value());
  * }
+ *
+ * describe(
+ *   'a white sphere with low detail on the y-axis, including a slider to adjust detailY'
+ * );
  * </code>
  * </div>
  */
@@ -449,6 +463,8 @@ const _truncatedCone = function(
  *   rotateZ(frameCount * 0.01);
  *   cylinder(20, 50);
  * }
+ *
+ * describe('a rotating white cylinder');
  * </code>
  * </div>
  *
@@ -469,6 +485,10 @@ const _truncatedCone = function(
  *   rotateY(millis() / 1000);
  *   cylinder(20, 75, detailX.value(), 1);
  * }
+ *
+ * describe(
+ *   'a rotating white cylinder with limited X detail, with a slider that adjusts detailX'
+ * );
  * </code>
  * </div>
  *
@@ -489,6 +509,10 @@ const _truncatedCone = function(
  *   rotateY(millis() / 1000);
  *   cylinder(20, 75, 16, detailY.value());
  * }
+ *
+ * describe(
+ *   'a rotating white cylinder with limited Y detail, with a slider that adjusts detailY'
+ * );
  * </code>
  * </div>
  */
@@ -584,6 +608,8 @@ p5.prototype.cylinder = function(
  *   rotateZ(frameCount * 0.01);
  *   cone(40, 70);
  * }
+ *
+ * describe('a rotating white cone');
  * </code>
  * </div>
  *
@@ -604,6 +630,10 @@ p5.prototype.cylinder = function(
  *   rotateY(millis() / 1000);
  *   cone(30, 65, detailX.value(), 16);
  * }
+ *
+ * describe(
+ *   'a rotating white cone with limited X detail, with a slider that adjusts detailX'
+ * );
  * </code>
  * </div>
  *
@@ -624,6 +654,10 @@ p5.prototype.cylinder = function(
  *   rotateY(millis() / 1000);
  *   cone(30, 65, 16, detailY.value());
  * }
+ *
+ * describe(
+ *   'a rotating white cone with limited Y detail, with a slider that adjusts detailY'
+ * );
  * </code>
  * </div>
  */
@@ -698,6 +732,8 @@ p5.prototype.cone = function(radius, height, detailX, detailY, cap) {
  *   background(205, 105, 94);
  *   ellipsoid(30, 40, 40);
  * }
+ *
+ * describe('a white 3d ellipsoid');
  * </code>
  * </div>
  *
@@ -718,6 +754,10 @@ p5.prototype.cone = function(radius, height, detailX, detailY, cap) {
  *   rotateY(millis() / 1000);
  *   ellipsoid(30, 40, 40, detailX.value(), 8);
  * }
+ *
+ * describe(
+ *   'a rotating white ellipsoid with limited X detail, with a slider that adjusts detailX'
+ * );
  * </code>
  * </div>
  *
@@ -738,6 +778,10 @@ p5.prototype.cone = function(radius, height, detailX, detailY, cap) {
  *   rotateY(millis() / 1000);
  *   ellipsoid(30, 40, 40, 12, detailY.value());
  * }
+ *
+ * describe(
+ *   'a rotating white ellipsoid with limited Y detail, with a slider that adjusts detailY'
+ * );
  * </code>
  * </div>
  */
@@ -834,6 +878,8 @@ p5.prototype.ellipsoid = function(radiusX, radiusY, radiusZ, detailX, detailY) {
  *   rotateY(frameCount * 0.01);
  *   torus(30, 15);
  * }
+ *
+ * describe('a rotating white torus');
  * </code>
  * </div>
  *
@@ -854,6 +900,10 @@ p5.prototype.ellipsoid = function(radiusX, radiusY, radiusZ, detailX, detailY) {
  *   rotateY(millis() / 1000);
  *   torus(30, 15, detailX.value(), 12);
  * }
+ *
+ * describe(
+ *   'a rotating white torus with limited X detail, with a slider that adjusts detailX'
+ * );
  * </code>
  * </div>
  *
@@ -874,6 +924,10 @@ p5.prototype.ellipsoid = function(radiusX, radiusY, radiusZ, detailX, detailY) {
  *   rotateY(millis() / 1000);
  *   torus(30, 15, 16, detailY.value());
  * }
+ *
+ * describe(
+ *   'a rotating white torus with limited Y detail, with a slider that adjusts detailY'
+ * );
  * </code>
  * </div>
  */

--- a/src/webgl/3d_primitives.js
+++ b/src/webgl/3d_primitives.js
@@ -27,14 +27,13 @@ import * as constants from '../core/constants';
  * // with width 50 and height 50
  * function setup() {
  *   createCanvas(100, 100, WEBGL);
+ *   describe('a white plane with black wireframe lines');
  * }
  *
  * function draw() {
  *   background(200);
  *   plane(50, 50);
  * }
- *
- * describe('a white plane with black wireframe lines');
  * </code>
  * </div>
  *
@@ -114,6 +113,7 @@ p5.prototype.plane = function(width, height, detailX, detailY) {
  * // with width, height and depth of 50
  * function setup() {
  *   createCanvas(100, 100, WEBGL);
+ *   describe('a white box rotating in 3D space');
  * }
  *
  * function draw() {
@@ -122,8 +122,6 @@ p5.prototype.plane = function(width, height, detailX, detailY) {
  *   rotateY(frameCount * 0.01);
  *   box(50);
  * }
- *
- * describe('a white box rotating in 3D space');
  * </code>
  * </div>
  */
@@ -235,14 +233,13 @@ p5.prototype.box = function(width, height, depth, detailX, detailY) {
  * // draw a sphere with radius 40
  * function setup() {
  *   createCanvas(100, 100, WEBGL);
+ *   describe('a white sphere with black wireframe lines');
  * }
  *
  * function draw() {
  *   background(205, 102, 94);
  *   sphere(40);
  * }
- *
- * describe('a white sphere with black wireframe lines');
  * </code>
  * </div>
  *
@@ -256,6 +253,9 @@ p5.prototype.box = function(width, height, depth, detailX, detailY) {
  *   detailX = createSlider(3, 24, 3);
  *   detailX.position(10, height + 5);
  *   detailX.style('width', '80px');
+ *   describe(
+ *     'a white sphere with low detail on the x-axis, including a slider to adjust detailX'
+ *   );
  * }
  *
  * function draw() {
@@ -263,10 +263,6 @@ p5.prototype.box = function(width, height, depth, detailX, detailY) {
  *   rotateY(millis() / 1000);
  *   sphere(40, detailX.value(), 16);
  * }
- *
- * describe(
- *   'a white sphere with low detail on the x-axis, including a slider to adjust detailX'
- * );
  * </code>
  * </div>
  *
@@ -280,6 +276,9 @@ p5.prototype.box = function(width, height, depth, detailX, detailY) {
  *   detailY = createSlider(3, 16, 3);
  *   detailY.position(10, height + 5);
  *   detailY.style('width', '80px');
+ *   describe(
+ *     'a white sphere with low detail on the y-axis, including a slider to adjust detailY'
+ *   );
  * }
  *
  * function draw() {
@@ -287,10 +286,6 @@ p5.prototype.box = function(width, height, depth, detailX, detailY) {
  *   rotateY(millis() / 1000);
  *   sphere(40, 16, detailY.value());
  * }
- *
- * describe(
- *   'a white sphere with low detail on the y-axis, including a slider to adjust detailY'
- * );
  * </code>
  * </div>
  */
@@ -455,6 +450,7 @@ const _truncatedCone = function(
  * // with radius 20 and height 50
  * function setup() {
  *   createCanvas(100, 100, WEBGL);
+ *   describe('a rotating white cylinder');
  * }
  *
  * function draw() {
@@ -463,8 +459,6 @@ const _truncatedCone = function(
  *   rotateZ(frameCount * 0.01);
  *   cylinder(20, 50);
  * }
- *
- * describe('a rotating white cylinder');
  * </code>
  * </div>
  *
@@ -478,6 +472,9 @@ const _truncatedCone = function(
  *   detailX = createSlider(3, 24, 3);
  *   detailX.position(10, height + 5);
  *   detailX.style('width', '80px');
+ *   describe(
+ *     'a rotating white cylinder with limited X detail, with a slider that adjusts detailX'
+ *   );
  * }
  *
  * function draw() {
@@ -485,10 +482,6 @@ const _truncatedCone = function(
  *   rotateY(millis() / 1000);
  *   cylinder(20, 75, detailX.value(), 1);
  * }
- *
- * describe(
- *   'a rotating white cylinder with limited X detail, with a slider that adjusts detailX'
- * );
  * </code>
  * </div>
  *
@@ -502,6 +495,9 @@ const _truncatedCone = function(
  *   detailY = createSlider(1, 16, 1);
  *   detailY.position(10, height + 5);
  *   detailY.style('width', '80px');
+ *   describe(
+ *     'a rotating white cylinder with limited Y detail, with a slider that adjusts detailY'
+ *   );
  * }
  *
  * function draw() {
@@ -509,10 +505,6 @@ const _truncatedCone = function(
  *   rotateY(millis() / 1000);
  *   cylinder(20, 75, 16, detailY.value());
  * }
- *
- * describe(
- *   'a rotating white cylinder with limited Y detail, with a slider that adjusts detailY'
- * );
  * </code>
  * </div>
  */
@@ -600,6 +592,7 @@ p5.prototype.cylinder = function(
  * // with radius 40 and height 70
  * function setup() {
  *   createCanvas(100, 100, WEBGL);
+ *   describe('a rotating white cone');
  * }
  *
  * function draw() {
@@ -608,8 +601,6 @@ p5.prototype.cylinder = function(
  *   rotateZ(frameCount * 0.01);
  *   cone(40, 70);
  * }
- *
- * describe('a rotating white cone');
  * </code>
  * </div>
  *
@@ -623,6 +614,9 @@ p5.prototype.cylinder = function(
  *   detailX = createSlider(3, 16, 3);
  *   detailX.position(10, height + 5);
  *   detailX.style('width', '80px');
+ *   describe(
+ *     'a rotating white cone with limited X detail, with a slider that adjusts detailX'
+ *   );
  * }
  *
  * function draw() {
@@ -630,10 +624,6 @@ p5.prototype.cylinder = function(
  *   rotateY(millis() / 1000);
  *   cone(30, 65, detailX.value(), 16);
  * }
- *
- * describe(
- *   'a rotating white cone with limited X detail, with a slider that adjusts detailX'
- * );
  * </code>
  * </div>
  *
@@ -647,6 +637,9 @@ p5.prototype.cylinder = function(
  *   detailY = createSlider(3, 16, 3);
  *   detailY.position(10, height + 5);
  *   detailY.style('width', '80px');
+ *   describe(
+ *     'a rotating white cone with limited Y detail, with a slider that adjusts detailY'
+ *   );
  * }
  *
  * function draw() {
@@ -654,10 +647,6 @@ p5.prototype.cylinder = function(
  *   rotateY(millis() / 1000);
  *   cone(30, 65, 16, detailY.value());
  * }
- *
- * describe(
- *   'a rotating white cone with limited Y detail, with a slider that adjusts detailY'
- * );
  * </code>
  * </div>
  */
@@ -726,14 +715,13 @@ p5.prototype.cone = function(radius, height, detailX, detailY, cap) {
  * // with radius 30, 40 and 40.
  * function setup() {
  *   createCanvas(100, 100, WEBGL);
+ *   describe('a white 3d ellipsoid');
  * }
  *
  * function draw() {
  *   background(205, 105, 94);
  *   ellipsoid(30, 40, 40);
  * }
- *
- * describe('a white 3d ellipsoid');
  * </code>
  * </div>
  *
@@ -747,6 +735,9 @@ p5.prototype.cone = function(radius, height, detailX, detailY, cap) {
  *   detailX = createSlider(2, 24, 12);
  *   detailX.position(10, height + 5);
  *   detailX.style('width', '80px');
+ *   describe(
+ *     'a rotating white ellipsoid with limited X detail, with a slider that adjusts detailX'
+ *   );
  * }
  *
  * function draw() {
@@ -754,10 +745,6 @@ p5.prototype.cone = function(radius, height, detailX, detailY, cap) {
  *   rotateY(millis() / 1000);
  *   ellipsoid(30, 40, 40, detailX.value(), 8);
  * }
- *
- * describe(
- *   'a rotating white ellipsoid with limited X detail, with a slider that adjusts detailX'
- * );
  * </code>
  * </div>
  *
@@ -771,6 +758,9 @@ p5.prototype.cone = function(radius, height, detailX, detailY, cap) {
  *   detailY = createSlider(2, 24, 6);
  *   detailY.position(10, height + 5);
  *   detailY.style('width', '80px');
+ *   describe(
+ *     'a rotating white ellipsoid with limited Y detail, with a slider that adjusts detailY'
+ *   );
  * }
  *
  * function draw() {
@@ -778,10 +768,6 @@ p5.prototype.cone = function(radius, height, detailX, detailY, cap) {
  *   rotateY(millis() / 1000);
  *   ellipsoid(30, 40, 40, 12, detailY.value());
  * }
- *
- * describe(
- *   'a rotating white ellipsoid with limited Y detail, with a slider that adjusts detailY'
- * );
  * </code>
  * </div>
  */
@@ -870,6 +856,7 @@ p5.prototype.ellipsoid = function(radiusX, radiusY, radiusZ, detailX, detailY) {
  * // with ring radius 30 and tube radius 15
  * function setup() {
  *   createCanvas(100, 100, WEBGL);
+ *   describe('a rotating white torus');
  * }
  *
  * function draw() {
@@ -878,8 +865,6 @@ p5.prototype.ellipsoid = function(radiusX, radiusY, radiusZ, detailX, detailY) {
  *   rotateY(frameCount * 0.01);
  *   torus(30, 15);
  * }
- *
- * describe('a rotating white torus');
  * </code>
  * </div>
  *
@@ -893,6 +878,9 @@ p5.prototype.ellipsoid = function(radiusX, radiusY, radiusZ, detailX, detailY) {
  *   detailX = createSlider(3, 24, 3);
  *   detailX.position(10, height + 5);
  *   detailX.style('width', '80px');
+ *   describe(
+ *     'a rotating white torus with limited X detail, with a slider that adjusts detailX'
+ *   );
  * }
  *
  * function draw() {
@@ -900,10 +888,6 @@ p5.prototype.ellipsoid = function(radiusX, radiusY, radiusZ, detailX, detailY) {
  *   rotateY(millis() / 1000);
  *   torus(30, 15, detailX.value(), 12);
  * }
- *
- * describe(
- *   'a rotating white torus with limited X detail, with a slider that adjusts detailX'
- * );
  * </code>
  * </div>
  *
@@ -917,6 +901,9 @@ p5.prototype.ellipsoid = function(radiusX, radiusY, radiusZ, detailX, detailY) {
  *   detailY = createSlider(3, 16, 3);
  *   detailY.position(10, height + 5);
  *   detailY.style('width', '80px');
+ *   describe(
+ *     'a rotating white torus with limited Y detail, with a slider that adjusts detailY'
+ *   );
  * }
  *
  * function draw() {
@@ -924,10 +911,6 @@ p5.prototype.ellipsoid = function(radiusX, radiusY, radiusZ, detailX, detailY) {
  *   rotateY(millis() / 1000);
  *   torus(30, 15, 16, detailY.value());
  * }
- *
- * describe(
- *   'a rotating white torus with limited Y detail, with a slider that adjusts detailY'
- * );
  * </code>
  * </div>
  */

--- a/src/webgl/interaction.js
+++ b/src/webgl/interaction.js
@@ -37,6 +37,7 @@ import * as constants from '../core/constants';
  *   rotateY(0.5);
  *   box(30, 50);
  * }
+ * describe('Camera orbits around a box when mouse is hold-clicked & then moved.');
  * </code>
  * </div>
  *
@@ -178,6 +179,9 @@ p5.prototype.orbitControl = function(sensitivityX, sensitivityY, sensitivityZ) {
  *     noDebugMode();
  *   }
  * }
+ * describe(
+ *   'a 3D box is centered on a grid in a 3D sketch. an icon indicates the direction of each axis: a red line points +X, a green line +Y, and a blue line +Z. the grid and icon disappear when the spacebar is pressed.'
+ * );
  * </code>
  * </div>
  * @alt
@@ -201,6 +205,8 @@ p5.prototype.orbitControl = function(sensitivityX, sensitivityY, sensitivityZ) {
  *   orbitControl();
  *   box(15, 30);
  * }
+ *
+ * describe('a 3D box is centered on a grid in a 3D sketch.');
  * </code>
  * </div>
  * @alt
@@ -221,6 +227,10 @@ p5.prototype.orbitControl = function(sensitivityX, sensitivityY, sensitivityZ) {
  *   orbitControl();
  *   box(15, 30);
  * }
+ *
+ * describe(
+ *   'a 3D box is centered in a 3D sketch. an icon indicates the direction of each axis: a red line points +X, a green line +Y, and a blue line +Z.'
+ * );
  * </code>
  * </div>
  * @alt
@@ -243,6 +253,8 @@ p5.prototype.orbitControl = function(sensitivityX, sensitivityY, sensitivityZ) {
  *   orbitControl();
  *   box(15, 30);
  * }
+ *
+ * describe('a 3D box is centered on a grid in a 3D sketch');
  * </code>
  * </div>
  * @alt
@@ -267,6 +279,10 @@ p5.prototype.orbitControl = function(sensitivityX, sensitivityY, sensitivityZ) {
  *   stroke(255, 0, 150);
  *   strokeWeight(0.8);
  * }
+ *
+ * describe(
+ *   'a 3D box is centered on a grid in a 3D sketch. an icon indicates the direction of each axis: a red line points +X, a green line +Y, and a blue line +Z.'
+ * );
  * </code>
  * </div>
  * @alt
@@ -372,6 +388,10 @@ p5.prototype.debugMode = function(...args) {
  *     noDebugMode();
  *   }
  * }
+ *
+ * describe(
+ *   'a 3D box is centered on a grid in a 3D sketch. an icon indicates the direction of each axis: a red line points +X, a green line +Y, and a blue line +Z. the grid and icon disappear when the spacebar is pressed.'
+ * );
  * </code>
  * </div>
  * @alt

--- a/src/webgl/interaction.js
+++ b/src/webgl/interaction.js
@@ -30,6 +30,9 @@ import * as constants from '../core/constants';
  * function setup() {
  *   createCanvas(100, 100, WEBGL);
  *   normalMaterial();
+ *   describe(
+ *     'Camera orbits around a box when mouse is hold-clicked & then moved.'
+ *   );
  * }
  * function draw() {
  *   background(200);
@@ -37,7 +40,6 @@ import * as constants from '../core/constants';
  *   rotateY(0.5);
  *   box(30, 50);
  * }
- * describe('Camera orbits around a box when mouse is hold-clicked & then moved.');
  * </code>
  * </div>
  *
@@ -168,6 +170,9 @@ p5.prototype.orbitControl = function(sensitivityX, sensitivityY, sensitivityZ) {
  *   camera(0, -30, 100, 0, 0, 0, 0, 1, 0);
  *   normalMaterial();
  *   debugMode();
+ *   describe(
+ *     'a 3D box is centered on a grid in a 3D sketch. an icon indicates the direction of each axis: a red line points +X, a green line +Y, and a blue line +Z. the grid and icon disappear when the spacebar is pressed.'
+ *   );
  * }
  *
  * function draw() {
@@ -179,9 +184,6 @@ p5.prototype.orbitControl = function(sensitivityX, sensitivityY, sensitivityZ) {
  *     noDebugMode();
  *   }
  * }
- * describe(
- *   'a 3D box is centered on a grid in a 3D sketch. an icon indicates the direction of each axis: a red line points +X, a green line +Y, and a blue line +Z. the grid and icon disappear when the spacebar is pressed.'
- * );
  * </code>
  * </div>
  * @alt
@@ -198,6 +200,7 @@ p5.prototype.orbitControl = function(sensitivityX, sensitivityY, sensitivityZ) {
  *   camera(0, -30, 100, 0, 0, 0, 0, 1, 0);
  *   normalMaterial();
  *   debugMode(GRID);
+ *   describe('a 3D box is centered on a grid in a 3D sketch.');
  * }
  *
  * function draw() {
@@ -205,8 +208,6 @@ p5.prototype.orbitControl = function(sensitivityX, sensitivityY, sensitivityZ) {
  *   orbitControl();
  *   box(15, 30);
  * }
- *
- * describe('a 3D box is centered on a grid in a 3D sketch.');
  * </code>
  * </div>
  * @alt
@@ -220,6 +221,9 @@ p5.prototype.orbitControl = function(sensitivityX, sensitivityY, sensitivityZ) {
  *   camera(0, -30, 100, 0, 0, 0, 0, 1, 0);
  *   normalMaterial();
  *   debugMode(AXES);
+ *   describe(
+ *     'a 3D box is centered in a 3D sketch. an icon indicates the direction of each axis: a red line points +X, a green line +Y, and a blue line +Z.'
+ *   );
  * }
  *
  * function draw() {
@@ -227,10 +231,6 @@ p5.prototype.orbitControl = function(sensitivityX, sensitivityY, sensitivityZ) {
  *   orbitControl();
  *   box(15, 30);
  * }
- *
- * describe(
- *   'a 3D box is centered in a 3D sketch. an icon indicates the direction of each axis: a red line points +X, a green line +Y, and a blue line +Z.'
- * );
  * </code>
  * </div>
  * @alt
@@ -246,6 +246,7 @@ p5.prototype.orbitControl = function(sensitivityX, sensitivityY, sensitivityZ) {
  *   camera(0, -30, 100, 0, 0, 0, 0, 1, 0);
  *   normalMaterial();
  *   debugMode(GRID, 100, 10, 0, 0, 0);
+ *   describe('a 3D box is centered on a grid in a 3D sketch');
  * }
  *
  * function draw() {
@@ -253,8 +254,6 @@ p5.prototype.orbitControl = function(sensitivityX, sensitivityY, sensitivityZ) {
  *   orbitControl();
  *   box(15, 30);
  * }
- *
- * describe('a 3D box is centered on a grid in a 3D sketch');
  * </code>
  * </div>
  * @alt
@@ -268,6 +267,9 @@ p5.prototype.orbitControl = function(sensitivityX, sensitivityY, sensitivityZ) {
  *   camera(0, -30, 100, 0, 0, 0, 0, 1, 0);
  *   normalMaterial();
  *   debugMode(100, 10, 0, 0, 0, 20, 0, -40, 0);
+ *   describe(
+ *     'a 3D box is centered on a grid in a 3D sketch. an icon indicates the direction of each axis: a red line points +X, a green line +Y, and a blue line +Z.'
+ *   );
  * }
  *
  * function draw() {
@@ -279,10 +281,6 @@ p5.prototype.orbitControl = function(sensitivityX, sensitivityY, sensitivityZ) {
  *   stroke(255, 0, 150);
  *   strokeWeight(0.8);
  * }
- *
- * describe(
- *   'a 3D box is centered on a grid in a 3D sketch. an icon indicates the direction of each axis: a red line points +X, a green line +Y, and a blue line +Z.'
- * );
  * </code>
  * </div>
  * @alt
@@ -377,6 +375,9 @@ p5.prototype.debugMode = function(...args) {
  *   camera(0, -30, 100, 0, 0, 0, 0, 1, 0);
  *   normalMaterial();
  *   debugMode();
+ *   describe(
+ *     'a 3D box is centered on a grid in a 3D sketch. an icon indicates the direction of each axis: a red line points +X, a green line +Y, and a blue line +Z. the grid and icon disappear when the spacebar is pressed.'
+ *   );
  * }
  *
  * function draw() {
@@ -388,10 +389,6 @@ p5.prototype.debugMode = function(...args) {
  *     noDebugMode();
  *   }
  * }
- *
- * describe(
- *   'a 3D box is centered on a grid in a 3D sketch. an icon indicates the direction of each axis: a red line points +X, a green line +Y, and a blue line +Z. the grid and icon disappear when the spacebar is pressed.'
- * );
  * </code>
  * </div>
  * @alt

--- a/src/webgl/light.js
+++ b/src/webgl/light.js
@@ -37,6 +37,7 @@ import * as constants from '../core/constants';
  * function setup() {
  *   createCanvas(100, 100, WEBGL);
  *   noStroke();
+ *   describe('sphere with coral color under black light');
  * }
  * function draw() {
  *   background(100);
@@ -44,7 +45,6 @@ import * as constants from '../core/constants';
  *   ambientMaterial(255, 127, 80); // coral material
  *   sphere(40);
  * }
- * describe('sphere with coral color under black light');
  * </code>
  * </div>
  * @alt
@@ -56,6 +56,7 @@ import * as constants from '../core/constants';
  * function setup() {
  *   createCanvas(100, 100, WEBGL);
  *   noStroke();
+ *   describe('sphere with coral color under white light');
  * }
  * function draw() {
  *   background(100);
@@ -63,7 +64,6 @@ import * as constants from '../core/constants';
  *   ambientMaterial(255, 127, 80); // coral material
  *   sphere(40);
  * }
- * describe('sphere with coral color under white light');
  * </code>
  * </div>
  * @alt
@@ -146,6 +146,9 @@ p5.prototype.ambientLight = function(v1, v2, v3, a) {
  * function setup() {
  *   createCanvas(100, 100, WEBGL);
  *   noStroke();
+ *   describe(
+ *     'Sphere with specular highlight. Clicking the mouse toggles the specular highlight color between red and the default white.'
+ *   );
  * }
  *
  * function draw() {
@@ -174,10 +177,6 @@ p5.prototype.ambientLight = function(v1, v2, v3, a) {
  * function mouseClicked() {
  *   setRedSpecularColor = !setRedSpecularColor;
  * }
- *
- * describe(
- *   'Sphere with specular highlight. Clicking the mouse toggles the specular highlight color between red and the default white.'
- * );
  * </code>
  * </div>
  *
@@ -262,6 +261,9 @@ p5.prototype.specularColor = function(v1, v2, v3) {
  * <code>
  * function setup() {
  *   createCanvas(100, 100, WEBGL);
+ *   describe(
+ *     'scene with sphere and directional light. The direction of the light is controlled with the mouse position.'
+ *   );
  * }
  * function draw() {
  *   background(0);
@@ -272,9 +274,6 @@ p5.prototype.specularColor = function(v1, v2, v3) {
  *   noStroke();
  *   sphere(40);
  * }
- * describe(
- *   'scene with sphere and directional light. The direction of the light is controlled with the mouse position.'
- * );
  * </code>
  * </div>
  *
@@ -383,6 +382,9 @@ p5.prototype.directionalLight = function(v1, v2, v3, x, y, z) {
  * <code>
  * function setup() {
  *   createCanvas(100, 100, WEBGL);
+ *   describe(
+ *     'scene with sphere and point light. The position of the light is controlled with the mouse position.'
+ *   );
  * }
  * function draw() {
  *   background(0);
@@ -400,9 +402,6 @@ p5.prototype.directionalLight = function(v1, v2, v3, x, y, z) {
  *   noStroke();
  *   sphere(40);
  * }
- * describe(
- *   'scene with sphere and point light. The position of the light is controlled with the mouse position.'
- * );
  * </code>
  * </div>
  *
@@ -493,6 +492,7 @@ p5.prototype.pointLight = function(v1, v2, v3, x, y, z) {
  * <code>
  * function setup() {
  *   createCanvas(100, 100, WEBGL);
+ *   describe('the light is partially ambient and partially directional');
  * }
  * function draw() {
  *   background(0);
@@ -502,7 +502,6 @@ p5.prototype.pointLight = function(v1, v2, v3, x, y, z) {
  *   rotateZ(millis() / 1000);
  *   box();
  * }
- * describe('the light is partially ambient and partially directional');
  * </code>
  * </div>
  *
@@ -547,6 +546,9 @@ p5.prototype.lights = function() {
  * function setup() {
  *   createCanvas(100, 100, WEBGL);
  *   noStroke();
+ *   describe(
+ *     'Two spheres with different falloff values show different intensity of light'
+ *   );
  * }
  * function draw() {
  *   ortho();
@@ -570,9 +572,6 @@ p5.prototype.lights = function() {
  *   sphere(20);
  *   pop();
  * }
- * describe(
- *   'Two spheres with different falloff values show different intensity of light'
- * );
  * </code>
  * </div>
  *
@@ -670,6 +669,9 @@ p5.prototype.lightFalloff = function(
  * <code>
  * function setup() {
  *   createCanvas(100, 100, WEBGL);
+ *   describe(
+ *     'scene with sphere and spot light. The position of the light is controlled with the mouse position.'
+ *   );
  * }
  * function draw() {
  *   background(0);
@@ -688,9 +690,6 @@ p5.prototype.lightFalloff = function(
  *   noStroke();
  *   sphere(40);
  * }
- * describe(
- *   'scene with sphere and spot light. The position of the light is controlled with the mouse position.'
- * );
  * </code>
  * </div>
  *
@@ -1004,6 +1003,9 @@ p5.prototype.spotLight = function(
  * <code>
  * function setup() {
  *   createCanvas(100, 100, WEBGL);
+ *   describe(
+ *     'Three white spheres. Each appears as a different color due to lighting.'
+ *   );
  * }
  * function draw() {
  *   background(200);
@@ -1024,9 +1026,6 @@ p5.prototype.spotLight = function(
  *   ambientMaterial(255);
  *   sphere(13);
  * }
- * describe(
- *   'Three white spheres. Each appears as a different color due to lighting.'
- * );
  * </code>
  * </div>
  *

--- a/src/webgl/light.js
+++ b/src/webgl/light.js
@@ -44,6 +44,7 @@ import * as constants from '../core/constants';
  *   ambientMaterial(255, 127, 80); // coral material
  *   sphere(40);
  * }
+ * describe('sphere with coral color under black light');
  * </code>
  * </div>
  * @alt
@@ -62,6 +63,7 @@ import * as constants from '../core/constants';
  *   ambientMaterial(255, 127, 80); // coral material
  *   sphere(40);
  * }
+ * describe('sphere with coral color under white light');
  * </code>
  * </div>
  * @alt
@@ -172,6 +174,10 @@ p5.prototype.ambientLight = function(v1, v2, v3, a) {
  * function mouseClicked() {
  *   setRedSpecularColor = !setRedSpecularColor;
  * }
+ *
+ * describe(
+ *   'Sphere with specular highlight. Clicking the mouse toggles the specular highlight color between red and the default white.'
+ * );
  * </code>
  * </div>
  *
@@ -266,6 +272,9 @@ p5.prototype.specularColor = function(v1, v2, v3) {
  *   noStroke();
  *   sphere(40);
  * }
+ * describe(
+ *   'scene with sphere and directional light. The direction of the light is controlled with the mouse position.'
+ * );
  * </code>
  * </div>
  *
@@ -391,6 +400,9 @@ p5.prototype.directionalLight = function(v1, v2, v3, x, y, z) {
  *   noStroke();
  *   sphere(40);
  * }
+ * describe(
+ *   'scene with sphere and point light. The position of the light is controlled with the mouse position.'
+ * );
  * </code>
  * </div>
  *
@@ -490,6 +502,7 @@ p5.prototype.pointLight = function(v1, v2, v3, x, y, z) {
  *   rotateZ(millis() / 1000);
  *   box();
  * }
+ * describe('the light is partially ambient and partially directional');
  * </code>
  * </div>
  *
@@ -557,6 +570,9 @@ p5.prototype.lights = function() {
  *   sphere(20);
  *   pop();
  * }
+ * describe(
+ *   'Two spheres with different falloff values show different intensity of light'
+ * );
  * </code>
  * </div>
  *
@@ -672,6 +688,9 @@ p5.prototype.lightFalloff = function(
  *   noStroke();
  *   sphere(40);
  * }
+ * describe(
+ *   'scene with sphere and spot light. The position of the light is controlled with the mouse position.'
+ * );
  * </code>
  * </div>
  *
@@ -1005,6 +1024,9 @@ p5.prototype.spotLight = function(
  *   ambientMaterial(255);
  *   sphere(13);
  * }
+ * describe(
+ *   'Three white spheres. Each appears as a different color due to lighting.'
+ * );
  * </code>
  * </div>
  *

--- a/src/webgl/loading.js
+++ b/src/webgl/loading.js
@@ -50,6 +50,7 @@ import './p5.Geometry';
  *
  * function setup() {
  *   createCanvas(100, 100, WEBGL);
+ *   describe('Vertically rotating 3-d octahedron.');
  * }
  *
  * function draw() {
@@ -58,8 +59,6 @@ import './p5.Geometry';
  *   rotateY(frameCount * 0.01);
  *   model(octahedron);
  * }
- *
- * describe('Vertically rotating 3-d octahedron.');
  * </code>
  * </div>
  *
@@ -79,6 +78,7 @@ import './p5.Geometry';
  *
  * function setup() {
  *   createCanvas(100, 100, WEBGL);
+ *   describe('Vertically rotating 3-d teapot with red, green and blue gradient.');
  * }
  *
  * function draw() {
@@ -89,8 +89,6 @@ import './p5.Geometry';
  *   normalMaterial(); // For effect
  *   model(teapot);
  * }
- *
- * describe('Vertically rotating 3-d teapot with red, green and blue gradient.');
  * </code>
  * </div>
  *
@@ -606,6 +604,7 @@ function parseASCIISTL(model, lines) {
  *
  * function setup() {
  *   createCanvas(100, 100, WEBGL);
+ *   describe('Vertically rotating 3-d octahedron.');
  * }
  *
  * function draw() {
@@ -614,8 +613,6 @@ function parseASCIISTL(model, lines) {
  *   rotateY(frameCount * 0.01);
  *   model(octahedron);
  * }
- *
- * describe('Vertically rotating 3-d octahedron.');
  * </code>
  * </div>
  *

--- a/src/webgl/loading.js
+++ b/src/webgl/loading.js
@@ -58,6 +58,8 @@ import './p5.Geometry';
  *   rotateY(frameCount * 0.01);
  *   model(octahedron);
  * }
+ *
+ * describe('Vertically rotating 3-d octahedron.');
  * </code>
  * </div>
  *
@@ -87,6 +89,8 @@ import './p5.Geometry';
  *   normalMaterial(); // For effect
  *   model(teapot);
  * }
+ *
+ * describe('Vertically rotating 3-d teapot with red, green and blue gradient.');
  * </code>
  * </div>
  *
@@ -610,6 +614,8 @@ function parseASCIISTL(model, lines) {
  *   rotateY(frameCount * 0.01);
  *   model(octahedron);
  * }
+ *
+ * describe('Vertically rotating 3-d octahedron.');
  * </code>
  * </div>
  *

--- a/src/webgl/material.js
+++ b/src/webgl/material.js
@@ -51,6 +51,8 @@ import './p5.Texture';
  *   mandel.setUniform('r', 1.5 * exp(-6.5 * (1 + sin(millis() / 2000))));
  *   quad(-1, -1, 1, -1, 1, 1, -1, 1);
  * }
+ *
+ * describe('zooming Mandelbrot set. a colorful, infinitely detailed fractal.');
  * </code>
  * </div>
  *
@@ -169,6 +171,8 @@ p5.prototype.loadShader = function(
  *   mandel.setUniform('r', 1.5 * exp(-6.5 * (1 + sin(millis() / 2000))));
  *   quad(-1, -1, 1, -1, 1, 1, -1, 1);
  * }
+ *
+ * describe('zooming Mandelbrot set. a colorful, infinitely detailed fractal.');
  * </code>
  * </div>
  *
@@ -253,6 +257,10 @@ p5.prototype.createShader = function(vertSrc, fragSrc) {
  * function mouseClicked() {
  *   showRedGreen = !showRedGreen;
  * }
+ *
+ * describe(
+ *   'canvas toggles between a circular gradient of orange and blue vertically. and a circular gradient of red and green moving horizontally when mouse is clicked/pressed.'
+ * );
  * </code>
  * </div>
  *
@@ -354,6 +362,10 @@ p5.prototype.shader = function(s) {
  *     box(width / 4);
  *     pop();
  * }
+ *
+ * describe(
+ *   'Two rotating cubes. The left one is painted using a custom (user-defined) shader, while the right one is painted using the default fill shader.'
+ * );
  * </code>
  * </div>
  * @alt
@@ -403,6 +415,8 @@ p5.prototype.resetShader = function() {
  *   texture(img);
  *   box(width / 2);
  * }
+ *
+ * describe('spinning cube with a texture from an image');
  * </code>
  * </div>
  * @alt
@@ -429,6 +443,8 @@ p5.prototype.resetShader = function() {
  *   noStroke();
  *   plane(50);
  * }
+ *
+ * describe('plane with a texture from an image created by createGraphics()');
  * </code>
  * </div>
  * @alt
@@ -456,6 +472,8 @@ p5.prototype.resetShader = function() {
  * function mousePressed() {
  *   vid.loop();
  * }
+ *
+ * describe('rectangle with video as texture');
  * </code>
  * </div>
  *
@@ -486,6 +504,8 @@ p5.prototype.resetShader = function() {
  *   vertex(-40, 40, 0, 1);
  *   endShape();
  * }
+ *
+ * describe('quad with a texture, mapped using normalized coordinates');
  * </code>
  * </div>
  * @alt
@@ -541,6 +561,8 @@ p5.prototype.texture = function(tex) {
  *   vertex(-50, 50, 0, 1);
  *   endShape();
  * }
+ *
+ * describe('quad with a texture, mapped using normalized coordinates');
  * </code>
  * </div>
  * @alt
@@ -569,6 +591,8 @@ p5.prototype.texture = function(tex) {
  *   vertex(-50, 50, 0, img.height);
  *   endShape();
  * }
+ *
+ * describe('quad with a texture, mapped using image coordinates');
  * </code>
  * </div>
  * @alt
@@ -640,6 +664,8 @@ p5.prototype.textureMode = function(mode) {
  *   vertex(-1, -1, 0, 0, 0);
  *   endShape();
  * }
+ *
+ * describe('an image of the rocky mountains repeated in mirrored tiles');
  * </code>
  * </div>
  *
@@ -682,6 +708,8 @@ p5.prototype.textureWrap = function(wrapX, wrapY = wrapX) {
  *   normalMaterial();
  *   sphere(40);
  * }
+ *
+ * describe('Sphere with normal material');
  * </code>
  * </div>
  * @alt
@@ -739,6 +767,7 @@ p5.prototype.normalMaterial = function(...args) {
  *   ambientMaterial(70, 130, 230);
  *   sphere(40);
  * }
+ * describe('sphere reflecting red, blue, and green light');
  * </code>
  * </div>
  * @alt
@@ -758,6 +787,7 @@ p5.prototype.normalMaterial = function(...args) {
  *   ambientMaterial(255); // white material
  *   box(30);
  * }
+ * describe('box reflecting only red and blue light');
  * </code>
  * </div>
  * @alt
@@ -777,6 +807,7 @@ p5.prototype.normalMaterial = function(...args) {
  *   ambientMaterial(255, 0, 255); // magenta material
  *   box(30);
  * }
+ * describe('box reflecting no light');
  * </code>
  * </div>
  * @alt
@@ -849,6 +880,7 @@ p5.prototype.ambientMaterial = function(v1, v2, v3) {
  *   emissiveMaterial(130, 230, 0);
  *   sphere(40);
  * }
+ * describe('sphere with green emissive material');
  * </code>
  * </div>
  *
@@ -932,6 +964,8 @@ p5.prototype.emissiveMaterial = function(v1, v2, v3, a) {
  *   shininess(50);
  *   torus(30, 10, 64, 64);
  * }
+ *
+ * describe('torus with specular material');
  * </code>
  * </div>
  * @alt
@@ -1002,6 +1036,7 @@ p5.prototype.specularMaterial = function(v1, v2, v3, alpha) {
  *   shininess(20);
  *   sphere(20);
  * }
+ * describe('two spheres, one more shiny than the other');
  * </code>
  * </div>
  * @alt

--- a/src/webgl/material.js
+++ b/src/webgl/material.js
@@ -45,14 +45,13 @@ import './p5.Texture';
  *   shader(mandel);
  *   noStroke();
  *   mandel.setUniform('p', [-0.74364388703, 0.13182590421]);
+ *   describe('zooming Mandelbrot set. a colorful, infinitely detailed fractal.');
  * }
  *
  * function draw() {
  *   mandel.setUniform('r', 1.5 * exp(-6.5 * (1 + sin(millis() / 2000))));
  *   quad(-1, -1, 1, -1, 1, 1, -1, 1);
  * }
- *
- * describe('zooming Mandelbrot set. a colorful, infinitely detailed fractal.');
  * </code>
  * </div>
  *
@@ -164,6 +163,7 @@ p5.prototype.loadShader = function(
  *
  *   // 'p' is the center point of the Mandelbrot image
  *   mandel.setUniform('p', [-0.74364388703, 0.13182590421]);
+ *   describe('zooming Mandelbrot set. a colorful, infinitely detailed fractal.');
  * }
  *
  * function draw() {
@@ -171,8 +171,6 @@ p5.prototype.loadShader = function(
  *   mandel.setUniform('r', 1.5 * exp(-6.5 * (1 + sin(millis() / 2000))));
  *   quad(-1, -1, 1, -1, 1, 1, -1, 1);
  * }
- *
- * describe('zooming Mandelbrot set. a colorful, infinitely detailed fractal.');
  * </code>
  * </div>
  *
@@ -237,6 +235,10 @@ p5.prototype.createShader = function(vertSrc, fragSrc) {
  *   orangeBlue.setUniform('colorBackground', [0.226, 0.0, 0.615]);
  *
  *   noStroke();
+ *
+ *   describe(
+ *     'canvas toggles between a circular gradient of orange and blue vertically. and a circular gradient of red and green moving horizontally when mouse is clicked/pressed.'
+ *   );
  * }
  *
  * function draw() {
@@ -257,10 +259,6 @@ p5.prototype.createShader = function(vertSrc, fragSrc) {
  * function mouseClicked() {
  *   showRedGreen = !showRedGreen;
  * }
- *
- * describe(
- *   'canvas toggles between a circular gradient of orange and blue vertically. and a circular gradient of red and green moving horizontally when mouse is clicked/pressed.'
- * );
  * </code>
  * </div>
  *
@@ -334,6 +332,10 @@ p5.prototype.shader = function(s) {
  *
  *   // Create our shader
  *   shaderProgram = createShader(vertSrc, fragSrc);
+ *
+ *   describe(
+ *     'Two rotating cubes. The left one is painted using a custom (user-defined) shader, while the right one is painted using the default fill shader.'
+ *   );
  * }
  *
  * // prettier-ignore
@@ -362,10 +364,6 @@ p5.prototype.shader = function(s) {
  *     box(width / 4);
  *     pop();
  * }
- *
- * describe(
- *   'Two rotating cubes. The left one is painted using a custom (user-defined) shader, while the right one is painted using the default fill shader.'
- * );
  * </code>
  * </div>
  * @alt
@@ -404,6 +402,7 @@ p5.prototype.resetShader = function() {
  *
  * function setup() {
  *   createCanvas(100, 100, WEBGL);
+ *   describe('spinning cube with a texture from an image');
  * }
  *
  * function draw() {
@@ -415,8 +414,6 @@ p5.prototype.resetShader = function() {
  *   texture(img);
  *   box(width / 2);
  * }
- *
- * describe('spinning cube with a texture from an image');
  * </code>
  * </div>
  * @alt
@@ -431,6 +428,7 @@ p5.prototype.resetShader = function() {
  *   createCanvas(100, 100, WEBGL);
  *   pg = createGraphics(200, 200);
  *   pg.textSize(75);
+ *   describe('plane with a texture from an image created by createGraphics()');
  * }
  *
  * function draw() {
@@ -443,8 +441,6 @@ p5.prototype.resetShader = function() {
  *   noStroke();
  *   plane(50);
  * }
- *
- * describe('plane with a texture from an image created by createGraphics()');
  * </code>
  * </div>
  * @alt
@@ -460,6 +456,7 @@ p5.prototype.resetShader = function() {
  * }
  * function setup() {
  *   createCanvas(100, 100, WEBGL);
+ *   describe('rectangle with video as texture');
  * }
  *
  * function draw() {
@@ -472,8 +469,6 @@ p5.prototype.resetShader = function() {
  * function mousePressed() {
  *   vid.loop();
  * }
- *
- * describe('rectangle with video as texture');
  * </code>
  * </div>
  *
@@ -491,6 +486,7 @@ p5.prototype.resetShader = function() {
  *
  * function setup() {
  *   createCanvas(100, 100, WEBGL);
+ *   describe('quad with a texture, mapped using normalized coordinates');
  * }
  *
  * function draw() {
@@ -504,8 +500,6 @@ p5.prototype.resetShader = function() {
  *   vertex(-40, 40, 0, 1);
  *   endShape();
  * }
- *
- * describe('quad with a texture, mapped using normalized coordinates');
  * </code>
  * </div>
  * @alt
@@ -549,6 +543,7 @@ p5.prototype.texture = function(tex) {
  *
  * function setup() {
  *   createCanvas(100, 100, WEBGL);
+ *   describe('quad with a texture, mapped using normalized coordinates');
  * }
  *
  * function draw() {
@@ -561,8 +556,6 @@ p5.prototype.texture = function(tex) {
  *   vertex(-50, 50, 0, 1);
  *   endShape();
  * }
- *
- * describe('quad with a texture, mapped using normalized coordinates');
  * </code>
  * </div>
  * @alt
@@ -579,6 +572,7 @@ p5.prototype.texture = function(tex) {
  *
  * function setup() {
  *   createCanvas(100, 100, WEBGL);
+ *   describe('quad with a texture, mapped using image coordinates');
  * }
  *
  * function draw() {
@@ -591,8 +585,6 @@ p5.prototype.texture = function(tex) {
  *   vertex(-50, 50, 0, img.height);
  *   endShape();
  * }
- *
- * describe('quad with a texture, mapped using image coordinates');
  * </code>
  * </div>
  * @alt
@@ -639,6 +631,7 @@ p5.prototype.textureMode = function(mode) {
  * function setup() {
  *   createCanvas(100, 100, WEBGL);
  *   textureWrap(MIRROR);
+ *   describe('an image of the rocky mountains repeated in mirrored tiles');
  * }
  *
  * function draw() {
@@ -664,8 +657,6 @@ p5.prototype.textureMode = function(mode) {
  *   vertex(-1, -1, 0, 0, 0);
  *   endShape();
  * }
- *
- * describe('an image of the rocky mountains repeated in mirrored tiles');
  * </code>
  * </div>
  *
@@ -701,6 +692,7 @@ p5.prototype.textureWrap = function(wrapX, wrapY = wrapX) {
  * <code>
  * function setup() {
  *   createCanvas(100, 100, WEBGL);
+ *   describe('Sphere with normal material');
  * }
  *
  * function draw() {
@@ -708,8 +700,6 @@ p5.prototype.textureWrap = function(wrapX, wrapY = wrapX) {
  *   normalMaterial();
  *   sphere(40);
  * }
- *
- * describe('Sphere with normal material');
  * </code>
  * </div>
  * @alt
@@ -759,6 +749,7 @@ p5.prototype.normalMaterial = function(...args) {
  * <code>
  * function setup() {
  *   createCanvas(100, 100, WEBGL);
+ *   describe('sphere reflecting red, blue, and green light');
  * }
  * function draw() {
  *   background(0);
@@ -767,7 +758,6 @@ p5.prototype.normalMaterial = function(...args) {
  *   ambientMaterial(70, 130, 230);
  *   sphere(40);
  * }
- * describe('sphere reflecting red, blue, and green light');
  * </code>
  * </div>
  * @alt
@@ -780,6 +770,7 @@ p5.prototype.normalMaterial = function(...args) {
  * // so object only reflects it's red and blue components
  * function setup() {
  *   createCanvas(100, 100, WEBGL);
+ *   describe('box reflecting only red and blue light');
  * }
  * function draw() {
  *   background(70);
@@ -787,7 +778,6 @@ p5.prototype.normalMaterial = function(...args) {
  *   ambientMaterial(255); // white material
  *   box(30);
  * }
- * describe('box reflecting only red and blue light');
  * </code>
  * </div>
  * @alt
@@ -800,6 +790,7 @@ p5.prototype.normalMaterial = function(...args) {
  * // green, it does not reflect any light
  * function setup() {
  *   createCanvas(100, 100, WEBGL);
+ *   describe('box reflecting no light');
  * }
  * function draw() {
  *   background(70);
@@ -807,7 +798,6 @@ p5.prototype.normalMaterial = function(...args) {
  *   ambientMaterial(255, 0, 255); // magenta material
  *   box(30);
  * }
- * describe('box reflecting no light');
  * </code>
  * </div>
  * @alt
@@ -872,6 +862,7 @@ p5.prototype.ambientMaterial = function(v1, v2, v3) {
  * <code>
  * function setup() {
  *   createCanvas(100, 100, WEBGL);
+ *   describe('sphere with green emissive material');
  * }
  * function draw() {
  *   background(0);
@@ -880,7 +871,6 @@ p5.prototype.ambientMaterial = function(v1, v2, v3) {
  *   emissiveMaterial(130, 230, 0);
  *   sphere(40);
  * }
- * describe('sphere with green emissive material');
  * </code>
  * </div>
  *
@@ -948,6 +938,7 @@ p5.prototype.emissiveMaterial = function(v1, v2, v3, a) {
  * function setup() {
  *   createCanvas(100, 100, WEBGL);
  *   noStroke();
+ *   describe('torus with specular material');
  * }
  *
  * function draw() {
@@ -964,8 +955,6 @@ p5.prototype.emissiveMaterial = function(v1, v2, v3, a) {
  *   shininess(50);
  *   torus(30, 10, 64, 64);
  * }
- *
- * describe('torus with specular material');
  * </code>
  * </div>
  * @alt
@@ -1020,6 +1009,7 @@ p5.prototype.specularMaterial = function(v1, v2, v3, alpha) {
  * <code>
  * function setup() {
  *   createCanvas(100, 100, WEBGL);
+ *   describe('two spheres, one more shiny than the other');
  * }
  * function draw() {
  *   background(0);
@@ -1036,7 +1026,6 @@ p5.prototype.specularMaterial = function(v1, v2, v3, alpha) {
  *   shininess(20);
  *   sphere(20);
  * }
- * describe('two spheres, one more shiny than the other');
  * </code>
  * </div>
  * @alt

--- a/src/webgl/p5.Camera.js
+++ b/src/webgl/p5.Camera.js
@@ -45,6 +45,7 @@ import p5 from '../core/main';
  * <code>
  * function setup() {
  *   createCanvas(100, 100, WEBGL);
+ *   describe('a square moving closer and then away from the camera.');
  * }
  * function draw() {
  *   background(204);
@@ -52,7 +53,6 @@ import p5 from '../core/main';
  *   camera(0, 0, 20 + sin(frameCount * 0.01) * 10, 0, 0, 0, 0, 1, 0);
  *   plane(10, 10);
  * }
- * describe('a square moving closer and then away from the camera.');
  * </code>
  * </div>
  *
@@ -83,6 +83,9 @@ import p5 from '../core/main';
  *     sliderGroup[i].position(10, height + h);
  *     sliderGroup[i].style('width', '80px');
  *   }
+ *   describe(
+ *     'White square repeatedly grows to fill canvas and then shrinks. An interactive example of a red cube with 3 sliders for moving it across x, y, z axis and 3 sliders for shifting its center.'
+ *   );
  * }
  *
  * function draw() {
@@ -99,10 +102,6 @@ import p5 from '../core/main';
  *   fill(255, 102, 94);
  *   box(85);
  * }
- *
- * describe(
- *   'White square repeatedly grows to fill canvas and then shrinks. An interactive example of a red cube with 3 sliders for moving it across x, y, z axis and 3 sliders for shifting its center.'
- * );
  * </code>
  * </div>
  * @alt
@@ -146,6 +145,9 @@ p5.prototype.camera = function(...args) {
  * function setup() {
  *   createCanvas(100, 100, WEBGL);
  *   perspective(PI / 3.0, width / height, 0.1, 500);
+ *   describe(
+ *     'two colored 3D boxes move back and forth, rotating as mouse is dragged.'
+ *   );
  * }
  * function draw() {
  *   background(200);
@@ -165,9 +167,6 @@ p5.prototype.camera = function(...args) {
  *   box(30);
  *   pop();
  * }
- * describe(
- *   'two colored 3D boxes move back and forth, rotating as mouse is dragged.'
- * );
  * </code>
  * </div>
  *
@@ -211,6 +210,9 @@ p5.prototype.perspective = function(...args) {
  * function setup() {
  *   createCanvas(100, 100, WEBGL);
  *   ortho(-width / 2, width / 2, height / 2, -height / 2, 0, 500);
+ *   describe(
+ *     'two 3D boxes move back and forth along same plane, rotating as mouse is dragged.'
+ *   );
  * }
  * function draw() {
  *   background(200);
@@ -228,9 +230,6 @@ p5.prototype.perspective = function(...args) {
  *   box(30);
  *   pop();
  * }
- * describe(
- *   'two 3D boxes move back and forth along same plane, rotating as mouse is dragged.'
- * );
  * </code>
  * </div>
  *
@@ -277,6 +276,9 @@ p5.prototype.ortho = function(...args) {
  *   createCanvas(100, 100, WEBGL);
  *   setAttributes('antialias', true);
  *   frustum(-0.1, 0.1, -0.1, 0.1, 0.1, 200);
+ *   describe(
+ *     'two 3D boxes move back and forth along same plane, rotating as mouse is dragged.'
+ *   );
  * }
  * function draw() {
  *   background(200);
@@ -294,9 +296,6 @@ p5.prototype.ortho = function(...args) {
  *   box(30);
  *   pop();
  * }
- * describe(
- *   'two 3D boxes move back and forth along same plane, rotating as mouse is dragged.'
- * );
  * </code>
  * </div>
  *
@@ -342,6 +341,7 @@ p5.prototype.frustum = function(...args) {
  *   createCanvas(100, 100, WEBGL);
  *   background(0);
  *   camera = createCamera();
+ *   describe('An example that creates a camera and moves it around the box.');
  * }
  *
  * function draw() {
@@ -349,8 +349,6 @@ p5.prototype.frustum = function(...args) {
  *   camera.setPosition(sin(frameCount / 60) * 200, 0, 100);
  *   box(20);
  * }
- *
- * describe('An example that creates a camera and moves it around the box.');
  * </code></div>
  *
  * @alt
@@ -414,6 +412,9 @@ p5.prototype.createCamera = function() {
  *   cam = createCamera();
  *   // set initial pan angle
  *   cam.pan(-0.8);
+ *   describe(
+ *     'camera view pans left and right across a series of rotating 3D boxes.'
+ *   );
  * }
  *
  * function draw() {
@@ -443,10 +444,6 @@ p5.prototype.createCamera = function() {
  *   translate(35, 0, 0);
  *   box(20);
  * }
- *
- * describe(
- *   'camera view pans left and right across a series of rotating 3D boxes.'
- * );
  * </code>
  * </div>
  *
@@ -475,6 +472,7 @@ p5.Camera = function(renderer) {
  *   cam = createCamera();
  *   div = createDiv();
  *   div.position(0, 0);
+ *   describe('An example showing the use of camera object properties');
  * }
  *
  * function draw() {
@@ -482,8 +480,6 @@ p5.Camera = function(renderer) {
  *   box(10);
  *   div.html('eyeX = ' + cam.eyeX);
  * }
- *
- * describe('An example showing the use of camera object properties');
  * </code></div>
  *
  * @alt
@@ -504,6 +500,7 @@ p5.Camera = function(renderer) {
  *   cam = createCamera();
  *   div = createDiv();
  *   div.position(0, 0);
+ *   describe('An example showing the use of camera object properties');
  * }
  *
  * function draw() {
@@ -511,8 +508,6 @@ p5.Camera = function(renderer) {
  *   box(10);
  *   div.html('eyeY = ' + cam.eyeY);
  * }
- *
- * describe('An example showing the use of camera object properties');
  * </code></div>
  *
  * @alt
@@ -533,6 +528,7 @@ p5.Camera = function(renderer) {
  *   cam = createCamera();
  *   div = createDiv();
  *   div.position(0, 0);
+ *   describe('An example showing the use of camera object properties');
  * }
  *
  * function draw() {
@@ -540,8 +536,6 @@ p5.Camera = function(renderer) {
  *   box(10);
  *   div.html('eyeZ = ' + cam.eyeZ);
  * }
- *
- * describe('An example showing the use of camera object properties');
  * </code></div>
  *
  * @alt
@@ -564,14 +558,13 @@ p5.Camera = function(renderer) {
  *   div = createDiv('centerX = ' + cam.centerX);
  *   div.position(0, 0);
  *   div.style('color', 'white');
+ *   describe('An example showing the use of camera object properties');
  * }
  *
  * function draw() {
  *   orbitControl();
  *   box(10);
  * }
- *
- * describe('An example showing the use of camera object properties');
  * </code></div>
  *
  * @alt
@@ -594,14 +587,13 @@ p5.Camera = function(renderer) {
  *   div = createDiv('centerY = ' + cam.centerY);
  *   div.position(0, 0);
  *   div.style('color', 'white');
+ *   describe('An example showing the use of camera object properties');
  * }
  *
  * function draw() {
  *   orbitControl();
  *   box(10);
  * }
- *
- * describe('An example showing the use of camera object properties');
  * </code></div>
  *
  * @alt
@@ -624,14 +616,13 @@ p5.Camera = function(renderer) {
  *   div = createDiv('centerZ = ' + cam.centerZ);
  *   div.position(0, 0);
  *   div.style('color', 'white');
+ *   describe('An example showing the use of camera object properties');
  * }
  *
  * function draw() {
  *   orbitControl();
  *   box(10);
  * }
- *
- * describe('An example showing the use of camera object properties');
  * </code></div>
  *
  * @alt
@@ -654,9 +645,8 @@ p5.Camera = function(renderer) {
  *   div.position(0, 0);
  *   div.style('color', 'blue');
  *   div.style('font-size', '18px');
+ *   describe('An example showing the use of camera object properties');
  * }
- *
- * describe('An example showing the use of camera object properties');
  * </code></div>
  *
  * @alt
@@ -679,9 +669,8 @@ p5.Camera = function(renderer) {
  *   div.position(0, 0);
  *   div.style('color', 'blue');
  *   div.style('font-size', '18px');
+ *   describe('An example showing the use of camera object properties');
  * }
- *
- * describe('An example showing the use of camera object properties');
  * </code></div>
  *
  * @alt
@@ -704,9 +693,8 @@ p5.Camera = function(renderer) {
  *   div.position(0, 0);
  *   div.style('color', 'blue');
  *   div.style('font-size', '18px');
+ *   describe('An example showing the use of camera object properties');
  * }
- *
- * describe('An example showing the use of camera object properties');
  * </code></div>
  *
  * @alt
@@ -1782,6 +1770,10 @@ p5.Camera.prototype._isActive = function() {
  *
  *   // set variable for previously active camera:
  *   currentCamera = 1;
+ *
+ *   describe(
+ *     'Canvas switches between two camera views, each showing a series of spinning 3D boxes.'
+ *   );
  * }
  *
  * function draw() {
@@ -1822,10 +1814,6 @@ p5.Camera.prototype._isActive = function() {
  *   translate(35, 0, 0);
  *   box(20);
  * }
- *
- * describe(
- *   'Canvas switches between two camera views, each showing a series of spinning 3D boxes.'
- * );
  * </code>
  * </div>
  *

--- a/src/webgl/p5.Camera.js
+++ b/src/webgl/p5.Camera.js
@@ -52,6 +52,7 @@ import p5 from '../core/main';
  *   camera(0, 0, 20 + sin(frameCount * 0.01) * 10, 0, 0, 0, 0, 1, 0);
  *   plane(10, 10);
  * }
+ * describe('a square moving closer and then away from the camera.');
  * </code>
  * </div>
  *
@@ -98,6 +99,10 @@ import p5 from '../core/main';
  *   fill(255, 102, 94);
  *   box(85);
  * }
+ *
+ * describe(
+ *   'White square repeatedly grows to fill canvas and then shrinks. An interactive example of a red cube with 3 sliders for moving it across x, y, z axis and 3 sliders for shifting its center.'
+ * );
  * </code>
  * </div>
  * @alt
@@ -160,6 +165,9 @@ p5.prototype.camera = function(...args) {
  *   box(30);
  *   pop();
  * }
+ * describe(
+ *   'two colored 3D boxes move back and forth, rotating as mouse is dragged.'
+ * );
  * </code>
  * </div>
  *
@@ -220,6 +228,9 @@ p5.prototype.perspective = function(...args) {
  *   box(30);
  *   pop();
  * }
+ * describe(
+ *   'two 3D boxes move back and forth along same plane, rotating as mouse is dragged.'
+ * );
  * </code>
  * </div>
  *
@@ -283,6 +294,9 @@ p5.prototype.ortho = function(...args) {
  *   box(30);
  *   pop();
  * }
+ * describe(
+ *   'two 3D boxes move back and forth along same plane, rotating as mouse is dragged.'
+ * );
  * </code>
  * </div>
  *
@@ -335,6 +349,8 @@ p5.prototype.frustum = function(...args) {
  *   camera.setPosition(sin(frameCount / 60) * 200, 0, 100);
  *   box(20);
  * }
+ *
+ * describe('An example that creates a camera and moves it around the box.');
  * </code></div>
  *
  * @alt
@@ -427,6 +443,10 @@ p5.prototype.createCamera = function() {
  *   translate(35, 0, 0);
  *   box(20);
  * }
+ *
+ * describe(
+ *   'camera view pans left and right across a series of rotating 3D boxes.'
+ * );
  * </code>
  * </div>
  *
@@ -462,6 +482,8 @@ p5.Camera = function(renderer) {
  *   box(10);
  *   div.html('eyeX = ' + cam.eyeX);
  * }
+ *
+ * describe('An example showing the use of camera object properties');
  * </code></div>
  *
  * @alt
@@ -489,6 +511,8 @@ p5.Camera = function(renderer) {
  *   box(10);
  *   div.html('eyeY = ' + cam.eyeY);
  * }
+ *
+ * describe('An example showing the use of camera object properties');
  * </code></div>
  *
  * @alt
@@ -516,6 +540,8 @@ p5.Camera = function(renderer) {
  *   box(10);
  *   div.html('eyeZ = ' + cam.eyeZ);
  * }
+ *
+ * describe('An example showing the use of camera object properties');
  * </code></div>
  *
  * @alt
@@ -544,6 +570,8 @@ p5.Camera = function(renderer) {
  *   orbitControl();
  *   box(10);
  * }
+ *
+ * describe('An example showing the use of camera object properties');
  * </code></div>
  *
  * @alt
@@ -572,6 +600,8 @@ p5.Camera = function(renderer) {
  *   orbitControl();
  *   box(10);
  * }
+ *
+ * describe('An example showing the use of camera object properties');
  * </code></div>
  *
  * @alt
@@ -600,6 +630,8 @@ p5.Camera = function(renderer) {
  *   orbitControl();
  *   box(10);
  * }
+ *
+ * describe('An example showing the use of camera object properties');
  * </code></div>
  *
  * @alt
@@ -623,6 +655,8 @@ p5.Camera = function(renderer) {
  *   div.style('color', 'blue');
  *   div.style('font-size', '18px');
  * }
+ *
+ * describe('An example showing the use of camera object properties');
  * </code></div>
  *
  * @alt
@@ -646,6 +680,8 @@ p5.Camera = function(renderer) {
  *   div.style('color', 'blue');
  *   div.style('font-size', '18px');
  * }
+ *
+ * describe('An example showing the use of camera object properties');
  * </code></div>
  *
  * @alt
@@ -669,6 +705,8 @@ p5.Camera = function(renderer) {
  *   div.style('color', 'blue');
  *   div.style('font-size', '18px');
  * }
+ *
+ * describe('An example showing the use of camera object properties');
  * </code></div>
  *
  * @alt
@@ -1784,6 +1822,10 @@ p5.Camera.prototype._isActive = function() {
  *   translate(35, 0, 0);
  *   box(20);
  * }
+ *
+ * describe(
+ *   'Canvas switches between two camera views, each showing a series of spinning 3D boxes.'
+ * );
  * </code>
  * </div>
  *

--- a/src/webgl/p5.Shader.js
+++ b/src/webgl/p5.Shader.js
@@ -363,6 +363,10 @@ p5.Shader.prototype.useProgram = function() {
  * function mouseClicked() {
  *   showRedGreen = !showRedGreen;
  * }
+ *
+ * describe(
+ *   'canvas toggles between a circular gradient of orange and blue vertically. and a circular gradient of red and green moving horizontally when mouse is clicked/pressed.'
+ * );
  * </code>
  * </div>
  *

--- a/src/webgl/p5.Shader.js
+++ b/src/webgl/p5.Shader.js
@@ -341,6 +341,10 @@ p5.Shader.prototype.useProgram = function() {
  *   createCanvas(100, 100, WEBGL);
  *   shader(grad);
  *   noStroke();
+ *
+ *   describe(
+ *     'canvas toggles between a circular gradient of orange and blue vertically. and a circular gradient of red and green moving horizontally when mouse is clicked/pressed.'
+ *   );
  * }
  *
  * function draw() {
@@ -363,10 +367,6 @@ p5.Shader.prototype.useProgram = function() {
  * function mouseClicked() {
  *   showRedGreen = !showRedGreen;
  * }
- *
- * describe(
- *   'canvas toggles between a circular gradient of orange and blue vertically. and a circular gradient of red and green moving horizontally when mouse is clicked/pressed.'
- * );
  * </code>
  * </div>
  *


### PR DESCRIPTION
Resolves #5705

Changes:
all reference examples for 3d methods now use describe()

#### PR Checklist
- [x ] `npm run lint` passes
