### PR TITLE
Replace os import to always use '\n' for EOL - resolves #6038

### DIFF
--- a/utils/sample-linter.js
+++ b/utils/sample-linter.js
@@ -1,5 +1,5 @@
 'use strict';
-import { EOL } from 'os';
+const EOL = '\n';
 import { ESLint } from 'eslint';
 import dataDoc from '../docs/reference/data.min.json';
 // envs: ['eslint-samples/p5'],


### PR DESCRIPTION
<!--
  Thank you for contributing! Please use this pull request (PR) template.


 In the description field of this PR, include "resolves #XXXX" tagging the issue you are fixing. If this PR addresses the issue but doesn't completely resolve it (ie the issue should remain open after your PR is merged), write "addresses #XXXX".-->
Resolves  #6038

 Changes:
<!-- Add here what changes were made in this pull request and if possible provide links showcasing the changes. -->
This modifies utils/sample-linter.js, replacing getting the EOL character from OS to initializing EOL as a const containing '\n'. This fixes an issue experienced by Windows users when running npm test.

#### PR Checklist
<!--
  To check any option, replace the "[ ]" with a "[x]". Be sure to check out how it looks in the Preview tab! Feel free to remove any portion of the template that is not relevant for your issue.
-->

- [x] `npm run lint` passes
- [ ] [Inline documentation] is included / updated
- [ ] [Unit tests] are included / updated

[Inline documentation]: https://github.com/processing/p5.js/blob/main/contributor_docs/inline_documentation.md
[Unit tests]: https://github.com/processing/p5.js/tree/main/contributor_docs#unit-tests
