### PR TITLE
Allow setting the image width and height. Addresses #5779 

### DIFF
--- a/src/image/loading_displaying.js
+++ b/src/image/loading_displaying.js
@@ -65,7 +65,13 @@ import '../core/friendly_errors/fes_core';
  * image of the underside of a white umbrella and grided ceililng above
  * image of the underside of a white umbrella and grided ceililng above
  */
-p5.prototype.loadImage = function(path, successCallback, failureCallback) {
+p5.prototype.loadImage = function(
+  path,
+  successCallback,
+  failureCallback,
+  width,
+  height
+) {
   p5._validateParameters('loadImage', arguments);
   const pImg = new p5.Image(1, 1, this);
   const self = this;
@@ -113,11 +119,11 @@ p5.prototype.loadImage = function(path, successCallback, failureCallback) {
         const img = new Image();
 
         img.onload = () => {
-          pImg.width = pImg.canvas.width = img.width;
-          pImg.height = pImg.canvas.height = img.height;
+          pImg.width = pImg.canvas.width = width ? width : img.width;
+          pImg.height = pImg.canvas.height = height ? height : img.height;
 
           // Draw the image into the backing canvas of the p5.Image
-          pImg.drawingContext.drawImage(img, 0, 0);
+          pImg.drawingContext.drawImage(img, 0, 0, pImg.width, pImg.height);
           pImg.modified = true;
           if (typeof successCallback === 'function') {
             successCallback(pImg);


### PR DESCRIPTION
Allow setting the image width and height to support proper loading of SVG images as canvas images.
This allows for better scalling of image elements relative to a given screen / canvas size.

SVG files can already be loading using this method. However, currently the intrinsic size stored in an SVG file is used to determine its size, which works against the idea of using SVGs-files as scalable templates for canvas images. Allowing for parameters for the desired width and height in which the SVG should be interpreted renders the SVG file correctly and allows for easy scalability.

I have tested this code and it seems to work fine.


 Changes:
<!-- Add here what changes were made in this pull request and if possible provide links showcasing the changes. -->
Two new parameters, `width` and `height`, have been added to `p5.prototype.loadImage`. If they are given they are used as the width and height for the canvas and image in the drawingContext, instead of the intrinsic image width and height.


#### PR Checklist

- [x] `npm run lint` passes
- [ ] [Inline documentation] is included / updated
- [ ] [Unit tests] are included / updated
