### PR TITLE
Make gif test less flaky

### DIFF
--- a/test/unit/image/loading.js
+++ b/test/unit/image/loading.js
@@ -129,10 +129,12 @@ suite('loading images', function() {
 
       // This gif has frames that are around for 100ms each.
       // After 100ms has elapsed, the display index should
-      // increment when we draw the image. We'll wait a little
-      // longer to make sure p5 knows it should be on the next
-      // image.
-      return wait(110);
+      // increment when we draw the image.
+      return wait(100);
+    }).then(function() {
+      return new Promise(function(resolve) {
+        window.requestAnimationFrame(resolve);
+      });
     }).then(function() {
       myp5.image(img, 0, 0);
       assert.equal(img.gifProperties.displayIndex, 1);


### PR DESCRIPTION
Resolves https://github.com/processing/p5.js/issues/6089

Changes:
- Before, this test waited 100ms for a gif to go to the next frame, plus a bit extra to wait for a draw to happen
- However, the draw doesn't reliably happen in that extra 10ms, causing tests to fail occasionally
- Now it explicitly waits for the next frame instead of adding a bit of extra time to the timeout


Screenshots of the change:
N/A

#### PR Checklist
- [x] `npm run lint` passes
- [ ] [Inline documentation] is included / updated
- [x] [Unit tests] are included / updated