### PR TITLE
Feature Implemeted -- Multiple Material support for geometry

### DIFF
--- a/lib/empty-example/sketch.js
+++ b/lib/empty-example/sketch.js
@@ -4,18 +4,30 @@ function setup() {
 }
 
 function draw() {
-  background(100);
+  background(0);
   // translate(width/2, height/2);
 
-  specularColor(255, 255, 255);
-  directionalLight(127, 127, 127, cos(frameCount * 0.1), 1, -1);
+  // specularColor(255, 255, 255);
+  // directionalLight(127, 127, 127, cos(frameCount * 0.1), 1, -1);
+
   ambientLight(255, 255, 255);
 
-  // fill(255, 0, 0);
-  // emissiveMaterial(0, 255, 0);
-  ambientMaterial(0, 0, 255);
-  specularMaterial(0, 255, 0);
-  // emissiveMaterial(255, 0, 255);
-  shininess(100);
+  fill(0, 0, 255);
+  // emissiveMaterial(255, 0, 0);
+  // ambientMaterial(0, 0, 255);
+  // specularMaterial(0, 0, 255);
+  // shininess(32);
   sphere(100);
 }
+
+
+// function setup() {
+//   createCanvas(400, 400, WEBGL);
+//   noStroke();
+// }
+
+// function draw() {
+//   background(0);
+//   directionalLight(127, 127, 127, cos(frameCount * 0.1), 1, -1);
+//   sphere(100);
+// }

--- a/lib/empty-example/sketch.js
+++ b/lib/empty-example/sketch.js
@@ -1,7 +1,20 @@
 function setup() {
-  // put setup code here
+  createCanvas(600, 600, WEBGL);
+  noStroke();
 }
 
 function draw() {
-  // put drawing code here
+  background(0);
+  // translate(width/2, height/2);
+
+  // SpecularColor(255, 255, 255);
+  directionalLight(127, 127, 127, cos(frameCount * 0.1), 1, -1);
+  ambientLight(255, 255, 255);
+
+  // fill(255, 0, 0);
+  // emissive(255, 0, 0);
+  ambientMaterial(0, 0, 255);
+  specularMaterial(255, 0, 0);
+  shininess(100);
+  sphere(100);
 }

--- a/lib/empty-example/sketch.js
+++ b/lib/empty-example/sketch.js
@@ -4,17 +4,18 @@ function setup() {
 }
 
 function draw() {
-  background(0);
+  background(100);
   // translate(width/2, height/2);
 
-  // SpecularColor(255, 255, 255);
+  specularColor(255, 255, 255);
   directionalLight(127, 127, 127, cos(frameCount * 0.1), 1, -1);
   ambientLight(255, 255, 255);
 
   // fill(255, 0, 0);
-  // emissive(255, 0, 0);
+  // emissiveMaterial(0, 255, 0);
   ambientMaterial(0, 0, 255);
-  specularMaterial(255, 0, 0);
+  specularMaterial(0, 255, 0);
+  // emissiveMaterial(255, 0, 255);
   shininess(100);
   sphere(100);
 }

--- a/lib/empty-example/sketch.js
+++ b/lib/empty-example/sketch.js
@@ -1,33 +1,7 @@
 function setup() {
-  createCanvas(600, 600, WEBGL);
-  noStroke();
+  // put setup code here
 }
 
 function draw() {
-  background(0);
-  // translate(width/2, height/2);
-
-  // specularColor(255, 255, 255);
-  // directionalLight(127, 127, 127, cos(frameCount * 0.1), 1, -1);
-
-  ambientLight(255, 255, 255);
-
-  fill(0, 0, 255);
-  // emissiveMaterial(255, 0, 0);
-  // ambientMaterial(0, 0, 255);
-  // specularMaterial(0, 0, 255);
-  // shininess(32);
-  sphere(100);
+  // put drawing code here
 }
-
-
-// function setup() {
-//   createCanvas(400, 400, WEBGL);
-//   noStroke();
-// }
-
-// function draw() {
-//   background(0);
-//   directionalLight(127, 127, 127, cos(frameCount * 0.1), 1, -1);
-//   sphere(100);
-// }

