### PR TITLE
Fixed Typos in steward_guidelines.md

### DIFF
--- a/contributor_docs/steward_guidelines.md
+++ b/contributor_docs/steward_guidelines.md
@@ -76,7 +76,7 @@ For feature request issues, they should be using the "New Feature Request" issue
 For feature enhancement issues, they should be using the "Existing Feature Enhancement" issue template. The process here very similar to new feature request. The difference between new feature request and feature enhancement can be blurred however feature enhancement mainly deals with existing functions of p5.js while new feature request could be requesting entirely new functions to be added.
 
 1. Similar to new feature request, feature enhancement should only be accepted if they increases access of p5.js. Please see point 1 of [section above](#feature-request)
-2. Inclusion criterias for feature enhancement are similar to those for feature request above but particular attention should be paid to potential breaking changes.
+2. Inclusion criteria for feature enhancement are similar to those for feature request above but particular attention should be paid to potential breaking changes.
 	- If modifying existing functions, all previous valid and documented function signatures must behave in the same way.
 3. Feature enhancements must be approved by at least one steward or maintainer before work should begin towards a PR. The PR review process for feature enhancement is documented below.
 
@@ -285,6 +285,6 @@ There are many other commands available in the GitHub CLI as well that you may o
 ## Managing notifications
 Instead of manually monitoring the "Issues" or "Pull Requests" tabs of the repo for new issues or PRs, you can "watch" the repo by clicking on the "Watch" button with an eye icon on the top of the repo page opposite the repo name. By watching a repo, events such as new issues, new pull requests, mentions of your user handle, and other activities you subscribed to on the repo will be sent as notification to your [notification page](https://github.com/notifications) where they can be marked as read or dismissed much like an email inbox.
 
-In some cases you may received emails from GitHub about events in repo you are watching as well and you can customize these (including unsubcribe from them completely) from your [notifications settings page](https://github.com/settings/notifications).
+In some cases you may received emails from GitHub about events in repo you are watching as well and you can customize these (including unsubscribe from them completely) from your [notifications settings page](https://github.com/settings/notifications).
 
 Setting these up to fit the way you work can be the difference between having to find relevant issues/PRs to review manually and being overwhelmed by endless notifications from GitHub. A good balance is required here. As a starting suggestion, stewards should watch this repo for "Issues" and "Pull Requests" and set to only receive email on "Participating, @mentions and custom".


### PR DESCRIPTION
Changes:
Earlier 'criteria' was spelled incorrectly as 'criterias' Also, 'unsubscribe' was spelled incorrectly as 'unsubcribe' Now it's been resolved

<!--
  Thank you for contributing! Please use this pull request (PR) template.


 In the description field of this PR, include "resolves #XXXX" tagging the issue you are fixing. If this PR addresses the issue but doesn't completely resolve it (ie the issue should remain open after your PR is merged), write "addresses #XXXX".-->
Resolves #[Add issue number here]

 Changes:
<!-- Add here what changes were made in this pull request and if possible provide links showcasing the changes. -->


 Screenshots of the change:

Earlier:
![image](https://user-images.githubusercontent.com/57569079/211449632-2d74b8ae-c04c-4333-96dc-fa606832171c.png)

and 


![image](https://user-images.githubusercontent.com/57569079/211450025-61a4de93-563a-4e35-8174-5148ab26b43e.png)


Now:


![image](https://user-images.githubusercontent.com/57569079/211449886-c6795b94-c538-4c3c-ac98-cbe50239f459.png)


#### PR Checklist
<!--
  To check any option, replace the "[ ]" with a "[x]". Be sure to check out how it looks in the Preview tab! Feel free to remove any portion of the template that is not relevant for your issue.
-->

- [ ] `npm run lint` passes
- [ ] [Inline documentation] is included / updated
- [ ] [Unit tests] are included / updated

[Inline documentation]: https://github.com/processing/p5.js/blob/main/contributor_docs/inline_documentation.md
[Unit tests]: https://github.com/processing/p5.js/tree/main/contributor_docs#unit-tests
