### PR TITLE
nf() not rounding correctly fixed

### DIFF
--- a/src/utilities/string_functions.js
+++ b/src/utilities/string_functions.js
@@ -213,7 +213,7 @@ function doNf(num, left, right) {
       decimal = '.';
     }
     if (decPart.length > right) {
-      decPart = decPart.substring(0, right);
+      decPart = roundOffDecPart(decPart, right);
     }
     for (let i = 0; i < left - intPart.length; i++) {
       str += '0';
@@ -231,6 +231,22 @@ function doNf(num, left, right) {
     }
     str += n;
     return str;
+  }
+
+  function roundOffDecPart(decPart, right) {
+    if (decPart[right] >= 5) {
+      let i = right - 1;
+      while (i >= 0) {
+        if (decPart[i] === '9') {
+          decPart = decPart.substring(0, i) + '0' + decPart.substring(i + 1);
+          i--;
+        } else {
+          decPart = decPart.substring(0, i) + (parseInt(decPart[i], 10) + 1).toString();
+          break;
+        }
+      }
+    }
+    return decPart.substring(0, right);
   }
 }
 

--- a/src/utilities/string_functions.js
+++ b/src/utilities/string_functions.js
@@ -233,6 +233,25 @@ function doNf(num, left, right) {
     return str;
   }
 
+  /**
+  * Utility function for rounding off decimal part of a number.
+  * To be used by doNf() function.
+  * Does not returns the trucated value, but returns the decimal part
+  * with appropriate last digit of the left after truncation.
+  *
+  * @example
+  * input:
+  *    console.log(nf(Math.PI,1,4))
+  * output:
+  *    3.141692653589793
+  *    3.1416 after truncation
+  *    decPart = 141592.. is changed to 141692..
+  *
+  *@method nf
+  * @param {Array}        nums     the Numbers to format
+  * @param {Integer|String}      [right]  the decimal part of the number
+  * @return {String[]}                formatted Strings
+  */
   function roundOffDecPart(decPart, right) {
     if (decPart[right] >= 5) {
       let i = right - 1;


### PR DESCRIPTION
<!--
  Thank you for contributing! Please use this pull request (PR) template.


 In the description field of this PR, include "resolves #XXXX" tagging the issue you are fixing. If this PR addresses the issue but doesn't completely resolve it (ie the issue should remain open after your PR is merged), write "addresses #XXXX".-->
Resolves #5959 

File Changed = `src/utilities/string_functions.js`

Problem:
- nf() call doNf() when it detects a number
- previously the doNf() was just truncating the number i.e. not rounding off

 Changes:
- inside doNf() , i added another utility function which rounds off the decimal part of the number correctly
- the added function named `roundOffDecPart` modifies the `decPart` but does not truncate it.
- the modified `decPart` is return to the `doNf()` which then truncates the `decPart` according to the `right` value.

 Outcomes of the change:
As mentioned in the issue decription, the improper rounding of the digits of Math.PI is fixed successfully.
Successfully tested it many times at all sorts of possible inputs

#### PR Checklist
<!--
  To check any option, replace the "[ ]" with a "[x]". Be sure to check out how it looks in the Preview tab! Feel free to remove any portion of the template that is not relevant for your issue.
-->

- [x] `npm run lint` passes
- [x] [Inline documentation] is included / updated
- [ ] [Unit tests] are included / updated

[Inline documentation]: https://github.com/processing/p5.js/blob/main/contributor_docs/inline_documentation.md
[Unit tests]: https://github.com/processing/p5.js/tree/main/contributor_docs#unit-tests
