### PR TITLE
Add EasyCam-like behavior to orbitControl() as an option

### DIFF
--- a/src/webgl/interaction.js
+++ b/src/webgl/interaction.js
@@ -29,9 +29,12 @@ import * as constants from '../core/constants';
  * Setting this to true makes mobile interactions smoother by preventing
  * accidental interactions with the page while orbiting. But if you're already
  * doing it via css or want the default touch actions, consider setting it to false.
- * free - Boolean, default value is false.
- * Setting this to true will always rotate in the direction you move the mouse or touch pointer.
- * Regarding zoom and move, both behave the same.
+ * freeRotation - Boolean, default value is false.
+ * By default, horizontal movement of the mouse or touch pointer rotates the camera
+ * around the y-axis, and vertical movement rotates the camera around the x-axis.
+ * But if setting this option to true, the camera always rotates in the direction
+ * the pointer is moving. For zoom and move, the behavior is the same regardless of
+ * true/false.
  * @chainable
  * @example
  * <div>
@@ -46,9 +49,10 @@ import * as constants from '../core/constants';
  * function draw() {
  *   background(200);
  *
- *   // If you write here like orbitControl(1, 1, 1, {free: true})
- *   // instead of this, the behavior will change.
+ *   // If you execute the line commented out instead of next line, the direction of rotation
+ *   // will be the direction the mouse or touch pointer moves, not around the X or Y axis.
  *   orbitControl();
+ *   // orbitControl(1, 1, 1, {freeRotation: true});
  *
  *   rotateY(0.5);
  *   box(30, 50);
@@ -112,9 +116,9 @@ p5.prototype.orbitControl = function(
     this._setProperty('touchActionsDisabled', true);
   }
 
-  // If option.free is true, it will always rotate freely in the direction
+  // If option.freeRotation is true, the camera always rotates freely in the direction
   // the pointer moves. default value is false (normal behavior)
-  const { free = false } = options;
+  const { freeRotation = false } = options;
 
   // get moved touches.
   const movedTouches = [];
@@ -243,8 +247,8 @@ p5.prototype.orbitControl = function(
     this._renderer.zoomVelocity += deltaRadius;
   }
   if (Math.abs(this._renderer.zoomVelocity) > 0.001) {
-    // if free, we use _orbitFree() instead of _orbit()
-    if (free) {
+    // if freeRotation is true, we use _orbitFree() instead of _orbit()
+    if (freeRotation) {
       this._renderer._curCamera._orbitFree(
         0, 0, this._renderer.zoomVelocity
       );
@@ -280,8 +284,8 @@ p5.prototype.orbitControl = function(
     );
   }
   if (this._renderer.rotateVelocity.magSq() > 0.000001) {
-    // if free, it will always rotate freely in the direction the pointer moves
-    if (free) {
+    // if freeRotation is true, the camera always rotates freely in the direction the pointer moves
+    if (freeRotation) {
       this._renderer._curCamera._orbitFree(
         -this._renderer.rotateVelocity.x,
         this._renderer.rotateVelocity.y,

--- a/src/webgl/interaction.js
+++ b/src/webgl/interaction.js
@@ -122,10 +122,9 @@ p5.prototype.orbitControl = function(
 
   // get moved touches.
   const movedTouches = [];
-  for (let i = 0; i < this.touches.length; i++) {
-    const curTouch = this.touches[i];
-    for (let k = 0; k < this._renderer.prevTouches.length; k++) {
-      const prevTouch = this._renderer.prevTouches[k];
+
+  this.touches.forEach(curTouch => {
+    this._renderer.prevTouches.forEach(prevTouch => {
       if (curTouch.id === prevTouch.id) {
         const movedTouch = {
           x: curTouch.x,
@@ -135,8 +134,9 @@ p5.prototype.orbitControl = function(
         };
         movedTouches.push(movedTouch);
       }
-    }
-  }
+    });
+  });
+
   this._renderer.prevTouches = this.touches;
 
   // The idea of using damping is based on the following website. thank you.

--- a/test/unit/webgl/p5.Camera.js
+++ b/test/unit/webgl/p5.Camera.js
@@ -551,7 +551,7 @@ suite('p5.Camera', function() {
     test('_orbitFree(1,0,0) sets correct matrix', function() {
       var expectedMatrix = new Float32Array([
         0.5403022766113281, 0, -0.8414709568023682, 0,
-        0, 1, 0, 0,
+        -0, 1, 0, 0,
         0.8414709568023682, 0, 0.5403022766113281, 0,
         -8.216248374992574e-7, 0, -86.6025390625, 1
       ]);

--- a/test/unit/webgl/p5.Camera.js
+++ b/test/unit/webgl/p5.Camera.js
@@ -584,6 +584,22 @@ suite('p5.Camera', function() {
 
       assert.deepEqual(myCam.cameraMatrix.mat4, expectedMatrix);
     });
+    test('Rotate camera 360° with _orbitFree() returns it to its original position', function() {
+      // Rotate the camera 360 degrees in any direction using _orbitFree()
+      // and it will return to its original state.
+      myCam.camera(100, 100, 100, 0, 0, 0, 1, 2, 3);
+      var myCamCopy = myCam.copy();
+      // Performing 200 rotations of Math.PI*0.01 makes exactly one rotation.
+      // However, we test in a slightly slanted direction instead of parallel with axis.
+      for (let i = 0; i < 200; i++) {
+        myCamCopy._orbitFree(Math.PI * 0.006, Math.PI * 0.008, 0);
+      }
+      for (let i = 0; i < myCamCopy.cameraMatrix.mat4.length; i++) {
+        expect(
+          myCamCopy.cameraMatrix.mat4[i]).to.be.closeTo(
+          myCam.cameraMatrix.mat4[i], 0.001);
+      }
+    });
   });
 
   suite('Projection', function() {

--- a/test/unit/webgl/p5.Camera.js
+++ b/test/unit/webgl/p5.Camera.js
@@ -548,6 +548,42 @@ suite('p5.Camera', function() {
       myCam._orbit(0, 0, -250);
       assert.deepEqual(myCam.cameraMatrix.mat4, myCamCopy.cameraMatrix.mat4, 'deep equal is failing');
     });
+    test('_orbitFree(1,0,0) sets correct matrix', function() {
+      var expectedMatrix = new Float32Array([
+        0.5403022766113281, 0, -0.8414709568023682, 0,
+        0, 1, 0, 0,
+        0.8414709568023682, 0, 0.5403022766113281, 0,
+        -8.216248374992574e-7, 0, -86.6025390625, 1
+      ]);
+
+      myCam._orbitFree(1, 0, 0);
+
+      assert.deepEqual(myCam.cameraMatrix.mat4, expectedMatrix);
+    });
+    test('_orbitFree(0,1,0) sets correct matrix', function() {
+      var expectedMatrix = new Float32Array([
+        1, -2.8148363983860944e-17, -5.1525235865883254e-17, 0,
+        -2.8148363983860944e-17, 0.5403022766113281, -0.8414709568023682, 0,
+        5.1525235865883254e-17, 0.8414709568023682, 0.5403022766113281, 0,
+        1.8143673340160988e-22, -8.216248374992574e-7, -86.6025390625, 1
+      ]);
+
+      myCam._orbitFree(0, 1, 0);
+
+      assert.deepEqual(myCam.cameraMatrix.mat4, expectedMatrix);
+    });
+    test('_orbitFree(0,0,1) sets correct matrix', function() {
+      var expectedMatrix = new Float32Array([
+        1, 0, 0, 0,
+        0, 1, 0, 0,
+        0, 0, 1, 0,
+        0, 0, -866.025390625, 1
+      ]);
+
+      myCam._orbitFree(0, 0, 1);
+
+      assert.deepEqual(myCam.cameraMatrix.mat4, expectedMatrix);
+    });
   });
 
   suite('Projection', function() {


### PR DESCRIPTION
Currently, the behavior of orbitControl() is similar to Three.js, vRoidHub, etc. But orbitControl() also has something like EasyCam's default behavior.
A feature of EasyCam's orbitControl() is that it always rotates in the direction of pointer movement. This is not always suitable when the top and bottom are clear, as the horizon line will be tilted, but it is useful when you simply want to see the object from various directions.
So I thought it would be nice to have such an option.
However, if the default behavior is this, it will be a destructive change, so the default will be the current behavior.

Resolves #6175

## Changes:
Add a "free" property to option in orbitControl(). If this "free" is true, _orbitFree() is used instead of the traditional _orbit().
Add _orbitFree(dx, dy, dRadius) to the camera method. This differs from _orbit() in that the direction of rotation always matches the direction of pointer movement. But as for zoom, behavior is the same.

## Screenshots of the change:
Demo is here: [orbitControl_Free_DEMO](https://editor.p5js.org/dark_fox/sketches/J2ceR_lgj)

https://github.com/processing/p5.js/assets/39549290/245475e2-9d51-4962-b8d3-b3af582a6405



#### PR Checklist
<!--
  To check any option, replace the "[ ]" with a "[x]". Be sure to check out how it looks in the Preview tab! Feel free to remove any portion of the template that is not relevant for your issue.
-->

- [x] `npm run lint` passes
- [x] [Inline documentation] is included / updated
- [x] [Unit tests] are included / updated

[Inline documentation]: https://github.com/processing/p5.js/blob/main/contributor_docs/inline_documentation.md
[Unit tests]: https://github.com/processing/p5.js/tree/main/contributor_docs#unit-tests
