### PR TITLE
Use textContent to avoid HTML special characters in options

### DIFF
--- a/src/dom/dom.js
+++ b/src/dom/dom.js
@@ -705,7 +705,7 @@ p5.prototype.createSelect = function() {
     }
     //see if there is already an option with this name
     for (let i = 0; i < this.elt.length; i += 1) {
-      if (this.elt[i].innerHTML === name) {
+      if (this.elt[i].textContent === name) {
         index = i;
         break;
       }
@@ -722,7 +722,7 @@ p5.prototype.createSelect = function() {
     } else {
       //if it doesn't exist create it
       const opt = document.createElement('option');
-      opt.innerHTML = name;
+      opt.textContent = name;
       opt.value = value === undefined ? name : value;
       this.elt.appendChild(opt);
       this._pInst._elements.push(opt);

--- a/test/unit/dom/dom.js
+++ b/test/unit/dom/dom.js
@@ -811,6 +811,7 @@ suite('DOM', function() {
     test('should update select value when HTML special characters are in the name', function() {
       testElement = myp5.createSelect(true);
       testElement.option('&', 'foo');
+      assert.equal(testElement.elt.options.length, 1);
       assert.equal(testElement.elt.options[0].value, 'foo');
       testElement.option('&', 'bar');
       assert.equal(testElement.elt.options[0].value, 'bar');

--- a/test/unit/dom/dom.js
+++ b/test/unit/dom/dom.js
@@ -808,6 +808,14 @@ suite('DOM', function() {
       }
     });
 
+    test('should update select value when HTML special characters are in the name', function() {
+      testElement = myp5.createSelect(true);
+      testElement.option('&', 'foo');
+      assert.equal(testElement.elt.options[0].value, 'foo');
+      testElement.option('&', 'bar');
+      assert.equal(testElement.elt.options[0].value, 'bar');
+    });
+
     test('calling selected(value) should updated selectedIndex', function() {
       testElement = myp5.createSelect(true);
       options = ['Sunday', 'Monday', 'Tuesday', 'Friday'];


### PR DESCRIPTION
Resolves https://github.com/processing/p5.js/issues/5778

Changes:

- Use `textContent` rather than `innerHTML` to set and compare options in a select menu, avoiding parsing HTML and escaping HTML special characters that might happen to be in the string (see linked issue for details).
- Add unit test with HTML special characters that fails on the old `innerHTML` and passes on `textContent`.

#### PR Checklist

- [x] `npm run lint` passes
- [x] [Inline documentation] is included / updated
- [x] [Unit tests] are included / updated

[Inline documentation]: https://github.com/processing/p5.js/blob/main/contributor_docs/inline_documentation.md
[Unit tests]: https://github.com/processing/p5.js/tree/main/contributor_docs#unit-tests
