### PR TITLE
Permit zero-temporary-value buffer binding

### DIFF
--- a/src/webgl/p5.RendererGL.js
+++ b/src/webgl/p5.RendererGL.js
@@ -1337,7 +1337,12 @@ p5.RendererGL.prototype._bindBuffer = function(
   if (!target) target = this.GL.ARRAY_BUFFER;
   this.GL.bindBuffer(target, buffer);
   if (values !== undefined) {
-    const data = new (type || Float32Array)(values);
+    let data;
+    if (ArrayBuffer.isView(values)) {
+      data = values;
+    } else {
+      data = new (type || Float32Array)(values);
+    }
     this.GL.bufferData(target, data, usage || this.GL.STATIC_DRAW);
   }
 };


### PR DESCRIPTION
When using custom 3D renderers, p5 can support much larger models, but this particular bit of code showed up as a hotspot: I was passing in a Float32 already, and it was getting cloned.

Without this change, my particular workload runs at 7-12 fps. With it 45-50fps.

In principle p5 can make use of this itself, though having webGL ready representations as the source of truth is a much larger change - but even so, taking steps in that direction seems broadly useful.

<!--
  Thank you for contributing! Please use this pull request (PR) template.


 In the description field of this PR, include "resolves #XXXX" tagging the issue you are fixing. If this PR addresses the issue but doesn't completely resolve it (ie the issue should remain open after your PR is merged), write "addresses #XXXX".-->
Resolves #[Add issue number here]

 Changes:
<!-- Add here what changes were made in this pull request and if possible provide links showcasing the changes. -->


 Screenshots of the change:
<!-- If applicable, add screenshots depicting the changes. -->

#### PR Checklist
<!--
  To check any option, replace the "[ ]" with a "[x]". Be sure to check out how it looks in the Preview tab! Feel free to remove any portion of the template that is not relevant for your issue.
-->

- [ ] `npm run lint` passes
- [ ] [Inline documentation] is included / updated
- [ ] [Unit tests] are included / updated

[Inline documentation]: https://github.com/processing/p5.js/blob/main/contributor_docs/inline_documentation.md
[Unit tests]: https://github.com/processing/p5.js/tree/main/contributor_docs#unit-tests

Fixes: https://github.com/processing/p5.js/issues/5739