### PR TITLE
Make sure p5.Graphics size is correct before resizing framebuffers

### DIFF
--- a/src/core/rendering.js
+++ b/src/core/rendering.js
@@ -164,9 +164,11 @@ p5.prototype.resizeCanvas = function(w, h, noRedraw) {
         props[key] = val;
       }
     }
-    this._renderer.resize(w, h);
     this.width = w;
     this.height = h;
+    // Make sure width and height are updated before the renderer resizes so
+    // that framebuffers updated from the resize read the correct size
+    this._renderer.resize(w, h);
     // reset canvas properties
     for (const savedKey in props) {
       try {

--- a/test/unit/core/rendering.js
+++ b/test/unit/core/rendering.js
@@ -73,6 +73,22 @@ suite('Rendering', function() {
       myp5.resizeCanvas(10, 10);
       assert.equal(myp5.drawingContext.lineCap, myp5.PROJECT);
     });
+
+    test('should resize framebuffers', function() {
+      myp5.createCanvas(10, 10, myp5.WEBGL);
+      const fbo = myp5.createFramebuffer();
+      myp5.resizeCanvas(5, 15);
+      assert.equal(fbo.width, 5);
+      assert.equal(fbo.height, 15);
+    });
+
+    test('should resize graphic framebuffers', function() {
+      const graphic = myp5.createGraphics(10, 10, myp5.WEBGL);
+      const fbo = graphic.createFramebuffer();
+      graphic.resizeCanvas(5, 15);
+      assert.equal(fbo.width, 5);
+      assert.equal(fbo.height, 15);
+    });
   });
 
   suite('p5.prototype.blendMode', function() {


### PR DESCRIPTION
Resolves https://github.com/processing/p5.js/issues/6233

### Changes:
- Sets the size of the thing being resized *before* calling the renderer's resize function instead of after

Live sketch checking that resized fbos match the graphic size: https://editor.p5js.org/davepagurek/sketches/dESa83d0U

#### PR Checklist

- [x] `npm run lint` passes
- [x] [Inline documentation] is included / updated
- [x] [Unit tests] are included / updated
