### PR TITLE
Omit processing to the 4th argument in p5.js webgl stroke()

### DIFF
--- a/src/webgl/p5.RendererGL.js
+++ b/src/webgl/p5.RendererGL.js
@@ -703,9 +703,6 @@ p5.RendererGL.prototype.fill = function(v1, v2, v3, a) {
  * black canvas with purple cube with pink outline spinning
  */
 p5.RendererGL.prototype.stroke = function(r, g, b, a) {
-  if(arguments[3] === undefined){
-    arguments[3] = 255;
-  }
   const color = p5.prototype.color.apply(this._pInst, arguments);
   this.curStrokeColor = color._array;
 };


### PR DESCRIPTION
Omit the process of setting the fourth argument to 255 in stroke(). Because it doesn't make sense.

<!--
  Thank you for contributing! Please use this pull request (PR) template.


 In the description field of this PR, include "resolves #XXXX" tagging the issue you are fixing. If this PR addresses the issue but doesn't completely resolve it (ie the issue should remain open after your PR is merged), write "addresses #XXXX".-->
Resolves #5988

 Changes:
<!-- Add here what changes were made in this pull request and if possible provide links showcasing the changes. -->
Even without setting the 4th argument to 255, for example, if there are 3 arguments, the 4th argument will automatically become the maximum transparency, so I thought this process was unnecessary.

#### PR Checklist
<!--
  To check any option, replace the "[ ]" with a "[x]". Be sure to check out how it looks in the Preview tab! Feel free to remove any portion of the template that is not relevant for your issue.
-->

- [ ] `npm run lint` passes
- [ ] [Inline documentation] is included / updated
- [ ] [Unit tests] are included / updated

[Inline documentation]: https://github.com/processing/p5.js/blob/main/contributor_docs/inline_documentation.md
[Unit tests]: https://github.com/processing/p5.js/tree/main/contributor_docs#unit-tests
