### PR TITLE
Improvement of orbitControl(): Behavior when going out of canvas during operation

### DIFF
--- a/src/webgl/interaction.js
+++ b/src/webgl/interaction.js
@@ -191,7 +191,7 @@ p5.prototype.orbitControl = function(
     // if mouseLeftButton is down, rotate
     // if mouseRightButton is down, move
 
-    // For mouse, it is calculated based on the mouse position.    
+    // For mouse, it is calculated based on the mouse position.
     pointersInCanvas =
       (this.mouseX > 0 && this.mouseX < this.width) &&
       (this.mouseY > 0 && this.mouseY < this.height);

--- a/src/webgl/p5.RendererGL.js
+++ b/src/webgl/p5.RendererGL.js
@@ -179,6 +179,9 @@ p5.RendererGL = function(elt, pInst, isMainCanvas, attr) {
   this.zoomVelocity = 0;
   this.rotateVelocity = new p5.Vector(0, 0);
   this.moveVelocity = new p5.Vector(0, 0);
+  // Flags for recording the state of zooming, rotation and moving
+  this.executeZoom = false;
+  this.executeRotateAndMove = false;
 
   this._defaultLightShader = undefined;
   this._defaultImmediateModeShader = undefined;


### PR DESCRIPTION
The current orbitControl() is designed to stop processing suddenly if it goes out of the canvas while operating inside the canvas.

I don't think it's a very clean behavior, so I'm trying to improve this.

Resolves #6168

## Changes:
Stop using mouseInCanvas and instead use pointersInCanvas, which indicates whether the mouse or touch pointer is inside the canvas.
Use this flag to start processing when you interact within the canvas.
Prepare some flags for p5.Renderer so that even if you go outside the canvas during the interaction, the processing will not end as long as the interaction continues.

## Screenshots of the change:

### Current behavior

https://github.com/processing/p5.js/assets/39549290/3959d5b4-999b-4283-b0f1-c0818553fa2e

### Expect behavior
OpenProcessing: [orbitControl_outsideBehavior](https://openprocessing.org/sketch/1941568)
p5Editor: [orbitControl_outsideBehavior](https://editor.p5js.org/dark_fox/sketches/-4WRlDrSf)

https://github.com/processing/p5.js/assets/39549290/aff115bb-bf2a-4c9e-a900-9951e86cc548

#### PR Checklist
<!--
  To check any option, replace the "[ ]" with a "[x]". Be sure to check out how it looks in the Preview tab! Feel free to remove any portion of the template that is not relevant for your issue.
-->

- [x] `npm run lint` passes
- [ ] [Inline documentation] is included / updated
- [ ] [Unit tests] are included / updated

[Inline documentation]: https://github.com/processing/p5.js/blob/main/contributor_docs/inline_documentation.md
[Unit tests]: https://github.com/processing/p5.js/tree/main/contributor_docs#unit-tests
