### PR TITLE
Allow textAlign(CENTER, CENTER) with max width but no max height

### DIFF
--- a/lib/addons/p5.sound.js
+++ b/lib/addons/p5.sound.js
@@ -10618,7 +10618,7 @@ var soundRecorder_ac = main.audiocontext;
  *      // send result to soundFile
  *      recorder.stop();
  *
- *      text('Done! Tap to play and download', width/2, height/2, width - 20);
+ *      text('Done! Tap to play and download', width/2, height/2, width - 100);
  *      state++;
  *    }
  *

--- a/lib/addons/p5.sound.js
+++ b/lib/addons/p5.sound.js
@@ -10618,7 +10618,7 @@ var soundRecorder_ac = main.audiocontext;
  *      // send result to soundFile
  *      recorder.stop();
  *
- *      text('Done! Tap to play and download', width/2, height/2, width - 100);
+ *      text('Done! Tap to play and download', width/2, height/2, width - 20);
  *      state++;
  *    }
  *

--- a/src/core/p5.Renderer.js
+++ b/src/core/p5.Renderer.js
@@ -301,7 +301,7 @@ p5.Renderer.prototype.text = function(str, x, y, maxWidth, maxHeight) {
       if (this._textBaseline === constants.BOTTOM ||
         this._textBaseline === constants.CENTER) {
         // use rectHeight as an approximation for text height
-        let rectHeight = p.textSize() * (this._textLeading);
+        let rectHeight = p.textSize() * this._textLeading;
         finalMinHeight = y - rectHeight / 2;
         finalMaxHeight = y + rectHeight / 2;
       }

--- a/src/core/p5.Renderer.js
+++ b/src/core/p5.Renderer.js
@@ -296,18 +296,20 @@ p5.Renderer.prototype.text = function(str, x, y, maxWidth, maxHeight) {
       if (this._textBaseline === constants.CENTER) {
         finalMaxHeight = originalY + maxHeight - ascent / 2;
       }
-    } else {
-      // no text-height specified, show warning for BOTTOM / CENTER
-      if (this._textBaseline === constants.BOTTOM) {
-        return console.warn(
-          'textAlign(*, BOTTOM) requires x, y, width and height'
-        );
-      }
-      if (this._textBaseline === constants.CENTER) {
-        return console.warn(
-          'textAlign(*, CENTER) requires x, y, width and height'
-        );
-      }
+      // fix for #5933 (when MaxHeight not defined)
+      else if (typeof maxHeight === 'undefined') {
+        let ascent = p.textAscent();
+        switch (this._textBaseline) {
+          case constants.BOTTOM:
+            y -= ascent;
+            finalMinHeight += ascent;
+            break;
+          case constants.CENTER:
+            y -= ascent / 2;
+            finalMinHeight += ascent / 2;
+            break;
+        }
+     }
     }
 
     // Render lines of text according to settings of textWrap

--- a/src/core/p5.Renderer.js
+++ b/src/core/p5.Renderer.js
@@ -296,19 +296,14 @@ p5.Renderer.prototype.text = function(str, x, y, maxWidth, maxHeight) {
       if (this._textBaseline === constants.CENTER) {
         finalMaxHeight = originalY + maxHeight - ascent / 2;
       }
-      // fix for #5933 (when MaxHeight not defined)
-      else if (typeof maxHeight === 'undefined') {
-        let ascent = p.textAscent();
-        switch (this._textBaseline) {
-          case constants.BOTTOM:
-            y -= ascent;
-            finalMinHeight += ascent;
-            break;
-          case constants.CENTER:
-            y -= ascent / 2;
-            finalMinHeight += ascent / 2;
-            break;
-        }
+    } else {
+      // no text-height specified, show warning for BOTTOM / CENTER
+      if (this._textBaseline === constants.BOTTOM ||
+        this._textBaseline === constants.CENTER) {
+        // use rectHeight as an approximation for text height
+        let rectHeight = p.textSize() * (this._textLeading || 1.25);
+        finalMinHeight = y - rectHeight / 2;
+        finalMaxHeight = y + rectHeight / 2;
       }
     }
 

--- a/src/core/p5.Renderer.js
+++ b/src/core/p5.Renderer.js
@@ -301,7 +301,7 @@ p5.Renderer.prototype.text = function(str, x, y, maxWidth, maxHeight) {
       if (this._textBaseline === constants.BOTTOM ||
         this._textBaseline === constants.CENTER) {
         // use rectHeight as an approximation for text height
-        let rectHeight = p.textSize() * (this._textLeading || 1.25);
+        let rectHeight = p.textSize() * (this._textLeading);
         finalMinHeight = y - rectHeight / 2;
         finalMaxHeight = y + rectHeight / 2;
       }

--- a/src/core/p5.Renderer.js
+++ b/src/core/p5.Renderer.js
@@ -309,7 +309,7 @@ p5.Renderer.prototype.text = function(str, x, y, maxWidth, maxHeight) {
             finalMinHeight += ascent / 2;
             break;
         }
-     }
+      }
     }
 
     // Render lines of text according to settings of textWrap

--- a/src/typography/attributes.js
+++ b/src/typography/attributes.js
@@ -61,9 +61,9 @@ import p5 from '../core/main';
  * textAlign(CENTER, BASELINE);
  * text('BASELINE', 0, 62, width);
  *
- * line(0, 87, width, 87);
+ * line(0, 97, width, 97);
  * textAlign(CENTER, BOTTOM);
- * text('BOTTOM', 0, 87, width);
+ * text('BOTTOM', 0, 97, width);
  *
  * describe(`The names of the four vertical alignments (TOP, CENTER, BASELINE,
  *   and BOTTOM) rendered each showing that alignment's placement relative to a


### PR DESCRIPTION
<!--
  Thank you for contributing! Please use this pull request (PR) template.


 In the description field of this PR, include "resolves #XXXX" tagging the issue you are fixing. If this PR addresses the issue but doesn't completely resolve it (ie the issue should remain open after your PR is merged), write "addresses #XXXX".-->
Resolves #5933 

 Changes:
Now we can use textAlign(CENTER, CENTER) and then call text('something', x, y, w) without specifying a height parameter.  

 Screenshots of the change:

### **Before:**
![text-align22](https://user-images.githubusercontent.com/49401909/224025682-37b1d2f1-3ab4-4bb3-9b0e-11efb9d261f6.png)

![p5 sound22](https://user-images.githubusercontent.com/49401909/224025736-82535b69-ce4a-4731-80a5-53ace2443a04.png)

### **After:**
![text-align](https://user-images.githubusercontent.com/49401909/224024811-17cfbe10-cfc0-4347-9256-dbed80a2ef90.png)

![image](https://user-images.githubusercontent.com/49401909/224506448-fc8794df-9211-4042-ba53-ddd7d679599e.png)



#### PR Checklist
<!--
  To check any option, replace the "[ ]" with a "[x]". Be sure to check out how it looks in the Preview tab! Feel free to remove any portion of the template that is not relevant for your issue.
-->

- [X] `npm run lint` passes
- [x] [Inline documentation] is included / updated
- [ ] [Unit tests] are included / updated

[Inline documentation]: https://github.com/processing/p5.js/blob/main/contributor_docs/inline_documentation.md
[Unit tests]: https://github.com/processing/p5.js/tree/main/contributor_docs#unit-tests
