### PR TITLE
Align the method of moving the camera with the right button in orbitControl() to the movement of the mouse

### DIFF
--- a/src/webgl/p5.Matrix.js
+++ b/src/webgl/p5.Matrix.js
@@ -720,6 +720,72 @@ p5.Matrix = class {
     return this;
   }
 
+ /**
+* apply a matrix to a vector with x,y,z,w components
+* get the results in the form of an array
+* @method multiplyVec4
+* @param {Number}
+* @return {Number[]}
+*/
+  multiplyVec4(x, y, z, w) {
+    const result = new Array(4);
+
+    result[0] = this.mat4[0] * x + this.mat4[4] * y + this.mat4[8] * z + this.mat4[12] * w;
+    result[1] = this.mat4[1] * x + this.mat4[5] * y + this.mat4[9] * z + this.mat4[13] * w;
+    result[2] = this.mat4[2] * x + this.mat4[6] * y + this.mat4[10] * z + this.mat4[14] * w;
+    result[3] = this.mat4[3] * x + this.mat4[7] * y + this.mat4[11] * z + this.mat4[15] * w;
+
+    return result;
+  }
+
+ /**
+* Applies a matrix to a vector.
+* The fourth component is set to 1.
+* Returns a vector consisting of the first
+* through third components of the result.
+* 
+* @method multiplyPoint
+* @param {p5.Vector}
+* @return {p5.Vector}
+*/
+  multiplyPoint(v) {
+    const array = this.multiplyVec4(v.x, v.y, v.z, 1);
+    return new p5.Vector(array[0], array[1], array[2]);
+  }
+
+ /**
+* Applies a matrix to a vector.
+* The fourth component is set to 1.
+* Returns the result of dividing the 1st to 3rd components
+* of the result by the 4th component as a vector.
+* 
+* @method multiplyAndNormalizePoint
+* @param {p5.Vector}
+* @return {p5.Vector}
+*/
+  multiplyAndNormalizePoint(v) {
+    const array = this.multiplyVec4(v.x, v.y, v.z, 1);
+    array[0] /= array[3];
+    array[1] /= array[3];
+    array[2] /= array[3];
+    return new p5.Vector(array[0], array[1], array[2]);
+  };
+
+ /**
+* Applies a matrix to a vector.
+* The fourth component is set to 0.
+* Returns a vector consisting of the first
+* through third components of the result.
+* 
+* @method multiplyDirection
+* @param {p5.Vector}
+* @return {p5.Vector}
+*/
+  multiplyDirection(v) {
+    const array = this.multiplyVec4(v.x, v.y, v.z, 0);
+    return new p5.Vector(array[0], array[1], array[2]);
+  }
+
   /**
  * PRIVATE
  */

--- a/src/webgl/p5.Matrix.js
+++ b/src/webgl/p5.Matrix.js
@@ -720,67 +720,68 @@ p5.Matrix = class {
     return this;
   }
 
- /**
-* apply a matrix to a vector with x,y,z,w components
-* get the results in the form of an array
-* @method multiplyVec4
-* @param {Number}
-* @return {Number[]}
-*/
+  /**
+ * apply a matrix to a vector with x,y,z,w components
+ * get the results in the form of an array
+ * @method multiplyVec4
+ * @param {Number}
+ * @return {Number[]}
+ */
   multiplyVec4(x, y, z, w) {
     const result = new Array(4);
+    const m = this.mat4;
 
-    result[0] = this.mat4[0] * x + this.mat4[4] * y + this.mat4[8] * z + this.mat4[12] * w;
-    result[1] = this.mat4[1] * x + this.mat4[5] * y + this.mat4[9] * z + this.mat4[13] * w;
-    result[2] = this.mat4[2] * x + this.mat4[6] * y + this.mat4[10] * z + this.mat4[14] * w;
-    result[3] = this.mat4[3] * x + this.mat4[7] * y + this.mat4[11] * z + this.mat4[15] * w;
+    result[0] = m[0] * x + m[4] * y + m[8] * z + m[12] * w;
+    result[1] = m[1] * x + m[5] * y + m[9] * z + m[13] * w;
+    result[2] = m[2] * x + m[6] * y + m[10] * z + m[14] * w;
+    result[3] = m[3] * x + m[7] * y + m[11] * z + m[15] * w;
 
     return result;
   }
 
