### PR TITLE
Simplified isNumber function

### DIFF
--- a/src/core/friendly_errors/validate_params.js
+++ b/src/core/friendly_errors/validate_params.js
@@ -342,14 +342,7 @@ if (typeof IS_MINIFIED !== 'undefined') {
    * @returns {String} a string indicating the type
    */
   const isNumber = param => {
-    switch (typeof param) {
-      case 'number':
-        return true;
-      case 'string':
-        return !isNaN(param);
-      default:
-        return false;
-    }
+    return !isNaN(parseFloat(param));
   };
 
   /**

--- a/src/core/friendly_errors/validate_params.js
+++ b/src/core/friendly_errors/validate_params.js
@@ -342,7 +342,15 @@ if (typeof IS_MINIFIED !== 'undefined') {
    * @returns {String} a string indicating the type
    */
   const isNumber = param => {
-    return !isNaN(parseFloat(param));
+    if (isNaN(parseFloat(param))) return false;
+    switch (typeof param) {
+      case 'number':
+        return true;
+      case 'string':
+        return !isNaN(param);
+      default:
+        return false;
+    }
   };
 
   /**

--- a/test/unit/core/error_helpers.js
+++ b/test/unit/core/error_helpers.js
@@ -189,9 +189,9 @@ suite('Error Helpers', function() {
       );
     });
 
-    testUnMinified('line: infinite value given', function() {
+    testUnMinified('line: NaN value given', function() {
       let err = assert.throws(function() {
-        p5._validateParameters('line', [1, 2, 4, Infinity]);
+        p5._validateParameters('line', [1, 2, 4, NaN]);
       }, p5.ValidationError);
       assert.strictEqual(
         err.type,

--- a/test/unit/core/error_helpers.js
+++ b/test/unit/core/error_helpers.js
@@ -177,6 +177,28 @@ suite('Error Helpers', function() {
         'ValidationError type is correct'
       );
     });
+
+    testUnMinified('line: null string given', function() {
+      let err = assert.throws(function() {
+        p5._validateParameters('line', [1, 2, 4, 'null']);
+      }, p5.ValidationError);
+      assert.strictEqual(
+        err.type,
+        'WRONG_TYPE',
+        'ValidationError type is correct'
+      );
+    });
+
+    testUnMinified('line: infinite value given', function() {
+      let err = assert.throws(function() {
+        p5._validateParameters('line', [1, 2, 4, Infinity]);
+      }, p5.ValidationError);
+      assert.strictEqual(
+        err.type,
+        'WRONG_TYPE',
+        'ValidationError type is correct'
+      );
+    });
   });
 
   suite('validateParameters: trailing undefined arguments', function() {


### PR DESCRIPTION
<!--
  Thank you for contributing! Please use this pull request (PR) template.


 In the description field of this PR, include "resolves #XXXX" tagging the issue you are fixing. If this PR addresses the issue but doesn't completely resolve it (ie the issue should remain open after your PR is merged), write "addresses #XXXX".-->
Resolves #5675

Changes: Going off of discussion surrounding Issue #5675 and PR #5846, this simplifies the isNumber parameter validation function using parseFloat and isNaN to return false when users use null, NaN, or an empty string (w/ or without spaces) as a parameter when drawing shapes. It still accepts Infinity for special circumstances.
<!-- Add here what changes were made in this pull request and if possible provide links showcasing the changes. -->

Screenshots of the change:
<img width="420" alt="Screenshot 2023-03-31 at 1 19 58 PM" src="https://user-images.githubusercontent.com/48136223/229187611-a37417de-8c71-44f9-80aa-d87314aa7e90.png">

#### PR Checklist
<!--
  To check any option, replace the "[ ]" with a "[x]". Be sure to check out how it looks in the Preview tab! Feel free to remove any portion of the template that is not relevant for your issue.
-->

- [x] `npm run lint` passes
- [x] [Inline documentation] is included / updated
- [x] [Unit tests] are included / updated

[Inline documentation]: https://github.com/processing/p5.js/blob/main/contributor_docs/inline_documentation.md
[Unit tests]: https://github.com/processing/p5.js/tree/main/contributor_docs#unit-tests
