### PR TITLE
Fix release action error due to unset secret

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,6 +13,8 @@ jobs:
   release:
     runs-on: ubuntu-latest
     name: Release
+    env:
+      INPUT_TOKEN: ${{ secrets.NPM_TOKEN }}
     steps:
       # 1. Setup
       - uses: actions/checkout@v3


### PR DESCRIPTION
Because of https://github.com/JS-DevTools/npm-publish/issues/15, there is some existing bug in the release action that is being used causing actions that runs after p5.js is released on NPM to fail.

This PR fixes the problem with a workaround as fixed version of the NPM release action is not available yet.

@Qianqianye We can test this with a 1.5.1 release.