--- a/src/webgl/material.js
+++ b/src/webgl/material.js
@@ -701,7 +701,7 @@ p5.prototype.normalMaterial = function(...args) {
 };
 
 /**
- * Sets the current material as an ambient material of the given color.
+ * Sets the ambient color of the material.
  *
  * The ambientMaterial() color is the color the object will reflect
  * under **any** lighting.
@@ -811,8 +811,7 @@ p5.prototype.ambientMaterial = function(v1, v2, v3) {
 };
 
 /**
- * Sets the current material as an emissive material of
- * the given color.
+ * Sets the emissive color of the material.
  *
  * An emissive material will display the emissive color at
  * full strength regardless of lighting. This can give the
@@ -883,7 +882,7 @@ p5.prototype.emissiveMaterial = function(v1, v2, v3, a) {
 };
 
 /**
- * Sets the current material as a specular material of the given color.
+ * Sets the specular color of the material.
  *
  * A specular material is reflective (shiny). The shininess can be
  * controlled by the <a href="#/p5/shininess">shininess()</a> function.

--- a/src/webgl/material.js
+++ b/src/webgl/material.js
@@ -803,7 +803,8 @@ p5.prototype.ambientMaterial = function(v1, v2, v3) {
 
   const color = p5.prototype.color.apply(this, arguments);
   this._renderer.curFillColor = color._array;
-  this._renderer._useSpecularMaterial = false;
+  this._renderer._useAmbientMaterial = true;
+  // this._renderer._useSpecularMaterial = false;
   this._renderer._useEmissiveMaterial = false;
   this._renderer._useNormalMaterial = false;
   this._renderer._enableLighting = true;
@@ -962,7 +963,12 @@ p5.prototype.specularMaterial = function(v1, v2, v3, alpha) {
   p5._validateParameters('specularMaterial', arguments);
 
   const color = p5.prototype.color.apply(this, arguments);
-  this._renderer.curFillColor = color._array;
+  // this._renderer.curFillColor = color._array;
+  if (!this._renderer._useAmbientMaterial) {
+    this._renderer.curFillColor = color._array;
+  } else {
+    this._renderer.curFillColor = color._array;
+  }
   this._renderer._useSpecularMaterial = true;
   this._renderer._useEmissiveMaterial = false;
   this._renderer._useNormalMaterial = false;

--- a/src/webgl/material.js
+++ b/src/webgl/material.js
@@ -802,11 +802,7 @@ p5.prototype.ambientMaterial = function(v1, v2, v3) {
   p5._validateParameters('ambientMaterial', arguments);
 
   const color = p5.prototype.color.apply(this, arguments);
-  // this._renderer.curFillColor = color._array;
   this._renderer.curAmbientColor = color._array;
-  // this._renderer._useAmbientMaterial = true;
-  // this._renderer._useSpecularMaterial = false;
-  // this._renderer._useEmissiveMaterial = false;
   this._renderer._useNormalMaterial = false;
   this._renderer._enableLighting = true;
   this._renderer._tex = null;
@@ -878,8 +874,6 @@ p5.prototype.emissiveMaterial = function(v1, v2, v3, a) {
 
   const color = p5.prototype.color.apply(this, arguments);
   this._renderer.curEmissiveColor = color._array;
-  // this._renderer.curFillColor = color._array;
-  // this._renderer._useSpecularMaterial = false;
   this._renderer._useEmissiveMaterial = true;
   this._renderer._useNormalMaterial = false;
   this._renderer._enableLighting = true;
@@ -965,13 +959,8 @@ p5.prototype.specularMaterial = function(v1, v2, v3, alpha) {
   p5._validateParameters('specularMaterial', arguments);
 
   const color = p5.prototype.color.apply(this, arguments);
-  // this._renderer.curFillColor = color._array;
   this._renderer.curSpecularColor = color._array;
-  // if (!this._renderer._useAmbientMaterial) {
-  //   this._renderer.curFillColor = color._array;
-  // }
   this._renderer._useSpecularMaterial = true;
-  // this._renderer._useEmissiveMaterial = false;
   this._renderer._useNormalMaterial = false;
   this._renderer._enableLighting = true;
   this._renderer._tex = null;

--- a/src/webgl/material.js
+++ b/src/webgl/material.js
@@ -804,7 +804,7 @@ p5.prototype.ambientMaterial = function(v1, v2, v3) {
   const color = p5.prototype.color.apply(this, arguments);
   // this._renderer.curFillColor = color._array;
   this._renderer.curAmbientColor = color._array;
-  this._renderer._useAmbientMaterial = true;
+  // this._renderer._useAmbientMaterial = true;
   // this._renderer._useSpecularMaterial = false;
   // this._renderer._useEmissiveMaterial = false;
   this._renderer._useNormalMaterial = false;
@@ -877,9 +877,9 @@ p5.prototype.emissiveMaterial = function(v1, v2, v3, a) {
   p5._validateParameters('emissiveMaterial', arguments);
 
   const color = p5.prototype.color.apply(this, arguments);
-  // this._renderer.curEmissiveColor = color._array;
-  this._renderer.curFillColor = color._array;
-  this._renderer._useSpecularMaterial = false;
+  this._renderer.curEmissiveColor = color._array;
+  // this._renderer.curFillColor = color._array;
+  // this._renderer._useSpecularMaterial = false;
   this._renderer._useEmissiveMaterial = true;
   this._renderer._useNormalMaterial = false;
   this._renderer._enableLighting = true;

--- a/src/webgl/material.js
+++ b/src/webgl/material.js
@@ -802,10 +802,11 @@ p5.prototype.ambientMaterial = function(v1, v2, v3) {
   p5._validateParameters('ambientMaterial', arguments);
 
   const color = p5.prototype.color.apply(this, arguments);
-  this._renderer.curFillColor = color._array;
+  // this._renderer.curFillColor = color._array;
+  this._renderer.curAmbientColor = color._array;
   this._renderer._useAmbientMaterial = true;
   // this._renderer._useSpecularMaterial = false;
-  this._renderer._useEmissiveMaterial = false;
+  // this._renderer._useEmissiveMaterial = false;
   this._renderer._useNormalMaterial = false;
   this._renderer._enableLighting = true;
   this._renderer._tex = null;
@@ -876,6 +877,7 @@ p5.prototype.emissiveMaterial = function(v1, v2, v3, a) {
   p5._validateParameters('emissiveMaterial', arguments);
 
   const color = p5.prototype.color.apply(this, arguments);
+  // this._renderer.curEmissiveColor = color._array;
   this._renderer.curFillColor = color._array;
   this._renderer._useSpecularMaterial = false;
   this._renderer._useEmissiveMaterial = true;
@@ -964,13 +966,12 @@ p5.prototype.specularMaterial = function(v1, v2, v3, alpha) {
 
   const color = p5.prototype.color.apply(this, arguments);
   // this._renderer.curFillColor = color._array;
-  if (!this._renderer._useAmbientMaterial) {
-    this._renderer.curFillColor = color._array;
-  } else {
-    this._renderer.curFillColor = color._array;
-  }
+  this._renderer.curSpecularColor = color._array;
+  // if (!this._renderer._useAmbientMaterial) {
+  //   this._renderer.curFillColor = color._array;
+  // }
   this._renderer._useSpecularMaterial = true;
-  this._renderer._useEmissiveMaterial = false;
+  // this._renderer._useEmissiveMaterial = false;
   this._renderer._useNormalMaterial = false;
   this._renderer._enableLighting = true;
   this._renderer._tex = null;

--- a/src/webgl/p5.RendererGL.js
+++ b/src/webgl/p5.RendererGL.js
@@ -95,6 +95,9 @@ p5.RendererGL = function(elt, pInst, isMainCanvas, attr) {
   this.drawMode = constants.FILL;
 
   this.curFillColor = this._cachedFillStyle = [1, 1, 1, 1];
+  this.curAmbientColor = this._cachedFillStyle = [1, 1, 1, 1];
+  this.curSpecularColor = this._cachedFillStyle = [1, 1, 1, 1];
+  // this.curEmissiveColor = this._cachedFillStyle = [1, 1, 1, 1];
   this.curStrokeColor = this._cachedStrokeStyle = [0, 0, 0, 1];
 
   this.curBlendMode = constants.BLEND;
@@ -1018,6 +1021,9 @@ p5.RendererGL.prototype.push = function() {
   properties.curStrokeWeight = this.curStrokeWeight;
   properties.curStrokeColor = this.curStrokeColor;
   properties.curFillColor = this.curFillColor;
+  properties.curAmbientColor = this.curAmbientColor;
+  properties.curSpecularColor = this.curSpecularColor;
+  // properties.curEmissiveColor = this.curEmissiveColor;
 
   properties._useAmbientMaterial = this._useAmbientMaterial;
   properties._useSpecularMaterial = this._useSpecularMaterial;
@@ -1259,6 +1265,9 @@ p5.RendererGL.prototype._setFillUniforms = function(fillShader) {
   fillShader.setUniform('uTint', this._tint);
 
   // fillShader.setUniform('uAmbient', this._useAmbientMaterial);
+  fillShader.setUniform('uAmbientMatColor', this.curAmbientColor);
+  fillShader.setUniform('uSpecularMatColor', this.curSpecularColor);
+  // fillShader.setUniform('uEmissiveMatColor', this.curEmissiveColor);
   fillShader.setUniform('uSpecular', this._useSpecularMaterial);
   fillShader.setUniform('uEmissive', this._useEmissiveMaterial);
   fillShader.setUniform('uShininess', this._useShininess);

--- a/src/webgl/p5.RendererGL.js
+++ b/src/webgl/p5.RendererGL.js
@@ -105,7 +105,6 @@ p5.RendererGL = function(elt, pInst, isMainCanvas, attr) {
   this.blendExt = this.GL.getExtension('EXT_blend_minmax');
   this._isBlending = false;
 
-  // this._useAmbientMaterial = false;
   this._useSpecularMaterial = false;
   this._useEmissiveMaterial = false;
   this._useNormalMaterial = false;

--- a/src/webgl/p5.RendererGL.js
+++ b/src/webgl/p5.RendererGL.js
@@ -95,9 +95,9 @@ p5.RendererGL = function(elt, pInst, isMainCanvas, attr) {
   this.drawMode = constants.FILL;
 
   this.curFillColor = this._cachedFillStyle = [1, 1, 1, 1];
-  this.curAmbientColor = this._cachedFillStyle = [1, 1, 1, 1];
-  this.curSpecularColor = this._cachedFillStyle = [1, 1, 1, 1];
-  // this.curEmissiveColor = this._cachedFillStyle = [1, 1, 1, 1];
+  this.curAmbientColor = this._cachedFillStyle = [0, 0, 0, 0];
+  this.curSpecularColor = this._cachedFillStyle = [0, 0, 0, 0];
+  this.curEmissiveColor = this._cachedFillStyle = [0, 0, 0, 0];
   this.curStrokeColor = this._cachedStrokeStyle = [0, 0, 0, 1];
 
   this.curBlendMode = constants.BLEND;
@@ -105,7 +105,7 @@ p5.RendererGL = function(elt, pInst, isMainCanvas, attr) {
   this.blendExt = this.GL.getExtension('EXT_blend_minmax');
   this._isBlending = false;
 
-  this._useAmbientMaterial = false;
+  // this._useAmbientMaterial = false;
   this._useSpecularMaterial = false;
   this._useEmissiveMaterial = false;
   this._useNormalMaterial = false;
@@ -1023,9 +1023,9 @@ p5.RendererGL.prototype.push = function() {
   properties.curFillColor = this.curFillColor;
   properties.curAmbientColor = this.curAmbientColor;
   properties.curSpecularColor = this.curSpecularColor;
-  // properties.curEmissiveColor = this.curEmissiveColor;
+  properties.curEmissiveColor = this.curEmissiveColor;
 
-  properties._useAmbientMaterial = this._useAmbientMaterial;
+  // properties._useAmbientMaterial = this._useAmbientMaterial;
   properties._useSpecularMaterial = this._useSpecularMaterial;
   properties._useEmissiveMaterial = this._useEmissiveMaterial;
   properties._useShininess = this._useShininess;
@@ -1267,7 +1267,7 @@ p5.RendererGL.prototype._setFillUniforms = function(fillShader) {
   // fillShader.setUniform('uAmbient', this._useAmbientMaterial);
   fillShader.setUniform('uAmbientMatColor', this.curAmbientColor);
   fillShader.setUniform('uSpecularMatColor', this.curSpecularColor);
-  // fillShader.setUniform('uEmissiveMatColor', this.curEmissiveColor);
+  fillShader.setUniform('uEmissiveMatColor', this.curEmissiveColor);
   fillShader.setUniform('uSpecular', this._useSpecularMaterial);
   fillShader.setUniform('uEmissive', this._useEmissiveMaterial);
   fillShader.setUniform('uShininess', this._useShininess);

--- a/src/webgl/p5.RendererGL.js
+++ b/src/webgl/p5.RendererGL.js
@@ -102,6 +102,7 @@ p5.RendererGL = function(elt, pInst, isMainCanvas, attr) {
   this.blendExt = this.GL.getExtension('EXT_blend_minmax');
   this._isBlending = false;
 
+  this._useAmbientMaterial = false;
   this._useSpecularMaterial = false;
   this._useEmissiveMaterial = false;
   this._useNormalMaterial = false;
@@ -1018,6 +1019,7 @@ p5.RendererGL.prototype.push = function() {
   properties.curStrokeColor = this.curStrokeColor;
   properties.curFillColor = this.curFillColor;
 
+  properties._useAmbientMaterial = this._useAmbientMaterial;
   properties._useSpecularMaterial = this._useSpecularMaterial;
   properties._useEmissiveMaterial = this._useEmissiveMaterial;
   properties._useShininess = this._useShininess;
@@ -1256,6 +1258,7 @@ p5.RendererGL.prototype._setFillUniforms = function(fillShader) {
   }
   fillShader.setUniform('uTint', this._tint);
 
+  // fillShader.setUniform('uAmbient', this._useAmbientMaterial);
   fillShader.setUniform('uSpecular', this._useSpecularMaterial);
   fillShader.setUniform('uEmissive', this._useEmissiveMaterial);
   fillShader.setUniform('uShininess', this._useShininess);

--- a/src/webgl/p5.RendererGL.js
+++ b/src/webgl/p5.RendererGL.js
@@ -1025,7 +1025,6 @@ p5.RendererGL.prototype.push = function() {
   properties.curSpecularColor = this.curSpecularColor;
   properties.curEmissiveColor = this.curEmissiveColor;
 
-  // properties._useAmbientMaterial = this._useAmbientMaterial;
   properties._useSpecularMaterial = this._useSpecularMaterial;
   properties._useEmissiveMaterial = this._useEmissiveMaterial;
   properties._useShininess = this._useShininess;
@@ -1264,7 +1263,6 @@ p5.RendererGL.prototype._setFillUniforms = function(fillShader) {
   }
   fillShader.setUniform('uTint', this._tint);
 
-  // fillShader.setUniform('uAmbient', this._useAmbientMaterial);
   fillShader.setUniform('uAmbientMatColor', this.curAmbientColor);
   fillShader.setUniform('uSpecularMatColor', this.curSpecularColor);
   fillShader.setUniform('uEmissiveMatColor', this.curEmissiveColor);

--- a/src/webgl/shaders/phong.frag
+++ b/src/webgl/shaders/phong.frag
@@ -23,11 +23,10 @@ void main(void) {
   totalLight(vViewPosition, normalize(vNormal), diffuse, specular);
 
   // Calculating final color as result of all lights (plus emissive term).
-  // Transparency is determined exclusively by the diffuse component.
 
   gl_FragColor = isTexture ? texture2D(uSampler, vTexCoord) * (uTint / vec4(255, 255, 255, 255)) : uMaterialColor;
   gl_FragColor.rgb = diffuse * gl_FragColor.rgb + 
-                   vAmbientColor * uAmbientMatColor.rgb + 
-                   specular * uSpecularMatColor.rgb + 
-                   uEmissiveMatColor.rgb;
+                    vAmbientColor * uAmbientMatColor.rgb + 
+                    specular * uSpecularMatColor.rgb + 
+                    uEmissiveMatColor.rgb;
 }

--- a/src/webgl/shaders/phong.frag
+++ b/src/webgl/shaders/phong.frag
@@ -2,6 +2,9 @@
 precision highp float;
 precision highp int;
 
+uniform vec4 uSpecularMatColor;
+uniform vec4 uAmbientMatColor;
+
 uniform vec4 uMaterialColor;
 uniform vec4 uTint;
 uniform sampler2D uSampler;
@@ -23,7 +26,15 @@ void main(void) {
     gl_FragColor = uMaterialColor;
   }
   else {
-    gl_FragColor = isTexture ? texture2D(uSampler, vTexCoord) * (uTint / vec4(255, 255, 255, 255)) : uMaterialColor;
-    gl_FragColor.rgb = gl_FragColor.rgb * (diffuse + vAmbientColor) + specular;
+    if(isTexture) {
+      gl_FragColor = texture2D(uSampler, vTexCoord) * (uTint / vec4(255, 255, 255, 255));
+      gl_FragColor.rgb = gl_FragColor.rgb * (diffuse + vAmbientColor) + specular;
+    } else {
+      gl_FragColor = vec4(diffuse, 1) * uMaterialColor + 
+                     vec4(vAmbientColor, 0) * uAmbientMatColor + 
+                     vec4(specular, 0) * uSpecularMatColor;
+    }
+    // gl_FragColor = isTexture ? texture2D(uSampler, vTexCoord) * (uTint / vec4(255, 255, 255, 255)) : uMaterialColor;
+    // gl_FragColor.rgb = gl_FragColor.rgb * diffuse + (vAmbientColor, 1.0) * uAmbientMatColor + specular * uSpecularMatColor;
   }
 }

--- a/src/webgl/shaders/phong.frag
+++ b/src/webgl/shaders/phong.frag
@@ -10,7 +10,6 @@ uniform vec4 uMaterialColor;
 uniform vec4 uTint;
 uniform sampler2D uSampler;
 uniform bool isTexture;
-uniform bool uEmissive;
 
 varying vec3 vNormal;
 varying vec2 vTexCoord;
@@ -26,24 +25,9 @@ void main(void) {
   // Calculating final color as result of all lights (plus emissive term).
   // Transparency is determined exclusively by the diffuse component.
 
-  if(uEmissive && !isTexture) {
-    gl_FragColor = vec4(diffuse, 1) * uMaterialColor + 
-                   vec4(vAmbientColor, 0) * uAmbientMatColor + 
-                   vec4(specular, 0) * uSpecularMatColor + 
-                   vec4(uEmissiveMatColor.rgb, 0);
-  }
-  else {
-    if(isTexture) {
-      gl_FragColor = texture2D(uSampler, vTexCoord) * (uTint / vec4(255, 255, 255, 255));
-      gl_FragColor.rgb = gl_FragColor.rgb * (diffuse + vAmbientColor) + specular;
-    } else {
-
-      // Calculating final color as result of all lights.
-      // Transparency is determined exclusively by the diffuse component.
-
-      gl_FragColor = vec4(diffuse, 1) * uMaterialColor + 
-                     vec4(vAmbientColor, 0) * uAmbientMatColor + 
-                     vec4(specular, 0) * uSpecularMatColor;
-    }
-  }
+  gl_FragColor = isTexture ? texture2D(uSampler, vTexCoord) * (uTint / vec4(255, 255, 255, 255)) : uMaterialColor;
+  gl_FragColor.rgb = diffuse * gl_FragColor.rgb + 
+                   vAmbientColor * uAmbientMatColor.rgb + 
+                   specular * uSpecularMatColor.rgb + 
+                   uEmissiveMatColor.rgb;
 }

--- a/src/webgl/shaders/phong.frag
+++ b/src/webgl/shaders/phong.frag
@@ -4,6 +4,7 @@ precision highp int;
 
 uniform vec4 uSpecularMatColor;
 uniform vec4 uAmbientMatColor;
+uniform vec4 uEmissiveMatColor;
 
 uniform vec4 uMaterialColor;
 uniform vec4 uTint;
@@ -22,19 +23,27 @@ void main(void) {
   vec3 specular;
   totalLight(vViewPosition, normalize(vNormal), diffuse, specular);
 
+  // Calculating final color as result of all lights (plus emissive term).
+  // Transparency is determined exclusively by the diffuse component.
+
   if(uEmissive && !isTexture) {
-    gl_FragColor = uMaterialColor;
+    gl_FragColor = vec4(diffuse, 1) * uMaterialColor + 
+                   vec4(vAmbientColor, 0) * uAmbientMatColor + 
+                   vec4(specular, 0) * uSpecularMatColor + 
+                   vec4(uEmissiveMatColor.rgb, 0);
   }
   else {
     if(isTexture) {
       gl_FragColor = texture2D(uSampler, vTexCoord) * (uTint / vec4(255, 255, 255, 255));
       gl_FragColor.rgb = gl_FragColor.rgb * (diffuse + vAmbientColor) + specular;
     } else {
+
+      // Calculating final color as result of all lights.
+      // Transparency is determined exclusively by the diffuse component.
+
       gl_FragColor = vec4(diffuse, 1) * uMaterialColor + 
                      vec4(vAmbientColor, 0) * uAmbientMatColor + 
                      vec4(specular, 0) * uSpecularMatColor;
     }
-    // gl_FragColor = isTexture ? texture2D(uSampler, vTexCoord) * (uTint / vec4(255, 255, 255, 255)) : uMaterialColor;
-    // gl_FragColor.rgb = gl_FragColor.rgb * diffuse + (vAmbientColor, 1.0) * uAmbientMatColor + specular * uSpecularMatColor;
   }
 }

--- a/test/unit/webgl/p5.Shader.js
+++ b/test/unit/webgl/p5.Shader.js
@@ -92,7 +92,6 @@ suite('p5.Shader', function() {
         'uMaterialColor',
         'uSampler',
         'isTexture',
-        'uEmissive',
         'uConstantAttenuation',
         'uLinearAttenuation',
         'uQuadraticAttenuation'


### PR DESCRIPTION
<!--
  Thank you for contributing! Please use this pull request (PR) template.


 In the description field of this PR, include "resolves #XXXX" tagging the issue you are fixing. If this PR addresses the issue but doesn't completely resolve it (ie the issue should remain open after your PR is merged), write "addresses #XXXX".-->
Resolves #3806 #5308

 Changes:
<!-- Add here what changes were made in this pull request and if possible provide links showcasing the changes. -->
Implemented a few new uniforms (uSpecularMatColor, uAmbientMatColor, uEmissiveMatColor) which store the RGB colors for different materials and fill the geometry with different color properties and thus contributing separately to the lighting of the surface.

So finally, we have decided to move away from the current overwriting of fill colors to the geometry, towards the approach that Processing uses where the material has different color properties (ambient, emissive, specular) that all contribute separately to the lighting of the surface.

 Screenshots of the change:
<!-- If applicable, add screenshots depicting the changes. -->
Before:
![image](https://user-images.githubusercontent.com/47415702/187476176-7b4799e5-dcaa-4e0d-a176-36195755c360.png)

[Code](https://editor.p5js.org/ShenpaiSharma/sketches/Rg-58jQmM)

After:
<img width="595" alt="image" src="https://user-images.githubusercontent.com/47415702/187476501-080d46d0-6712-486f-83fb-4abc109333dc.png">

[Code](https://editor.p5js.org/cfoss/sketches/xTZuZViai)


#### PR Checklist
<!--
  To check any option, replace the "[ ]" with a "[x]". Be sure to check out how it looks in the Preview tab! Feel free to remove any portion of the template that is not relevant for your issue.
-->

- [x] `npm run lint` passes
- [x] [Inline documentation] is included / updated

[Inline documentation]: https://github.com/processing/p5.js/blob/main/contributor_docs/inline_documentation.md
[Unit tests]: https://github.com/processing/p5.js/tree/main/contributor_docs#unit-tests
