### PR TITLE
Fix applyMatrix example missing from reference page

### DIFF
--- a/src/core/transform.js
+++ b/src/core/transform.js
@@ -30,36 +30,6 @@ import p5 from './main';
  * @method applyMatrix
  * @param  {Array} arr an array of numbers - should be 6 or 16 length (2*3 or 4*4 matrix values)
  * @chainable
- */
-/**
- * @method applyMatrix
- * @param  {Number} a numbers which define the 2×3 or 4x4 matrix to be multiplied
- * @param  {Number} b numbers which define the 2×3 or 4x4 matrix to be multiplied
- * @param  {Number} c numbers which define the 2×3 or 4x4 matrix to be multiplied
- * @param  {Number} d numbers which define the 2×3 or 4x4 matrix to be multiplied
- * @param  {Number} e numbers which define the 2×3 or 4x4 matrix to be multiplied
- * @param  {Number} f numbers which define the 2×3 or 4x4 matrix to be multiplied
- * @chainable
- */
-/**
- * @method applyMatrix
- * @param  {Number} a
- * @param  {Number} b
- * @param  {Number} c
- * @param  {Number} d
- * @param  {Number} e
- * @param  {Number} f
- * @param  {Number} g numbers which define the 4x4 matrix to be multiplied
- * @param  {Number} h numbers which define the 4x4 matrix to be multiplied
- * @param  {Number} i numbers which define the 4x4 matrix to be multiplied
- * @param  {Number} j numbers which define the 4x4 matrix to be multiplied
- * @param  {Number} k numbers which define the 4x4 matrix to be multiplied
- * @param  {Number} l numbers which define the 4x4 matrix to be multiplied
- * @param  {Number} m numbers which define the 4x4 matrix to be multiplied
- * @param  {Number} n numbers which define the 4x4 matrix to be multiplied
- * @param  {Number} o numbers which define the 4x4 matrix to be multiplied
- * @param  {Number} p numbers which define the 4x4 matrix to be multiplied
- * @chainable
  * @example
  * <div>
  * <code>
@@ -182,6 +152,36 @@ import p5 from './main';
  * A rectangle rotating clockwise about the center
  * A rectangle shearing
  * A rectangle in the upper left corner
+ */
+/**
+ * @method applyMatrix
+ * @param  {Number} a numbers which define the 2×3 or 4x4 matrix to be multiplied
+ * @param  {Number} b numbers which define the 2×3 or 4x4 matrix to be multiplied
+ * @param  {Number} c numbers which define the 2×3 or 4x4 matrix to be multiplied
+ * @param  {Number} d numbers which define the 2×3 or 4x4 matrix to be multiplied
+ * @param  {Number} e numbers which define the 2×3 or 4x4 matrix to be multiplied
+ * @param  {Number} f numbers which define the 2×3 or 4x4 matrix to be multiplied
+ * @chainable
+ */
+/**
+ * @method applyMatrix
+ * @param  {Number} a
+ * @param  {Number} b
+ * @param  {Number} c
+ * @param  {Number} d
+ * @param  {Number} e
+ * @param  {Number} f
+ * @param  {Number} g numbers which define the 4x4 matrix to be multiplied
+ * @param  {Number} h numbers which define the 4x4 matrix to be multiplied
+ * @param  {Number} i numbers which define the 4x4 matrix to be multiplied
+ * @param  {Number} j numbers which define the 4x4 matrix to be multiplied
+ * @param  {Number} k numbers which define the 4x4 matrix to be multiplied
+ * @param  {Number} l numbers which define the 4x4 matrix to be multiplied
+ * @param  {Number} m numbers which define the 4x4 matrix to be multiplied
+ * @param  {Number} n numbers which define the 4x4 matrix to be multiplied
+ * @param  {Number} o numbers which define the 4x4 matrix to be multiplied
+ * @param  {Number} p numbers which define the 4x4 matrix to be multiplied
+ * @chainable
  */
 p5.prototype.applyMatrix = function() {
   let isTypedArray = arguments[0] instanceof Object.getPrototypeOf(Uint8Array);


### PR DESCRIPTION
<!--
  Thank you for contributing! Please use this pull request (PR) template.


 In the description field of this PR, include "resolves #XXXX" tagging the issue you are fixing. If this PR addresses the issue but doesn't completely resolve it (ie the issue should remain open after your PR is merged), write "addresses #XXXX".-->
Addresses https://github.com/processing/p5.js-website/issues/1248

 Changes:
<!-- Add here what changes were made in this pull request and if possible provide links showcasing the changes. -->
The example code is moved to to main function reference definition so that it renders.

#### PR Checklist
<!--
  To check any option, replace the "[ ]" with a "[x]". Be sure to check out how it looks in the Preview tab! Feel free to remove any portion of the template that is not relevant for your issue.
-->

- [x] `npm run lint` passes
- [x] [Inline documentation] is included / updated
- [ ] [Unit tests] are included / updated

[Inline documentation]: https://github.com/processing/p5.js/blob/main/contributor_docs/inline_documentation.md
[Unit tests]: https://github.com/processing/p5.js/tree/main/contributor_docs#unit-tests
