### PR TITLE
Clear depth when background() is called

### DIFF
--- a/src/webgl/p5.RendererGL.js
+++ b/src/webgl/p5.RendererGL.js
@@ -587,9 +587,7 @@ p5.RendererGL.prototype.background = function(...args) {
   const _g = _col.levels[1] / 255;
   const _b = _col.levels[2] / 255;
   const _a = _col.levels[3] / 255;
-  this.GL.clearColor(_r, _g, _b, _a);
-
-  this.GL.clear(this.GL.COLOR_BUFFER_BIT);
+  this.clear(_r, _g, _b, _a);
 };
 
 //////////////////////////////////////////////

--- a/test/unit/webgl/p5.RendererGL.js
+++ b/test/unit/webgl/p5.RendererGL.js
@@ -399,6 +399,46 @@ suite('p5.RendererGL', function() {
     });
   });
 
+  suite('background()', function() {
+    function assertAllPixelsAreColor(target, r, g, b, a) {
+      target.loadPixels();
+      const expectedPixels = [];
+      for (let i = 0; i < target.width * target.height; i++) {
+        expectedPixels.push(r, g, b, a);
+      }
+      assert.deepEqual([ ...target.pixels ], expectedPixels);
+    }
+
+    function testDepthGetsCleared(target) {
+      target.pixelDensity(1);
+      target.noStroke();
+      target.fill(255, 0, 0);
+      target.plane(target.width, target.height);
+      assertAllPixelsAreColor(target, 255, 0, 0, 255);
+
+      target.background(255);
+      target.push();
+      target.translate(0, 0, -10); // Move farther away
+      target.fill(0, 0, 255);
+      // expanded to fill the screen
+      target.plane(target.width * 4, target.height * 4);
+      target.pop();
+      // The farther-away plane should not be occluded because we cleared
+      // the screen with background()
+      assertAllPixelsAreColor(target, 0, 0, 255, 255);
+    }
+
+    test('background() resets the depth buffer of the main canvas', function() {
+      myp5.createCanvas(10, 10, myp5.WEBGL);
+      testDepthGetsCleared(myp5);
+    });
+
+    test('background() resets the depth buffer of p5.Graphics', function() {
+      const graphics = myp5.createGraphics(10, 10, myp5.WEBGL);
+      testDepthGetsCleared(graphics);
+    });
+  });
+
   suite('blendMode()', function() {
     var testBlend = function(mode, intended) {
       myp5.blendMode(mode);


### PR DESCRIPTION
Resolves #5514

### Changes:
- WebGL mode `background()` now also clears the depth buffer


### Screenshots of the change:

Given this code, drawing a cube to a p5.Graphics:
```js
let graphics
function setup() {
  createCanvas(400, 400, WEBGL);
  graphics = createGraphics(400, 400, WEBGL);
}

function draw() {
  graphics.background(255);
  graphics.fill('red')
  graphics.rotateY(0.02);
  graphics.box(width/2, width/2, width/2);
  
  imageMode(CENTER)
  image(graphics, 0, 0)
}
```

<table>
<tr>
<th>Before</th>
<th>After</th>
</tr>
<tr>
<td>
<img src="https://user-images.githubusercontent.com/5315059/206174750-2699eb55-1c83-4b22-92e6-c3ac611f1e11.gif" />
</td>
<td>
<img src="https://user-images.githubusercontent.com/5315059/206174807-4f90c67a-15fc-4f4d-97ed-e050f7345ef1.gif" />
</td>
</tr>
</table>

Live: https://editor.p5js.org/davepagurek/sketches/C1Y7IN_Uf

#### PR Checklist


- [x] `npm run lint` passes
- [ ] [Inline documentation] is included / updated
- [x] [Unit tests] are included / updated

