### PR TITLE
removed .prettierrc file

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,3 +1,0 @@
-{
-  "singleQuote": true
-}


### PR DESCRIPTION
### Changes:

since **prettier** dependency was _removed_ from the project then their is no use of **.prettierrc** file, that should be _removed._ this thing is already discussed with @limzykenneth on issue #6038 

### Impact:

1. no impact other files or anything.
2. will be helpful to all the contributors who have **vscode prettier** extension installed, after the file will be _removed_ the _extension_ will not get automatically activated thus no unnecessary style related changes will take place. I was facing this problem so I had to disable my extension manually.