### PR TITLE
 Remove camera and depth test effects from image function in webgl

### DIFF
--- a/src/webgl/3d_primitives.js
+++ b/src/webgl/3d_primitives.js
@@ -2018,12 +2018,18 @@ p5.RendererGL.prototype.image = function(
     v1 = (sy + sHeight) / img.height;
   }
 
+  const gl = this.GL;
+  gl.disable(gl.DEPTH_TEST);
+  this._curCamera._setDefaultCamera();
+
   this.beginShape();
   this.vertex(dx, dy, 0, u0, v0);
   this.vertex(dx + dWidth, dy, 0, u1, v0);
   this.vertex(dx + dWidth, dy + dHeight, 0, u1, v1);
   this.vertex(dx, dy + dHeight, 0, u0, v1);
   this.endShape(constants.CLOSE);
+
+  gl.enable(gl.DEPTH_TEST);
 
   this._pInst.pop();
 

--- a/src/webgl/3d_primitives.js
+++ b/src/webgl/3d_primitives.js
@@ -2019,7 +2019,11 @@ p5.RendererGL.prototype.image = function(
   }
 
   const gl = this.GL;
+  const depthTestIsEnable = gl.getParameter(gl.DEPTH_TEST);
+  const cullFaceIsEnable = gl.getParameter(gl.CULL_FACE);
   gl.disable(gl.DEPTH_TEST);
+  gl.disable(gl.CULL_FACE);
+
   this._curCamera._setDefaultCamera();
 
   this.beginShape();
@@ -2029,7 +2033,8 @@ p5.RendererGL.prototype.image = function(
   this.vertex(dx, dy + dHeight, 0, u0, v1);
   this.endShape(constants.CLOSE);
 
-  gl.enable(gl.DEPTH_TEST);
+  if (depthTestIsEnable) { gl.enable(gl.DEPTH_TEST); }
+  if (cullFaceIsEnable) { gl.enable(gl.CULL_FACE); }
 
   this._pInst.pop();
 

--- a/src/webgl/p5.Camera.js
+++ b/src/webgl/p5.Camera.js
@@ -1640,6 +1640,7 @@ p5.Camera.prototype.copy = function() {
   _cam.cameraMatrix = this.cameraMatrix.copy();
   _cam.projMatrix = this.projMatrix.copy();
 
+  _cam._computeCameraDefaultSettings();
   return _cam;
 };
 


### PR DESCRIPTION
Currently, the image function in WebGL is affected by the camera, so it is difficult to use the graphic used as an argument as a background, for example, in setup() to manipulate the camera.
Even if it's not, it also writes to depth, so even if you try to use it as a background, the object will wrap around the back of the image, so you have to remove the effect of depth as well.
In some sketches, in order to use image() for this purpose, processing such as accessing the drawingContext and cutting the depth is done, but it is still inconvenient.
So I thought it would be better to remove the effects of the camera and depth from the image function, and use the same specification method and the same appearance as 2D, except for the specification method of the 2nd and 3rd arguments.
<!--
  Thank you for contributing! Please use this pull request (PR) template.


 In the description field of this PR, include "resolves #XXXX" tagging the issue you are fixing. If this PR addresses the issue but doesn't completely resolve it (ie the issue should remain open after your PR is merged), write "addresses #XXXX".-->
Resolves #5947
# Changes:
<!-- Add here what changes were made in this pull request and if possible provide links showcasing the changes. -->
When drawing a rectangle in the image function, temporarily turn off the depth and set the camera to the default state.
However, the camera's copy function does not add default information, so rewrite it so that it is added.

# Screenshots of the change:
```javascript
function setup() {
  createCanvas(600, 400, WEBGL);
  const gr = createGraphics(600, 400, WEBGL);
  gr.background(128);
  noStroke();
  camera(400,400,400,0,0,0,0,0,-1);

  clear();
  image(gr, -300, -200, 600, 400, 0, 0, 600, 400);

  directionalLight(255, 255, 255, 0, 0, -1);
  ambientLight(64);
  ambientMaterial(255);

  fill(255,200,200);
  plane(800, 600);
  translate(0, 0, 100);
  fill(0,128,255);
  sphere(80);
}
```
## left: current, right: expected.
![hjfehuhgfbbrejukh](https://user-images.githubusercontent.com/39549290/211892767-de8d2914-513d-4246-9577-ace01cf7f03c.png)

<!-- If applicable, add screenshots depicting the changes. -->

#### PR Checklist
<!--
  To check any option, replace the "[ ]" with a "[x]". Be sure to check out how it looks in the Preview tab! Feel free to remove any portion of the template that is not relevant for your issue.
-->
- [ ] `npm run lint` passes
- [ ] [Inline documentation] is included / updated
- [ ] [Unit tests] are included / updated

[Inline documentation]: https://github.com/processing/p5.js/blob/main/contributor_docs/inline_documentation.md
[Unit tests]: https://github.com/processing/p5.js/tree/main/contributor_docs#unit-tests
