### PR TITLE
Modify  bezierVertex() and quadraticVertex() so that curFillColor becomes an interpolated value

### DIFF
--- a/src/webgl/3d_primitives.js
+++ b/src/webgl/3d_primitives.js
@@ -1753,8 +1753,8 @@ p5.RendererGL.prototype.quadraticVertex = function(...args) {
       w_x = [this.immediateMode._quadraticVertex[0], args[0], args[2]];
       w_y = [this.immediateMode._quadraticVertex[1], args[1], args[3]];
 
-      // The ratio of the distance between the start point, the two control-
-      // points, and the end point determines the intermediate color.
+      // The ratio of the distance between the start point, the control-
+      // point, and the end point determines the intermediate color.
       let d0 = Math.hypot(w_x[0]-w_x[1], w_y[0]-w_y[1]);
       let d1 = Math.hypot(w_x[1]-w_x[2], w_y[1]-w_y[2]);
       const totalLength = d0 + d1;
@@ -1796,8 +1796,8 @@ p5.RendererGL.prototype.quadraticVertex = function(...args) {
       w_y = [this.immediateMode._quadraticVertex[1], args[1], args[4]];
       w_z = [this.immediateMode._quadraticVertex[2], args[2], args[5]];
 
-      // The ratio of the distance between the start point, the two control-
-      // points, and the end point determines the intermediate color.
+      // The ratio of the distance between the start point, the control-
+      // point, and the end point determines the intermediate color.
       let d0 = Math.hypot(w_x[0]-w_x[1], w_y[0]-w_y[1], w_z[0]-w_z[1]);
       let d1 = Math.hypot(w_x[1]-w_x[2], w_y[1]-w_y[2], w_z[1]-w_z[2]);
       const totalLength = d0 + d1;

--- a/src/webgl/3d_primitives.js
+++ b/src/webgl/3d_primitives.js
@@ -1556,7 +1556,7 @@ p5.RendererGL.prototype.bezierVertex = function(...args) {
     let w_x = [];
     let w_y = [];
     let w_z = [];
-    let t, _x, _y, _z, i;
+    let t, _x, _y, _z, i, k;
     const argLength = args.length;
 
     t = 0;
@@ -1587,14 +1587,46 @@ p5.RendererGL.prototype.bezierVertex = function(...args) {
     }
 
     const LUTLength = this._lookUpTableBezier.length;
+    
+    // Get the last fill color
+    const _vertexColors = this.immediateMode.geometry.vertexColors;
+    const _vertexColorSize = _vertexColors.length;
+    const lastFillColor = [
+      _vertexColors[_vertexColorSize - 4],
+      _vertexColors[_vertexColorSize - 3],
+      _vertexColors[_vertexColorSize - 2],
+      _vertexColors[_vertexColorSize - 1]
+    ];
+    const finalFillColor = this.curFillColor.slice();
 
     if (argLength === 6) {
       this.isBezier = true;
 
       w_x = [this.immediateMode._bezierVertex[0], args[0], args[2], args[4]];
       w_y = [this.immediateMode._bezierVertex[1], args[1], args[3], args[5]];
+      // calCalculate intermediate colors
+      let d0 = sqrt(pow(w_x[0]-w_x[1],2) + pow(w_y[0]-w_y[1],2));
+      let d1 = sqrt(pow(w_x[1]-w_x[2],2) + pow(w_y[1]-w_y[2],2));
+      let d2 = sqrt(pow(w_x[2]-w_x[3],2) + pow(w_y[2]-w_y[3],2));
+      const totalLength = d0 + d1 + d2;
+      d0 /= totalLength;
+      d2 /= totalLength;
+      const firstFillColor = [];
+      const secondFillColor = [];
+      for (k = 0; k < 4; k++) {
+        firstFillColor.push(lastFillColor[k] * (1-d0) + finalFillColor[k] * d0);
+        secondFillColor.push(lastFillColor[k] * d2 + finalFillColor[k] * (1-d2));
+      }
 
       for (i = 0; i < LUTLength; i++) {
+        // Interpolate colors using control points
+        this.curFillColor = [0, 0, 0, 0];
+        for (k = 0; k < 4; k++) {
+          this.curFillColor[k] += this._lookUpTableBezier[i][0] * lastFillColor[k];
+          this.curFillColor[k] += this._lookUpTableBezier[i][1] * firstFillColor[k];
+          this.curFillColor[k] += this._lookUpTableBezier[i][2] * secondFillColor[k];
+          this.curFillColor[k] += this._lookUpTableBezier[i][3] * finalFillColor[k];
+        }
         _x =
           w_x[0] * this._lookUpTableBezier[i][0] +
           w_x[1] * this._lookUpTableBezier[i][1] +
@@ -1607,6 +1639,7 @@ p5.RendererGL.prototype.bezierVertex = function(...args) {
           w_y[3] * this._lookUpTableBezier[i][3];
         this.vertex(_x, _y);
       }
+      this.curFillColor = finalFillColor; // Set curFillColor back to finalFillColor
       this.immediateMode._bezierVertex[0] = args[4];
       this.immediateMode._bezierVertex[1] = args[5];
     } else if (argLength === 9) {
@@ -1615,7 +1648,28 @@ p5.RendererGL.prototype.bezierVertex = function(...args) {
       w_x = [this.immediateMode._bezierVertex[0], args[0], args[3], args[6]];
       w_y = [this.immediateMode._bezierVertex[1], args[1], args[4], args[7]];
       w_z = [this.immediateMode._bezierVertex[2], args[2], args[5], args[8]];
+      // Calculate intermediate colors
+      let d0 = sqrt(pow(w_x[0]-w_x[1],2) + pow(w_y[0]-w_y[1],2) + pow(w_z[0]-w_z[1],2));
+      let d1 = sqrt(pow(w_x[1]-w_x[2],2) + pow(w_y[1]-w_y[2],2) + pow(w_z[1]-w_z[2],2));
+      let d2 = sqrt(pow(w_x[2]-w_x[3],2) + pow(w_y[2]-w_y[3],2) + pow(w_z[2]-w_z[3],2));
+      const totalLength = d0 + d1 + d2;
+      d0 /= totalLength;
+      d2 /= totalLength;
+      const firstFillColor = [];
+      const secondFillColor = [];
+      for (k = 0; k < 4; k++) {
+        firstFillColor.push(lastFillColor[k] * (1-d0) + finalFillColor[k] * d0);
+        secondFillColor.push(lastFillColor[k] * d2 + finalFillColor[k] * (1-d2));
+      }
       for (i = 0; i < LUTLength; i++) {
+        // Interpolate colors using control points
+        this.curFillColor = [0, 0, 0, 0];
+        for (k = 0; k < 4; k++) {
+          this.curFillColor[k] += this._lookUpTableBezier[i][0] * lastFillColor[k];
+          this.curFillColor[k] += this._lookUpTableBezier[i][1] * firstFillColor[k];
+          this.curFillColor[k] += this._lookUpTableBezier[i][2] * secondFillColor[k];
+          this.curFillColor[k] += this._lookUpTableBezier[i][3] * finalFillColor[k];
+        }
         _x =
           w_x[0] * this._lookUpTableBezier[i][0] +
           w_x[1] * this._lookUpTableBezier[i][1] +
@@ -1633,6 +1687,7 @@ p5.RendererGL.prototype.bezierVertex = function(...args) {
           w_z[3] * this._lookUpTableBezier[i][3];
         this.vertex(_x, _y, _z);
       }
+      this.curFillColor = finalFillColor; // Set curFillColor back to finalFillColor
       this.immediateMode._bezierVertex[0] = args[6];
       this.immediateMode._bezierVertex[1] = args[7];
       this.immediateMode._bezierVertex[2] = args[8];
@@ -1647,7 +1702,7 @@ p5.RendererGL.prototype.quadraticVertex = function(...args) {
     let w_x = [];
     let w_y = [];
     let w_z = [];
-    let t, _x, _y, _z, i;
+    let t, _x, _y, _z, i, k;
     const argLength = args.length;
 
     t = 0;
@@ -1678,14 +1733,42 @@ p5.RendererGL.prototype.quadraticVertex = function(...args) {
     }
 
     const LUTLength = this._lookUpTableQuadratic.length;
+    
+    // Get the last fill color
+    const _vertexColors = this.immediateMode.geometry.vertexColors;
+    const _vertexColorSize = _vertexColors.length;
+    const lastFillColor = [
+      _vertexColors[_vertexColorSize - 4],
+      _vertexColors[_vertexColorSize - 3],
+      _vertexColors[_vertexColorSize - 2],
+      _vertexColors[_vertexColorSize - 1]
+    ];
+    const finalFillColor = this.curFillColor.slice();
 
     if (argLength === 4) {
       this.isQuadratic = true;
 
       w_x = [this.immediateMode._quadraticVertex[0], args[0], args[2]];
       w_y = [this.immediateMode._quadraticVertex[1], args[1], args[3]];
+      
+      // calCalculate intermediate colors
+      let d0 = sqrt(pow(w_x[0]-w_x[1],2) + pow(w_y[0]-w_y[1],2));
+      let d1 = sqrt(pow(w_x[1]-w_x[2],2) + pow(w_y[1]-w_y[2],2));
+      const totalLength = d0 + d1;
+      d0 /= totalLength;
+      const middleFillColor = [];
+      for (k = 0; k < 4; k++) {
+        middleFillColor.push(lastFillColor[k] * (1-d0) + finalFillColor[k] * d0);
+      }
 
       for (i = 0; i < LUTLength; i++) {
+        // Interpolate colors using control points
+        this.curFillColor = [0, 0, 0, 0];
+        for (k = 0; k < 4; k++) {
+          this.curFillColor[k] += this._lookUpTableQuadratic[i][0] * lastFillColor[k];
+          this.curFillColor[k] += this._lookUpTableQuadratic[i][1] * middleFillColor[k];
+          this.curFillColor[k] += this._lookUpTableQuadratic[i][2] * finalFillColor[k];
+        }
         _x =
           w_x[0] * this._lookUpTableQuadratic[i][0] +
           w_x[1] * this._lookUpTableQuadratic[i][1] +
@@ -1697,6 +1780,7 @@ p5.RendererGL.prototype.quadraticVertex = function(...args) {
         this.vertex(_x, _y);
       }
 
+      this.curFillColor = finalFillColor; // Set curFillColor back to finalFillColor
       this.immediateMode._quadraticVertex[0] = args[2];
       this.immediateMode._quadraticVertex[1] = args[3];
     } else if (argLength === 6) {
@@ -1705,8 +1789,25 @@ p5.RendererGL.prototype.quadraticVertex = function(...args) {
       w_x = [this.immediateMode._quadraticVertex[0], args[0], args[3]];
       w_y = [this.immediateMode._quadraticVertex[1], args[1], args[4]];
       w_z = [this.immediateMode._quadraticVertex[2], args[2], args[5]];
+      
+      // calCalculate intermediate colors
+      let d0 = sqrt(pow(w_x[0]-w_x[1],2) + pow(w_y[0]-w_y[1],2) + pow(w_z[0]-w_z[1],2));
+      let d1 = sqrt(pow(w_x[1]-w_x[2],2) + pow(w_y[1]-w_y[2],2) + pow(w_z[1]-w_z[2],2));
+      const totalLength = d0 + d1;
+      d0 /= totalLength;
+      const middleFillColor = [];
+      for (k = 0; k < 4; k++) {
+        middleFillColor.push(lastFillColor[k] * (1-d0) + finalFillColor[k] * d0);
+      }
 
       for (i = 0; i < LUTLength; i++) {
+        // Interpolate colors using control points
+        this.curFillColor = [0, 0, 0, 0];
+        for (k = 0; k < 4; k++) {
+          this.curFillColor[k] += this._lookUpTableQuadratic[i][0] * lastFillColor[k];
+          this.curFillColor[k] += this._lookUpTableQuadratic[i][1] * middleFillColor[k];
+          this.curFillColor[k] += this._lookUpTableQuadratic[i][2] * finalFillColor[k];
+        }
         _x =
           w_x[0] * this._lookUpTableQuadratic[i][0] +
           w_x[1] * this._lookUpTableQuadratic[i][1] +
@@ -1722,6 +1823,7 @@ p5.RendererGL.prototype.quadraticVertex = function(...args) {
         this.vertex(_x, _y, _z);
       }
 
+      this.curFillColor = finalFillColor; // Set curFillColor back to finalFillColor
       this.immediateMode._quadraticVertex[0] = args[3];
       this.immediateMode._quadraticVertex[1] = args[4];
       this.immediateMode._quadraticVertex[2] = args[5];

--- a/src/webgl/3d_primitives.js
+++ b/src/webgl/3d_primitives.js
@@ -1597,6 +1597,12 @@ p5.RendererGL.prototype.bezierVertex = function(...args) {
     fillColors[0] = this.immediateMode.geometry.vertexColors.slice(-4);
     fillColors[3] = this.curFillColor.slice();
 
+    // Do the same for strokeColor.
+    const strokeColors = [];
+    for (m = 0; m < 4; m++) strokeColors.push([]);
+    strokeColors[0] = this.immediateMode.geometry.lineVertexColors.slice(-4);
+    strokeColors[3] = this.curStrokeColor.slice();
+
     if (argLength === 6) {
       this.isBezier = true;
 
@@ -1617,24 +1623,34 @@ p5.RendererGL.prototype.bezierVertex = function(...args) {
         fillColors[2].push(
           fillColors[0][k] * d2 + fillColors[3][k] * (1-d2)
         );
+        strokeColors[1].push(
+          strokeColors[0][k] * (1-d0) + strokeColors[3][k] * d0
+        );
+        strokeColors[2].push(
+          strokeColors[0][k] * d2 + strokeColors[3][k] * (1-d2)
+        );
       }
 
       for (i = 0; i < LUTLength; i++) {
         // Interpolate colors using control points
         this.curFillColor = [0, 0, 0, 0];
+        this.curStrokeColor = [0, 0, 0, 0];
         _x = _y = 0;
         for (m = 0; m < 4; m++) {
           for (k = 0; k < 4; k++) {
             this.curFillColor[k] +=
               this._lookUpTableBezier[i][m] * fillColors[m][k];
+            this.curStrokeColor[k] +=
+              this._lookUpTableBezier[i][m] * strokeColors[m][k];
           }
           _x += w_x[m] * this._lookUpTableBezier[i][m];
           _y += w_y[m] * this._lookUpTableBezier[i][m];
         }
         this.vertex(_x, _y);
       }
-      // so that we leave curFillColor with the last value the user set it to
+      // so that we leave currentColor with the last value the user set it to
       this.curFillColor = fillColors[3];
+      this.curStrokeColor = strokeColors[3];
       this.immediateMode._bezierVertex[0] = args[4];
       this.immediateMode._bezierVertex[1] = args[5];
     } else if (argLength === 9) {
@@ -1658,15 +1674,24 @@ p5.RendererGL.prototype.bezierVertex = function(...args) {
         fillColors[2].push(
           fillColors[0][k] * d2 + fillColors[3][k] * (1-d2)
         );
+        strokeColors[1].push(
+          strokeColors[0][k] * (1-d0) + strokeColors[3][k] * d0
+        );
+        strokeColors[2].push(
+          strokeColors[0][k] * d2 + strokeColors[3][k] * (1-d2)
+        );
       }
       for (i = 0; i < LUTLength; i++) {
         // Interpolate colors using control points
         this.curFillColor = [0, 0, 0, 0];
+        this.curStrokeColor = [0, 0, 0, 0];
         _x = _y = _z = 0;
         for (m = 0; m < 4; m++) {
           for (k = 0; k < 4; k++) {
             this.curFillColor[k] +=
               this._lookUpTableBezier[i][m] * fillColors[m][k];
+            this.curStrokeColor[k] +=
+              this._lookUpTableBezier[i][m] * strokeColors[m][k];
           }
           _x += w_x[m] * this._lookUpTableBezier[i][m];
           _y += w_y[m] * this._lookUpTableBezier[i][m];
@@ -1674,8 +1699,9 @@ p5.RendererGL.prototype.bezierVertex = function(...args) {
         }
         this.vertex(_x, _y, _z);
       }
-      // so that we leave curFillColor with the last value the user set it to
+      // so that we leave currentColor with the last value the user set it to
       this.curFillColor = fillColors[3];
+      this.curStrokeColor = strokeColors[3];
       this.immediateMode._bezierVertex[0] = args[6];
       this.immediateMode._bezierVertex[1] = args[7];
       this.immediateMode._bezierVertex[2] = args[8];
@@ -1731,6 +1757,12 @@ p5.RendererGL.prototype.quadraticVertex = function(...args) {
     fillColors[0] = this.immediateMode.geometry.vertexColors.slice(-4);
     fillColors[2] = this.curFillColor.slice();
 
+    // Do the same for strokeColor.
+    const strokeColors = [];
+    for (m = 0; m < 3; m++) strokeColors.push([]);
+    strokeColors[0] = this.immediateMode.geometry.lineVertexColors.slice(-4);
+    strokeColors[2] = this.curStrokeColor.slice();
+
     if (argLength === 4) {
       this.isQuadratic = true;
 
@@ -1747,16 +1779,22 @@ p5.RendererGL.prototype.quadraticVertex = function(...args) {
         fillColors[1].push(
           fillColors[0][k] * (1-d0) + fillColors[2][k] * d0
         );
+        strokeColors[1].push(
+          strokeColors[0][k] * (1-d0) + strokeColors[2][k] * d0
+        );
       }
 
       for (i = 0; i < LUTLength; i++) {
         // Interpolate colors using control points
         this.curFillColor = [0, 0, 0, 0];
+        this.curStrokeColor = [0, 0, 0, 0];
         _x = _y = 0;
         for (m = 0; m < 3; m++) {
           for (k = 0; k < 4; k++) {
             this.curFillColor[k] +=
               this._lookUpTableQuadratic[i][m] * fillColors[m][k];
+            this.curStrokeColor[k] +=
+              this._lookUpTableQuadratic[i][m] * strokeColors[m][k];
           }
           _x += w_x[m] * this._lookUpTableQuadratic[i][m];
           _y += w_y[m] * this._lookUpTableQuadratic[i][m];
@@ -1764,8 +1802,9 @@ p5.RendererGL.prototype.quadraticVertex = function(...args) {
         this.vertex(_x, _y);
       }
 
-      // so that we leave curFillColor with the last value the user set it to
+      // so that we leave currentColor with the last value the user set it to
       this.curFillColor = fillColors[2];
+      this.curStrokeColor = strokeColors[2];
       this.immediateMode._quadraticVertex[0] = args[2];
       this.immediateMode._quadraticVertex[1] = args[3];
     } else if (argLength === 6) {
@@ -1785,16 +1824,22 @@ p5.RendererGL.prototype.quadraticVertex = function(...args) {
         fillColors[1].push(
           fillColors[0][k] * (1-d0) + fillColors[2][k] * d0
         );
+        strokeColors[1].push(
+          strokeColors[0][k] * (1-d0) + strokeColors[2][k] * d0
+        );
       }
 
       for (i = 0; i < LUTLength; i++) {
         // Interpolate colors using control points
         this.curFillColor = [0, 0, 0, 0];
+        this.curStrokeColor = [0, 0, 0, 0];
         _x = _y = _z = 0;
         for (m = 0; m < 3; m++) {
           for (k = 0; k < 4; k++) {
             this.curFillColor[k] +=
               this._lookUpTableQuadratic[i][m] * fillColors[m][k];
+            this.curStrokeColor[k] +=
+              this._lookUpTableQuadratic[i][m] * strokeColors[m][k];
           }
           _x += w_x[m] * this._lookUpTableQuadratic[i][m];
           _y += w_y[m] * this._lookUpTableQuadratic[i][m];
@@ -1803,8 +1848,9 @@ p5.RendererGL.prototype.quadraticVertex = function(...args) {
         this.vertex(_x, _y, _z);
       }
 
-      // so that we leave curFillColor with the last value the user set it to
+      // so that we leave currentColor with the last value the user set it to
       this.curFillColor = fillColors[2];
+      this.curStrokeColor = strokeColors[2];
       this.immediateMode._quadraticVertex[0] = args[3];
       this.immediateMode._quadraticVertex[1] = args[4];
       this.immediateMode._quadraticVertex[2] = args[5];

--- a/src/webgl/3d_primitives.js
+++ b/src/webgl/3d_primitives.js
@@ -1557,6 +1557,7 @@ p5.RendererGL.prototype.bezierVertex = function(...args) {
     let w_y = [];
     let w_z = [];
     let t, _x, _y, _z, i, k, m;
+    // variable i for bezierPoints, k for components, and m for anchor points.
     const argLength = args.length;
 
     t = 0;
@@ -1589,7 +1590,7 @@ p5.RendererGL.prototype.bezierVertex = function(...args) {
     const LUTLength = this._lookUpTableBezier.length;
 
     // fillColors[0]: start point color
-    // fillColors[1],[2]: intermediate point color
+    // fillColors[1],[2]: control point color
     // fillColors[3]: end point color
     const fillColors = [];
     for (m = 0; m < 4; m++) fillColors.push([]);
@@ -1621,22 +1622,15 @@ p5.RendererGL.prototype.bezierVertex = function(...args) {
       for (i = 0; i < LUTLength; i++) {
         // Interpolate colors using control points
         this.curFillColor = [0, 0, 0, 0];
+        _x = _y = 0;
         for (m = 0; m < 4; m++) {
           for (k = 0; k < 4; k++) {
             this.curFillColor[k] +=
               this._lookUpTableBezier[i][m] * fillColors[m][k];
           }
+          _x += w_x[m] * this._lookUpTableBezier[i][m];
+          _y += w_y[m] * this._lookUpTableBezier[i][m];
         }
-        _x =
-          w_x[0] * this._lookUpTableBezier[i][0] +
-          w_x[1] * this._lookUpTableBezier[i][1] +
-          w_x[2] * this._lookUpTableBezier[i][2] +
-          w_x[3] * this._lookUpTableBezier[i][3];
-        _y =
-          w_y[0] * this._lookUpTableBezier[i][0] +
-          w_y[1] * this._lookUpTableBezier[i][1] +
-          w_y[2] * this._lookUpTableBezier[i][2] +
-          w_y[3] * this._lookUpTableBezier[i][3];
         this.vertex(_x, _y);
       }
       // so that we leave curFillColor with the last value the user set it to
@@ -1668,27 +1662,16 @@ p5.RendererGL.prototype.bezierVertex = function(...args) {
       for (i = 0; i < LUTLength; i++) {
         // Interpolate colors using control points
         this.curFillColor = [0, 0, 0, 0];
+        _x = _y = _z = 0;
         for (m = 0; m < 4; m++) {
           for (k = 0; k < 4; k++) {
             this.curFillColor[k] +=
               this._lookUpTableBezier[i][m] * fillColors[m][k];
           }
+          _x += w_x[m] * this._lookUpTableBezier[i][m];
+          _y += w_y[m] * this._lookUpTableBezier[i][m];
+          _z += w_z[m] * this._lookUpTableBezier[i][m];
         }
-        _x =
-          w_x[0] * this._lookUpTableBezier[i][0] +
-          w_x[1] * this._lookUpTableBezier[i][1] +
-          w_x[2] * this._lookUpTableBezier[i][2] +
-          w_x[3] * this._lookUpTableBezier[i][3];
-        _y =
-          w_y[0] * this._lookUpTableBezier[i][0] +
-          w_y[1] * this._lookUpTableBezier[i][1] +
-          w_y[2] * this._lookUpTableBezier[i][2] +
-          w_y[3] * this._lookUpTableBezier[i][3];
-        _z =
-          w_z[0] * this._lookUpTableBezier[i][0] +
-          w_z[1] * this._lookUpTableBezier[i][1] +
-          w_z[2] * this._lookUpTableBezier[i][2] +
-          w_z[3] * this._lookUpTableBezier[i][3];
         this.vertex(_x, _y, _z);
       }
       // so that we leave curFillColor with the last value the user set it to
@@ -1708,6 +1691,7 @@ p5.RendererGL.prototype.quadraticVertex = function(...args) {
     let w_y = [];
     let w_z = [];
     let t, _x, _y, _z, i, k, m;
+    // variable i for bezierPoints, k for components, and m for anchor points.
     const argLength = args.length;
 
     t = 0;
@@ -1740,7 +1724,7 @@ p5.RendererGL.prototype.quadraticVertex = function(...args) {
     const LUTLength = this._lookUpTableQuadratic.length;
 
     // fillColors[0]: start point color
-    // fillColors[1]: intermediate point color
+    // fillColors[1]: control point color
     // fillColors[2]: end point color
     const fillColors = [];
     for (m = 0; m < 3; m++) fillColors.push([]);
@@ -1768,20 +1752,15 @@ p5.RendererGL.prototype.quadraticVertex = function(...args) {
       for (i = 0; i < LUTLength; i++) {
         // Interpolate colors using control points
         this.curFillColor = [0, 0, 0, 0];
+        _x = _y = 0;
         for (m = 0; m < 3; m++) {
           for (k = 0; k < 4; k++) {
             this.curFillColor[k] +=
               this._lookUpTableQuadratic[i][m] * fillColors[m][k];
           }
+          _x += w_x[m] * this._lookUpTableQuadratic[i][m];
+          _y += w_y[m] * this._lookUpTableQuadratic[i][m];
         }
-        _x =
-          w_x[0] * this._lookUpTableQuadratic[i][0] +
-          w_x[1] * this._lookUpTableQuadratic[i][1] +
-          w_x[2] * this._lookUpTableQuadratic[i][2];
-        _y =
-          w_y[0] * this._lookUpTableQuadratic[i][0] +
-          w_y[1] * this._lookUpTableQuadratic[i][1] +
-          w_y[2] * this._lookUpTableQuadratic[i][2];
         this.vertex(_x, _y);
       }
 
@@ -1811,24 +1790,16 @@ p5.RendererGL.prototype.quadraticVertex = function(...args) {
       for (i = 0; i < LUTLength; i++) {
         // Interpolate colors using control points
         this.curFillColor = [0, 0, 0, 0];
+        _x = _y = _z = 0;
         for (m = 0; m < 3; m++) {
           for (k = 0; k < 4; k++) {
             this.curFillColor[k] +=
               this._lookUpTableQuadratic[i][m] * fillColors[m][k];
           }
+          _x += w_x[m] * this._lookUpTableQuadratic[i][m];
+          _y += w_y[m] * this._lookUpTableQuadratic[i][m];
+          _z += w_z[m] * this._lookUpTableQuadratic[i][m];
         }
-        _x =
-          w_x[0] * this._lookUpTableQuadratic[i][0] +
-          w_x[1] * this._lookUpTableQuadratic[i][1] +
-          w_x[2] * this._lookUpTableQuadratic[i][2];
-        _y =
-          w_y[0] * this._lookUpTableQuadratic[i][0] +
-          w_y[1] * this._lookUpTableQuadratic[i][1] +
-          w_y[2] * this._lookUpTableQuadratic[i][2];
-        _z =
-          w_z[0] * this._lookUpTableQuadratic[i][0] +
-          w_z[1] * this._lookUpTableQuadratic[i][1] +
-          w_z[2] * this._lookUpTableQuadratic[i][2];
         this.vertex(_x, _y, _z);
       }
 

--- a/src/webgl/3d_primitives.js
+++ b/src/webgl/3d_primitives.js
@@ -1556,7 +1556,7 @@ p5.RendererGL.prototype.bezierVertex = function(...args) {
     let w_x = [];
     let w_y = [];
     let w_z = [];
-    let t, _x, _y, _z, i, k;
+    let t, _x, _y, _z, i, k, m;
     const argLength = args.length;
 
     t = 0;
@@ -1588,61 +1588,44 @@ p5.RendererGL.prototype.bezierVertex = function(...args) {
 
     const LUTLength = this._lookUpTableBezier.length;
 
-    // Get the last fill color
-    const _vertexColors = this.immediateMode.geometry.vertexColors;
-    const _vertexColorSize = _vertexColors.length;
-    const lastFillColor = [
-      _vertexColors[_vertexColorSize - 4],
-      _vertexColors[_vertexColorSize - 3],
-      _vertexColors[_vertexColorSize - 2],
-      _vertexColors[_vertexColorSize - 1]
-    ];
-    const finalFillColor = this.curFillColor.slice();
+    // fillColors[0]: start point color
+    // fillColors[1],[2]: intermediate point color
+    // fillColors[3]: end point color
+    const fillColors = [];
+    for (m = 0; m < 4; m++) fillColors.push([]);
+    fillColors[0] = this.immediateMode.geometry.vertexColors.slice(-4);
+    fillColors[3] = this.curFillColor.slice();
 
     if (argLength === 6) {
       this.isBezier = true;
 
       w_x = [this.immediateMode._bezierVertex[0], args[0], args[2], args[4]];
       w_y = [this.immediateMode._bezierVertex[1], args[1], args[3], args[5]];
-      // calCalculate intermediate colors
-      let d0 = Math.sqrt(
-        Math.pow(w_x[0]-w_x[1],2) +
-        Math.pow(w_y[0]-w_y[1],2)
-      );
-      let d1 = Math.sqrt(
-        Math.pow(w_x[1]-w_x[2],2) +
-        Math.pow(w_y[1]-w_y[2],2)
-      );
-      let d2 = Math.sqrt(
-        Math.pow(w_x[2]-w_x[3],2) +
-        Math.pow(w_y[2]-w_y[3],2)
-      );
+      // The ratio of the distance between the start point, the two control-
+      // points, and the end point determines the intermediate color.
+      let d0 = Math.hypot(w_x[0]-w_x[1], w_y[0]-w_y[1]);
+      let d1 = Math.hypot(w_x[1]-w_x[2], w_y[1]-w_y[2]);
+      let d2 = Math.hypot(w_x[2]-w_x[3], w_y[2]-w_y[3]);
       const totalLength = d0 + d1 + d2;
       d0 /= totalLength;
       d2 /= totalLength;
-      const firstFillColor = [];
-      const secondFillColor = [];
       for (k = 0; k < 4; k++) {
-        firstFillColor.push(
-          lastFillColor[k] * (1-d0) + finalFillColor[k] * d0
+        fillColors[1].push(
+          fillColors[0][k] * (1-d0) + fillColors[3][k] * d0
         );
-        secondFillColor.push(
-          lastFillColor[k] * d2 + finalFillColor[k] * (1-d2)
+        fillColors[2].push(
+          fillColors[0][k] * d2 + fillColors[3][k] * (1-d2)
         );
       }
 
       for (i = 0; i < LUTLength; i++) {
         // Interpolate colors using control points
         this.curFillColor = [0, 0, 0, 0];
-        for (k = 0; k < 4; k++) {
-          this.curFillColor[k] +=
-            this._lookUpTableBezier[i][0] * lastFillColor[k];
-          this.curFillColor[k] +=
-            this._lookUpTableBezier[i][1] * firstFillColor[k];
-          this.curFillColor[k] +=
-            this._lookUpTableBezier[i][2] * secondFillColor[k];
-          this.curFillColor[k] +=
-            this._lookUpTableBezier[i][3] * finalFillColor[k];
+        for (m = 0; m < 4; m++) {
+          for (k = 0; k < 4; k++) {
+            this.curFillColor[k] +=
+              this._lookUpTableBezier[i][m] * fillColors[m][k];
+          }
         }
         _x =
           w_x[0] * this._lookUpTableBezier[i][0] +
@@ -1656,7 +1639,8 @@ p5.RendererGL.prototype.bezierVertex = function(...args) {
           w_y[3] * this._lookUpTableBezier[i][3];
         this.vertex(_x, _y);
       }
-      this.curFillColor = finalFillColor; // Set curFillColor to finalFillColor
+      // so that we leave curFillColor with the last value the user set it to
+      this.curFillColor = fillColors[3];
       this.immediateMode._bezierVertex[0] = args[4];
       this.immediateMode._bezierVertex[1] = args[5];
     } else if (argLength === 9) {
@@ -1665,47 +1649,30 @@ p5.RendererGL.prototype.bezierVertex = function(...args) {
       w_x = [this.immediateMode._bezierVertex[0], args[0], args[3], args[6]];
       w_y = [this.immediateMode._bezierVertex[1], args[1], args[4], args[7]];
       w_z = [this.immediateMode._bezierVertex[2], args[2], args[5], args[8]];
-      // Calculate intermediate colors
-      let d0 = Math.sqrt(
-        Math.pow(w_x[0]-w_x[1],2) +
-        Math.pow(w_y[0]-w_y[1],2) +
-        Math.pow(w_z[0]-w_z[1],2)
-      );
-      let d1 = Math.sqrt(
-        Math.pow(w_x[1]-w_x[2],2) +
-        Math.pow(w_y[1]-w_y[2],2) +
-        Math.pow(w_z[1]-w_z[2],2)
-      );
-      let d2 = Math.sqrt(
-        Math.pow(w_x[2]-w_x[3],2) +
-        Math.pow(w_y[2]-w_y[3],2) +
-        Math.pow(w_z[2]-w_z[3],2)
-      );
+      // The ratio of the distance between the start point, the two control-
+      // points, and the end point determines the intermediate color.
+      let d0 = Math.hypot(w_x[0]-w_x[1], w_y[0]-w_y[1], w_z[0]-w_z[1]);
+      let d1 = Math.hypot(w_x[1]-w_x[2], w_y[1]-w_y[2], w_z[1]-w_z[2]);
+      let d2 = Math.hypot(w_x[2]-w_x[3], w_y[2]-w_y[3], w_z[2]-w_z[3]);
       const totalLength = d0 + d1 + d2;
       d0 /= totalLength;
       d2 /= totalLength;
-      const firstFillColor = [];
-      const secondFillColor = [];
       for (k = 0; k < 4; k++) {
-        firstFillColor.push(
-          lastFillColor[k] * (1-d0) + finalFillColor[k] * d0
+        fillColors[1].push(
+          fillColors[0][k] * (1-d0) + fillColors[3][k] * d0
         );
-        secondFillColor.push(
-          lastFillColor[k] * d2 + finalFillColor[k] * (1-d2)
+        fillColors[2].push(
+          fillColors[0][k] * d2 + fillColors[3][k] * (1-d2)
         );
       }
       for (i = 0; i < LUTLength; i++) {
         // Interpolate colors using control points
         this.curFillColor = [0, 0, 0, 0];
-        for (k = 0; k < 4; k++) {
-          this.curFillColor[k] +=
-            this._lookUpTableBezier[i][0] * lastFillColor[k];
-          this.curFillColor[k] +=
-            this._lookUpTableBezier[i][1] * firstFillColor[k];
-          this.curFillColor[k] +=
-            this._lookUpTableBezier[i][2] * secondFillColor[k];
-          this.curFillColor[k] +=
-            this._lookUpTableBezier[i][3] * finalFillColor[k];
+        for (m = 0; m < 4; m++) {
+          for (k = 0; k < 4; k++) {
+            this.curFillColor[k] +=
+              this._lookUpTableBezier[i][m] * fillColors[m][k];
+          }
         }
         _x =
           w_x[0] * this._lookUpTableBezier[i][0] +
@@ -1724,7 +1691,8 @@ p5.RendererGL.prototype.bezierVertex = function(...args) {
           w_z[3] * this._lookUpTableBezier[i][3];
         this.vertex(_x, _y, _z);
       }
-      this.curFillColor = finalFillColor; // Set curFillColor to finalFillColor
+      // so that we leave curFillColor with the last value the user set it to
+      this.curFillColor = fillColors[3];
       this.immediateMode._bezierVertex[0] = args[6];
       this.immediateMode._bezierVertex[1] = args[7];
       this.immediateMode._bezierVertex[2] = args[8];
@@ -1739,7 +1707,7 @@ p5.RendererGL.prototype.quadraticVertex = function(...args) {
     let w_x = [];
     let w_y = [];
     let w_z = [];
-    let t, _x, _y, _z, i, k;
+    let t, _x, _y, _z, i, k, m;
     const argLength = args.length;
 
     t = 0;
@@ -1771,16 +1739,13 @@ p5.RendererGL.prototype.quadraticVertex = function(...args) {
 
     const LUTLength = this._lookUpTableQuadratic.length;
 
-    // Get the last fill color
-    const _vertexColors = this.immediateMode.geometry.vertexColors;
-    const _vertexColorSize = _vertexColors.length;
-    const lastFillColor = [
-      _vertexColors[_vertexColorSize - 4],
-      _vertexColors[_vertexColorSize - 3],
-      _vertexColors[_vertexColorSize - 2],
-      _vertexColors[_vertexColorSize - 1]
-    ];
-    const finalFillColor = this.curFillColor.slice();
+    // fillColors[0]: start point color
+    // fillColors[1]: intermediate point color
+    // fillColors[2]: end point color
+    const fillColors = [];
+    for (m = 0; m < 3; m++) fillColors.push([]);
+    fillColors[0] = this.immediateMode.geometry.vertexColors.slice(-4);
+    fillColors[2] = this.curFillColor.slice();
 
     if (argLength === 4) {
       this.isQuadratic = true;
@@ -1788,34 +1753,26 @@ p5.RendererGL.prototype.quadraticVertex = function(...args) {
       w_x = [this.immediateMode._quadraticVertex[0], args[0], args[2]];
       w_y = [this.immediateMode._quadraticVertex[1], args[1], args[3]];
 
-      // calCalculate intermediate colors
-      let d0 = Math.sqrt(
-        Math.pow(w_x[0]-w_x[1],2) +
-        Math.pow(w_y[0]-w_y[1],2)
-      );
-      let d1 = Math.sqrt(
-        Math.pow(w_x[1]-w_x[2],2) +
-        Math.pow(w_y[1]-w_y[2],2)
-      );
+      // The ratio of the distance between the start point, the two control-
+      // points, and the end point determines the intermediate color.
+      let d0 = Math.hypot(w_x[0]-w_x[1], w_y[0]-w_y[1]);
+      let d1 = Math.hypot(w_x[1]-w_x[2], w_y[1]-w_y[2]);
       const totalLength = d0 + d1;
       d0 /= totalLength;
-      const middleFillColor = [];
       for (k = 0; k < 4; k++) {
-        middleFillColor.push(
-          lastFillColor[k] * (1-d0) + finalFillColor[k] * d0
+        fillColors[1].push(
+          fillColors[0][k] * (1-d0) + fillColors[2][k] * d0
         );
       }
 
       for (i = 0; i < LUTLength; i++) {
         // Interpolate colors using control points
         this.curFillColor = [0, 0, 0, 0];
-        for (k = 0; k < 4; k++) {
-          this.curFillColor[k] +=
-            this._lookUpTableQuadratic[i][0] * lastFillColor[k];
-          this.curFillColor[k] +=
-            this._lookUpTableQuadratic[i][1] * middleFillColor[k];
-          this.curFillColor[k] +=
-            this._lookUpTableQuadratic[i][2] * finalFillColor[k];
+        for (m = 0; m < 3; m++) {
+          for (k = 0; k < 4; k++) {
+            this.curFillColor[k] +=
+              this._lookUpTableQuadratic[i][m] * fillColors[m][k];
+          }
         }
         _x =
           w_x[0] * this._lookUpTableQuadratic[i][0] +
@@ -1828,7 +1785,8 @@ p5.RendererGL.prototype.quadraticVertex = function(...args) {
         this.vertex(_x, _y);
       }
 
-      this.curFillColor = finalFillColor; // Set curFillColor to finalFillColor
+      // so that we leave curFillColor with the last value the user set it to
+      this.curFillColor = fillColors[2];
       this.immediateMode._quadraticVertex[0] = args[2];
       this.immediateMode._quadraticVertex[1] = args[3];
     } else if (argLength === 6) {
@@ -1838,36 +1796,26 @@ p5.RendererGL.prototype.quadraticVertex = function(...args) {
       w_y = [this.immediateMode._quadraticVertex[1], args[1], args[4]];
       w_z = [this.immediateMode._quadraticVertex[2], args[2], args[5]];
 
-      // calCalculate intermediate colors
-      let d0 = Math.sqrt(
-        Math.pow(w_x[0]-w_x[1],2) +
-        Math.pow(w_y[0]-w_y[1],2) +
-        Math.pow(w_z[0]-w_z[1],2)
-      );
-      let d1 = Math.sqrt(
-        Math.pow(w_x[1]-w_x[2],2) +
-        Math.pow(w_y[1]-w_y[2],2) +
-        Math.pow(w_z[1]-w_z[2],2)
-      );
+      // The ratio of the distance between the start point, the two control-
+      // points, and the end point determines the intermediate color.
+      let d0 = Math.hypot(w_x[0]-w_x[1], w_y[0]-w_y[1], w_z[0]-w_z[1]);
+      let d1 = Math.hypot(w_x[1]-w_x[2], w_y[1]-w_y[2], w_z[1]-w_z[2]);
       const totalLength = d0 + d1;
       d0 /= totalLength;
-      const middleFillColor = [];
       for (k = 0; k < 4; k++) {
-        middleFillColor.push(
-          lastFillColor[k] * (1-d0) + finalFillColor[k] * d0
+        fillColors[1].push(
+          fillColors[0][k] * (1-d0) + fillColors[2][k] * d0
         );
       }
 
       for (i = 0; i < LUTLength; i++) {
         // Interpolate colors using control points
         this.curFillColor = [0, 0, 0, 0];
-        for (k = 0; k < 4; k++) {
-          this.curFillColor[k] +=
-            this._lookUpTableQuadratic[i][0] * lastFillColor[k];
-          this.curFillColor[k] +=
-            this._lookUpTableQuadratic[i][1] * middleFillColor[k];
-          this.curFillColor[k] +=
-            this._lookUpTableQuadratic[i][2] * finalFillColor[k];
+        for (m = 0; m < 3; m++) {
+          for (k = 0; k < 4; k++) {
+            this.curFillColor[k] +=
+              this._lookUpTableQuadratic[i][m] * fillColors[m][k];
+          }
         }
         _x =
           w_x[0] * this._lookUpTableQuadratic[i][0] +
@@ -1884,7 +1832,8 @@ p5.RendererGL.prototype.quadraticVertex = function(...args) {
         this.vertex(_x, _y, _z);
       }
 
-      this.curFillColor = finalFillColor; // Set curFillColor to finalFillColor
+      // so that we leave curFillColor with the last value the user set it to
+      this.curFillColor = fillColors[2];
       this.immediateMode._quadraticVertex[0] = args[3];
       this.immediateMode._quadraticVertex[1] = args[4];
       this.immediateMode._quadraticVertex[2] = args[5];

--- a/src/webgl/3d_primitives.js
+++ b/src/webgl/3d_primitives.js
@@ -1783,7 +1783,9 @@ p5.RendererGL.prototype.quadraticVertex = function(...args) {
       d0 /= totalLength;
       const middleFillColor = [];
       for (k = 0; k < 4; k++) {
-        middleFillColor.push(lastFillColor[k] * (1-d0) + finalFillColor[k] * d0);
+        middleFillColor.push(
+          lastFillColor[k] * (1-d0) + finalFillColor[k] * d0
+        );
       }
 
       for (i = 0; i < LUTLength; i++) {
@@ -1831,7 +1833,9 @@ p5.RendererGL.prototype.quadraticVertex = function(...args) {
       d0 /= totalLength;
       const middleFillColor = [];
       for (k = 0; k < 4; k++) {
-        middleFillColor.push(lastFillColor[k] * (1-d0) + finalFillColor[k] * d0);
+        middleFillColor.push(
+          lastFillColor[k] * (1-d0) + finalFillColor[k] * d0
+        );
       }
 
       for (i = 0; i < LUTLength; i++) {

--- a/src/webgl/3d_primitives.js
+++ b/src/webgl/3d_primitives.js
@@ -1605,9 +1605,18 @@ p5.RendererGL.prototype.bezierVertex = function(...args) {
       w_x = [this.immediateMode._bezierVertex[0], args[0], args[2], args[4]];
       w_y = [this.immediateMode._bezierVertex[1], args[1], args[3], args[5]];
       // calCalculate intermediate colors
-      let d0 = sqrt(pow(w_x[0]-w_x[1],2) + pow(w_y[0]-w_y[1],2));
-      let d1 = sqrt(pow(w_x[1]-w_x[2],2) + pow(w_y[1]-w_y[2],2));
-      let d2 = sqrt(pow(w_x[2]-w_x[3],2) + pow(w_y[2]-w_y[3],2));
+      let d0 = Math.sqrt(
+        Math.pow(w_x[0]-w_x[1],2) +
+        Math.pow(w_y[0]-w_y[1],2)
+      );
+      let d1 = Math.sqrt(
+        Math.pow(w_x[1]-w_x[2],2) +
+        Math.pow(w_y[1]-w_y[2],2)
+      );
+      let d2 = Math.sqrt(
+        Math.pow(w_x[2]-w_x[3],2) +
+        Math.pow(w_y[2]-w_y[3],2)
+      );
       const totalLength = d0 + d1 + d2;
       d0 /= totalLength;
       d2 /= totalLength;
@@ -1657,18 +1666,21 @@ p5.RendererGL.prototype.bezierVertex = function(...args) {
       w_y = [this.immediateMode._bezierVertex[1], args[1], args[4], args[7]];
       w_z = [this.immediateMode._bezierVertex[2], args[2], args[5], args[8]];
       // Calculate intermediate colors
-      let d0 = sqrt(
-        pow(w_x[0]-w_x[1],2) +
-        pow(w_y[0]-w_y[1],2) +
-        pow(w_z[0]-w_z[1],2));
-      let d1 = sqrt(
-        pow(w_x[1]-w_x[2],2) +
-        pow(w_y[1]-w_y[2],2) +
-        pow(w_z[1]-w_z[2],2));
-      let d2 = sqrt(
-        pow(w_x[2]-w_x[3],2) +
-        pow(w_y[2]-w_y[3],2) +
-        pow(w_z[2]-w_z[3],2));
+      let d0 = Math.sqrt(
+        Math.pow(w_x[0]-w_x[1],2) +
+        Math.pow(w_y[0]-w_y[1],2) +
+        Math.pow(w_z[0]-w_z[1],2)
+      );
+      let d1 = Math.sqrt(
+        Math.pow(w_x[1]-w_x[2],2) +
+        Math.pow(w_y[1]-w_y[2],2) +
+        Math.pow(w_z[1]-w_z[2],2)
+      );
+      let d2 = Math.sqrt(
+        Math.pow(w_x[2]-w_x[3],2) +
+        Math.pow(w_y[2]-w_y[3],2) +
+        Math.pow(w_z[2]-w_z[3],2)
+      );
       const totalLength = d0 + d1 + d2;
       d0 /= totalLength;
       d2 /= totalLength;
@@ -1777,8 +1789,14 @@ p5.RendererGL.prototype.quadraticVertex = function(...args) {
       w_y = [this.immediateMode._quadraticVertex[1], args[1], args[3]];
 
       // calCalculate intermediate colors
-      let d0 = sqrt(pow(w_x[0]-w_x[1],2) + pow(w_y[0]-w_y[1],2));
-      let d1 = sqrt(pow(w_x[1]-w_x[2],2) + pow(w_y[1]-w_y[2],2));
+      let d0 = Math.sqrt(
+        Math.pow(w_x[0]-w_x[1],2) +
+        Math.pow(w_y[0]-w_y[1],2)
+      );
+      let d1 = Math.sqrt(
+        Math.pow(w_x[1]-w_x[2],2) +
+        Math.pow(w_y[1]-w_y[2],2)
+      );
       const totalLength = d0 + d1;
       d0 /= totalLength;
       const middleFillColor = [];
@@ -1821,14 +1839,16 @@ p5.RendererGL.prototype.quadraticVertex = function(...args) {
       w_z = [this.immediateMode._quadraticVertex[2], args[2], args[5]];
 
       // calCalculate intermediate colors
-      let d0 = sqrt(
-        pow(w_x[0]-w_x[1],2) +
-        pow(w_y[0]-w_y[1],2) +
-        pow(w_z[0]-w_z[1],2));
-      let d1 = sqrt(
-        pow(w_x[1]-w_x[2],2) +
-        pow(w_y[1]-w_y[2],2) +
-        pow(w_z[1]-w_z[2],2));
+      let d0 = Math.sqrt(
+        Math.pow(w_x[0]-w_x[1],2) +
+        Math.pow(w_y[0]-w_y[1],2) +
+        Math.pow(w_z[0]-w_z[1],2)
+      );
+      let d1 = Math.sqrt(
+        Math.pow(w_x[1]-w_x[2],2) +
+        Math.pow(w_y[1]-w_y[2],2) +
+        Math.pow(w_z[1]-w_z[2],2)
+      );
       const totalLength = d0 + d1;
       d0 /= totalLength;
       const middleFillColor = [];

--- a/src/webgl/3d_primitives.js
+++ b/src/webgl/3d_primitives.js
@@ -1587,7 +1587,7 @@ p5.RendererGL.prototype.bezierVertex = function(...args) {
     }
 
     const LUTLength = this._lookUpTableBezier.length;
-    
+
     // Get the last fill color
     const _vertexColors = this.immediateMode.geometry.vertexColors;
     const _vertexColorSize = _vertexColors.length;
@@ -1614,18 +1614,26 @@ p5.RendererGL.prototype.bezierVertex = function(...args) {
       const firstFillColor = [];
       const secondFillColor = [];
       for (k = 0; k < 4; k++) {
-        firstFillColor.push(lastFillColor[k] * (1-d0) + finalFillColor[k] * d0);
-        secondFillColor.push(lastFillColor[k] * d2 + finalFillColor[k] * (1-d2));
+        firstFillColor.push(
+          lastFillColor[k] * (1-d0) + finalFillColor[k] * d0
+        );
+        secondFillColor.push(
+          lastFillColor[k] * d2 + finalFillColor[k] * (1-d2)
+        );
       }
 
       for (i = 0; i < LUTLength; i++) {
         // Interpolate colors using control points
         this.curFillColor = [0, 0, 0, 0];
         for (k = 0; k < 4; k++) {
-          this.curFillColor[k] += this._lookUpTableBezier[i][0] * lastFillColor[k];
-          this.curFillColor[k] += this._lookUpTableBezier[i][1] * firstFillColor[k];
-          this.curFillColor[k] += this._lookUpTableBezier[i][2] * secondFillColor[k];
-          this.curFillColor[k] += this._lookUpTableBezier[i][3] * finalFillColor[k];
+          this.curFillColor[k] +=
+            this._lookUpTableBezier[i][0] * lastFillColor[k];
+          this.curFillColor[k] +=
+            this._lookUpTableBezier[i][1] * firstFillColor[k];
+          this.curFillColor[k] +=
+            this._lookUpTableBezier[i][2] * secondFillColor[k];
+          this.curFillColor[k] +=
+            this._lookUpTableBezier[i][3] * finalFillColor[k];
         }
         _x =
           w_x[0] * this._lookUpTableBezier[i][0] +
@@ -1639,7 +1647,7 @@ p5.RendererGL.prototype.bezierVertex = function(...args) {
           w_y[3] * this._lookUpTableBezier[i][3];
         this.vertex(_x, _y);
       }
-      this.curFillColor = finalFillColor; // Set curFillColor back to finalFillColor
+      this.curFillColor = finalFillColor; // Set curFillColor to finalFillColor
       this.immediateMode._bezierVertex[0] = args[4];
       this.immediateMode._bezierVertex[1] = args[5];
     } else if (argLength === 9) {
@@ -1649,26 +1657,43 @@ p5.RendererGL.prototype.bezierVertex = function(...args) {
       w_y = [this.immediateMode._bezierVertex[1], args[1], args[4], args[7]];
       w_z = [this.immediateMode._bezierVertex[2], args[2], args[5], args[8]];
       // Calculate intermediate colors
-      let d0 = sqrt(pow(w_x[0]-w_x[1],2) + pow(w_y[0]-w_y[1],2) + pow(w_z[0]-w_z[1],2));
-      let d1 = sqrt(pow(w_x[1]-w_x[2],2) + pow(w_y[1]-w_y[2],2) + pow(w_z[1]-w_z[2],2));
-      let d2 = sqrt(pow(w_x[2]-w_x[3],2) + pow(w_y[2]-w_y[3],2) + pow(w_z[2]-w_z[3],2));
+      let d0 = sqrt(
+        pow(w_x[0]-w_x[1],2) +
+        pow(w_y[0]-w_y[1],2) +
+        pow(w_z[0]-w_z[1],2));
+      let d1 = sqrt(
+        pow(w_x[1]-w_x[2],2) +
+        pow(w_y[1]-w_y[2],2) +
+        pow(w_z[1]-w_z[2],2));
+      let d2 = sqrt(
+        pow(w_x[2]-w_x[3],2) +
+        pow(w_y[2]-w_y[3],2) +
+        pow(w_z[2]-w_z[3],2));
       const totalLength = d0 + d1 + d2;
       d0 /= totalLength;
       d2 /= totalLength;
       const firstFillColor = [];
       const secondFillColor = [];
       for (k = 0; k < 4; k++) {
-        firstFillColor.push(lastFillColor[k] * (1-d0) + finalFillColor[k] * d0);
-        secondFillColor.push(lastFillColor[k] * d2 + finalFillColor[k] * (1-d2));
+        firstFillColor.push(
+          lastFillColor[k] * (1-d0) + finalFillColor[k] * d0
+        );
+        secondFillColor.push(
+          lastFillColor[k] * d2 + finalFillColor[k] * (1-d2)
+        );
       }
       for (i = 0; i < LUTLength; i++) {
         // Interpolate colors using control points
         this.curFillColor = [0, 0, 0, 0];
         for (k = 0; k < 4; k++) {
-          this.curFillColor[k] += this._lookUpTableBezier[i][0] * lastFillColor[k];
-          this.curFillColor[k] += this._lookUpTableBezier[i][1] * firstFillColor[k];
-          this.curFillColor[k] += this._lookUpTableBezier[i][2] * secondFillColor[k];
-          this.curFillColor[k] += this._lookUpTableBezier[i][3] * finalFillColor[k];
+          this.curFillColor[k] +=
+            this._lookUpTableBezier[i][0] * lastFillColor[k];
+          this.curFillColor[k] +=
+            this._lookUpTableBezier[i][1] * firstFillColor[k];
+          this.curFillColor[k] +=
+            this._lookUpTableBezier[i][2] * secondFillColor[k];
+          this.curFillColor[k] +=
+            this._lookUpTableBezier[i][3] * finalFillColor[k];
         }
         _x =
           w_x[0] * this._lookUpTableBezier[i][0] +
@@ -1687,7 +1712,7 @@ p5.RendererGL.prototype.bezierVertex = function(...args) {
           w_z[3] * this._lookUpTableBezier[i][3];
         this.vertex(_x, _y, _z);
       }
-      this.curFillColor = finalFillColor; // Set curFillColor back to finalFillColor
+      this.curFillColor = finalFillColor; // Set curFillColor to finalFillColor
       this.immediateMode._bezierVertex[0] = args[6];
       this.immediateMode._bezierVertex[1] = args[7];
       this.immediateMode._bezierVertex[2] = args[8];
@@ -1733,7 +1758,7 @@ p5.RendererGL.prototype.quadraticVertex = function(...args) {
     }
 
     const LUTLength = this._lookUpTableQuadratic.length;
-    
+
     // Get the last fill color
     const _vertexColors = this.immediateMode.geometry.vertexColors;
     const _vertexColorSize = _vertexColors.length;
@@ -1750,7 +1775,7 @@ p5.RendererGL.prototype.quadraticVertex = function(...args) {
 
       w_x = [this.immediateMode._quadraticVertex[0], args[0], args[2]];
       w_y = [this.immediateMode._quadraticVertex[1], args[1], args[3]];
-      
+
       // calCalculate intermediate colors
       let d0 = sqrt(pow(w_x[0]-w_x[1],2) + pow(w_y[0]-w_y[1],2));
       let d1 = sqrt(pow(w_x[1]-w_x[2],2) + pow(w_y[1]-w_y[2],2));
@@ -1765,9 +1790,12 @@ p5.RendererGL.prototype.quadraticVertex = function(...args) {
         // Interpolate colors using control points
         this.curFillColor = [0, 0, 0, 0];
         for (k = 0; k < 4; k++) {
-          this.curFillColor[k] += this._lookUpTableQuadratic[i][0] * lastFillColor[k];
-          this.curFillColor[k] += this._lookUpTableQuadratic[i][1] * middleFillColor[k];
-          this.curFillColor[k] += this._lookUpTableQuadratic[i][2] * finalFillColor[k];
+          this.curFillColor[k] +=
+            this._lookUpTableQuadratic[i][0] * lastFillColor[k];
+          this.curFillColor[k] +=
+            this._lookUpTableQuadratic[i][1] * middleFillColor[k];
+          this.curFillColor[k] +=
+            this._lookUpTableQuadratic[i][2] * finalFillColor[k];
         }
         _x =
           w_x[0] * this._lookUpTableQuadratic[i][0] +
@@ -1780,7 +1808,7 @@ p5.RendererGL.prototype.quadraticVertex = function(...args) {
         this.vertex(_x, _y);
       }
 
-      this.curFillColor = finalFillColor; // Set curFillColor back to finalFillColor
+      this.curFillColor = finalFillColor; // Set curFillColor to finalFillColor
       this.immediateMode._quadraticVertex[0] = args[2];
       this.immediateMode._quadraticVertex[1] = args[3];
     } else if (argLength === 6) {
@@ -1789,10 +1817,16 @@ p5.RendererGL.prototype.quadraticVertex = function(...args) {
       w_x = [this.immediateMode._quadraticVertex[0], args[0], args[3]];
       w_y = [this.immediateMode._quadraticVertex[1], args[1], args[4]];
       w_z = [this.immediateMode._quadraticVertex[2], args[2], args[5]];
-      
+
       // calCalculate intermediate colors
-      let d0 = sqrt(pow(w_x[0]-w_x[1],2) + pow(w_y[0]-w_y[1],2) + pow(w_z[0]-w_z[1],2));
-      let d1 = sqrt(pow(w_x[1]-w_x[2],2) + pow(w_y[1]-w_y[2],2) + pow(w_z[1]-w_z[2],2));
+      let d0 = sqrt(
+        pow(w_x[0]-w_x[1],2) +
+        pow(w_y[0]-w_y[1],2) +
+        pow(w_z[0]-w_z[1],2));
+      let d1 = sqrt(
+        pow(w_x[1]-w_x[2],2) +
+        pow(w_y[1]-w_y[2],2) +
+        pow(w_z[1]-w_z[2],2));
       const totalLength = d0 + d1;
       d0 /= totalLength;
       const middleFillColor = [];
@@ -1804,9 +1838,12 @@ p5.RendererGL.prototype.quadraticVertex = function(...args) {
         // Interpolate colors using control points
         this.curFillColor = [0, 0, 0, 0];
         for (k = 0; k < 4; k++) {
-          this.curFillColor[k] += this._lookUpTableQuadratic[i][0] * lastFillColor[k];
-          this.curFillColor[k] += this._lookUpTableQuadratic[i][1] * middleFillColor[k];
-          this.curFillColor[k] += this._lookUpTableQuadratic[i][2] * finalFillColor[k];
+          this.curFillColor[k] +=
+            this._lookUpTableQuadratic[i][0] * lastFillColor[k];
+          this.curFillColor[k] +=
+            this._lookUpTableQuadratic[i][1] * middleFillColor[k];
+          this.curFillColor[k] +=
+            this._lookUpTableQuadratic[i][2] * finalFillColor[k];
         }
         _x =
           w_x[0] * this._lookUpTableQuadratic[i][0] +
@@ -1823,7 +1860,7 @@ p5.RendererGL.prototype.quadraticVertex = function(...args) {
         this.vertex(_x, _y, _z);
       }
 
-      this.curFillColor = finalFillColor; // Set curFillColor back to finalFillColor
+      this.curFillColor = finalFillColor; // Set curFillColor to finalFillColor
       this.immediateMode._quadraticVertex[0] = args[3];
       this.immediateMode._quadraticVertex[1] = args[4];
       this.immediateMode._quadraticVertex[2] = args[5];

--- a/test/unit/webgl/p5.RendererGL.js
+++ b/test/unit/webgl/p5.RendererGL.js
@@ -1078,7 +1078,6 @@ suite('p5.RendererGL', function() {
       // end color: (255, 0, 0)
       // Intermediate values are expected to be approximately half the value.
 
-      renderer.noStroke();
       renderer.beginShape();
       renderer.fill(255);
       renderer.vertex(-128, -128);
@@ -1097,7 +1096,6 @@ suite('p5.RendererGL', function() {
       // end color: (255, 0, 0)
       // Intermediate values are expected to be approximately half the value.
 
-      renderer.noStroke();
       renderer.beginShape();
       renderer.fill(255);
       renderer.vertex(-128, -128);

--- a/test/unit/webgl/p5.RendererGL.js
+++ b/test/unit/webgl/p5.RendererGL.js
@@ -1071,6 +1071,44 @@ suite('p5.RendererGL', function() {
 
       done();
     });
+    test('bezierVertex() should interpolate curFillColor', function(done) {
+      const renderer = myp5.createCanvas(256, 256, myp5.WEBGL);
+
+      // start color: (255, 255, 255)
+      // end color: (255, 0, 0)
+      // Intermediate values are expected to be approximately half the value.
+
+      renderer.noStroke();
+      renderer.beginShape();
+      renderer.fill(255);
+      renderer.vertex(-128, -128);
+      renderer.fill(255, 0, 0);
+      renderer.bezierVertex(128, -128, 128, 128, -128, 128);
+      renderer.endShape();
+
+      assert.deepEqual(myp5.get(128, 128), [255, 129, 129, 255]);
+
+      done();
+    });
+    test('quadraticVertex() should interpolate curFillColor', function(done) {
+      const renderer = myp5.createCanvas(256, 256, myp5.WEBGL);
+
+      // start color: (255, 255, 255)
+      // end color: (255, 0, 0)
+      // Intermediate values are expected to be approximately half the value.
+
+      renderer.noStroke();
+      renderer.beginShape();
+      renderer.fill(255);
+      renderer.vertex(-128, -128);
+      renderer.fill(255, 0, 0);
+      renderer.quadraticVertex(256, 0, -128, 128);
+      renderer.endShape();
+
+      assert.deepEqual(myp5.get(128, 128), [255, 128, 128, 255]);
+
+      done();
+    });
   });
 
   suite('setAttributes', function() {


### PR DESCRIPTION
Inside the vertex functions called inside the bezierVertex and quadraticVertex functions, curFillColor is now all the same.
I want this to be interpolated between the curFillColor value when the previous vertex function was called (external or internal) and the current curFillColor value.

<!--
  Thank you for contributing! Please use this pull request (PR) template.


 In the description field of this PR, include "resolves #XXXX" tagging the issue you are fixing. If this PR addresses the issue but doesn't completely resolve it (ie the issue should remain open after your PR is merged), write "addresses #XXXX".-->
Resolves #5919

 ## Changes:
Both bezierVertex and quadraticVertex functions must always be executed after at least one vertex function has been called. So the vertexColors array is always non-empty and we can get the previous color. Rewrite it like that.
In addition, we want to interpolate based on the length of the polygonal line that connects the control points, and then determine the color at each point from the color assigned to the control point and the Bezier coefficient.
<!-- Add here what changes were made in this pull request and if possible provide links showcasing the changes. -->


 ## Screenshots of the change:
<!-- If applicable, add screenshots depicting the changes. -->
![bezierSample_Fill_compare](https://user-images.githubusercontent.com/39549290/209857944-65040c41-8c15-4d96-8370-ab28bcdfdcb5.png)

## PR Checklist

- [x] WEBGL

[Inline documentation]: https://github.com/processing/p5.js/blob/main/contributor_docs/inline_documentation.md
[Unit tests]: https://github.com/processing/p5.js/tree/main/contributor_docs#unit-tests
