### PR TITLE
Add Framebuffer support

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -93,6 +93,7 @@ import './webgl/p5.Matrix';
 import './webgl/p5.RendererGL.Immediate';
 import './webgl/p5.RendererGL';
 import './webgl/p5.RendererGL.Retained';
+import './webgl/p5.Framebuffer';
 import './webgl/p5.Shader';
 import './webgl/p5.RenderBuffer';
 import './webgl/p5.Texture';

--- a/src/core/constants.js
+++ b/src/core/constants.js
@@ -753,6 +753,12 @@ export const COVER = 'cover';
 export const UNSIGNED_BYTE = 'unsigned-byte';
 
 /**
+ * @property {String} UNSIGNED_INT
+ * @final
+ */
+export const UNSIGNED_INT = 'unsigned-int';
+
+/**
  * @property {String} FLOAT
  * @final
  */

--- a/src/core/constants.js
+++ b/src/core/constants.js
@@ -745,3 +745,27 @@ export const CONTAIN = 'contain';
  * @final
  */
 export const COVER = 'cover';
+
+/**
+ * @property {String} UNSIGNED_BYTE
+ * @final
+ */
+export const UNSIGNED_BYTE = 'unsigned-byte';
+
+/**
+ * @property {String} FLOAT
+ * @final
+ */
+export const FLOAT = 'float';
+
+/**
+ * @property {String} FLOAT
+ * @final
+ */
+export const HALF_FLOAT = 'half-float';
+
+/**
+ * @property {String} RGBA
+ * @final
+ */
+export const RGBA = 'rgba';

--- a/src/core/p5.Graphics.js
+++ b/src/core/p5.Graphics.js
@@ -186,6 +186,15 @@ p5.Graphics.prototype.remove = function() {
   }
 };
 
+/**
+ * Creates and returns a new <a href="#/p5.Framebuffer">p5.Framebuffer</a>
+ * inside a p5.Graphics WebGL context.
+ *
+ * This takes the same parameters as the <a href="#/p5/createFramebuffer">global
+ * createFramebuffer function.</a>
+ *
+ * @method createFramebuffer
+ */
 p5.Graphics.prototype.createFramebuffer = function(options) {
   return new p5.Framebuffer(this, options);
 };

--- a/src/core/p5.Graphics.js
+++ b/src/core/p5.Graphics.js
@@ -186,4 +186,8 @@ p5.Graphics.prototype.remove = function() {
   }
 };
 
+p5.Graphics.prototype.createFramebuffer = function(options) {
+  return new p5.Framebuffer(this, options);
+};
+
 export default p5.Graphics;

--- a/src/core/rendering.js
+++ b/src/core/rendering.js
@@ -250,6 +250,22 @@ p5.prototype.createGraphics = function(w, h, renderer) {
   return new p5.Graphics(w, h, renderer, this);
 };
 
+/**
+ * Creates and returns a new <a href="#/p5.Framebuffer">p5.Framebuffer</a>, a
+ * high-performance WebGL object that you can draw to and then use as a texture.
+ *
+ * Options can include:
+ * - `format`: The data format of the texture, either `UNSIGNED_BYTE`, `FLOAT`, or `HALF_FLOAT`. The default is `UNSIGNED_BYTE`.
+ * - `channels`: What color channels to store, either `RGB` or `RGBA`. The default is to match the channels in the main canvas (with alpha unless disabled with `setAttributes`.)
+ * - `depthFormat`: The data format for depth information, either `UNSIGNED_BYTE` or `FLOAT`. The default is `UNSIGNED_BYTE` if `format` is that as well, or `FLOAT` otherwise.
+ * - `antialias`: Boolean, whether or not to render with antialiased edges. Defaults to whether or not the main canvas is antialiased. Antialiasing is only supported when WebGL 2 is available.
+ * - `width`: The width of the texture. Defaults to matching the main canvas. If unspecified, the framebuffer will resize when the main canvas resizes.
+ * - `height`: The height of the texture. Defaults to matching the main canvas. If unspecified, the framebuffer will resize when the main canvas resizes.
+ * - `density`: The pixel density of the texture. Defaults to the pixel density of the main canvas.
+ *
+ * @method createFramebuffer
+ * @param {Object} [options] An optional object with configuration
+ */
 p5.prototype.createFramebuffer = function(options) {
   return new p5.Framebuffer(this, options);
 };

