### PR TITLE
 Resolves Issue#5958 3D orbitControl allowing +-90 degrees not enough.

### DIFF
--- a/src/webgl/p5.Camera.js
+++ b/src/webgl/p5.Camera.js
@@ -1720,12 +1720,14 @@ p5.Camera.prototype._orbit = function(dTheta, dPhi, dRadius) {
   let camTheta = Math.atan2(diffX, diffZ); // equatorial angle
   let camPhi = Math.acos(Math.max(-1, Math.min(1, diffY / camRadius))); // polar angle
 
-  // add change according to the direction of this.upY
-  let directionflag = this.upY > 0 ? 1 : -1;
-  camTheta += directionflag*dTheta;
-  camPhi += directionflag*dPhi;
-  if (camPhi <= 0 || camPhi>=Math.PI) {
-    directionflag *= -1;
+  let newUpY = this.upY > 0 ? 1 : -1;
+  // add change according to the direction of newupY
+  camTheta += newUpY * dTheta;
+  camPhi += newUpY * dPhi;
+  // if camPhi becomes >= PI or <= 0,
+  // upY of camera need to be flipped to the other side
+  if (camPhi <= 0 || camPhi >= Math.PI) {
+    newUpY *= -1;
   }
 
   camRadius += dRadius;
@@ -1746,7 +1748,7 @@ p5.Camera.prototype._orbit = function(dTheta, dPhi, dRadius) {
     this.centerY,
     this.centerZ,
     0,
-    directionflag,
+    newUpY,
     0
   );
 };

--- a/src/webgl/p5.Camera.js
+++ b/src/webgl/p5.Camera.js
@@ -1733,9 +1733,6 @@ p5.Camera.prototype._orbit = function(dTheta, dPhi, dRadius) {
   if (camRadius < 0) {
     camRadius = 0.1;
   }
-
-  // prevent rotation over the zenith / under bottom
-
   // from https://github.com/mrdoob/three.js/blob/dev/src/math/Vector3.js#L628-L632
   const _x = Math.sin(camPhi) * camRadius * Math.sin(camTheta);
   const _y = Math.cos(camPhi) * camRadius;

--- a/src/webgl/p5.Camera.js
+++ b/src/webgl/p5.Camera.js
@@ -1720,22 +1720,21 @@ p5.Camera.prototype._orbit = function(dTheta, dPhi, dRadius) {
   let camTheta = Math.atan2(diffX, diffZ); // equatorial angle
   let camPhi = Math.acos(Math.max(-1, Math.min(1, diffY / camRadius))); // polar angle
 
-  // add change
-  camTheta += dTheta;
-  camPhi += dPhi;
-  camRadius += dRadius;
+  // add change according to the direction of this.upY
+  let directionflag = this.upY > 0 ? 1 : -1;
+  camTheta += directionflag*dTheta;
+  camPhi += directionflag*dPhi;
+  if (camPhi <= 0 || camPhi>=Math.PI) {
+    directionflag *= -1;
+  }
 
+  camRadius += dRadius;
   // prevent zooming through the center:
   if (camRadius < 0) {
     camRadius = 0.1;
   }
 
   // prevent rotation over the zenith / under bottom
-  if (camPhi > Math.PI) {
-    camPhi = Math.PI;
-  } else if (camPhi <= 0) {
-    camPhi = 0.001;
-  }
 
   // from https://github.com/mrdoob/three.js/blob/dev/src/math/Vector3.js#L628-L632
   const _x = Math.sin(camPhi) * camRadius * Math.sin(camTheta);
@@ -1750,7 +1749,7 @@ p5.Camera.prototype._orbit = function(dTheta, dPhi, dRadius) {
     this.centerY,
     this.centerZ,
     0,
-    1,
+    directionflag,
     0
   );
 };

--- a/test/unit/webgl/p5.Camera.js
+++ b/test/unit/webgl/p5.Camera.js
@@ -449,6 +449,53 @@ suite('p5.Camera', function() {
 
       assert.deepEqual(myCam.cameraMatrix.mat4, expectedMatrix);
     });
+
+    test('_orbit() ensures myCam.upY switches direction (from 1 to -1) at camPhi <= 0', function() {
+      // the following should produce the upY with inverted direction(from 1 to -1)
+      // when camPhi changes from positive to negative or zero
+      myCam._orbit(0, -PI, 0);
+      // upY should switch from 1(dPhi=0) to -1 (dPhi=-PI)
+      // myCam.upY should be -1
+      assert(myCam.upY === -1);
+    });
+
+    test('_orbit() ensures myCam.upY switches direction (from -1 to 1) at camPhi <= 0', function() {
+      // the following should produce the upY with inverted direction(from -1 to 1)
+      // when camPhi changes from negative to positive or zero
+      myCam._orbit(0, -PI, 0);
+      myCam._orbit(0, PI, 0);
+      // upY should switch from -1(dPhi=-PI) to 1 (dPhi=PI)
+      // myCam.upY should be 1
+      assert(myCam.upY === 1);
+    });
+
+    test('_orbit() ensures myCam.upY switches direction (from 1 to -1) at camPhi >= PI', function() {
+      // the following should produce the upY with inverted direction(from 1 to -1)
+      // when camPhi reaches PI
+      myCam._orbit(0, PI, 0);
+      // upY should switch from 1(dPhi=0) to -1 (dPhi=PI)
+      // myCam.upY should be -1
+      assert(myCam.upY === -1);
+    });
+
+    test('_orbit() ensures myCam.upY switches direction (from -1 to 1) at camPhi >= PI', function() {
+      // the following should produce the upY with inverted direction(from -1 to 1)
+      // when camPhi reaches PI
+      myCam._orbit(0, PI, 0);
+      myCam._orbit(0, -PI, 0);
+      // upY should switch from -1(dPhi=PI) to 1 (dPhi=-PI)
+      // myCam.upY should be 1
+      assert(myCam.upY === 1);
+    });
+
+    test('_orbit() ensures camera can do multiple continuous 360deg rotations', function() {
+      // the following should produce same values as myCam does a 360deg rotation twice
+      var myCamCopy = myCam.copy();
+      myCam._orbit(0, 4*PI, 0);
+      // upY should switch from 1 to -1, then to 1 again
+      assert.deepEqual(myCam.cameraMatrix.mat4, myCamCopy.cameraMatrix.mat4);
+    });
+    /*
     test('_orbit() ensures altitude phi <= PI', function() {
       var myCamCopy = myCam.copy();
 
@@ -468,6 +515,7 @@ suite('p5.Camera', function() {
 
       assert.deepEqual(myCam.cameraMatrix.mat4, myCamCopy.cameraMatrix.mat4);
     });
+    */
     test('_orbit() ensures radius > 0', function() {
       var myCamCopy = myCam.copy();
 

--- a/test/unit/webgl/p5.Camera.js
+++ b/test/unit/webgl/p5.Camera.js
@@ -484,21 +484,24 @@ suite('p5.Camera', function() {
       assert(myCam.upY === 1);
     });
     test('_orbit() ensures camera can do multiple continuous 360deg rotations', function() {
-      // the following should produce same values as myCam does a 360deg rotation twice
+      // the following should produce two camera objects having same properties.
+      myCam._orbit(0, Math.PI, 0);
       var myCamCopy = myCam.copy();
-      myCam._orbit(0, 4*Math.PI, 0);
-      // upY should switch from 1 to -1, then to 1 again
-      assert.deepEqual(myCam.cameraMatrix.mat4, myCamCopy.cameraMatrix.mat4);
+      myCamCopy._orbit(0, Math.PI, 0);
+      myCamCopy._orbit(0, Math.PI, 0);
+      for (let i = 0; i < myCamCopy.cameraMatrix.mat4.length; i++) {
+        expect(
+          myCamCopy.cameraMatrix.mat4[i]).to.be.closeTo(
+          myCam.cameraMatrix.mat4[i], 0.001);
+      }
     });
     test('_orbit() ensures radius > 0', function() {
+      // the following should produce two camera objects having same properties.
+      myCam._orbit(0, Math.PI, 0);
       var myCamCopy = myCam.copy();
-
-      // the following should produce the same values because radius is
-      // restricted to > 0
-      myCamCopy._orbit(0, 0, -200);
-      myCam._orbit(0, 0, -300);
-
-      assert.deepEqual(myCam.cameraMatrix.mat4, myCamCopy.cameraMatrix.mat4);
+      myCamCopy._orbit(0, 0, -100);
+      myCam._orbit(0, 0, -250);
+      assert.deepEqual(myCam.cameraMatrix.mat4, myCamCopy.cameraMatrix.mat4, 'deep equal is failing');
     });
   });
 

--- a/test/unit/webgl/p5.Camera.js
+++ b/test/unit/webgl/p5.Camera.js
@@ -449,7 +449,6 @@ suite('p5.Camera', function() {
 
       assert.deepEqual(myCam.cameraMatrix.mat4, expectedMatrix);
     });
-
     test('_orbit() ensures myCam.upY switches direction (from 1 to -1) at camPhi <= 0', function() {
       // the following should produce the upY with inverted direction(from 1 to -1)
       // when camPhi changes from positive to negative or zero
@@ -458,7 +457,6 @@ suite('p5.Camera', function() {
       // myCam.upY should be -1
       assert(myCam.upY === -1);
     });
-
     test('_orbit() ensures myCam.upY switches direction (from -1 to 1) at camPhi <= 0', function() {
       // the following should produce the upY with inverted direction(from -1 to 1)
       // when camPhi changes from negative to positive or zero
@@ -468,7 +466,6 @@ suite('p5.Camera', function() {
       // myCam.upY should be 1
       assert(myCam.upY === 1);
     });
-
     test('_orbit() ensures myCam.upY switches direction (from 1 to -1) at camPhi >= PI', function() {
       // the following should produce the upY with inverted direction(from 1 to -1)
       // when camPhi reaches PI
@@ -477,7 +474,6 @@ suite('p5.Camera', function() {
       // myCam.upY should be -1
       assert(myCam.upY === -1);
     });
-
     test('_orbit() ensures myCam.upY switches direction (from -1 to 1) at camPhi >= PI', function() {
       // the following should produce the upY with inverted direction(from -1 to 1)
       // when camPhi reaches PI
@@ -487,7 +483,6 @@ suite('p5.Camera', function() {
       // myCam.upY should be 1
       assert(myCam.upY === 1);
     });
-
     test('_orbit() ensures camera can do multiple continuous 360deg rotations', function() {
       // the following should produce same values as myCam does a 360deg rotation twice
       var myCamCopy = myCam.copy();
@@ -495,27 +490,6 @@ suite('p5.Camera', function() {
       // upY should switch from 1 to -1, then to 1 again
       assert.deepEqual(myCam.cameraMatrix.mat4, myCamCopy.cameraMatrix.mat4);
     });
-    /*
-    test('_orbit() ensures altitude phi <= PI', function() {
-      var myCamCopy = myCam.copy();
-
-      // the following should produce the same values because phi is capped at PI
-      myCamCopy._orbit(0, 10, 0);
-      myCam._orbit(0, 20, 0);
-
-      assert.deepEqual(myCam.cameraMatrix.mat4, myCamCopy.cameraMatrix.mat4);
-    });
-    test('_orbit() ensures altitude phi > 0', function() {
-      var myCamCopy = myCam.copy();
-
-      // the following should produce the same values because phi is restricted
-      // to > 0
-      myCamCopy._orbit(0, -10, 0);
-      myCam._orbit(0, -20, 0);
-
-      assert.deepEqual(myCam.cameraMatrix.mat4, myCamCopy.cameraMatrix.mat4);
-    });
-    */
     test('_orbit() ensures radius > 0', function() {
       var myCamCopy = myCam.copy();
 

--- a/test/unit/webgl/p5.Camera.js
+++ b/test/unit/webgl/p5.Camera.js
@@ -452,7 +452,7 @@ suite('p5.Camera', function() {
     test('_orbit() ensures myCam.upY switches direction (from 1 to -1) at camPhi <= 0', function() {
       // the following should produce the upY with inverted direction(from 1 to -1)
       // when camPhi changes from positive to negative or zero
-      myCam._orbit(0, -PI, 0);
+      myCam._orbit(0, -Math.PI, 0);
       // upY should switch from 1(dPhi=0) to -1 (dPhi=-PI)
       // myCam.upY should be -1
       assert(myCam.upY === -1);
@@ -460,8 +460,8 @@ suite('p5.Camera', function() {
     test('_orbit() ensures myCam.upY switches direction (from -1 to 1) at camPhi <= 0', function() {
       // the following should produce the upY with inverted direction(from -1 to 1)
       // when camPhi changes from negative to positive or zero
-      myCam._orbit(0, -PI, 0);
-      myCam._orbit(0, PI, 0);
+      myCam._orbit(0, -Math.PI, 0);
+      myCam._orbit(0, Math.PI, 0);
       // upY should switch from -1(dPhi=-PI) to 1 (dPhi=PI)
       // myCam.upY should be 1
       assert(myCam.upY === 1);
@@ -469,7 +469,7 @@ suite('p5.Camera', function() {
     test('_orbit() ensures myCam.upY switches direction (from 1 to -1) at camPhi >= PI', function() {
       // the following should produce the upY with inverted direction(from 1 to -1)
       // when camPhi reaches PI
-      myCam._orbit(0, PI, 0);
+      myCam._orbit(0, Math.PI, 0);
       // upY should switch from 1(dPhi=0) to -1 (dPhi=PI)
       // myCam.upY should be -1
       assert(myCam.upY === -1);
@@ -477,8 +477,8 @@ suite('p5.Camera', function() {
     test('_orbit() ensures myCam.upY switches direction (from -1 to 1) at camPhi >= PI', function() {
       // the following should produce the upY with inverted direction(from -1 to 1)
       // when camPhi reaches PI
-      myCam._orbit(0, PI, 0);
-      myCam._orbit(0, -PI, 0);
+      myCam._orbit(0, Math.PI, 0);
+      myCam._orbit(0, -Math.PI, 0);
       // upY should switch from -1(dPhi=PI) to 1 (dPhi=-PI)
       // myCam.upY should be 1
       assert(myCam.upY === 1);
@@ -486,7 +486,7 @@ suite('p5.Camera', function() {
     test('_orbit() ensures camera can do multiple continuous 360deg rotations', function() {
       // the following should produce same values as myCam does a 360deg rotation twice
       var myCamCopy = myCam.copy();
-      myCam._orbit(0, 4*PI, 0);
+      myCam._orbit(0, 4*Math.PI, 0);
       // upY should switch from 1 to -1, then to 1 again
       assert.deepEqual(myCam.cameraMatrix.mat4, myCamCopy.cameraMatrix.mat4);
     });


### PR DESCRIPTION
Resolves #5958 

 Changes:
<!-- Add here what changes were made in this pull request and if possible provide links showcasing the changes. -->

- `camPhi` was bound in the range `[0,pi]` and `upY` was only `1`, 
- a `directionflag` is added to change the direction of `upY` of the `camera` object,
- `camPhi` gets increment with respect to the direction of `upY`
- Now `camPhi` can rotate 360 deg and continue rotating in any direction,
- Along with that `camTheta` is modified by multiplying the sign of `directionflag` to the increment/decrement
- `directionflag` used to determine the `upY` property of the `camera` object
- Changing of the limits of `camPhi` resulted in a need of new tests
- 2 new tests added related to the to and fro motion at 0 rad
- 2 new tests added related to the to and fro motion at PI rad
- 1 new test for continuous multiple rotations
- Modified 1 test for checking the camRadius correctly.
- Detailed Inline documentation also added.

#### PR Checklist
<!--
  To check any option, replace the "[ ]" with a "[x]". Be sure to check out how it looks in the Preview tab! Feel free to remove any portion of the template that is not relevant for your issue.
-->
- [x] `npm test`
- [x] `npm run build` passes
- [x] `npm run lint` passes
- [x] Inline documentation is included / updated
- [x] Unit tests are included(5) / updated(1)