### PR TITLE
fix : setPosition and move method modified in p5.Camera.js

### DIFF
--- a/src/webgl/p5.Camera.js
+++ b/src/webgl/p5.Camera.js
@@ -1493,9 +1493,9 @@ p5.Camera.prototype.move = function(x, y, z) {
     this.centerX + dx[0] + dy[0] + dz[0],
     this.centerY + dx[1] + dy[1] + dz[1],
     this.centerZ + dx[2] + dy[2] + dz[2],
-    0,
-    1,
-    0
+    this.upX,
+    this.upY,
+    this.upZ
   );
 };
 
@@ -1555,9 +1555,9 @@ p5.Camera.prototype.setPosition = function(x, y, z) {
     this.centerX + diffX,
     this.centerY + diffY,
     this.centerZ + diffZ,
-    0,
-    1,
-    0
+    this.upX,
+    this.upY,
+    this.upZ
   );
 };
 


### PR DESCRIPTION

Resolves #5943 

 Changes
  setPosition and move method  modified in p5.Camera.js , as these methods were not maintaining the camera orientation before

<!-- Add here what changes were made in this pull request and if possible provide links showcasing the changes. -->




#### PR Checklist
<!--
  To check any option, replace the "[ ]" with a "[x]". Be sure to check out how it looks in the Preview tab! Feel free to remove any portion of the template that is not relevant for your issue.
-->

- [X] `npm run lint` passes
- [ ] [Inline documentation] is included / updated
- [ ] [Unit tests] are included / updated

[Inline documentation]: https://github.com/processing/p5.js/blob/main/contributor_docs/inline_documentation.md
[Unit tests]: https://github.com/processing/p5.js/tree/main/contributor_docs#unit-tests
