### PR TITLE
#6056 Issue: Update attributes,js

### DIFF
--- a/src/typography/attributes.js
+++ b/src/typography/attributes.js
@@ -50,7 +50,7 @@ import p5 from '../core/main';
  * strokeWeight(0.5);
  *
  * line(0, 12, width, 12);
- * textAlign(CENTER, TOP);
+ * textAlign(CENTER, [TOP]);
  * text('TOP', 0, 12, width);
  *
  * line(0, 37, width, 37);
@@ -58,7 +58,7 @@ import p5 from '../core/main';
  * text('CENTER', 0, 37, width);
  *
  * line(0, 62, width, 62);
- * textAlign(CENTER, BASELINE);
+ * textAlign(CENTER, [BASELINE]);
  * text('BASELINE', 0, 62, width);
  *
  * line(0, 97, width, 97);

--- a/src/typography/attributes.js
+++ b/src/typography/attributes.js
@@ -54,16 +54,16 @@ import p5 from '../core/main';
  * text('TOP', 0, 12, width);
  *
  * line(0, 37, width, 37);
- * textAlign(CENTER, CENTER);
+ * textAlign(CENTER, [CENTER]);
  * text('CENTER', 0, 37, width);
  *
  * line(0, 62, width, 62);
  * textAlign(CENTER, BASELINE);
  * text('BASELINE', 0, 62, width);
  *
- * line(0, 87, width, 87);
- * textAlign(CENTER, BOTTOM);
- * text('BOTTOM', 0, 87, width);
+ * line(0, 97, width, 97);
+ * textAlign(CENTER, [BOTTOM]);
+ * text('BOTTOM', 0, 97, width);
  *
  * describe(`The names of the four vertical alignments (TOP, CENTER, BASELINE,
  *   and BOTTOM) rendered each showing that alignment's placement relative to a


### PR DESCRIPTION
Updated the attributes.js As per the textAlign(horizAlign, [vertAlign]) syntax. 
The vertAlign must be in square brackets.


 Screenshots of the change:
![image](https://user-images.githubusercontent.com/97503662/224496143-1c828376-e333-4307-a4e5-2becec530786.png)


#### PR Checklist


- [x] `npm run lint` passes
- [ ] [Inline documentation] is included / updated
- [ ] [Unit tests] are included / updated

[Inline documentation]: https://github.com/processing/p5.js/blob/main/contributor_docs/inline_documentation.md
[Unit tests]: https://github.com/processing/p5.js/tree/main/contributor_docs#unit-tests
