### PR TITLE
Factor transformations into position and area for shapes' accessible outputs - addresses #4721

### DIFF
--- a/src/accessibility/outputs.js
+++ b/src/accessibility/outputs.js
@@ -424,7 +424,9 @@ function _getMiddle(f, args) {
 //gets position of shape in the canvas
 p5.prototype._getPos = function (x, y) {
   const untransformedPosition = new DOMPointReadOnly(x, y);
-  const currentTransform = this.drawingContext.getTransform();
+  const currentTransform = this._renderer.isP3D ?
+    new DOMMatrix(this._renderer.uMVMatrix.mat4) :
+    this.drawingContext.getTransform();
   const { x: transformedX, y: transformedY } = untransformedPosition
     .matrixTransform(currentTransform);
   const { width: canvasWidth, height: canvasHeight } = this;
@@ -541,7 +543,9 @@ p5.prototype._getArea = function (objectType, shapeArgs) {
     new DOMPoint(0, canvasHeight)
   ];
   //  Apply the inverse of the current transformations to the canvas corners
-  const currentTransform = this.drawingContext.getTransform();
+  const currentTransform = this._renderer.isP3D ?
+    new DOMMatrix(this._renderer.uMVMatrix.mat4) :
+    this.drawingContext.getTransform();
   const invertedTransform = currentTransform.inverse();
   const tc = canvasCorners.map(
     corner => corner.matrixTransform(invertedTransform)


### PR DESCRIPTION
Addresses suggestion raised in #4721
Specifically [this comment](https://github.com/processing/p5.js/issues/4721#issuecomment-1522431660)
<!--
  Thank you for contributing! Please use this pull request (PR) template.


 In the description field of this PR, include "resolves #XXXX" tagging the issue you are fixing. If this PR addresses the issue but doesn't completely resolve it (ie the issue should remain open after your PR is merged), write "addresses #XXXX".-->

 Changes:
<!-- Add here what changes were made in this pull request and if possible provide links showcasing the changes. -->
Currently, transformations are not taken into account for outputs generated through textOutput() or gridOutput(). This PR modifies _getPos and _getArea to be methods on the p5 prototype and to factor in the current transformations into their calculations.

You can see that in [this example](https://editor.p5js.org/cfoss/sketches/7MsMdLkNo). Three squares are on the canvas in different positions with the square in the lower right being scaled down, but the text output describes only one shape because the arguments passed into square() are the same and because the color is the same.

[Here's that same example with the build from this PR.](https://editor.p5js.org/cfoss/sketches/UJGZW_KJe)

#### PR Checklist
<!--
  To check any option, replace the "[ ]" with a "[x]". Be sure to check out how it looks in the Preview tab! Feel free to remove any portion of the template that is not relevant for your issue.
-->

- [x] `npm run lint` passes
- [ ] [Inline documentation] is included / updated
- [ ] [Unit tests] are included / updated

[Inline documentation]: https://github.com/processing/p5.js/blob/main/contributor_docs/inline_documentation.md
[Unit tests]: https://github.com/processing/p5.js/tree/main/contributor_docs#unit-tests
