### PR TITLE
add missing chainable/doc.

### DIFF
--- a/src/core/p5.Element.js
+++ b/src/core/p5.Element.js
@@ -266,9 +266,9 @@ class Element {
    *                                double clicked over the element.
    *                                if `false` is passed instead, the previously
    *                                firing function will no longer fire.
-   * @return {p5.Element}
-   * @example
    * @chainable
+   * @example
+
    * <div class='norender'><code>
    * let cnv, d, g;
    * function setup() {

--- a/src/core/p5.Element.js
+++ b/src/core/p5.Element.js
@@ -14,12 +14,12 @@ import p5 from './main';
  *
  * @class p5.Element
  */
-class Element {
+p5.Element = class {
   /**
    * @constructor
    * @param {HTMLElement} elt DOM node that is wrapped
    * @param {p5} [pInst] pointer to p5 instance
-   */
+ */
   constructor(elt, pInst) {
     /**
      * Underlying HTML element. All normal HTML methods can be called on this.
@@ -49,10 +49,12 @@ class Element {
     this._events = {};
     /**
      * @type {Number}
+     * @property width
      */
     this.width = this.elt.offsetWidth;
     /**
      * @type {Number}
+     * @property height
      */
     this.height = this.elt.offsetHeight;
   }
@@ -117,7 +119,7 @@ class Element {
         p = p.substring(1);
       }
       p = document.getElementById(p);
-    } else if (p instanceof Element) {
+    } else if (p instanceof p5.Element) {
       p = p.elt;
     }
     p.appendChild(this.elt);
@@ -252,7 +254,7 @@ class Element {
       return fxn.call(this, event);
     };
     // Pass along the event-prepended form of the callback.
-    Element._adjustListener('mousedown', eventPrependedFxn, this);
+    p5.Element._adjustListener('mousedown', eventPrependedFxn, this);
     return this;
   }
 
@@ -268,7 +270,6 @@ class Element {
    *                                firing function will no longer fire.
    * @chainable
    * @example
-
    * <div class='norender'><code>
    * let cnv, d, g;
    * function setup() {
@@ -299,7 +300,7 @@ class Element {
    * no display.
    */
   doubleClicked(fxn) {
-    Element._adjustListener('dblclick', fxn, this);
+    p5.Element._adjustListener('dblclick', fxn, this);
     return this;
   }
 
@@ -361,7 +362,7 @@ class Element {
    * no display.
    */
   mouseWheel(fxn) {
-    Element._adjustListener('wheel', fxn, this);
+    p5.Element._adjustListener('wheel', fxn, this);
     return this;
   }
 
@@ -410,7 +411,7 @@ class Element {
    * no display.
    */
   mouseReleased(fxn) {
-    Element._adjustListener('mouseup', fxn, this);
+    p5.Element._adjustListener('mouseup', fxn, this);
     return this;
   }
 
@@ -461,7 +462,7 @@ class Element {
    * no display.
    */
   mouseClicked(fxn) {
-    Element._adjustListener('click', fxn, this);
+    p5.Element._adjustListener('click', fxn, this);
     return this;
   }
 
@@ -517,7 +518,7 @@ class Element {
    * no display.
    */
   mouseMoved(fxn) {
-    Element._adjustListener('mousemove', fxn, this);
+    p5.Element._adjustListener('mousemove', fxn, this);
     return this;
   }
 
@@ -558,7 +559,7 @@ class Element {
    * no display.
    */
   mouseOver(fxn) {
-    Element._adjustListener('mouseover', fxn, this);
+    p5.Element._adjustListener('mouseover', fxn, this);
     return this;
   }
 
@@ -599,7 +600,7 @@ class Element {
    * no display.
    */
   mouseOut(fxn) {
-    Element._adjustListener('mouseout', fxn, this);
+    p5.Element._adjustListener('mouseout', fxn, this);
     return this;
   }
 
@@ -646,7 +647,7 @@ class Element {
    * no display.
    */
   touchStarted(fxn) {
-    Element._adjustListener('touchstart', fxn, this);
+    p5.Element._adjustListener('touchstart', fxn, this);
     return this;
   }
 
@@ -685,7 +686,7 @@ class Element {
    * no display.
    */
   touchMoved(fxn) {
-    Element._adjustListener('touchmove', fxn, this);
+    p5.Element._adjustListener('touchmove', fxn, this);
     return this;
   }
 
@@ -732,7 +733,7 @@ class Element {
    * no display.
    */
   touchEnded(fxn) {
-    Element._adjustListener('touchend', fxn, this);
+    p5.Element._adjustListener('touchend', fxn, this);
     return this;
   }
 
@@ -770,7 +771,7 @@ class Element {
    * nothing displayed
    */
   dragOver(fxn) {
-    Element._adjustListener('dragover', fxn, this);
+    p5.Element._adjustListener('dragover', fxn, this);
     return this;
   }
 
@@ -808,7 +809,7 @@ class Element {
    * nothing displayed
    */
   dragLeave(fxn) {
-    Element._adjustListener('dragleave', fxn, this);
+    p5.Element._adjustListener('dragleave', fxn, this);
     return this;
   }
 
@@ -826,9 +827,9 @@ class Element {
    */
   static _adjustListener(ev, fxn, ctx) {
     if (fxn === false) {
-      Element._detachListener(ev, ctx);
+      p5.Element._detachListener(ev, ctx);
     } else {
-      Element._attachListener(ev, fxn, ctx);
+      p5.Element._attachListener(ev, fxn, ctx);
     }
     return this;
   }
@@ -843,7 +844,7 @@ class Element {
   static _attachListener(ev, fxn, ctx) {
     // detach the old listener if there was one
     if (ctx._events[ev]) {
-      Element._detachListener(ev, ctx);
+      p5.Element._detachListener(ev, ctx);
     }
     const f = fxn.bind(ctx);
     ctx.elt.addEventListener(ev, f, false);
@@ -868,8 +869,6 @@ class Element {
   _setProperty(prop, value) {
     this[prop] = value;
   }
-}
-
-p5.Element = Element;
+};
 
 export default p5.Element;

--- a/src/core/p5.Element.js
+++ b/src/core/p5.Element.js
@@ -13,11 +13,13 @@ import p5 from './main';
  * <a href="#/p5/createDiv">createDiv()</a>, <a href="#/p5/createImg">createImg()</a>, <a href="#/p5/createInput">createInput()</a>, etc.
  *
  * @class p5.Element
- * @constructor
- * @param {String} elt DOM node that is wrapped
- * @param {p5} [pInst] pointer to p5 instance
  */
-p5.Element = class {
+class Element {
+  /**
+   * @constructor
+   * @param {HTMLElement} elt DOM node that is wrapped
+   * @param {p5} [pInst] pointer to p5 instance
+   */
   constructor(elt, pInst) {
     /**
      * Underlying HTML element. All normal HTML methods can be called on this.
@@ -39,9 +41,19 @@ p5.Element = class {
      * @readOnly
      */
     this.elt = elt;
+    /**
+     * @private
+     * @type {p5.Element}
+     */
     this._pInst = this._pixelsState = pInst;
     this._events = {};
+    /**
+     * @type {Number}
+     */
     this.width = this.elt.offsetWidth;
+    /**
+     * @type {Number}
+     */
     this.height = this.elt.offsetHeight;
   }
 
@@ -105,7 +117,7 @@ p5.Element = class {
         p = p.substring(1);
       }
       p = document.getElementById(p);
-    } else if (p instanceof p5.Element) {
+    } else if (p instanceof Element) {
       p = p.elt;
     }
     p.appendChild(this.elt);
@@ -240,7 +252,7 @@ p5.Element = class {
       return fxn.call(this, event);
     };
     // Pass along the event-prepended form of the callback.
-    p5.Element._adjustListener('mousedown', eventPrependedFxn, this);
+    Element._adjustListener('mousedown', eventPrependedFxn, this);
     return this;
   }
 
@@ -256,6 +268,7 @@ p5.Element = class {
    *                                firing function will no longer fire.
    * @return {p5.Element}
    * @example
+   * @chainable
    * <div class='norender'><code>
    * let cnv, d, g;
    * function setup() {
@@ -286,7 +299,7 @@ p5.Element = class {
    * no display.
    */
   doubleClicked(fxn) {
-    p5.Element._adjustListener('dblclick', fxn, this);
+    Element._adjustListener('dblclick', fxn, this);
     return this;
   }
 
@@ -348,7 +361,7 @@ p5.Element = class {
    * no display.
    */
   mouseWheel(fxn) {
-    p5.Element._adjustListener('wheel', fxn, this);
+    Element._adjustListener('wheel', fxn, this);
     return this;
   }
 
@@ -397,7 +410,7 @@ p5.Element = class {
    * no display.
    */
   mouseReleased(fxn) {
-    p5.Element._adjustListener('mouseup', fxn, this);
+    Element._adjustListener('mouseup', fxn, this);
     return this;
   }
 
@@ -448,7 +461,7 @@ p5.Element = class {
    * no display.
    */
   mouseClicked(fxn) {
-    p5.Element._adjustListener('click', fxn, this);
+    Element._adjustListener('click', fxn, this);
     return this;
   }
 
@@ -504,7 +517,7 @@ p5.Element = class {
    * no display.
    */
   mouseMoved(fxn) {
-    p5.Element._adjustListener('mousemove', fxn, this);
+    Element._adjustListener('mousemove', fxn, this);
     return this;
   }
 
@@ -545,7 +558,7 @@ p5.Element = class {
    * no display.
    */
   mouseOver(fxn) {
-    p5.Element._adjustListener('mouseover', fxn, this);
+    Element._adjustListener('mouseover', fxn, this);
     return this;
   }
 
@@ -586,7 +599,7 @@ p5.Element = class {
    * no display.
    */
   mouseOut(fxn) {
-    p5.Element._adjustListener('mouseout', fxn, this);
+    Element._adjustListener('mouseout', fxn, this);
     return this;
   }
 
@@ -633,7 +646,7 @@ p5.Element = class {
    * no display.
    */
   touchStarted(fxn) {
-    p5.Element._adjustListener('touchstart', fxn, this);
+    Element._adjustListener('touchstart', fxn, this);
     return this;
   }
 
@@ -672,7 +685,7 @@ p5.Element = class {
    * no display.
    */
   touchMoved(fxn) {
-    p5.Element._adjustListener('touchmove', fxn, this);
+    Element._adjustListener('touchmove', fxn, this);
     return this;
   }
 
@@ -719,7 +732,7 @@ p5.Element = class {
    * no display.
    */
   touchEnded(fxn) {
-    p5.Element._adjustListener('touchend', fxn, this);
+    Element._adjustListener('touchend', fxn, this);
     return this;
   }
 
@@ -757,7 +770,7 @@ p5.Element = class {
    * nothing displayed
    */
   dragOver(fxn) {
-    p5.Element._adjustListener('dragover', fxn, this);
+    Element._adjustListener('dragover', fxn, this);
     return this;
   }
 
@@ -795,30 +808,54 @@ p5.Element = class {
    * nothing displayed
    */
   dragLeave(fxn) {
-    p5.Element._adjustListener('dragleave', fxn, this);
+    Element._adjustListener('dragleave', fxn, this);
     return this;
   }
 
-  // General handler for event attaching and detaching
+
+  /**
+   *
+   * @private
+   * @static
+   * @param {String} ev
+   * @param {Boolean|Function} fxn
+   * @param {Element} ctx
+   * @chainable
+   * @alt
+   * General handler for event attaching and detaching
+   */
   static _adjustListener(ev, fxn, ctx) {
     if (fxn === false) {
-      p5.Element._detachListener(ev, ctx);
+      Element._detachListener(ev, ctx);
     } else {
-      p5.Element._attachListener(ev, fxn, ctx);
+      Element._attachListener(ev, fxn, ctx);
     }
     return this;
   }
-
+  /**
+   *
+   * @private
+   * @static
+   * @param {String} ev
+   * @param {Function} fxn
+   * @param {Element} ctx
+   */
   static _attachListener(ev, fxn, ctx) {
     // detach the old listener if there was one
     if (ctx._events[ev]) {
-      p5.Element._detachListener(ev, ctx);
+      Element._detachListener(ev, ctx);
     }
     const f = fxn.bind(ctx);
     ctx.elt.addEventListener(ev, f, false);
     ctx._events[ev] = f;
   }
-
+  /**
+   *
+   * @private
+   * @static
+   * @param {String} ev
+   * @param {Element} ctx
+   */
   static _detachListener(ev, ctx) {
     const f = ctx._events[ev];
     ctx.elt.removeEventListener(ev, f, false);
@@ -831,6 +868,8 @@ p5.Element = class {
   _setProperty(prop, value) {
     this[prop] = value;
   }
-};
+}
+
+p5.Element = Element;
 
 export default p5.Element;


### PR DESCRIPTION
<!--
  Thank you for contributing! Please use this pull request (PR) template.


 In the description field of this PR, include "resolves #XXXX" tagging the issue you are fixing. If this PR addresses the issue but doesn't completely resolve it (ie the issue should remain open after your PR is merged), write "addresses #XXXX".-->
Resolves #6208 , https://github.com/p5-types/p5.ts/issues/58

 Changes:
<!-- Add here what changes were made in this pull request and if possible provide links showcasing the changes. -->

1. add `@chainable` to `doubleClicked` 's doc.
2. move/add some doc to properly place.

> It's strange that `p5.Element = class Element {` doesn't work but `p5.Element = class {` works.

 Screenshots of the change:
<!-- If applicable, add screenshots depicting the changes. -->

#### PR Checklist
<!--
  To check any option, replace the "[ ]" with a "[x]". Be sure to check out how it looks in the Preview tab! Feel free to remove any portion of the template that is not relevant for your issue.
-->

- [x] `npm run lint` passes
- [x] [Inline documentation] is included / updated
- [x] [Unit tests] are included / updated

[Inline documentation]: https://github.com/processing/p5.js/blob/main/contributor_docs/inline_documentation.md
[Unit tests]: https://github.com/processing/p5.js/tree/main/contributor_docs#unit-tests
