### PR TITLE
Handle MULTIPLY with alpha in WebGL

### DIFF
--- a/src/webgl/material.js
+++ b/src/webgl/material.js
@@ -1095,7 +1095,12 @@ p5.RendererGL.prototype._applyBlendMode = function() {
       break;
     case constants.MULTIPLY:
       gl.blendEquationSeparate(gl.FUNC_ADD, gl.FUNC_ADD);
-      gl.blendFuncSeparate(gl.ZERO, gl.SRC_COLOR, gl.ONE, gl.ONE);
+      gl.blendFuncSeparate(
+        gl.DST_COLOR,
+        gl.ONE_MINUS_SRC_ALPHA,
+        gl.ONE,
+        gl.ONE_MINUS_SRC_ALPHA
+      );
       break;
     case constants.SCREEN:
       gl.blendEquationSeparate(gl.FUNC_ADD, gl.FUNC_ADD);

--- a/test/unit/webgl/p5.RendererGL.js
+++ b/test/unit/webgl/p5.RendererGL.js
@@ -447,7 +447,9 @@ suite('p5.RendererGL', function() {
       assert.deepEqual([133, 255, 133, 255], mixAndReturn(myp5.SUBTRACT, 255));
       assert.deepEqual([255, 0, 255, 255], mixAndReturn(myp5.SCREEN, 0));
       assert.deepEqual([0, 255, 0, 255], mixAndReturn(myp5.EXCLUSION, 255));
-      assert.deepEqual([0, 0, 0, 255], mixAndReturn(myp5.MULTIPLY, 255));
+      // Note that in 2D mode, this would just return black, because 2D mode
+      // ignores alpha in this case.
+      assert.deepEqual([133, 69, 202, 255], mixAndReturn(myp5.MULTIPLY, 255));
       assert.deepEqual([255, 0, 255, 255], mixAndReturn(myp5.LIGHTEST, 0));
       assert.deepEqual([0, 0, 0, 255], mixAndReturn(myp5.DARKEST, 255));
       done();
@@ -486,18 +488,22 @@ suite('p5.RendererGL', function() {
         }
       };
 
-      const red = '#F53';
-      const blue = '#13F';
-      assertSameIn2D(red, blue, myp5.BLEND);
-      assertSameIn2D(red, blue, myp5.ADD);
-      assertSameIn2D(red, blue, myp5.DARKEST);
-      assertSameIn2D(red, blue, myp5.LIGHTEST);
-      assertSameIn2D(red, blue, myp5.EXCLUSION);
-      assertSameIn2D(red, blue, myp5.MULTIPLY);
-      assertSameIn2D(red, blue, myp5.SCREEN);
-      assertSameIn2D(red, blue, myp5.REPLACE);
-      assertSameIn2D(red, blue, myp5.REMOVE);
-      done();
+      for (const alpha of [255, 200]) {
+        const red = myp5.color('#F53');
+        const blue = myp5.color('#13F');
+        red.setAlpha(alpha);
+        blue.setAlpha(alpha);
+        assertSameIn2D(red, blue, myp5.BLEND);
+        assertSameIn2D(red, blue, myp5.ADD);
+        assertSameIn2D(red, blue, myp5.DARKEST);
+        assertSameIn2D(red, blue, myp5.LIGHTEST);
+        assertSameIn2D(red, blue, myp5.EXCLUSION);
+        assertSameIn2D(red, blue, myp5.MULTIPLY);
+        assertSameIn2D(red, blue, myp5.SCREEN);
+        assertSameIn2D(red, blue, myp5.REPLACE);
+        assertSameIn2D(red, blue, myp5.REMOVE);
+        done();
+      }
     });
 
     test('blendModes are included in push/pop', function(done) {


### PR DESCRIPTION
Resolves #5854

Changes:
- Uses the MULTIPLY blend mode settings that Pixi.js uses
- Updates an existing blend test that ignored alpha (only fully opaque blue multiplied with fully opaque red would yield black; unfortunately, this is how 2D mode works, so this is different than before)
- Updates tests that check if WebGL blending matches 2D to test with some transparency

Note that **2D and WebGL MULTIPLY modes work differently now!** The 2D mode has [a bunch of quirks](https://www.davepagurek.com/blog/p5-tint/) where it blends semi transparent colors with white and makes them opaque before multiplication. This PR chooses to handle MULTIPLY in WebGL in a more expected way. If we decide we want to preserve the existing alpha-ignoring method for everything but text, I can update this code to only use the new blend function when drawing text.

Screenshots of the change:
<table>
<tr>
<th>
Before
</th>
<th>
After
</th>
<tr>
<td>
<img src="https://user-images.githubusercontent.com/5315059/200186009-b63449c6-38e4-4b35-8b01-7f807cd6ec5a.png" />
</td>
<td>
<img src="https://user-images.githubusercontent.com/5315059/200190139-b569ae64-e6b9-4de0-ae7f-6936c976aba0.png" />
</td>
</tr>
</table>


#### PR Checklist

- [x] `npm run lint` passes
- [ ] [Inline documentation] is included / updated
- [x] [Unit tests] are included / updated