### PR TITLE
Fix black first frame when rendering gifs in setup

### DIFF
--- a/src/image/loading_displaying.js
+++ b/src/image/loading_displaying.js
@@ -317,6 +317,14 @@ p5.prototype.saveGif = async function(
   // stop the loop since we are going to manually redraw
   this.noLoop();
 
+  // Defer execution until the rest of the call stack finishes, allowing the
+  // rest of `setup` to be called (and, importantly, canvases hidden in setup
+  // to be unhidden.)
+  //
+  // Waiting on this empty promise means we'll continue as soon as setup
+  // finishes without waiting for another frame.
+  await Promise.resolve();
+
   while (frameIterator < totalNumberOfFrames) {
     /*
       we draw the next frame. this is important, since


### PR DESCRIPTION
Resolves https://github.com/processing/p5.js/issues/6080

### Changes
- Previously, the first frame of a gif rendered in setup would be black
- This looks like it's because we hide canvases until setup finishes, and that seems to be affecting our ability to grab pixels
- Awaits an immediately-resolving promise before starting to render frames defers execution so that `setup` completes before we pick back up again


### Screenshots of the change

Before: the downloaded gif starts on a black frame
<img src="https://user-images.githubusercontent.com/5315059/226754349-5a883523-f597-4baa-8c26-651f3d4c49d3.png" />

After: the first frame has content!
![image](https://user-images.githubusercontent.com/5315059/226757804-a5d5d6bb-a4a9-4424-9536-3694c8fd3666.png)

Working gif, for reference:

![mySketch(11)](https://user-images.githubusercontent.com/5315059/226757884-f3816453-3346-48a2-98df-b45b36f0d9ae.gif)


#### PR Checklist
- [x] `npm run lint` passes
- [ ] [Inline documentation] is included / updated
- [ ] [Unit tests] are included / updated

