### PR TITLE
Check for the existence of _friendlyAutoplayError before calling it

### DIFF
--- a/src/dom/dom.js
+++ b/src/dom/dom.js
@@ -2531,7 +2531,11 @@ p5.MediaElement.prototype.play = function() {
     promise.catch(e => {
       // if it's an autoplay failure error
       if (e.name === 'NotAllowedError') {
-        p5._friendlyAutoplayError(this.src);
+        if (p5._friendlyAutoplayError) {
+          p5._friendlyAutoplayError(this.src);
+        } else {
+          console.error(e);
+        }
       } else {
         // any other kind of error
         console.error('Media play method encountered an unexpected error', e);
@@ -2782,7 +2786,13 @@ p5.MediaElement.prototype.noLoop = function() {
  * @private
  */
 p5.MediaElement.prototype._setupAutoplayFailDetection = function() {
-  const timeout = setTimeout(() => p5._friendlyAutoplayError(this.src), 500);
+  const timeout = setTimeout(() => {
+    if (p5._friendlyAutoplayError) {
+      p5._friendlyAutoplayError(this.src);
+    } else {
+      console.error(e);
+    }
+  }, 500);
   this.elt.addEventListener('play', () => clearTimeout(timeout), {
     passive: true,
     once: true

--- a/src/dom/dom.js
+++ b/src/dom/dom.js
@@ -2531,7 +2531,7 @@ p5.MediaElement.prototype.play = function() {
     promise.catch(e => {
       // if it's an autoplay failure error
       if (e.name === 'NotAllowedError') {
-        if (p5._friendlyAutoplayError) {
+        if (typeof IS_MINIFIED === 'undefined') {
           p5._friendlyAutoplayError(this.src);
         } else {
           console.error(e);
@@ -2787,7 +2787,7 @@ p5.MediaElement.prototype.noLoop = function() {
  */
 p5.MediaElement.prototype._setupAutoplayFailDetection = function() {
   const timeout = setTimeout(() => {
-    if (p5._friendlyAutoplayError) {
+    if (typeof IS_MINIFIED === 'undefined') {
       p5._friendlyAutoplayError(this.src);
     } else {
       console.error(e);


### PR DESCRIPTION
Resolves https://github.com/processing/p5.js/issues/5820

#### The problem

Sometimes, videos never start playing on mobile. It's a bit flaky, but it seems to happen only if the following conditions are met:
- The video is not cached
- The user has not interacted with the page yet (so, this won't be reproducible in the p5 editor, where you have to click the play button, but is reproducible in codepen)
- p5.min.js is loaded instead of p5.js

I hooked up Firefox mobile on Android to my computer for remote debugging, and found that this is what's happening:
- For whatever reason, when the video isn't fully loaded yet, it throws a NotAllowedError when you immediately tell a video to play even if it would work when you reload the page
- We have existing code to handle this and retry, but before doing so, it tries to run `p5._friendlyAutoplayError()`
- In a minified build, this function doesn't exist, so a new error is thrown
- This interrupts the retry logic and the video never starts

#### The change

I now just check for the existence of `p5._friendlyAutoplayError` before trying to call it, and fall back to a `console.error` otherwise.

I wasn't sure how to add a test for something like this, let me know if you have any suggestions!

#### PR Checklist

- [x] `npm run lint` passes
- [ ] [Inline documentation] is included / updated
- [ ] [Unit tests] are included / updated
