### PR TITLE
Resolves Issue #5511 : GIF's don't update when using setUniform

### DIFF
--- a/src/webgl/p5.Shader.js
+++ b/src/webgl/p5.Shader.js
@@ -476,7 +476,7 @@ p5.Shader.prototype.setUniform = function(uniformName, data) {
       break;
     case gl.SAMPLER_2D:
       gl.activeTexture(gl.TEXTURE0 + uniform.samplerIndex);
-      uniform.texture = data instanceof _main.default.Texture ?
+      uniform.texture = data instanceof p5.Texture  ?
         data : this._renderer.getTexture(data);
       gl.uniform1i(location, uniform.samplerIndex);
       if (uniform.texture.src.gifProperties){

--- a/src/webgl/p5.Shader.js
+++ b/src/webgl/p5.Shader.js
@@ -476,9 +476,12 @@ p5.Shader.prototype.setUniform = function(uniformName, data) {
       break;
     case gl.SAMPLER_2D:
       gl.activeTexture(gl.TEXTURE0 + uniform.samplerIndex);
-      uniform.texture =
-        data instanceof p5.Texture ? data : this._renderer.getTexture(data);
+      uniform.texture = data instanceof _main.default.Texture ?
+        data : this._renderer.getTexture(data);
       gl.uniform1i(location, uniform.samplerIndex);
+      if (uniform.texture.src.gifProperties){
+        uniform.texture.src._animateGif(this._renderer._pInst);
+      }
       break;
     //@todo complete all types
   }

--- a/src/webgl/p5.Shader.js
+++ b/src/webgl/p5.Shader.js
@@ -476,10 +476,10 @@ p5.Shader.prototype.setUniform = function(uniformName, data) {
       break;
     case gl.SAMPLER_2D:
       gl.activeTexture(gl.TEXTURE0 + uniform.samplerIndex);
-      uniform.texture = data instanceof p5.Texture  ?
+      uniform.texture = data instanceof p5.Texture ?
         data : this._renderer.getTexture(data);
       gl.uniform1i(location, uniform.samplerIndex);
-      if (uniform.texture.src.gifProperties){
+      if (uniform.texture.src.gifProperties) {
         uniform.texture.src._animateGif(this._renderer._pInst);
       }
       break;


### PR DESCRIPTION
<!--
  Thank you for contributing! Please use this pull request (PR) template.


 In the description field of this PR, include "resolves #XXXX" tagging the issue you are fixing. If this PR addresses the issue but doesn't completely resolve it (ie the issue should remain open after your PR is merged), write "addresses #XXXX".-->
Resolves #5511

 #### Changes:
Earlier Gif's were not updating their frames inside `setUniform()` function and there was a need to make an `image()` call with argument as a Gif, to make the texture start updating. 
So I figured out that the function `_animateGif()` wasn't getting called, which is supposed to update  Gif frames. For that I added an if else checking if the input object has `gifProperties` and if it's true, then the `animateGif` gets called.


#### PR Checklist
<!--
  To check any option, replace the "[ ]" with a "[x]". Be sure to check out how it looks in the Preview tab! Feel free to remove any portion of the template that is not relevant for your issue.
-->

- [x] `npm run build` passes
- [x] `npm test` passes

