### PR TITLE
rename identifier `globalFunctions` to `classesWithGlobalFns`

### DIFF
--- a/src/core/friendly_errors/sketch_reader.js
+++ b/src/core/friendly_errors/sketch_reader.js
@@ -319,12 +319,12 @@ if (typeof IS_MINIFIED !== 'undefined') {
       }
     }
     const keyArray = Object.keys(p5Constructors);
-    const globalFunctions = ['Renderer', 'Renderer2D', 'RendererGL'];
+    const classesWithGlobalFns = ['Renderer', 'Renderer2D', 'RendererGL'];
     let functionArray = [];
     //get the names of all p5.js functions which are available globally
-    for (let i = 0; i < globalFunctions.length; i++) {
+    for (let i = 0; i < classesWithGlobalFns.length; i++) {
       functionArray.push(...Object.keys(
-        p5Constructors[globalFunctions[i]].prototype
+        p5Constructors[classesWithGlobalFns[i]].prototype
       ));
     }
 


### PR DESCRIPTION
Related to #6055 

 Changes:
Since `globalFunctions` identifier refers to an array that contains classes whose functions are exposed in the global scope, the name of the identifier is not accurate and might be confusing, So I renamed it to `classesWithGlobalFns` which is very clear.

Already discussed with @davepagurek in #6055 