### PR TITLE
In orbitControl(), use movedX,Y instead of difference of mouseX,Y

### DIFF
--- a/src/webgl/interaction.js
+++ b/src/webgl/interaction.js
@@ -225,11 +225,11 @@ p5.prototype.orbitControl = function(
     }
     if (this.mouseIsPressed) {
       if (this.mouseButton === this.LEFT) {
-        deltaTheta = -sensitivityX * (this.mouseX - this.pmouseX) / scaleFactor;
-        deltaPhi = sensitivityY * (this.mouseY - this.pmouseY) / scaleFactor;
+        deltaTheta = -sensitivityX * this.movedX / scaleFactor;
+        deltaPhi = sensitivityY * this.movedY / scaleFactor;
       } else if (this.mouseButton === this.RIGHT) {
-        moveDeltaX = this.mouseX - this.pmouseX;
-        moveDeltaY = this.mouseY - this.pmouseY;
+        moveDeltaX = this.movedX;
+        moveDeltaY = this.movedY;
       }
       // start rotate and move when mouse is pressed within the canvas.
       if (pointersInCanvas) this._renderer.executeRotateAndMove = true;


### PR DESCRIPTION
Calculations like mouseX-pmouseX cause unintended behavior when you open the menu outside the canvas and then return inside. So I use something like movedX instead.

Resolves #6191

### Changes:
Replace mouseX-pmouseX with movedX. Perform a similar replacement for Y.

### Screenshots of the change:

https://github.com/processing/p5.js/assets/39549290/d9570b1d-bf8f-42c9-9206-c8b58b26e650

#### PR Checklist

- [ ] `npm run lint` passes
- [ ] [Inline documentation] is included / updated
- [ ] [Unit tests] are included / updated

[Inline documentation]: https://github.com/processing/p5.js/blob/main/contributor_docs/inline_documentation.md
[Unit tests]: https://github.com/processing/p5.js/tree/main/contributor_docs#unit-tests
