### PR TITLE
 Modify the lightingShader to allow per-vertex coloring

### DIFF
--- a/src/webgl/p5.RendererGL.Immediate.js
+++ b/src/webgl/p5.RendererGL.Immediate.js
@@ -368,6 +368,7 @@ p5.RendererGL.prototype._tesselateShape = function() {
  */
 p5.RendererGL.prototype._drawImmediateFill = function() {
   const gl = this.GL;
+  this._useVertexColor = (this.immediateMode.geometry.vertexColors.length > 0);
   const shader = this._getImmediateFillShader();
 
   this._setFillUniforms(shader);

--- a/src/webgl/p5.RendererGL.Retained.js
+++ b/src/webgl/p5.RendererGL.Retained.js
@@ -130,6 +130,7 @@ p5.RendererGL.prototype.drawBuffers = function(gId) {
   }
 
   if (this._doFill) {
+    this._useVertexColor = (geometry.model.vertexColors.length > 0);
     const fillShader = this._getRetainedFillShader();
     this._setFillUniforms(fillShader);
     for (const buff of this.retainedMode.buffers.fill) {

--- a/src/webgl/p5.RendererGL.js
+++ b/src/webgl/p5.RendererGL.js
@@ -111,6 +111,7 @@ p5.RendererGL = function(elt, pInst, isMainCanvas, attr) {
   this._useShininess = 1;
 
   this._useLineColor = false;
+  this._useVertexColor = false;
 
   this._tint = [255, 255, 255, 255];
 
@@ -139,6 +140,7 @@ p5.RendererGL = function(elt, pInst, isMainCanvas, attr) {
   this._defaultImmediateModeShader = undefined;
   this._defaultNormalShader = undefined;
   this._defaultColorShader = undefined;
+  this._defaultVertexColorShader = undefined;
   this._defaultPointShader = undefined;
 
   this.userFillShader = undefined;
@@ -1197,6 +1199,14 @@ p5.RendererGL.prototype._getColorShader = function() {
     );
   }
 
+  if (!this._defaultVertexColorShader) {
+    this._defaultVertexColorShader = new p5.Shader(
+      this,
+      defaultShaders.vertexColorVert,
+      defaultShaders.vertexColorFrag
+    );
+  }
+  if (this._useVertexColor) return this._defaultVertexColorShader;
   return this._defaultColorShader;
 };
 
@@ -1270,6 +1280,7 @@ p5.RendererGL.prototype._setFillUniforms = function(fillShader) {
   fillShader.bindShader();
 
   // TODO: optimize
+  fillShader.setUniform('uUseVertexColor', this._useVertexColor);
   fillShader.setUniform('uMaterialColor', this.curFillColor);
   fillShader.setUniform('isTexture', !!this._tex);
   if (this._tex) {

--- a/src/webgl/p5.RendererGL.js
+++ b/src/webgl/p5.RendererGL.js
@@ -140,7 +140,6 @@ p5.RendererGL = function(elt, pInst, isMainCanvas, attr) {
   this._defaultImmediateModeShader = undefined;
   this._defaultNormalShader = undefined;
   this._defaultColorShader = undefined;
-  this._defaultVertexColorShader = undefined;
   this._defaultPointShader = undefined;
 
   this.userFillShader = undefined;
@@ -1198,15 +1197,6 @@ p5.RendererGL.prototype._getColorShader = function() {
       defaultShaders.basicFrag
     );
   }
-
-  if (!this._defaultVertexColorShader) {
-    this._defaultVertexColorShader = new p5.Shader(
-      this,
-      defaultShaders.vertexColorVert,
-      defaultShaders.vertexColorFrag
-    );
-  }
-  if (this._useVertexColor) return this._defaultVertexColorShader;
   return this._defaultColorShader;
 };
 

--- a/src/webgl/p5.RendererGL.js
+++ b/src/webgl/p5.RendererGL.js
@@ -1197,6 +1197,7 @@ p5.RendererGL.prototype._getColorShader = function() {
       defaultShaders.basicFrag
     );
   }
+
   return this._defaultColorShader;
 };
 

--- a/src/webgl/shaders/basic.frag
+++ b/src/webgl/shaders/basic.frag
@@ -1,5 +1,5 @@
 precision mediump float;
-uniform vec4 uMaterialColor;
+varying vec4 vColor;
 void main(void) {
-  gl_FragColor = vec4(uMaterialColor.rgb, 1.) * uMaterialColor.a;
+  gl_FragColor = vec4(vColor.rgb, 1.) * vColor.a;
 }

--- a/src/webgl/shaders/light.vert
+++ b/src/webgl/shaders/light.vert
@@ -3,14 +3,19 @@
 attribute vec3 aPosition;
 attribute vec3 aNormal;
 attribute vec2 aTexCoord;
+attribute vec4 aVertexColor;
 
 uniform mat4 uModelViewMatrix;
 uniform mat4 uProjectionMatrix;
 uniform mat3 uNormalMatrix;
 
+uniform bool uUseVertexColor;
+uniform vec4 uMaterialColor;
+
 varying highp vec2 vVertTexCoord;
 varying vec3 vDiffuseColor;
 varying vec3 vSpecularColor;
+varying vec4 vColor;
 
 void main(void) {
 
@@ -27,4 +32,6 @@ void main(void) {
       vDiffuseColor += uAmbientColor[i];
     }
   }
+  
+  vColor = (uUseVertexColor ? aVertexColor : uMaterialColor);
 }

--- a/src/webgl/shaders/light_texture.frag
+++ b/src/webgl/shaders/light_texture.frag
@@ -1,6 +1,5 @@
 precision highp float;
 
-uniform vec4 uMaterialColor;
 uniform vec4 uTint;
 uniform sampler2D uSampler;
 uniform bool isTexture;
@@ -9,13 +8,14 @@ uniform bool uEmissive;
 varying highp vec2 vVertTexCoord;
 varying vec3 vDiffuseColor;
 varying vec3 vSpecularColor;
+varying vec4 vColor;
 
 void main(void) {
   if(uEmissive && !isTexture) {
-    gl_FragColor = uMaterialColor;
+    gl_FragColor = vColor;
   }
   else {
-    vec4 baseColor = isTexture ? texture2D(uSampler, vVertTexCoord) * (uTint / vec4(255, 255, 255, 255)) : uMaterialColor;
+    vec4 baseColor = isTexture ? texture2D(uSampler, vVertTexCoord) * (uTint / vec4(255, 255, 255, 255)) : vColor;
     gl_FragColor = vec4(gl_FragColor.rgb * vDiffuseColor + vSpecularColor, 1.) * baseColor.a;
   }
 }

--- a/src/webgl/shaders/normal.vert
+++ b/src/webgl/shaders/normal.vert
@@ -1,17 +1,23 @@
 attribute vec3 aPosition;
 attribute vec3 aNormal;
 attribute vec2 aTexCoord;
+attribute vec4 aVertexColor;
 
 uniform mat4 uModelViewMatrix;
 uniform mat4 uProjectionMatrix;
 uniform mat3 uNormalMatrix;
 
+uniform vec4 uMaterialColor;
+uniform bool uUseVertexColor;
+
 varying vec3 vVertexNormal;
 varying highp vec2 vVertTexCoord;
+varying vec4 vColor;
 
 void main(void) {
   vec4 positionVec4 = vec4(aPosition, 1.0);
   gl_Position = uProjectionMatrix * uModelViewMatrix * positionVec4;
   vVertexNormal = normalize(vec3( uNormalMatrix * aNormal ));
   vVertTexCoord = aTexCoord;
+  vColor = (uUseVertexColor ? aVertexColor : uMaterialColor);
 }

--- a/src/webgl/shaders/phong.frag
+++ b/src/webgl/shaders/phong.frag
@@ -6,7 +6,6 @@ uniform vec4 uSpecularMatColor;
 uniform vec4 uAmbientMatColor;
 uniform vec4 uEmissiveMatColor;
 
-uniform vec4 uMaterialColor;
 uniform vec4 uTint;
 uniform sampler2D uSampler;
 uniform bool isTexture;
@@ -15,6 +14,7 @@ varying vec3 vNormal;
 varying vec2 vTexCoord;
 varying vec3 vViewPosition;
 varying vec3 vAmbientColor;
+varying vec4 vColor;
 
 void main(void) {
 
@@ -24,7 +24,7 @@ void main(void) {
 
   // Calculating final color as result of all lights (plus emissive term).
 
-  vec4 baseColor = isTexture ? texture2D(uSampler, vTexCoord) * (uTint / vec4(255, 255, 255, 255)) : uMaterialColor;
+  vec4 baseColor = isTexture ? texture2D(uSampler, vTexCoord) * (uTint / vec4(255, 255, 255, 255)) : vColor;
   gl_FragColor = vec4(diffuse * baseColor.rgb + 
                     vAmbientColor * uAmbientMatColor.rgb + 
                     specular * uSpecularMatColor.rgb + 

--- a/src/webgl/shaders/phong.vert
+++ b/src/webgl/shaders/phong.vert
@@ -4,6 +4,7 @@ precision highp int;
 attribute vec3 aPosition;
 attribute vec3 aNormal;
 attribute vec2 aTexCoord;
+attribute vec4 aVertexColor;
 
 uniform vec3 uAmbientColor[5];
 
@@ -12,10 +13,14 @@ uniform mat4 uProjectionMatrix;
 uniform mat3 uNormalMatrix;
 uniform int uAmbientLightCount;
 
+uniform bool uUseVertexColor;
+uniform vec4 uMaterialColor;
+
 varying vec3 vNormal;
 varying vec2 vTexCoord;
 varying vec3 vViewPosition;
 varying vec3 vAmbientColor;
+varying vec4 vColor;
 
 void main(void) {
 
@@ -35,4 +40,6 @@ void main(void) {
       vAmbientColor += uAmbientColor[i];
     }
   }
+  
+  vColor = (uUseVertexColor ? aVertexColor : uMaterialColor);
 }

--- a/test/unit/webgl/p5.RendererGL.js
+++ b/test/unit/webgl/p5.RendererGL.js
@@ -1111,7 +1111,7 @@ suite('p5.RendererGL', function() {
 
   suite('interpolation of vertex colors', function(){
     test('immediate mode uses vertex colors (noLight)', function(done) {
-      const renderer = createCanvas(256, 256, myp5.WEBGL);
+      const renderer = myp5.createCanvas(256, 256, myp5.WEBGL);
 
       // upper color: (200, 0, 0, 255);
       // lower color: (0, 0, 200, 255);
@@ -1134,7 +1134,7 @@ suite('p5.RendererGL', function() {
     });
 
     test('immediate mode uses vertex colors (light)', function(done) {
-      const renderer = createCanvas(256, 256, myp5.WEBGL);
+      const renderer = myp5.createCanvas(256, 256, myp5.WEBGL);
 
       myp5.directionalLight(255, 255, 255, 0, 0, -1);
       // diffuseFactor:0.73
@@ -1157,7 +1157,7 @@ suite('p5.RendererGL', function() {
     });
 
     test('geom without vertex colors use curFillCol (noLight)', function(done) {
-      const renderer = createCanvas(256, 256, myp5.WEBGL);
+      const renderer = myp5.createCanvas(256, 256, myp5.WEBGL);
 
       // expected center color is curFillColor.
 
@@ -1171,9 +1171,9 @@ suite('p5.RendererGL', function() {
     });
 
     test('geom without vertex colors use curFillCol (light)', function(done) {
-      const renderer = createCanvas(256, 256, myp5.WEBGL);
+      const renderer = myp5.createCanvas(256, 256, myp5.WEBGL);
 
-      directionalLight(255, 255, 255, 0, 0, -1);
+      myp5.directionalLight(255, 255, 255, 0, 0, -1);
       // diffuseFactor:0.73
       // so, expected color is (146, 0, 146, 255).
 
@@ -1187,7 +1187,7 @@ suite('p5.RendererGL', function() {
     });
 
     test('geom with vertex colors use their color (noLight)', function(done) {
-      const renderer = createCanvas(256, 256, myp5.WEBGL);
+      const renderer = myp5.createCanvas(256, 256, myp5.WEBGL);
 
       // upper color: (200, 0, 0, 255);
       // lower color: (0, 0, 200, 255);
@@ -1219,7 +1219,7 @@ suite('p5.RendererGL', function() {
     });
 
     test('geom with vertex colors use their color (light)', function(done) {
-      const renderer = createCanvas(256, 256, myp5.WEBGL);
+      const renderer = myp5.createCanvas(256, 256, myp5.WEBGL);
 
       const myGeom = new p5.Geometry(1, 1, function() {
         this.gid = 'vertexColorTestWithLighs';

--- a/test/unit/webgl/p5.RendererGL.js
+++ b/test/unit/webgl/p5.RendererGL.js
@@ -1108,7 +1108,7 @@ suite('p5.RendererGL', function() {
       done();
     });
   });
-  
+
   suite('interpolation of vertex colors', function(){
     test('immediate mode uses vertex colors (noLight)', function(done) {
       const renderer = createCanvas(256, 256, myp5.WEBGL);
@@ -1155,7 +1155,7 @@ suite('p5.RendererGL', function() {
       assert.deepEqual(myp5.get(128, 128), [73, 0, 73, 255]);
       done();
     });
-    
+
     test('geom without vertex colors use curFillCol (noLight)', function(done) {
       const renderer = createCanvas(256, 256, myp5.WEBGL);
 
@@ -1185,7 +1185,7 @@ suite('p5.RendererGL', function() {
       assert.deepEqual(myp5.get(128, 128), [146, 0, 146, 255]);
       done();
     });
-    
+
     test('geom with vertex colors use their color (noLight)', function(done) {
       const renderer = createCanvas(256, 256, myp5.WEBGL);
 
@@ -1217,7 +1217,7 @@ suite('p5.RendererGL', function() {
       assert.deepEqual(myp5.get(128, 128), [100, 0, 100, 255]);
       done();
     });
-    
+
     test('geom with vertex colors use their color (light)', function(done) {
       const renderer = createCanvas(256, 256, myp5.WEBGL);
 


### PR DESCRIPTION
<!--
  Thank you for contributing! Please use this pull request (PR) template.


 In the description field of this PR, include "resolves #XXXX" tagging the issue you are fixing. If this PR addresses the issue but doesn't completely resolve it (ie the issue should remain open after your PR is merged), write "addresses #XXXX".-->
Currently, if you try to do per-vertex coloring, for example in immediateMode, using functions like pointLight won't enable it.
By modifying the shader, we will be able to achieve both coloring for each vertex and lighting processing by the shader.
Also, even in retainedMode, if vertexColors contains a color element, it will be possible to color each vertex.

Resolves #5936

 # Changes
<!-- Add here what changes were made in this pull request and if possible provide links showcasing the changes. -->
## Source code:
```javascript
function setup() {
  createCanvas(400, 400, WEBGL);
  noStroke();
  
  pointLight(0, 255, 255, 0, 0, 30);

  beginShape();
  fill(255);
  vertex(-100,-100);
  fill(255,0,0);
  vertex(100,-100);
  fill(0,255,0);
  vertex(100,100);
  fill(0,0,255);
  vertex(-100,100);
  endShape();
}
```
## Screenshots of the change:
![compare_vc](https://user-images.githubusercontent.com/39549290/210852805-e21db79e-c7b7-4ff9-b5ec-ca707d25f46e.png)


<!-- If applicable, add screenshots depicting the changes. -->

#### PR Checklist
<!--
  To check any option, replace the "[ ]" with a "[x]". Be sure to check out how it looks in the Preview tab! Feel free to remove any portion of the template that is not relevant for your issue.
-->

- [x] WebGL
- [x] Color

[Inline documentation]: https://github.com/processing/p5.js/blob/main/contributor_docs/inline_documentation.md
[Unit tests]: https://github.com/processing/p5.js/tree/main/contributor_docs#unit-tests
