### PR TITLE
fix min() and max() crashing on large arrays

### DIFF
--- a/src/math/calculation.js
+++ b/src/math/calculation.js
@@ -498,7 +498,7 @@ p5.prototype.map = function(n, start1, stop1, start2, stop2, withinBounds) {
  * @param  {Number[]} nums Numbers to compare
  * @return {Number}
  */
-p5.prototype.max = function (...args) {
+p5.prototype.max = function(...args) {
   const findMax = arr => {
     let max = -Infinity;
     for (let x of arr) {
@@ -554,7 +554,7 @@ p5.prototype.max = function (...args) {
  * @param  {Number[]} nums Numbers to compare
  * @return {Number}
  */
-p5.prototype.min = function (...args) {
+p5.prototype.min = function(...args) {
   const findMin = arr => {
     let min = Infinity;
     for (let x of arr) {

--- a/src/math/calculation.js
+++ b/src/math/calculation.js
@@ -498,11 +498,19 @@ p5.prototype.map = function(n, start1, stop1, start2, stop2, withinBounds) {
  * @param  {Number[]} nums Numbers to compare
  * @return {Number}
  */
-p5.prototype.max = function(...args) {
+p5.prototype.max = function (...args) {
+  const findMax = arr => {
+    let max = -Infinity;
+    for (let x of arr) {
+      max = x > max ? x : max;
+    }
+    return max;
+  };
+
   if (args[0] instanceof Array) {
-    return Math.max.apply(null, args[0]);
+    return findMax(args[0]);
   } else {
-    return Math.max.apply(null, args);
+    return findMax(args);
   }
 };
 
@@ -546,11 +554,19 @@ p5.prototype.max = function(...args) {
  * @param  {Number[]} nums Numbers to compare
  * @return {Number}
  */
-p5.prototype.min = function(...args) {
+p5.prototype.min = function (...args) {
+  const findMin = arr => {
+    let min = Infinity;
+    for (let x of arr) {
+      min = x < min ? x : min;
+    }
+    return min;
+  };
+
   if (args[0] instanceof Array) {
-    return Math.min.apply(null, args[0]);
+    return findMin(args[0]);
   } else {
-    return Math.min.apply(null, args);
+    return findMin(args);
   }
 };
 


### PR DESCRIPTION
Resolves #6101 

Changes:
The previous implementation of the `max()` and `min()` methods used `Function.prototype.apply()`, which would have a stack error on arrays of length more than ~120000. On the back of a discussion under the issue, I benchmarked a few alternative implementations and we settled with a simple for loop, which is one of the fastest if not the fastest implementation across all array sizes.

#### PR Checklist
- [x] `npm run lint` passes
- [ ] [Inline documentation] is included / updated
- [ ] [Unit tests] are included / updated

no doc or unit test changes given that the functionality has not really been changed
