### PR TITLE
Clean up YUIDoc warnings

### DIFF
--- a/src/core/p5.Element.js
+++ b/src/core/p5.Element.js
@@ -13,13 +13,11 @@ import p5 from './main';
  * <a href="#/p5/createDiv">createDiv()</a>, <a href="#/p5/createImg">createImg()</a>, <a href="#/p5/createInput">createInput()</a>, etc.
  *
  * @class p5.Element
+ * @constructor
+ * @param {HTMLElement} elt DOM node that is wrapped
+ * @param {p5} [pInst] pointer to p5 instance
  */
 p5.Element = class {
-  /**
-   * @constructor
-   * @param {HTMLElement} elt DOM node that is wrapped
-   * @param {p5} [pInst] pointer to p5 instance
- */
   constructor(elt, pInst) {
     /**
      * Underlying HTML element. All normal HTML methods can be called on this.

--- a/src/events/acceleration.js
+++ b/src/events/acceleration.js
@@ -3,6 +3,7 @@
  * @submodule Acceleration
  * @for p5
  * @requires core
+ * @main Events
  */
 
 import p5 from '../core/main';


### PR DESCRIPTION
<!--
  Thank you for contributing! Please use this pull request (PR) template.


 In the description field of this PR, include "resolves #XXXX" tagging the issue you are fixing. If this PR addresses the issue but doesn't completely resolve it (ie the issue should remain open after your PR is merged), write "addresses #XXXX".-->
Resolves #5114

 Changes:
<!-- Add here what changes were made in this pull request and if possible provide links showcasing the changes. -->
Fix p5.Element constructor inline documentation not formatted correctly.

Mark main module for the Events module documentation, practically this has no effect on how we use and display the documentation (essentially a no-op) and is done just to remove a warning when building the documentation.

#### PR Checklist
<!--
  To check any option, replace the "[ ]" with a "[x]". Be sure to check out how it looks in the Preview tab! Feel free to remove any portion of the template that is not relevant for your issue.
-->

- [x] `npm run lint` passes
- [x] [Inline documentation] is included / updated
- [ ] [Unit tests] are included / updated

[Inline documentation]: https://github.com/processing/p5.js/blob/main/contributor_docs/inline_documentation.md
[Unit tests]: https://github.com/processing/p5.js/tree/main/contributor_docs#unit-tests
