### PR TITLE
Fixed typo in comment

### DIFF
--- a/src/webgl/p5.RendererGL.Retained.js
+++ b/src/webgl/p5.RendererGL.Retained.js
@@ -78,7 +78,7 @@ p5.RendererGL.prototype.createBuffers = function(gId, model) {
 
     // If any face references a vertex with an index greater than the maximum
     // un-singed 16 bit integer, then we need to use a Uint32Array instead of a
-    // Uint32Array
+    // Uint16Array
     const hasVertexIndicesOverMaxUInt16 = vals.some(v => v > 65535);
     let type = hasVertexIndicesOverMaxUInt16 ? Uint32Array : Uint16Array;
     this._bindBuffer(indexBuffer, gl.ELEMENT_ARRAY_BUFFER, vals, type);


### PR DESCRIPTION
Resolves #5832

Changes: substituted a mistaken `Uint32Array` with `Uint16Array` in a comment only
