### PR TITLE
Make sure setAttributes updates lingering references to the old canvas

### DIFF
--- a/src/webgl/p5.RendererGL.js
+++ b/src/webgl/p5.RendererGL.js
@@ -297,6 +297,7 @@ p5.RendererGL.prototype._resetContext = function(options, callback) {
       document.body.appendChild(c);
     }
     this._pInst.canvas = c;
+    this.canvas = c;
   }
 
   const renderer = new p5.RendererGL(

--- a/test/unit/webgl/p5.RendererGL.js
+++ b/test/unit/webgl/p5.RendererGL.js
@@ -756,4 +756,15 @@ suite('p5.RendererGL', function() {
       done();
     });
   });
+
+  suite('setAttributes', function() {
+    test('It leaves a reference to the correct canvas', function(done) {
+      const renderer = myp5.createCanvas(10, 10, myp5.WEBGL);
+      assert.equal(myp5.canvas, renderer.canvas);
+
+      myp5.setAttributes({ alpha: true });
+      assert.equal(myp5.canvas, renderer.canvas);
+      done();
+    });
+  });
 });


### PR DESCRIPTION
Resolves #5817

#### Changes
Previously, when `setAttributes` creates a new canvas, it wouldn't update the `canvas` property of the renderer, leaving a reference to the old canvas. Now, when it's set correctly, sketches that try to read back the main canvas via a reference to a renderer will see the contents of the canvas instead of a blank canvas.

#### Screenshots of the change
Before: 
- Open https://editor.p5js.org/hlp/sketches/ncJGM9DNj
- Add `setAttributes({ alpha: true })` to `setup`

![image](https://user-images.githubusercontent.com/5315059/194439850-66b4037c-b785-49ca-9a38-e3609393c112.png)


After:
- Open https://editor.p5js.org/davepagurek/sketches/794nSzyvE

![image](https://user-images.githubusercontent.com/5315059/194439965-377af28e-52f3-47c9-8365-93e41bf66970.png)


#### PR Checklist
- [x] `npm run lint` passes
- [ ] [Inline documentation] is included / updated
- [x] [Unit tests] are included / updated
