### PR TITLE
added deletion of the success message in the saveGif function

### DIFF
--- a/src/image/loading_displaying.js
+++ b/src/image/loading_displaying.js
@@ -494,8 +494,8 @@ p5.prototype.saveGif = async function(
 
   if (!silent){
     p.html('Done. Downloading your gif!🌸');
-    if(notificationDuration>0)
-      setTimeout(()=> p.remove(),notificationDuration*1000);
+    if(notificationDuration > 0)
+      setTimeout(() => p.remove(), notificationDuration * 1000);
   }
 
   p5.prototype.downloadFile(blob, fileName, extension);

--- a/src/image/loading_displaying.js
+++ b/src/image/loading_displaying.js
@@ -463,6 +463,7 @@ p5.prototype.saveGif = async function(
   this.loop();
 
   p.html('Done. Downloading your gif!🌸');
+  setTimeout(()=> p.remove(),5000);
   p5.prototype.downloadFile(blob, fileName, extension);
 };
 


### PR DESCRIPTION
<!--
  Thank you for contributing! Please use this pull request (PR) template.


 In the description field of this PR, include "resolves #XXXX" tagging the issue you are fixing. If this PR addresses the issue but doesn't completely resolve it (ie the issue should remain open after your PR is merged), write "addresses #XXXX".-->
Resolves #6084 

 Changes:
<!-- Add here what changes were made in this pull request and if possible provide links showcasing the changes. -->
Success message after saving a gif with the saveGif() function will not last forever and will disappear in 5 seconds

#### PR Checklist
<!--
  To check any option, replace the "[ ]" with a "[x]". Be sure to check out how it looks in the Preview tab! Feel free to remove any portion of the template that is not relevant for your issue.
-->

- [x] `npm run lint` passes

[Inline documentation]: https://github.com/processing/p5.js/blob/main/contributor_docs/inline_documentation.md
[Unit tests]: https://github.com/processing/p5.js/tree/main/contributor_docs#unit-tests
