### PR TITLE
Fix WebGL blending bugs

### DIFF
--- a/src/core/rendering.js
+++ b/src/core/rendering.js
@@ -252,7 +252,8 @@ p5.prototype.createGraphics = function(w, h, renderer) {
  * min(A*factor, B).</li>
  * <li><code>LIGHTEST</code> - only the lightest colour succeeds: C =
  * max(A*factor, B).</li>
- * <li><code>DIFFERENCE</code> - subtract colors from underlying image.</li>
+ * <li><code>DIFFERENCE</code> - subtract colors from underlying image.
+ * <em>(2D)</em></li>
  * <li><code>EXCLUSION</code> - similar to <code>DIFFERENCE</code>, but less
  * extreme.</li>
  * <li><code>MULTIPLY</code> - multiply the colors, result will always be

--- a/src/webgl/material.js
+++ b/src/webgl/material.js
@@ -1054,7 +1054,10 @@ p5.RendererGL.prototype._applyColorBlend = function(colors) {
 
   const isTexture = this.drawMode === constants.TEXTURE;
   const doBlend =
-    isTexture || colors[colors.length - 1] < 1.0 || this._isErasing;
+    isTexture ||
+    this.curBlendMode !== constants.BLEND ||
+    colors[colors.length - 1] < 1.0 ||
+    this._isErasing;
 
   if (doBlend !== this._isBlending) {
     if (
@@ -1085,9 +1088,12 @@ p5.RendererGL.prototype._applyBlendMode = function() {
   const gl = this.GL;
   switch (this.curBlendMode) {
     case constants.BLEND:
-    case constants.ADD:
       gl.blendEquation(gl.FUNC_ADD);
       gl.blendFunc(gl.SRC_ALPHA, gl.ONE_MINUS_SRC_ALPHA);
+      break;
+    case constants.ADD:
+      gl.blendEquation(gl.FUNC_ADD);
+      gl.blendFunc(gl.SRC_ALPHA, gl.ONE);
       break;
     case constants.REMOVE:
       gl.blendEquation(gl.FUNC_REVERSE_SUBTRACT);

--- a/src/webgl/p5.RendererGL.js
+++ b/src/webgl/p5.RendererGL.js
@@ -1032,6 +1032,7 @@ p5.RendererGL.prototype.push = function() {
   properties.drawMode = this.drawMode;
 
   properties._currentNormal = this._currentNormal;
+  properties.curBlendMode = this.curBlendMode;
 
   return style;
 };


### PR DESCRIPTION
Resolves #5793

Changes:
- Applies blending when the blend mode is not `BLEND` regardless of opacity
- Handles the `ADD` blend mode more similarly to in 2D mode
- Makes sure the blend mode is saved/restored in `push()`/`pop()`
- Updates docs to mention that `DIFFERENCE` is not implemented in WebGL mode


**Screenshots of the change:**

In each image, left is 2D mode, and right is WebGL
<table>
<tr>
<th>Before</th><th>After</th>
</tr>
<tr>
<td>
<img width="400" alt="image" src="https://user-images.githubusercontent.com/5315059/189445079-016b4363-b4af-4aba-9b7d-fab074fda251.png">
</td>
<td>
<img width="403" alt="image" src="https://user-images.githubusercontent.com/5315059/189444986-e3a9eb9d-dad3-453a-ba88-670245934bbe.png">
</td>
</tr>
</table>

#### PR Checklist
<!--
  To check any option, replace the "[ ]" with a "[x]". Be sure to check out how it looks in the Preview tab! Feel free to remove any portion of the template that is not relevant for your issue.
-->

- [x] `npm run lint` passes
- [x] [Inline documentation] is included / updated
- [x] [Unit tests] are included / updated
