### PR TITLE
NaN and infinity check for isNumber

### DIFF
--- a/src/core/friendly_errors/validate_params.js
+++ b/src/core/friendly_errors/validate_params.js
@@ -344,7 +344,7 @@ if (typeof IS_MINIFIED !== 'undefined') {
   const isNumber = param => {
     switch (typeof param) {
       case 'number':
-        return true;
+        return isFinite(param);
       case 'string':
         return !isNaN(param);
       default:

--- a/src/core/friendly_errors/validate_params.js
+++ b/src/core/friendly_errors/validate_params.js
@@ -346,7 +346,7 @@ if (typeof IS_MINIFIED !== 'undefined') {
       case 'number':
         return isFinite(param);
       case 'string':
-        return !isNaN(param);
+        return !(isNaN(param) || param == "null");
       default:
         return false;
     }

--- a/test/unit/core/error_helpers.js
+++ b/test/unit/core/error_helpers.js
@@ -177,6 +177,28 @@ suite('Error Helpers', function() {
         'ValidationError type is correct'
       );
     });
+
+    testUnMinified('line: null string given', function() {
+      let err = assert.throws(function() {
+        p5._validateParameters('line', [1, 2, 4, "null"]);
+      }, p5.ValidationError);
+      assert.strictEqual(
+        err.type,
+        'WRONG_TYPE',
+        'ValidationError type is correct'
+      );
+    });
+
+    testUnMinified('line: infinite value given', function() {
+      let err = assert.throws(function() {
+        p5._validateParameters('line', [1, 2, 4, Infinity]);
+      }, p5.ValidationError);
+      assert.strictEqual(
+        err.type,
+        'WRONG_TYPE',
+        'ValidationError type is correct'
+      );
+    });
   });
 
   suite('validateParameters: trailing undefined arguments', function() {


### PR DESCRIPTION
<!--
  Thank you for contributing! Please use this pull request (PR) template.


 In the description field of this PR, include "resolves #XXXX" tagging the issue you are fixing. If this PR addresses the issue but doesn't completely resolve it (ie the issue should remain open after your PR is merged), write "addresses #XXXX".-->
Resolves #5675 

 Changes:
<!-- Add here what changes were made in this pull request and if possible provide links showcasing the changes. -->
Implemented an additional checker for null strings and infinite values in isNumber within validate_params.js

 Screenshots of the change:
<!-- If applicable, add screenshots depicting the changes. -->
<img width="403" alt="Screen Shot 2022-10-25 at 11 28 20 pm" src="https://user-images.githubusercontent.com/110585243/197885517-50c4523c-f754-43f9-aa9a-4fbc58ababb3.png">


#### PR Checklist
<!--
  To check any option, replace the "[ ]" with a "[x]". Be sure to check out how it looks in the Preview tab! Feel free to remove any portion of the template that is not relevant for your issue.
-->

- [ ] `npm run lint` passes
- [x] [Inline documentation] is included / updated
- [x] [Unit tests] are included / updated

[Inline documentation]: https://github.com/processing/p5.js/blob/main/contributor_docs/inline_documentation.md
[Unit tests]: https://github.com/processing/p5.js/tree/main/contributor_docs#unit-tests
