### PR TITLE
Add texture coordinates to WebGL rounded rects

### DIFF
--- a/src/webgl/3d_primitives.js
+++ b/src/webgl/3d_primitives.js
@@ -1336,6 +1336,14 @@ p5.RendererGL.prototype.rect = function(args) {
     } else {
       this.vertex(x1, y1);
     }
+
+    this.immediateMode.geometry.uvs.length = 0;
+    for (const vert of this.immediateMode.geometry.vertices) {
+      const u = (vert.x - x1) / width;
+      const v = (vert.y - y1) / height;
+      this.immediateMode.geometry.uvs.push(u, v);
+    }
+
     this.endShape(constants.CLOSE);
   }
   return this;


### PR DESCRIPTION
Addresses https://github.com/processing/p5.js/issues/5001

Currently, textures only work for rounded rects in WebGL if you have `textureMode(IMAGE)` set. If you don't add border radii, then any texture mode works. This explicitly specifies texture coordinates in the WebGL `rect` implementation so that it always works with provided textures regardless of mode.

Changes:
- Adds texture coordinates to the immediate mode rendering of rounded rects in WebGL mode

Problems not addressed yet:
- Still doesn't use retained geometry
- Still doesn't use a generalized solution for texture coordinates in curves (https://github.com/processing/p5.js/issues/5722)
- Still doesn't fix thick strokes not being connected in WebGL (https://github.com/processing/p5.js/issues/5790)

Screenshots of the change:
<table>
<tr>
<td>

```js
let w, h, tl, tr, bl, br
let img

function preload() {
  img = loadImage('cat.jpg')
}

function setup() {
  createCanvas(400, 400, WEBGL)
  w = createSlider(0, 400, 200)
  h = createSlider(0, 400, 200)
  tl = createSlider(0, 300, 0)
  tr = createSlider(0, 300, 0)
  bl = createSlider(0, 300, 0)
  br = createSlider(0, 300, 0)
}

function draw() {
  background(255)
  rectMode(CENTER)
  textureMode(NORMAL) // This breaks on main
  texture(img)
  rect(
    0,
    0,
    w.value(),
    h.value(),
    tl.value(),
    tr.value(),
    br.value(),
    bl.value()
  )
}
```

</td>
<td>

![rounded-rect](https://user-images.githubusercontent.com/5315059/189463146-71d5ce52-0859-47b8-a468-4ebf799b30a5.gif)


</td>
</tr>
</table>

#### PR Checklist

- [x] `npm run lint` passes
- [ ] [Inline documentation] is included / updated
- [ ] [Unit tests] are included / updated