### PR TITLE
p5.Element.elt be HTMLElement instead of any

### DIFF
--- a/src/core/p5.Element.js
+++ b/src/core/p5.Element.js
@@ -14,7 +14,7 @@ import p5 from './main';
  *
  * @class p5.Element
  * @constructor
- * @param {String} elt DOM node that is wrapped
+ * @param {HTMLElement} elt DOM node that is wrapped
  * @param {p5} [pInst] pointer to p5 instance
  */
 p5.Element = class {
@@ -37,6 +37,7 @@ p5.Element = class {
      *
      * @property elt
      * @readOnly
+     * @type {HTMLElement}
      */
     this.elt = elt;
     this._pInst = this._pixelsState = pInst;


### PR DESCRIPTION
<!--
  Thank you for contributing! Please use this pull request (PR) template.


 In the description field of this PR, include "resolves #XXXX" tagging the issue you are fixing. If this PR addresses the issue but doesn't completely resolve it (ie the issue should remain open after your PR is merged), write "addresses #XXXX".-->

partly resolves https://github.com/p5-types/p5.ts/issues/31

yui-doc doesn't has generic AFAIK.

 Changes:
<!-- Add here what changes were made in this pull request and if possible provide links showcasing the changes. -->

change type.

 Screenshots of the change:
<!-- If applicable, add screenshots depicting the changes. -->

#### PR Checklist
<!--
  To check any option, replace the "[ ]" with a "[x]". Be sure to check out how it looks in the Preview tab! Feel free to remove any portion of the template that is not relevant for your issue.
-->

- [x] `npm run lint` passes
- [x] [Inline documentation] is included / updated
- [ ] [Unit tests] are included / updated

[Inline documentation]: https://github.com/processing/p5.js/blob/main/contributor_docs/inline_documentation.md
[Unit tests]: https://github.com/processing/p5.js/tree/main/contributor_docs#unit-tests
