### PR TITLE
Update FES check for internal errors to support ES6 classes

### DIFF
--- a/src/core/friendly_errors/fes_core.js
+++ b/src/core/friendly_errors/fes_core.js
@@ -497,6 +497,17 @@ if (typeof IS_MINIFIED !== 'undefined') {
     // isInternal - Did this error happen inside the library
     let isInternal = false;
     let p5FileName, friendlyStack, currentEntryPoint;
+
+    // Intentionally throw an error that we catch so that we can check the name
+    // of the current file. Any errors we see from this file, we treat as
+    // internal errors.
+    try {
+      throw new Error();
+    } catch (testError) {
+      const testStacktrace = p5._getErrorStackParser().parse(testError);
+      p5FileName = testStacktrace[0].fileName;
+    }
+
     for (let i = stacktrace.length - 1; i >= 0; i--) {
       let splitted = stacktrace[i].functionName.split('.');
       if (entryPoints.includes(splitted[splitted.length - 1])) {
@@ -504,15 +515,14 @@ if (typeof IS_MINIFIED !== 'undefined') {
         // (it's usually the internal initialization calls)
         friendlyStack = stacktrace.slice(0, i + 1);
         currentEntryPoint = splitted[splitted.length - 1];
-        for (let j = 0; j < i; j++) {
-          // Due to the current build process, all p5 functions have
-          // _main.default in their names in the final build. This is the
-          // easiest way to check if a function is inside the p5 library
-          if (stacktrace[j].functionName.search('_main.default') !== -1) {
-            isInternal = true;
-            p5FileName = stacktrace[j].fileName;
-            break;
-          }
+        // We call the error "internal" if the source of the error was a
+        // function from within the p5.js library file, but called from the
+        // user's code directly. We only need to check the topmost frame in
+        // the stack trace since any function internal to p5 should pass this
+        // check, not just public p5 functions.
+        if (stacktrace[0].fileName === p5FileName) {
+          isInternal = true;
+          break;
         }
         break;
       }

--- a/test/unit/core/error_helpers.js
+++ b/test/unit/core/error_helpers.js
@@ -589,6 +589,28 @@ suite('Global Error Handling', function() {
     });
   });
 
+  testUnMinified(
+    'identifies errors happenning internally in ES6 classes',
+    function() {
+      return new Promise(function(resolve) {
+        prepSyntaxTest(
+          [
+            'function setup() {',
+            'let cnv = createCanvas(10, 10, WEBGL);',
+            'let fbo = createFramebuffer();',
+            'fbo.draw();', // Error in p5 library as no callback passed
+            '}'
+          ],
+          resolve
+        );
+      }).then(function() {
+        assert.strictEqual(log.length, 1);
+        assert.match(log[0], /inside the p5js library/);
+        assert.match(log[0], /draw/);
+      });
+    }
+  );
+
   testUnMinified('identifies errors in preload', function() {
     return new Promise(function(resolve) {
       prepSyntaxTest(


### PR DESCRIPTION
Resolves https://github.com/processing/p5.js/issues/6172


### Changes

Previously, to tell if an error was internal, we'd see if the function name in the stack trace included `_main.default`, which used to be the case for all `p5.prototype` functions. This seemed to no longer be the case for internal ES6 classes, so I've implemented a different method: throwing a test error, recording the filename, and then checking the real stack trace for frames originating in that same file.

We also used to check *all* frames between the entrypoint (e.g. draw()) up to the source of the error looking for `_main.default`. I think this is because the error could have originated in a non `p5.prototype` function (like an anonymous function) that was called from a `p5.prototype` function, and we want to catch that too. We don't need to loop using this new method, since both sorts of functions will originate from within the p5.js library file.

We had an existing check for internal errors that used p5.Element. I've added a new test that does the same sort of thing but on p5.Framebuffer, which is an ES6 class.

#### PR Checklist

- [x] `npm run lint` passes
- [x] [Inline documentation] is included / updated
- [x] [Unit tests] are included / updated
