### PR TITLE
Add project_wrapup README link to smrghsh GSoC 22

### DIFF
--- a/contributor_docs/project_wrapups/README.md
+++ b/contributor_docs/project_wrapups/README.md
@@ -7,6 +7,7 @@ This folder contains wrap-up reports from p5.js related [Google Summer of Code](
 
 ### Google Summer of Code 2022
 * [p5 /teach reorganize & update](https://github.com/processing/p5.js/blob/main/contributor_docs/project_wrapups/graciazhang_gsoc_2022.md) by Gracia Zhang, 2022
+* [p5xr Immersive Session Process and Controller API update](https://github.com/processing/p5.js/blob/main/contributor_docs/project_wrapups/smrghsh_gsoc_2022.md) by Samir Ghosh, 2022
 
 ### Google Summer of Code 2021
 * [Adding Alt Text to the p5.js Website](https://github.com/processing/p5.js/blob/main/contributor_docs/project_wrapups/katiejliu_gsoc_2021.md) by Katie Liu, 2021


### PR DESCRIPTION
 Changes:
Added a link to [smrghsh GSoC '222 project wrapup](https://github.com/processing/p5.js/pull/5798) in the [project wrapup README](https://github.com/processing/p5.js/tree/main/contributor_docs/project_wrapups#google-summer-of-code)

@Qianqianye , @stalgiag per discussion on https://github.com/processing/p5.js/pull/5798