### PR TITLE
implementation of p5.Camera.set() function

### DIFF
--- a/src/webgl/p5.Camera.js
+++ b/src/webgl/p5.Camera.js
@@ -1569,6 +1569,72 @@ p5.Camera = class Camera {
     );
   }
 
+  /**
+ * Copies information about the argument camera's view and projection to
+ * the target camera. If the target camera is active, it will be reflected
+ * on the screen.
+ *
+ * @method set
+ * @param {p5.Camera} cam source camera
+ *
+ * @example
+ * <div>
+ * <code>
+ * let cam, initialCam;
+ *
+ * function setup() {
+ *   createCanvas(100, 100, WEBGL);
+ *   strokeWeight(3);
+ *
+ *   // Set the initial state to initialCamera and set it to the camera
+ *   // used for drawing. Then set cam to be the active camera.
+ *   cam = createCamera();
+ *   initialCam = createCamera();
+ *   initialCam.camera(100, 100, 100, 0, 0, 0, 0, 0, -1);
+ *   cam.set(initialCam);
+ *
+ *   setCamera(cam);
+ * }
+ *
+ * function draw() {
+ *   orbitControl();
+ *   background(255);
+ *   box(50);
+ *   translate(0, 0, -25);
+ *   plane(100);
+ * }
+ *
+ * function doubleClicked(){
+ *   // Double-click to return the camera to its initial position.
+ *   cam.set(initialCam);
+ * }
+ * </code>
+ * </div>
+ * @alt
+ * Prepare two cameras. One is the camera that sets the initial state,
+ * and the other is the camera that moves with interaction.
+ * Draw a plane and a box on top of it, operate the camera using orbitControl().
+ * Double-click to set the camera in the initial state and return to
+ * the initial state.
+ */
+  set(cam) {
+    ['eyeX', 'eyeY', 'eyeZ',
+     'centerX', 'centerY', 'centerZ',
+     'upX', 'upY', 'upZ',
+     'cameraFOV', 'aspectRatio', 'cameraNear', 'cameraFar', 'cameraType']
+      .forEach((keyName) => { this[keyName] = cam[keyName]; }
+    );
+
+    this.cameraMatrix = cam.cameraMatrix.copy();
+    this.projMatrix = cam.projMatrix.copy();
+
+    // If the target camera is active, update uMVMatrix and uPMatrix.
+    if (this._isActive()) {
+      this._renderer.uMVMatrix.mat4 = this.cameraMatrix.mat4.slice();
+      this._renderer.uPMatrix.mat4 = this.projMatrix.mat4.slice();
+    }
+  }
+
   ////////////////////////////////////////////////////////////////////////////////
   // Camera Helper Methods
   ////////////////////////////////////////////////////////////////////////////////

--- a/src/webgl/p5.Camera.js
+++ b/src/webgl/p5.Camera.js
@@ -1621,9 +1621,8 @@ p5.Camera = class Camera {
     ['eyeX', 'eyeY', 'eyeZ',
      'centerX', 'centerY', 'centerZ',
      'upX', 'upY', 'upZ',
-     'cameraFOV', 'aspectRatio', 'cameraNear', 'cameraFar', 'cameraType']
-      .forEach((keyName) => { this[keyName] = cam[keyName]; }
-    );
+     'cameraFOV', 'aspectRatio', 'cameraNear', 'cameraFar', 'cameraType'
+    ].forEach((keyName) => { this[keyName] = cam[keyName]; });
 
     this.cameraMatrix = cam.cameraMatrix.copy();
     this.projMatrix = cam.projMatrix.copy();

