### PR TITLE
Handle v1.div(v2) when vectors are 2D

### DIFF
--- a/src/math/p5.Vector.js
+++ b/src/math/p5.Vector.js
@@ -757,7 +757,9 @@ p5.Vector.prototype.mult = function mult(x, y, z) {
  * and `z` components of the vector are all divided by the scalar. When dividing a vector by a vector,
  * the `x`, `y`, `z` components of the source vector are treated as the dividend, and the `x`, `y`, `z` components
  * of the argument is treated as the divisor. (For example, with two vectors
- * `a` and `b`: `a.x / b.x`, `a.y / b.y`, `a.z / b.z`.)
+ * `a` and `b`: `a.x / b.x`, `a.y / b.y`, `a.z / b.z`.) If any component of the second vector is 0, a division by 0
+ * error will be logged, unless both two vectors have 0 in their `z` components, in which case only the `x` and `y`
+ * components will be divided.
  * The static version of this method creates a
  * new <a href="#/p5.Vector">p5.Vector</a> while the non-static version acts on the vector directly.
  * Additionally, you may provide arguments to this method as an array.

--- a/src/math/p5.Vector.js
+++ b/src/math/p5.Vector.js
@@ -877,13 +877,16 @@ p5.Vector.prototype.div = function div(x, y, z) {
       typeof x.y === 'number' &&
       typeof x.z === 'number'
     ) {
-      if (x.x === 0 || x.y === 0 || x.z === 0) {
+      const isLikely2D = x.z === 0 && this.z === 0;
+      if (x.x === 0 || x.y === 0 || (!isLikely2D && x.z === 0)) {
         console.warn('p5.Vector.prototype.div:', 'divide by 0');
         return this;
       }
       this.x /= x.x;
       this.y /= x.y;
-      this.z /= x.z;
+      if (!isLikely2D) {
+        this.z /= x.z;
+      }
     } else {
       console.warn(
         'p5.Vector.prototype.div:',

--- a/test/unit/math/p5.Vector.js
+++ b/test/unit/math/p5.Vector.js
@@ -684,11 +684,38 @@ suite('p5.Vector', function() {
         expect(v0.z).to.eql(3);
       });
 
-      test('should not change x, y, z if v3 contains 0', function() {
+      test('should not change x, y, z if v3 is all 0', function() {
         v2.div(v3);
         expect(v2.x).to.eql(1);
         expect(v2.y).to.eql(1);
         expect(v2.z).to.eql(1);
+      });
+
+      test('should work on 2D vectors', function() {
+        const v = new p5.Vector(1, 1);
+        const divisor = new p5.Vector(2, 2);
+        v.div(divisor);
+        expect(v.x).to.eql(0.5);
+        expect(v.y).to.eql(0.5);
+        expect(v.z).to.eql(0);
+      });
+
+      test('should work when the dividend has 0', function() {
+        const v = new p5.Vector(1, 0);
+        const divisor = new p5.Vector(2, 2);
+        v.div(divisor);
+        expect(v.x).to.eql(0.5);
+        expect(v.y).to.eql(0);
+        expect(v.z).to.eql(0);
+      });
+
+      test('should do nothing when the divisor has 0', function() {
+        const v = new p5.Vector(1, 1);
+        const divisor = new p5.Vector(0, 2);
+        v.div(divisor);
+        expect(v.x).to.eql(1);
+        expect(v.y).to.eql(1);
+        expect(v.z).to.eql(0);
       });
     });
 


### PR DESCRIPTION
Resolves https://github.com/processing/p5.js/issues/5821

Changes:
- Allows the divisor's z to be 0 if the dividend's z is also 0, as this is likely a 2D vector
- The above only applies when passing a vector as the divisor, as 2D vectors store z as 0; if explicitly passing number arguments or an array, it still will log an error if z is 0
  - Is this ok or should we use the same logic for all arguments?

#### PR Checklist

- [x] `npm run lint` passes
- [ ] [Inline documentation] is included / updated
- [x] [Unit tests] are included / updated
