### PR TITLE
solved the issue related to wrong link generation of p5.[Class] reference link. 

### DIFF
--- a/src/core/friendly_errors/fes_core.js
+++ b/src/core/friendly_errors/fes_core.js
@@ -143,9 +143,9 @@ if (typeof IS_MINIFIED !== 'undefined') {
       const funcName =
         methodParts.length === 1 ? func : methodParts.slice(2).join('/');
       //msgWithReference = `${message} (http://p5js.org/reference/#/${referenceSection}/${funcName})`;
-      funcName.substring(0,2) === "p5." ?               // ths funcName is the name of function and whenever a function is defined 
-      msgWithReference = `${message} (http://p5js.org/reference/#/${referenceSection}.${funcName})` : // with p5[class] then it starts with "p5."
-       msgWithReference = `${message} (http://p5js.org/reference/#/${referenceSection}/${funcName})`; // this is used correct the link
+      funcName.substring(0,2) === 'p5.' ?               // ths funcName is the name of function and whenever a function is defined
+        msgWithReference = `${message} (http://p5js.org/reference/#/${referenceSection}.${funcName})` : // with p5[class] then it starts with "p5."
+        msgWithReference = `${message} (http://p5js.org/reference/#/${referenceSection}/${funcName})`; // this is used correct the link
     }
     return msgWithReference;
   };

--- a/src/core/friendly_errors/fes_core.js
+++ b/src/core/friendly_errors/fes_core.js
@@ -142,7 +142,10 @@ if (typeof IS_MINIFIED !== 'undefined') {
 
       const funcName =
         methodParts.length === 1 ? func : methodParts.slice(2).join('/');
-      msgWithReference = `${message} (http://p5js.org/reference/#/${referenceSection}/${funcName})`;
+      //msgWithReference = `${message} (http://p5js.org/reference/#/${referenceSection}/${funcName})`;
+      funcName.substring(0,2) === "p5." ?               // ths funcName is the name of function and whenever a function is defined 
+      msgWithReference = `${message} (http://p5js.org/reference/#/${referenceSection}.${funcName})` : // with p5[class] then it starts with "p5."
+       msgWithReference = `${message} (http://p5js.org/reference/#/${referenceSection}/${funcName})`; // this is used correct the link
     }
     return msgWithReference;
   };


### PR DESCRIPTION
Solved the issue #5576 . The link in the console was incorrect whenever p5.[Class] was called and it was because of the using the same logic to produce the link. I divided the logic in two parts as it is shown in my code.