### PR TITLE
Match TRIANGLE_FAN strokes in WebGL mode

### DIFF
--- a/src/webgl/p5.RendererGL.Immediate.js
+++ b/src/webgl/p5.RendererGL.Immediate.js
@@ -255,6 +255,13 @@ p5.RendererGL.prototype._calculateEdges = function(
       }
       res.push([i, i + 1]);
       break;
+    case constants.TRIANGLE_FAN:
+      for (i = 1; i < verts.length - 1; i++) {
+        res.push([0, i]);
+        res.push([i, i + 1]);
+      }
+      res.push([0, verts.length - 1]);
+      break;
     case constants.TRIANGLES:
       for (i = 0; i < verts.length - 2; i = i + 3) {
         res.push([i, i + 1]);

--- a/test/unit/webgl/p5.RendererGL.js
+++ b/test/unit/webgl/p5.RendererGL.js
@@ -802,6 +802,25 @@ suite('p5.RendererGL', function() {
       done();
     });
 
+    test('TRIANGLE_FAN mode makes edges for each triangle', function(done) {
+      var renderer = myp5.createCanvas(10, 10, myp5.WEBGL);
+      //    x
+      //    | \
+      // x--x--x
+      //  \ | /
+      //    x
+      renderer.beginShape(myp5.TRIANGLE_FAN);
+      renderer.vertex(0, 0);
+      renderer.vertex(0, -5);
+      renderer.vertex(5, 0);
+      renderer.vertex(0, 5);
+      renderer.vertex(-5, 0);
+      renderer.endShape();
+
+      assert.equal(renderer.immediateMode.geometry.edges.length, 7);
+      done();
+    });
+
     test('TESS preserves vertex data', function(done) {
       var renderer = myp5.createCanvas(10, 10, myp5.WEBGL);
 


### PR DESCRIPTION
Resolves https://github.com/processing/p5.js/issues/5900

Changes:
- Handles edges in the TRIANGLE_FAN drawing mode to match the behaviour of 2D mode


Screenshots of the change:

<table>
<tr>
<th>2D</th>
<th>WebGL (Before)</th>
<th>WebGL (After)</th>
</tr>
<tr>
<td>

![image](https://user-images.githubusercontent.com/5315059/208202678-da1d2c12-8326-4ef0-a45c-bd4a03b24a76.png)

</td>
<td>

![image](https://user-images.githubusercontent.com/5315059/208202637-a1a4e731-0f05-4fa7-a76f-f99405a88443.png)

</td>
<td>

![image](https://user-images.githubusercontent.com/5315059/208202611-1caa2e6a-17aa-43b4-8c9c-5a301acb307f.png)


</td>
</table>

Live version: https://editor.p5js.org/davepagurek/sketches/7WueblCde

#### PR Checklist
<!--
  To check any option, replace the "[ ]" with a "[x]". Be sure to check out how it looks in the Preview tab! Feel free to remove any portion of the template that is not relevant for your issue.
-->

- [x] `npm run lint` passes
- [ ] [Inline documentation] is included / updated
- [x] [Unit tests] are included / updated

[Inline documentation]: https://github.com/processing/p5.js/blob/main/contributor_docs/inline_documentation.md
[Unit tests]: https://github.com/processing/p5.js/tree/main/contributor_docs#unit-tests
