### PR TITLE
Fix gifs not animating in 1.6.0

### DIFF
--- a/src/image/p5.Image.js
+++ b/src/image/p5.Image.js
@@ -224,7 +224,7 @@ p5.Image = function(width, height) {
  */
 p5.Image.prototype._animateGif = function(pInst) {
   const props = this.gifProperties;
-  const curTime = pInst._lastFrameTime;
+  const curTime = pInst._lastRealFrameTime;
   if (props.lastChangeTime === 0) {
     props.lastChangeTime = curTime;
   }

--- a/test/unit/image/loading.js
+++ b/test/unit/image/loading.js
@@ -34,6 +34,10 @@ suite('loading images', function() {
         myp5 = p;
         done();
       };
+
+      // Make sure draw() exists so timing functions still run each frame
+      // and we can test gif animation
+      p.draw = function() {};
     });
   });
 
@@ -107,6 +111,31 @@ suite('loading images', function() {
       myp5.loadImage('unit/assets/white_black.gif', resolve, reject);
     }).then(function(img) {
       assert.deepEqual(img.get(0, 0), [255, 255, 255, 255]);
+    });
+  });
+
+  test('animated gifs animate correctly', function() {
+    const wait = function(ms) {
+      return new Promise(function(resolve) {
+        setTimeout(resolve, ms);
+      });
+    };
+    let img;
+    return new Promise(function(resolve, reject) {
+      img = myp5.loadImage('unit/assets/nyan_cat.gif', resolve, reject);
+    }).then(function() {
+      assert.equal(img.gifProperties.displayIndex, 0);
+      myp5.image(img, 0, 0);
+
+      // This gif has frames that are around for 100ms each.
+      // After 100ms has elapsed, the display index should
+      // increment when we draw the image. We'll wait a little
+      // longer to make sure p5 knows it should be on the next
+      // image.
+      return wait(110);
+    }).then(function() {
+      myp5.image(img, 0, 0);
+      assert.equal(img.gifProperties.displayIndex, 1);
     });
   });
 


### PR DESCRIPTION
Resolves https://github.com/processing/p5.js/issues/6066

Changes:
- Gifs now refer to `_lastRealFrameTime` instead of `_lastFrameTime`, which was removed in https://github.com/processing/p5.js/pull/5847
- Adds tests to ensure gifs still animate so we don't accidentally break this again

Live: https://editor.p5js.org/davepagurek/sketches/KIOnOm2qu

#### PR Checklist

- [x] `npm run lint` passes
- [ ] [Inline documentation] is included / updated
- [x] [Unit tests] are included / updated
