### PR TITLE
Allow texture() to work under specular in WEBGL mode

### DIFF
--- a/src/webgl/material.js
+++ b/src/webgl/material.js
@@ -512,8 +512,6 @@ p5.prototype.texture = function(tex) {
   }
 
   this._renderer.drawMode = constants.TEXTURE;
-  this._renderer._useSpecularMaterial = false;
-  this._renderer._useEmissiveMaterial = false;
   this._renderer._useNormalMaterial = false;
   this._renderer._tex = tex;
   this._renderer._setProperty('_doFill', true);

--- a/src/webgl/material.js
+++ b/src/webgl/material.js
@@ -825,7 +825,6 @@ p5.prototype.ambientMaterial = function(v1, v2, v3) {
   this._renderer.curAmbientColor = color._array;
   this._renderer._useNormalMaterial = false;
   this._renderer._enableLighting = true;
-  this._renderer._tex = null;
   this._renderer._setProperty('_doFill', true);
   return this;
 };
@@ -897,7 +896,6 @@ p5.prototype.emissiveMaterial = function(v1, v2, v3, a) {
   this._renderer._useEmissiveMaterial = true;
   this._renderer._useNormalMaterial = false;
   this._renderer._enableLighting = true;
-  this._renderer._tex = null;
 
   return this;
 };
@@ -984,7 +982,6 @@ p5.prototype.specularMaterial = function(v1, v2, v3, alpha) {
   this._renderer._useSpecularMaterial = true;
   this._renderer._useNormalMaterial = false;
   this._renderer._enableLighting = true;
-  this._renderer._tex = null;
 
   return this;
 };

--- a/test/unit/webgl/p5.RendererGL.js
+++ b/test/unit/webgl/p5.RendererGL.js
@@ -432,7 +432,7 @@ suite('p5.RendererGL', function() {
 
       myp5.plane(100);
       const pixel = myp5.get(50, 50);
-      assert.deepEqual(pixel, [56, 56, 56, 255]);
+      assert.deepEqual(pixel, [88, 88, 88, 255]);
     });
 
     test('emissiveMaterial() does not kill texture', function() {

--- a/test/unit/webgl/p5.RendererGL.js
+++ b/test/unit/webgl/p5.RendererGL.js
@@ -389,6 +389,66 @@ suite('p5.RendererGL', function() {
       expect(pixel[1]).to.equal(128);
       expect(pixel[2]).to.equal(128);
     });
+
+    test('specular is not lost by texture()', function() {
+      myp5.createCanvas(100, 100, myp5.WEBGL);
+      const tex = myp5.createGraphics(100, 100);
+      tex.background(64);
+      myp5.noStroke();
+      myp5.lights();
+
+      myp5.specularMaterial(128);
+      myp5.texture(tex);
+
+      myp5.plane(100);
+      const pixel = myp5.get(50, 50);
+      assert.deepEqual(pixel, [184, 184, 184, 255]);
+    });
+
+    test('specularMaterial() does not kill texture', function() {
+      myp5.createCanvas(100, 100, myp5.WEBGL);
+      const tex = myp5.createGraphics(100, 100);
+      tex.background(64);
+      myp5.noStroke();
+      myp5.lights();
+
+      myp5.texture(tex);
+      myp5.specularMaterial(128);
+
+      myp5.plane(100);
+      const pixel = myp5.get(50, 50);
+      assert.deepEqual(pixel, [184, 184, 184, 255]);
+    });
+
+    test('ambientMaterial() does not kill texture', function() {
+      myp5.createCanvas(100, 100, myp5.WEBGL);
+      const tex = myp5.createGraphics(100, 100);
+      tex.background(64);
+      myp5.noStroke();
+      myp5.lights();
+
+      myp5.texture(tex);
+      myp5.ambientMaterial(128);
+
+      myp5.plane(100);
+      const pixel = myp5.get(50, 50);
+      assert.deepEqual(pixel, [56, 56, 56, 255]);
+    });
+
+    test('emissiveMaterial() does not kill texture', function() {
+      myp5.createCanvas(100, 100, myp5.WEBGL);
+      const tex = myp5.createGraphics(100, 100);
+      tex.background(64);
+      myp5.noStroke();
+      myp5.lights();
+
+      myp5.texture(tex);
+      myp5.emissiveMaterial(128);
+
+      myp5.plane(100);
+      const pixel = myp5.get(50, 50);
+      assert.deepEqual(pixel, [184, 184, 184, 255]);
+    });
   });
 
   suite('loadpixels()', function() {


### PR DESCRIPTION
The purpose is to make texture() and specular coexist.

Resolves #6137

 ## Changes:
Since ambientMaterial(), emissiveMaterial(), specularMaterial() used to process _tex to null, this process has been removed.
Since texture() was setting _useSpecularMaterial etc. to false, that process was removed.


## Screenshots of the change:

### before/after
<!-- If applicable, add screenshots depicting the changes. -->

![before](https://github.com/processing/p5.js/assets/39549290/6f8af64d-46a4-4956-bd72-0f2ee02259e0)

#### PR Checklist
<!--
  To check any option, replace the "[ ]" with a "[x]". Be sure to check out how it looks in the Preview tab! Feel free to remove any portion of the template that is not relevant for your issue.
-->

- [ ] `npm run lint` passes
- [ ] [Inline documentation] is included / updated
- [ ] [Unit tests] are included / updated

[Inline documentation]: https://github.com/processing/p5.js/blob/main/contributor_docs/inline_documentation.md
[Unit tests]: https://github.com/processing/p5.js/tree/main/contributor_docs#unit-tests
