### PR TITLE
Don't unpack premultiply alpha for text data textures

### DIFF
--- a/src/webgl/text.js
+++ b/src/webgl/text.js
@@ -735,7 +735,6 @@ p5.RendererGL.prototype._renderText = function(p, line, x, y, maxY) {
       if (gi.uGlyphRect) {
         const rowInfo = gi.rowInfo;
         const colInfo = gi.colInfo;
-        const gl = this.GL;
         sh.setUniform('uSamplerStrokes', gi.strokeImageInfo.imageData);
         sh.setUniform('uSamplerRowStrokes', rowInfo.cellImageInfo.imageData);
         sh.setUniform('uSamplerRows', rowInfo.dimImageInfo.imageData);

--- a/src/webgl/text.js
+++ b/src/webgl/text.js
@@ -719,6 +719,7 @@ p5.RendererGL.prototype._renderText = function(p, line, x, y, maxY) {
 
   // this will have to do for now...
   sh.setUniform('uMaterialColor', this.curFillColor);
+  gl.pixelStorei(gl.UNPACK_PREMULTIPLY_ALPHA_WEBGL, false);
 
   try {
     let dx = 0; // the x position in the line
@@ -734,6 +735,7 @@ p5.RendererGL.prototype._renderText = function(p, line, x, y, maxY) {
       if (gi.uGlyphRect) {
         const rowInfo = gi.rowInfo;
         const colInfo = gi.colInfo;
+        const gl = this.GL;
         sh.setUniform('uSamplerStrokes', gi.strokeImageInfo.imageData);
         sh.setUniform('uSamplerRowStrokes', rowInfo.cellImageInfo.imageData);
         sh.setUniform('uSamplerRows', rowInfo.dimImageInfo.imageData);
@@ -757,6 +759,7 @@ p5.RendererGL.prototype._renderText = function(p, line, x, y, maxY) {
 
     this._doStroke = doStroke;
     this.drawMode = drawMode;
+    gl.pixelStorei(gl.UNPACK_PREMULTIPLY_ALPHA_WEBGL, true);
 
     p.pop();
   }


### PR DESCRIPTION
Resolves https://github.com/processing/p5.js/issues/6235

Text rendering was breaking because we premultiply alpha on all images that get loaded in to WebGL now. This is good for image rendering, but the text shader passes in *data textures* where the alpha channel doesn't actually represent the opacity of a color, it just represents numbers. We don't want to mess up the numbers, so I turn it off now in the text shader.

Changes:
- Temporarily turns off `UNPACK_PREMULTIPLIED_ALPHA` when passing data images into the text shader


Screenshots of the change:
<img width="769" alt="image" src="https://github.com/processing/p5.js/assets/5315059/29d07819-728a-42d0-a317-a7b392d8b686">


#### PR Checklist

- [x] `npm run lint` passes
- [ ] [Inline documentation] is included / updated
- [ ] [Unit tests] are included / updated
