### PR TITLE
Update loading_displaying.js

### DIFF
--- a/src/image/loading_displaying.js
+++ b/src/image/loading_displaying.js
@@ -61,6 +61,29 @@ import '../core/friendly_errors/fes_core';
  * }
  * </code>
  * </div>
+ * <div>
+ * <code>
+ * // JSON file containing a list of files to load
+ * // ["assets/laDefense.jpg", "assets/rockies.jpg"]
+ * // In this case we use a callback, so once the JSON file is loaded, it will load the images.
+ * let imageList = [];
+ * function preload() {
+ *   loadJSON('assets/images.json', jsonData => {
+ *     for (let filename of jsonData) {
+ *       imageList.push(loadImage(filename));
+ *     }
+ *   }) ;
+ * }
+ *
+ * function setup() {
+ *   let x = 0;
+ *   for (let img of imageList) {
+ *      image(img, x, 0);
+ *      x += img.width;
+ *   }
+ * }
+ * </code>
+ * </div>
  *
  * @alt
  * image of the underside of a white umbrella and grided ceililng above


### PR DESCRIPTION
A useful example of using callbacks when preloading images.

Sometimes we don't directly have the names of the images, but those have to be loaded from a JSON file.

Loading a JSON file without callbacks will make the data not available immediately, therefore avoiding the preloading of images.

With this example, we can preload a JSON file and use the callback to then preload the list of images, so everything gets ready when the `setup()` function is called.

I find this example very useful and I think it should be included either here, or in the `preload()` documentation

<!--
  Thank you for contributing! Please use this pull request (PR) template.


 In the description field of this PR, include "resolves #XXXX" tagging the issue you are fixing. If this PR addresses the issue but doesn't completely resolve it (ie the issue should remain open after your PR is merged), write "addresses #XXXX".-->
Resolves #[Add issue number here]

 Changes:
<!-- Add here what changes were made in this pull request and if possible provide links showcasing the changes. -->


 Screenshots of the change:
<!-- If applicable, add screenshots depicting the changes. -->

#### PR Checklist
<!--
  To check any option, replace the "[ ]" with a "[x]". Be sure to check out how it looks in the Preview tab! Feel free to remove any portion of the template that is not relevant for your issue.
-->

- [ ] `npm run lint` passes
- [ ] [Inline documentation] is included / updated
- [ ] [Unit tests] are included / updated

[Inline documentation]: https://github.com/processing/p5.js/blob/main/contributor_docs/inline_documentation.md
[Unit tests]: https://github.com/processing/p5.js/tree/main/contributor_docs#unit-tests
