### PR TITLE
Fix visual glitches in WebGL font rendering

### DIFF
--- a/src/webgl/shaders/font.vert
+++ b/src/webgl/shaders/font.vert
@@ -17,13 +17,27 @@ void main() {
   // scale by the size of the glyph's rectangle
   positionVec4.xy *= uGlyphRect.zw - uGlyphRect.xy;
 
+  // Expand glyph bounding boxes by 1px on each side to give a bit of room
+  // for antialiasing
+  vec2 pixelScale = vec2(
+    1. / uModelViewMatrix[0][0],
+    1. / uModelViewMatrix[1][1]
+  );
+  vec2 offset = pixelScale * normalize(aTexCoord - vec2(0.5, 0.5)) * vec2(1., -1.);
+  vec2 textureOffset = offset * (1. / vec2(
+    uGlyphRect.z - uGlyphRect.x,
+    uGlyphRect.w - uGlyphRect.y
+  ));
+
   // move to the corner of the glyph
   positionVec4.xy += uGlyphRect.xy;
 
   // move to the letter's line offset
   positionVec4.x += uGlyphOffset;
+
+  positionVec4.xy += offset;
   
   gl_Position = uProjectionMatrix * uModelViewMatrix * positionVec4;
-  vTexCoord = aTexCoord;
+  vTexCoord = aTexCoord + textureOffset;
   w = gl_Position.w;
 }

--- a/src/webgl/text.js
+++ b/src/webgl/text.js
@@ -217,17 +217,33 @@ const FontInfo = function(font) {
         return { min, max };
       }
 
+      // Expand the bounding box of the glyph by the number of cells below
+      // before rounding. Curves only partially through a cell won't be added
+      // to adjacent cells, but ones that are close will be. This helps fix
+      // small visual glitches that occur when curves are close to grid cell
+      // boundaries.
+      const cellOffset = 0.5;
+
       // loop through the rows & columns that the curve intersects
       // adding the curve to those slices
       const mmX = minMax(xs, 1, 0);
-      const ixMin = Math.max(Math.floor(mmX.min * charGridWidth), 0);
-      const ixMax = Math.min(Math.ceil(mmX.max * charGridWidth), charGridWidth);
+      const ixMin = Math.max(
+        Math.floor(mmX.min * charGridWidth - cellOffset),
+        0
+      );
+      const ixMax = Math.min(
+        Math.ceil(mmX.max * charGridWidth + cellOffset),
+        charGridWidth
+      );
       for (let iCol = ixMin; iCol < ixMax; ++iCol) cols[iCol].push(index);
 
       const mmY = minMax(ys, 1, 0);
-      const iyMin = Math.max(Math.floor(mmY.min * charGridHeight), 0);
+      const iyMin = Math.max(
+        Math.floor(mmY.min * charGridHeight - cellOffset),
+        0
+      );
       const iyMax = Math.min(
-        Math.ceil(mmY.max * charGridHeight),
+        Math.ceil(mmY.max * charGridHeight + cellOffset),
         charGridHeight
       );
       for (let iRow = iyMin; iRow < iyMax; ++iRow) rows[iRow].push(index);


### PR DESCRIPTION
Resolves https://github.com/processing/p5.js/issues/5852

## Changes
- Slightly expands the bounding box of glyphs when picking which grid rows/columns they overlap with to fix the slight glitches you see when they're very close to grid edges
- Slightly expands the bounding box of rendered glyphs on canvas to allow for better antialiasing on edges


## Screenshots of the change
Here's a gif that flips between before/after images so the difference stands out:
![font-changes](https://user-images.githubusercontent.com/5315059/201429922-484e5af1-0dda-487f-a4e3-8a7b55683b9f.gif)

Here's a visualization of the bounding box sizing changes going on under the hood to fix edge antialiasing:
![bbox-changes](https://user-images.githubusercontent.com/5315059/201429963-b85f396c-0158-4461-82a8-3ee54574d9d1.gif)

You can test out the changes on a few different fonts and sizes here: https://editor.p5js.org/davepagurek/sketches/l1ulBxXnK

#### PR Checklist


- [x] `npm run lint` passes

