### PR TITLE
Don't run draw right after setup if saving a gif

### DIFF
--- a/src/core/main.js
+++ b/src/core/main.js
@@ -204,6 +204,7 @@ class p5 {
       blur: null
     };
     this._millisStart = -1;
+    this._recording = false;
 
     // States used in the custom random generators
     this._lcg_random_state = null;
@@ -272,7 +273,9 @@ class p5 {
         this._runIfPreloadsAreDone();
       } else {
         this._setup();
-        this._draw();
+        if (!this._recording) {
+          this._draw();
+        }
       }
     };
 
@@ -287,7 +290,9 @@ class p5 {
           this._lastTargetFrameTime = window.performance.now();
           this._lastRealFrameTime = window.performance.now();
           context._setup();
-          context._draw();
+          if (!this._recording) {
+            context._draw();
+          }
         }
       }
     };

--- a/src/image/loading_displaying.js
+++ b/src/image/loading_displaying.js
@@ -180,8 +180,7 @@ p5.prototype.loadImage = function(path, successCallback, failureCallback) {
  * will be created. If 'frames', the arguments now correspond to the number of frames you want your
  * animation to be, if you are very sure of this number.
  *
- * It is not recommended to write this function inside setup, since it won't work properly.
- * The recommended use can be seen in the example, where we use it inside an event function,
+ * This may be called in setup, or, like in the example below, inside an event function,
  * like keyPressed or mousePressed.
  *
  * @method saveGif
@@ -255,7 +254,7 @@ p5.prototype.saveGif = async function(
     throw TypeError('Units parameter must be either "frames" or "seconds"');
   }
 
-  //   console.log(options);
+  this._recording = true;
 
   // get the project's framerate
   let _frameRate = this._targetFrameRate;
@@ -460,6 +459,7 @@ p5.prototype.saveGif = async function(
   });
 
   frames = [];
+  this._recording = false;
   this.loop();
 
   p.html('Done. Downloading your gif!🌸');


### PR DESCRIPTION
Resolves https://github.com/processing/p5.js/issues/5999

### Changes:
- Logs whether p5 is currently recording a gif so that we can skip calling an initial `draw` after `setup` if recording a gif, which will call that for us

### Screenshots of the change:
Using the example code from the docs, but exporting in `setup`:

```js
function setup() {
  createCanvas(100, 100);
  saveGif('mySketch', 5);
}

function draw() {
  colorMode(RGB);
  background(30);

  // create a bunch of circles that move in... circles!
  for (let i = 0; i < 10; i++) {
    let opacity = map(i, 0, 10, 0, 255);
    noStroke();
    fill(230, 250, 90, opacity);
    circle(
      30 * sin(frameCount / (30 - i)) + width / 2,
      30 * cos(frameCount / (30 - i)) + height / 2,
      10
    );
  }
}
```

Before:
![mySketch(4)](https://user-images.githubusercontent.com/5315059/216778721-aff87e2b-a8e3-4c8c-ae9f-5a13f95f5653.gif)

After:
![mySketch(5)](https://user-images.githubusercontent.com/5315059/216778726-439a1d7e-7d22-4c02-ae08-bf41f286e30c.gif)

Live: https://editor.p5js.org/davepagurek/sketches/ksZs-HqGt

#### PR Checklist
<!--
  To check any option, replace the "[ ]" with a "[x]". Be sure to check out how it looks in the Preview tab! Feel free to remove any portion of the template that is not relevant for your issue.
-->

- [x] `npm run lint` passes
- [x] [Inline documentation] is included / updated
- [ ] [Unit tests] are included / updated

