### PR TITLE
Use TESS as the default shape mode in WebGL

### DIFF
--- a/src/webgl/p5.RendererGL.Immediate.js
+++ b/src/webgl/p5.RendererGL.Immediate.js
@@ -32,7 +32,7 @@ import './p5.RenderBuffer';
  */
 p5.RendererGL.prototype.beginShape = function(mode) {
   this.immediateMode.shapeMode =
-    mode !== undefined ? mode : constants.TRIANGLE_FAN;
+    mode !== undefined ? mode : constants.TESS;
   this.immediateMode.geometry.reset();
   return this;
 };


### PR DESCRIPTION
Resolves https://github.com/processing/p5.js/issues/5907

Changes the default mode in WebGL to `TESS` to better match 2D mode.

<table>
<tr>
<td rowspan="2">

```js
strokeWeight(3)
beginShape()
vertex(-50, 0)
vertex(-25, -50)
vertex(25, 50)
vertex(50, 0)
endShape()
```

</td>
<th>2D</th>
<th>WebGL (1.5.0)</th>
<th>WebGL (main)</th>
<th>WebGL (fixed)</th>
</tr>
<tr>
<td>

![image](https://user-images.githubusercontent.com/5315059/208271365-829fe21d-84bd-40ba-b22b-f16ea20b9e31.png)

</td>
<td>

![image](https://user-images.githubusercontent.com/5315059/208271762-f256b25c-3ebd-4eb6-9fe2-5a324efac472.png)

</td>
<td>

![image](https://user-images.githubusercontent.com/5315059/208271373-bac915e2-a1ff-4bca-8456-b565dfe9278d.png)

</td>
<td>

![image](https://user-images.githubusercontent.com/5315059/208271414-167a8d2e-effe-4933-bba9-5e8ffd7b1c5b.png)

</td>
</tr>
</table>

#### PR Checklist
<!--
  To check any option, replace the "[ ]" with a "[x]". Be sure to check out how it looks in the Preview tab! Feel free to remove any portion of the template that is not relevant for your issue.
-->

- [x] `npm run lint` passes
- [ ] [Inline documentation] is included / updated
- [ ] [Unit tests] are included / updated

[Inline documentation]: https://github.com/processing/p5.js/blob/main/contributor_docs/inline_documentation.md
[Unit tests]: https://github.com/processing/p5.js/tree/main/contributor_docs#unit-tests
