### PR TITLE
fix textWidth() and textToPoints()

### DIFF
--- a/src/typography/attributes.js
+++ b/src/typography/attributes.js
@@ -218,10 +218,10 @@ p5.prototype.textStyle = function(theStyle) {
  * <code>
  * textSize(28);
  *
- * let aChar = 'text\nWidth()';
+ * let aChar = 'text\nWidth';
  * let cWidth = textWidth(aChar);
  * text(aChar, 0, 40);
- * line(cWidth, 0, cWidth, 50);
+ * line(cWidth, 0, cWidth, 100);
  *
  * describe('Text text and Width() are displayed with vertical lines at end of Width().');
  * </code>

--- a/src/typography/attributes.js
+++ b/src/typography/attributes.js
@@ -233,10 +233,8 @@ p5.prototype.textWidth = function (...args) {
   if (args[0].length === 0) {
     return 0;
   }
-  //   replace choose the max lengthed text
-  const seperateArr = args[0].split(/\r?\n|\r|\n/g);
-
-  //   replace choose the max lengthed text & replace the tab
+  // Only use the line with the longest width, and replace tabs with double-space
+  const textLines = args[0].split(/\r?\n|\r|\n/g);
   const longest = seperateArr.reduce((a, b) => (a.length > b.length ? a : b), '').replace(/\t/g, '  ');
 
   return this._renderer.textWidth(longest);

--- a/src/typography/attributes.js
+++ b/src/typography/attributes.js
@@ -239,7 +239,7 @@ p5.prototype.textWidth = function (...args) {
 
   const newArr = [];
 
-  // Reutrn the textWidth for every line
+  // Return the textWidth for every line
   for(let i=0; i<textLines.length; i++){
     newArr.push(this._renderer.textWidth(textLines[i]));
   }

--- a/src/typography/attributes.js
+++ b/src/typography/attributes.js
@@ -189,7 +189,7 @@ p5.prototype.textStyle = function(theStyle) {
 };
 
 /**
- * Calculates and returns the width of any character or text string.
+ * Calculates and returns the width of any character or the maximum width of any paragrph.
  *
  * @method textWidth
  * @param {String} theText the String of characters to measure
@@ -212,14 +212,34 @@ p5.prototype.textStyle = function(theStyle) {
  * describe('Letter P and p5.js are displayed with vertical lines at end.');
  * </code>
  * </div>
+ *
+ *
+ * <div>
+ * <code>
+ * textSize(28);
+ *
+ * let aChar = 'text\nWidth()';
+ * let cWidth = textWidth(aChar);
+ * text(aChar, 0, 40);
+ * line(cWidth, 0, cWidth, 50);
+ *
+ * describe('Text text and Width() are displayed with vertical lines at end of Width().');
+ * </code>
+ * </div>
  */
-p5.prototype.textWidth = function(...args) {
+p5.prototype.textWidth = function (...args) {
   args[0] += '';
   p5._validateParameters('textWidth', args);
   if (args[0].length === 0) {
     return 0;
   }
-  return this._renderer.textWidth(...args);
+  //   replace choose the max lengthed text
+  const seperateArr = args[0].split(/\r?\n|\r|\n/g);
+
+  //   replace choose the max lengthed text & replace the tab
+  const longest = seperateArr.reduce((a, b) => (a.length > b.length ? a : b), '').replace(/\t/g, '  ');
+
+  return this._renderer.textWidth(longest);
 };
 
 /**

--- a/src/typography/attributes.js
+++ b/src/typography/attributes.js
@@ -221,7 +221,7 @@ p5.prototype.textStyle = function(theStyle) {
  * let aChar = 'text\nWidth()';
  * let cWidth = textWidth(aChar);
  * text(aChar, 0, 40);
- * line(cWidth, 0, cWidth, 100);
+ * line(cWidth, 0, cWidth, 50);
  *
  * describe('Text text and Width() are displayed with vertical lines at end of Width().');
  * </code>
@@ -233,11 +233,21 @@ p5.prototype.textWidth = function (...args) {
   if (args[0].length === 0) {
     return 0;
   }
-  // Only use the line with the longest width, and replace tabs with double-space
-  const textLines = args[0].split(/\r?\n|\r|\n/g);
-  const longest = seperateArr.reduce((a, b) => (a.length > b.length ? a : b), '').replace(/\t/g, '  ');
 
-  return this._renderer.textWidth(longest);
+  // Only use the line with the longest width, and replace tabs with double-space
+  const textLines = args[0].replace(/\t/g, '  ').split(/\r?\n|\r|\n/g);
+
+  const newArr = [];
+
+  // Reutrn the textWidth for every line
+  for(let i=0; i<textLines.length; i++){
+    newArr.push(this._renderer.textWidth(textLines[i]));
+  }
+
+  // Return the largest textWidth
+  const largestWidth = Math.max(...newArr);
+
+  return largestWidth;
 };
 
 /**

--- a/src/typography/attributes.js
+++ b/src/typography/attributes.js
@@ -221,7 +221,7 @@ p5.prototype.textStyle = function(theStyle) {
  * let aChar = 'text\nWidth()';
  * let cWidth = textWidth(aChar);
  * text(aChar, 0, 40);
- * line(cWidth, 0, cWidth, 50);
+ * line(cWidth, 0, cWidth, 100);
  *
  * describe('Text text and Width() are displayed with vertical lines at end of Width().');
  * </code>

--- a/src/typography/p5.Font.js
+++ b/src/typography/p5.Font.js
@@ -235,7 +235,7 @@ p5.Font = class {
     const xOriginal = x;
     const result = [];
 
-    let lines = txt.split('\n');
+    let lines = txt.split(/\r?\n|\r|\n/g);
     fontSize = fontSize || this.parent._renderer._textSize;
 
     function isSpace(i, text, glyphsLine) {

--- a/src/typography/p5.Font.js
+++ b/src/typography/p5.Font.js
@@ -475,7 +475,8 @@ p5.Font = class {
   _handleAlignment(renderer, line, x, y, textWidth) {
     const fontSize = renderer._textSize;
 
-    if (typeof textWidth === 'undefined') {
+    if (typeof textWidth === 'undefined' &&
+    renderer._textAlign !== constants.LEFT) {
       textWidth = this._textWidth(line, fontSize);
     }
 

--- a/src/typography/p5.Font.js
+++ b/src/typography/p5.Font.js
@@ -475,8 +475,7 @@ p5.Font = class {
   _handleAlignment(renderer, line, x, y, textWidth) {
     const fontSize = renderer._textSize;
 
-    if (typeof textWidth === 'undefined' &&
-    renderer._textAlign !== constants.LEFT) {
+    if (typeof textWidth === 'undefined') {
       textWidth = this._textWidth(line, fontSize);
     }
 

--- a/src/typography/p5.Font.js
+++ b/src/typography/p5.Font.js
@@ -232,38 +232,49 @@ p5.Font = class {
  * </div>
  */
   textToPoints(txt, x, y, fontSize, options) {
-    let xoff = 0;
+    const xOriginal = x;
     const result = [];
-    const glyphs = this._getGlyphs(txt);
 
-    function isSpace(i) {
+    let lines = txt.split('\n');
+    fontSize = fontSize || this.parent._renderer._textSize;
+
+    function isSpace(i, text, glyphsLine) {
       return (
-        (glyphs[i].name && glyphs[i].name === 'space') ||
-      (txt.length === glyphs.length && txt[i] === ' ') //||
-      //(glyphs[i].index && glyphs[i].index === 3)
+        (glyphsLine[i].name && glyphsLine[i].name === 'space') ||
+        (text.length === glyphsLine.length && text[i] === ' ') //||
+        //(glyphs[i].index && glyphs[i].index === 3)
       );
     }
 
-    fontSize = fontSize || this.parent._renderer._textSize;
+    for (let i = 0; i < lines.length; i++) {
+      let xoff = 0;
+      x = xOriginal;
+      let line = lines[i];
 
-    for (let i = 0; i < glyphs.length; i++) {
-      if (!isSpace(i)) {
-      // fix to #1817, #2069
+      line = line.replace('\t', '  ');
+      const glyphs = this._getGlyphs(line);
 
-        const gpath = glyphs[i].getPath(x, y, fontSize),
-          paths = splitPaths(gpath.commands);
+      for (let j = 0; j < glyphs.length; j++) {
+        if (!isSpace(j, line, glyphs)) {
+          // fix to #1817, #2069
 
-        for (let j = 0; j < paths.length; j++) {
-          const pts = pathToPoints(paths[j], options);
+          const gpath = glyphs[j].getPath(x, y, fontSize),
+            paths = splitPaths(gpath.commands);
 
-          for (let k = 0; k < pts.length; k++) {
-            pts[k].x += xoff;
-            result.push(pts[k]);
+          for (let k = 0; k < paths.length; k++) {
+            const pts = pathToPoints(paths[k], options);
+
+            for (let l = 0; l < pts.length; l++) {
+              pts[l].x += xoff;
+              result.push(pts[l]);
+            }
           }
         }
+
+        xoff += glyphs[j].advanceWidth * this._scale(fontSize);
       }
 
-      xoff += glyphs[i].advanceWidth * this._scale(fontSize);
+      y = y + this.parent._renderer._textLeading;
     }
 
     return result;


### PR DESCRIPTION
<!--
  Thank you for contributing! Please use this pull request (PR) template.


 In the description field of this PR, include "resolves #XXXX" tagging the issue you are fixing. If this PR addresses the issue but doesn't completely resolve it (ie the issue should remain open after your PR is merged), write "addresses #XXXX".-->
Resolves #5036 
Resolves #5474 

 Changes:
<!-- Add here what changes were made in this pull request and if possible provide links showcasing the changes. -->
- Both `textWidth()` and `textToPoints()` have trouble dealing with `\n` or `\t`, [escape character](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Regular_expressions/Character_escape)
- Or when there’s line break in [template literals](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Template_literals)
- I fixed both of them without changing `opentype.js`

- Try the new `textWidth` [here](https://editor.p5js.org/munusshih/sketches/yDdgjeBXl)
- Try the new `textToPoints` [here](https://editor.p5js.org/munusshih/sketches/xNUOwmP1h)

 Screenshots of the change:
<!-- If applicable, add screenshots depicting the changes. -->
- Black box: the original `textWidth()`
- Red box: the fixed `textWidth()`
<img width="506" alt="Screenshot 2023-06-06 at 7 09 33 PM" src="https://github.com/processing/p5.js/assets/34775424/4b8549cf-4c12-4e91-9fde-a8af34471439">

- Original `textToPoints()` breaks down when encounter line breaks or tabs
<img width="1146" alt="Screenshot 2023-06-06 at 7 14 34 PM" src="https://github.com/processing/p5.js/assets/34775424/058e57c8-6298-45b3-b270-8d4456c2b66d">

- Fixed `textToPoints()` handle them correctly
<img width="1047" alt="Screenshot 2023-06-06 at 7 18 13 PM" src="https://github.com/processing/p5.js/assets/34775424/21fde2a5-759c-4f34-b19b-af86bcf67887">


#### PR Checklist
<!--
  To check any option, replace the "[ ]" with a "[x]". Be sure to check out how it looks in the Preview tab! Feel free to remove any portion of the template that is not relevant for your issue.
-->

- [x] `npm run lint` passes
- [x] [Inline documentation] is included / updated

[Inline documentation]: https://github.com/processing/p5.js/blob/main/contributor_docs/inline_documentation.md
[Unit tests]: https://github.com/processing/p5.js/tree/main/contributor_docs#unit-tests
