### PR TITLE
only include necessary files in zip

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -365,7 +365,19 @@ module.exports = grunt => {
         options: {
           archive: 'release/p5.zip'
         },
-        files: [{ cwd: 'lib/', src: ['**/*'], expand: true }]
+        files: [
+          {
+            cwd: 'lib/',
+            src: [
+              'p5.js',
+              'p5.min.js',
+              'addons/*',
+              'empty-example/*',
+              'README.txt'
+            ],
+            expand: true
+          }
+        ]
       }
     },
 


### PR DESCRIPTION
fixes #5619 

instead of including everything in `lib/`, we only include specific files in the final compressed zip

@Qianqianye and i hit this again in the release today, and i found this fix