### PR TITLE
use atan2 to calculate angleBetween()

### DIFF
--- a/src/math/p5.Vector.js
+++ b/src/math/p5.Vector.js
@@ -1637,15 +1637,16 @@ p5.Vector = class {
  */
 
   angleBetween(v) {
-    const dotmagmag = this.dot(v) / (this.mag() * v.mag());
-    // Mathematically speaking: the dotmagmag variable will be between -1 and 1
-    // inclusive. Practically though it could be slightly outside this range due
-    // to floating-point rounding issues. This can make Math.acos return NaN.
-    //
-    // Solution: we'll clamp the value to the -1,1 range
-    let angle;
-    angle = Math.acos(Math.min(1, Math.max(-1, dotmagmag)));
-    angle = angle * Math.sign(this.cross(v).z || 1);
+    const magSqMult = this.magSq() * v.magSq();
+    // Returns NaN if either vector is the zero vector.
+    if (magSqMult === 0) {
+      return NaN;
+    }
+    const u = this.cross(v);
+    // The dot product computes the cos value, and the cross product computes
+    // the sin value. Find the angle based on them. In addition, in the case of
+    // 2D vectors, a sign is added according to the direction of the vector.
+    let angle = Math.atan2(u.mag(), this.dot(v)) * Math.sign(u.z || 1);
     if (this.isPInst) {
       angle = this._fromRadians(angle);
     }

--- a/test/unit/math/p5.Vector.js
+++ b/test/unit/math/p5.Vector.js
@@ -276,6 +276,18 @@ suite('p5.Vector', function() {
           0.01
         );
       });
+
+      test('For the same vectors, the angle between them should always be 0.', function() {
+        v1 = myp5.createVector(288, 814);
+        v2 = myp5.createVector(288, 814);
+        expect(v1.angleBetween(v2)).to.equal(0);
+      });
+
+      test('The angle between vectors pointing in opposite is always PI.', function() {
+        v1 = myp5.createVector(219, 560);
+        v2 = myp5.createVector(-219, -560);
+        expect(v1.angleBetween(v2)).to.be.closeTo(Math.PI, 0.0000001);
+      });
     });
 
     suite('p5.Vector.angleBetween() [CLASS]', function() {


### PR DESCRIPTION
Currently angleBetween() computes the angle using only the inner product, so values ​​near 0 and PI are inaccurate.
To solve this, I would like to use atan2 to calculate the angle.

Resolves #6204

## Changes:
Instead of using only the inner product to produce the value, rewrite it so that it produces the value using the inner product and the outer product.
On the other hand, the method of adding signs and the method of handling exceptions are completely the same as before.

#### PR Checklist
<!--
  To check any option, replace the "[ ]" with a "[x]". Be sure to check out how it looks in the Preview tab! Feel free to remove any portion of the template that is not relevant for your issue.
-->

- [x] `npm run lint` passes
- [ ] [Inline documentation] is included / updated
- [x] [Unit tests] are included / updated

[Inline documentation]: https://github.com/processing/p5.js/blob/main/contributor_docs/inline_documentation.md
[Unit tests]: https://github.com/processing/p5.js/tree/main/contributor_docs#unit-tests
