### PR TITLE
Support beginShape(TESS) for faces that don't face the camera

### DIFF
--- a/test/unit/webgl/p5.RendererGL.js
+++ b/test/unit/webgl/p5.RendererGL.js
@@ -1014,6 +1014,46 @@ suite('p5.RendererGL', function() {
 
       done();
     });
+
+    test('TESS interpolates vertex data perpendicular to the camera', function(done) {
+      var renderer = myp5.createCanvas(10, 10, myp5.WEBGL);
+
+      myp5.textureMode(myp5.NORMAL);
+      renderer.beginShape(myp5.TESS);
+      renderer.vertex(-10, 0, -10);
+      renderer.vertex(10, 0, -10);
+      renderer.vertex(10, 0, 10);
+      renderer.vertex(-10, 0, 10);
+      renderer.endShape(myp5.CLOSE);
+
+      assert.equal(renderer.immediateMode.geometry.vertices.length, 6);
+      assert.deepEqual(
+        renderer.immediateMode.geometry.vertices[0].array(),
+        [10, 0, 10]
+      );
+      assert.deepEqual(
+        renderer.immediateMode.geometry.vertices[1].array(),
+        [-10, 0, -10]
+      );
+      assert.deepEqual(
+        renderer.immediateMode.geometry.vertices[2].array(),
+        [10, 0, -10]
+      );
+      assert.deepEqual(
+        renderer.immediateMode.geometry.vertices[3].array(),
+        [-10, 0, -10]
+      );
+      assert.deepEqual(
+        renderer.immediateMode.geometry.vertices[4].array(),
+        [10, 0, 10]
+      );
+      assert.deepEqual(
+        renderer.immediateMode.geometry.vertices[5].array(),
+        [-10, 0, 10]
+      );
+
+      done();
+    });
   });
 
   suite('setAttributes', function() {

--- a/test/unit/webgl/p5.RendererGL.js
+++ b/test/unit/webgl/p5.RendererGL.js
@@ -1015,7 +1015,7 @@ suite('p5.RendererGL', function() {
       done();
     });
 
-    test('TESS interpolates vertex data perpendicular to the camera', function(done) {
+    test('TESS handles vertex data perpendicular to the camera', function(done) {
       var renderer = myp5.createCanvas(10, 10, myp5.WEBGL);
 
       myp5.textureMode(myp5.NORMAL);


### PR DESCRIPTION
Resolves https://github.com/processing/p5.js/issues/5913

Previously, all vertices sent to libtess were assumed to be on the XY plane. Libtess can fit a plane to the vertices and use its normal for tesselation, if we tell it the plane's normal is (0,0,0). Presumably this is a little bit slower than not having to do that step, so rather than doing that all the time, I first check if all the vertices have the same z value (likely the most common use case) and tell libtess to use (0,0,1) as the normal if so. Otherwise, it calculates its own normal to use.


Screenshots of the change:

Before: (faces perpendicular to the initial camera turn into holes)
![image](https://user-images.githubusercontent.com/5315059/208564468-235be870-8ed1-4648-a830-eba80c8d141b.png)

After:
![image](https://user-images.githubusercontent.com/5315059/208564481-ac4b7245-6012-47ae-b79d-15e6ed5b947c.png)

Live: https://editor.p5js.org/davepagurek/sketches/X8o0LFCGd

#### PR Checklist


- [x] `npm run lint` passes
- [ ] [Inline documentation] is included / updated
- [x] [Unit tests] are included / updated
