### PR TITLE
Apply blendMode inside _drawPoints

### DIFF
--- a/src/webgl/p5.RendererGL.Retained.js
+++ b/src/webgl/p5.RendererGL.Retained.js
@@ -238,6 +238,8 @@ p5.RendererGL.prototype._drawPoints = function(vertices, vertexBuffer) {
 
   pointShader.enableAttrib(pointShader.attributes.aPosition, 3);
 
+  this._applyColorBlend(this.curStrokeColor); 
+ 
   gl.drawArrays(gl.Points, 0, vertices.length);
 
   pointShader.unbindShader();

--- a/src/webgl/p5.RendererGL.Retained.js
+++ b/src/webgl/p5.RendererGL.Retained.js
@@ -238,8 +238,8 @@ p5.RendererGL.prototype._drawPoints = function(vertices, vertexBuffer) {
 
   pointShader.enableAttrib(pointShader.attributes.aPosition, 3);
 
-  this._applyColorBlend(this.curStrokeColor); 
- 
+  this._applyColorBlend(this.curStrokeColor);
+
   gl.drawArrays(gl.Points, 0, vertices.length);
 
   pointShader.unbindShader();

--- a/test/unit/webgl/p5.RendererGL.js
+++ b/test/unit/webgl/p5.RendererGL.js
@@ -622,6 +622,18 @@ suite('p5.RendererGL', function() {
       );
       done();
     });
+
+    test('blendModes are applied to point drawing', function(done) {
+      myp5.createCanvas(32, 32, myp5.WEBGL);
+      myp5.background(0);
+      myp5.blendMode(myp5.ADD);
+      myp5.strokeWeight(32);
+      myp5.stroke(255, 0, 0);
+      myp5.point(0, 0, 0);
+      myp5.stroke(0, 0, 255);
+      myp5.point(0, 0, 0);
+      assert.deepEqual(myp5.get(16, 16), [255, 0, 255, 255]);
+    });
   });
 
   suite('BufferDef', function() {

--- a/test/unit/webgl/p5.RendererGL.js
+++ b/test/unit/webgl/p5.RendererGL.js
@@ -633,6 +633,7 @@ suite('p5.RendererGL', function() {
       myp5.stroke(0, 0, 255);
       myp5.point(0, 0, 0);
       assert.deepEqual(myp5.get(16, 16), [255, 0, 255, 255]);
+      done();
     });
   });
 


### PR DESCRIPTION
The blend function was not applied inside _drawPoints, so let's apply it.

<!--
  Thank you for contributing! Please use this pull request (PR) template.


 In the description field of this PR, include "resolves #XXXX" tagging the issue you are fixing. If this PR addresses the issue but doesn't completely resolve it (ie the issue should remain open after your PR is merged), write "addresses #XXXX".-->
Resolves #6068

 ## Changes:
<!-- Add here what changes were made in this pull request and if possible provide links showcasing the changes. -->
Do _applyColorBlend() with strokeColor in _drawPoints().

 ## Screenshots of the change:
<!-- If applicable, add screenshots depicting the changes. -->
### sample code:
```js
function setup(){
  createCanvas(400,400,WEBGL);
  background(0);
  blendMode(ADD);
  strokeWeight(100);

  stroke(255,0,0);
  point(0,0,0);
  stroke(0,0,255);
  point(50,0,0);
}
```
### left : before,  right : after
![pointBug_compare](https://user-images.githubusercontent.com/39549290/224700574-9bc9b1ca-963f-4c8e-a282-fc4af1c16bcb.png)

#### PR Checklist
<!--
  To check any option, replace the "[ ]" with a "[x]". Be sure to check out how it looks in the Preview tab! Feel free to remove any portion of the template that is not relevant for your issue.
-->

- [x] `npm run lint` passes
- [ ] [Inline documentation] is included / updated
- [x] [Unit tests] are included / updated

[Inline documentation]: https://github.com/processing/p5.js/blob/main/contributor_docs/inline_documentation.md
[Unit tests]: https://github.com/processing/p5.js/tree/main/contributor_docs#unit-tests

I would also like to add a unit test later.
