### PR TITLE
Supporting existing canvas element for createCanvas() and createGraphics()

### DIFF
--- a/src/core/p5.Graphics.js
+++ b/src/core/p5.Graphics.js
@@ -21,16 +21,26 @@ import * as constants from './constants';
  * @param {Number} h            height
  * @param {Constant} renderer   the renderer to use, either P2D or WEBGL
  * @param {p5} [pInst]          pointer to p5 instance
+ * @param {Object} [canvas]     existing html canvas element
  */
 p5.Graphics = class extends p5.Element {
-  constructor(w, h, renderer, pInst) {
-    let canvas = document.createElement('canvas');
-    super(canvas, pInst);
+  constructor(w, h, renderer, pInst, canvas) {
+    let canvasTemp;
+    if (canvas) {
+      canvasTemp = canvas;
+    } else {
+      canvasTemp = document.createElement('canvas');
+    }
+
+    super(canvasTemp, pInst);
+    this.canvas = canvasTemp;
+
     const r = renderer || constants.P2D;
 
-    this.canvas = canvas;
     const node = pInst._userNode || document.body;
-    node.appendChild(this.canvas);
+    if (!canvas) {
+      node.appendChild(this.canvas);
+    }
 
     // bind methods and props of p5 to the new object
     for (const p in p5.prototype) {

--- a/src/core/rendering.js
+++ b/src/core/rendering.js
@@ -279,7 +279,6 @@ p5.prototype.noCanvas = function() {
  *
  * @alt
  * 4 grey squares alternating light and dark grey. White quarter circle mid-left.
- * Random circles across the page.
  */
 /**
  * @method createGraphics

--- a/src/core/rendering.js
+++ b/src/core/rendering.js
@@ -242,11 +242,39 @@ p5.prototype.noCanvas = function() {
  * }
  * </code>
  * </div>
+ * <div>
+ * <code>
+ * let ar;
+ * function setup() {
+ *   createCanvas(100, 100);
+ *   ar = createGraphics(100, 100, document.getElementById('canvas-ar'));
+ * }
+ *
+ * function draw() {
+ *   circle(random(width), random(height), random(15));
+ *
+ *   // grab visuals and pass to ar layer
+ *   ar.image(get(0, 0, width, height), 0, 0, ar.width, ar.height);
+ * }
+ * </code>
+ * </div>
  *
  * @alt
  * 4 grey squares alternating light and dark grey. White quarter circle mid-left.
+ * Random circles across the page.
+ */
+/**
+ * @method createGraphics
+ * @param  {Number} w
+ * @param  {Number} h
+ * @param  {Object} [canvas]
+ * @return {p5.Graphics} offscreen graphics buffer
  */
 p5.prototype.createGraphics = function(w, h, renderer, canvas) {
+  if (arguments[2] instanceof HTMLCanvasElement) {
+    renderer = constants.P2D;
+    canvas = arguments[2];
+  }
   p5._validateParameters('createGraphics', arguments);
   return new p5.Graphics(w, h, renderer, this, canvas);
 };

--- a/src/core/rendering.js
+++ b/src/core/rendering.js
@@ -221,6 +221,7 @@ p5.prototype.noCanvas = function() {
  * @param  {Number} h height of the offscreen graphics buffer
  * @param  {Constant} [renderer] either P2D or WEBGL
  *                               undefined defaults to p2d
+ * @param  {Object} [canvas] existing html canvas element
  * @return {p5.Graphics} offscreen graphics buffer
  * @example
  * <div>
@@ -245,9 +246,9 @@ p5.prototype.noCanvas = function() {
  * @alt
  * 4 grey squares alternating light and dark grey. White quarter circle mid-left.
  */
-p5.prototype.createGraphics = function(w, h, renderer) {
+p5.prototype.createGraphics = function(w, h, renderer, canvas) {
   p5._validateParameters('createGraphics', arguments);
-  return new p5.Graphics(w, h, renderer, this);
+  return new p5.Graphics(w, h, renderer, this, canvas);
 };
 
 /**

--- a/src/core/rendering.js
+++ b/src/core/rendering.js
@@ -34,7 +34,8 @@ const defaultClass = 'p5Canvas';
  * function. If <a href="#/p5/createCanvas">createCanvas()</a> is not used, the
  * window will be given a default size of 100×100 pixels.
  *
- * Optionally, an existing canvas can be passed using a selector, ie. document.getElementById('').
+ * Optionally, an existing canvas can be passed using a selector, ie. `document.getElementById('')`.
+ * If specified, avoid using `setAttributes()` afterwards, as this will remove and recreate the existing canvas.
  *
  * For more ways to position the canvas, see the
  * <a href='https://github.com/processing/p5.js/wiki/Positioning-your-canvas'>


### PR DESCRIPTION
Resolves #4564

 Changes: `createCanvas()` and `createGraphics()` (including `p5.Graphics`), to both accept passing a 3rd or 4th param (depending on if `renderer` is given) with an existing html canvas element. Within `createGraphics()`, it was necessary to both replace the `defaultCanvas0` (created with setup) and tell p5 that the `_defaultGraphicsCreated` is false to re-initiate the renderer. With `createGraphics()`, in only required intercepting the creation of a canvas element which would have been applied to the body (or node).
<!-- Add here what changes were made in this pull request and if possible provide links showcasing the changes. -->
[`createCanvas()` changes](https://github.com/ffd8/p5.js/blob/a3eb3de15c83823fa31f9c115abc8e6c9265c93f/src/core/rendering.js#L70)
[`createGraphics()` changes](https://github.com/ffd8/p5.js/blob/a3eb3de15c83823fa31f9c115abc8e6c9265c93f/src/core/rendering.js#L291)
[`p5.Graphics` changes](https://github.com/ffd8/p5.js/blob/a3eb3de15c83823fa31f9c115abc8e6c9265c93f/src/core/p5.Graphics.js#L26)

#### PR Checklist
- [x] `npm run lint` passes
- [x] [Inline documentation] is included / updated
- [ ] [Unit tests] are included / updated

[Inline documentation]: https://github.com/processing/p5.js/blob/main/contributor_docs/inline_documentation.md
[Unit tests]: https://github.com/processing/p5.js/tree/main/contributor_docs#unit-tests
