### PR TITLE
Enable WebGL blending when drawing with shaders

### DIFF
--- a/src/webgl/material.js
+++ b/src/webgl/material.js
@@ -1048,6 +1048,9 @@ p5.RendererGL.prototype._applyColorBlend = function(colors) {
 
   const isTexture = this.drawMode === constants.TEXTURE;
   const doBlend =
+    this.userFillShader ||
+    this.userStrokeShader ||
+    this.userPointShader ||
     isTexture ||
     this.curBlendMode !== constants.BLEND ||
     colors[colors.length - 1] < 1.0 ||


### PR DESCRIPTION
Resolves #5853

Changes:
- Enables blending when a user shader is set

Screenshots of the change:
(Using the pass-through shader example in the issue)
<table>
<tr>
<th>
Before
</th>
<th>
After
</th>
<tr>
<td>
<img src="https://user-images.githubusercontent.com/5315059/200185621-06d598c6-d7d4-4fa4-a931-b4f9fe547512.png" />
</td>
<td>
<img src="https://user-images.githubusercontent.com/5315059/200185703-acd738bd-836e-4faa-a0fe-963415e6f710.png" />
</td>
</tr>
</table>


#### PR Checklist

- [x] `npm run lint` passes
- [ ] [Inline documentation] is included / updated
- [ ] [Unit tests] are included / updated
