### PR TITLE
Modify the shader so that the line can be colored per vertex

### DIFF
--- a/src/webgl/p5.Geometry.js
+++ b/src/webgl/p5.Geometry.js
@@ -267,10 +267,12 @@ p5.Geometry.prototype._edgesToVertices = function() {
     this.lineNormals.push(dirAdd, dirSub, dirAdd, dirAdd, dirSub, dirSub);
     this.lineVertices.push(a, b, c, c, b, d);
     if (data.length > 0) {
-      var beginColor = [lineColorData[4*endIndex0], lineColorData[4*endIndex0+1],
-                        lineColorData[4*endIndex0+2], lineColorData[4*endIndex0+3]];
-      var endColor = [lineColorData[4*endIndex1], lineColorData[4*endIndex1+1],
-                      lineColorData[4*endIndex1+2], lineColorData[4*endIndex1+3]];
+      const offset0 = 4*endIndex0;
+      const offset1 = 4*endIndex1;
+      var beginColor = [lineColorData[offset0], lineColorData[offset0+1],
+      lineColorData[offset0+2], lineColorData[offset0+3]];
+      var endColor = [lineColorData[offset1], lineColorData[offset1+1],
+      lineColorData[offset1+2], lineColorData[offset1+3]];
       this.lineVertexColors.push(
         beginColor, beginColor, endColor, endColor, beginColor, endColor
       );

--- a/src/webgl/p5.Geometry.js
+++ b/src/webgl/p5.Geometry.js
@@ -240,16 +240,16 @@ p5.Geometry.prototype._makeTriangleEdges = function() {
  * @chainable
  */
 p5.Geometry.prototype._edgesToVertices = function() {
-  const data = this.lineVertexColors.slice();
+  const lineColorData = this.lineVertexColors.slice();
   this.lineVertexColors.length = 0;
   this.lineVertices.length = 0;
   this.lineNormals.length = 0;
 
   for (let i = 0; i < this.edges.length; i++) {
-    const e0 = this.edges[i][0];
-    const e1 = this.edges[i][1];
-    var begin = this.vertices[e0];
-    var end = this.vertices[e1];
+    const endIndex0 = this.edges[i][0];
+    const endIndex1 = this.edges[i][1];
+    var begin = this.vertices[endIndex0];
+    var end = this.vertices[endIndex1];
     const dir = end
       .copy()
       .sub(begin)
@@ -266,9 +266,11 @@ p5.Geometry.prototype._edgesToVertices = function() {
     dirSub.push(-1);
     this.lineNormals.push(dirAdd, dirSub, dirAdd, dirAdd, dirSub, dirSub);
     this.lineVertices.push(a, b, c, c, b, d);
-    if(data.length > 0){
-      var beginColor = [data[4*e0], data[4*e0+1], data[4*e0+2], data[4*e0+3]];
-      var endColor = [data[4*e1], data[4*e1+1], data[4*e1+2], data[4*e1+3]];
+    if (data.length > 0) {
+      var beginColor = [lineColorData[4*endIndex0], lineColorData[4*endIndex0+1],
+                        lineColorData[4*endIndex0+2], lineColorData[4*endIndex0+3]];
+      var endColor = [lineColorData[4*endIndex1], lineColorData[4*endIndex1+1],
+                      lineColorData[4*endIndex1+2], lineColorData[4*endIndex1+3]];
       this.lineVertexColors.push(
         beginColor, beginColor, endColor, endColor, beginColor, endColor
       );

--- a/src/webgl/p5.Geometry.js
+++ b/src/webgl/p5.Geometry.js
@@ -270,9 +270,9 @@ p5.Geometry.prototype._edgesToVertices = function() {
       const offset0 = 4*endIndex0;
       const offset1 = 4*endIndex1;
       var beginColor = [lineColorData[offset0], lineColorData[offset0+1],
-      lineColorData[offset0+2], lineColorData[offset0+3]];
+        lineColorData[offset0+2], lineColorData[offset0+3]];
       var endColor = [lineColorData[offset1], lineColorData[offset1+1],
-      lineColorData[offset1+2], lineColorData[offset1+3]];
+        lineColorData[offset1+2], lineColorData[offset1+3]];
       this.lineVertexColors.push(
         beginColor, beginColor, endColor, endColor, beginColor, endColor
       );

--- a/src/webgl/p5.Geometry.js
+++ b/src/webgl/p5.Geometry.js
@@ -266,7 +266,7 @@ p5.Geometry.prototype._edgesToVertices = function() {
     dirSub.push(-1);
     this.lineNormals.push(dirAdd, dirSub, dirAdd, dirAdd, dirSub, dirSub);
     this.lineVertices.push(a, b, c, c, b, d);
-    if (data.length > 0) {
+    if (lineColorData.length > 0) {
       const offset0 = 4*endIndex0;
       const offset1 = 4*endIndex1;
       var beginColor = [lineColorData[offset0], lineColorData[offset0+1],

--- a/src/webgl/p5.Geometry.js
+++ b/src/webgl/p5.Geometry.js
@@ -240,8 +240,7 @@ p5.Geometry.prototype._makeTriangleEdges = function() {
  * @chainable
  */
 p5.Geometry.prototype._edgesToVertices = function() {
-  const lineColorData = this.lineVertexColors.slice();
-  this.lineVertexColors.length = 0;
+  const lineColorData = [];
   this.lineVertices.length = 0;
   this.lineNormals.length = 0;
 
@@ -266,18 +265,25 @@ p5.Geometry.prototype._edgesToVertices = function() {
     dirSub.push(-1);
     this.lineNormals.push(dirAdd, dirSub, dirAdd, dirAdd, dirSub, dirSub);
     this.lineVertices.push(a, b, c, c, b, d);
-    if (lineColorData.length > 0) {
-      const offset0 = 4*endIndex0;
-      const offset1 = 4*endIndex1;
-      var beginColor = [lineColorData[offset0], lineColorData[offset0+1],
-        lineColorData[offset0+2], lineColorData[offset0+3]];
-      var endColor = [lineColorData[offset1], lineColorData[offset1+1],
-        lineColorData[offset1+2], lineColorData[offset1+3]];
-      this.lineVertexColors.push(
+    if (this.lineVertexColors.length > 0) {
+      var beginColor = [
+        this.lineVertexColors[4*endIndex0],
+        this.lineVertexColors[4*endIndex0+1],
+        this.lineVertexColors[4*endIndex0+2],
+        this.lineVertexColors[4*endIndex0+3]
+      ];
+      var endColor = [
+        this.lineVertexColors[4*endIndex1],
+        this.lineVertexColors[4*endIndex1+1],
+        this.lineVertexColors[4*endIndex1+2],
+        this.lineVertexColors[4*endIndex1+3]
+      ];
+      lineColorData.push(
         beginColor, beginColor, endColor, endColor, beginColor, endColor
       );
     }
   }
+  this.lineVertexColors = lineColorData;
   return this;
 };
 

--- a/src/webgl/p5.Geometry.js
+++ b/src/webgl/p5.Geometry.js
@@ -45,6 +45,7 @@ p5.Geometry = function(detailX, detailY, callback) {
   //based on faces for most objects;
   this.edges = [];
   this.vertexColors = [];
+  this.lineVertexColors = [];
   this.detailX = detailX !== undefined ? detailX : 1;
   this.detailY = detailY !== undefined ? detailY : 1;
   this.dirtyFlags = {};
@@ -62,6 +63,7 @@ p5.Geometry.prototype.reset = function() {
   this.vertices.length = 0;
   this.edges.length = 0;
   this.vertexColors.length = 0;
+  this.lineVertexColors.length = 0;
   this.vertexNormals.length = 0;
   this.uvs.length = 0;
 
@@ -238,12 +240,16 @@ p5.Geometry.prototype._makeTriangleEdges = function() {
  * @chainable
  */
 p5.Geometry.prototype._edgesToVertices = function() {
+  const data = this.lineVertexColors.slice();
+  this.lineVertexColors.length = 0;
   this.lineVertices.length = 0;
   this.lineNormals.length = 0;
 
   for (let i = 0; i < this.edges.length; i++) {
-    const begin = this.vertices[this.edges[i][0]];
-    const end = this.vertices[this.edges[i][1]];
+    const e0 = this.edges[i][0];
+    const e1 = this.edges[i][1];
+    var begin = this.vertices[e0];
+    var end = this.vertices[e1];
     const dir = end
       .copy()
       .sub(begin)
@@ -260,6 +266,13 @@ p5.Geometry.prototype._edgesToVertices = function() {
     dirSub.push(-1);
     this.lineNormals.push(dirAdd, dirSub, dirAdd, dirAdd, dirSub, dirSub);
     this.lineVertices.push(a, b, c, c, b, d);
+    if(data.length > 0){
+      var beginColor = [data[4*e0], data[4*e0+1], data[4*e0+2], data[4*e0+3]];
+      var endColor = [data[4*e1], data[4*e1+1], data[4*e1+2], data[4*e1+3]];
+      this.lineVertexColors.push(
+        beginColor, beginColor, endColor, endColor, beginColor, endColor
+      );
+    }
   }
   return this;
 };

--- a/src/webgl/p5.RendererGL.Immediate.js
+++ b/src/webgl/p5.RendererGL.Immediate.js
@@ -412,7 +412,7 @@ p5.RendererGL.prototype._drawImmediateFill = function() {
 p5.RendererGL.prototype._drawImmediateStroke = function() {
   const gl = this.GL;
   const shader = this._getImmediateStrokeShader();
-  this._useLineColor　=
+  this._useLineColor =
     (this.immediateMode.geometry.lineVertexColors.length > 0);
   this._setStrokeUniforms(shader);
   for (const buff of this.immediateMode.buffers.stroke) {

--- a/src/webgl/p5.RendererGL.Immediate.js
+++ b/src/webgl/p5.RendererGL.Immediate.js
@@ -109,6 +109,13 @@ p5.RendererGL.prototype.vertex = function(x, y) {
     vertexColor[2],
     vertexColor[3]
   );
+  var lineVertexColor = this.curStrokeColor || [0.5, 0.5, 0.5, 1];
+  this.immediateMode.geometry.lineVertexColors.push(
+    lineVertexColor[0],
+    lineVertexColor[1],
+    lineVertexColor[2],
+    lineVertexColor[3]
+  );
 
   if (this.textureMode === constants.IMAGE) {
     if (this._tex !== null) {
@@ -405,6 +412,7 @@ p5.RendererGL.prototype._drawImmediateFill = function() {
 p5.RendererGL.prototype._drawImmediateStroke = function() {
   const gl = this.GL;
   const shader = this._getImmediateStrokeShader();
+  this._useLineColor = (this.immediateMode.geometry.lineVertexColors.length > 0);
   this._setStrokeUniforms(shader);
   for (const buff of this.immediateMode.buffers.stroke) {
     buff._prepareBuffer(this.immediateMode.geometry, shader);

--- a/src/webgl/p5.RendererGL.Immediate.js
+++ b/src/webgl/p5.RendererGL.Immediate.js
@@ -412,7 +412,8 @@ p5.RendererGL.prototype._drawImmediateFill = function() {
 p5.RendererGL.prototype._drawImmediateStroke = function() {
   const gl = this.GL;
   const shader = this._getImmediateStrokeShader();
-  this._useLineColor = (this.immediateMode.geometry.lineVertexColors.length > 0);
+  this._useLineColor　=
+    (this.immediateMode.geometry.lineVertexColors.length > 0);
   this._setStrokeUniforms(shader);
   for (const buff of this.immediateMode.buffers.stroke) {
     buff._prepareBuffer(this.immediateMode.geometry, shader);

--- a/src/webgl/p5.RendererGL.Retained.js
+++ b/src/webgl/p5.RendererGL.Retained.js
@@ -119,6 +119,7 @@ p5.RendererGL.prototype.drawBuffers = function(gId) {
 
   if (this._doStroke && geometry.lineVertexCount > 0) {
     const strokeShader = this._getRetainedStrokeShader();
+    this._useLineColor = (geometry.model.lineVertexColors.length > 0);
     this._setStrokeUniforms(strokeShader);
     for (const buff of this.retainedMode.buffers.stroke) {
       buff._prepareBuffer(geometry, strokeShader);

--- a/src/webgl/p5.RendererGL.js
+++ b/src/webgl/p5.RendererGL.js
@@ -110,6 +110,8 @@ p5.RendererGL = function(elt, pInst, isMainCanvas, attr) {
   this._useNormalMaterial = false;
   this._useShininess = 1;
 
+  this._useLineColor = false;
+
   this._tint = [255, 255, 255, 255];
 
   // lightFalloff variables
@@ -149,6 +151,7 @@ p5.RendererGL = function(elt, pInst, isMainCanvas, attr) {
     geometry: {},
     buffers: {
       stroke: [
+        new p5.RenderBuffer(4, 'lineVertexColors', 'lineColorBuffer', 'aVertexColor', this, this._flatten),
         new p5.RenderBuffer(3, 'lineVertices', 'lineVertexBuffer', 'aPosition', this, this._flatten),
         new p5.RenderBuffer(4, 'lineNormals', 'lineNormalBuffer', 'aDirection', this, this._flatten)
       ],
@@ -184,6 +187,7 @@ p5.RendererGL = function(elt, pInst, isMainCanvas, attr) {
         new p5.RenderBuffer(2, 'uvs', 'uvBuffer', 'aTexCoord', this, this._flatten)
       ],
       stroke: [
+        new p5.RenderBuffer(4, 'lineVertexColors', 'lineColorBuffer', 'aVertexColor', this, this._flatten),
         new p5.RenderBuffer(3, 'lineVertices', 'lineVertexBuffer', 'aPosition', this, this._flatten),
         new p5.RenderBuffer(4, 'lineNormals', 'lineNormalBuffer', 'aDirection', this, this._flatten)
       ],
@@ -1257,6 +1261,7 @@ p5.RendererGL.prototype._setStrokeUniforms = function(strokeShader) {
   strokeShader.bindShader();
 
   // set the uniform values
+  strokeShader.setUniform('uUseLineColor', this._useLineColor);
   strokeShader.setUniform('uMaterialColor', this.curStrokeColor);
   strokeShader.setUniform('uStrokeWeight', this.curStrokeWeight);
 };

--- a/src/webgl/shaders/line.frag
+++ b/src/webgl/shaders/line.frag
@@ -1,8 +1,11 @@
 precision mediump float;
 precision mediump int;
 
+varying vec4 vColor;
+
+uniform bool uUseLineColor;
 uniform vec4 uMaterialColor;
 
 void main() {
-  gl_FragColor = uMaterialColor;
+  gl_FragColor = (uUseLineColor ? vColor : uMaterialColor);
 }

--- a/src/webgl/shaders/line.frag
+++ b/src/webgl/shaders/line.frag
@@ -4,5 +4,5 @@ precision mediump int;
 varying vec4 vColor;
 
 void main() {
-  gl_FragColor = vec4(vColor.rgb, 1.) * vColor.a
+  gl_FragColor = vec4(vColor.rgb, 1.) * vColor.a;
 }

--- a/src/webgl/shaders/line.frag
+++ b/src/webgl/shaders/line.frag
@@ -3,9 +3,6 @@ precision mediump int;
 
 varying vec4 vColor;
 
-uniform bool uUseLineColor;
-uniform vec4 uMaterialColor;
-
 void main() {
-  gl_FragColor = (uUseLineColor ? vColor : uMaterialColor);
+  gl_FragColor = vColor;
 }

--- a/src/webgl/shaders/line.vert
+++ b/src/webgl/shaders/line.vert
@@ -22,6 +22,9 @@ uniform mat4 uModelViewMatrix;
 uniform mat4 uProjectionMatrix;
 uniform float uStrokeWeight;
 
+uniform bool uUseLineColor;
+uniform vec4 uMaterialColor;
+
 uniform vec4 uViewport;
 uniform int uPerspective;
 
@@ -98,5 +101,5 @@ void main() {
   gl_Position.xy = p.xy + offset.xy * curPerspScale;
   gl_Position.zw = p.zw;
   
-  vColor = aVertexColor;
+  vColor = (uUseLineColor ? aVertexColor : uMaterialColor);
 }

--- a/src/webgl/shaders/line.vert
+++ b/src/webgl/shaders/line.vert
@@ -27,7 +27,10 @@ uniform int uPerspective;
 
 attribute vec4 aPosition;
 attribute vec4 aDirection;
-  
+attribute vec4 aVertexColor;
+
+varying vec4 vColor;
+
 void main() {
   // using a scale <1 moves the lines towards the camera
   // in order to prevent popping effects due to half of
@@ -94,4 +97,6 @@ void main() {
 
   gl_Position.xy = p.xy + offset.xy * curPerspScale;
   gl_Position.zw = p.zw;
+  
+  vColor = aVertexColor;
 }

--- a/test/unit/webgl/p5.RendererGL.js
+++ b/test/unit/webgl/p5.RendererGL.js
@@ -1050,6 +1050,27 @@ suite('p5.RendererGL', function() {
 
       done();
     });
+    test('strokes should interpolate colors between vertices', function(done) {
+      const renderer = myp5.createCanvas(512, 4, myp5.WEBGL);
+
+      // far left color: (242, 236, 40)
+      // far right color: (42, 36, 240)
+      // expected middle color: (142, 136, 140)
+
+      renderer.strokeWeight(4);
+      renderer.beginShape();
+      renderer.stroke(242, 236, 40);
+      renderer.vertex(-256, 0);
+      renderer.stroke(42, 36, 240);
+      renderer.vertex(256, 0);
+      renderer.endShape();
+
+      assert.deepEqual(myp5.get(0, 2), [242, 236, 40, 255]);
+      assert.deepEqual(myp5.get(256, 2), [142, 136, 140, 255]);
+      assert.deepEqual(myp5.get(511, 2), [42, 36, 240, 255]);
+
+      done();
+    });
   });
 
   suite('setAttributes', function() {


### PR DESCRIPTION
<!--
  Thank you for contributing! Please use this pull request (PR) template.


 In the description field of this PR, include "resolves #XXXX" tagging the issue you are fixing. If this PR addresses the issue but doesn't completely resolve it (ie the issue should remain open after your PR is merged), write "addresses #XXXX".-->

Currently, calling the stroke function per vertex in immediateMode does not cause the line color to be tinted per vertex.

These changes are meant to make that possible.

Resolves #5916

Changes:

First, modify line.vert and line.frag to prepare an attribute variable to receive the color of each vertex, and pass it from vert to frag with varying.
In addition, prepare a flag for whether or not to use it as a color. This is to coexist with conventional coloring methods.
We also prepare a new buffer to store the color of each vertex in stroke drawing.
And in immediateMode, by calling the stroke function just before the vertex function, you can store the line color for each vertex.
By processing this in the _edgesToVertices function, the vertices and colors will correspond properly.
<!-- Add here what changes were made in this pull request and if possible provide links showcasing the changes. -->


 Screenshots of the change:
<!-- If applicable, add screenshots depicting the changes. -->
sample code:
```javascript
function setup(){
  createCanvas(400, 400, WEBGL);
  background(0);
  strokeWeight(3);

  beginShape();
  stroke(255);
  vertex(-100, 0, 0);
  stroke(0, 0, 255);
  vertex(0, 0, 0);
  stroke(255, 0, 0);
  vertex(100, 0, 0);
  endShape();
}
```
left: before, right:after
![lineColor2](https://user-images.githubusercontent.com/39549290/209035564-e8a61fcd-6f1b-481b-9694-93e7fee69f53.png)

Furthermore, even in retainedMode, if you build your own using p5.Geometry, you can color the line for each vertex.

sample code:
```javascript
function setup(){
  createCanvas(400, 400, WEBGL);
  strokeWeight(3);

  const _gl = this._renderer;
  const geom = new p5.Geometry();
  geom.vertices = [createVector(-100, 0, 0), createVector(100, 0, 0)];
  geom.lineVertexColors = [1, 1, 1, 1, 0, 1, 0, 1];
  geom.edges = [[0, 1]];
  geom._edgesToVertices();
  _gl.createBuffers("customLine", geom);

  _gl.drawBuffers("customLine");
}
```
![lineColor4](https://user-images.githubusercontent.com/39549290/209036268-f5bc55ef-c4d1-4e29-9283-30f9c1a1eb28.png)


#### PR Checklist
<!--
  To check any option, replace the "[ ]" with a "[x]". Be sure to check out how it looks in the Preview tab! Feel free to remove any portion of the template that is not relevant for your issue.
-->

- [x] WebGL

[Inline documentation]: https://github.com/processing/p5.js/blob/main/contributor_docs/inline_documentation.md
[Unit tests]: https://github.com/processing/p5.js/tree/main/contributor_docs#unit-tests
