### PR TITLE
Made image loading failure in preload() not to stop whole process

### DIFF
--- a/src/image/loading_displaying.js
+++ b/src/image/loading_displaying.js
@@ -104,6 +104,7 @@ p5.prototype.loadImage = function(path, successCallback, failureCallback) {
           e => {
             if (typeof failureCallback === 'function') {
               failureCallback(e);
+              self._decrementPreload();
             } else {
               console.error(e);
             }
@@ -130,6 +131,7 @@ p5.prototype.loadImage = function(path, successCallback, failureCallback) {
           p5._friendlyFileLoadError(0, img.src);
           if (typeof failureCallback === 'function') {
             failureCallback(e);
+            self._decrementPreload();
           } else {
             console.error(e);
           }
@@ -152,6 +154,7 @@ p5.prototype.loadImage = function(path, successCallback, failureCallback) {
       p5._friendlyFileLoadError(0, path);
       if (typeof failureCallback === 'function') {
         failureCallback(e);
+        self._decrementPreload();
       } else {
         console.error(e);
       }

--- a/test/unit/image/loading.js
+++ b/test/unit/image/loading.js
@@ -221,6 +221,49 @@ suite('loading images', function() {
     };
   };
   new p5(mySketch, null, false);
+
+  // Test loading image failure in preload() without failure callback
+  mySketch = function(this_p5) {
+    this_p5.preload = function() {
+      this_p5.loadImage('', function() {
+        throw new Error('Should not be called');
+      });
+    };
+
+    this_p5.setup = function() {
+      throw new Error('Should not be called');
+    };
+  };
+  new p5(mySketch, null, false);
+
+  // Test loading image failure in preload() with failure callback
+  mySketch = function(this_p5) {
+    var myImage;
+    this_p5.preload = function() {
+      suite('Test loading image failure in preload() with failure callback', function() {
+        test('Load fail and use failure callback', function(done) {
+          myImage = this_p5.loadImage('', function() {
+            assert.fail();
+            done();
+          }, function() {
+            assert.ok(myImage);
+            done();
+          });
+        });
+      });
+    };
+
+    this_p5.setup = function() {
+      suite('setup() after preload() failure with failure callback', function() {
+        test('should be loaded now preload() finished', function(done) {
+          assert.isTrue(myImage instanceof p5.Image);
+          assert.isTrue(myImage.width === 1 && myImage.height === 1);
+          done();
+        });
+      });
+    };
+  };
+  new p5(mySketch, null, false);
 });
 
 suite('loading animated gif images', function() {


### PR DESCRIPTION
Resolves #5032 

### Issue
- `setup()`, `draw()` was not called if an image loading in `preload()` failed
  - It's inconvenient for the case like the image was on server and network connection issue

### Changes
- Made image loading failure in `preload()` not to stop whole process
  - `setup()`, `draw()` will be called if there was an failure callback in `p5.loadImage()`
  - `setup()`, `draw()` will not be called if there was no failure callback in `p5.loadImage()`

I know @limzykenneth says [this might be breaking changes](https://github.com/processing/p5.js/issues/5032).
So please check this changes are right way or not.

#### PR Checklist
<!--
  To check any option, replace the "[ ]" with a "[x]". Be sure to check out how it looks in the Preview tab! Feel free to remove any portion of the template that is not relevant for your issue.
-->

- [x] `npm run lint` passes
- [ ] [Inline documentation] is included / updated
- [x] [Unit tests] are included / updated

[Inline documentation]: https://github.com/processing/p5.js/blob/main/contributor_docs/inline_documentation.md
[Unit tests]: https://github.com/processing/p5.js/tree/main/contributor_docs#unit-tests
