### PR TITLE
Add a read-only flag to indicate if the current canvas is Web GL

### DIFF
--- a/src/core/main.js
+++ b/src/core/main.js
@@ -387,7 +387,7 @@ class p5 {
         this._frameRate = 1000.0 / (now - this._lastFrameTime);
         this.deltaTime = now - this._lastFrameTime;
         this._setProperty('deltaTime', this.deltaTime);
-        this._lastFrameTime = this._lastFrameTime+target_time_between_frames;
+        this._lastFrameTime = now;
 
         // If the user is actually using mouse module, then update
         // coordinates, otherwise skip. We can test this by simply
@@ -688,9 +688,6 @@ class p5 {
         globalObject[prop] = value;
       }
     };
-  }
-  isWebGL() {
-    return Graphics.isWebGL;
   }
 }
 

--- a/src/core/main.js
+++ b/src/core/main.js
@@ -387,7 +387,7 @@ class p5 {
         this._frameRate = 1000.0 / (now - this._lastFrameTime);
         this.deltaTime = now - this._lastFrameTime;
         this._setProperty('deltaTime', this.deltaTime);
-        this._lastFrameTime = now;
+        this._lastFrameTime = this._lastFrameTime+target_time_between_frames;
 
         // If the user is actually using mouse module, then update
         // coordinates, otherwise skip. We can test this by simply
@@ -688,6 +688,9 @@ class p5 {
         globalObject[prop] = value;
       }
     };
+  }
+  isWebGL() {
+    return Graphics.isWebGL;
   }
 }
 

--- a/src/core/rendering.js
+++ b/src/core/rendering.js
@@ -127,10 +127,8 @@ p5.prototype.createCanvas = function(w, h, renderer) {
       writable: false
     });
     }
-    //createCanvas runs twice. The first call sets the renderer to
-    //2D even if WEBGL is specified in the arguments, on the second call it
-    //uses the correct renderer. Therefore only on the second call does 
-    //createCanvas check, set and lock isWebGL 
+    //createCanvas is run automatically with the 2D renderer.
+    //Auto-set isWebGL to false if undefined because of this
     if (this.isWebGL === undefined) {
       this.isWebGL = false;
     }

--- a/src/core/rendering.js
+++ b/src/core/rendering.js
@@ -121,7 +121,7 @@ p5.prototype.createCanvas = function(w, h, renderer) {
   this._renderer._applyDefaults();
 
   //isWebGL flag is set and made read-only
-  if (this.isWebGL == 1) {
+  if (this.isWebGL == false) {
     Object.defineProperty(this,"isWebGL" , {
       value: this._renderer.drawingContext instanceof WebGLRenderingContext,
       writable: false
@@ -132,7 +132,7 @@ p5.prototype.createCanvas = function(w, h, renderer) {
     //uses the correct renderer. Therefore only on the second call does 
     //createCanvas check, set and lock isWebGL 
     if (this.isWebGL === undefined) {
-      this.isWebGL = 1;
+      this.isWebGL = false;
     }
 
   return this._renderer;

--- a/src/core/rendering.js
+++ b/src/core/rendering.js
@@ -119,6 +119,21 @@ p5.prototype.createCanvas = function(w, h, renderer) {
   }
   this._renderer.resize(w, h);
   this._renderer._applyDefaults();
+
+  //isWebGL flag is set and made read-only
+  if (this.isWebGL == 1) {
+    Object.defineProperty(this,"isWebGL" , {
+      value: this._renderer.drawingContext instanceof WebGLRenderingContext,
+      writable: false
+    });
+    }
+    //createCanvas runs twice when called. The first call sets the renderer to 2D
+    //even if WEBGL is specified in the arguments. There only on the
+    //second call does createCanvas check, set and lock isWebGL 
+    if (this.isWebGL === undefined) {
+      this.isWebGL = 1;
+    }
+
   return this._renderer;
 };
 

--- a/src/core/rendering.js
+++ b/src/core/rendering.js
@@ -127,9 +127,10 @@ p5.prototype.createCanvas = function(w, h, renderer) {
       writable: false
     });
     }
-    //createCanvas runs twice when called. The first call sets the renderer to 2D
-    //even if WEBGL is specified in the arguments. There only on the
-    //second call does createCanvas check, set and lock isWebGL 
+    //createCanvas runs twice. The first call sets the renderer to
+    //2D even if WEBGL is specified in the arguments, on the second call it
+    //uses the correct renderer. Therefore only on the second call does 
+    //createCanvas check, set and lock isWebGL 
     if (this.isWebGL === undefined) {
       this.isWebGL = 1;
     }


### PR DESCRIPTION
Resolves #5750

Changes:
Added a read-only `.isWebGL` flag to p5 instances. This flag is set in createCavnas. Included comments, no inline docs.


Usage screenshot:
![image](https://user-images.githubusercontent.com/94106002/197766766-ec989065-c183-460f-a60b-149d6943c8a5.png)

#### PR Checklist

- [x] `npm run lint` passes
