### PR TITLE
Default ambientMaterial to the base material color if unspecified

### DIFF
--- a/src/webgl/material.js
+++ b/src/webgl/material.js
@@ -821,6 +821,7 @@ p5.prototype.ambientMaterial = function(v1, v2, v3) {
   p5._validateParameters('ambientMaterial', arguments);
 
   const color = p5.prototype.color.apply(this, arguments);
+  this._renderer._hasSetAmbient = true;
   this._renderer.curAmbientColor = color._array;
   this._renderer._useNormalMaterial = false;
   this._renderer._enableLighting = true;

--- a/src/webgl/p5.RendererGL.js
+++ b/src/webgl/p5.RendererGL.js
@@ -138,6 +138,7 @@ p5.RendererGL = function(elt, pInst, isMainCanvas, attr) {
   }
   this._isBlending = false;
 
+  this._hasSetAmbient = false;
   this._useSpecularMaterial = false;
   this._useEmissiveMaterial = false;
   this._useNormalMaterial = false;
@@ -1235,6 +1236,7 @@ p5.RendererGL.prototype.push = function() {
   properties.curSpecularColor = this.curSpecularColor;
   properties.curEmissiveColor = this.curEmissiveColor;
 
+  properties._hasSetAmbient = this._hasSetAmbient;
   properties._useSpecularMaterial = this._useSpecularMaterial;
   properties._useEmissiveMaterial = this._useEmissiveMaterial;
   properties._useShininess = this._useShininess;
@@ -1526,6 +1528,7 @@ p5.RendererGL.prototype._setFillUniforms = function(fillShader) {
   }
   fillShader.setUniform('uTint', this._tint);
 
+  fillShader.setUniform('uHasSetAmbient', this._hasSetAmbient);
   fillShader.setUniform('uAmbientMatColor', this.curAmbientColor);
   fillShader.setUniform('uSpecularMatColor', this.curSpecularColor);
   fillShader.setUniform('uEmissiveMatColor', this.curEmissiveColor);

--- a/src/webgl/shaders/phong.frag
+++ b/src/webgl/shaders/phong.frag
@@ -2,6 +2,7 @@
 precision highp float;
 precision highp int;
 
+uniform bool uHasSetAmbient;
 uniform vec4 uSpecularMatColor;
 uniform vec4 uAmbientMatColor;
 uniform vec4 uEmissiveMatColor;
@@ -33,7 +34,9 @@ void main(void) {
     // channels by alpha to convert it to premultiplied alpha.
     : vec4(vColor.rgb * vColor.a, vColor.a);
   gl_FragColor = vec4(diffuse * baseColor.rgb + 
-                    vAmbientColor * uAmbientMatColor.rgb + 
+                    vAmbientColor * (
+                      uHasSetAmbient ? uAmbientMatColor.rgb : baseColor.rgb
+                    ) + 
                     specular * uSpecularMatColor.rgb + 
                     uEmissiveMatColor.rgb, baseColor.a);
 }

--- a/test/unit/webgl/p5.RendererGL.js
+++ b/test/unit/webgl/p5.RendererGL.js
@@ -364,6 +364,33 @@ suite('p5.RendererGL', function() {
     });
   });
 
+  suite('materials', function() {
+    test('ambient color defaults to the fill color', function() {
+      myp5.createCanvas(100, 100, myp5.WEBGL);
+      myp5.noStroke();
+      myp5.lights();
+      myp5.fill('red');
+      myp5.sphere(25);
+      const pixel = myp5.get(50, 50);
+      expect(pixel[0]).to.equal(221);
+      expect(pixel[1]).to.equal(0);
+      expect(pixel[2]).to.equal(0);
+    });
+
+    test('ambient color can be set manually', function() {
+      myp5.createCanvas(100, 100, myp5.WEBGL);
+      myp5.noStroke();
+      myp5.lights();
+      myp5.fill('red');
+      myp5.ambientMaterial(255, 255, 255);
+      myp5.sphere(25);
+      const pixel = myp5.get(50, 50);
+      expect(pixel[0]).to.equal(221);
+      expect(pixel[1]).to.equal(128);
+      expect(pixel[2]).to.equal(128);
+    });
+  });
+
   suite('loadpixels()', function() {
     test('loadPixels color check', function(done) {
       myp5.createCanvas(100, 100, myp5.WEBGL);


### PR DESCRIPTION
Resolves https://github.com/processing/p5.js/issues/6125

## Changes

- In https://github.com/processing/p5.js/pull/5774, we updated p5's material model to be a bit more like Processing's, where one can specify a separate color for the ambient, specular, and emissive components of the material
- Unlike in processing, the p5 implementation *required* all components to be set separately
  - This meant that previous code that only specified, for example, `fill()`, would look different due to the ambient component remaining at a default value
- In Processing, the ambient color defaults to the same color as the specular color or fill if left unspecified
- This PR updates the p5 implementation to match Processing:
  - If you only specify the specular color or fill, it will be used for the ambient color too
  - Otherwise, your explicitly set ambient color will be used

##  Screenshots of the change

<table>
<tr>
<td>

```js
//v1.4.2
fill('red')
```

</td>
<td>

```js
//v1.6.0
fill('red')
```

</td>
<td>

```js
//updated
fill('red')
```

</td>
<td>

```js
//updated
fill('red')

// Explicitly specified white
// ambient material
ambientMaterial(255, 255, 255)
```

</td>
</tr>
<tr>
<td>

<img src="https://user-images.githubusercontent.com/5315059/236356086-addfa899-ae0e-4682-8585-515dadc25c3d.png" width="150" />

</td>
<td>

<img src="https://user-images.githubusercontent.com/5315059/236356099-c5fa2e16-5a46-4d11-8e0d-338cd0b33d69.png" width="150" />

</td>

<td>

<img src="https://user-images.githubusercontent.com/5315059/236356086-addfa899-ae0e-4682-8585-515dadc25c3d.png" width="150" />

</td>
<td>

<img src="https://user-images.githubusercontent.com/5315059/236356099-c5fa2e16-5a46-4d11-8e0d-338cd0b33d69.png" width="150" />

</td>
</tr>
</table>

#### PR Checklist

- [x] `npm run lint` passes
- [x] [Inline documentation] is included / updated
- [x] [Unit tests] are included / updated