### PR TITLE
Add automatic labelling to issues

### DIFF
--- a/.github/ISSUE_TEMPLATE/existing-feature-enhancement.yml
+++ b/.github/ISSUE_TEMPLATE/existing-feature-enhancement.yml
@@ -14,22 +14,22 @@ body:
       label: Most appropriate sub-area of p5.js?
       description: You may select more than one.
       options:
-        - label: Accessibility (Web Accessibility)
+        - label: Accessibility
         - label: Color
         - label: Core/Environment/Rendering
         - label: Data
         - label: DOM
         - label: Events
         - label: Image
-        - label: IO (Input/Output)
+        - label: IO
         - label: Math
         - label: Typography
         - label: Utilities
         - label: WebGL
-        - label: Build tools and processes
+        - label: Build Process
         - label: Unit Testing
-        - label: Friendly error system
-        - label: Localization
+        - label: Localization Tools
+        - label: Friendly Errors
         - label: Other (specify if possible)
   - type: textarea
     attributes:

--- a/.github/ISSUE_TEMPLATE/existing-feature-enhancement.yml
+++ b/.github/ISSUE_TEMPLATE/existing-feature-enhancement.yml
@@ -2,37 +2,37 @@ name: 💡 Existing Feature Enhancement
 description: This template is for suggesting an improvement for an existing feature.
 labels: [enhancement]
 body:
