### PR TITLE
Fix noSmooth printing message when used with a non WebGL graphics

### DIFF
--- a/src/core/shape/attributes.js
+++ b/src/core/shape/attributes.js
@@ -103,11 +103,12 @@ p5.prototype.ellipseMode = function(m) {
  * 2 pixelated 36×36 white ellipses to left & right of center, black background
  */
 p5.prototype.noSmooth = function() {
-  this.setAttributes('antialias', false);
   if (!this._renderer.isP3D) {
     if ('imageSmoothingEnabled' in this.drawingContext) {
       this.drawingContext.imageSmoothingEnabled = false;
     }
+  } else {
+    this.setAttributes('antialias', false);
   }
   return this;
 };


### PR DESCRIPTION
<!--
  Thank you for contributing! Please use this pull request (PR) template.


 In the description field of this PR, include "resolves #XXXX" tagging the issue you are fixing. If this PR addresses the issue but doesn't completely resolve it (ie the issue should remain open after your PR is merged), write "addresses #XXXX".-->
Resolves #5723

 Changes:
<!-- Add here what changes were made in this pull request and if possible provide links showcasing the changes. -->
Put the `setAttribute` call behind a check that current renderer is WebGL.

#### PR Checklist
<!--
  To check any option, replace the "[ ]" with a "[x]". Be sure to check out how it looks in the Preview tab! Feel free to remove any portion of the template that is not relevant for your issue.
-->

- [x] `npm run lint` passes
- [x] [Inline documentation] is included / updated
- [x] [Unit tests] are included / updated

[Inline documentation]: https://github.com/processing/p5.js/blob/main/contributor_docs/inline_documentation.md
[Unit tests]: https://github.com/processing/p5.js/tree/main/contributor_docs#unit-tests
