### PR TITLE
Enable orbitControl() on mobile environment

### DIFF
--- a/src/events/touch.js
+++ b/src/events/touch.js
@@ -39,9 +39,11 @@ p5.prototype.touches = [];
 
 p5.prototype._updateTouchCoords = function(e) {
   if (this._curElement !== null) {
-    const touches = [];
+    // Get an array of previous touch objects
+    const prevTouches = this.touches.slice();
+    var curTouches = [];
     for (let i = 0; i < e.touches.length; i++) {
-      touches[i] = getTouchInfo(
+      curTouches[i] = getTouchInfo(
         this._curElement.elt,
         this.width,
         this.height,
@@ -49,7 +51,18 @@ p5.prototype._updateTouchCoords = function(e) {
         i
       );
     }
-    this._setProperty('touches', touches);
+    // Compare with the previous array of touch objects
+    for (let i = 0; i < curTouches.length; i++) {
+      for (let k = 0; k < prevTouches.length; k++) {
+        if (curTouches[i].id === prevTouches[k].id) {
+          curTouches[i].px = prevTouches[k].x;
+          curTouches[i].py = prevTouches[k].y;
+          curTouches[i].moved = true;
+          break;
+        }
+      }
+    }
+    this._setProperty('touches', curTouches);
   }
 };
 
@@ -63,7 +76,10 @@ function getTouchInfo(canvas, w, h, e, i = 0) {
     y: (touch.clientY - rect.top) / sy,
     winX: touch.clientX,
     winY: touch.clientY,
-    id: touch.identifier
+    id: touch.identifier,
+    px: undefined,
+    py: undefined,
+    moved: false
   };
 }
 

--- a/src/events/touch.js
+++ b/src/events/touch.js
@@ -39,11 +39,9 @@ p5.prototype.touches = [];
 
 p5.prototype._updateTouchCoords = function(e) {
   if (this._curElement !== null) {
-    // Get an array of previous touch objects
-    const prevTouches = this.touches.slice();
-    var curTouches = [];
+    const touches = [];
     for (let i = 0; i < e.touches.length; i++) {
-      curTouches[i] = getTouchInfo(
+      touches[i] = getTouchInfo(
         this._curElement.elt,
         this.width,
         this.height,
@@ -51,18 +49,7 @@ p5.prototype._updateTouchCoords = function(e) {
         i
       );
     }
-    // Compare with the previous array of touch objects
-    for (let i = 0; i < curTouches.length; i++) {
-      for (let k = 0; k < prevTouches.length; k++) {
-        if (curTouches[i].id === prevTouches[k].id) {
-          curTouches[i].px = prevTouches[k].x;
-          curTouches[i].py = prevTouches[k].y;
-          curTouches[i].moved = true;
-          break;
-        }
-      }
-    }
-    this._setProperty('touches', curTouches);
+    this._setProperty('touches', touches);
   }
 };
 
@@ -76,10 +63,7 @@ function getTouchInfo(canvas, w, h, e, i = 0) {
     y: (touch.clientY - rect.top) / sy,
     winX: touch.clientX,
     winY: touch.clientY,
-    id: touch.identifier,
-    px: undefined,
-    py: undefined,
-    moved: false
+    id: touch.identifier
   };
 }
 

--- a/src/webgl/interaction.js
+++ b/src/webgl/interaction.js
@@ -55,8 +55,12 @@ import * as constants from '../core/constants';
 
 // implementation based on three.js 'orbitControls':
 // https://github.com/mrdoob/three.js/blob/dev/examples/js/controls/OrbitControls.js
-p5.prototype.orbitControl =
-  function(sensitivityX, sensitivityY, sensitivityZ, options) {
+p5.prototype.orbitControl = function(
+  sensitivityX,
+  sensitivityY,
+  sensitivityZ,
+  options
+) {
   this._assert3d('orbitControl');
   p5._validateParameters('orbitControl', arguments);
 

--- a/src/webgl/interaction.js
+++ b/src/webgl/interaction.js
@@ -55,7 +55,8 @@ import * as constants from '../core/constants';
 
 // implementation based on three.js 'orbitControls':
 // https://github.com/mrdoob/three.js/blob/dev/examples/js/controls/OrbitControls.js
-p5.prototype.orbitControl = function(sensitivityX, sensitivityY, sensitivityZ, options) {
+p5.prototype.orbitControl =
+  function(sensitivityX, sensitivityY, sensitivityZ, options) {
   this._assert3d('orbitControl');
   p5._validateParameters('orbitControl', arguments);
 
@@ -104,7 +105,7 @@ p5.prototype.orbitControl = function(sensitivityX, sensitivityY, sensitivityZ, o
   // 'touchActionsDisabled' flag to p5 instance
   const { disableTouchActions = true } = options;
   if (this.touchActionsDisabled !== true && disableTouchActions) {
-    this.canvas.style["touch-action"] = "none";
+    this.canvas.style['touch-action'] = "none";
     this._setProperty('touchActionsDisabled', true);
   }
 

--- a/src/webgl/interaction.js
+++ b/src/webgl/interaction.js
@@ -125,7 +125,7 @@ p5.prototype.orbitControl = function(
           y: curTouch.y,
           px: prevTouch.x,
           py: prevTouch.y
-        }
+        };
         movedTouches.push(movedTouch);
       }
     }

--- a/src/webgl/interaction.js
+++ b/src/webgl/interaction.js
@@ -109,7 +109,7 @@ p5.prototype.orbitControl = function(
   // 'touchActionsDisabled' flag to p5 instance
   const { disableTouchActions = true } = options;
   if (this.touchActionsDisabled !== true && disableTouchActions) {
-    this.canvas.style['touch-action'] = "none";
+    this.canvas.style['touch-action'] = 'none';
     this._setProperty('touchActionsDisabled', true);
   }
 

--- a/src/webgl/interaction.js
+++ b/src/webgl/interaction.js
@@ -9,20 +9,26 @@ import p5 from '../core/main';
 import * as constants from '../core/constants';
 
 /**
- * Allows movement around a 3D sketch using a mouse or trackpad.  Left-clicking
- * and dragging will rotate the camera position about the center of the sketch,
- * right-clicking and dragging will pan the camera position without rotation,
- * and using the mouse wheel (scrolling) will move the camera closer or further
+ * Allows movement around a 3D sketch using a mouse or trackpad or touch.
+ * Left-clicking and dragging or swipe motion will rotate the camera position
+ * about the center of the sketch, right-clicking and dragging or multi-swipe
+ * will pan the camera position without rotation, and using the mouse wheel
+ * (scrolling) or pinch in/out will move the camera further or closer
  * from the center of the sketch. This function can be called with parameters
- * dictating sensitivity to mouse movement along the X and Y axes.  Calling
- * this function without parameters is equivalent to calling orbitControl(1,1).
- * To reverse direction of movement in either axis, enter a negative number
- * for sensitivity.
+ * dictating sensitivity to mouse/touch movement along the X and Y axes.
+ * Calling this function without parameters is equivalent to calling
+ * orbitControl(1,1). To reverse direction of movement in either axis,
+ * enter a negative number for sensitivity.
  * @method orbitControl
  * @for p5
  * @param  {Number} [sensitivityX] sensitivity to mouse movement along X axis
  * @param  {Number} [sensitivityY] sensitivity to mouse movement along Y axis
  * @param  {Number} [sensitivityZ] sensitivity to scroll movement along Z axis
+ * @param  {Object} [options] An optional object that can contain additional settings,
+ * disableTouchActions - Boolean, default value is true.
+ * Setting this to true makes mobile interactions smoother by preventing
+ * accidental interactions with the page while orbiting. But if you're already
+ * doing it via css or want the default touch actions, consider setting it to false.
  * @chainable
  * @example
  * <div>
@@ -49,7 +55,7 @@ import * as constants from '../core/constants';
 
 // implementation based on three.js 'orbitControls':
 // https://github.com/mrdoob/three.js/blob/dev/examples/js/controls/OrbitControls.js
-p5.prototype.orbitControl = function(sensitivityX, sensitivityY, sensitivityZ) {
+p5.prototype.orbitControl = function(sensitivityX, sensitivityY, sensitivityZ, options) {
   this._assert3d('orbitControl');
   p5._validateParameters('orbitControl', arguments);
 
@@ -72,10 +78,13 @@ p5.prototype.orbitControl = function(sensitivityX, sensitivityY, sensitivityZ) {
   if (typeof sensitivityZ === 'undefined') {
     sensitivityZ = 1;
   }
+  if (typeof options !== 'object') {
+    options = {};
+  }
 
   // default right-mouse and mouse-wheel behaviors (context menu and scrolling,
   // respectively) are disabled here to allow use of those events for panning and
-  // zooming
+  // zooming. However, whether or not to disable touch actions is an option.
 
   // disable context menu for canvas element and add 'contextMenuDisabled'
   // flag to p5 instance
@@ -91,14 +100,81 @@ p5.prototype.orbitControl = function(sensitivityX, sensitivityY, sensitivityZ) {
     this._setProperty('wheelDefaultDisabled', true);
   }
 
-  const zoomScaleFactor = 0.02;
+  // disable default touch behavior on the canvas element and add
+  // 'touchActionsDisabled' flag to p5 instance
+  const { disableTouchActions = true } = options;
+  if (this.touchActionsDisabled !== true && disableTouchActions) {
+    this.canvas.style["touch-action"] = "none";
+    this._setProperty('touchActionsDisabled', true);
+  }
+
+  // get moved touches
+  const movedTouches = this.touches.filter(t => t.moved);
+  // flags for interaction
+  let zoomFlag = false;
+  let rotateFlag = false;
+  let moveFlag = false;
+  // variables for interaction
+  let deltaRadius, deltaPhi, deltaTheta;
+  let moveDeltaX, moveDeltaY;
+
+  // For touches, the appropriate scale is different
+  // because the distance difference is multiplied.
+  const mouseZoomScaleFactor = 0.02;
+  const touchZoomScaleFactor = 0.0008;
   const scaleFactor = this.height < this.width ? this.height : this.width;
 
-  // ZOOM if there is a change in mouseWheelDelta
-  if (this._mouseWheelDeltaY !== 0) {
-    // zoom according to direction of mouseWheelDeltaY rather than value
-    const mouseWheelSign = (this._mouseWheelDeltaY > 0 ? 1 : -1);
-    const deltaRadius = mouseWheelSign * sensitivityZ * zoomScaleFactor;
+  // calculate and determine flags and variables.
+  if (movedTouches.length > 0) {
+    /* for touch */
+    // if length === 1, rotate
+    // if length > 1, zoom and move
+    if (movedTouches.length === 1) {
+      rotateFlag = true;
+      const t = movedTouches[0];
+      deltaTheta = -sensitivityX * (t.x - t.px) / scaleFactor;
+      deltaPhi = sensitivityY * (t.y - t.py) / scaleFactor;
+    } else {
+      zoomFlag = true;
+      const t0 = movedTouches[0];
+      const t1 = movedTouches[1];
+      const distWithTouches = Math.hypot(t0.x - t1.x, t0.y - t1.y);
+      const prevDistWithTouches = Math.hypot(t0.px - t1.px, t0.py - t1.py);
+      const changeDist = distWithTouches - prevDistWithTouches;
+      deltaRadius = -changeDist * sensitivityZ * touchZoomScaleFactor;
+
+      moveFlag = true;
+      moveDeltaX = 0.5 * (t0.x + t1.x) - 0.5 * (t0.px + t1.px);
+      moveDeltaY = 0.5 * (t0.y + t1.y) - 0.5 * (t0.py + t1.py);
+    }
+  } else {
+    /* for mouse */
+    // if wheelDeltaY !== 0, zoom
+    // if mouseLeftButton is down, rotate
+    // if mouseRightButton is down, move
+    if (this._mouseWheelDeltaY !== 0) {
+      zoomFlag = true;
+      // zoom according to direction of mouseWheelDeltaY rather than value.
+      const mouseWheelSign = (this._mouseWheelDeltaY > 0 ? 1 : -1);
+      deltaRadius = mouseWheelSign * sensitivityZ * mouseZoomScaleFactor;
+      this._mouseWheelDeltaY = 0;
+    }
+    if (this.mouseIsPressed) {
+      if (this.mouseButton === this.LEFT) {
+        rotateFlag = true;
+        deltaTheta = -sensitivityX * (this.mouseX - this.pmouseX) / scaleFactor;
+        deltaPhi = sensitivityY * (this.mouseY - this.pmouseY) / scaleFactor;
+      } else if (this.mouseButton === this.RIGHT) {
+        moveFlag = true;
+        moveDeltaX = this.mouseX - this.pmouseX;
+        moveDeltaY = this.mouseY - this.pmouseY;
+      }
+    }
+  }
+
+  // interactions
+  // zoom
+  if (zoomFlag) {
     this._renderer._curCamera._orbit(0, 0, deltaRadius);
     // In orthogonal projection, the scale does not change even if
     // the distance to the gaze point is changed, so the projection matrix
@@ -108,67 +184,61 @@ p5.prototype.orbitControl = function(sensitivityX, sensitivityY, sensitivityZ) {
       this._renderer.uPMatrix.mat4[5] *= Math.pow(10, -deltaRadius);
     }
   }
-  this._mouseWheelDeltaY = 0;
-
-  if (this.mouseIsPressed) {
-    // ORBIT BEHAVIOR
-    if (this.mouseButton === this.LEFT) {
-      const deltaTheta =
-        -sensitivityX * (this.mouseX - this.pmouseX) / scaleFactor;
-      const deltaPhi =
-        sensitivityY * (this.mouseY - this.pmouseY) / scaleFactor;
-      this._renderer._curCamera._orbit(deltaTheta, deltaPhi, 0);
-    } else if (this.mouseButton === this.RIGHT) {
-      // Translate the camera so that the entire object moves
-      // perpendicular to the line of sight when the mouse is moved
-      const local = cam._getLocalAxes();
-
-      // Calculate the z coordinate in the view coordinates of
-      // the center, that is, the distance to the view point.
-      const diffX = cam.eyeX - cam.centerX;
-      const diffY = cam.eyeY - cam.centerY;
-      const diffZ = cam.eyeZ - cam.centerZ;
-      const viewZ = Math.sqrt(diffX * diffX + diffY * diffY + diffZ * diffZ);
-
-      // position vector of the center
-      let cv = createVector(cam.centerX, cam.centerY, cam.centerZ);
-
-      // Calculate the normalized device coordinates of the center
-      cv = cam.cameraMatrix.multiplyPoint(cv);
-      cv = this._renderer.uPMatrix.multiplyAndNormalizePoint(cv);
-
-      // Normalize mouse movement distance
-      const ndcX = (this.mouseX - this.pmouseX) * 2 / this.width;
-      const ndcY = -(this.mouseY - this.pmouseY) * 2 / this.height;
-
-      // Move the center by this distance
-      // in the normalized device coordinate system
-      cv.x -= ndcX;
-      cv.y -= ndcY;
-
-      // Calculate the translation vector
-      // in the direction perpendicular to the line of sight of center
-      let dx, dy;
-      const uP = this._renderer.uPMatrix.mat4;
-      // When calculating the view coordinates, the calculation method is
-      // different depending on whether ortho() or not, so separate the cases.
-      // uP[15] is non-zero only for ortho().
-      if (uP[15] === 0) {
-        dx = ((uP[8] + cv.x) / uP[0]) * viewZ;
-        dy = ((uP[9] + cv.y) / uP[5]) * viewZ;
-      } else {
-        dx = (cv.x - uP[12]) / uP[0];
-        dy = (cv.y - uP[13]) / uP[5];
-      }
-
-      // translate the camera
-      cam.setPosition(
-        cam.eyeX + dx * local.x[0] + dy * local.y[0],
-        cam.eyeY + dx * local.x[1] + dy * local.y[1],
-        cam.eyeZ + dx * local.x[2] + dy * local.y[2]
-      );
-    }
+  // rotate
+  if (rotateFlag) {
+    this._renderer._curCamera._orbit(deltaTheta, deltaPhi, 0);
   }
+  // move
+  if (moveFlag) {
+    // Translate the camera so that the entire object moves
+    // perpendicular to the line of sight when the mouse is moved
+    // or when the centers of gravity of the two touch pointers move.
+    var local = cam._getLocalAxes();
+
+    // Calculate the z coordinate in the view coordinates of
+    // the center, that is, the distance to the view point
+    const diffX = cam.eyeX - cam.centerX;
+    const diffY = cam.eyeY - cam.centerY;
+    const diffZ = cam.eyeZ - cam.centerZ;
+    const viewZ = Math.sqrt(diffX * diffX + diffY * diffY + diffZ * diffZ);
+
+    // position vector of the center.
+    let cv = new p5.Vector(cam.centerX, cam.centerY, cam.centerZ);
+
+    // Calculate the normalized device coordinates of the center.
+    cv = cam.cameraMatrix.multiplyPoint(cv);
+    cv = this._renderer.uPMatrix.multiplyAndNormalizePoint(cv);
+
+    // Normalize movement distance
+    const ndcX = moveDeltaX * 2/this.width;
+    const ndcY = -moveDeltaY * 2/this.height;
+
+    // Move the center by this distance
+    // in the normalized device coordinate system.
+    cv.x -= ndcX;
+    cv.y -= ndcY;
+
+    // Calculate the translation vector
+    // in the direction perpendicular to the line of sight of center.
+    let dx, dy;
+    const uP = this._renderer.uPMatrix.mat4;
+
+    if (uP[15] === 0) {
+      dx = ((uP[8] + cv.x)/uP[0]) * viewZ;
+      dy = ((uP[9] + cv.y)/uP[5]) * viewZ;
+    } else {
+      dx = (cv.x - uP[12])/uP[0];
+      dy = (cv.y - uP[13])/uP[5];
+    }
+
+    // translate the camera.
+    cam.setPosition(
+      cam.eyeX + dx * local.x[0] + dy * local.y[0],
+      cam.eyeY + dx * local.x[1] + dy * local.y[1],
+      cam.eyeZ + dx * local.x[2] + dy * local.y[2]
+    );
+  }
+
   return this;
 };
 

--- a/src/webgl/p5.RendererGL.js
+++ b/src/webgl/p5.RendererGL.js
@@ -170,7 +170,7 @@ p5.RendererGL = function(elt, pInst, isMainCanvas, attr) {
   this._curCamera = new p5.Camera(this);
   this._curCamera._computeCameraDefaultSettings();
   this._curCamera._setDefaultCamera();
-  
+
   // Information about the previous frame's touch object
   // for executing orbitControl()
   this.prevTouches = [];

--- a/src/webgl/p5.RendererGL.js
+++ b/src/webgl/p5.RendererGL.js
@@ -170,6 +170,10 @@ p5.RendererGL = function(elt, pInst, isMainCanvas, attr) {
   this._curCamera = new p5.Camera(this);
   this._curCamera._computeCameraDefaultSettings();
   this._curCamera._setDefaultCamera();
+  
+  // Information about the previous frame's touch object
+  // for executing orbitControl()
+  this.prevTouches = [];
 
   this._defaultLightShader = undefined;
   this._defaultImmediateModeShader = undefined;


### PR DESCRIPTION
Currently, webgl's orbitControl() allows only mouse behavior.
It can be done with touch, but at most it's just a swipe action that causes rotation, and you can't scale or move.
This pull request attempts to make that possible.

Resolves #6118

 ## Changes:
<!-- Add here what changes were made in this pull request and if possible provide links showcasing the changes. -->
First, let the touch objects record their position in the previous frame, if any, so that we can get the set of moved touch objects.

It then detects swipe, multi-swipe and pinch in/out touch gestures to flag interactions that should be performed.
It also avoids duplication of methods by flagging the mouse operation only when no touch object has moved.

It also determines the values ​​of variables required for the corresponding interaction when flagging (although it may be arguable whether or not some of the factors used at this time are correct...).

Finally, execute each flagged interaction.

## Screenshots of the change:
<!-- If applicable, add screenshots depicting the changes. -->
Sample Code: [touch-orbitControl-Demo](https://editor.p5js.org/dark_fox/sketches/wClVcwamH)
OpenProcessing: [orbitControl() mobile](https://openprocessing.org/sketch/1898661)

#### PR Checklist
<!--
  To check any option, replace the "[ ]" with a "[x]". Be sure to check out how it looks in the Preview tab! Feel free to remove any portion of the template that is not relevant for your issue.
-->

- [x] `npm run lint` passes
- [ ] [Inline documentation] is included / updated
- [ ] [Unit tests] are included / updated

[Inline documentation]: https://github.com/processing/p5.js/blob/main/contributor_docs/inline_documentation.md
[Unit tests]: https://github.com/processing/p5.js/tree/main/contributor_docs#unit-tests
