### PR TITLE
Fix lights() to properly specify gray

### DIFF
--- a/src/webgl/light.js
+++ b/src/webgl/light.js
@@ -530,15 +530,10 @@ p5.prototype.pointLight = function(v1, v2, v3, x, y, z) {
  */
 p5.prototype.lights = function() {
   this._assert3d('lights');
-  // only restore the colorMode to default if it is not in default already
-  if (this._colorMode === constants.RGB) {
-    this.ambientLight(128, 128, 128);
-    this.directionalLight(128, 128, 128, 0, 0, -1);
-  } else {
-    const maxBright = this._colorMaxes[this._colorMode][2];
-    this.ambientLight(0, 0, maxBright);
-    this.directionalLight(0, 0, maxBright, 0, 0, -1);
-  }
+  // Both specify gray by default.
+  const grayColor = color("rgb(128,128,128)");
+  this.ambientLight(grayColor);
+  this.directionalLight(grayColor, 0, 0, -1);
   return this;
 };
 

--- a/src/webgl/light.js
+++ b/src/webgl/light.js
@@ -6,7 +6,6 @@
  */
 
 import p5 from '../core/main';
-import * as constants from '../core/constants';
 
 /**
  * Creates an ambient light with the given color.
@@ -531,7 +530,7 @@ p5.prototype.pointLight = function(v1, v2, v3, x, y, z) {
 p5.prototype.lights = function() {
   this._assert3d('lights');
   // Both specify gray by default.
-  const grayColor = color("rgb(128,128,128)");
+  const grayColor = color('rgb(128,128,128)');
   this.ambientLight(grayColor);
   this.directionalLight(grayColor, 0, 0, -1);
   return this;

--- a/src/webgl/light.js
+++ b/src/webgl/light.js
@@ -530,7 +530,7 @@ p5.prototype.pointLight = function(v1, v2, v3, x, y, z) {
 p5.prototype.lights = function() {
   this._assert3d('lights');
   // Both specify gray by default.
-  const grayColor = color('rgb(128,128,128)');
+  const grayColor = this.color('rgb(128,128,128)');
   this.ambientLight(grayColor);
   this.directionalLight(grayColor, 0, 0, -1);
   return this;


### PR DESCRIPTION
Lights() did not support changing the color specification method by colorMode(), so I fixed it.

<!--
  Thank you for contributing! Please use this pull request (PR) template.


 In the description field of this PR, include "resolves #XXXX" tagging the issue you are fixing. If this PR addresses the issue but doesn't completely resolve it (ie the issue should remain open after your PR is merged), write "addresses #XXXX".-->
Resolves #6127

## Changes:
<!-- Add here what changes were made in this pull request and if possible provide links showcasing the changes. -->
The way to specify the color was inappropriate, so I fixed it.

## Screenshots of the change:
<!-- If applicable, add screenshots depicting the changes. -->
### before:

![lights_bug1](https://user-images.githubusercontent.com/39549290/235653916-af85ed25-3af8-4856-a0e4-6d8531bbb243.png)

### after:

![lights_bug_fix](https://user-images.githubusercontent.com/39549290/235653820-ba58d7df-341a-4cc6-8270-bd9b72e49b8c.png)


#### PR Checklist
<!--
  To check any option, replace the "[ ]" with a "[x]". Be sure to check out how it looks in the Preview tab! Feel free to remove any portion of the template that is not relevant for your issue.
-->

- [x] `npm run lint` passes
- [ ] [Inline documentation] is included / updated
- [ ] [Unit tests] are included / updated

[Inline documentation]: https://github.com/processing/p5.js/blob/main/contributor_docs/inline_documentation.md
[Unit tests]: https://github.com/processing/p5.js/tree/main/contributor_docs#unit-tests
