### PR TITLE
fix: saveGif's third argument made more optional

### DIFF
--- a/src/image/loading_displaying.js
+++ b/src/image/loading_displaying.js
@@ -244,7 +244,7 @@ p5.prototype.saveGif = async function(
   const units = (options && options.units) || 'seconds';  // either 'seconds' or 'frames'
 
   // if arguments in the options object are not correct, cancel operation
-  if (typeof delay !== 'number' && delay !== null) {
+  if (typeof delay !== 'number') {
     throw TypeError('Delay parameter must be a number');
   }
   // if units is not seconds nor frames, throw error

--- a/src/image/loading_displaying.js
+++ b/src/image/loading_displaying.js
@@ -240,8 +240,8 @@ p5.prototype.saveGif = async function(
   }
 
   // extract variables for more comfortable use
-  const delay = (options && options.delay) || 0  // in seconds
-  const units = (options && options.units) || 'seconds'  // either 'seconds' or 'frames'
+  const delay = (options && options.delay) || 0  // in seconds;
+  const units = (options && options.units) || 'seconds'  // either 'seconds' or 'frames';
 
   //   console.log(options);
 

--- a/src/image/loading_displaying.js
+++ b/src/image/loading_displaying.js
@@ -238,18 +238,10 @@ p5.prototype.saveGif = async function(
   if (typeof duration !== 'number') {
     throw TypeError('Duration parameter must be a number');
   }
-  // if arguments in the options object are not correct, cancel operation
-  if (typeof options.delay !== 'number') {
-    throw TypeError('Delay parameter must be a number');
-  }
-  // if units is not seconds nor frames, throw error
-  if (options.units !== 'seconds' && options.units !== 'frames') {
-    throw TypeError('Units parameter must be either "frames" or "seconds"');
-  }
 
   // extract variables for more comfortable use
-  let units = options.units;
-  let delay = options.delay;
+  const delay = (options && options.delay) || 0  // in seconds
+  const units = (options && options.units) || 'seconds'  // either 'seconds' or 'frames'
 
   //   console.log(options);
 

--- a/src/image/loading_displaying.js
+++ b/src/image/loading_displaying.js
@@ -243,6 +243,15 @@ p5.prototype.saveGif = async function(
   const delay = (options && options.delay) || 0;  // in seconds
   const units = (options && options.units) || 'seconds';  // either 'seconds' or 'frames'
 
+  // if arguments in the options object are not correct, cancel operation
+  if (typeof delay !== 'number' && delay !== null) {
+    throw TypeError('Delay parameter must be a number');
+  }
+  // if units is not seconds nor frames, throw error
+  if (units !== 'seconds' && units !== 'frames') {
+    throw TypeError('Units parameter must be either "frames" or "seconds"');
+  }
+
   //   console.log(options);
 
   // get the project's framerate

--- a/src/image/loading_displaying.js
+++ b/src/image/loading_displaying.js
@@ -240,8 +240,8 @@ p5.prototype.saveGif = async function(
   }
 
   // extract variables for more comfortable use
-  const delay = (options && options.delay) || 0  // in seconds;
-  const units = (options && options.units) || 'seconds'  // either 'seconds' or 'frames';
+  const delay = (options && options.delay) || 0;  // in seconds
+  const units = (options && options.units) || 'seconds';  // either 'seconds' or 'frames'
 
   //   console.log(options);
 


### PR DESCRIPTION
`saveGif` currently accepts an optional third argument in the form of an object with delay and unit keys. If an object is passed with only one of those keys defined, then it returns an error message respectively.

#### Resolves #5927 

 #### Changes:

- Made optional third argument of `saveGif` even more optional.
- Checks are now performed on `delay` and `units` rather than `options.delay` and `options.units`

#### PR Checklist
<!--
  To check any option, replace the "[ ]" with a "[x]". Be sure to check out how it looks in the Preview tab! Feel free to remove any portion of the template that is not relevant for your issue.
-->

- [ ] `npm run lint` passes
- [ ] [Inline documentation] is included / updated
- [ ] [Unit tests] are included / updated

[Inline documentation]: https://github.com/processing/p5.js/blob/main/contributor_docs/inline_documentation.md
[Unit tests]: https://github.com/processing/p5.js/tree/main/contributor_docs#unit-tests

Thanks for the assist @davepagurek 🙌 
