### PR TITLE
Disable unused registers to avoid environment-dependent vanishing bugs

### DIFF
--- a/src/webgl/p5.RenderBuffer.js
+++ b/src/webgl/p5.RenderBuffer.js
@@ -58,6 +58,14 @@ p5.RenderBuffer.prototype._prepareBuffer = function(geometry, shader) {
     }
     // enable the attribute
     shader.enableAttrib(attr, this.size);
+  } else {
+    const loc = attr.location;
+    if (loc == -1 || !this._renderer.registerEnabled[loc]) { return; }
+    // Disable register corresponding to unused attribute
+    gl.disableVertexAttribArray(loc);
+    attr.enabled = false;
+    // Record register availability
+    this._renderer.registerEnabled[loc] = false;
   }
 };
 

--- a/src/webgl/p5.RenderBuffer.js
+++ b/src/webgl/p5.RenderBuffer.js
@@ -60,7 +60,7 @@ p5.RenderBuffer.prototype._prepareBuffer = function(geometry, shader) {
     shader.enableAttrib(attr, this.size);
   } else {
     const loc = attr.location;
-    if (loc == -1 || !this._renderer.registerEnabled[loc]) { return; }
+    if (loc === -1 || !this._renderer.registerEnabled[loc]) { return; }
     // Disable register corresponding to unused attribute
     gl.disableVertexAttribArray(loc);
     attr.enabled = false;

--- a/src/webgl/p5.RenderBuffer.js
+++ b/src/webgl/p5.RenderBuffer.js
@@ -63,7 +63,6 @@ p5.RenderBuffer.prototype._prepareBuffer = function(geometry, shader) {
     if (loc === -1 || !this._renderer.registerEnabled[loc]) { return; }
     // Disable register corresponding to unused attribute
     gl.disableVertexAttribArray(loc);
-    attr.enabled = false;
     // Record register availability
     this._renderer.registerEnabled[loc] = false;
   }

--- a/src/webgl/p5.RendererGL.js
+++ b/src/webgl/p5.RendererGL.js
@@ -112,6 +112,8 @@ p5.RendererGL = function(elt, pInst, isMainCanvas, attr) {
 
   this._useLineColor = false;
   this._useVertexColor = false;
+  
+  this.registerEnabled = [];
 
   this._tint = [255, 255, 255, 255];
 

--- a/src/webgl/p5.RendererGL.js
+++ b/src/webgl/p5.RendererGL.js
@@ -112,7 +112,7 @@ p5.RendererGL = function(elt, pInst, isMainCanvas, attr) {
 
   this._useLineColor = false;
   this._useVertexColor = false;
-  
+
   this.registerEnabled = [];
 
   this._tint = [255, 255, 255, 255];

--- a/src/webgl/p5.Shader.js
+++ b/src/webgl/p5.Shader.js
@@ -561,16 +561,13 @@ p5.Shader.prototype.enableAttrib = function(
       );
     }
     const loc = attr.location;
-    // Get register availability
-    const registerIsEnabled = this._renderer.registerEnabled[loc];
     if (loc !== -1) {
       const gl = this._renderer.GL;
       // Enable register even if it is disabled
-      if (!attr.enabled || !registerIsEnabled) {
+      if (!this._renderer.registerEnabled[loc]) {
         gl.enableVertexAttribArray(loc);
         // Record register availability
         this._renderer.registerEnabled[loc] = true;
-        attr.enabled = true;
       }
       this._renderer.GL.vertexAttribPointer(
         loc,

--- a/src/webgl/p5.Shader.js
+++ b/src/webgl/p5.Shader.js
@@ -565,6 +565,8 @@ p5.Shader.prototype.enableAttrib = function(
       const gl = this._renderer.GL;
       if (!attr.enabled) {
         gl.enableVertexAttribArray(loc);
+        // Record register availability
+        this._renderer.registerEnabled[loc] = true;
         attr.enabled = true;
       }
       this._renderer.GL.vertexAttribPointer(

--- a/src/webgl/p5.Shader.js
+++ b/src/webgl/p5.Shader.js
@@ -561,9 +561,12 @@ p5.Shader.prototype.enableAttrib = function(
       );
     }
     const loc = attr.location;
+    // Get register availability
+    const registerIsEnabled = this._renderer.registerEnabled[loc];
     if (loc !== -1) {
       const gl = this._renderer.GL;
-      if (!attr.enabled) {
+      // Enable register even if it is disabled
+      if (!attr.enabled || !registerIsEnabled) {
         gl.enableVertexAttribArray(loc);
         // Record register availability
         this._renderer.registerEnabled[loc] = true;

--- a/test/unit/webgl/p5.RendererGL.js
+++ b/test/unit/webgl/p5.RendererGL.js
@@ -1399,10 +1399,10 @@ suite('p5.RendererGL', function() {
       // geometry without aTexCoord.
       const myGeom = new p5.Geometry(1, 1, function() {
         this.gid = 'registerEnabledTest';
-        this.vertices.push(createVector(-8, -8));
-        this.vertices.push(createVector(8, -8));
-        this.vertices.push(createVector(8, 8));
-        this.vertices.push(createVector(-8, 8));
+        this.vertices.push(myp5.createVector(-8, -8));
+        this.vertices.push(myp5.createVector(8, -8));
+        this.vertices.push(myp5.createVector(8, 8));
+        this.vertices.push(myp5.createVector(-8, 8));
         this.faces.push([0, 1, 2]);
         this.faces.push([0, 2, 3]);
         this.computeNormals();

--- a/test/unit/webgl/p5.RendererGL.js
+++ b/test/unit/webgl/p5.RendererGL.js
@@ -1392,6 +1392,44 @@ suite('p5.RendererGL', function() {
     });
   });
 
+  suite('Test for register availability', function() {
+    test('register enable/disable flag test', function(done) {
+      const renderer = myp5.createCanvas(16, 16, myp5.WEBGL);
+
+      // geometry without aTexCoord.
+      const myGeom = new p5.Geometry(1, 1, function() {
+        this.gid = 'registerEnabledTest';
+        this.vertices.push(createVector(-8, -8));
+        this.vertices.push(createVector(8, -8));
+        this.vertices.push(createVector(8, 8));
+        this.vertices.push(createVector(-8, 8));
+        this.faces.push([0, 1, 2]);
+        this.faces.push([0, 2, 3]);
+        this.computeNormals();
+      });
+
+      myp5.fill(255);
+      myp5.directionalLight(255, 255, 255, 0, 0, -1);
+
+      myp5.triangle(-8, -8, 8, -8, 8, 8);
+
+      // get register location of
+      // lightingShader's aTexCoord attribute.
+      const attributes = renderer._curShader.attributes;
+      const loc = attributes.aTexCoord.location;
+
+      assert.equal(renderer.registerEnabled[loc], true);
+
+      myp5.model(myGeom);
+      assert.equal(renderer.registerEnabled[loc], false);
+
+      myp5.triangle(-8, -8, 8, 8, -8, 8);
+      assert.equal(renderer.registerEnabled[loc], true);
+
+      done();
+    });
+  });
+
   suite('setAttributes', function() {
     test('It leaves a reference to the correct canvas', function(done) {
       const renderer = myp5.createCanvas(10, 10, myp5.WEBGL);


### PR DESCRIPTION
Resolves #5968
<!--
  Thank you for contributing! Please use this pull request (PR) template.


 In the description field of this PR, include "resolves #XXXX" tagging the issue you are fixing. If this PR addresses the issue but doesn't completely resolve it (ie the issue should remain open after your PR is merged), write "addresses #XXXX".-->
In some environments, such as my favorite Android phone, rendering in webgl of p5.js may not be rendered correctly.
For example, see the sketch below.
[minimum_bug_demo](https://editor.p5js.org/dark_fox/sketches/dJFfDh8cb)
```javascript
function setup() {
  createCanvas(400, 400, WEBGL);
  const geom = new p5.Geometry();
  geom.vertices.push(
    createVector(-100,-100), createVector(100,-100),
    createVector(100,100), createVector(-100,100)
  );
  geom.faces.push([0,1,2],[0,2,3]);
  geom.computeNormals();
  this._renderer.createBuffers("myPlane", geom);
  
  const gr = createGraphics(100,100);
  gr.background(255);

  background(0);
  texture(gr);
  triangle(-200,-200,0,-200,0,0);

  directionalLight(255,255,255,0,0,-1);
  ambientLight(64);
  ambientMaterial(255);
  fill(0,0,255);
  this._renderer.drawBuffers("myPlane");
}
```
My Android doesn't show the blue square in the middle.
On the other hand, my laptop at home displays squares.
![bugbug2](https://user-images.githubusercontent.com/39549290/214004882-c7fbe1eb-eeef-4560-95df-6d75f0203ac2.png)


Problems like this occur when some shader attributes are unused and the corresponding registers are not closed, causing the data in them to be corrupted. Therefore, I would like to propose a specification change to close unused registers each time so that such a thing does not occur.
It also records information about whether a register is closed or not, so that unnecessary closing instructions are not executed.
 Changes:
<!-- Add here what changes were made in this pull request and if possible provide links showcasing the changes. -->

1. Have the renderer have an array that keeps track of whether a register is open or not.
2. Tells the renderer to store true in that number when opening the register in the enableAttrib function.
3. In the _prepareBuffer function, close the registers reserved by the shader for attributes that the geometry doesn't have that the shader might use. Notify it to shaders and renderers.
4. Notifying the shader is to open the register when it's likely to be used again, and notifying the renderer is to avoid closing the same register over and over again when repeating the same instruction

<!-- If applicable, add screenshots depicting the changes. -->

#### PR Checklist
<!--
  To check any option, replace the "[ ]" with a "[x]". Be sure to check out how it looks in the Preview tab! Feel free to remove any portion of the template that is not relevant for your issue.
-->

- [x] `npm run lint` passes
- [ ] [Inline documentation] is included / updated
- [ ] [Unit tests] are included / updated

[Inline documentation]: https://github.com/processing/p5.js/blob/main/contributor_docs/inline_documentation.md
[Unit tests]: https://github.com/processing/p5.js/tree/main/contributor_docs#unit-tests
