### PR TITLE
Fix textureWrap REPEAT for WebGL Power Of Two Image Element

### DIFF
--- a/src/webgl/p5.Texture.js
+++ b/src/webgl/p5.Texture.js
@@ -334,9 +334,21 @@ p5.Texture.prototype.setWrapMode = function(wrapX, wrapY) {
   // if it isn't we will set the wrap mode to CLAMP
   // webgl2 will support npot REPEAT and MIRROR but we don't check for it yet
   const isPowerOfTwo = x => (x & (x - 1)) === 0;
+  const textureData = this._getTextureDataFromSource();
 
-  const widthPowerOfTwo = isPowerOfTwo(this.width);
-  const heightPowerOfTwo = isPowerOfTwo(this.height);
+  let wrapWidth;
+  let wrapHeight;
+
+  if (textureData.naturalWidth && textureData.naturalHeight) {
+    wrapWidth = textureData.naturalWidth;
+    wrapHeight = textureData.naturalHeight;
+  } else {
+    wrapWidth = this.width;
+    wrapHeight = this.height;
+  }
+
+  const widthPowerOfTwo = isPowerOfTwo(wrapWidth);
+  const heightPowerOfTwo = isPowerOfTwo(wrapHeight);
 
   if (wrapX === constants.REPEAT) {
     if (widthPowerOfTwo && heightPowerOfTwo) {

--- a/test/unit/webgl/p5.Texture.js
+++ b/test/unit/webgl/p5.Texture.js
@@ -2,6 +2,9 @@ suite('p5.Texture', function() {
   var myp5;
   var texImg1;
   var texImg2;
+  var texImg3;
+  var imgElementNotPowerOfTwo;
+  var imgElementPowerOfTwo;
   var canvas;
 
   if (!window.Modernizr.webgl) {
@@ -12,8 +15,10 @@ suite('p5.Texture', function() {
   setup(function(done) {
     myp5 = new p5(function(p) {
       p.preload = function() {
+        // texImg2 must have powerOfTwo dimensions
         texImg2 = p.loadImage('unit/assets/target.gif');
-
+        // texImg3 must NOT have powerOfTwo dimensions
+        texImg3 = p.loadImage('unit/assets/nyan_cat.gif');
         // texture object isn't created until it's used for something:
         //p.box(70, 70, 70);
       };
@@ -21,6 +26,16 @@ suite('p5.Texture', function() {
         canvas = p.createCanvas(100, 100, p.WEBGL);
         texImg1 = p.createGraphics(2, 2, p.WEBGL);
         p.texture(texImg1);
+        p.createImg(texImg2.canvas.toDataURL(), '', 'anonymous', el => {
+          el.size(50, 50);
+          imgElementPowerOfTwo = el;
+          p.texture(imgElementPowerOfTwo);
+        });
+        p.createImg(texImg3.canvas.toDataURL(), '', 'anonymous', el => {
+          el.size(50, 50);
+          imgElementNotPowerOfTwo = el;
+          p.texture(imgElementNotPowerOfTwo);
+        });
         done();
       };
     });
@@ -86,6 +101,18 @@ suite('p5.Texture', function() {
       tex.setWrapMode(myp5.MIRROR, myp5.MIRROR);
       assert.deepEqual(tex.glWrapS, myp5._renderer.GL.MIRRORED_REPEAT);
       assert.deepEqual(tex.glWrapT, myp5._renderer.GL.MIRRORED_REPEAT);
+    });
+    test('Set wrap mode REPEAT if src dimensions is powerOfTwo', function() {
+      const tex = myp5._renderer.getTexture(imgElementPowerOfTwo);
+      tex.setWrapMode(myp5.REPEAT, myp5.REPEAT);
+      assert.deepEqual(tex.glWrapS, myp5._renderer.GL.REPEAT);
+      assert.deepEqual(tex.glWrapT, myp5._renderer.GL.REPEAT);
+    });
+    test('Set default wrap mode CLAMP if src dimensions != powerOfTwo', function() {
+      const tex = myp5._renderer.getTexture(imgElementNotPowerOfTwo);
+      tex.setWrapMode(myp5.REPEAT, myp5.REPEAT);
+      assert.deepEqual(tex.glWrapS, myp5._renderer.GL.CLAMP_TO_EDGE);
+      assert.deepEqual(tex.glWrapT, myp5._renderer.GL.CLAMP_TO_EDGE);
     });
     test('Set textureMode to NORMAL', function() {
       myp5.textureMode(myp5.NORMAL);

--- a/test/unit/webgl/p5.Texture.js
+++ b/test/unit/webgl/p5.Texture.js
@@ -25,18 +25,24 @@ suite('p5.Texture', function() {
       p.setup = function() {
         canvas = p.createCanvas(100, 100, p.WEBGL);
         texImg1 = p.createGraphics(2, 2, p.WEBGL);
-        p.texture(texImg1);
-        p.createImg(texImg2.canvas.toDataURL(), '', 'anonymous', el => {
-          el.size(50, 50);
-          imgElementPowerOfTwo = el;
-          p.texture(imgElementPowerOfTwo);
+        new Promise(resolve => {
+          p.createImg(texImg2.canvas.toDataURL(), '', 'anonymous', el => {
+            el.size(50, 50);
+            imgElementPowerOfTwo = el;
+            p.texture(imgElementPowerOfTwo);
+            resolve();
+          });
+        }).then(() => new Promise(resolve => {
+          p.createImg(texImg3.canvas.toDataURL(), '', 'anonymous', el => {
+            el.size(50, 50);
+            imgElementNotPowerOfTwo = el;
+            p.texture(imgElementNotPowerOfTwo);
+            resolve();
+          });
+        })).then(() => {
+          p.texture(texImg1);
+          done();
         });
-        p.createImg(texImg3.canvas.toDataURL(), '', 'anonymous', el => {
-          el.size(50, 50);
-          imgElementNotPowerOfTwo = el;
-          p.texture(imgElementNotPowerOfTwo);
-        });
-        done();
       };
     });
   });


### PR DESCRIPTION
Resolves #5668
Previously `setWrapMode` checked `isPowerOfTwo` on element dimensions and not on src image dimensions. This caused `textureWrap(REPEAT)` to set to CLAMP if `this` was an HTML element with non-power-of-two element dimensions, but this outcome was designed for non-power-of-two src image dimensions. 

 Changes:

- I changed `p5.Texture.prototype.setWrapMode` to add `wrapWidth` and `wrapHeight` to differentiate between HTML element src image dimensions vs. the element dimensions.
- Added unit tests for textureWrap REPEAT on textures from image elements for power-of-two and non-power-of-two.
- The power-of-two case should allow REPEAT and the non-power-of-two case should set to CLAMP.


#### PR Checklist

- [x] `npm run lint` passes
- [x] [Inline documentation] is included / updated
inline documentation already existed but the code did not perform as described
- [x] [Unit tests] are included / updated

