### PR TITLE
Match line drawing orientation to primitive face

### DIFF
--- a/src/webgl/shaders/line.vert
+++ b/src/webgl/shaders/line.vert
@@ -72,7 +72,7 @@ void main() {
   vec2 tangent = normalize((q.xy*p.w - p.xy*q.w) * uViewport.zw);
 
   // flip tangent to normal (it's already normalized)
-  vec2 normal = vec2(-tangent.y, tangent.x);
+  vec2 normal = vec2(tangent.y, -tangent.x);
 
   float thickness = aDirection.w * uStrokeWeight;
   vec2 offset = normal * thickness / 2.0;


### PR DESCRIPTION
Line drawing in p5.js is done by creating a rectangle with both vertices offset slightly in the direction perpendicular to the line.   
In doing so, the orientation of the triangles that make it up is the opposite of the orientation of the faces of primitives (sphere, box, and so on).   
This orientation can be matched by reversing the direction of the normals used to shift the vertices in the shader.

<!--
  Thank you for contributing! Please use this pull request (PR) template.


 In the description field of this PR, include "resolves #XXXX" tagging the issue you are fixing. If this PR addresses the issue but doesn't completely resolve it (ie the issue should remain open after your PR is merged), write "addresses #XXXX".-->
Resolves #5877

 Changes:
<!-- Add here what changes were made in this pull request and if possible provide links showcasing the changes. -->
here: [src/webgl/shaders/line.vert](https://github.com/processing/p5.js/blob/main/src/webgl/shaders/line.vert)
Reverses the direction of vertices that are displaced when drawing lines.  
This ensures that culling the FRONT to draw only the front face does not cause the lines to disappear.

 Screenshots of the change:
<!-- If applicable, add screenshots depicting the changes. -->
[sampleCode](https://editor.p5js.org/dark_fox/sketches/7vViKD4F0)
left: before, right: after
```javascript
let gl;

function setup(){
  createCanvas(400, 400, WEBGL);
  
  gl = this._renderer.GL;
  gl.enable(gl.CULL_FACE);
  gl.cullFace(gl.FRONT);
  
  background(128);
  fill(255, 128, 0);
  stroke(255);
  strokeWeight(3);
  directionalLight(255, 255, 255, 0, 0, -1);
  ambientLight(128);
  rotateX(TAU/8);
  rotateY(TAU/12);

  box(120);
}
```
![sample0](https://user-images.githubusercontent.com/39549290/208251338-9bc16b3d-19a1-4090-a7c5-83ecab51a6bf.png)


#### PR Checklist
<!--
  To check any option, replace the "[ ]" with a "[x]". Be sure to check out how it looks in the Preview tab! Feel free to remove any portion of the template that is not relevant for your issue.
-->

- [x] WebGL

[Inline documentation]: https://github.com/processing/p5.js/blob/main/contributor_docs/inline_documentation.md
[Unit tests]: https://github.com/processing/p5.js/tree/main/contributor_docs#unit-tests
