### PR TITLE
Bug fix for frameRate()

### DIFF
--- a/src/core/main.js
+++ b/src/core/main.js
@@ -390,10 +390,10 @@ class p5 {
         time_since_last >= target_time_between_frames - epsilon
       ) {
         //mandatory update values(matrixes and stack)
-        this.redraw();
-        this._frameRate = 1000.0 / (now - this._lastRealFrameTime);
         this.deltaTime = now - this._lastRealFrameTime;
         this._setProperty('deltaTime', this.deltaTime);
+        this._frameRate = 1000.0 / this.deltaTime;
+        this.redraw();
         this._lastTargetFrameTime = Math.max(this._lastTargetFrameTime
           + target_time_between_frames, now);
         this._lastRealFrameTime = now;

--- a/src/events/touch.js
+++ b/src/events/touch.js
@@ -13,8 +13,7 @@ import p5 from '../core/main';
  * unique touch as it moves. Each element in the array is an object with x, y,
  * and id properties.
  *
- * The touches[] array is not supported on Safari and IE on touch-based
- * desktops (laptops).
+ * The touches[] array is not supported in IE on touch-based devices.
  *
  * @property {Object[]} touches
  * @readOnly

--- a/src/events/touch.js
+++ b/src/events/touch.js
@@ -13,7 +13,8 @@ import p5 from '../core/main';
  * unique touch as it moves. Each element in the array is an object with x, y,
  * and id properties.
  *
- * The touches[] array is not supported in IE on touch-based devices.
+ * The touches[] array is not supported on Safari and IE on touch-based
+ * desktops (laptops).
  *
  * @property {Object[]} touches
  * @readOnly


### PR DESCRIPTION
My first pr to p5.js! 🎊  This pr doesn't provide a solution to issue #6013 or add any new functionality, it just fixes a bug I found.

I saw that the _frameRate and deltaTime values were calculated after `redraw()` but they should be calculated before `redraw()`

I also avoided subtracting the same values twice by putting the deltaTime calculation first.

See @davepagurek 's example sketches to see the fix in action.

Ball's speed doesn't not match when using `frameRate()` vs `millis()`:

https://editor.p5js.org/davepagurek/sketches/K7cKw7bie

With the fix the balls' speeds match:

https://editor.p5js.org/davepagurek/sketches/VXHoBahkN
