### PR TITLE
Correct msgWithReference logic in FES to fix issue 5576

### DIFF
--- a/src/core/friendly_errors/fes_core.js
+++ b/src/core/friendly_errors/fes_core.js
@@ -142,7 +142,11 @@ if (typeof IS_MINIFIED !== 'undefined') {
 
       const funcName =
         methodParts.length === 1 ? func : methodParts.slice(2).join('/');
-      msgWithReference = `${message} (http://p5js.org/reference/#/${referenceSection}/${funcName})`;
+
+      //Whenever func having p5.[Class] is encountered, we need to have the error link as mentioned below else different link
+      funcName.substring(0,2) === 'p5.' ?               
+        msgWithReference = `${message} (http://p5js.org/reference/#/${referenceSection}.${funcName})` : 
+        msgWithReference = `${message} (http://p5js.org/reference/#/${referenceSection}/${funcName})`; 
     }
     return msgWithReference;
   };

--- a/src/core/friendly_errors/fes_core.js
+++ b/src/core/friendly_errors/fes_core.js
@@ -144,9 +144,9 @@ if (typeof IS_MINIFIED !== 'undefined') {
         methodParts.length === 1 ? func : methodParts.slice(2).join('/');
 
       //Whenever func having p5.[Class] is encountered, we need to have the error link as mentioned below else different link
-      funcName.substring(0,2) === 'p5.' ?               
-        msgWithReference = `${message} (http://p5js.org/reference/#/${referenceSection}.${funcName})` : 
-        msgWithReference = `${message} (http://p5js.org/reference/#/${referenceSection}/${funcName})`; 
+      funcName.substring(0,2) === 'p5.' ?
+        msgWithReference = `${message} (http://p5js.org/reference/#/${referenceSection}.${funcName})` :
+        msgWithReference = `${message} (http://p5js.org/reference/#/${referenceSection}/${funcName})`;
     }
     return msgWithReference;
   };

--- a/src/core/friendly_errors/fes_core.js
+++ b/src/core/friendly_errors/fes_core.js
@@ -144,7 +144,7 @@ if (typeof IS_MINIFIED !== 'undefined') {
         methodParts.length === 1 ? func : methodParts.slice(2).join('/');
 
       //Whenever func having p5.[Class] is encountered, we need to have the error link as mentioned below else different link
-      funcName.startsWith(0,2) === 'p5.' ?
+      funcName.startsWith('p5.')  ?
         msgWithReference = `${message} (http://p5js.org/reference/#/${referenceSection}.${funcName})` :
         msgWithReference = `${message} (http://p5js.org/reference/#/${referenceSection}/${funcName})`;
     }

--- a/src/core/friendly_errors/fes_core.js
+++ b/src/core/friendly_errors/fes_core.js
@@ -144,7 +144,7 @@ if (typeof IS_MINIFIED !== 'undefined') {
         methodParts.length === 1 ? func : methodParts.slice(2).join('/');
 
       //Whenever func having p5.[Class] is encountered, we need to have the error link as mentioned below else different link
-      funcName.substring(0,2) === 'p5.' ?
+      funcName.startsWith(0,2) === 'p5.' ?
         msgWithReference = `${message} (http://p5js.org/reference/#/${referenceSection}.${funcName})` :
         msgWithReference = `${message} (http://p5js.org/reference/#/${referenceSection}/${funcName})`;
     }


### PR DESCRIPTION
<!--
  Thank you for contributing! Please use this pull request (PR) template.


 In the description field of this PR, include "resolves #XXXX" tagging the issue you are fixing. If this PR addresses the issue but doesn't completely resolve it (ie the issue should remain open after your PR is merged), write "addresses #XXXX".-->
Resolves [#5576 ]

 Changes:
<!-- Add here what changes were made in this pull request and if possible provide links showcasing the changes. -->
Whenever a function having p5.[Class] in its name encounters an error, we need to have the a different FES error link as compared to when a different p5 function name encounters error.
This issue fixes #5576 

 Screenshots of the change:
<!-- If applicable, add screenshots depicting the changes. -->
<img width="885" alt="Screenshot 2023-06-19 at 12 33 01 AM" src="https://github.com/processing/p5.js/assets/40827680/d4cc8ecf-7c8d-43b4-8cdd-ed3092f40baf">


#### PR Checklist
<!--
  To check any option, replace the "[ ]" with a "[x]". Be sure to check out how it looks in the Preview tab! Feel free to remove any portion of the template that is not relevant for your issue.
-->

- [x] `npm run lint` passes
- [x] [Inline documentation] is included / updated
- [x] [Unit tests] are included / updated

[Inline documentation]: https://github.com/processing/p5.js/blob/main/contributor_docs/inline_documentation.md
[Unit tests]: https://github.com/processing/p5.js/tree/main/contributor_docs#unit-tests
