### PR TITLE
Speed up line rendering with WebGL2 instancing

### DIFF
--- a/src/webgl/p5.RenderBuffer.js
+++ b/src/webgl/p5.RenderBuffer.js
@@ -8,6 +8,28 @@ p5.RenderBuffer = class {
     this.attr = attr; // the name of the vertex attribute
     this._renderer = renderer;
     this.map = map; // optional, a transformation function to apply to src
+    this._namespace = undefined;
+    this._stride = 0;
+    this._offset = 0;
+    this._divisor = undefined;
+  }
+  namespace(namespace) {
+    // A namespace within a p5.Geometry in which to find the source buffer and
+    // to store the destination buffer
+    this._namespace = namespace.split('.');
+    return this;
+  }
+  stride(stride) {
+    this._stride = stride; // how many bytes between the starts of adjacent values
+    return this;
+  }
+  offset(offset) {
+    this._offset = offset; // how many bytes to start at
+    return this;
+  }
+  divisor(divisor) {
+    this._divisor = divisor; // how many instances it stays the same for
+    return this;
   }
 
   /**
@@ -27,6 +49,25 @@ p5.RenderBuffer = class {
       model = geometry;
     }
 
+    let geometryData = geometry;
+    if (this._namespace) {
+      for (const prefix of this._namespace) {
+        if (!geometryData[prefix]) {
+          geometryData[prefix] = {};
+        }
+        geometryData = geometryData[prefix];
+      }
+    }
+    let modelData = model;
+    if (this._namespace) {
+      for (const prefix of this._namespace) {
+        if (!modelData[prefix]) {
+          modelData[prefix] = {};
+        }
+        modelData = modelData[prefix];
+      }
+    }
+
     // loop through each of the buffer definitions
     const attr = attributes[this.attr];
     if (!attr) {
@@ -34,20 +75,24 @@ p5.RenderBuffer = class {
     }
 
     // check if the model has the appropriate source array
-    let buffer = geometry[this.dst];
-    const src = model[this.src];
+    let buffer = geometryData[this.dst];
+    const src = modelData[this.src];
     if (src.length > 0) {
     // check if we need to create the GL buffer
       const createBuffer = !buffer;
       if (createBuffer) {
       // create and remember the buffer
-        geometry[this.dst] = buffer = gl.createBuffer();
+        geometryData[this.dst] = buffer = gl.createBuffer();
       }
       // bind the buffer
       gl.bindBuffer(gl.ARRAY_BUFFER, buffer);
 
       // check if we need to fill the buffer with data
-      if (createBuffer || model.dirtyFlags[this.src] !== false) {
+      let key = this.dst;
+      if (this._namespace) {
+        key = this._namespace.join('.') + '.' + key;
+      }
+      if (createBuffer || model.dirtyFlags[key] !== false) {
         const map = this.map;
         // get the values from the model, possibly transformed
         const values = map ? map(src) : src;
@@ -55,17 +100,26 @@ p5.RenderBuffer = class {
         this._renderer._bindBuffer(buffer, gl.ARRAY_BUFFER, values);
 
         // mark the model's source array as clean
-        model.dirtyFlags[this.src] = false;
+        model.dirtyFlags[key] = false;
       }
+
       // enable the attribute
-      shader.enableAttrib(attr, this.size);
+      shader.enableAttrib(
+        attr, // location
+        this.size, // size
+        gl.FLOAT, // type
+        false, // normalized
+        this._stride,
+        this._offset,
+        this._divisor
+      );
     } else {
       const loc = attr.location;
-      if (loc === -1 || !this._renderer.registerEnabled[loc]) { return; }
+      if (loc === -1 || !this._renderer.registerEnabled.has(loc)) { return; }
       // Disable register corresponding to unused attribute
       gl.disableVertexAttribArray(loc);
       // Record register availability
-      this._renderer.registerEnabled[loc] = false;
+      this._renderer.registerEnabled.delete(loc);
     }
   }
 };

--- a/src/webgl/p5.RendererGL.Immediate.js
+++ b/src/webgl/p5.RendererGL.Immediate.js
@@ -439,13 +439,15 @@ p5.RendererGL.prototype._drawImmediateStroke = function() {
       );
     }
   } else {
+    this.immediateMode.geometry._makeStrokeBufferData();
     for (const buff of this.immediateMode.buffers.stroke) {
       buff._prepareBuffer(this.immediateMode.geometry, shader);
     }
     gl.drawArrays(
       gl.TRIANGLES,
       0,
-      this.immediateMode.geometry.lineData.lineVertices.length
+      this.immediateMode.geometry.lineData.stroke.lineVertices.length
+        / 2
     );
   }
   if (faceCullingEnabled) {

--- a/src/webgl/p5.RendererGL.Retained.js
+++ b/src/webgl/p5.RendererGL.Retained.js
@@ -148,6 +148,7 @@ p5.RendererGL.prototype.drawBuffers = function(gId) {
         this._drawArraysInstanced(gl.TRIANGLES, gId, key);
       }
     } else {
+      geometry._makeStrokeBufferData();
       for (const buff of this.retainedMode.buffers.stroke) {
         buff._prepareBuffer(geometry, strokeShader);
       }
@@ -197,6 +198,7 @@ p5.RendererGL.prototype._drawArrays = function(drawMode, gId) {
     drawMode,
     0,
     this.retainedMode.geometry[gId].model.lineData.stroke.lineVertices.length
+      / 2
   );
   return this;
 };

--- a/src/webgl/p5.RendererGL.js
+++ b/src/webgl/p5.RendererGL.js
@@ -193,10 +193,22 @@ p5.RendererGL = function(elt, pInst, isMainCanvas, attr) {
   const makeStrokeBuffers = () => {
     return {
       stroke: [
-        new p5.RenderBuffer(4, 'lineVertexColors', 'lineColorBuffer', 'aVertexColor', this, this._flatten)
-          .namespace('lineData.stroke'),
-        new p5.RenderBuffer(3, 'lineVertices', 'lineVerticesBuffer', 'aPosition', this, this._flatten)
-          .namespace('lineData.stroke'),
+        new p5.RenderBuffer(4, 'lineVertexColors', 'lineFromColorBuffer', 'aFromVertexColor', this, this._flatten)
+          .namespace('lineData.stroke')
+          .stride(Float32Array.BYTES_PER_ELEMENT * 4 * 2)
+          .offset(0),
+        new p5.RenderBuffer(4, 'lineVertexColors', 'lineToColorBuffer', 'aToVertexColor', this, this._flatten)
+          .namespace('lineData.stroke')
+          .stride(Float32Array.BYTES_PER_ELEMENT * 4 * 2)
+          .offset(Float32Array.BYTES_PER_ELEMENT * 4),
+        new p5.RenderBuffer(3, 'lineVertices', 'lineFromVerticesBuffer', 'aFromPosition', this, this._flatten)
+          .namespace('lineData.stroke')
+          .stride(Float32Array.BYTES_PER_ELEMENT * 3 * 2)
+          .offset(0),
+        new p5.RenderBuffer(3, 'lineVertices', 'lineToVerticesBuffer', 'aToPosition', this, this._flatten)
+          .namespace('lineData.stroke')
+          .stride(Float32Array.BYTES_PER_ELEMENT * 3 * 2)
+          .offset(Float32Array.BYTES_PER_ELEMENT * 3),
         new p5.RenderBuffer(3, 'lineTangentsIn', 'lineTangentsInBuffer', 'aTangentIn', this, this._flatten)
           .namespace('lineData.stroke'),
         new p5.RenderBuffer(3, 'lineTangentsOut', 'lineTangentsOutBuffer', 'aTangentOut', this, this._flatten)

--- a/src/webgl/shaders/line.vert
+++ b/src/webgl/shaders/line.vert
@@ -78,12 +78,11 @@ void main() {
     aTangentIn != aTangentOut
   ) ? 1. : 0.;
 
-  // TODO rename aPosition, aVertexColor
-  vec4 aPosition = abs(aSide) == 1. ? aFromPosition : aToPosition;
-  vec4 aVertexColor = abs(aSide) == 1. ? aFromVertexColor : aToVertexColor;
-  vec4 posp = uModelViewMatrix * aPosition;
-  vec4 posqIn = uModelViewMatrix * (aPosition + vec4(aTangentIn, 0));
-  vec4 posqOut = uModelViewMatrix * (aPosition + vec4(aTangentOut, 0));
+  vec4 position = abs(aSide) == 1. ? aFromPosition : aToPosition;
+  vec4 vertexColor = abs(aSide) == 1. ? aFromVertexColor : aToVertexColor;
+  vec4 posp = uModelViewMatrix * position;
+  vec4 posqIn = uModelViewMatrix * (position + vec4(aTangentIn, 0));
+  vec4 posqOut = uModelViewMatrix * (position + vec4(aTangentOut, 0));
 
   float facingCamera = pow(
     // The word space tangent's z value is 0 if it's facing the camera
@@ -219,5 +218,5 @@ void main() {
   gl_Position.xy = p.xy + offset.xy;
   gl_Position.zw = p.zw;
   
-  vColor = (uUseLineColor ? aVertexColor : uMaterialColor);
+  vColor = (uUseLineColor ? vertexColor : uMaterialColor);
 }

--- a/src/webgl/shaders/line.vert
+++ b/src/webgl/shaders/line.vert
@@ -32,11 +32,13 @@ uniform vec4 uViewport;
 uniform int uPerspective;
 uniform int uStrokeJoin;
 
-attribute vec4 aPosition;
+attribute vec4 aFromPosition;
+attribute vec4 aToPosition;
 attribute vec3 aTangentIn;
 attribute vec3 aTangentOut;
 attribute float aSide;
-attribute vec4 aVertexColor;
+attribute vec4 aFromVertexColor;
+attribute vec4 aToVertexColor;
 
 varying vec4 vColor;
 varying vec2 vTangent;
@@ -76,6 +78,9 @@ void main() {
     aTangentIn != aTangentOut
   ) ? 1. : 0.;
 
+  // TODO rename aPosition, aVertexColor
+  vec4 aPosition = abs(aSide) == 1. ? aFromPosition : aToPosition;
+  vec4 aVertexColor = abs(aSide) == 1. ? aFromVertexColor : aToVertexColor;
   vec4 posp = uModelViewMatrix * aPosition;
   vec4 posqIn = uModelViewMatrix * (aPosition + vec4(aTangentIn, 0));
   vec4 posqOut = uModelViewMatrix * (aPosition + vec4(aTangentOut, 0));
@@ -204,7 +209,7 @@ void main() {
     float normalOffset = sign(aSide);
     // Caps will have side values of -2 or 2 on the edge of the cap that
     // extends out from the line
-    float tangentOffset = abs(aSide) - 1.;
+    float tangentOffset = abs(aSide) == 2. ? 1. : 0.;
     offset = (normal * normalOffset + tangent * tangentOffset) *
       uStrokeWeight * 0.5 * curPerspScale;
     vMaxDist = uStrokeWeight / 2.;


### PR DESCRIPTION
Resolves https://github.com/processing/p5.js/issues/6091

### Changes

Currently, drawing strokes in WebGL mode is fairly slow. Since each segment/cap/join of a stroke is made of at least 2 triangles, we had to duplicate data per vertex of each triangle on the CPU.

Now that WebGL2 is enabled by default, we can use instanced rendering, which lets us repeat attributes per instance being rendered. This lets the GPU do the copying for us.

Here's a stress test example: https://editor.p5js.org/davepagurek/sketches/cWr5RmNAK

If you toggle between the 1.6.0 CDN `<script>` tag to the uploaded p5.min.js, **the frame rate goes up from ~40fps to ~60fps** on Chrome my M1 Macbook Pro (closer to ~18fps and ~40fps in Firefox.)

If you toggle `version: 2` to `version: 1`, it goes back to copying the vertex data on the CPU and the frame rate drops to ~35fps. This is slower than before since the format required for instancing is a bit less efficient when done on the CPU, but WebGL2 support is pretty broad now so this should only happen on legacy code.

### Future work
The new bottleneck in line rendering seems to be libtess. There are a few things we might consider doing:
- Update how `curveDetail` works to maybe be relative to curve length (or curvature) to save vertices
- Move away from libtess, maybe to [mapbox/earcut](https://github.com/mapbox/earcut) which apparently is faster, but would require extra work to tesselate shapes that aren't on the XY plane

#### PR Checklist

- [x] `npm run lint` passes
- [x] [Inline documentation] is included / updated
- [ ] [Unit tests] are included / updated
