### PR TITLE
Prevent load* methods outside of preload from rerunning setup

### DIFF
--- a/src/core/main.js
+++ b/src/core/main.js
@@ -167,6 +167,7 @@ class p5 {
     //////////////////////////////////////////////
 
     this._setupDone = false;
+    this._preloadDone = false;
     // for handling hidpi
     this._pixelDensity = Math.ceil(window.devicePixelRatio) || 1;
     this._userNode = node;
@@ -292,7 +293,7 @@ class p5 {
 
     this._decrementPreload = function() {
       const context = this._isGlobal ? window : this;
-      if (typeof context.preload === 'function') {
+      if (!context._preloadDone && typeof context.preload === 'function') {
         context._setProperty('_preloadCount', context._preloadCount - 1);
         context._runIfPreloadsAreDone();
       }
@@ -309,6 +310,8 @@ class p5 {
 
     this._incrementPreload = function() {
       const context = this._isGlobal ? window : this;
+      // Do nothing if we tried to increment preloads outside of `preload`
+      if (context._preloadDone) return;
       context._setProperty('_preloadCount', context._preloadCount + 1);
     };
 
@@ -335,6 +338,8 @@ class p5 {
 
       // Record the time when sketch starts
       this._millisStart = window.performance.now();
+
+      context._preloadDone = true;
 
       // Short-circuit on this, in case someone used the library in "global"
       // mode earlier

--- a/test/unit/io/loadShader.js
+++ b/test/unit/io/loadShader.js
@@ -162,4 +162,15 @@ suite('loadShader', function() {
     });
     assert.instanceOf(model, p5.Shader);
   });
+
+  test('does not run setup after complete when called outside of preload', async function() {
+    let setupCallCount = 0;
+    await promisedSketch(function(sketch, resolve, reject) {
+      sketch.setup = function() {
+        setupCallCount++;
+        sketch.loadShader(vertFile, fragFile, resolve, reject);
+      };
+    });
+    assert.equal(setupCallCount, 1);
+  });
 });


### PR DESCRIPTION
Resolves https://github.com/processing/p5.js/issues/5810

Changes:
- Before user setup/draw methods are called, a flag is set indicating that the preload phase is done
- After this point, load* methods will no longer increment/decrement preloads, and will no longer trigger `setup` getting run again

I've made an updated version of the p5 editor sketch from the issue, using a build with this new code. Previously, this would keep loading the shader again and again. Now, it just loads once: https://editor.p5js.org/davepagurek/sketches/4I3mDwb_u

#### PR Checklist

- [x] `npm run lint` passes
- [ ] [Inline documentation] is included / updated
- [x] [Unit tests] are included / updated