-- type: textarea
-  attributes:
-    label: Increasing Access 
-    description: How would this new feature help [increase access](https://github.com/processing/p5.js/blob/main/contributor_docs/access.md) to p5.js? (If you're not sure, you can type "Unsure" here and let others from the community offer their thoughts.)
-  validations:
-    required: true
-- type: checkboxes
-  id: sub-area
-  attributes:
-    label: Most appropriate sub-area of p5.js?
-    description: You may select more than one.
-    options:
-      - label: Accessibility (Web Accessibility)
-      - label: Build tools and processes
-      - label: Color
-      - label: Core/Environment/Rendering
-      - label: Data
-      - label: DOM
-      - label: Events
-      - label: Friendly error system
-      - label: Image
-      - label: IO (Input/Output)
-      - label: Localization
-      - label: Math
-      - label: Unit Testing
-      - label: Typography
-      - label: Utilities
-      - label: WebGL
-      - label: Other (specify if possible)
-- type: textarea
-  attributes:
-    label: Feature enhancement details 
-  validations:
-    required: true
+  - type: textarea
+    attributes:
+      label: Increasing Access
+      description: How would this new feature help [increase access](https://github.com/processing/p5.js/blob/main/contributor_docs/access.md) to p5.js? (If you're not sure, you can type "Unsure" here and let others from the community offer their thoughts.)
+    validations:
+      required: true
+  - type: checkboxes
+    id: sub-area
+    attributes:
+      label: Most appropriate sub-area of p5.js?
+      description: You may select more than one.
+      options:
+        - label: Accessibility (Web Accessibility)
+        - label: Color
+        - label: Core/Environment/Rendering
+        - label: Data
+        - label: DOM
+        - label: Events
+        - label: Image
+        - label: IO (Input/Output)
+        - label: Math
+        - label: Typography
+        - label: Utilities
+        - label: WebGL
+        - label: Build tools and processes
+        - label: Unit Testing
+        - label: Friendly error system
+        - label: Localization
+        - label: Other (specify if possible)
+  - type: textarea
+    attributes:
+      label: Feature enhancement details
+    validations:
+      required: true

--- a/.github/ISSUE_TEMPLATE/feature-request.yml
+++ b/.github/ISSUE_TEMPLATE/feature-request.yml
@@ -14,22 +14,22 @@ body:
       label: Most appropriate sub-area of p5.js?
       description: You may select more than one.
       options:
-        - label: Accessibility (Web Accessibility)
+        - label: Accessibility
         - label: Color
         - label: Core/Environment/Rendering
         - label: Data
         - label: DOM
         - label: Events
         - label: Image
-        - label: IO (Input/Output)
+        - label: IO
         - label: Math
         - label: Typography
         - label: Utilities
         - label: WebGL
-        - label: Build tools and processes
+        - label: Build Process
         - label: Unit Testing
-        - label: Friendly error system
-        - label: Localization
+        - label: Localization Tools
+        - label: Friendly Errors
         - label: Other (specify if possible)
   - type: textarea
     attributes:

--- a/.github/ISSUE_TEMPLATE/feature-request.yml
+++ b/.github/ISSUE_TEMPLATE/feature-request.yml
@@ -2,37 +2,37 @@ name: 🌱 New Feature Request
 description: This template is for requesting a new feature be added.
 labels: [feature request]
 body:
-- type: textarea
-  attributes:
-    label: Increasing Access 
-    description: How would this new feature help [increase access](https://github.com/processing/p5.js/blob/main/contributor_docs/access.md) to p5.js? (If you're not sure, you can type "Unsure" here and let others from the community offer their thoughts.)
-  validations:
-    required: true
-- type: checkboxes
-  id: sub-area
-  attributes:
-    label: Most appropriate sub-area of p5.js?
-    description: You may select more than one.
-    options:
-      - label: Accessibility (Web Accessibility)
-      - label: Build tools and processes
-      - label: Color
-      - label: Core/Environment/Rendering
-      - label: Data
-      - label: DOM
-      - label: Events
-      - label: Friendly error system
-      - label: Image
-      - label: IO (Input/Output)
-      - label: Localization
-      - label: Math
-      - label: Unit Testing
-      - label: Typography
-      - label: Utilities
-      - label: WebGL
-      - label: Other (specify if possible)
-- type: textarea
-  attributes:
-    label: Feature request details 
-  validations:
-    required: true
+  - type: textarea
+    attributes:
+      label: Increasing Access
+      description: How would this new feature help [increase access](https://github.com/processing/p5.js/blob/main/contributor_docs/access.md) to p5.js? (If you're not sure, you can type "Unsure" here and let others from the community offer their thoughts.)
+    validations:
+      required: true
+  - type: checkboxes
+    id: sub-area
+    attributes:
+      label: Most appropriate sub-area of p5.js?
+      description: You may select more than one.
+      options:
+        - label: Accessibility (Web Accessibility)
+        - label: Color
+        - label: Core/Environment/Rendering
+        - label: Data
+        - label: DOM
+        - label: Events
+        - label: Image
+        - label: IO (Input/Output)
+        - label: Math
+        - label: Typography
+        - label: Utilities
+        - label: WebGL
+        - label: Build tools and processes
+        - label: Unit Testing
+        - label: Friendly error system
+        - label: Localization
+        - label: Other (specify if possible)
+  - type: textarea
+    attributes:
+      label: Feature request details
+    validations:
+      required: true

--- a/.github/ISSUE_TEMPLATE/found-a-bug.yml
+++ b/.github/ISSUE_TEMPLATE/found-a-bug.yml
@@ -8,22 +8,22 @@ body:
     label: Most appropriate sub-area of p5.js?
     description: You may select more than one.
     options:
-        - label: Accessibility (Web Accessibility)
+        - label: Accessibility
         - label: Color
         - label: Core/Environment/Rendering
         - label: Data
         - label: DOM
         - label: Events
         - label: Image
-        - label: IO (Input/Output)
+        - label: IO
         - label: Math
         - label: Typography
         - label: Utilities
         - label: WebGL
-        - label: Build tools and processes
+        - label: Build Process
         - label: Unit Testing
-        - label: Friendly error system
-        - label: Localization
+        - label: Localization Tools
+        - label: Friendly Errors
         - label: Other (specify if possible)
 - type: input
   attributes:

--- a/.github/ISSUE_TEMPLATE/found-a-bug.yml
+++ b/.github/ISSUE_TEMPLATE/found-a-bug.yml
@@ -8,23 +8,23 @@ body:
     label: Most appropriate sub-area of p5.js?
     description: You may select more than one.
     options:
-      - label: Accessibility (Web Accessibility)
-      - label: Build tools and processes
-      - label: Color
-      - label: Core/Environment/Rendering
-      - label: Data
-      - label: DOM
-      - label: Events
-      - label: Friendly error system
-      - label: Image
-      - label: IO (Input/Output)
-      - label: Localization
-      - label: Math
-      - label: Unit Testing
-      - label: Typography
-      - label: Utilities
-      - label: WebGL
-      - label: Other (specify if possible)
+        - label: Accessibility (Web Accessibility)
+        - label: Color
+        - label: Core/Environment/Rendering
+        - label: Data
+        - label: DOM
+        - label: Events
+        - label: Image
+        - label: IO (Input/Output)
+        - label: Math
+        - label: Typography
+        - label: Utilities
+        - label: WebGL
+        - label: Build tools and processes
+        - label: Unit Testing
+        - label: Friendly error system
+        - label: Localization
+        - label: Other (specify if possible)
 - type: input
   attributes:
     label: p5.js version 

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,5 +1,5 @@
 "Area:Accessibility":
-  - '\[X\] Accessibility \(Web Accessibility\)'
+  - '\[X\] Accessibility'
 "Area:Color":
   - '\[X\] Color'
 "Area:Core":
@@ -13,7 +13,7 @@
 "Area:Image":
   - '\[X\] Image'
 "Area:IO":
-  - '\[X\] IO \(Input/Output\)'
+  - '\[X\] IO'
 "Area:Math":
   - '\[X\] Math'
 "Area:Typography":
@@ -23,10 +23,10 @@
 "Area:WebGL":
   - '\[X\] WebGL'
 "Build Process":
-  - '\[X\] Build tools and processes'
+  - '\[X\] Build Process'
 "Unit Testing":
   - '\[X\] Unit Testing'
 "Localization":
-  - '\[X\] Localization'
+  - '\[X\] Localization Tools'
 "Friendly Errors":
-  - '\[X\] Friendly error system'
+  - '\[X\] Friendly Errors'

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,10 +1,10 @@
 "area:Accessibility":
   - '\[X\] Accessibility \(Web Accessibility\)'
-"area:Build Process":
+"Build Process":
   - '\[X\] Build tools and processes'
 "area:Color":
   - '\[X\] Color'
-"area:Core/Environment/Rendering":
+"area:Core":
   - '\[X\] Core'
 "area:Data":
   - '\[X\] Data'
@@ -12,7 +12,7 @@
   - '\[X\] DOM'
 "area:Events":
   - '\[X\] Events'
-"area:Friendly-Errors":
+"Friendly-Errors":
   - '\[X\] Friendly error system'
 "area:Image":
   - '\[X\] Image'
@@ -22,7 +22,7 @@
   - '\[X\] Localization'
 "area:Math":
   - '\[X\] Math'
-"area:Unit Testing":
+"Unit Testing":
   - '\[X\] Unit Testing'
 "area:Typography":
   - '\[X\] Typography'

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,12 +1,32 @@
-# Number of labels to fetch (optional). Defaults to 20
-numLabels: 20
-# These labels will not be used even if the issue contains them
-excludeLabels:
-  - bug
-  - can't reproduce
-  - known issue
-  - more info needed
-  - will not fix
-  - severity:critical
-  - severity:major
-  - severity:minor
+"area:Accessibility":
+  - '\[X\] Accessibility \(Web Accessibility\)'
+"area:Build Process":
+  - '\[X\] Build tools and processes'
+"area:Color":
+  - '\[X\] Color'
+"area:Core/Environment/Rendering":
+  - '\[X\] Core'
+"area:Data":
+  - '\[X\] Data'
+"area:DOM":
+  - '\[X\] DOM'
+"area:Events":
+  - '\[X\] Events'
+"area:Friendly-Errors":
+  - '\[X\] Friendly error system'
+"area:Image":
+  - '\[X\] Image'
+"area:IO":
+  - '\[X\] IO \(Input/Output\)'
+"Localization":
+  - '\[X\] Localization'
+"area:Math":
+  - '\[X\] Math'
+"area:Unit Testing":
+  - '\[X\] Unit Testing'
+"area:Typography":
+  - '\[X\] Typography'
+"area:Utilities":
+  - '\[X\] Utilities'
+"area:WebGL":
+  - '\[X\] WebGL'

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,32 +1,32 @@
-"area:Accessibility":
+"Area:Accessibility":
   - '\[X\] Accessibility \(Web Accessibility\)'
+"Area:Color":
+  - '\[X\] Color'
+"Area:Core":
+  - '\[X\] Core'
+"Area:Data":
+  - '\[X\] Data'
+"Area:DOM":
+  - '\[X\] DOM'
+"Area:Events":
+  - '\[X\] Events'
+"Area:Image":
+  - '\[X\] Image'
+"Area:IO":
+  - '\[X\] IO \(Input/Output\)'
+"Area:Math":
+  - '\[X\] Math'
+"Area:Typography":
+  - '\[X\] Typography'
+"Area:Utilities":
+  - '\[X\] Utilities'
+"Area:WebGL":
+  - '\[X\] WebGL'
 "Build Process":
   - '\[X\] Build tools and processes'
-"area:Color":
-  - '\[X\] Color'
-"area:Core":
-  - '\[X\] Core'
-"area:Data":
-  - '\[X\] Data'
-"area:DOM":
-  - '\[X\] DOM'
-"area:Events":
-  - '\[X\] Events'
-"Friendly-Errors":
-  - '\[X\] Friendly error system'
-"area:Image":
-  - '\[X\] Image'
-"area:IO":
-  - '\[X\] IO \(Input/Output\)'
-"Localization":
-  - '\[X\] Localization'
-"area:Math":
-  - '\[X\] Math'
 "Unit Testing":
   - '\[X\] Unit Testing'
-"area:Typography":
-  - '\[X\] Typography'
-"area:Utilities":
-  - '\[X\] Utilities'
-"area:WebGL":
-  - '\[X\] WebGL'
+"Localization":
+  - '\[X\] Localization'
+"Friendly Errors":
+  - '\[X\] Friendly error system'

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -1,0 +1,14 @@
+name: "Issue Labeler"
+on:
+  issues:
+    types: [opened, edited]
+
+jobs:
+  triage:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: github/issue-labeler@v2.0
+        with:
+          repo-token: "${{ secrets.GITHUB_TOKEN }}"
+          configuration-path: .github/labeler.yml
+          enable-versioned-regex: 0


### PR DESCRIPTION
<!--
  Thank you for contributing! Please use this pull request (PR) template.


 In the description field of this PR, include "resolves #XXXX" tagging the issue you are fixing. If this PR addresses the issue but doesn't completely resolve it (ie the issue should remain open after your PR is merged), write "addresses #XXXX".-->
Resolves #5636

 Changes:
<!-- Add here what changes were made in this pull request and if possible provide links showcasing the changes. -->
Issues are now automatically labelled as per the check boxes ticked in the issue form which all types of issues include other than discussion issues. Additionally, the issue form is reordered as requested by [Qianqianye](https://github.com/Qianqianye).

A prototype is [here](https://github.com/stampyzfanz/TestingGithubActions/issues) which works as expected. 

 Screenshots of the change:
<!-- If applicable, add screenshots depicting the changes. -->
![image](https://user-images.githubusercontent.com/34364128/180331793-43c31705-045f-4f5c-923b-18ed0e78e5ea.png)
![image](https://user-images.githubusercontent.com/34364128/180331615-1014c44f-d7f0-40cc-a0c4-69e38dbbf87e.png)


