### PR TITLE
Fix malformed json in .all-contributorsrc

### DIFF
--- a/.all-contributorsrc
+++ b/.all-contributorsrc
@@ -3553,7 +3553,7 @@
       "contributions": [
         "bug"
       ]
-    }，
+    },
     {
       "login": "nown1ne",
       "name": "Abhinav Srinivas",


### PR DESCRIPTION
I just noticed from this message https://github.com/processing/p5.js/pull/6047#issuecomment-1455126054 that @all-contributors can no longer parse the JSON file. Seems like it just had a different comma character than the one expected for JSON.

Changes:
- Replaces a different unicode comma with `,`