--- a/src/core/rendering.js
+++ b/src/core/rendering.js
@@ -263,7 +263,7 @@ p5.prototype.createGraphics = function(w, h, renderer) {
  * - `width`: The width of the texture. Defaults to matching the main canvas.
  * - `height`: The height of the texture. Defaults to matching the main canvas.
  * - `density`: The pixel density of the texture. Defaults to the pixel density of the main canvas.
- * - `textureSmoothing`: A boolean, whether or not to interpolate between nearby pixels when reading values from the color texture. Generally, turn this on when using the texture as an image, and turn it off if reading the texture as data. Defaults to true.
+ * - `textureFiltering`: A boolean, whether or not to interpolate between nearby pixels when reading values from the color texture. Generally, turn this on when using the texture as an image, and turn it off if reading the texture as data. Defaults to true.
  *
  * If `width`, `height`, or `density` are specified, then the framebuffer will
  * keep that size until manually changed. Otherwise, it will be autosized, and

--- a/src/core/rendering.js
+++ b/src/core/rendering.js
@@ -259,10 +259,12 @@ p5.prototype.createGraphics = function(w, h, renderer) {
  * - `channels`: What color channels to store, either `RGB` or `RGBA`. The default is to match the channels in the main canvas (with alpha unless disabled with `setAttributes`.)
  * - `depth`: A boolean, whether or not to include a depth buffer. Defaults to true.
  * - `depthFormat`: The data format for depth information, either `UNSIGNED_BYTE` or `FLOAT`. The default is `UNSIGNED_BYTE` if `format` is that as well, or `FLOAT` otherwise.
- * - `antialias`: Boolean or Number, whether or not to render with antialiased edges, and if so, optionally the number of samples to use. Defaults to whether or not the main canvas is antialiased. Antialiasing is only supported when WebGL 2 is available.
+ * - `antialias`: Boolean or Number, whether or not to render with antialiased edges, and if so, optionally the number of samples to use. Defaults to whether or not the main canvas is antialiased, using a default of 2 samples if so. Antialiasing is only supported when WebGL 2 is available.
  * - `width`: The width of the texture. Defaults to matching the main canvas.
  * - `height`: The height of the texture. Defaults to matching the main canvas.
  * - `density`: The pixel density of the texture. Defaults to the pixel density of the main canvas.
+ * - `textureSmoothing`: A boolean, whether or not to interpolate between nearby pixels when reading values from the color texture. Generally, turn this on when using the texture as an image, and turn it off if reading the texture as data. Defaults to true.
+ * - `depthTextureSmoothing`: A boolean, whether or not to interpolate between nearby pixels when reading values from the depth texture. Generally, turn this on when using the texture as an image, and turn it off if reading the texture as data. Defaults to false.
  *
  * If `width`, `height`, or `density` are specified, then the framebuffer will
  * keep that size until manually changed. Otherwise, it will be autosized, and

--- a/src/core/rendering.js
+++ b/src/core/rendering.js
@@ -257,6 +257,7 @@ p5.prototype.createGraphics = function(w, h, renderer) {
  * Options can include:
  * - `format`: The data format of the texture, either `UNSIGNED_BYTE`, `FLOAT`, or `HALF_FLOAT`. The default is `UNSIGNED_BYTE`.
  * - `channels`: What color channels to store, either `RGB` or `RGBA`. The default is to match the channels in the main canvas (with alpha unless disabled with `setAttributes`.)
+ * - `depth`: A boolean, whether or not to include a depth buffer. Defaults to true.
  * - `depthFormat`: The data format for depth information, either `UNSIGNED_BYTE` or `FLOAT`. The default is `UNSIGNED_BYTE` if `format` is that as well, or `FLOAT` otherwise.
  * - `antialias`: Boolean, whether or not to render with antialiased edges. Defaults to whether or not the main canvas is antialiased. Antialiasing is only supported when WebGL 2 is available.
  * - `width`: The width of the texture. Defaults to matching the main canvas.

--- a/src/core/rendering.js
+++ b/src/core/rendering.js
@@ -250,6 +250,10 @@ p5.prototype.createGraphics = function(w, h, renderer) {
   return new p5.Graphics(w, h, renderer, this);
 };
 
+p5.prototype.createFramebuffer = function(options) {
+  return new p5.Framebuffer(this, options);
+};
+
 /**
  * Blends the pixels in the display window according to the defined mode.
  * There is a choice of the following modes to blend the source pixels (A)

--- a/src/core/rendering.js
+++ b/src/core/rendering.js
@@ -299,9 +299,8 @@ p5.prototype.createGraphics = function(w, h, renderer) {
  *   // up to fill the screen, plus a bit extra scale so it grows
  *   translate(0, 0, -200);
  *   scale(1.001 * (200 + cam.eyeZ) / cam.eyeZ);
- *   texture(prev);
  *   tint(255, 253);
- *   plane(width, -height);
+ *   image(prev, -width/2, -height/2);
  *   pop();
  *
  *   push();
@@ -313,10 +312,7 @@ p5.prototype.createGraphics = function(w, h, renderer) {
  *   pop();
  *   next.end();
  *
- *   push();
- *   texture(next);
- *   plane(width, -height);
- *   pop();
+ *   image(next, -width/2, -height/2);
  * }
  * </code>
  * </div>

--- a/src/core/rendering.js
+++ b/src/core/rendering.js
@@ -264,7 +264,6 @@ p5.prototype.createGraphics = function(w, h, renderer) {
  * - `height`: The height of the texture. Defaults to matching the main canvas.
  * - `density`: The pixel density of the texture. Defaults to the pixel density of the main canvas.
  * - `textureSmoothing`: A boolean, whether or not to interpolate between nearby pixels when reading values from the color texture. Generally, turn this on when using the texture as an image, and turn it off if reading the texture as data. Defaults to true.
- * - `depthTextureSmoothing`: A boolean, whether or not to interpolate between nearby pixels when reading values from the depth texture. Generally, turn this on when using the texture as an image, and turn it off if reading the texture as data. Defaults to false.
  *
  * If `width`, `height`, or `density` are specified, then the framebuffer will
  * keep that size until manually changed. Otherwise, it will be autosized, and
@@ -273,6 +272,58 @@ p5.prototype.createGraphics = function(w, h, renderer) {
  *
  * @method createFramebuffer
  * @param {Object} [options] An optional object with configuration
+ *
+ * @example
+ * <div>
+ * <code>
+ * let prev, next, cam;
+ * function setup() {
+ *   createCanvas(100, 100, WEBGL);
+ *   prev = createFramebuffer({ format: FLOAT });
+ *   next = createFramebuffer({ format: FLOAT });
+ *   cam = createCamera();
+ *   noStroke();
+ * }
+ *
+ * function draw() {
+ *   // Swap prev and next so that we can use the previous
+ *   // frame as a texture when drawing the current frame
+ *   [prev, next] = [next, prev];
+ *
+ *   // Draw to the framebuffer
+ *   next.begin();
+ *   background(255);
+ *
+ *   push();
+ *   // Draw the previous texture farther away, but scaled
+ *   // up to fill the screen, plus a bit extra scale so it grows
+ *   translate(0, 0, -200);
+ *   scale(1.001 * (200 + cam.eyeZ) / cam.eyeZ);
+ *   texture(prev);
+ *   tint(255, 253);
+ *   plane(width, -height);
+ *   pop();
+ *
+ *   push();
+ *   normalMaterial();
+ *   translate(25*sin(frameCount * 0.014), 25*sin(frameCount * 0.02), 0);
+ *   rotateX(frameCount * 0.01);
+ *   rotateY(frameCount * 0.01);
+ *   box(12);
+ *   pop();
+ *   next.end();
+ *
+ *   push();
+ *   texture(next);
+ *   plane(width, -height);
+ *   pop();
+ * }
+ * </code>
+ * </div>
+ *
+ * @alt
+ * A red, green, and blue box (using normalMaterial) moves and rotates around
+ * the canvas, leaving a trail behind it that slowly grows and fades away.
  */
 p5.prototype.createFramebuffer = function(options) {
   return new p5.Framebuffer(this, options);

--- a/src/core/rendering.js
+++ b/src/core/rendering.js
@@ -259,9 +259,14 @@ p5.prototype.createGraphics = function(w, h, renderer) {
  * - `channels`: What color channels to store, either `RGB` or `RGBA`. The default is to match the channels in the main canvas (with alpha unless disabled with `setAttributes`.)
  * - `depthFormat`: The data format for depth information, either `UNSIGNED_BYTE` or `FLOAT`. The default is `UNSIGNED_BYTE` if `format` is that as well, or `FLOAT` otherwise.
  * - `antialias`: Boolean, whether or not to render with antialiased edges. Defaults to whether or not the main canvas is antialiased. Antialiasing is only supported when WebGL 2 is available.
- * - `width`: The width of the texture. Defaults to matching the main canvas. If unspecified, the framebuffer will resize when the main canvas resizes.
- * - `height`: The height of the texture. Defaults to matching the main canvas. If unspecified, the framebuffer will resize when the main canvas resizes.
+ * - `width`: The width of the texture. Defaults to matching the main canvas.
+ * - `height`: The height of the texture. Defaults to matching the main canvas.
  * - `density`: The pixel density of the texture. Defaults to the pixel density of the main canvas.
+ *
+ * If `width`, `height`, or `density` are specified, then the framebuffer will
+ * keep that size until manually changed. Otherwise, it will be autosized, and
+ * it will update to match the main canvas's size and density when the main
+ * canvas changes.
  *
  * @method createFramebuffer
  * @param {Object} [options] An optional object with configuration

--- a/src/core/rendering.js
+++ b/src/core/rendering.js
@@ -259,7 +259,7 @@ p5.prototype.createGraphics = function(w, h, renderer) {
  * - `channels`: What color channels to store, either `RGB` or `RGBA`. The default is to match the channels in the main canvas (with alpha unless disabled with `setAttributes`.)
  * - `depth`: A boolean, whether or not to include a depth buffer. Defaults to true.
  * - `depthFormat`: The data format for depth information, either `UNSIGNED_BYTE` or `FLOAT`. The default is `UNSIGNED_BYTE` if `format` is that as well, or `FLOAT` otherwise.
- * - `antialias`: Boolean, whether or not to render with antialiased edges. Defaults to whether or not the main canvas is antialiased. Antialiasing is only supported when WebGL 2 is available.
+ * - `antialias`: Boolean or Number, whether or not to render with antialiased edges, and if so, optionally the number of samples to use. Defaults to whether or not the main canvas is antialiased. Antialiasing is only supported when WebGL 2 is available.
  * - `width`: The width of the texture. Defaults to matching the main canvas.
  * - `height`: The height of the texture. Defaults to matching the main canvas.
  * - `density`: The pixel density of the texture. Defaults to the pixel density of the main canvas.

--- a/src/core/rendering.js
+++ b/src/core/rendering.js
@@ -258,12 +258,12 @@ p5.prototype.createGraphics = function(w, h, renderer) {
  * - `format`: The data format of the texture, either `UNSIGNED_BYTE`, `FLOAT`, or `HALF_FLOAT`. The default is `UNSIGNED_BYTE`.
  * - `channels`: What color channels to store, either `RGB` or `RGBA`. The default is to match the channels in the main canvas (with alpha unless disabled with `setAttributes`.)
  * - `depth`: A boolean, whether or not to include a depth buffer. Defaults to true.
- * - `depthFormat`: The data format for depth information, either `UNSIGNED_BYTE` or `FLOAT`. The default is `UNSIGNED_BYTE` if `format` is that as well, or `FLOAT` otherwise.
+ * - `depthFormat`: The data format for depth information, either `UNSIGNED_INT` or `FLOAT`. The default is `FLOAT` if available, or `UNSIGNED_INT` otherwise.
  * - `antialias`: Boolean or Number, whether or not to render with antialiased edges, and if so, optionally the number of samples to use. Defaults to whether or not the main canvas is antialiased, using a default of 2 samples if so. Antialiasing is only supported when WebGL 2 is available.
  * - `width`: The width of the texture. Defaults to matching the main canvas.
  * - `height`: The height of the texture. Defaults to matching the main canvas.
  * - `density`: The pixel density of the texture. Defaults to the pixel density of the main canvas.
- * - `textureFiltering`: A boolean, whether or not to interpolate between nearby pixels when reading values from the color texture. Generally, turn this on when using the texture as an image, and turn it off if reading the texture as data. Defaults to true.
+ * - `textureFiltering`: Either `LINEAR` (nearby pixels will be interpolated when reading values from the color texture) or `NEAREST` (no interpolation.) Generally, use `LINEAR` when using the texture as an image, and use `NEAREST` if reading the texture as data. Defaults to `LINEAR`.
  *
  * If `width`, `height`, or `density` are specified, then the framebuffer will
  * keep that size until manually changed. Otherwise, it will be autosized, and

--- a/src/image/loading_displaying.js
+++ b/src/image/loading_displaying.js
@@ -822,7 +822,7 @@ function _sAssign(sVal, iVal) {
  *
  *
  * @method image
- * @param  {p5.Image|p5.Element|p5.Texture} img    the image to display
+ * @param  {p5.Image|p5.Element|p5.Texture|p5.Framebuffer|p5.FramebufferTexture} img    the image to display
  * @param  {Number}   x     the x-coordinate of the top-left corner of the image
  * @param  {Number}   y     the y-coordinate of the top-left corner of the image
  * @param  {Number}   [width]  the width to draw the image
@@ -924,7 +924,7 @@ function _sAssign(sVal, iVal) {
  */
 /**
  * @method image
- * @param  {p5.Image|p5.Element|p5.Texture} img
+ * @param  {p5.Image|p5.Element|p5.Texture|p5.Framebuffer|p5.FramebufferTexture} img
  * @param  {Number}   dx     the x-coordinate of the destination
  *                           rectangle in which to draw the source image
  * @param  {Number}   dy     the y-coordinate of the destination

--- a/src/webgl/material.js
+++ b/src/webgl/material.js
@@ -389,7 +389,7 @@ p5.prototype.resetShader = function() {
  * <a href="https://p5js.org/examples/3d-materials.html">example</a>.
  *
  * @method texture
- * @param {p5.Image|p5.MediaElement|p5.Graphics|p5.Texture} tex  image to use as texture
+ * @param {p5.Image|p5.MediaElement|p5.Graphics|p5.Texture|p5.Framebuffer|p5.FramebufferTexture} tex  image to use as texture
  * @chainable
  * @example
  * <div>

--- a/src/webgl/material.js
+++ b/src/webgl/material.js
@@ -666,9 +666,8 @@ p5.prototype.textureWrap = function(wrapX, wrapY = wrapX) {
   this._renderer.textureWrapX = wrapX;
   this._renderer.textureWrapY = wrapY;
 
-  const textures = this._renderer.textures;
-  for (let i = 0; i < textures.length; i++) {
-    textures[i].setWrapMode(wrapX, wrapY);
+  for (const texture of this._renderer.textures.values()) {
+    texture.setWrapMode(wrapX, wrapY);
   }
 };
 

--- a/src/webgl/p5.Camera.js
+++ b/src/webgl/p5.Camera.js
@@ -470,6 +470,7 @@ p5.Camera = function(renderer) {
 
   this.cameraMatrix = new p5.Matrix();
   this.projMatrix = new p5.Matrix();
+  this.yScale = 1;
 };
 /**
  * camera position value on x axis
@@ -811,7 +812,7 @@ p5.Camera.prototype.perspective = function(fovy, aspect, near, far) {
 
   /* eslint-disable indent */
   this.projMatrix.set(f / aspect,  0,                     0,  0,
-                      0,          -f,                     0,  0,
+                      0,          -f * this.yScale,       0,  0,
                       0,           0,     (far + near) * nf, -1,
                       0,           0, (2 * far * near) * nf,  0);
   /* eslint-enable indent */
@@ -895,7 +896,7 @@ p5.Camera.prototype.ortho = function(left, right, bottom, top, near, far) {
   const d = far - near;
 
   const x = +2.0 / w;
-  const y = +2.0 / h;
+  const y = +2.0 / h * this.yScale;
   const z = -2.0 / d;
 
   const tx = -(right + left) / w;
@@ -991,7 +992,7 @@ p5.Camera.prototype.frustum = function(left, right, bottom, top, near, far) {
   const d = far - near;
 
   const x = +(2.0 * near) / w;
-  const y = +(2.0 * near) / h;
+  const y = +(2.0 * near) / h * this.yScale;
   const z = -(2.0 * far * near) / d;
 
   const tx = (right + left) / w;

--- a/src/webgl/p5.Framebuffer.js
+++ b/src/webgl/p5.Framebuffer.js
@@ -110,14 +110,8 @@ class Framebuffer {
         : constants.RGB
     );
     this.useDepth = settings.depth === undefined ? true : settings.depth;
-    this.depthFormat = settings.depthFormat || (
-      this.format === constants.UNSIGNED_BYTE
-        ? constants.UNSIGNED_BYTE
-        : constants.FLOAT
-    );
-    this.textureFiltering = settings.textureFiltering === undefined
-      ? true
-      : settings.textureFiltering;
+    this.depthFormat = settings.depthFormat || constants.FLOAT;
+    this.textureFiltering = settings.textureFiltering || constants.LINEAR;
     if (settings.antialias === undefined) {
       this.antialiasSamples = target._renderer._pInst._glAttributes.antialias
         ? 2
@@ -303,9 +297,9 @@ class Framebuffer {
     ) {
       console.warn(
         'FLOAT depth format is unavailable in WebGL 1. ' +
-          'Defaulting to UNSIGNED_BYTE.'
+          'Defaulting to UNSIGNED_INT.'
       );
-      this.depthFormat = constants.UNSIGNED_BYTE;
+      this.depthFormat = constants.UNSIGNED_INT;
     }
 
     if (![
@@ -321,14 +315,14 @@ class Framebuffer {
       this.format = constants.UNSIGNED_BYTE;
     }
     if (this.useDepth && ![
-      constants.UNSIGNED_BYTE,
+      constants.UNSIGNED_INT,
       constants.FLOAT
     ].includes(this.depthFormat)) {
       console.warn(
         'Unknown Framebuffer depth format. ' +
-          'Please use UNSIGNED_BYTE or FLOAT. Defaulting to UNSIGNED_BYTE.'
+          'Please use UNSIGNED_INT or FLOAT. Defaulting to FLOAT.'
       );
-      this.depthFormat = constants.UNSIGNED_BYTE;
+      this.depthFormat = constants.FLOAT;
     }
 
     const support = checkWebGLCapabilities(this.target._renderer);
@@ -346,9 +340,9 @@ class Framebuffer {
     ) {
       console.warn(
         'This environment does not support FLOAT depth textures. ' +
-          'Falling back to UNSIGNED_BYTE.'
+          'Falling back to UNSIGNED_INT.'
       );
-      this.depthFormat = constants.UNSIGNED_BYTE;
+      this.depthFormat = constants.UNSIGNED_INT;
     }
     if (!support.halfFloat && this.format === constants.HALF_FLOAT) {
       console.warn(
@@ -504,7 +498,9 @@ class Framebuffer {
     }
 
     this.color = new FramebufferTexture(this, 'colorTexture');
-    const filter = this.textureFiltering ? gl.LINEAR : gl.NEAREST;
+    const filter = this.textureFiltering === constants.LINEAR
+      ? gl.LINEAR
+      : gl.NEAREST;
     this.colorP5Texture = new p5.Texture(
       this.target._renderer,
       this.color,

--- a/src/webgl/p5.Framebuffer.js
+++ b/src/webgl/p5.Framebuffer.js
@@ -1,0 +1,548 @@
+import p5 from '../core/main';
+import * as constants from '../core/constants';
+import { checkWebGLCapabilities } from './p5.Texture';
+
+class FramebufferCamera extends p5.Camera {
+  constructor(fbo) {
+    super(fbo.target._renderer);
+    this.fbo = fbo;
+  }
+
+  _computeCameraDefaultSettings() {
+    super._computeCameraDefaultSettings();
+    this.defaultAspectRatio = this.fbo.width / this.fbo.height;
+    this.defaultEyeZ =
+      this.fbo.height / 2.0 / Math.tan(this.defaultCameraFOV / 2.0);
+    this.defaultCameraNear = this.defaultEyeZ * 0.1;
+    this.defaultCameraFar = this.defaultEyeZ * 10;
+  }
+
+  resize() {
+    // If we're using the default camera, update the aspect ratio
+    if (this.cameraType === 'default') {
+      this._computeCameraDefaultSettings();
+      this._setDefaultCamera();
+    } else {
+      this.perspective(
+        this.cameraFOV,
+        this.fbo.width / this.fbo.height
+      );
+    }
+  }
+}
+
+p5.FramebufferCamera = FramebufferCamera;
+
+class FramebufferTexture {
+  constructor(framebuffer, property) {
+    this.framebuffer = framebuffer;
+    this.property = property;
+  }
+
+  get width() {
+    return this.framebuffer.width * this.framebuffer.density;
+  }
+
+  get height() {
+    return this.framebuffer.height * this.framebuffer.density;
+  }
+
+  rawTexture() {
+    return this.framebuffer[this.property];
+  }
+}
+
+p5.FramebufferTexture = FramebufferTexture;
+
+class Framebuffer {
+  /**
+   * @param target A p5 global instance of p5.Graphics
+   * @param settings An optional settings object
+   */
+  constructor(target, settings = {}) {
+    this.target = target;
+    this.target._renderer.framebuffers.add(this);
+
+    this.format = settings.format || constants.UNSIGNED_BYTE;
+    this.channels = settings.channels || (
+      target._renderer._glAttributes.alpha ? constants.RGBA : constants.RGB
+    );
+    this.depthFormat = settings.depthFormat || (
+      this.format === constants.UNSIGNED_BYTE
+        ? constants.UNSIGNED_BYTE
+        : constants.FLOAT
+    );
+    this.antialias = (
+      settings.antialias === undefined
+        ? target._renderer._glAttributes.antialias
+        : settings.antialias
+    );
+    if (this.antialias && target.webglVersion !== constants.WEBGL2) {
+      console.warn('Antialiasing is unsupported in a WebGL 1 context');
+      this.antialias = false;
+    }
+    if (settings.width && settings.height) {
+      this.width = settings.width;
+      this.height = settings.height;
+      this.autoSized = false;
+    } else {
+      this.width = target.width;
+      this.height = target.height;
+      this.autoSized = true;
+    }
+    this.density = settings.density || target.pixelDensity();
+
+    const gl = target._renderer.GL;
+    this.gl = gl;
+
+    this._checkIfFormatsAvailable();
+
+    this.framebuffer = gl.createFramebuffer();
+    if (!this.framebuffer) {
+      throw new Error('Unable to create a framebuffer');
+    }
+    if (this.antialias) {
+      this.aaFramebuffer = gl.createFramebuffer();
+      if (!this.aaFramebuffer) {
+        throw new Error('Unable to create a framebuffer');
+      }
+    }
+
+    this._recreateTextures();
+
+    const prevCam = this.target._renderer._curCamera;
+    this.defaultCamera = this.createCamera();
+    this.target._renderer._curCamera = prevCam;
+  }
+
+  resizeCanvas(width, height) {
+    this.autoSized = false;
+    this.width = width;
+    this.height = height;
+    this._handleResize();
+  }
+
+  pixelDensity(density) {
+    if (density) {
+      this.autoSized = false;
+      this.density = density;
+      this._handleResize();
+    } else {
+      return this.density;
+    }
+  }
+
+  autoSized(autoSized) {
+    if (autoSized === undefined) {
+      return this.autoSized;
+    } else {
+      this.autoSized = autoSized;
+      this._handleResize();
+    }
+  }
+
+  _checkIfFormatsAvailable() {
+    const gl = this.gl;
+
+    if (
+      this.target.webglVersion === constants.WEBGL &&
+      !gl.getExtension('WEBGL_depth_texture')
+    ) {
+      throw new Error('Unable to create depth textures in this environment');
+    }
+
+    if (
+      this.target.webglVersion === constants.WEBGL &&
+      this.depthFormat === constants.FLOAT
+    ) {
+      console.warn(
+        'FLOAT depth format is unavailable in WebGL 1. ' +
+          'Defaulting to UNSIGNED_BYTE.'
+      );
+      this.depthFormat = constants.UNSIGNED_BYTE;
+    }
+
+    if (![
+      constants.UNSIGNED_BYTE,
+      constants.FLOAT,
+      constants.HALF_FLOAT
+    ].includes(this.format)) {
+      console.warn(
+        'Unknown Framebuffer format. ' +
+          'Please use UNSIGNED_BYTE, FLOAT, or HALF_FLOAT. ' +
+          'Defaulting to UNSIGNED_BYTE.'
+      );
+      this.format = constants.UNSIGNED_BYTE;
+    }
+    if (![
+      constants.UNSIGNED_BYTE,
+      constants.FLOAT
+    ].includes(this.depthFormat)) {
+      console.warn(
+        'Unknown Framebuffer depth format. ' +
+          'Please use UNSIGNED_BYTE or FLOAT. Defaulting to UNSIGNED_BYTE.'
+      );
+      this.depthFormat = constants.UNSIGNED_BYTE;
+    }
+
+    const support = checkWebGLCapabilities(this.target._renderer);
+    if (!support.float && this.format === constants.FLOAT) {
+      console.warn(
+        'This environment does not support FLOAT textures. ' +
+          'Falling back to UNSIGNED_BYTE.'
+      );
+      this.format = constants.UNSIGNED_BYTE;
+    }
+    if (!support.float && this.depthFormat === constants.FLOAT) {
+      console.warn(
+        'This environment does not support FLOAT depth textures. ' +
+          'Falling back to UNSIGNED_BYTE.'
+      );
+      this.depthFormat = constants.UNSIGNED_BYTE;
+    }
+    if (!support.halfFloat && this.format === constants.HALF_FLOAT) {
+      console.warn(
+        'This environment does not support HALF_FLOAT textures. ' +
+          'Falling back to UNSIGNED_BYTE.'
+      );
+      this.format = constants.UNSIGNED_BYTE;
+    }
+
+    if (
+      this.channels === constants.RGB &&
+      [constants.FLOAT, constants.HALF_FLOAT].includes(this.format)
+    ) {
+      console.warn(
+        'FLOAT and HALF_FLOAT formats do not work cross-platform with only ' +
+          'RGB channels. Falling back to RGBA.'
+      );
+      this.channels = constants.RGBA;
+    }
+  }
+
+  _recreateTextures() {
+    const gl = this.gl;
+
+    this._updateSize();
+
+    const prevBoundTexture = gl.getParameter(gl.TEXTURE_BINDING_2D);
+    const prevBoundFramebuffer = gl.getParameter(gl.FRAMEBUFFER_BINDING);
+
+    const colorTexture = gl.createTexture();
+    if (!colorTexture) {
+      throw new Error('Unable to create color texture');
+    }
+    gl.bindTexture(gl.TEXTURE_2D, colorTexture);
+    const colorFormat = this._glColorFormat();
+    gl.texImage2D(
+      gl.TEXTURE_2D,
+      0,
+      colorFormat.internalFormat,
+      this.width * this.density,
+      this.height * this.density,
+      0,
+      colorFormat.format,
+      colorFormat.type,
+      null
+    );
+
+    // Create the depth texture
+    const depthTexture = gl.createTexture();
+    if (!depthTexture) {
+      throw new Error('Unable to create depth texture');
+    }
+    const depthFormat = this._glDepthFormat();
+    gl.bindTexture(gl.TEXTURE_2D, depthTexture);
+    gl.texImage2D(
+      gl.TEXTURE_2D,
+      0,
+      depthFormat.internalFormat,
+      this.width * this.density,
+      this.height * this.density,
+      0,
+      depthFormat.format,
+      depthFormat.type,
+      null
+    );
+
+    gl.bindFramebuffer(gl.FRAMEBUFFER, this.framebuffer);
+    gl.framebufferTexture2D(
+      gl.FRAMEBUFFER,
+      gl.COLOR_ATTACHMENT0,
+      gl.TEXTURE_2D,
+      colorTexture,
+      0
+    );
+    gl.framebufferTexture2D(
+      gl.FRAMEBUFFER,
+      gl.DEPTH_ATTACHMENT,
+      gl.TEXTURE_2D,
+      depthTexture,
+      0
+    );
+
+    // Create separate framebuffer for antialiasing
+    if (this.antialias) {
+      this.colorRenderbuffer = gl.createRenderbuffer();
+      gl.bindRenderbuffer(gl.RENDERBUFFER, this.colorRenderbuffer);
+      gl.renderbufferStorageMultisample(
+        gl.RENDERBUFFER,
+        Math.min(4, gl.getParameter(gl.MAX_SAMPLES)),
+        colorFormat.internalFormat,
+        this.width * this.density,
+        this.height * this.density
+      );
+
+      this.depthRenderbuffer = gl.createRenderbuffer();
+      gl.bindRenderbuffer(gl.RENDERBUFFER, this.depthRenderbuffer);
+      gl.renderbufferStorageMultisample(
+        gl.RENDERBUFFER,
+        Math.min(4, gl.getParameter(gl.MAX_SAMPLES)),
+        depthFormat.internalFormat,
+        this.width * this.density,
+        this.height * this.density
+      );
+
+      gl.bindFramebuffer(gl.FRAMEBUFFER, this.aaFramebuffer);
+      gl.framebufferRenderbuffer(
+        gl.FRAMEBUFFER,
+        gl.COLOR_ATTACHMENT0,
+        gl.RENDERBUFFER,
+        this.colorRenderbuffer
+      );
+      gl.framebufferRenderbuffer(
+        gl.FRAMEBUFFER,
+        gl.DEPTH_ATTACHMENT,
+        gl.RENDERBUFFER,
+        this.depthRenderbuffer
+      );
+    }
+
+    this.depthTexture = depthTexture;
+    this.colorTexture = colorTexture;
+
+    this.depth = new FramebufferTexture(this, 'depthTexture');
+    const depthP5Texture = new p5.Texture(
+      this.target._renderer,
+      this.depth,
+      {
+        minFilter: gl.NEAREST,
+        magFilter: gl.NEAREST
+      }
+    );
+    this.target._renderer.textures.set(this.color, depthP5Texture);
+
+    this.color = new FramebufferTexture(this, 'colorTexture');
+    const colorP5Texture = new p5.Texture(
+      this.target._renderer,
+      this.color,
+      {
+        glMinFilter: gl.LINEAR,
+        glMagFilter: gl.LINEAR
+      }
+    );
+    this.target._renderer.textures.set(this.color, colorP5Texture);
+
+    gl.bindTexture(gl.TEXTURE_2D, prevBoundTexture);
+    gl.bindFramebuffer(gl.FRAMEBUFFER, prevBoundFramebuffer);
+  }
+
+  _glColorFormat() {
+    let type, format, internalFormat;
+    const gl = this.gl;
+
+    if (this.format === constants.FLOAT) {
+      type = gl.FLOAT;
+    } else if (this.format === constants.HALF_FLOAT) {
+      type = this.target.webglVersion === constants.WEBGL2
+        ? gl.HALF_FLOAT
+        : gl.getExtension('OES_texture_half_float').HALF_FLOAT_OES;
+    } else {
+      type = gl.UNSIGNED_BYTE;
+    }
+
+    if (this.channels === constants.RGBA) {
+      format = gl.RGBA;
+    } else {
+      format = gl.RGB;
+    }
+
+    if (this.target.webglVersion === constants.WEBGL2) {
+      // https://webgl2fundamentals.org/webgl/lessons/webgl-data-textures.html
+      const table = {
+        [gl.FLOAT]: {
+          [gl.RGBA]: gl.RGBA32F
+          // gl.RGB32F is not available in Firefox without an alpha channel
+        },
+        [gl.HALF_FLOAT]: {
+          [gl.RGBA]: gl.RGBA16F
+          // gl.RGB16F is not available in Firefox without an alpha channel
+        },
+        [gl.UNSIGNED_BYTE]: {
+          [gl.RGBA]: gl.RGBA8, // gl.RGBA4
+          [gl.RGB]: gl.RGB8 // gl.RGB565
+        }
+      };
+      internalFormat = table[type][format];
+    } else if (this.format === constants.HALF_FLOAT) {
+      internalFormat = gl.RGBA;
+    } else {
+      internalFormat = format;
+    }
+
+    return { internalFormat, format, type };
+  }
+
+  _glDepthFormat() {
+    let type, format, internalFormat;
+    const gl = this.gl;
+
+    if (this.depthFormat === constants.FLOAT) {
+      type = gl.FLOAT;
+    } else {
+      type = gl.UNSIGNED_INT;
+    }
+
+    format = gl.DEPTH_COMPONENT;
+
+    if (this.target.webglVersion === constants.WEBGL2) {
+      if (this.depthFormat === constants.FLOAT) {
+        internalFormat = gl.DEPTH_COMPONENT32F;
+      } else {
+        internalFormat = gl.DEPTH_COMPONENT24;
+      }
+    } else {
+      internalFormat = gl.DEPTH_COMPONENT;
+    }
+
+    return { internalFormat, format, type };
+  }
+
+  _updateSize() {
+    if (this.autoSized) {
+      this.width = this.target.width;
+      this.height = this.target.height;
+      this.density = this.target.pixelDensity();
+    }
+  }
+
+  _handleResize() {
+    this.cam.resize();
+
+    const oldColor = this.color;
+    const oldDepth = this.depth;
+    const oldColorRenderbuffer = this.colorRenderbuffer;
+    const oldDepthRenderbuffer = this.depthRenderbuffer;
+
+    this.recreateTextures();
+
+    this._deleteTexture(oldColor);
+    this._deleteTexture(oldDepth);
+    const gl = this.gl;
+    if (oldColorRenderbuffer) gl.deleteRenderbuffer(oldColorRenderbuffer);
+    if (oldDepthRenderbuffer) gl.deleteRenderbuffer(oldDepthRenderbuffer);
+  }
+
+  createCamera() {
+    const cam = new FramebufferCamera(this);
+    cam._computeCameraDefaultSettings();
+    cam._setDefaultCamera();
+    this.target._renderer._curCamera = cam;
+    return cam;
+  }
+
+  _deleteTexture(texture) {
+    const gl = this.gl;
+    gl.deleteTexture(texture.rawTexture());
+
+    this.target._renderer.textures.delete(texture);
+  }
+
+  remove() {
+    const gl = this.gl;
+    this._deleteTexture(this.color);
+    this._deleteTexture(this.depth);
+    gl.deleteFramebuffer(this.framebuffer);
+    if (this.aaFramebuffer) {
+      gl.deleteFramebuffer(this.aaFramebuffer);
+    }
+    if (this.depthRenderbuffer) {
+      gl.deleteRenderbuffer(this.depthRenderbuffer);
+    }
+    if (this.colorRenderbuffer) {
+      gl.deleteRenderbuffer(this.colorRenderbuffer);
+    }
+    this.target._renderer.framebuffers.delete(this);
+  }
+
+  begin() {
+    const gl = this.gl;
+    this.prevFramebuffer = gl.getParameter(gl.FRAMEBUFFER_BINDING);
+    if (this.antialias) {
+      gl.bindFramebuffer(gl.FRAMEBUFFER, this.aaFramebuffer);
+    } else {
+      gl.bindFramebuffer(gl.FRAMEBUFFER, this.framebuffer);
+    }
+    this.prevViewport = gl.getParameter(gl.VIEWPORT);
+    gl.viewport(
+      0,
+      0,
+      this.width * this.density,
+      this.height * this.density
+    );
+    this.target.push();
+    this.target.setCamera(this.defaultCamera);
+    this.target._renderer.uMVMatrix.set(
+      this.target._renderer._curCamera.cameraMatrix.mat4[0],
+      this.target._renderer._curCamera.cameraMatrix.mat4[1],
+      this.target._renderer._curCamera.cameraMatrix.mat4[2],
+      this.target._renderer._curCamera.cameraMatrix.mat4[3],
+      this.target._renderer._curCamera.cameraMatrix.mat4[4],
+      this.target._renderer._curCamera.cameraMatrix.mat4[5],
+      this.target._renderer._curCamera.cameraMatrix.mat4[6],
+      this.target._renderer._curCamera.cameraMatrix.mat4[7],
+      this.target._renderer._curCamera.cameraMatrix.mat4[8],
+      this.target._renderer._curCamera.cameraMatrix.mat4[9],
+      this.target._renderer._curCamera.cameraMatrix.mat4[10],
+      this.target._renderer._curCamera.cameraMatrix.mat4[11],
+      this.target._renderer._curCamera.cameraMatrix.mat4[12],
+      this.target._renderer._curCamera.cameraMatrix.mat4[13],
+      this.target._renderer._curCamera.cameraMatrix.mat4[14],
+      this.target._renderer._curCamera.cameraMatrix.mat4[15]
+    );
+  }
+
+  end() {
+    const gl = this.gl;
+    if (this.antialias) {
+      gl.bindFramebuffer(gl.READ_FRAMEBUFFER, this.aaFramebuffer);
+      gl.bindFramebuffer(gl.DRAW_FRAMEBUFFER, this.framebuffer);
+      for (const [flag, filter] of [
+        [gl.COLOR_BUFFER_BIT, gl.LINEAR],
+        [gl.DEPTH_BUFFER_BIT, gl.NEAREST]
+      ]) {
+        gl.blitFramebuffer(
+          0, 0,
+          this.width * this.density, this.height * this.density,
+          0, 0,
+          this.width * this.density, this.height * this.density,
+          flag,
+          filter
+        );
+      }
+    }
+    gl.bindFramebuffer(gl.FRAMEBUFFER, this.prevFramebuffer);
+    gl.viewport(...this.prevViewport);
+    this.target.pop();
+  }
+
+  draw(callback) {
+    this.begin();
+    callback();
+    this.end();
+  }
+}
+
+p5.Framebuffer = Framebuffer;
+
+export default Framebuffer;

--- a/src/webgl/p5.Framebuffer.js
+++ b/src/webgl/p5.Framebuffer.js
@@ -114,6 +114,8 @@ class Framebuffer {
         ? constants.UNSIGNED_BYTE
         : constants.FLOAT
     );
+    this.textureSmoothing = settings.textureSmoothing || true;
+    this.depthTextureSmoothing = settings.depthTextureSmoothing || false;
     if (settings.antialias === undefined) {
       this.antialiasSamples = target._pInst._glAttributes.antialias
         ? 2
@@ -399,7 +401,10 @@ class Framebuffer {
       gl.bindRenderbuffer(gl.RENDERBUFFER, this.colorRenderbuffer);
       gl.renderbufferStorageMultisample(
         gl.RENDERBUFFER,
-        Math.min(this.antialiasSamples, gl.getParameter(gl.MAX_SAMPLES)),
+        Math.max(
+          0,
+          Math.min(this.antialiasSamples, gl.getParameter(gl.MAX_SAMPLES))
+        ),
         colorFormat.internalFormat,
         this.width * this.density,
         this.height * this.density
@@ -410,7 +415,10 @@ class Framebuffer {
         gl.bindRenderbuffer(gl.RENDERBUFFER, this.depthRenderbuffer);
         gl.renderbufferStorageMultisample(
           gl.RENDERBUFFER,
-          Math.min(this.antialiasSamples, gl.getParameter(gl.MAX_SAMPLES)),
+          Math.max(
+            0,
+            Math.min(this.antialiasSamples, gl.getParameter(gl.MAX_SAMPLES))
+          ),
           depthFormat.internalFormat,
           this.width * this.density,
           this.height * this.density
@@ -436,24 +444,26 @@ class Framebuffer {
 
     if (this.useDepth) {
       this.depth = new FramebufferTexture(this, 'depthTexture');
+      const depthFilter = this.depthTextureSmoothing ? gl.LINEAR : gl.NEAREST;
       this.depthP5Texture = new p5.Texture(
         this.target._renderer,
         this.depth,
         {
-          minFilter: gl.NEAREST,
-          magFilter: gl.NEAREST
+          minFilter: depthFilter,
+          magFilter: depthFilter
         }
       );
       this.target._renderer.textures.set(this.depth, this.depthP5Texture);
     }
 
     this.color = new FramebufferTexture(this, 'colorTexture');
+    const filter = this.textureSmoothing ? gl.LINEAR : gl.NEAREST;
     this.colorP5Texture = new p5.Texture(
       this.target._renderer,
       this.color,
       {
-        glMinFilter: gl.LINEAR,
-        glMagFilter: gl.LINEAR
+        glMinFilter: filter,
+        glMagFilter: filter
       }
     );
     this.target._renderer.textures.set(this.color, this.colorP5Texture);

--- a/src/webgl/p5.Framebuffer.js
+++ b/src/webgl/p5.Framebuffer.js
@@ -37,8 +37,9 @@ class FramebufferCamera extends p5.Camera {
    * the p5.Framebuffer it is attached to.
    *
    * @method resize
+   * @private
    */
-  resize() {
+  _resize() {
     // If we're using the default camera, update the aspect ratio
     if (this.cameraType === 'default') {
       this._computeCameraDefaultSettings();
@@ -114,9 +115,9 @@ class Framebuffer {
         ? constants.UNSIGNED_BYTE
         : constants.FLOAT
     );
-    this.textureSmoothing = settings.textureSmoothing === undefined
+    this.textureFiltering = settings.textureFiltering === undefined
       ? true
-      : settings.textureSmoothing;
+      : settings.textureFiltering;
     if (settings.antialias === undefined) {
       this.antialiasSamples = target._renderer._pInst._glAttributes.antialias
         ? 2
@@ -503,7 +504,7 @@ class Framebuffer {
     }
 
     this.color = new FramebufferTexture(this, 'colorTexture');
-    const filter = this.textureSmoothing ? gl.LINEAR : gl.NEAREST;
+    const filter = this.textureFiltering ? gl.LINEAR : gl.NEAREST;
     this.colorP5Texture = new p5.Texture(
       this.target._renderer,
       this.color,
@@ -666,7 +667,7 @@ class Framebuffer {
     if (oldDepthRenderbuffer) gl.deleteRenderbuffer(oldDepthRenderbuffer);
 
     this._recreateTextures();
-    this.defaultCamera.resize();
+    this.defaultCamera._resize();
   }
 
   /**

--- a/src/webgl/p5.Framebuffer.js
+++ b/src/webgl/p5.Framebuffer.js
@@ -56,8 +56,10 @@ p5.FramebufferTexture = FramebufferTexture;
 
 class Framebuffer {
   /**
-   * @param target A p5 global instance of p5.Graphics
-   * @param settings An optional settings object
+   * @class p5.Framebuffer
+   * @constructor
+   * @param {p5.Graphics|p5} target A p5 global instance or p5.Graphics
+   * @param {Object} [settings] A settings object
    */
   constructor(target, settings = {}) {
     this.target = target;

--- a/src/webgl/p5.Framebuffer.js
+++ b/src/webgl/p5.Framebuffer.js
@@ -114,11 +114,16 @@ class Framebuffer {
         ? constants.UNSIGNED_BYTE
         : constants.FLOAT
     );
-    this.antialias = (
-      settings.antialias === undefined
-        ? target._pInst._glAttributes.antialias
-        : settings.antialias
-    );
+    if (settings.antialias === undefined) {
+      this.antialiasSamples = target._pInst._glAttributes.antialias
+        ? 2
+        : 0;
+    } else if (typeof settings.antialias === 'number') {
+      this.antialiasSamples = settings.antialias;
+    } else {
+      this.antialiasSamples = settings.antialias ? 2 : 0;
+    }
+    this.antialias = this.antialiasSamples > 0;
     if (this.antialias && target.webglVersion !== constants.WEBGL2) {
       console.warn('Antialiasing is unsupported in a WebGL 1 context');
       this.antialias = false;
@@ -394,7 +399,7 @@ class Framebuffer {
       gl.bindRenderbuffer(gl.RENDERBUFFER, this.colorRenderbuffer);
       gl.renderbufferStorageMultisample(
         gl.RENDERBUFFER,
-        Math.min(2, gl.getParameter(gl.MAX_SAMPLES)),
+        Math.min(this.antialiasSamples, gl.getParameter(gl.MAX_SAMPLES)),
         colorFormat.internalFormat,
         this.width * this.density,
         this.height * this.density
@@ -405,7 +410,7 @@ class Framebuffer {
         gl.bindRenderbuffer(gl.RENDERBUFFER, this.depthRenderbuffer);
         gl.renderbufferStorageMultisample(
           gl.RENDERBUFFER,
-          Math.min(2, gl.getParameter(gl.MAX_SAMPLES)),
+          Math.min(this.antialiasSamples, gl.getParameter(gl.MAX_SAMPLES)),
           depthFormat.internalFormat,
           this.width * this.density,
           this.height * this.density

--- a/src/webgl/p5.Framebuffer.js
+++ b/src/webgl/p5.Framebuffer.js
@@ -65,7 +65,9 @@ class Framebuffer {
 
     this.format = settings.format || constants.UNSIGNED_BYTE;
     this.channels = settings.channels || (
-      target._renderer._glAttributes.alpha ? constants.RGBA : constants.RGB
+      target._renderer._pInst._glAttributes.alpha
+        ? constants.RGBA
+        : constants.RGB
     );
     this.depthFormat = settings.depthFormat || (
       this.format === constants.UNSIGNED_BYTE
@@ -74,7 +76,7 @@ class Framebuffer {
     );
     this.antialias = (
       settings.antialias === undefined
-        ? target._renderer._glAttributes.antialias
+        ? target._pInst._glAttributes.antialias
         : settings.antialias
     );
     if (this.antialias && target.webglVersion !== constants.WEBGL2) {
@@ -330,7 +332,7 @@ class Framebuffer {
         magFilter: gl.NEAREST
       }
     );
-    this.target._renderer.textures.set(this.color, depthP5Texture);
+    this.target._renderer.textures.set(this.depth, depthP5Texture);
 
     this.color = new FramebufferTexture(this, 'colorTexture');
     const colorP5Texture = new p5.Texture(

--- a/src/webgl/p5.Framebuffer.js
+++ b/src/webgl/p5.Framebuffer.js
@@ -21,6 +21,12 @@ class FramebufferCamera extends p5.Camera {
   constructor(framebuffer) {
     super(framebuffer.target._renderer);
     this.fbo = framebuffer;
+
+    // WebGL textures are upside-down compared to textures that come from
+    // images and graphics. Framebuffer cameras need to invert their y
+    // axes when being rendered to so that the texture comes out rightway up
+    // when read in shaders or image().
+    this.yScale = -1;
   }
 
   _computeCameraDefaultSettings() {
@@ -201,14 +207,7 @@ class Framebuffer {
    *
    *   background(100);
    *   // Draw the framebuffer to the main canvas
-   *   push();
-   *   translate(
-   *     -width / 2 + framebuffer.width / 2,
-   *     -height / 2 + framebuffer.height / 2
-   *   );
-   *   texture(framebuffer);
-   *   plane(framebuffer.width, -framebuffer.height);
-   *   pop();
+   *   image(framebuffer, -width/2, -height/2);
    * }
    * </code>
    * </div>
@@ -732,11 +731,7 @@ class Framebuffer {
    *     box(30);
    *     framebuffer.end();
    *
-   *     push();
-   *     noStroke();
-   *     texture(framebuffer);
-   *     plane(width, -height);
-   *     pop();
+   *     image(framebuffer, -width/2, -height/2);
    *   }
    * }
    * </code>
@@ -795,15 +790,8 @@ class Framebuffer {
    *
    *   background(100);
    *   // Draw the framebuffer to the main canvas
-   *   texture(framebuffer);
-   *   push();
-   *   translate(-25, -25);
-   *   plane(25, 25);
-   *   pop();
-   *   push();
-   *   translate(15, 15);
-   *   plane(35, 35);
-   *   pop();
+   *   image(framebuffer, -50, -50, 25, 25);
+   *   image(framebuffer, 0, 0, 35, 35);
    * }
    * </code>
    * </div>
@@ -928,17 +916,8 @@ class Framebuffer {
    *
    *   background(100);
    *   // Draw the framebuffer to the main canvas
-   *   push();
-   *   texture(framebuffer);
-   *   push();
-   *   translate(-25, -25);
-   *   plane(25, 25);
-   *   pop();
-   *   push();
-   *   translate(15, 15);
-   *   plane(35, 35);
-   *   pop();
-   *   pop();
+   *   image(framebuffer, -50, -50, 25, 25);
+   *   image(framebuffer, 0, 0, 35, 35);
    * }
    * </code>
    * </div>
@@ -987,10 +966,7 @@ class Framebuffer {
  *   framebuffer.end();
  *
  *   // Draw the framebuffer to the main canvas
- *   push();
- *   texture(framebuffer.color); // or texture(framebuffer)
- *   plane(framebuffer.width, -framebuffer.height);
- *   pop();
+ *   image(framebuffer.color, -width/2, -height/2);
  * }
  * </code>
  * </div>
@@ -1066,7 +1042,7 @@ class Framebuffer {
  *   push();
  *   shader(depthShader);
  *   depthShader.setUniform('depth', framebuffer.depth);
- *   plane(framebuffer.width, -framebuffer.height);
+ *   plane(framebuffer.width, framebuffer.height);
  *   pop();
  * }
  * </code>

--- a/src/webgl/p5.Framebuffer.js
+++ b/src/webgl/p5.Framebuffer.js
@@ -701,6 +701,49 @@ class Framebuffer {
    * Removes the framebuffer and frees its resources.
    *
    * @method remove
+   *
+   * @example
+   * <div>
+   * <code>
+   * let framebuffer;
+   * function setup() {
+   *   createCanvas(100, 100, WEBGL);
+   * }
+   *
+   * function draw() {
+   *   const useFramebuffer = (frameCount % 120) > 60;
+   *   if (useFramebuffer && !framebuffer) {
+   *     // Create a new framebuffer for us to use
+   *     framebuffer = createFramebuffer();
+   *   } else if (!useFramebuffer && framebuffer) {
+   *     // Free the old framebuffer's resources
+   *     framebuffer.remove();
+   *     framebuffer = undefined;
+   *   }
+   *
+   *   background(255);
+   *   if (useFramebuffer) {
+   *     // Draw to the framebuffer
+   *     framebuffer.begin();
+   *     background(255);
+   *     rotateX(frameCount * 0.01);
+   *     rotateY(frameCount * 0.01);
+   *     fill(255, 0, 0);
+   *     box(30);
+   *     framebuffer.end();
+   *
+   *     push();
+   *     noStroke();
+   *     texture(framebuffer);
+   *     plane(width, -height);
+   *     pop();
+   *   }
+   * }
+   * </code>
+   * </div>
+   *
+   * @alt
+   * A rotating red cube blinks on and off every second.
    */
   remove() {
     const gl = this.gl;

--- a/src/webgl/p5.RendererGL.js
+++ b/src/webgl/p5.RendererGL.js
@@ -325,6 +325,10 @@ p5.RendererGL.prototype._initContext = function() {
     gl.enable(gl.DEPTH_TEST);
     gl.depthFunc(gl.LEQUAL);
     gl.viewport(0, 0, gl.drawingBufferWidth, gl.drawingBufferHeight);
+    // Make sure all images are loaded into the canvas premultiplied so that
+    // they match the way we render colors. This will make framebuffer textures
+    // be encoded the same way as textures from everything else.
+    gl.pixelStorei(gl.UNPACK_PREMULTIPLY_ALPHA_WEBGL, true);
     this._viewport = this.drawingContext.getParameter(
       this.drawingContext.VIEWPORT
     );

--- a/src/webgl/p5.RendererGL.js
+++ b/src/webgl/p5.RendererGL.js
@@ -1346,7 +1346,7 @@ p5.RendererGL.prototype.getTexture = function(input) {
   }
 
   const tex = new p5.Texture(this, src);
-  textures.set(src, tex);
+  this.textures.set(src, tex);
   return tex;
 };
 

--- a/src/webgl/p5.RendererGL.js
+++ b/src/webgl/p5.RendererGL.js
@@ -946,7 +946,7 @@ p5.RendererGL.prototype.resize = function(w, h) {
   for (const framebuffer of this.framebuffers) {
     // Notify framebuffers of the resize so that any auto-sized framebuffers
     // can also update their size
-    framebuffer._handleResize();
+    framebuffer._canvasSizeChanged();
   }
 };
 

--- a/src/webgl/p5.RendererGL.js
+++ b/src/webgl/p5.RendererGL.js
@@ -308,10 +308,8 @@ p5.RendererGL.prototype._initContext = function() {
       this.canvas.getContext('webgl2', this._pInst._glAttributes);
   }
   this.webglVersion = this.drawingContext ? constants.WEBGL2 : constants.WEBGL;
-  if (this._isMainCanvas) {
-    // If this is the main canvas, make sure the global `webglVersion` is set
-    this._pInst._setProperty('webglVersion', this.webglVersion);
-  }
+  // If this is the main canvas, make sure the global `webglVersion` is set
+  this._pInst._setProperty('webglVersion', this.webglVersion);
   if (!this.drawingContext) {
     // If we were unable to create a WebGL2 context (either because it was
     // disabled via `setAttributes({ version: 1 })` or because the device

--- a/src/webgl/p5.RendererGL.js
+++ b/src/webgl/p5.RendererGL.js
@@ -240,8 +240,11 @@ p5.RendererGL = function(elt, pInst, isMainCanvas, attr) {
   this.curStrokeCap = constants.ROUND;
   this.curStrokeJoin = constants.ROUND;
 
-  // array of textures created in this gl context via this.getTexture(src)
-  this.textures = [];
+  // map of texture sources to textures created in this gl context via this.getTexture(src)
+  this.textures = new Map();
+
+  // set of framebuffers in use
+  this.framebuffers = new Set();
 
   this.textureMode = constants.IMAGE;
   // default wrap settings
@@ -939,6 +942,12 @@ p5.RendererGL.prototype.resize = function(w, h) {
       )
     );
   }
+
+  for (const framebuffer of this.framebuffers) {
+    // Notify framebuffers of the resize so that any auto-sized framebuffers
+    // can also update their size
+    framebuffer._handleResize();
+  }
 };
 
 /**
@@ -1325,16 +1334,24 @@ p5.RendererGL.prototype._getEmptyTexture = function() {
   return this._emptyTexture;
 };
 
-p5.RendererGL.prototype.getTexture = function(img) {
-  const textures = this.textures;
-
-  for (const texture of textures) {
-    if (texture.src === img) return texture;
+p5.RendererGL.prototype.getTexture = function(input) {
+  let src = input;
+  if (src instanceof p5.Framebuffer) {
+    src = src.color;
   }
 
-  const tex = new p5.Texture(this, img);
-  textures.push(tex);
+  const texture = this.textures.get(src);
+  if (texture) {
+    return texture;
+  }
+
+  const tex = new p5.Texture(this, src);
+  textures.set(src, tex);
   return tex;
+};
+
+p5.RendererGL.prototype.createFramebuffer = function(options) {
+  return new p5.Framebuffer(this, options);
 };
 
 p5.RendererGL.prototype._setStrokeUniforms = function(strokeShader) {

--- a/src/webgl/p5.Texture.js
+++ b/src/webgl/p5.Texture.js
@@ -455,7 +455,8 @@ p5.Texture = class Texture {
 export function checkWebGLCapabilities(renderer) {
   const gl = renderer.GL;
   const supportsFloat = renderer.webglVersion === constants.WEBGL2
-    ? gl.getExtension('EXT_color_buffer_float')
+    ? (gl.getExtension('EXT_color_buffer_float') &&
+        gl.getExtension('EXT_float_blend'))
     : gl.getExtension('OES_texture_float');
   const supportsFloatLinear = supportsFloat &&
     gl.getExtension('OES_texture_float_linear');

--- a/src/webgl/p5.Texture.js
+++ b/src/webgl/p5.Texture.js
@@ -40,7 +40,7 @@ import * as constants from '../core/constants';
  * data. Possible values are gl.UNSIGNED_BYTE or gl.FLOAT. There are more
  * formats that are not implemented in p5. Defaults to gl.UNSIGNED_BYTE.
  */
-p5.Texture = class{
+p5.Texture = class Texture {
   constructor (renderer, obj, settings) {
     this._renderer = renderer;
 
@@ -191,12 +191,12 @@ p5.Texture = class{
   }
 
   /**
- * Checks if the source data for this texture has changed (if it's
- * easy to do so) and reuploads the texture if necessary. If it's not
- * possible or to expensive to do a calculation to determine wheter or
- * not the data has occurred, this method simply re-uploads the texture.
- * @method update
- */
+   * Checks if the source data for this texture has changed (if it's
+   * easy to do so) and reuploads the texture if necessary. If it's not
+   * possible or to expensive to do a calculation to determine wheter or
+   * not the data has occurred, this method simply re-uploads the texture.
+   * @method update
+   */
   update () {
     const data = this.src;
     if (data.width === 0 || data.height === 0) {
@@ -214,8 +214,10 @@ p5.Texture = class{
 
     const gl = this._renderer.GL;
     // pull texture from data, make sure width & height are appropriate
-    if (textureData.width !== this.width ||
-       textureData.height !== this.height) {
+    if (
+      textureData.width !== this.width ||
+      textureData.height !== this.height
+    ) {
       updated = true;
 
       // make sure that if the width and height of this.src have changed
@@ -226,39 +228,39 @@ p5.Texture = class{
       if (this.isSrcP5Image) {
         data.setModified(false);
       } else if (this.isSrcMediaElement || this.isSrcHTMLElement) {
-      // on the first frame the metadata comes in, the size will be changed
-      // from 0 to actual size, but pixels may not be available.
-      // flag for update in a future frame.
-      // if we don't do this, a paused video, for example, may not
-      // send the first frame to texture memory.
+        // on the first frame the metadata comes in, the size will be changed
+        // from 0 to actual size, but pixels may not be available.
+        // flag for update in a future frame.
+        // if we don't do this, a paused video, for example, may not
+        // send the first frame to texture memory.
         data.setModified(true);
       }
     } else if (this.isSrcP5Image) {
-    // for an image, we only update if the modified field has been set,
-    // for example, by a call to p5.Image.set
+      // for an image, we only update if the modified field has been set,
+      // for example, by a call to p5.Image.set
       if (data.isModified()) {
         updated = true;
         data.setModified(false);
       }
     } else if (this.isSrcMediaElement) {
-    // for a media element (video), we'll check if the current time in
-    // the video frame matches the last time. if it doesn't match, the
-    // video has advanced or otherwise been taken to a new frame,
-    // and we need to upload it.
+      // for a media element (video), we'll check if the current time in
+      // the video frame matches the last time. if it doesn't match, the
+      // video has advanced or otherwise been taken to a new frame,
+      // and we need to upload it.
       if (data.isModified()) {
-      // p5.MediaElement may have also had set/updatePixels, etc. called
-      // on it and should be updated, or may have been set for the first
-      // time!
+        // p5.MediaElement may have also had set/updatePixels, etc. called
+        // on it and should be updated, or may have been set for the first
+        // time!
         updated = true;
         data.setModified(false);
       } else if (data.loadedmetadata) {
-      // if the meta data has been loaded, we can ask the video
-      // what it's current position (in time) is.
+        // if the meta data has been loaded, we can ask the video
+        // what it's current position (in time) is.
         if (this._videoPrevUpdateTime !== data.time()) {
-        // update the texture in gpu mem only if the current
-        // video timestamp does not match the timestamp of the last
-        // time we uploaded this texture (and update the time we
-        // last uploaded, too)
+          // update the texture in gpu mem only if the current
+          // video timestamp does not match the timestamp of the last
+          // time we uploaded this texture (and update the time we
+          // last uploaded, too)
           this._videoPrevUpdateTime = data.time();
           updated = true;
         }
@@ -269,9 +271,9 @@ p5.Texture = class{
         updated = true;
       }
     } else {
-    /* data instanceof p5.Graphics, probably */
-    // there is not enough information to tell if the texture can be
-    // conditionally updated; so to be safe, we just go ahead and upload it.
+      /* data instanceof p5.Graphics, probably */
+      // there is not enough information to tell if the texture can be
+      // conditionally updated; so to be safe, we just go ahead and upload it.
       updated = true;
     }
 
@@ -291,12 +293,12 @@ p5.Texture = class{
   }
 
   /**
- * Binds the texture to the appropriate GL target.
- * @method bindTexture
- */
+   * Binds the texture to the appropriate GL target.
+   * @method bindTexture
+   */
   bindTexture () {
-  // bind texture using gl context + glTarget and
-  // generated gl texture object
+    // bind texture using gl context + glTarget and
+    // generated gl texture object
     const gl = this._renderer.GL;
     gl.bindTexture(this.glTarget, this.getTexture());
 
@@ -304,11 +306,11 @@ p5.Texture = class{
   }
 
   /**
- * Unbinds the texture from the appropriate GL target.
- * @method unbindTexture
- */
+   * Unbinds the texture from the appropriate GL target.
+   * @method unbindTexture
+   */
   unbindTexture () {
-  // unbind per above, disable texturing on glTarget
+    // unbind per above, disable texturing on glTarget
     const gl = this._renderer.GL;
     gl.bindTexture(this.glTarget, null);
   }
@@ -322,16 +324,16 @@ p5.Texture = class{
   }
 
   /**
- * Sets how a texture is be interpolated when upscaled or downscaled.
- * Nearest filtering uses nearest neighbor scaling when interpolating
- * Linear filtering uses WebGL's linear scaling when interpolating
- * @method setInterpolation
- * @param {String} downScale Specifies the texture filtering when
- *                           textures are shrunk. Options are LINEAR or NEAREST
- * @param {String} upScale Specifies the texture filtering when
- *                         textures are magnified. Options are LINEAR or NEAREST
- * @todo implement mipmapping filters
- */
+   * Sets how a texture is be interpolated when upscaled or downscaled.
+   * Nearest filtering uses nearest neighbor scaling when interpolating
+   * Linear filtering uses WebGL's linear scaling when interpolating
+   * @method setInterpolation
+   * @param {String} downScale Specifies the texture filtering when
+   *                           textures are shrunk. Options are LINEAR or NEAREST
+   * @param {String} upScale Specifies the texture filtering when
+   *                         textures are magnified. Options are LINEAR or NEAREST
+   * @todo implement mipmapping filters
+   */
   setInterpolation (downScale, upScale) {
     const gl = this._renderer.GL;
 
@@ -354,14 +356,14 @@ p5.Texture = class{
   }
 
   /**
- * Sets the texture wrapping mode. This controls how textures behave
- * when their uv's go outside of the 0 - 1 range. There are three options:
- * CLAMP, REPEAT, and MIRROR. REPEAT & MIRROR are only available if the texture
- * is a power of two size (128, 256, 512, 1024, etc.).
- * @method setWrapMode
- * @param {String} wrapX Controls the horizontal texture wrapping behavior
- * @param {String} wrapY Controls the vertical texture wrapping behavior
- */
+   * Sets the texture wrapping mode. This controls how textures behave
+   * when their uv's go outside of the 0 - 1 range. There are three options:
+   * CLAMP, REPEAT, and MIRROR. REPEAT & MIRROR are only available if the texture
+   * is a power of two size (128, 256, 512, 1024, etc.).
+   * @method setWrapMode
+   * @param {String} wrapX Controls the horizontal texture wrapping behavior
+   * @param {String} wrapY Controls the vertical texture wrapping behavior
+   */
   setWrapMode (wrapX, wrapY) {
     const gl = this._renderer.GL;
 
@@ -410,7 +412,7 @@ p5.Texture = class{
         this.glWrapS = gl.CLAMP_TO_EDGE;
       }
     } else {
-    // falling back to default if didn't get a proper mode
+      // falling back to default if didn't get a proper mode
       this.glWrapS = gl.CLAMP_TO_EDGE;
     }
 
@@ -439,7 +441,7 @@ p5.Texture = class{
         this.glWrapT = gl.CLAMP_TO_EDGE;
       }
     } else {
-    // falling back to default if didn't get a proper mode
+      // falling back to default if didn't get a proper mode
       this.glWrapT = gl.CLAMP_TO_EDGE;
     }
 

--- a/src/webgl/shaders/light_texture.frag
+++ b/src/webgl/shaders/light_texture.frag
@@ -15,7 +15,9 @@ void main(void) {
     gl_FragColor = vColor;
   }
   else {
-    vec4 baseColor = isTexture ? texture2D(uSampler, vVertTexCoord) * (uTint / vec4(255, 255, 255, 255)) : vColor;
-    gl_FragColor = vec4(gl_FragColor.rgb * vDiffuseColor + vSpecularColor, 1.) * baseColor.a;
+    vec4 baseColor = isTexture
+      ? texture2D(uSampler, vVertTexCoord) * vec4(uTint.rgb/255., 1.) * (uTint.a/255.)
+      : vec4(vColor.rgb * vColor.a, vColor.a);
+    gl_FragColor = vec4(baseColor.rgb * vDiffuseColor + vSpecularColor, baseColor.a);
   }
 }

--- a/src/webgl/shaders/light_texture.frag
+++ b/src/webgl/shaders/light_texture.frag
@@ -16,7 +16,12 @@ void main(void) {
   }
   else {
     vec4 baseColor = isTexture
+      // Textures come in with premultiplied alpha. To apply tint and still have
+      // premultiplied alpha output, we need to multiply the RGB channels by the
+      // tint RGB, and all channels by the tint alpha.
       ? texture2D(uSampler, vVertTexCoord) * vec4(uTint.rgb/255., 1.) * (uTint.a/255.)
+      // Colors come in with unmultiplied alpha, so we need to multiply the RGB
+      // channels by alpha to convert it to premultiplied alpha.
       : vec4(vColor.rgb * vColor.a, vColor.a);
     gl_FragColor = vec4(baseColor.rgb * vDiffuseColor + vSpecularColor, baseColor.a);
   }

--- a/src/webgl/shaders/phong.frag
+++ b/src/webgl/shaders/phong.frag
@@ -24,9 +24,11 @@ void main(void) {
 
   // Calculating final color as result of all lights (plus emissive term).
 
-  vec4 baseColor = isTexture ? texture2D(uSampler, vTexCoord) * (uTint / vec4(255, 255, 255, 255)) : vColor;
+  vec4 baseColor = isTexture
+    ? texture2D(uSampler, vTexCoord) * vec4(uTint.rgb/255., 1.) * (uTint.a/255.)
+    : vec4(vColor.rgb * vColor.a, vColor.a);
   gl_FragColor = vec4(diffuse * baseColor.rgb + 
                     vAmbientColor * uAmbientMatColor.rgb + 
                     specular * uSpecularMatColor.rgb + 
-                    uEmissiveMatColor.rgb, 1.) * baseColor.a;
+                    uEmissiveMatColor.rgb, baseColor.a);
 }

--- a/src/webgl/shaders/phong.frag
+++ b/src/webgl/shaders/phong.frag
@@ -25,7 +25,12 @@ void main(void) {
   // Calculating final color as result of all lights (plus emissive term).
 
   vec4 baseColor = isTexture
+    // Textures come in with premultiplied alpha. To apply tint and still have
+    // premultiplied alpha output, we need to multiply the RGB channels by the
+    // tint RGB, and all channels by the tint alpha.
     ? texture2D(uSampler, vTexCoord) * vec4(uTint.rgb/255., 1.) * (uTint.a/255.)
+    // Colors come in with unmultiplied alpha, so we need to multiply the RGB
+    // channels by alpha to convert it to premultiplied alpha.
     : vec4(vColor.rgb * vColor.a, vColor.a);
   gl_FragColor = vec4(diffuse * baseColor.rgb + 
                     vAmbientColor * uAmbientMatColor.rgb + 

--- a/test/manual-test-examples/webgl/framebuffer/depth/index.html
+++ b/test/manual-test-examples/webgl/framebuffer/depth/index.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<html>
+
+<head>
+  <meta charset="utf-8">
+  <meta http-equiv="X-UA-Compatible" content="IE=edge">
+  <title></title>
+  <link rel="stylesheet" href="../../../styles.css">
+  <script language="javascript" type="text/javascript" src="../../../../../lib/p5.js"></script>
+  <script language="javascript" type="text/javascript" src="sketch.js"></script>
+  <script src="../../stats.js"></script>
+</head>
+
+<body>
+  <div id="gl-info">
+    <p>
+      If you click the canvas should resize without any errors.<br><br>
+      <em>Tests: setAttributes(), resizeCanvas()</em>
+    </p>
+  </div>
+</body>
+
+</html>

--- a/test/manual-test-examples/webgl/framebuffer/depth/index.html
+++ b/test/manual-test-examples/webgl/framebuffer/depth/index.html
@@ -13,10 +13,6 @@
 
 <body>
   <div id="gl-info">
-    <p>
-      If you click the canvas should resize without any errors.<br><br>
-      <em>Tests: setAttributes(), resizeCanvas()</em>
-    </p>
   </div>
 </body>
 

--- a/test/manual-test-examples/webgl/framebuffer/depth/sketch.js
+++ b/test/manual-test-examples/webgl/framebuffer/depth/sketch.js
@@ -1,0 +1,12 @@
+function setup() {
+  createCanvas(640, 480, WEBGL);
+  setAttributes('antialias', true);
+}
+
+function mouseClicked() {
+  resizeCanvas(1280, 720);
+}
+function draw() {
+  background(0);
+  ellipse(0, 0, width / 2);
+}

--- a/test/manual-test-examples/webgl/framebuffer/depth/sketch.js
+++ b/test/manual-test-examples/webgl/framebuffer/depth/sketch.js
@@ -1,12 +1,30 @@
+let fbo;
+
 function setup() {
   createCanvas(640, 480, WEBGL);
-  setAttributes('antialias', true);
+  fbo = createFramebuffer({ antialias: true });
 }
 
-function mouseClicked() {
-  resizeCanvas(1280, 720);
-}
 function draw() {
-  background(0);
-  ellipse(0, 0, width / 2);
+  fbo.begin();
+  clear();
+  rotateX(frameCount * 0.001);
+  rotateZ(frameCount * 0.0013);
+  for (let i = 0; i < 20; i++) {
+    push();
+    translate(
+      200 * sin(i),
+      200 * cos(i * 0.8),
+      200 * sin(i * 1.2)
+    );
+    box(50);
+    pop();
+  }
+  fbo.end();
+
+  push();
+  texture(fbo.depth);
+  noStroke();
+  plane(width, -height);
+  pop();
 }

--- a/test/manual-test-examples/webgl/framebuffer/feedback/index.html
+++ b/test/manual-test-examples/webgl/framebuffer/feedback/index.html
@@ -1,0 +1,26 @@
+<!DOCTYPE html>
+<html>
+
+<head>
+  <meta charset="utf-8">
+  <meta http-equiv="X-UA-Compatible" content="IE=edge">
+  <title></title>
+  <link rel="stylesheet" href="../../../styles.css">
+  <script language="javascript" type="text/javascript" src="../../../../../lib/p5.js"></script>
+  <script language="javascript" type="text/javascript" src="sketch.js"></script>
+  <script src="../../stats.js"></script>
+</head>
+
+<body>
+  <div id="gl-info">
+    <p>
+      See through rotating box with distorted perspective<br><br>
+      <em>Tests: frustum()</em>
+    </p>
+    <p>
+      Average FPS should be above 45 on a modern laptop/desktop
+    </p>
+  </div>
+</body>
+
+</html>

--- a/test/manual-test-examples/webgl/framebuffer/feedback/index.html
+++ b/test/manual-test-examples/webgl/framebuffer/feedback/index.html
@@ -13,13 +13,6 @@
 
 <body>
   <div id="gl-info">
-    <p>
-      See through rotating box with distorted perspective<br><br>
-      <em>Tests: frustum()</em>
-    </p>
-    <p>
-      Average FPS should be above 45 on a modern laptop/desktop
-    </p>
   </div>
 </body>
 

--- a/test/manual-test-examples/webgl/framebuffer/feedback/sketch.js
+++ b/test/manual-test-examples/webgl/framebuffer/feedback/sketch.js
@@ -1,0 +1,15 @@
+function setup() {
+  createCanvas(windowWidth, windowHeight, WEBGL);
+  frustum(-1.5, 1.5, -0.3, 0.3, 0.5, 1000);
+  setAttributes('antialias', true);
+}
+
+function draw() {
+  background(200);
+  rotateX(map(mouseY, 0, height, 0, TWO_PI));
+  rotateY(map(mouseX, 0, width, 0, TWO_PI));
+  noFill();
+  strokeWeight(10);
+  stroke(0, 0, 255);
+  box(500);
+}

--- a/test/manual-test-examples/webgl/framebuffer/feedback/sketch.js
+++ b/test/manual-test-examples/webgl/framebuffer/feedback/sketch.js
@@ -25,9 +25,8 @@ function draw() {
     background(255);
 
     push();
-    //scale(1.003);
-    texture(fboPrev);
-    plane(width, -height);
+    scale(1.003);
+    image(fboPrev, 0, 0);
     pop();
 
     push();
@@ -50,8 +49,5 @@ function draw() {
   });
 
   clear();
-  push();
-  texture(fboNext);
-  plane(width, -height);
-  pop();
+  image(fboNext, 0, 0);
 }

--- a/test/manual-test-examples/webgl/framebuffer/formats/index.html
+++ b/test/manual-test-examples/webgl/framebuffer/formats/index.html
@@ -1,0 +1,44 @@
+<!DOCTYPE html>
+<html>
+
+<head>
+  <meta charset="utf-8">
+  <meta http-equiv="X-UA-Compatible" content="IE=edge">
+  <title></title>
+  <link rel="stylesheet" href="../../../styles.css">
+  <script language="javascript" type="text/javascript" src="../../../../../lib/p5.js"></script>
+</head>
+
+<body>
+  <div id="controls">
+    <select id="webglVersion">
+      <option value="2" selected>WebGL 2</option>
+      <option value="1">WebGL 1</option>
+    </select>
+
+    <select id="alpha">
+      <option value="alpha" selected>Alpha</option>
+      <option value="noAlpha">No Alpha</option>
+    </select>
+
+    <select id="antialias">
+      <option value="antialias" selected>Antialiased</option>
+      <option value="noAntialias">No antialiasing</option>
+    </select>
+
+    <select id="format">
+      <option value="unsigned-byte" selected>Unsigned Byte Textures</option>
+      <option value="half-float">Half Float Textures</option>
+      <option value="float">Float Textures</option>
+    </select>
+  </div>
+
+  <div id="sketch"></div>
+
+  <pre id="errors">
+  </pre>
+
+  <script language="javascript" type="text/javascript" src="sketch.js"></script>
+</body>
+
+</html>

--- a/test/manual-test-examples/webgl/framebuffer/formats/sketch.js
+++ b/test/manual-test-examples/webgl/framebuffer/formats/sketch.js
@@ -23,7 +23,6 @@ function makeSketch(p5) {
     try {
       p5.createCanvas(400, 400, p5.WEBGL).parent('sketch');
       p5.setAttributes({ version: webglVersion.value === '1' ? 1 : 2 });
-      console.log(p5.webglVersion);
       fbo = p5.createFramebuffer({
         format: format.value,
         antialias: antialias.value === 'antialias',

--- a/test/manual-test-examples/webgl/framebuffer/formats/sketch.js
+++ b/test/manual-test-examples/webgl/framebuffer/formats/sketch.js
@@ -1,0 +1,64 @@
+let sketch;
+let fbo;
+const format = document.getElementById('format');
+const alpha = document.getElementById('alpha');
+const antialias = document.getElementById('antialias');
+const webglVersion = document.getElementById('webglVersion');
+const errors = document.getElementById('errors');
+
+for (const input of [format, alpha, antialias, webglVersion]) {
+  input.addEventListener('input', remakeSketch);
+}
+
+function remakeSketch() {
+  errors.textContent = '';
+  if (fbo) fbo.remove();
+  if (sketch) sketch.remove();
+  sketch = new p5(makeSketch);
+}
+remakeSketch();
+
+function makeSketch(p5) {
+  p5.setup = function() {
+    try {
+      p5.createCanvas(400, 400, p5.WEBGL).parent('sketch');
+      p5.setAttributes({ version: webglVersion.value === '1' ? 1 : 2 });
+      console.log(p5.webglVersion);
+      fbo = p5.createFramebuffer({
+        format: format.value,
+        antialias: antialias.value === 'antialias',
+        channels: alpha.value === 'alpha' ? p5.RGBA : p5.RGB
+      });
+    } catch (e) {
+      errors.textContent = e.message + '\n\n' + e.stack;
+    }
+  };
+
+  p5.draw = function() {
+    // Draw to the Framebuffer
+    fbo.draw(() => {
+      p5.clear();
+      p5.background(255);
+      p5.push();
+      p5.noStroke();
+      p5.fill(255, 0, 0);
+      p5.translate(0, 100*p5.sin(p5.frameCount * 0.01), 0);
+      p5.rotateX(p5.frameCount * 0.01);
+      p5.rotateY(p5.frameCount * 0.01);
+      p5.box(50);
+      p5.pop();
+    });
+
+    // Do something with fbo.color or dbo.depth
+    p5.clear();
+    p5.background(255);
+
+    p5.push();
+    p5.noStroke();
+    p5.texture(fbo.color);
+    p5.plane(p5.width, -p5.height);
+    p5.pop();
+  };
+
+  return p5;
+}

--- a/test/unit/image/loading.js
+++ b/test/unit/image/loading.js
@@ -131,8 +131,8 @@ suite('loading images', function() {
       // After 100ms has elapsed, the display index should
       // increment when we draw the image. We'll wait a little
       // longer to make sure p5 knows it should be on the next
-      // image.
-      return wait(110);
+      // image (and reduce test flakiness)
+      return wait(150);
     }).then(function() {
       myp5.image(img, 0, 0);
       assert.equal(img.gifProperties.displayIndex, 1);

--- a/test/unit/image/loading.js
+++ b/test/unit/image/loading.js
@@ -129,10 +129,12 @@ suite('loading images', function() {
 
       // This gif has frames that are around for 100ms each.
       // After 100ms has elapsed, the display index should
-      // increment when we draw the image. We'll wait a little
-      // longer to make sure p5 knows it should be on the next
-      // image (and reduce test flakiness)
-      return wait(150);
+      // increment when we draw the image.
+      return wait(100);
+    }).then(function() {
+      return new Promise(function(resolve) {
+        window.requestAnimationFrame(resolve);
+      });
     }).then(function() {
       myp5.image(img, 0, 0);
       assert.equal(img.gifProperties.displayIndex, 1);

--- a/test/unit/spec.js
+++ b/test/unit/spec.js
@@ -41,6 +41,7 @@ var spec = {
     'interaction',
     'p5.Matrix',
     'p5.Camera',
+    'p5.Framebuffer',
     'p5.Geometry',
     'p5.RendererGL',
     'p5.Shader',

--- a/test/unit/webgl/p5.Framebuffer.js
+++ b/test/unit/webgl/p5.Framebuffer.js
@@ -274,4 +274,47 @@ suite('p5.Framebuffer', function() {
       }
     );
   });
+
+  suite('defaultCamera', function() {
+    let fbo;
+    setup(function() {
+      myp5.createCanvas(10, 10, myp5.WEBGL);
+      myp5.pixelDensity(1);
+      fbo = myp5.createFramebuffer({ width: 5, height: 15 });
+    });
+
+    suite('the default camera', function() {
+      test('it uses the aspect ratio of the framebuffer', function() {
+        expect(fbo.defaultCamera.aspectRatio).to.equal(5 / 15);
+        const z = -fbo.height / 2.0 / Math.tan(Math.PI / 3 / 2);
+        const expectedCameraMatrix = [
+          1, 0, 0, 0,
+          0, 1, 0, 0,
+          0, 0, 1, 0,
+          0, 0, z, 1
+        ];
+        for (let i = 0; i < expectedCameraMatrix.length; i++) {
+          expect(fbo.defaultCamera.cameraMatrix.mat4[i])
+            .to.be.closeTo(expectedCameraMatrix[i], 0.01);
+        }
+      });
+
+      test('it updates the aspect ratio after resizing', function() {
+        fbo.resize(20, 10);
+        expect(fbo.defaultCamera.aspectRatio).to.equal(2);
+
+        const z = -fbo.height / 2.0 / Math.tan(Math.PI / 3 / 2);
+        const expectedCameraMatrix = [
+          1, 0, 0, 0,
+          0, 1, 0, 0,
+          0, 0, 1, 0,
+          0, 0, z, 1
+        ];
+        for (let i = 0; i < expectedCameraMatrix.length; i++) {
+          expect(fbo.defaultCamera.cameraMatrix.mat4[i])
+            .to.be.closeTo(expectedCameraMatrix[i], 0.01);
+        }
+      });
+    });
+  });
 });

--- a/test/unit/webgl/p5.Framebuffer.js
+++ b/test/unit/webgl/p5.Framebuffer.js
@@ -1,0 +1,277 @@
+suite('p5.Framebuffer', function() {
+  let myp5;
+
+  if (!window.Modernizr.webgl) {
+    return;
+  }
+
+  setup(function() {
+    myp5 = new p5(function(p) {
+      p.setup = function() {};
+      p.draw = function() {};
+    });
+  });
+
+  teardown(function() {
+    myp5.remove();
+  });
+
+  suite('formats and channels', function() {
+    function testWithConfiguration(
+      version,
+      format,
+      channels,
+      depth,
+      antialias
+    ) {
+      test(
+        `framebuffers work with WebGL ${version}, ${format} ${channels} ${depth ? '' : 'no '}depth ${antialias ? ' antialiased' : ''}`,
+        function() {
+          myp5.createCanvas(10, 10, myp5.WEBGL);
+          myp5.setAttributes({ version });
+
+          // Draw a box to the framebuffer
+          const fbo = myp5.createFramebuffer({
+            format,
+            channels,
+            antialias,
+            depth
+          });
+          fbo.draw(() => {
+            myp5.background(255);
+            myp5.noStroke();
+            myp5.fill('red');
+            myp5.box(5, 5, 5);
+          });
+
+          // Draw the framebuffer to the canvas
+          myp5.background(0);
+          myp5.noStroke();
+          myp5.texture(fbo);
+          myp5.plane(myp5.width, -myp5.height);
+
+          // Make sure it drew
+          assert.deepEqual(
+            myp5.get(0, 0),
+            [255, 255, 255, 255]
+          );
+          assert.deepEqual(
+            myp5.get(5, 5),
+            [255, 0, 0, 255]
+          );
+        }
+      );
+    }
+
+    const versions = [1, 2];
+    const formats = ['unsigned-byte', 'float', 'half-float'];
+    const channelOptions = ['rgba', 'rgb'];
+    const antialiasOptions = [true, false];
+    const depthOptions = [true, false];
+    for (const version of versions) {
+      for (const format of formats) {
+        for (const channels of channelOptions) {
+          for (const antialias of antialiasOptions) {
+            for (const depth of depthOptions) {
+              testWithConfiguration(
+                version,
+                format,
+                channels,
+                antialias,
+                depth
+              );
+            }
+          }
+        }
+      }
+    }
+  });
+
+  suite('sizing', function() {
+    test('auto-sized framebuffers change size with their canvas', function() {
+      myp5.createCanvas(10, 10, myp5.WEBGL);
+      myp5.pixelDensity(1);
+      const fbo = myp5.createFramebuffer();
+      const oldTexture = fbo.color.rawTexture();
+      expect(fbo.width).to.equal(10);
+      expect(fbo.height).to.equal(10);
+      expect(fbo.density).to.equal(1);
+
+      myp5.resizeCanvas(5, 15);
+      myp5.pixelDensity(2);
+      expect(fbo.width).to.equal(5);
+      expect(fbo.height).to.equal(15);
+      expect(fbo.density).to.equal(2);
+
+      // The texture should be recreated
+      expect(fbo.color.rawTexture()).not.to.equal(oldTexture);
+    });
+
+    test('manually-sized framebuffers do not change size with their canvas', function() {
+      myp5.createCanvas(10, 10, myp5.WEBGL);
+      myp5.pixelDensity(3);
+      const fbo = myp5.createFramebuffer({ width: 20, height: 20, density: 1 });
+      const oldTexture = fbo.color.rawTexture();
+      expect(fbo.width).to.equal(20);
+      expect(fbo.height).to.equal(20);
+      expect(fbo.density).to.equal(1);
+
+      myp5.resizeCanvas(5, 15);
+      myp5.pixelDensity(2);
+      expect(fbo.width).to.equal(20);
+      expect(fbo.height).to.equal(20);
+      expect(fbo.density).to.equal(1);
+
+      // The texture should not be recreated
+      expect(fbo.color.rawTexture()).to.equal(oldTexture);
+    });
+
+    suite('resizing', function() {
+      let fbo;
+      let oldTexture;
+      setup(function() {
+        myp5.createCanvas(10, 10, myp5.WEBGL);
+        myp5.pixelDensity(1);
+        fbo = myp5.createFramebuffer();
+        oldTexture = fbo.color.rawTexture();
+
+        fbo.resize(5, 15);
+        fbo.pixelDensity(2);
+      });
+
+      test('framebuffers can be resized', function() {
+        expect(fbo.width).to.equal(5);
+        expect(fbo.height).to.equal(15);
+        expect(fbo.density).to.equal(2);
+
+        // The texture should be recreated
+        expect(fbo.color.rawTexture()).not.to.equal(oldTexture);
+      });
+
+      test('resizing a framebuffer turns off auto-sizing', function() {
+        oldTexture = fbo.color.rawTexture();
+
+        myp5.resizeCanvas(20, 20);
+        myp5.pixelDensity(3);
+
+        expect(fbo.width).to.equal(5);
+        expect(fbo.height).to.equal(15);
+        expect(fbo.density).to.equal(2);
+
+        // The texture should not be recreated
+        expect(fbo.color.rawTexture()).to.equal(oldTexture);
+      });
+    });
+  });
+
+  suite('rendering', function() {
+    function setupAndReturnFramebuffer() {
+      myp5.createCanvas(10, 10, myp5.WEBGL);
+
+      // Draw a box to the framebuffer
+      const fbo = myp5.createFramebuffer();
+      fbo.draw(() => {
+        myp5.background(255);
+        myp5.noStroke();
+        myp5.fill('red');
+        myp5.box(5, 5, 5);
+      });
+
+      return fbo;
+    }
+
+    test('rendering works with fbo.color as a texture', function() {
+      const fbo = setupAndReturnFramebuffer();
+
+      // Draw the framebuffer to the canvas
+      myp5.background(0);
+      myp5.noStroke();
+      myp5.texture(fbo.color);
+      myp5.plane(myp5.width, -myp5.height);
+
+      assert.deepEqual(
+        myp5.get(5, 5),
+        [255, 0, 0, 255]
+      );
+    });
+
+    test('rendering works with fbo as a texture', function() {
+      const fbo = setupAndReturnFramebuffer();
+
+      // Draw the framebuffer to the canvas
+      myp5.background(0);
+      myp5.noStroke();
+      myp5.texture(fbo);
+      myp5.plane(myp5.width, -myp5.height);
+
+      assert.deepEqual(
+        myp5.get(5, 5),
+        [255, 0, 0, 255]
+      );
+    });
+
+    test('rendering works with fbo.depth as a texture', function() {
+      const fbo = setupAndReturnFramebuffer();
+
+      // Draw the framebuffer to the canvas
+      myp5.background(0);
+      myp5.noStroke();
+      myp5.texture(fbo.depth);
+      myp5.plane(myp5.width, -myp5.height);
+
+      // Just check the red channel, other channels might vary across browsers
+      assert.equal(myp5.get(5, 5)[0], 221);
+    });
+  });
+
+  test('Framebuffers work on p5.Graphics', function() {
+    myp5.createCanvas(10, 10);
+    const graphic = myp5.createGraphics(10, 10, myp5.WEBGL);
+
+    // Draw a box to the framebuffer
+    const fbo = graphic.createFramebuffer();
+    fbo.draw(() => {
+      graphic.background(255);
+      graphic.noStroke();
+      graphic.fill('red');
+      graphic.box(5, 5, 5);
+    });
+
+    // Draw the framebuffer to the graphic
+    graphic.background(0);
+    graphic.noStroke();
+    graphic.texture(fbo);
+    graphic.plane(graphic.width, -graphic.height);
+
+    // Make sure it drew
+    assert.deepEqual(
+      graphic.get(0, 0),
+      [255, 255, 255, 255]
+    );
+    assert.deepEqual(
+      graphic.get(5, 5),
+      [255, 0, 0, 255]
+    );
+  });
+
+  suite('remove()', function() {
+    test('remove() cleans up textures', function() {
+      myp5.createCanvas(10, 10, myp5.WEBGL);
+      const fbo = myp5.createFramebuffer();
+      const numTextures = myp5._renderer.textures.size;
+      fbo.remove();
+      expect(myp5._renderer.textures.size).to.equal(numTextures - 2);
+    });
+
+    test(
+      'remove() cleans up textures when the framebuffer has no depth',
+      function() {
+        myp5.createCanvas(10, 10, myp5.WEBGL);
+        const fbo = myp5.createFramebuffer({ depth: false });
+        const numTextures = myp5._renderer.textures.size;
+        fbo.remove();
+        expect(myp5._renderer.textures.size).to.equal(numTextures - 1);
+      }
+    );
+  });
+});

--- a/test/unit/webgl/p5.Framebuffer.js
+++ b/test/unit/webgl/p5.Framebuffer.js
@@ -21,11 +21,11 @@ suite('p5.Framebuffer', function() {
       version,
       format,
       channels,
-      depth,
-      antialias
+      antialias,
+      depth
     ) {
       test(
-        `framebuffers work with WebGL ${version}, ${format} ${channels} ${depth ? '' : 'no '}depth ${antialias ? ' antialiased' : ''}`,
+        `framebuffers work with WebGL ${version}, ${format} ${channels} ${depth || 'no'} depth ${antialias ? ' antialiased' : ''}`,
         function() {
           myp5.createCanvas(10, 10, myp5.WEBGL);
           myp5.setAttributes({ version });
@@ -35,7 +35,8 @@ suite('p5.Framebuffer', function() {
             format,
             channels,
             antialias,
-            depth
+            depth: depth !== null,
+            depthFormat: depth
           });
           fbo.draw(() => {
             myp5.background(255);
@@ -67,7 +68,7 @@ suite('p5.Framebuffer', function() {
     const formats = ['unsigned-byte', 'float', 'half-float'];
     const channelOptions = ['rgba', 'rgb'];
     const antialiasOptions = [true, false];
-    const depthOptions = [true, false];
+    const depthOptions = ['unsigned-int', 'float', null];
     for (const version of versions) {
       for (const format of formats) {
         for (const channels of channelOptions) {

--- a/test/unit/webgl/p5.RendererGL.js
+++ b/test/unit/webgl/p5.RendererGL.js
@@ -35,6 +35,14 @@ suite('p5.RendererGL', function() {
       assert.equal(myp5.webglVersion, myp5.WEBGL);
     });
 
+    test('works on p5.Graphics', function() {
+      myp5.createCanvas(10, 10, myp5.WEBGL);
+      myp5.setAttributes({ version: 1 });
+      const g = myp5.createGraphics(10, 10, myp5.WEBGL);
+      assert.equal(myp5.webglVersion, myp5.WEBGL);
+      assert.equal(g.webglVersion, myp5.WEBGL2);
+    });
+
     suite('when WebGL2 is unavailable', function() {
       let prevGetContext;
       setup(function() {


### PR DESCRIPTION
**This is still WIP!** I appreciate any incremental feedback anyone has in the mean time though! Here's my to-do list:
- [x] Add unit tests for various format/channel/alpha combinations
- [x] Add unit tests for `texture()` using fbos, and specific fbo textures (color/depth)
- [x] Add doc comments everywhere (e.g. what options are supported, example usage)
- [ ] Make follow-up issues for:
  - [x] Verifying that all the format/channel/alpha combinations work on Windows too (I don't have a Windows PC so unfortunately I can't test this easily)
  - [x] An API for reading back pixels
  - [x] A Learn page on the reference including:
    - An example using a framebuffer on a p5.Graphics
    - An example demonstrating autosize vs fixed size
    - An example for working with `fbo.defaultCamera` and `fbo.createCamera()`
    - An explainer about the difference between Framebuffers and p5.Graphics
    - An explainer about the purpose of FLOAT colors
  - [x] More interesting Framebuffer examples (maybe a fog shader?)
  - [ ] Making ortho cameras resize when the canvas/framebuffer resizes

Resolves https://github.com/processing/p5.js/issues/6018
Resolves https://github.com/processing/p5.js/issues/5516

### Changes
- Adds a p5.Framebuffer class that can be used in WebGL mode to draw to a texture
  - `manual-test-examples/webgl/framebuffer/formats` lets you test different combinations of inputs in one spot to make sure they all work
- Refactors texture storage in `p5.RendererGL` to use a `Map` from source to texture rather than iterating through a list
- Adds a `Set` of framebuffers in `p5.RendererGL` so that ones defaulting to the full size of the canvas also get updated when you resize the canvas


### Screenshots of the change

`manual-test-examples/webgl/framebuffer/feedback`, showing how floating point Framebuffers can be used to fade out to white without leaving a trail:
![Screen Shot 2023-03-15 at 1 40 23 PM](https://user-images.githubusercontent.com/5315059/225400901-ba1339e2-ddd2-410c-9cea-c1d2424a8b7f.png)

`manual-test-examples/webgl/framebuffer/depth`, showing reading the depth texture (note that only the red channel is reliably present; in some browsers, depth info might be copied to all three channels, making it look black and white instead of tinted red):
![Screen Shot 2023-03-15 at 1 46 43 PM](https://user-images.githubusercontent.com/5315059/225401317-90d60529-7493-41b0-97be-e2601696d7bc.png)

#### PR Checklist
<!--
  To check any option, replace the "[ ]" with a "[x]". Be sure to check out how it looks in the Preview tab! Feel free to remove any portion of the template that is not relevant for your issue.
-->

- [x] `npm run lint` passes
- [ ] [Inline documentation] is included / updated
- [ ] [Unit tests] are included / updated

