### PR TITLE
Fix texture coordinate warning when using beginShape(TESS)

### DIFF
--- a/src/webgl/p5.RendererGL.Immediate.js
+++ b/src/webgl/p5.RendererGL.Immediate.js
@@ -116,7 +116,11 @@ p5.RendererGL.prototype.vertex = function(x, y) {
         u /= this._tex.width;
         v /= this._tex.height;
       }
-    } else if (this._tex === null && arguments.length >= 4) {
+    } else if (
+      !this.isProcessingVertices &&
+      this._tex === null &&
+      arguments.length >= 4
+    ) {
       // Only throw this warning if custom uv's have  been provided
       console.warn(
         'You must first call texture() before using' +
@@ -179,7 +183,9 @@ p5.RendererGL.prototype.endShape = function(
     );
     return this;
   }
+  this.isProcessingVertices = true;
   this._processVertices(...arguments);
+  this.isProcessingVertices = false;
   if (this._doFill) {
     if (this.immediateMode.geometry.vertices.length > 1) {
       this._drawImmediateFill();

--- a/src/webgl/p5.RendererGL.js
+++ b/src/webgl/p5.RendererGL.js
@@ -214,6 +214,8 @@ p5.RendererGL = function(elt, pInst, isMainCanvas, attr) {
   // current curveDetail in the Quadratic lookUpTable
   this._lutQuadraticDetail = 0;
 
+  // Used to distinguish between user calls to vertex() and internal calls
+  this.isProcessingVertices = false;
   this._tessy = this._initTessy();
 
   this.fontInfos = {};


### PR DESCRIPTION
Resolves https://github.com/processing/p5.js/issues/5908

Changes:
- Adds some internal state so we know when p5 is in a mode that generates vertices vs when the user is directly writing vertices
- Only shows a warning when using texture coordinates without an image if it comes directly from the user

Live: https://editor.p5js.org/davepagurek/sketches/owyxdX00K


#### PR Checklist

- [x] `npm run lint` passes
- [ ] [Inline documentation] is included / updated
- [ ] [Unit tests] are included / updated
