### PR TITLE
Handle vertex data in TESS mode

### DIFF
--- a/src/webgl/p5.RendererGL.Immediate.js
+++ b/src/webgl/p5.RendererGL.Immediate.js
@@ -309,17 +309,36 @@ p5.RendererGL.prototype._calculateEdges = function(
 p5.RendererGL.prototype._tesselateShape = function() {
   this.immediateMode.shapeMode = constants.TRIANGLES;
   const contours = [
-    new Float32Array(this._vToNArray(this.immediateMode.geometry.vertices))
+    this._flatten(this.immediateMode.geometry.vertices.map((vert, i) => [
+      vert.x,
+      vert.y,
+      vert.z,
+      this.immediateMode.geometry.uvs[i * 2],
+      this.immediateMode.geometry.uvs[i * 2 + 1],
+      this.immediateMode.geometry.vertexColors[i * 4],
+      this.immediateMode.geometry.vertexColors[i * 4 + 1],
+      this.immediateMode.geometry.vertexColors[i * 4 + 2],
+      this.immediateMode.geometry.vertexColors[i * 4 + 3],
+      this.immediateMode.geometry.vertexNormals[i].x,
+      this.immediateMode.geometry.vertexNormals[i].y,
+      this.immediateMode.geometry.vertexNormals[i].z
+    ]))
   ];
   const polyTriangles = this._triangulate(contours);
   this.immediateMode.geometry.vertices = [];
+  this.immediateMode.geometry.vertexNormals = [];
+  this.immediateMode.geometry.uvs = [];
+  const colors = [];
   for (
     let j = 0, polyTriLength = polyTriangles.length;
     j < polyTriLength;
-    j = j + 3
+    j = j + 12
   ) {
-    this.vertex(polyTriangles[j], polyTriangles[j + 1], polyTriangles[j + 2]);
+    colors.push(...polyTriangles.slice(j + 5, j + 9));
+    this.normal(...polyTriangles.slice(j + 9, j + 12));
+    this.vertex(...polyTriangles.slice(j, j + 5));
   }
+  this.immediateMode.geometry.vertexColors = colors;
 };
 
 /**

--- a/src/webgl/p5.RendererGL.js
+++ b/src/webgl/p5.RendererGL.js
@@ -1454,6 +1454,7 @@ p5.RendererGL.prototype._initTessy = function initTesselator() {
     const result = [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0];
     for (let i = 0; i < weight.length; i++) {
       for (let j = 0; j < result.length; j++) {
+        if (weight[i] === 0 || !data[i]) continue;
         result[j] += data[i][j] * weight[i];
       }
     }

--- a/src/webgl/p5.RendererGL.js
+++ b/src/webgl/p5.RendererGL.js
@@ -1434,9 +1434,9 @@ p5.prototype._assert3d = function(name) {
 p5.RendererGL.prototype._initTessy = function initTesselator() {
   // function called for each vertex of tesselator output
   function vertexCallback(data, polyVertArray) {
-    polyVertArray[polyVertArray.length] = data[0];
-    polyVertArray[polyVertArray.length] = data[1];
-    polyVertArray[polyVertArray.length] = data[2];
+    for (let i = 0; i < data.length; i++) {
+      polyVertArray[polyVertArray.length] = data[i];
+    }
   }
 
   function begincallback(type) {
@@ -1451,7 +1451,13 @@ p5.RendererGL.prototype._initTessy = function initTesselator() {
   }
   // callback for when segments intersect and must be split
   function combinecallback(coords, data, weight) {
-    return [coords[0], coords[1], coords[2]];
+    const result = [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0];
+    for (let i = 0; i < weight.length; i++) {
+      for (let j = 0; j < result.length; j++) {
+        result[j] += data[i][j] * weight[i];
+      }
+    }
+    return result;
   }
 
   function edgeCallback(flag) {
@@ -1481,8 +1487,8 @@ p5.RendererGL.prototype._triangulate = function(contours) {
   for (let i = 0; i < contours.length; i++) {
     this._tessy.gluTessBeginContour();
     const contour = contours[i];
-    for (let j = 0; j < contour.length; j += 3) {
-      const coords = [contour[j], contour[j + 1], contour[j + 2]];
+    for (let j = 0; j < contour.length; j += 12) {
+      const coords = contour.slice(j, j + 12);
       this._tessy.gluTessVertex(coords, coords);
     }
     this._tessy.gluTessEndContour();

--- a/test/unit/webgl/p5.RendererGL.js
+++ b/test/unit/webgl/p5.RendererGL.js
@@ -755,5 +755,199 @@ suite('p5.RendererGL', function() {
       assert.equal(renderer.immediateMode.geometry.edges.length, 10);
       done();
     });
+
+    test('TESS preserves vertex data', function(done) {
+      var renderer = myp5.createCanvas(10, 10, myp5.WEBGL);
+
+      myp5.textureMode(myp5.NORMAL);
+      renderer.beginShape(myp5.TESS);
+      renderer.fill(255, 255, 255);
+      renderer.normal(-1, -1, 1);
+      renderer.vertex(-10, -10, 0, 0);
+      renderer.fill(255, 0, 0);
+      renderer.normal(1, -1, 1);
+      renderer.vertex(10, -10, 1, 0);
+      renderer.fill(0, 255, 0);
+      renderer.normal(1, 1, 1);
+      renderer.vertex(10, 10, 1, 1);
+      renderer.fill(0, 0, 255);
+      renderer.normal(-1, 1, 1);
+      renderer.vertex(-10, 10, 0, 1);
+      renderer.endShape(myp5.CLOSE);
+
+      assert.equal(renderer.immediateMode.geometry.vertices.length, 6);
+      assert.deepEqual(
+        renderer.immediateMode.geometry.vertices[0].array(),
+        [10, -10, 0]
+      );
+      assert.deepEqual(
+        renderer.immediateMode.geometry.vertices[1].array(),
+        [-10, 10, 0]
+      );
+      assert.deepEqual(
+        renderer.immediateMode.geometry.vertices[2].array(),
+        [-10, -10, 0]
+      );
+      assert.deepEqual(
+        renderer.immediateMode.geometry.vertices[3].array(),
+        [-10, 10, 0]
+      );
+      assert.deepEqual(
+        renderer.immediateMode.geometry.vertices[4].array(),
+        [10, -10, 0]
+      );
+      assert.deepEqual(
+        renderer.immediateMode.geometry.vertices[5].array(),
+        [10, 10, 0]
+      );
+
+      assert.equal(renderer.immediateMode.geometry.vertexNormals.length, 6);
+      assert.deepEqual(
+        renderer.immediateMode.geometry.vertexNormals[0].array(),
+        [1, -1, 1]
+      );
+      assert.deepEqual(
+        renderer.immediateMode.geometry.vertexNormals[1].array(),
+        [-1, 1, 1]
+      );
+      assert.deepEqual(
+        renderer.immediateMode.geometry.vertexNormals[2].array(),
+        [-1, -1, 1]
+      );
+      assert.deepEqual(
+        renderer.immediateMode.geometry.vertexNormals[3].array(),
+        [-1, 1, 1]
+      );
+      assert.deepEqual(
+        renderer.immediateMode.geometry.vertexNormals[4].array(),
+        [1, -1, 1]
+      );
+      assert.deepEqual(
+        renderer.immediateMode.geometry.vertexNormals[5].array(),
+        [1, 1, 1]
+      );
+
+      assert.deepEqual(renderer.immediateMode.geometry.vertexColors, [
+        1, 0, 0, 1,
+        0, 0, 1, 1,
+        1, 1, 1, 1,
+        0, 0, 1, 1,
+        1, 0, 0, 1,
+        0, 1, 0, 1
+      ]);
+
+      assert.deepEqual(renderer.immediateMode.geometry.uvs, [
+        1, 0,
+        0, 1,
+        0, 0,
+        0, 1,
+        1, 0,
+        1, 1
+      ]);
+
+      done();
+    });
+
+    test('TESS interpolates vertex data at intersections', function(done) {
+      var renderer = myp5.createCanvas(10, 10, myp5.WEBGL);
+
+      // Hourglass shape:
+      //
+      // 1     3
+      // o     o
+      // | \ / |
+      // | / \ |
+      // o     o
+      // 4     2
+      //
+      // Tessy will add a vertex in the middle
+      myp5.textureMode(myp5.NORMAL);
+      renderer.beginShape(myp5.TESS);
+      renderer.fill(255, 255, 255);
+      renderer.normal(-1, -1, 1);
+      renderer.vertex(-10, -10, 0, 0);
+      renderer.fill(0, 255, 0);
+      renderer.normal(1, 1, 1);
+      renderer.vertex(10, 10, 1, 1);
+      renderer.fill(255, 0, 0);
+      renderer.normal(1, -1, 1);
+      renderer.vertex(10, -10, 1, 0);
+      renderer.fill(0, 0, 255);
+      renderer.normal(-1, 1, 1);
+      renderer.vertex(-10, 10, 0, 1);
+      renderer.endShape(myp5.CLOSE);
+
+      assert.equal(renderer.immediateMode.geometry.vertices.length, 6);
+      assert.deepEqual(
+        renderer.immediateMode.geometry.vertices[0].array(),
+        [0, 0, 0]
+      );
+      assert.deepEqual(
+        renderer.immediateMode.geometry.vertices[1].array(),
+        [-10, 10, 0]
+      );
+      assert.deepEqual(
+        renderer.immediateMode.geometry.vertices[2].array(),
+        [-10, -10, 0]
+      );
+      assert.deepEqual(
+        renderer.immediateMode.geometry.vertices[3].array(),
+        [10, 10, 0]
+      );
+      assert.deepEqual(
+        renderer.immediateMode.geometry.vertices[4].array(),
+        [0, 0, 0]
+      );
+      assert.deepEqual(
+        renderer.immediateMode.geometry.vertices[5].array(),
+        [10, -10, 0]
+      );
+
+      assert.equal(renderer.immediateMode.geometry.vertexNormals.length, 6);
+      assert.deepEqual(
+        renderer.immediateMode.geometry.vertexNormals[0].array(),
+        [0, 0, 1]
+      );
+      assert.deepEqual(
+        renderer.immediateMode.geometry.vertexNormals[1].array(),
+        [-1, 1, 1]
+      );
+      assert.deepEqual(
+        renderer.immediateMode.geometry.vertexNormals[2].array(),
+        [-1, -1, 1]
+      );
+      assert.deepEqual(
+        renderer.immediateMode.geometry.vertexNormals[3].array(),
+        [1, 1, 1]
+      );
+      assert.deepEqual(
+        renderer.immediateMode.geometry.vertexNormals[4].array(),
+        [0, 0, 1]
+      );
+      assert.deepEqual(
+        renderer.immediateMode.geometry.vertexNormals[5].array(),
+        [1, -1, 1]
+      );
+
+      assert.deepEqual(renderer.immediateMode.geometry.vertexColors, [
+        0.5, 0.5, 0.5, 1,
+        0, 0, 1, 1,
+        1, 1, 1, 1,
+        0, 1, 0, 1,
+        0.5, 0.5, 0.5, 1,
+        1, 0, 0, 1
+      ]);
+
+      assert.deepEqual(renderer.immediateMode.geometry.uvs, [
+        0.5, 0.5,
+        0, 1,
+        0, 0,
+        1, 1,
+        0.5, 0.5,
+        1, 0
+      ]);
+
+      done();
+    });
   });
 });


### PR DESCRIPTION
Resolves https://github.com/processing/p5.js/issues/5631

Changes:
- Passes all vertex data to Tessy when using `beginshape(TESS)`
- Updates Tessy callbacks to properly interpolate data at intersection points


Screenshots of the change:
<table>
<tr>
<td rowspan="2">

```js
let tex;

function preload() {
  tex = loadImage('cat.jpg');
}

function setup() {
  createCanvas(400, 400, WEBGL);
  textureMode(NORMAL)
  noLoop();
}

function draw() {
  background(220);
  scale(3, 3);
  translate(-50, -50);
  texture(tex);
  beginShape(TESS);
  vertex(20, 20, 0, 0);
  vertex(80, 20, 1, 0);
  vertex(80, 40, 1, 0.33);
  vertex(40, 40, 0.33, 0.33);
  vertex(40, 60, 0.33, 0.67);
  vertex(80, 60, 1, 0.67);
  vertex(80, 80, 1, 1);
  vertex(20, 80, 0, 1);
  endShape(CLOSE);
}
```

</td>

<th>Before</th>
<th>After</th>
</tr>
<tr>
<td>
<img src="https://user-images.githubusercontent.com/5315059/195337246-30360876-e515-4092-aad8-9c4a99c1cafd.png" />
</td>
<td>
<img src="https://user-images.githubusercontent.com/5315059/195337303-1ae4bf73-c3d4-4e97-b3ce-8e50659f80ae.png" />
</td>
</tr>
</table>



#### PR Checklist

- [x] `npm run lint` passes
- [ ] [Inline documentation] is included / updated
- [x] [Unit tests] are included / updated
