### PR TITLE
Fixed line drawing in WebGL when there is a previously defined texture

### DIFF
--- a/src/webgl/3d_primitives.js
+++ b/src/webgl/3d_primitives.js
@@ -1994,8 +1994,8 @@ p5.RendererGL.prototype.image = function(
   this._pInst.push();
 
   this._pInst.noLights();
+  this._pInst.noStroke();
 
-  noStroke();
   this._pInst.texture(img);
   this._pInst.textureMode(constants.NORMAL);
 

--- a/src/webgl/3d_primitives.js
+++ b/src/webgl/3d_primitives.js
@@ -1995,6 +1995,7 @@ p5.RendererGL.prototype.image = function(
 
   this._pInst.noLights();
 
+  noStroke();
   this._pInst.texture(img);
   this._pInst.textureMode(constants.NORMAL);
 

--- a/src/webgl/p5.RendererGL.Immediate.js
+++ b/src/webgl/p5.RendererGL.Immediate.js
@@ -226,7 +226,7 @@ p5.RendererGL.prototype.endShape = function(
 p5.RendererGL.prototype._processVertices = function(mode) {
   if (this.immediateMode.geometry.vertices.length === 0) return;
 
-  const calculateStroke = this._doStroke && this.drawMode !== constants.TEXTURE;
+  const calculateStroke = this._doStroke;
   const shouldClose = mode === constants.CLOSE;
   if (calculateStroke) {
     this.immediateMode.geometry.edges = this._calculateEdges(


### PR DESCRIPTION
<!--
  Thank you for contributing! Please use this pull request (PR) template.


 In the description field of this PR, include "resolves #XXXX" tagging the issue you are fixing. If this PR addresses the issue but doesn't completely resolve it (ie the issue should remain open after your PR is merged), write "addresses #XXXX".-->
Resolves #5440 

 Changes:
Removed `&& this.drawMode !== constants.TEXTURE` from `calculateStroke`.

 Screenshots of the change:

Using the example from #5440,

- Before:

![Screenshot 2023-01-28 at 18-21-06 p5 js example](https://user-images.githubusercontent.com/90888680/215262476-8f5cc79e-d3fe-4544-a289-11d06c50e0c3.png)

- After:

![Screenshot 2023-01-28 at 18-02-46 p5 js example](https://user-images.githubusercontent.com/90888680/215262473-46846f7b-bcdb-4c7b-aedb-177976ea4833.png)

#### PR Checklist
<!--
  To check any option, replace the "[ ]" with a "[x]". Be sure to check out how it looks in the Preview tab! Feel free to remove any portion of the template that is not relevant for your issue.
-->

- [x] `npm run lint` passes
- [ ] [Inline documentation] is included / updated
- [ ] [Unit tests] are included / updated

[Inline documentation]: https://github.com/processing/p5.js/blob/main/contributor_docs/inline_documentation.md
[Unit tests]: https://github.com/processing/p5.js/tree/main/contributor_docs#unit-tests
