### PR TITLE
Fix palette generation bugs in saveGif()

### DIFF
--- a/src/image/loading_displaying.js
+++ b/src/image/loading_displaying.js
@@ -369,6 +369,11 @@ p5.prototype.saveGif = async function(
   // calculate the global palette for this set of frames
   const globalPalette = _generateGlobalPalette(frames);
 
+  // Rather than using applyPalette() from the gifenc library, we use our
+  // own function to map frame pixels to a palette color. This way, we can
+  // cache palette color mappings between frames for extra performance, and
+  // use our own caching mechanism to avoid flickering colors from cache
+  // key collisions.
   const paletteCache = {};
   const getIndexedFrame = frame => {
     const length = frame.length / 4;
@@ -399,7 +404,7 @@ p5.prototype.saveGif = async function(
     //const indexedFrame = applyPalette(frames[i], globalPaletteWithoutAlpha, 'rgba565');
     const indexedFrame = getIndexedFrame(frames[i]);
 
-    // Make a copy of the palette-applied frame before edit the original
+    // Make a copy of the palette-applied frame before editing the original
     // to use transparent pixels
     const originalIndexedFrame = indexedFrame.slice();
 

--- a/src/image/loading_displaying.js
+++ b/src/image/loading_displaying.js
@@ -9,7 +9,7 @@ import p5 from '../core/main';
 import canvas from '../core/helpers';
 import * as constants from '../core/constants';
 import omggif from 'omggif';
-import { GIFEncoder, quantize, applyPalette } from 'gifenc';
+import { GIFEncoder, quantize, nearestColorIndex } from 'gifenc';
 
 import '../core/friendly_errors/validate_params';
 import '../core/friendly_errors/file_errors';
@@ -369,72 +369,67 @@ p5.prototype.saveGif = async function(
   // calculate the global palette for this set of frames
   const globalPalette = _generateGlobalPalette(frames);
 
+  const paletteCache = {};
+  const getIndexedFrame = frame => {
+    const length = frame.length / 4;
+    const index = new Uint8Array(length);
+    for (let i = 0; i < length; i++) {
+      const key =
+        (frame[i * 4] << 24) |
+        (frame[i * 4 + 1] << 16) |
+        (frame[i * 4 + 2] << 8) |
+        frame[i * 4 + 3];
+      if (paletteCache[key] === undefined) {
+        paletteCache[key] = nearestColorIndex(
+          globalPalette,
+          frame.slice(i * 4, (i + 1) * 4)
+        );
+      }
+      index[i] = paletteCache[key];
+    }
+    return index;
+  };
+
   // the way we designed the palette means we always take the last index for transparency
   const transparentIndex = globalPalette.length - 1;
 
   // we are going to iterate the frames in pairs, n-1 and n
+  let prevIndexedFrame = [];
   for (let i = 0; i < frames.length; i++) {
+    //const indexedFrame = applyPalette(frames[i], globalPaletteWithoutAlpha, 'rgba565');
+    const indexedFrame = getIndexedFrame(frames[i]);
+
+    // Make a copy of the palette-applied frame before edit the original
+    // to use transparent pixels
+    const originalIndexedFrame = indexedFrame.slice();
+
     if (i === 0) {
-      const indexedFrame = applyPalette(frames[i], globalPalette, {
-        format: 'rgba4444'
-      });
       gif.writeFrame(indexedFrame, this.width, this.height, {
         palette: globalPalette,
         delay: gifFrameDelay,
         dispose: 1
       });
-      continue;
-    }
-
-    // matching pixels between frames can be set to full transparency,
-    // kinda digging a "hole" into the frame to see the pixels that where behind it
-    // (which would be the exact same, so not noticeable changes)
-    // this helps make the file quite smaller
-    let currFramePixels = frames[i];
-    let lastFramePixels = frames[i - 1];
-    let matchingPixelsInFrames = [];
-    for (let p = 0; p < currFramePixels.length; p += 4) {
-      let currPixel = [
-        currFramePixels[p],
-        currFramePixels[p + 1],
-        currFramePixels[p + 2],
-        currFramePixels[p + 3]
-      ];
-      let lastPixel = [
-        lastFramePixels[p],
-        lastFramePixels[p + 1],
-        lastFramePixels[p + 2],
-        lastFramePixels[p + 3]
-      ];
-
-      // if the pixels are equal, save this index to be used later
-      if (_pixelEquals(currPixel, lastPixel)) {
-        matchingPixelsInFrames.push(p / 4);
+    } else {
+      // Matching pixels between frames can be set to full transparency,
+      // allowing the previous frame's pixels to show through. We only do
+      // this for pixels that get mapped to the same quantized color so that
+      // the resulting image would be the same.
+      for (let i = 0; i < indexedFrame.length; i++) {
+        if (indexedFrame[i] === prevIndexedFrame[i]) {
+          indexedFrame[i] = transparentIndex;
+        }
       }
-    }
-    // we decide on one of this colors to be fully transparent
-    // Apply palette to RGBA data to get an indexed bitmap
-    const indexedFrame = applyPalette(currFramePixels, globalPalette, {
-      format: 'rgba4444'
-    });
 
-    for (let i = 0; i < matchingPixelsInFrames.length; i++) {
-      // here, we overwrite whatever color this pixel was assigned to
-      // with the color that we decided we are going to use as transparent.
-      // down in writeFrame we are going to tell the encoder that whenever
-      // it runs into "transparentIndex", just dig a hole there allowing to
-      // see through what was in the frame before it.
-      let pixelIndex = matchingPixelsInFrames[i];
-      indexedFrame[pixelIndex] = transparentIndex;
+      // Write frame into the encoder
+      gif.writeFrame(indexedFrame, this.width, this.height, {
+        delay: gifFrameDelay,
+        transparent: true,
+        transparentIndex: transparentIndex,
+        dispose: 1
+      });
     }
 
-    // Write frame into the encoder
-    gif.writeFrame(indexedFrame, this.width, this.height, {
-      delay: gifFrameDelay,
-      transparent: true,
-      transparentIndex: transparentIndex,
-      dispose: 1
-    });
+    prevIndexedFrame = originalIndexedFrame;
 
     p.html(
       'Rendered frame <b>' + i.toString() + '</b> out of ' + nFrames.toString()
@@ -499,12 +494,12 @@ function _generateGlobalPalette(frames) {
   // this array will hold absolutely every pixel from the animation.
   // the set function on the Uint8Array works super fast tho!
   for (let f = 0; f < frames.length; f++) {
-    allColors.set(frames[0], f * frames[0].length);
+    allColors.set(frames[f], f * frames[0].length);
   }
 
   // quantize this massive array into 256 colors and return it!
   let colorPalette = quantize(allColors, 256, {
-    format: 'rgba444',
+    format: 'rgba4444',
     oneBitAlpha: true
   });
 
@@ -533,15 +528,6 @@ function _generateGlobalPalette(frames) {
     ]);
   }
   return colorPalette;
-}
-
-function _pixelEquals(a, b) {
-  return (
-    Array.isArray(a) &&
-    Array.isArray(b) &&
-    a.length === b.length &&
-    a.every((val, index) => val === b[index])
-  );
 }
 
 /**


### PR DESCRIPTION
There are a few palette-related changes in here:

### 1. The palette for gifs was based only on the first frame
Resolves https://github.com/processing/p5.js/issues/5881

When building the list of colors to quantize into a palette, we accidentally were adding the first frame over and over instead of all the frames of the gif. It now sends all the frames' colors into quantization. I didn't notice this when looking at the original PR, oops!

Input sketch: https://editor.p5js.org/davepagurek/sketches/wZWa8l9jh
<table>
<tr><th>Before</th><th>After</th></tr>
<tr>
<td>
<img src="https://user-images.githubusercontent.com/5315059/205464666-ef2b77ef-b51f-4b34-9843-5e258e6514bf.gif" />
</td>
<td>
<img src="https://user-images.githubusercontent.com/5315059/205464675-0cbe0974-ad09-4adc-8264-d7297b6ab3f6.gif" />
</td>
</tr>
</table>

### 2. Some elements left trails in gifs
Resolves https://github.com/processing/p5.js/issues/5882

To determine what frames are unchanged between frames of gifs, we were comparing colors in the original frames. Unfortunately, the same colors in the input frames don't necessarily map to the same output frame color depending on the ordering of colors in the frames, which I'll go into a bit later. If we instead apply the gif palette first, and then check for a difference in the palette colors, we don't see any more trails. Unfortunately, this reveals some flickering caused by that nondeterminism I mentioned:

Input sketch: https://editor.p5js.org/davepagurek/sketches/ANZ-YhpXA
<table>
<tr><th>Before</th><th>Broken in a different way 🥲</th></tr>
<tr>
<td>
<img src="https://user-images.githubusercontent.com/5315059/205464790-200c6ae1-9fc0-44ab-9ee6-729d2a8a1c9c.gif" />
</td>
<td>
<img src="https://user-images.githubusercontent.com/5315059/205464942-0f77991f-d046-424a-baff-9b6e2355693d.gif" />
</td>
</tr>
</table>

The `applyPalette` method from the gif encoding library we use, for the sake of speed, caches the palette color so it doesn't have to check again when it encounters the same color. However, the cache key is not the original color, but instead a bit-reduced version of the color (presumably also for speed/memory.) Unfortunately, this means that multiple input colors get put into the same cache key, and not all of those input colors necessarily correspond to the same palette color.

To avoid this issue, I've stopped using `applyPalette` from the library, and wrote a new version. It's mostly based on the library's code, but:
- it caches colors based on the original input to avoid the flickering issue
- it also uses the same cache for all frames rather than resetting it each frame, hopefully yielding better performance for sketches that share a lot of colors between frames

Now, finally, the output looks more expected! I've kept the change I made to compare the gif palette colors rather than the source colors because, even though the original method should still work with the fixed palette application, comparing the palette involves 1/4 the number of comparisons.

Input sketch: https://editor.p5js.org/davepagurek/sketches/ANZ-YhpXA
<table>
<tr><th>Before</th><th>After</th></tr>
<tr>
<td>
<img src="https://user-images.githubusercontent.com/5315059/205464790-200c6ae1-9fc0-44ab-9ee6-729d2a8a1c9c.gif" />
</td>
<td>
<img src="https://user-images.githubusercontent.com/5315059/205464793-6c801756-af8b-4a44-ac1c-94c7ec9a2080.gif" />
</td>
</tr>
</table>

#### PR Checklist
- [x] `npm run lint` passes
- [ ] [Inline documentation] is included / updated
- [ ] [Unit tests] are included / updated

I haven't added unit tests for these because exporting a gif seems a bit heavy of an operation for a unit test. I can add a manual test if you think that would be helpful though!