### PR TITLE
Do away with strokeIndices and construct Geometry directly with edges

### DIFF
--- a/src/webgl/3d_primitives.js
+++ b/src/webgl/3d_primitives.js
@@ -158,9 +158,9 @@ p5.prototype.box = function(width, height, depth, detailX, detailY) {
         [0, 2, 1, 3], // 0, 0, -1],// -z
         [4, 5, 6, 7] // 0, 0, +1] // +z
       ];
-      //using strokeIndices instead of faces for strokes
+      //using custom edges
       //to avoid diagonal stroke lines across face of box
-      this.strokeIndices = [
+      this.edges = [
         [0, 1],
         [1, 3],
         [3, 2],
@@ -197,7 +197,7 @@ p5.prototype.box = function(width, height, depth, detailX, detailY) {
     const boxGeom = new p5.Geometry(detailX, detailY, _box);
     boxGeom.computeNormals();
     if (detailX <= 4 && detailY <= 4) {
-      boxGeom._makeTriangleEdges()._edgesToVertices();
+      boxGeom._edgesToVertices();
     } else if (this._renderer._doStroke) {
       console.log(
         'Cannot draw stroke on box objects with more' +
@@ -1048,13 +1048,13 @@ p5.RendererGL.prototype.triangle = function(args) {
       vertices.push(new p5.Vector(0, 0, 0));
       vertices.push(new p5.Vector(1, 0, 0));
       vertices.push(new p5.Vector(0, 1, 0));
-      this.strokeIndices = [[0, 1], [1, 2], [2, 0]];
+      this.edges = [[0, 1], [1, 2], [2, 0]];
       this.vertices = vertices;
       this.faces = [[0, 1, 2]];
       this.uvs = [0, 0, 1, 0, 1, 1];
     };
     const triGeom = new p5.Geometry(1, 1, _triangle);
-    triGeom._makeTriangleEdges()._edgesToVertices();
+    triGeom._edgesToVertices();
     triGeom.computeNormals();
     this.createBuffers(gId, triGeom);
   }
@@ -1121,7 +1121,6 @@ p5.RendererGL.prototype.arc = function(args) {
 
   if (!this.geometryInHash(gId)) {
     const _arc = function() {
-      this.strokeIndices = [];
 
       // if the start and stop angles are not the same, push vertices to the array
       if (start.toFixed(10) !== stop.toFixed(10)) {
@@ -1144,7 +1143,7 @@ p5.RendererGL.prototype.arc = function(args) {
 
           if (i < detail - 1) {
             this.faces.push([0, i + 1, i + 2]);
-            this.strokeIndices.push([i + 1, i + 2]);
+            this.edges.push([i + 1, i + 2]);
           }
         }
 
@@ -1156,21 +1155,21 @@ p5.RendererGL.prototype.arc = function(args) {
               this.vertices.length - 2,
               this.vertices.length - 1
             ]);
-            this.strokeIndices.push([0, 1]);
-            this.strokeIndices.push([
+            this.edges.push([0, 1]);
+            this.edges.push([
               this.vertices.length - 2,
               this.vertices.length - 1
             ]);
-            this.strokeIndices.push([0, this.vertices.length - 1]);
+            this.edges.push([0, this.vertices.length - 1]);
             break;
 
           case constants.CHORD:
-            this.strokeIndices.push([0, 1]);
-            this.strokeIndices.push([0, this.vertices.length - 1]);
+            this.edges.push([0, 1]);
+            this.edges.push([0, this.vertices.length - 1]);
             break;
 
           case constants.OPEN:
-            this.strokeIndices.push([0, 1]);
+            this.edges.push([0, 1]);
             break;
 
           default:
@@ -1179,7 +1178,7 @@ p5.RendererGL.prototype.arc = function(args) {
               this.vertices.length - 2,
               this.vertices.length - 1
             ]);
-            this.strokeIndices.push([
+            this.edges.push([
               this.vertices.length - 2,
               this.vertices.length - 1
             ]);
@@ -1191,7 +1190,7 @@ p5.RendererGL.prototype.arc = function(args) {
     arcGeom.computeNormals();
 
     if (detail <= 50) {
-      arcGeom._makeTriangleEdges()._edgesToVertices(arcGeom);
+      arcGeom._edgesToVertices(arcGeom);
     } else if (this._doStroke) {
       console.log(
         `Cannot apply a stroke to an ${shape} with more than 50 detail`
@@ -1241,7 +1240,7 @@ p5.RendererGL.prototype.rect = function(args) {
         }
         // using stroke indices to avoid stroke over face(s) of rectangle
         if (detailX > 0 && detailY > 0) {
-          this.strokeIndices = [
+          this.edges = [
             [0, detailX],
             [detailX, (detailX + 1) * (detailY + 1) - 1],
             [(detailX + 1) * (detailY + 1) - 1, (detailX + 1) * detailY],
@@ -1253,7 +1252,6 @@ p5.RendererGL.prototype.rect = function(args) {
       rectGeom
         .computeFaces()
         .computeNormals()
-        ._makeTriangleEdges()
         ._edgesToVertices();
       this.createBuffers(gId, rectGeom);
     }

--- a/src/webgl/loading.js
+++ b/src/webgl/loading.js
@@ -624,7 +624,12 @@ p5.prototype.model = function(model) {
   p5._validateParameters('model', arguments);
   if (model.vertices.length > 0) {
     if (!this._renderer.geometryInHash(model.gid)) {
-      model._makeTriangleEdges()._edgesToVertices();
+
+      if (model.edges.length === 0) {
+        model._makeTriangleEdges();
+      }
+
+      model._edgesToVertices();
       this._renderer.createBuffers(model.gid, model);
     }
 

--- a/src/webgl/p5.Geometry.js
+++ b/src/webgl/p5.Geometry.js
@@ -236,17 +236,13 @@ p5.Geometry = class  {
  */
   _makeTriangleEdges() {
     this.edges.length = 0;
-    if (Array.isArray(this.strokeIndices)) {
-      for (let i = 0, max = this.strokeIndices.length; i < max; i++) {
-        this.edges.push(this.strokeIndices[i]);
-      }
-    } else {
-      for (let j = 0; j < this.faces.length; j++) {
-        this.edges.push([this.faces[j][0], this.faces[j][1]]);
-        this.edges.push([this.faces[j][1], this.faces[j][2]]);
-        this.edges.push([this.faces[j][2], this.faces[j][0]]);
-      }
+
+    for (let j = 0; j < this.faces.length; j++) {
+      this.edges.push([this.faces[j][0], this.faces[j][1]]);
+      this.edges.push([this.faces[j][1], this.faces[j][2]]);
+      this.edges.push([this.faces[j][2], this.faces[j][0]]);
     }
+
     return this;
   }
 


### PR DESCRIPTION
Currently, strokeIndices is used to define edges regardless of faces when composing geometry.  

However, the way to configure edges using it is to copy the contents of strokeIndices to edges as they are in _makeTriangleEdges(), which is a wasteful process.  

So, I wanted to rewrite the processing method so that edge information is stored in edges from the beginning.
StrokeIndices is not prepared even at initialization, and in that sense it is not a very natural process.  

Also, when creating APIs in the future, I thought it would cause confusion if there was a way of processing that didn't matter which way, so I wanted to unify it.

In addition to that, the specification of model() was changed so that edges are constructed from faces only when edges are not provided in the model function. This allows p5.Geometry to construct a geometry without losing its contents for edges, even if it has no faces and only edges, or constructs its own edges.

Resolves #6120

## Changes:
<!-- Add here what changes were made in this pull request and if possible provide links showcasing the changes. -->
- replace "strokeIndices" with "edges" in arc, box, triangle, rect and avoid calling _makeTriangleEdges()
- In _makeTriangleEdges(), omit the processing performed for strokeIndices
- In model(), construct edges from faces only when edges.length is 0.

## Screenshots of the change:
<!-- If applicable, add screenshots depicting the changes. -->
Demo: [patch_model_2](https://editor.p5js.org/dark_fox/sketches/oyoU66x9T)

I tried it, but the box, triangle, arc, and rect whose specifications were changed here were all drawn as usual.

![gottani](https://user-images.githubusercontent.com/39549290/235224559-75864533-58ea-4e64-8109-39805d5f7050.png)

#### PR Checklist
<!--
  To check any option, replace the "[ ]" with a "[x]". Be sure to check out how it looks in the Preview tab! Feel free to remove any portion of the template that is not relevant for your issue.
-->

- [ ] `npm run lint` passes
- [ ] [Inline documentation] is included / updated
- [ ] [Unit tests] are included / updated

[Inline documentation]: https://github.com/processing/p5.js/blob/main/contributor_docs/inline_documentation.md
[Unit tests]: https://github.com/processing/p5.js/tree/main/contributor_docs#unit-tests