- /**
-* Applies a matrix to a vector.
-* The fourth component is set to 1.
-* Returns a vector consisting of the first
-* through third components of the result.
-* 
-* @method multiplyPoint
-* @param {p5.Vector}
-* @return {p5.Vector}
-*/
+  /**
+ * Applies a matrix to a vector.
+ * The fourth component is set to 1.
+ * Returns a vector consisting of the first
+ * through third components of the result.
+ *
+ * @method multiplyPoint
+ * @param {p5.Vector}
+ * @return {p5.Vector}
+ */
   multiplyPoint(v) {
     const array = this.multiplyVec4(v.x, v.y, v.z, 1);
     return new p5.Vector(array[0], array[1], array[2]);
   }
 
- /**
-* Applies a matrix to a vector.
-* The fourth component is set to 1.
-* Returns the result of dividing the 1st to 3rd components
-* of the result by the 4th component as a vector.
-* 
-* @method multiplyAndNormalizePoint
-* @param {p5.Vector}
-* @return {p5.Vector}
-*/
+  /**
+ * Applies a matrix to a vector.
+ * The fourth component is set to 1.
+ * Returns the result of dividing the 1st to 3rd components
+ * of the result by the 4th component as a vector.
+ *
+ * @method multiplyAndNormalizePoint
+ * @param {p5.Vector}
+ * @return {p5.Vector}
+ */
   multiplyAndNormalizePoint(v) {
     const array = this.multiplyVec4(v.x, v.y, v.z, 1);
     array[0] /= array[3];
     array[1] /= array[3];
     array[2] /= array[3];
     return new p5.Vector(array[0], array[1], array[2]);
-  };
+  }
 
- /**
-* Applies a matrix to a vector.
-* The fourth component is set to 0.
-* Returns a vector consisting of the first
-* through third components of the result.
-* 
-* @method multiplyDirection
-* @param {p5.Vector}
-* @return {p5.Vector}
-*/
+  /**
+ * Applies a matrix to a vector.
+ * The fourth component is set to 0.
+ * Returns a vector consisting of the first
+ * through third components of the result.
+ *
+ * @method multiplyDirection
+ * @param {p5.Vector}
+ * @return {p5.Vector}
+ */
   multiplyDirection(v) {
     const array = this.multiplyVec4(v.x, v.y, v.z, 0);
     return new p5.Vector(array[0], array[1], array[2]);


### PR DESCRIPTION

Resolves #6107

## Changes:
Currently, the orbitControl() method for moving the camera with the right mouse button only allows movement parallel to the XZ plane.

However, in software such as blender, parallel movement of the camera is implemented by movement within the plane perpendicular to the line of sight. So I wanted to do it that way.

This moves the center position of the appearance according to the movement of the mouse. Intuitive operation is possible by shifting the viewpoint in the opposite direction to the operation direction, like a map application.

It's also true that the movement distance depends on the actual value of the mouse movement distance, so it has a similar problem to mouse scrolling, where it moves too much at small scales. In order to solve this problem, I thought it would be natural to move the mouse along with the movement of the mouse.

## Screenshots of the change:
sample code: [improve panning Demo](https://editor.p5js.org/dark_fox/sketches/fxWMOHeEE)

https://user-images.githubusercontent.com/39549290/233799780-65ae1a44-f9ba-46f0-9620-9e5c2dfdda54.mp4


#### PR Checklist
<!--
  To check any option, replace the "[ ]" with a "[x]". Be sure to check out how it looks in the Preview tab! Feel free to remove any portion of the template that is not relevant for your issue.
-->

- [x] `npm run lint` passes
- [ ] [Inline documentation] is included / updated
- [ ] [Unit tests] are included / updated

[Inline documentation]: https://github.com/processing/p5.js/blob/main/contributor_docs/inline_documentation.md
[Unit tests]: https://github.com/processing/p5.js/tree/main/contributor_docs#unit-tests
