### PR TITLE
FES throws an error when non globally exposed function's name used in other context

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -6,8 +6,7 @@
   "recommendations": [
     "eg2.vscode-npm-script",
     "yzhang.markdown-all-in-one",
-    "dbaeumer.vscode-eslint",
-    "esbenp.prettier-vscode"
+    "dbaeumer.vscode-eslint"
   ],
   // List of extensions recommended by VS Code that should not be recommended for users of this workspace.
   "unwantedRecommendations": []

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -6,7 +6,8 @@
   "recommendations": [
     "eg2.vscode-npm-script",
     "yzhang.markdown-all-in-one",
-    "dbaeumer.vscode-eslint"
+    "dbaeumer.vscode-eslint",
+    "esbenp.prettier-vscode"
   ],
   // List of extensions recommended by VS Code that should not be recommended for users of this workspace.
   "unwantedRecommendations": []

--- a/src/core/friendly_errors/sketch_reader.js
+++ b/src/core/friendly_errors/sketch_reader.js
@@ -321,7 +321,7 @@ if (typeof IS_MINIFIED !== 'undefined') {
     const keyArray = Object.keys(p5Constructors);
     const globalFunctions = ['Renderer', 'Renderer2D', 'RendererGL'];
     let functionArray = [];
-    //get the names of all p5.js functions
+    //get the names of all p5.js functions which are available globally
     for (let i = 0; i < globalFunctions.length; i++) {
       functionArray.push(...Object.keys(
         p5Constructors[globalFunctions[i]].prototype

--- a/src/core/friendly_errors/sketch_reader.js
+++ b/src/core/friendly_errors/sketch_reader.js
@@ -319,12 +319,14 @@ if (typeof IS_MINIFIED !== 'undefined') {
       }
     }
     const keyArray = Object.keys(p5Constructors);
+    const globalFunctions = ['Renderer', 'Renderer2D', 'RendererGL'];
     let functionArray = [];
     //get the names of all p5.js functions
-    for (let i = 0; i < keyArray.length; i++) {
-      functionArray.push(...Object.keys(p5Constructors[keyArray[i]].prototype));
+    for (let i = 0; i < globalFunctions.length; i++) {
+      functionArray.push(...Object.keys(
+        p5Constructors[globalFunctions[i]].prototype
+      ));
     }
-    functionArray = functionArray.filter(ele => !ele.includes('_'));
 
     //we have p5.js function names with us so we will check
     //if they have been declared or not.

--- a/test/unit/core/error_helpers.js
+++ b/test/unit/core/error_helpers.js
@@ -976,11 +976,11 @@ suite('Tests for p5.js sketch_reader', function() {
   );
 
   testUnMinified(
-    'detects reassignment of p5.js function (size from TypedDict or Dom) outside setup',
+    'detects reassignment of p5.js function (textSize from Typography) outside setup',
     function() {
       return new Promise(function(resolve) {
         prepSketchReaderTest(
-          ['let size = 100', 'function setup() {}'],
+          ['let textSize = 100', 'function setup() {}'],
           resolve
         );
       }).then(function() {
@@ -991,11 +991,11 @@ suite('Tests for p5.js sketch_reader', function() {
   );
 
   testUnMinified(
-    'detects reassignment of p5.js function (textSize from Typography) outside setup',
+    'detects reassignment of p5.js function (size from TypedDict or Dom) outside setup',
     function() {
       return new Promise(function(resolve) {
         prepSketchReaderTest(
-          ['let textSize = 100', 'function setup() {}'],
+          ['let size = 100', 'function setup() {}'],
           resolve
         );
       }).then(function() {

--- a/test/unit/core/error_helpers.js
+++ b/test/unit/core/error_helpers.js
@@ -999,8 +999,7 @@ suite('Tests for p5.js sketch_reader', function() {
           resolve
         );
       }).then(function() {
-        assert.strictEqual(log.length, 1);
-        assert.match(log[0], /you have used a p5.js reserved function/);
+        assert.strictEqual(log.length, 0);
       });
     }
   );

--- a/test/unit/core/error_helpers.js
+++ b/test/unit/core/error_helpers.js
@@ -991,7 +991,7 @@ suite('Tests for p5.js sketch_reader', function() {
   );
 
   testUnMinified(
-    'detects reassignment of p5.js function (size from TypedDict or Dom) outside setup',
+    'does not detect reassignment of p5.js function (size from TypedDict or Dom) outside setup',
     function() {
       return new Promise(function(resolve) {
         prepSketchReaderTest(

--- a/test/unit/core/error_helpers.js
+++ b/test/unit/core/error_helpers.js
@@ -961,11 +961,56 @@ suite('Tests for p5.js sketch_reader', function() {
   );
 
   testUnMinified(
-    'detects reassignment of p5.js function outside setup',
+    'detects reassignment of p5.js function (text) outside setup',
     function() {
       return new Promise(function(resolve) {
         prepSketchReaderTest(
           ['let text = 100', 'function setup() {}'],
+          resolve
+        );
+      }).then(function() {
+        assert.strictEqual(log.length, 1);
+        assert.match(log[0], /you have used a p5.js reserved function/);
+      });
+    }
+  );
+
+  testUnMinified(
+    'detects reassignment of p5.js function (size from TypedDict or Dom) outside setup',
+    function() {
+      return new Promise(function(resolve) {
+        prepSketchReaderTest(
+          ['let size = 100', 'function setup() {}'],
+          resolve
+        );
+      }).then(function() {
+        assert.strictEqual(log.length, 1);
+        assert.match(log[0], /you have used a p5.js reserved function/);
+      });
+    }
+  );
+
+  testUnMinified(
+    'detects reassignment of p5.js function (textSize from Typography) outside setup',
+    function() {
+      return new Promise(function(resolve) {
+        prepSketchReaderTest(
+          ['let textSize = 100', 'function setup() {}'],
+          resolve
+        );
+      }).then(function() {
+        assert.strictEqual(log.length, 1);
+        assert.match(log[0], /you have used a p5.js reserved function/);
+      });
+    }
+  );
+
+  testUnMinified(
+    'detects reassignment of p5.js function (point from shape) outside setup',
+    function() {
+      return new Promise(function(resolve) {
+        prepSketchReaderTest(
+          ['let point = 100', 'function setup() {}'],
           resolve
         );
       }).then(function() {


### PR DESCRIPTION


### Resolves #5753 

### Changes:
Previously we were adding all the methods of all p5 classes as reserved functions in the `functionArray`, but all p5 classes do not have their functions added to the global scope.
So, as suggested by @davepagurek that only the methods/functions inside `p5`, `p5.Renderer`, `p5.RendererGL`, and `p5.Renderer2D` are available in the global scope, so only those should be added to `functionArray` so that FES do not throw an error when a function's name (which is not exposed or defined by p5.js in the global scope) is used as a variable or any other way.

#### PR Checklist

- [x] `npm run lint` passes
- [ ] [Inline documentation] is included / updated
- [x] [Unit tests] are included / updated

[Inline documentation]: https://github.com/processing/p5.js/blob/main/contributor_docs/inline_documentation.md
[Unit tests]: https://github.com/processing/p5.js/tree/main/contributor_docs#unit-tests
