### PR TITLE
Fixed setHeading() not using the current angle mode

### DIFF
--- a/src/math/p5.Vector.js
+++ b/src/math/p5.Vector.js
@@ -1490,6 +1490,7 @@ p5.Vector.prototype.heading = function heading() {
  */
 
 p5.Vector.prototype.setHeading = function setHeading(a) {
+  if (this.isPInst) a = this._toRadians(a);
   let m = this.mag();
   this.x = m * Math.cos(a);
   this.y = m * Math.sin(a);

--- a/test/unit/math/p5.Vector.js
+++ b/test/unit/math/p5.Vector.js
@@ -18,15 +18,28 @@ suite('p5.Vector', function() {
   });
   var v;
 
-  suite('setHeading', function() {
+  suite('p5.prototype.setHeading() RADIANS', function() {
     setup(function() {
+      myp5.angleMode(RADIANS);
       v = myp5.createVector(1, 1);
       v.setHeading(1);
     });
-    test('should have heading() value of 1', function() {
+    test('should have heading() value of 1 (RADIANS)', function() {
       assert.closeTo(v.heading(), 1, 0.001);
     });
   });
+
+  suite('p5.prototype.setHeading() DEGREES', function() {
+    setup(function() {
+      myp5.angleMode(DEGREES);
+      v = myp5.createVector(1, 1);
+      v.setHeading(1);
+    });
+    test('should have heading() value of 1 (DEGREES)', function() {
+      assert.closeTo(v.heading(), 1, 0.001);
+    });
+  });
+
   suite('p5.prototype.createVector()', function() {
     setup(function() {
       v = myp5.createVector();


### PR DESCRIPTION
<!--
  Thank you for contributing! Please use this pull request (PR) template.


 In the description field of this PR, include "resolves #XXXX" tagging the issue you are fixing. If this PR addresses the issue but doesn't completely resolve it (ie the issue should remain open after your PR is merged), write "addresses #XXXX".-->
Resolves #5497

 Changes:
<!-- Add here what changes were made in this pull request and if possible provide links showcasing the changes. -->

- setHeading now takes into account angleMode(DEGREES)
- added test for setHeading using radians and degrees

#### PR Checklist
<!--
  To check any option, replace the "[ ]" with a "[x]". Be sure to check out how it looks in the Preview tab! Feel free to remove any portion of the template that is not relevant for your issue.
-->

- [x] `npm run lint` passes
- [ ] [Inline documentation] is included / updated
- [x] [Unit tests] are included / updated

[Inline documentation]: https://github.com/processing/p5.js/blob/main/contributor_docs/inline_documentation.md
[Unit tests]: https://github.com/processing/p5.js/tree/main/contributor_docs#unit-tests
