### PR TITLE
Improve orbitControl() to make it smoother

### DIFF
--- a/src/webgl/interaction.js
+++ b/src/webgl/interaction.js
@@ -147,8 +147,8 @@ p5.prototype.orbitControl = function(
   const moveAccelerationFactor = 0.15;
   // For touches, the appropriate scale is different
   // because the distance difference is multiplied.
-  const mouseZoomScaleFactor = 0.00008;
-  const touchZoomScaleFactor = 0.00032;
+  const mouseZoomScaleFactor = 0.0001;
+  const touchZoomScaleFactor = 0.0004;
   const scaleFactor = this.height < this.width ? this.height : this.width;
 
   // calculate and determine flags and variables.
@@ -166,8 +166,11 @@ p5.prototype.orbitControl = function(
       const distWithTouches = Math.hypot(t0.x - t1.x, t0.y - t1.y);
       const prevDistWithTouches = Math.hypot(t0.px - t1.px, t0.py - t1.py);
       const changeDist = distWithTouches - prevDistWithTouches;
+      // move the camera farther when the distance between the two touch points
+      // decreases, move the camera closer when it increases.
       deltaRadius = -changeDist * sensitivityZ * touchZoomScaleFactor;
-
+      // Move the center of the camera along with the movement of
+      // the center of gravity of the two touch points.
       moveDeltaX = 0.5 * (t0.x + t1.x) - 0.5 * (t0.px + t1.px);
       moveDeltaY = 0.5 * (t0.y + t1.y) - 0.5 * (t0.py + t1.py);
     }
@@ -177,7 +180,8 @@ p5.prototype.orbitControl = function(
     // if mouseLeftButton is down, rotate
     // if mouseRightButton is down, move
     if (this._mouseWheelDeltaY !== 0) {
-      // zoom according to direction of mouseWheelDeltaY rather than value.
+      // zoom the camera depending on the value of _mouseWheelDeltaY.
+      // move away if positive, move closer if negative
       deltaRadius = this._mouseWheelDeltaY * sensitivityZ;
       deltaRadius *= mouseZoomScaleFactor;
       this._mouseWheelDeltaY = 0;

--- a/src/webgl/interaction.js
+++ b/src/webgl/interaction.js
@@ -135,13 +135,12 @@ p5.prototype.orbitControl = function(
   // The idea of using damping is based on the following website. thank you.
   // https://github.com/freshfork/p5.EasyCam/blob/9782964680f6a5c4c9bee825c475d9f2021d5134/p5.easycam.js#L1124
 
-  // A flag that determines whether to accelerate
-  let accelerateZoomVelocity = false;
-  let accelerateRotateVelocity = false;
-  let accelerateMoveVelocity = false;
   // variables for interaction
-  let deltaRadius, deltaPhi, deltaTheta;
-  let moveDeltaX, moveDeltaY;
+  let deltaRadius = 0;
+  let deltaTheta = 0;
+  let deltaPhi = 0;
+  let moveDeltaX = 0;
+  let moveDeltaY = 0;
   // constants for dampingProcess
   const damping = 0.85;
   const rotateAccelerationFactor = 0.6;
@@ -158,12 +157,10 @@ p5.prototype.orbitControl = function(
     // if length === 1, rotate
     // if length > 1, zoom and move
     if (movedTouches.length === 1) {
-      accelerateRotateVelocity = true;
       const t = movedTouches[0];
       deltaTheta = -sensitivityX * (t.x - t.px) / scaleFactor;
       deltaPhi = sensitivityY * (t.y - t.py) / scaleFactor;
     } else {
-      accelerateZoomVelocity = true;
       const t0 = movedTouches[0];
       const t1 = movedTouches[1];
       const distWithTouches = Math.hypot(t0.x - t1.x, t0.y - t1.y);
@@ -171,7 +168,6 @@ p5.prototype.orbitControl = function(
       const changeDist = distWithTouches - prevDistWithTouches;
       deltaRadius = -changeDist * sensitivityZ * touchZoomScaleFactor;
 
-      accelerateMoveVelocity = true;
       moveDeltaX = 0.5 * (t0.x + t1.x) - 0.5 * (t0.px + t1.px);
       moveDeltaY = 0.5 * (t0.y + t1.y) - 0.5 * (t0.py + t1.py);
     }
@@ -181,7 +177,6 @@ p5.prototype.orbitControl = function(
     // if mouseLeftButton is down, rotate
     // if mouseRightButton is down, move
     if (this._mouseWheelDeltaY !== 0) {
-      accelerateZoomVelocity = true;
       // zoom according to direction of mouseWheelDeltaY rather than value.
       deltaRadius = this._mouseWheelDeltaY * sensitivityZ;
       deltaRadius *= mouseZoomScaleFactor;
@@ -189,11 +184,9 @@ p5.prototype.orbitControl = function(
     }
     if (this.mouseIsPressed) {
       if (this.mouseButton === this.LEFT) {
-        accelerateRotateVelocity = true;
         deltaTheta = -sensitivityX * (this.mouseX - this.pmouseX) / scaleFactor;
         deltaPhi = sensitivityY * (this.mouseY - this.pmouseY) / scaleFactor;
       } else if (this.mouseButton === this.RIGHT) {
-        accelerateMoveVelocity = true;
         moveDeltaX = this.mouseX - this.pmouseX;
         moveDeltaY = this.mouseY - this.pmouseY;
       }
@@ -203,7 +196,7 @@ p5.prototype.orbitControl = function(
   // interactions
 
   // zoom process
-  if (accelerateZoomVelocity) {
+  if (deltaRadius !== 0) {
     // accelerate zoom velocity
     this._renderer.zoomVelocity += deltaRadius;
   }
@@ -227,7 +220,7 @@ p5.prototype.orbitControl = function(
   }
 
   // rotate process
-  if (accelerateRotateVelocity) {
+  if (deltaTheta !== 0 || deltaPhi !== 0) {
     // accelerate rotate velocity
     this._renderer.rotateVelocity.add(
       deltaTheta * rotateAccelerationFactor,
@@ -248,7 +241,7 @@ p5.prototype.orbitControl = function(
   }
 
   // move process
-  if (accelerateMoveVelocity) {
+  if (moveDeltaX !== 0 || moveDeltaY !== 0) {
     // Normalize movement distance
     const ndcX = moveDeltaX * 2/this.width;
     const ndcY = -moveDeltaY * 2/this.height;

--- a/src/webgl/interaction.js
+++ b/src/webgl/interaction.js
@@ -183,7 +183,8 @@ p5.prototype.orbitControl = function(
     if (this._mouseWheelDeltaY !== 0) {
       accelerateZoomVelocity = true;
       // zoom according to direction of mouseWheelDeltaY rather than value.
-      deltaRadius = this._mouseWheelDeltaY * sensitivityZ * mouseZoomScaleFactor;
+      deltaRadius = this._mouseWheelDeltaY * sensitivityZ;
+      deltaRadius *= mouseZoomScaleFactor;
       this._mouseWheelDeltaY = 0;
     }
     if (this.mouseIsPressed) {

--- a/src/webgl/interaction.js
+++ b/src/webgl/interaction.js
@@ -133,7 +133,7 @@ p5.prototype.orbitControl = function(
   this._renderer.prevTouches = this.touches;
 
   // The idea of using damping is based on the following website. thank you.
-  // https://github.com/freshfork/p5.EasyCam/blob/master/p5.easycam.js
+  // https://github.com/freshfork/p5.EasyCam/blob/9782964680f6a5c4c9bee825c475d9f2021d5134/p5.easycam.js#L1124
 
   // A flag that determines whether to accelerate
   let accelerateZoomVelocity = false;

--- a/src/webgl/interaction.js
+++ b/src/webgl/interaction.js
@@ -132,18 +132,24 @@ p5.prototype.orbitControl = function(
   }
   this._renderer.prevTouches = this.touches;
 
-  // flags for interaction
-  let executeZoomProcess = false;
-  let executeRotateProcess = false;
-  let executeMoveProcess = false;
+  // The idea of using damping is based on the following website. thank you.
+  // https://github.com/freshfork/p5.EasyCam/blob/master/p5.easycam.js
+
+  // A flag that determines whether to accelerate
+  let accelerateZoomVelocity = false;
+  let accelerateRotateVelocity = false;
+  let accelerateMoveVelocity = false;
   // variables for interaction
   let deltaRadius, deltaPhi, deltaTheta;
   let moveDeltaX, moveDeltaY;
-
+  // constants for dampingProcess
+  const damping = 0.85;
+  const rotateAccelerationFactor = 0.6;
+  const moveAccelerationFactor = 0.15;
   // For touches, the appropriate scale is different
   // because the distance difference is multiplied.
-  const mouseZoomScaleFactor = 0.02;
-  const touchZoomScaleFactor = 0.0008;
+  const mouseZoomScaleFactor = 0.00008;
+  const touchZoomScaleFactor = 0.00032;
   const scaleFactor = this.height < this.width ? this.height : this.width;
 
   // calculate and determine flags and variables.
@@ -152,12 +158,12 @@ p5.prototype.orbitControl = function(
     // if length === 1, rotate
     // if length > 1, zoom and move
     if (movedTouches.length === 1) {
-      executeRotateProcess = true;
+      accelerateRotateVelocity = true;
       const t = movedTouches[0];
       deltaTheta = -sensitivityX * (t.x - t.px) / scaleFactor;
       deltaPhi = sensitivityY * (t.y - t.py) / scaleFactor;
     } else {
-      executeZoomProcess = true;
+      accelerateZoomVelocity = true;
       const t0 = movedTouches[0];
       const t1 = movedTouches[1];
       const distWithTouches = Math.hypot(t0.x - t1.x, t0.y - t1.y);
@@ -165,7 +171,7 @@ p5.prototype.orbitControl = function(
       const changeDist = distWithTouches - prevDistWithTouches;
       deltaRadius = -changeDist * sensitivityZ * touchZoomScaleFactor;
 
-      executeMoveProcess = true;
+      accelerateMoveVelocity = true;
       moveDeltaX = 0.5 * (t0.x + t1.x) - 0.5 * (t0.px + t1.px);
       moveDeltaY = 0.5 * (t0.y + t1.y) - 0.5 * (t0.py + t1.py);
     }
@@ -175,19 +181,18 @@ p5.prototype.orbitControl = function(
     // if mouseLeftButton is down, rotate
     // if mouseRightButton is down, move
     if (this._mouseWheelDeltaY !== 0) {
-      executeZoomProcess = true;
+      accelerateZoomVelocity = true;
       // zoom according to direction of mouseWheelDeltaY rather than value.
-      const mouseWheelSign = (this._mouseWheelDeltaY > 0 ? 1 : -1);
-      deltaRadius = mouseWheelSign * sensitivityZ * mouseZoomScaleFactor;
+      deltaRadius = this._mouseWheelDeltaY * sensitivityZ * mouseZoomScaleFactor;
       this._mouseWheelDeltaY = 0;
     }
     if (this.mouseIsPressed) {
       if (this.mouseButton === this.LEFT) {
-        executeRotateProcess = true;
+        accelerateRotateVelocity = true;
         deltaTheta = -sensitivityX * (this.mouseX - this.pmouseX) / scaleFactor;
         deltaPhi = sensitivityY * (this.mouseY - this.pmouseY) / scaleFactor;
       } else if (this.mouseButton === this.RIGHT) {
-        executeMoveProcess = true;
+        accelerateMoveVelocity = true;
         moveDeltaX = this.mouseX - this.pmouseX;
         moveDeltaY = this.mouseY - this.pmouseY;
       }
@@ -195,23 +200,64 @@ p5.prototype.orbitControl = function(
   }
 
   // interactions
-  // zoom
-  if (executeZoomProcess) {
-    this._renderer._curCamera._orbit(0, 0, deltaRadius);
+
+  // zoom process
+  if (accelerateZoomVelocity) {
+    // accelerate zoom velocity
+    this._renderer.zoomVelocity += deltaRadius;
+  }
+  if (Math.abs(this._renderer.zoomVelocity) > 0.001) {
+    this._renderer._curCamera._orbit(0, 0, this._renderer.zoomVelocity);
     // In orthogonal projection, the scale does not change even if
     // the distance to the gaze point is changed, so the projection matrix
     // needs to be modified.
     if (this._renderer.uPMatrix.mat4[15] !== 0) {
-      this._renderer.uPMatrix.mat4[0] *= Math.pow(10, -deltaRadius);
-      this._renderer.uPMatrix.mat4[5] *= Math.pow(10, -deltaRadius);
+      this._renderer.uPMatrix.mat4[0] *= Math.pow(
+        10, -this._renderer.zoomVelocity
+      );
+      this._renderer.uPMatrix.mat4[5] *= Math.pow(
+        10, -this._renderer.zoomVelocity
+      );
     }
+    // damping
+    this._renderer.zoomVelocity *= damping;
+  } else {
+    this._renderer.zoomVelocity = 0;
   }
-  // rotate
-  if (executeRotateProcess) {
-    this._renderer._curCamera._orbit(deltaTheta, deltaPhi, 0);
+
+  // rotate process
+  if (accelerateRotateVelocity) {
+    // accelerate rotate velocity
+    this._renderer.rotateVelocity.add(
+      deltaTheta * rotateAccelerationFactor,
+      deltaPhi * rotateAccelerationFactor,
+      0
+    );
   }
-  // move
-  if (executeMoveProcess) {
+  if (this._renderer.rotateVelocity.mag() > 0.001) {
+    this._renderer._curCamera._orbit(
+      this._renderer.rotateVelocity.x,
+      this._renderer.rotateVelocity.y,
+      0
+    );
+    // damping
+    this._renderer.rotateVelocity.mult(damping);
+  } else {
+    this._renderer.rotateVelocity.set(0, 0);
+  }
+
+  // move process
+  if (accelerateMoveVelocity) {
+    // Normalize movement distance
+    const ndcX = moveDeltaX * 2/this.width;
+    const ndcY = -moveDeltaY * 2/this.height;
+    // accelerate move velocity
+    this._renderer.moveVelocity.add(
+      ndcX * moveAccelerationFactor,
+      ndcY * moveAccelerationFactor
+    );
+  }
+  if (this._renderer.moveVelocity.mag() > 0.001) {
     // Translate the camera so that the entire object moves
     // perpendicular to the line of sight when the mouse is moved
     // or when the centers of gravity of the two touch pointers move.
@@ -231,14 +277,10 @@ p5.prototype.orbitControl = function(
     cv = cam.cameraMatrix.multiplyPoint(cv);
     cv = this._renderer.uPMatrix.multiplyAndNormalizePoint(cv);
 
-    // Normalize movement distance
-    const ndcX = moveDeltaX * 2/this.width;
-    const ndcY = -moveDeltaY * 2/this.height;
-
     // Move the center by this distance
     // in the normalized device coordinate system.
-    cv.x -= ndcX;
-    cv.y -= ndcY;
+    cv.x -= this._renderer.moveVelocity.x;
+    cv.y -= this._renderer.moveVelocity.y;
 
     // Calculate the translation vector
     // in the direction perpendicular to the line of sight of center.
@@ -259,10 +301,15 @@ p5.prototype.orbitControl = function(
       cam.eyeY + dx * local.x[1] + dy * local.y[1],
       cam.eyeZ + dx * local.x[2] + dy * local.y[2]
     );
+    // damping
+    this._renderer.moveVelocity.mult(damping);
+  } else {
+    this._renderer.moveVelocity.set(0, 0);
   }
 
   return this;
 };
+
 
 /**
  * debugMode() helps visualize 3D space by adding a grid to indicate where the

--- a/src/webgl/material.js
+++ b/src/webgl/material.js
@@ -825,6 +825,7 @@ p5.prototype.ambientMaterial = function(v1, v2, v3) {
   this._renderer.curAmbientColor = color._array;
   this._renderer._useNormalMaterial = false;
   this._renderer._enableLighting = true;
+  this._renderer._tex = null;
   this._renderer._setProperty('_doFill', true);
   return this;
 };
@@ -896,6 +897,7 @@ p5.prototype.emissiveMaterial = function(v1, v2, v3, a) {
   this._renderer._useEmissiveMaterial = true;
   this._renderer._useNormalMaterial = false;
   this._renderer._enableLighting = true;
+  this._renderer._tex = null;
 
   return this;
 };
@@ -982,6 +984,7 @@ p5.prototype.specularMaterial = function(v1, v2, v3, alpha) {
   this._renderer._useSpecularMaterial = true;
   this._renderer._useNormalMaterial = false;
   this._renderer._enableLighting = true;
+  this._renderer._tex = null;
 
   return this;
 };

--- a/src/webgl/material.js
+++ b/src/webgl/material.js
@@ -825,7 +825,6 @@ p5.prototype.ambientMaterial = function(v1, v2, v3) {
   this._renderer.curAmbientColor = color._array;
   this._renderer._useNormalMaterial = false;
   this._renderer._enableLighting = true;
-  this._renderer._tex = null;
   this._renderer._setProperty('_doFill', true);
   return this;
 };
@@ -897,7 +896,6 @@ p5.prototype.emissiveMaterial = function(v1, v2, v3, a) {
   this._renderer._useEmissiveMaterial = true;
   this._renderer._useNormalMaterial = false;
   this._renderer._enableLighting = true;
-  this._renderer._tex = null;
 
   return this;
 };
@@ -984,7 +982,6 @@ p5.prototype.specularMaterial = function(v1, v2, v3, alpha) {
   this._renderer._useSpecularMaterial = true;
   this._renderer._useNormalMaterial = false;
   this._renderer._enableLighting = true;
-  this._renderer._tex = null;
 
   return this;
 };

--- a/src/webgl/p5.RendererGL.js
+++ b/src/webgl/p5.RendererGL.js
@@ -175,6 +175,10 @@ p5.RendererGL = function(elt, pInst, isMainCanvas, attr) {
   // Information about the previous frame's touch object
   // for executing orbitControl()
   this.prevTouches = [];
+  // Velocity variable for use with orbitControl()
+  this.zoomVelocity = 0;
+  this.rotateVelocity = new p5.Vector(0, 0);
+  this.moveVelocity = new p5.Vector(0, 0);
 
   this._defaultLightShader = undefined;
   this._defaultImmediateModeShader = undefined;


### PR DESCRIPTION
Introduce the idea of ​​using p5.EasyCam's damping to make the behavior of orbitControl() smoother.

Resolves #6139

## Changes:
When you set up your renderer, you provide velocity variables to handle each of the scaling, rotation, and translation. 
Interactions accelerate these velocity variables.
The velocity variable is moderately damped every frame.
You can smooth out the behavior by performing an update on these velocity variables.

## Demo
Demo is here:[newOrbitControl](https://openprocessing.org/sketch/1924658)

#### PR Checklist

- [ ] `npm run lint` passes
- [ ] [Inline documentation] is included / updated
- [ ] [Unit tests] are included / updated

[Inline documentation]: https://github.com/processing/p5.js/blob/main/contributor_docs/inline_documentation.md
[Unit tests]: https://github.com/processing/p5.js/tree/main/contributor_docs#unit-tests