--- a/src/webgl/p5.Camera.js
+++ b/src/webgl/p5.Camera.js
@@ -1618,11 +1618,15 @@ p5.Camera = class Camera {
  * the initial state.
  */
   set(cam) {
-    ['eyeX', 'eyeY', 'eyeZ',
-     'centerX', 'centerY', 'centerZ',
-     'upX', 'upY', 'upZ',
-     'cameraFOV', 'aspectRatio', 'cameraNear', 'cameraFar', 'cameraType'
-    ].forEach((keyName) => { this[keyName] = cam[keyName]; });
+    const keyNamesOfThePropToCopy = [
+      'eyeX', 'eyeY', 'eyeZ',
+      'centerX', 'centerY', 'centerZ',
+      'upX', 'upY', 'upZ',
+      'cameraFOV', 'aspectRatio', 'cameraNear', 'cameraFar', 'cameraType'
+    ];
+    for (const keyName of keyNamesOfThePropToCopy) {
+      this[keyName] = cam[keyName];
+    }
 
     this.cameraMatrix = cam.cameraMatrix.copy();
     this.projMatrix = cam.projMatrix.copy();

--- a/test/unit/webgl/p5.Camera.js
+++ b/test/unit/webgl/p5.Camera.js
@@ -378,8 +378,8 @@ suite('p5.Camera', function() {
     });
 
     test('test for matrix manipulation with set()', function() {
-      myCam = p5.createCamera();
-      p5.setCamera(myCam);
+      myCam = myp5.createCamera();
+      myp5.setCamera(myCam);
       const copyCam = myCam.copy();
       copyCam.camera(100, 100, 100, 20, 30, 40, 0, 0, -1);
       myCam.set(copyCam);

--- a/test/unit/webgl/p5.Camera.js
+++ b/test/unit/webgl/p5.Camera.js
@@ -377,6 +377,29 @@ suite('p5.Camera', function() {
       assert.deepEqual(myCam.cameraMatrix.mat4, expectedMatrix);
     });
 
+    test('test for matrix manipulation with set()', function() {
+      myCam = p5.createCamera();
+      p5.setCamera(myCam);
+      const copyCam = myCam.copy();
+      copyCam.camera(100, 100, 100, 20, 30, 40, 0, 0, -1);
+      myCam.set(copyCam);
+
+      // Confirmation that the argument camera and the matrix of the camera
+      // that received set() match
+      assert.deepEqual(copyCam.cameraMatrix.mat4, myCam.cameraMatrix.mat4);
+      assert.deepEqual(copyCam.projMatrix.mat4, myCam.projMatrix.mat4);
+      // If the set()ed camera is active,
+      // the renderer's matrix will also change.
+      assert.deepEqual(
+        copyCam.cameraMatrix.mat4,
+        myp5._renderer._curCamera.uMVMatrix.mat4
+      );
+      assert.deepEqual(
+        copyCam.projMatrix.mat4,
+        myp5._renderer._curCamera.uPMatrix.mat4
+      );
+    });
+
     test('_orbit(1,0,0) sets correct matrix', function() {
       var expectedMatrix = new Float32Array([
         0.5403022766113281, -5.1525235865883254e-17, 0.8414709568023682, 0,

--- a/test/unit/webgl/p5.Camera.js
+++ b/test/unit/webgl/p5.Camera.js
@@ -392,11 +392,11 @@ suite('p5.Camera', function() {
       // the renderer's matrix will also change.
       assert.deepEqual(
         copyCam.cameraMatrix.mat4,
-        myp5._renderer._curCamera.uMVMatrix.mat4
+        myp5._renderer.uMVMatrix.mat4
       );
       assert.deepEqual(
         copyCam.projMatrix.mat4,
-        myp5._renderer._curCamera.uPMatrix.mat4
+        myp5._renderer.uPMatrix.mat4
       );
     });
 


### PR DESCRIPTION
Implement the set() function of p5.Camera.

This function copies the argument camera information to the target camera, just like p5.Vector's set().
The information to be copied is the view matrix and its parameters, projection matrix and its parameters, and cameraType.
There is no particular meaning in transferring the cameraType, but since this information is determined in a way related to how the projection is set, I thought it would be appropriate to copy it.
If the target camera is active, the renderer's view and projection matrices are updated with the same matrices.

Resolves #6238

## Example
[p5.Camera.set()_DEMO](https://editor.p5js.org/dark_fox/sketches/y0tTOjprQ)
```js
let cam, initialCam;

function setup() {
  createCanvas(400, 400, WEBGL);
  strokeWeight(3);

  // Set the initial state to initialCamera and set it to the camera
  // used for drawing. Then set cam to be the active camera.
  cam = createCamera();
  initialCam = createCamera();
  initialCam.camera(100, 100, 100, 0, 0, 0, 0, 0, -1);
  cam.set(initialCam);

  setCamera(cam);
}

function draw() {
  orbitControl();
  background(255);
  box(50);
  translate(0, 0, -25);
  plane(100);
}

function doubleClicked(){
  // Double-click to return the camera to its initial position.
  cam.set(initialCam);
}
```

https://github.com/processing/p5.js/assets/39549290/f760870b-24db-472d-8783-103c62b7b667

When double-clicked, the camera whose initial state is registered is set as the active camera by set(), and the screen state is reset. As it stands now, this requires resetting the initial state somehow. setCamera() cannot be used because the active camera will change. With this function, you can restore only the settings without changing the active camera.

#### PR Checklist
<!--
  To check any option, replace the "[ ]" with a "[x]". Be sure to check out how it looks in the Preview tab! Feel free to remove any portion of the template that is not relevant for your issue.
-->

- [x] `npm run lint` passes
- [x] [Inline documentation] is included / updated
- [x] [Unit tests] are included / updated

[Inline documentation]: https://github.com/processing/p5.js/blob/main/contributor_docs/inline_documentation.md
[Unit tests]: https://github.com/processing/p5.js/tree/main/contributor_docs#unit-tests
