### PR TITLE
Do not use angleBetween() for angle calculation in _orbit() inside orbtiControl().

### DIFF
--- a/src/webgl/p5.Camera.js
+++ b/src/webgl/p5.Camera.js
@@ -1746,7 +1746,8 @@ p5.Camera.prototype._orbit = function(dTheta, dPhi, dRadius) {
 
   // calculate updated camera angle
   // Find the angle between the "up" and the "front", add dPhi to that.
-  const camPhi = front.angleBetween(up) + dPhi;
+  const camPhi =
+    Math.acos(Math.max(-1, Math.min(1, p5.Vector.dot(front, up)))) + dPhi;
   // Rotate by dTheta in the shortest direction from "vertical" to "side"
   const camTheta = dTheta;
 

--- a/src/webgl/p5.Camera.js
+++ b/src/webgl/p5.Camera.js
@@ -1746,6 +1746,9 @@ p5.Camera.prototype._orbit = function(dTheta, dPhi, dRadius) {
 
   // calculate updated camera angle
   // Find the angle between the "up" and the "front", add dPhi to that.
+  // angleBetween() may return negative value. Since this specification is subject to change
+  // due to version updates, it cannot be adopted, so here we calculate using a method
+  // that directly obtains the absolute value.
   const camPhi =
     Math.acos(Math.max(-1, Math.min(1, p5.Vector.dot(front, up)))) + dPhi;
   // Rotate by dTheta in the shortest direction from "vertical" to "side"


### PR DESCRIPTION
Since angleBetween() can return negative numbers, modify it so that it only returns positive numbers.
This function is not used because it is inconvenient to be affected by the specification change of angleBetween().


Resolves #6153

## Changes:

before:
```js
  // Find the angle between the "up" and the "front", add dPhi to that.
  const camPhi = front.angleBetween(up) + dPhi;
```
after:
```js
  // Find the angle between the "up" and the "front", add dPhi to that.
  const camPhi =
    Math.acos(Math.max(-1, Math.min(1, p5.Vector.dot(front, up)))) + dPhi;
```

#### PR Checklist

- [x] `npm run lint` passes
- [ ] [Inline documentation] is included / updated
- [ ] [Unit tests] are included / updated

[Inline documentation]: https://github.com/processing/p5.js/blob/main/contributor_docs/inline_documentation.md
[Unit tests]: https://github.com/processing/p5.js/tree/main/contributor_docs#unit-tests
