### PR TITLE
Fix bugs in saveGif for WebGL2 contexts

### DIFF
--- a/src/image/loading_displaying.js
+++ b/src/image/loading_displaying.js
@@ -319,8 +319,9 @@ p5.prototype.saveGif = async function(
   if (document.getElementById(notificationID) !== null)
     document.getElementById(notificationID).remove();
 
+  let p;
   if (!silent){
-    let p = this.createP('');
+    p = this.createP('');
     p.id(notificationID);
     p.style('font-size', '16px');
     p.style('font-family', 'Montserrat');
@@ -332,10 +333,10 @@ p5.prototype.saveGif = async function(
 
   let pixels;
   let gl;
-  if (this.drawingContext instanceof WebGLRenderingContext) {
+  if (this._renderer instanceof p5.RendererGL) {
     // if we have a WEBGL context, initialize the pixels array
     // and the gl context to use them inside the loop
-    gl = document.getElementById('defaultCanvas0').getContext('webgl');
+    gl = this.drawingContext;
     pixels = new Uint8Array(gl.drawingBufferWidth * gl.drawingBufferHeight * 4);
   }
 
@@ -363,7 +364,7 @@ p5.prototype.saveGif = async function(
     // or another
     let data = undefined;
 
-    if (this.drawingContext instanceof WebGLRenderingContext) {
+    if (this._renderer instanceof p5.RendererGL) {
       pixels = new Uint8Array(
         gl.drawingBufferWidth * gl.drawingBufferHeight * 4
       );


### PR DESCRIPTION
Resolves https://github.com/processing/p5.js/issues/6200

### Changes
- Uses a more futureproof method of detecting a WebGL sketch that will work regardless of the WebGL version
- Moves `p` out of an if statement to avoid errors accessing the variable


### Screenshots of the change

I ran into this when trying to export a gif that uses framebuffers from the main branch. Here's the gif I exported after making these changes 🙂 

![feedback](https://github.com/processing/p5.js/assets/5315059/5771c28b-d50d-47b6-935e-4e17e6dab49d)

```js
let prev, next;
function setup() {
  createCanvas(200, 200, WEBGL)
  prev = createFramebuffer({ format: FLOAT });
  next = createFramebuffer({ format: FLOAT });
}

function draw() {
  // Swap prev and next
  [prev, next] = [next, prev];
  
  imageMode(CENTER);
  
  next.begin();
  clear();
  push()
  tint(255, 250)
  rotate(0.01)
  scale(0.99)
  image(prev, 0, 0)
  pop()
  translate(sin(frameCount*0.1)*50, sin(frameCount*0.11)*50)
  noStroke()
  normalMaterial()
  sphere(25)
  next.end();
  
  background(255);
  image(next, 0, 0);
}

function keyPressed() {
  saveGif('feedback.gif', 5)
}
```

#### PR Checklist
<!--
  To check any option, replace the "[ ]" with a "[x]". Be sure to check out how it looks in the Preview tab! Feel free to remove any portion of the template that is not relevant for your issue.
-->

- [x] `npm run lint` passes
- [ ] [Inline documentation] is included / updated
- [ ] [Unit tests] are included / updated

[Inline documentation]: https://github.com/processing/p5.js/blob/main/contributor_docs/inline_documentation.md
[Unit tests]: https://github.com/processing/p5.js/tree/main/contributor_docs#unit-tests
