### PR TITLE
implement p5.Camera.slerp(), 3x3Matrix functions and minor spec-change of orbitControl()

### DIFF
--- a/src/webgl/interaction.js
+++ b/src/webgl/interaction.js
@@ -154,7 +154,7 @@ p5.prototype.orbitControl = function(
   const moveAccelerationFactor = 0.15;
   // For touches, the appropriate scale is different
   // because the distance difference is multiplied.
-  const mouseZoomScaleFactor = 0.0001;
+  const mouseZoomScaleFactor = 0.01;
   const touchZoomScaleFactor = 0.0004;
   const scaleFactor = this.height < this.width ? this.height : this.width;
   // Flag whether the mouse or touch pointer is inside the canvas
@@ -214,7 +214,7 @@ p5.prototype.orbitControl = function(
     if (this._mouseWheelDeltaY !== 0) {
       // zoom the camera depending on the value of _mouseWheelDeltaY.
       // move away if positive, move closer if negative
-      deltaRadius = this._mouseWheelDeltaY * sensitivityZ;
+      deltaRadius = Math.sign(this._mouseWheelDeltaY) * sensitivityZ;
       deltaRadius *= mouseZoomScaleFactor;
       this._mouseWheelDeltaY = 0;
       // start zoom when the mouse is wheeled within the canvas.
@@ -249,24 +249,27 @@ p5.prototype.orbitControl = function(
   if (Math.abs(this._renderer.zoomVelocity) > 0.001) {
     // if freeRotation is true, we use _orbitFree() instead of _orbit()
     if (freeRotation) {
-      this._renderer._curCamera._orbitFree(
+      cam._orbitFree(
         0, 0, this._renderer.zoomVelocity
       );
     } else {
-      this._renderer._curCamera._orbit(
+      cam._orbit(
         0, 0, this._renderer.zoomVelocity
       );
     }
     // In orthogonal projection, the scale does not change even if
     // the distance to the gaze point is changed, so the projection matrix
     // needs to be modified.
-    if (this._renderer.uPMatrix.mat4[15] !== 0) {
-      this._renderer.uPMatrix.mat4[0] *= Math.pow(
+    if (cam.projMatrix.mat4[15] !== 0) {
+      cam.projMatrix.mat4[0] *= Math.pow(
         10, -this._renderer.zoomVelocity
       );
-      this._renderer.uPMatrix.mat4[5] *= Math.pow(
+      cam.projMatrix.mat4[5] *= Math.pow(
         10, -this._renderer.zoomVelocity
       );
+      // modify uPMatrix
+      this._renderer.uPMatrix.mat4[0] = cam.projMatrix.mat4[0];
+      this._renderer.uPMatrix.mat4[5] = cam.projMatrix.mat4[5];
     }
     // damping
     this._renderer.zoomVelocity *= damping;
@@ -286,13 +289,13 @@ p5.prototype.orbitControl = function(
   if (this._renderer.rotateVelocity.magSq() > 0.000001) {
     // if freeRotation is true, the camera always rotates freely in the direction the pointer moves
     if (freeRotation) {
-      this._renderer._curCamera._orbitFree(
+      cam._orbitFree(
         -this._renderer.rotateVelocity.x,
         this._renderer.rotateVelocity.y,
         0
       );
     } else {
-      this._renderer._curCamera._orbit(
+      cam._orbit(
         this._renderer.rotateVelocity.x,
         this._renderer.rotateVelocity.y,
         0

--- a/src/webgl/p5.Camera.js
+++ b/src/webgl/p5.Camera.js
@@ -1856,6 +1856,7 @@ p5.Camera = class Camera {
     // An orthogonal matrix is just an orthonormal basis. If this is not the identity
     // matrix, it is a centered orthonormal basis plus some angle of rotation about
     // some axis. That's the angle. Letting this be theta, trace becomes 1+2cos(theta).
+    // reference: https://en.wikipedia.org/wiki/Rotation_matrix#Determining_the_angle
     let cosTheta = 0.5 * (m[0] + m[4] + m[8] - 1);
     // If the angle is close to 0, the two matrices are very close,
     // so in that case we execute linearly interpolate.
@@ -1890,7 +1891,7 @@ p5.Camera = class Camera {
     // Calculates the axis vector and the angle of the difference orthogonal matrix.
     // The axis vector is what I explained earlier in the comments.
     // similar calculation is here:
-    // https://github.com/mrdoob/three.js/blob/dev/src/math/Quaternion.js#L294
+    // https://github.com/mrdoob/three.js/blob/883249620049d1632e8791732808fefd1a98c871/src/math/Quaternion.js#L294
     let a, b, c, sinTheta;
     let invOneMinusCosTheta = 1 / (1 - cosTheta);
     if (m[0] > m[4] && m[0] > m[8]) {

--- a/src/webgl/p5.Camera.js
+++ b/src/webgl/p5.Camera.js
@@ -1774,9 +1774,9 @@ p5.Camera = class Camera {
 
     // Calculate the distance between eye and center for each camera.
     // Then linearly interpolate them by amt.
-    const lerpedDist = lerp(
-      p5.Vector.dist(eye0, center0), p5.Vector.dist(eye1, center1), amt
-    );
+    const dist0 = p5.Vector.dist(eye0, center0);
+    const dist1 = p5.Vector.dist(eye1, center1);
+    const lerpedDist = (1 - amt) * dist0 + amt * dist1;
 
     // Next, calculate the ratio to interpolate the eye and center by a constant
     // ratio for each camera. This ratio is the same for both. Also, with this ratio

--- a/src/webgl/p5.Camera.js
+++ b/src/webgl/p5.Camera.js
@@ -1645,9 +1645,10 @@ p5.Camera = class Camera {
  * to the right and amt is 0.5, the applied camera will look to the halfway
  * between front and right.
  * If the applied camera is active, the applied result will be reflected on the screen.
- * When applying this function, the projection modes of all appearing cameras
- * must match. For example, if one is perspective, ortho, frustum, the other
- * two must also be perspective, ortho, frustum respectively.
+ * When applying this function, all cameras involved must have exactly the same projection
+ * settings. For example, if one is perspective, ortho, frustum, the other two must also be
+ * perspective, ortho, frustum respectively. However, if all cameras have ortho settings,
+ * only orbitControl's change of the projection settings is permissive.
  *
  * @method slerp
  * @param {p5.Camera} cam0 first p5.Camera

--- a/src/webgl/p5.Camera.js
+++ b/src/webgl/p5.Camera.js
@@ -1768,10 +1768,14 @@ p5.Camera = class Camera {
     // Linearly interpolates the distance between the viewpoint and the center,
     // and the position of the center.
     const eyeDist0 = Math.hypot(
-      cam0.eyeX - cam0.centerX, cam0.eyeY - cam0.centerY, cam0.eyeZ - cam0.centerZ
+      cam0.eyeX - cam0.centerX,
+      cam0.eyeY - cam0.centerY,
+      cam0.eyeZ - cam0.centerZ
     );
     const eyeDist1 = Math.hypot(
-      cam1.eyeX - cam1.centerX, cam1.eyeY - cam1.centerY, cam1.eyeZ - cam1.centerZ
+      cam1.eyeX - cam1.centerX,
+      cam1.eyeY - cam1.centerY,
+      cam1.eyeZ - cam1.centerZ
     );
     const eyeDist = (1 - amt) * eyeDist0 + amt * eyeDist1;
     const lerpedCenterX = (1 - amt) * cam0.centerX + amt * cam1.centerX;

--- a/src/webgl/p5.Matrix.js
+++ b/src/webgl/p5.Matrix.js
@@ -922,14 +922,17 @@ p5.Matrix = class {
  *
  * @method multiplyVec3
  * @param {p5.Vector} multVector the vector to which this matrix applies
+ * @param {p5.Vector} [target] The vector to receive the result
  * @return {p5.Vector}
  */
-  multiplyVec3(multVector) {
-    return new p5.Vector(
-      p5.Vector.dot(this.row(0), multVector),
-      p5.Vector.dot(this.row(1), multVector),
-      p5.Vector.dot(this.row(2), multVector)
-    );
+  multiplyVec3(multVector, target) {
+    if (target === undefined) {
+      target = multVector.copy();
+    }
+    target.x = this.row(0).dot(multVector);
+    target.y = this.row(1).dot(multVector);
+    target.z = this.row(2).dot(multVector);
+    return target;
   }
 
   /**

--- a/src/webgl/p5.Matrix.js
+++ b/src/webgl/p5.Matrix.js
@@ -110,9 +110,36 @@ p5.Matrix = class {
  */
   copy() {
     if (this.mat3 !== undefined) {
-      return new p5.Matrix('mat3', this.mat3.slice(), this.p5);
+      const copied3x3 = new p5.Matrix('mat3', this.p5);
+      copied3x3.mat3[0] = this.mat3[0];
+      copied3x3.mat3[1] = this.mat3[1];
+      copied3x3.mat3[2] = this.mat3[2];
+      copied3x3.mat3[3] = this.mat3[3];
+      copied3x3.mat3[4] = this.mat3[4];
+      copied3x3.mat3[5] = this.mat3[5];
+      copied3x3.mat3[6] = this.mat3[6];
+      copied3x3.mat3[7] = this.mat3[7];
+      copied3x3.mat3[8] = this.mat3[8];
+      return copied3x3;
     }
-    return new p5.Matrix(this.mat4.slice(), this.p5);
+    const copied = new p5.Matrix(this.p5);
+    copied.mat4[0] = this.mat4[0];
+    copied.mat4[1] = this.mat4[1];
+    copied.mat4[2] = this.mat4[2];
+    copied.mat4[3] = this.mat4[3];
+    copied.mat4[4] = this.mat4[4];
+    copied.mat4[5] = this.mat4[5];
+    copied.mat4[6] = this.mat4[6];
+    copied.mat4[7] = this.mat4[7];
+    copied.mat4[8] = this.mat4[8];
+    copied.mat4[9] = this.mat4[9];
+    copied.mat4[10] = this.mat4[10];
+    copied.mat4[11] = this.mat4[11];
+    copied.mat4[12] = this.mat4[12];
+    copied.mat4[13] = this.mat4[13];
+    copied.mat4[14] = this.mat4[14];
+    copied.mat4[15] = this.mat4[15];
+    return copied;
   }
 
   /**

--- a/src/webgl/p5.Matrix.js
+++ b/src/webgl/p5.Matrix.js
@@ -110,18 +110,9 @@ p5.Matrix = class {
  */
   copy() {
     if (this.mat3 !== undefined) {
-      return new p5.Matrix('mat3', [
-        this.mat3[0], this.mat3[1], this.mat3[2],
-        this.mat3[3], this.mat3[4], this.mat3[5],
-        this.mat3[6], this.mat3[7], this.mat3[8]
-      ], this.p5);
+      return new p5.Matrix('mat3', this.mat3.slice(), this.p5);
     }
-    return new p5.Matrix([
-      this.mat4[0], this.mat4[1], this.mat4[2], this.mat4[3],
-      this.mat4[4], this.mat4[5], this.mat4[6], this.mat4[7],
-      this.mat4[8], this.mat4[9], this.mat4[10], this.mat4[11],
-      this.mat4[12], this.mat4[13], this.mat4[14], this.mat4[15]
-    ], this.p5);
+    return new p5.Matrix(this.mat4.slice(), this.p5);
   }
 
   /**

--- a/src/webgl/p5.Matrix.js
+++ b/src/webgl/p5.Matrix.js
@@ -940,11 +940,17 @@ p5.Matrix = class {
  * @return {p5.Matrix}
  */
   createSubMatrix3x3() {
-    return new p5.Matrix('mat3', [
-      this.mat4[0], this.mat4[1], this.mat4[2],
-      this.mat4[4], this.mat4[5], this.mat4[6],
-      this.mat4[8], this.mat4[9], this.mat4[10]
-    ]);
+    const result = new p5.Matrix('mat3');
+    result.mat3[0] = this.mat4[0];
+    result.mat3[1] = this.mat4[1];
+    result.mat3[2] = this.mat4[2];
+    result.mat3[3] = this.mat4[4];
+    result.mat3[4] = this.mat4[5];
+    result.mat3[5] = this.mat4[6];
+    result.mat3[6] = this.mat4[8];
+    result.mat3[7] = this.mat4[9];
+    result.mat3[8] = this.mat4[10];
+    return result;
   }
 
   /**

--- a/src/webgl/p5.Matrix.js
+++ b/src/webgl/p5.Matrix.js
@@ -120,7 +120,7 @@ p5.Matrix = class {
       this.mat4[0], this.mat4[1], this.mat4[2], this.mat4[3],
       this.mat4[4], this.mat4[5], this.mat4[6], this.mat4[7],
       this.mat4[8], this.mat4[9], this.mat4[10], this.mat4[11],
-      this.mat4[12], this.mat4[13], this.mat4[14], this.mat4[15],
+      this.mat4[12], this.mat4[13], this.mat4[14], this.mat4[15]
     ], this.p5);
   }
 

--- a/test/unit/webgl/p5.Camera.js
+++ b/test/unit/webgl/p5.Camera.js
@@ -748,9 +748,9 @@ suite('p5.Camera', function() {
     const expectCameraMatricesAreClose = function(cam0, cam1) {
       for (let i = 0; i < cam0.cameraMatrix.mat4.length; i++) {
         expect(cam0.cameraMatrix.mat4[i])
-        .to.be.closeTo(cam1.cameraMatrix.mat4[i], 0.001);
+          .to.be.closeTo(cam1.cameraMatrix.mat4[i], 0.001);
       }
-    }
+    };
     test('if amt is 0 or 1, the argument camera is set', function() {
       myCam = myp5.createCamera();
       const cam0 = myCam.copy();

--- a/test/unit/webgl/p5.Camera.js
+++ b/test/unit/webgl/p5.Camera.js
@@ -745,6 +745,12 @@ suite('p5.Camera', function() {
   });
 
   suite('slerp()', function() {
+    const expectCameraMatricesAreClose = function(cam0, cam1) {
+      for (let i = 0; i < cam0.cameraMatrix.mat4.length; i++) {
+        expect(cam0.cameraMatrix.mat4[i])
+        .to.be.closeTo(cam1.cameraMatrix.mat4[i], 0.001);
+      }
+    }
     test('if amt is 0 or 1, the argument camera is set', function() {
       myCam = myp5.createCamera();
       const cam0 = myCam.copy();
@@ -759,6 +765,28 @@ suite('p5.Camera', function() {
       // if amt is 1, cam is set to cam1.
       myCam.slerp(cam0, cam1, 1);
       assert.deepEqual(myCam.cameraMatrix.mat4, cam1.cameraMatrix.mat4);
+    });
+    test('Behavior of slerp() for camera moved by pan()', function() {
+      myCam = myp5.createCamera();
+      const cam0 = myCam.copy();
+      const cam1 = myCam.copy();
+      cam1.pan(Math.PI * 0.9);
+
+      // Prepare cameras supposed to be obtained by slerp cam0 and cam1.
+      const cam2 = myCam.copy();
+      cam2.pan(Math.PI * 0.4);
+      const cam3 = myCam.copy();
+      cam3.pan(-Math.PI * 0.2);
+      const cam4 = myCam.copy();
+      cam4.pan(Math.PI * 1.1);
+
+      // Compare these views with the view set by slerp().
+      myCam.slerp(cam0, cam1, 4/9);
+      expectCameraMatricesAreClose(myCam, cam2);
+      myCam.slerp(cam0, cam1, -2/9);
+      expectCameraMatricesAreClose(myCam, cam3);
+      myCam.slerp(cam0, cam1, 11/9);
+      expectCameraMatricesAreClose(myCam, cam4);
     });
   });
 

--- a/test/unit/webgl/p5.Camera.js
+++ b/test/unit/webgl/p5.Camera.js
@@ -788,6 +788,89 @@ suite('p5.Camera', function() {
       myCam.slerp(cam0, cam1, 11/9);
       expectCameraMatricesAreClose(myCam, cam4);
     });
+    test('Behavior of slerp() for camera moved by tilt()', function() {
+      myCam = myp5.createCamera();
+      const cam0 = myCam.copy();
+      const cam1 = myCam.copy();
+      cam1.tilt(Math.PI * 0.3);
+
+      // Prepare cameras supposed to be obtained by slerp cam0 and cam1.
+      const cam2 = myCam.copy();
+      cam2.tilt(Math.PI * 0.1);
+      const cam3 = myCam.copy();
+      cam3.tilt(-Math.PI * 0.2);
+      const cam4 = myCam.copy();
+      cam4.tilt(Math.PI * 0.4);
+
+      // Compare these views with the view set by slerp().
+      myCam.slerp(cam0, cam1, 1/3);
+      expectCameraMatricesAreClose(myCam, cam2);
+      myCam.slerp(cam0, cam1, -2/3);
+      expectCameraMatricesAreClose(myCam, cam3);
+      myCam.slerp(cam0, cam1, 4/3);
+      expectCameraMatricesAreClose(myCam, cam4);
+    });
+    test('Behavior of slerp() for camera moved by _orbit()', function() {
+      myCam = myp5.createCamera();
+      const cam0 = myCam.copy();
+      const cam1 = myCam.copy();
+      cam1._orbit(Math.PI * 0.8, 0, 0);
+      const cam2 = myCam.copy();
+      cam2._orbit(0, Math.PI * 0.7, 0);
+
+      // Prepare cameras supposed to be obtained by slerp cam0 and cam1.
+      const cam3 = myCam.copy();
+      cam3._orbit(Math.PI * 0.3, 0, 0);
+      const cam4 = myCam.copy();
+      cam4._orbit(-Math.PI * 0.5, 0, 0);
+      const cam5 = myCam.copy();
+      cam5._orbit(Math.PI * 1.1, 0, 0);
+
+      // Prepare cameras supposed to be obtained by slerp cam0 and cam2.
+      const cam6 = myCam.copy();
+      cam6._orbit(0, Math.PI * 0.3, 0);
+      const cam7 = myCam.copy();
+      cam7._orbit(0, -Math.PI * 0.5, 0);
+      const cam8 = myCam.copy();
+      cam8._orbit(0, Math.PI * 1.1, 0);
+
+      // Compare these views with the view set by slerp().
+      myCam.slerp(cam0, cam1, 3/8);
+      expectCameraMatricesAreClose(myCam, cam3);
+      myCam.slerp(cam0, cam1, -5/8);
+      expectCameraMatricesAreClose(myCam, cam4);
+      myCam.slerp(cam0, cam1, 11/8);
+      expectCameraMatricesAreClose(myCam, cam5);
+
+      myCam.slerp(cam0, cam2, 3/7);
+      expectCameraMatricesAreClose(myCam, cam6);
+      myCam.slerp(cam0, cam2, -5/7);
+      expectCameraMatricesAreClose(myCam, cam7);
+      myCam.slerp(cam0, cam2, 11/7);
+      expectCameraMatricesAreClose(myCam, cam8);
+    });
+    test('Behavior of slerp() for camera moved by _orbitFree()', function() {
+      myCam = myp5.createCamera();
+      const cam0 = myCam.copy();
+      const cam1 = myCam.copy();
+      cam1._orbitFree(Math.PI * 0.8, Math.PI * 0.6, 0);
+
+      // Prepare cameras supposed to be obtained by slerp cam0 and cam1.
+      const cam2 = myCam.copy();
+      cam2._orbitFree(Math.PI * 0.4, Math.PI * 0.3, 0);
+      const cam3 = myCam.copy();
+      cam3._orbitFree(-Math.PI * 0.2, -Math.PI * 0.15, 0);
+      const cam4 = myCam.copy();
+      cam4._orbitFree(Math.PI * 1.2, Math.PI * 0.9, 0);
+
+      // Compare these views with the view set by slerp().
+      myCam.slerp(cam0, cam1, 1/2);
+      expectCameraMatricesAreClose(myCam, cam2);
+      myCam.slerp(cam0, cam1, -1/4);
+      expectCameraMatricesAreClose(myCam, cam3);
+      myCam.slerp(cam0, cam1, 3/2);
+      expectCameraMatricesAreClose(myCam, cam4);
+    });
   });
 
   suite('Helper Functions', function() {

--- a/test/unit/webgl/p5.Camera.js
+++ b/test/unit/webgl/p5.Camera.js
@@ -881,9 +881,9 @@ suite('p5.Camera', function() {
       // Run slerp() and compare viewpoints.
       for (let i = 1; i < 100; i++) {
         myCam.slerp(cam0, cam1, i * 0.01);
-        assert.strictEqual(myCam.eyeX, cam0.eyeX);
-        assert.strictEqual(myCam.eyeY, cam0.eyeY);
-        assert.strictEqual(myCam.eyeZ, cam0.eyeZ);
+        expect(myCam.eyeX).to.be.closeTo(cam0.eyeX, 0.00001);
+        expect(myCam.eyeY).to.be.closeTo(cam0.eyeY, 0.00001);
+        expect(myCam.eyeZ).to.be.closeTo(cam0.eyeZ, 0.00001);
       }
     });
     test('if center of cam0, cam1 are same, all the same.', function() {
@@ -896,9 +896,9 @@ suite('p5.Camera', function() {
       // Run slerp() and compare centers.
       for (let i = 1; i < 100; i++) {
         myCam.slerp(cam0, cam1, i * 0.01);
-        assert.strictEqual(myCam.centerX, cam0.centerX);
-        assert.strictEqual(myCam.centerY, cam0.centerY);
-        assert.strictEqual(myCam.centerZ, cam0.centerZ);
+        expect(myCam.centerX).to.be.closeTo(cam0.centerX, 0.00001);
+        expect(myCam.centerY).to.be.closeTo(cam0.centerY, 0.00001);
+        expect(myCam.centerZ).to.be.closeTo(cam0.centerZ, 0.00001);
       }
     });
     test('if all camera is ortho, 0,5 component is interpolated', function() {
@@ -917,11 +917,11 @@ suite('p5.Camera', function() {
       const p0_0 = cam0.projMatrix.mat4[0];
       const p1_0 = cam1.projMatrix.mat4[0];
       expect(myCam.projMatrix.mat4[0])
-        .to.be.closeTo(0.7 * p0_0 + 0.3 * p1_0, 0.0001);
+        .to.be.closeTo(0.7 * p0_0 + 0.3 * p1_0, 0.00001);
       const p0_5 = cam0.projMatrix.mat4[5];
       const p1_5 = cam1.projMatrix.mat4[5];
       expect(myCam.projMatrix.mat4[5])
-        .to.be.closeTo(0.7 * p0_5 + 0.3 * p1_5, 0.0001);
+        .to.be.closeTo(0.7 * p0_5 + 0.3 * p1_5, 0.00001);
     });
   });
 

--- a/test/unit/webgl/p5.Camera.js
+++ b/test/unit/webgl/p5.Camera.js
@@ -822,7 +822,7 @@ suite('p5.Camera', function() {
       const cam3 = myCam.copy();
       cam3._orbit(Math.PI * 0.3, 0, 0);
       const cam4 = myCam.copy();
-      cam4._orbit(-Math.PI * 0.5, 0, 0);
+      cam4._orbit(-Math.PI * 0.7, 0, 0);
       const cam5 = myCam.copy();
       cam5._orbit(Math.PI * 1.1, 0, 0);
 
@@ -830,21 +830,21 @@ suite('p5.Camera', function() {
       const cam6 = myCam.copy();
       cam6._orbit(0, Math.PI * 0.3, 0);
       const cam7 = myCam.copy();
-      cam7._orbit(0, -Math.PI * 0.5, 0);
+      cam7._orbit(0, -Math.PI * 0.4, 0);
       const cam8 = myCam.copy();
       cam8._orbit(0, Math.PI * 1.1, 0);
 
       // Compare these views with the view set by slerp().
       myCam.slerp(cam0, cam1, 3/8);
       expectCameraMatricesAreClose(myCam, cam3);
-      myCam.slerp(cam0, cam1, -5/8);
+      myCam.slerp(cam0, cam1, -7/8);
       expectCameraMatricesAreClose(myCam, cam4);
       myCam.slerp(cam0, cam1, 11/8);
       expectCameraMatricesAreClose(myCam, cam5);
 
       myCam.slerp(cam0, cam2, 3/7);
       expectCameraMatricesAreClose(myCam, cam6);
-      myCam.slerp(cam0, cam2, -5/7);
+      myCam.slerp(cam0, cam2, -4/7);
       expectCameraMatricesAreClose(myCam, cam7);
       myCam.slerp(cam0, cam2, 11/7);
       expectCameraMatricesAreClose(myCam, cam8);

--- a/test/unit/webgl/p5.Camera.js
+++ b/test/unit/webgl/p5.Camera.js
@@ -744,6 +744,24 @@ suite('p5.Camera', function() {
     });
   });
 
+  suite('slerp()', function() {
+    test('if amt is 0 or 1, the argument camera is set', function() {
+      myCam = myp5.createCamera();
+      const cam0 = myCam.copy();
+      cam0.camera(20, 30, 40, 2, 3, 8, 0, 9, -6);
+      const cam1 = myCam.copy();
+      cam1.camera(90, 70, 33, 4, 1, 9, -3, 2, 5);
+
+      // if amt is 0, cam is set to cam0.
+      myCam.slerp(cam0, cam1, 0);
+      assert.deepEqual(myCam.cameraMatrix.mat4, cam0.cameraMatrix.mat4);
+
+      // if amt is 1, cam is set to cam1.
+      myCam.slerp(cam0, cam1, 1);
+      assert.deepEqual(myCam.cameraMatrix.mat4, cam1.cameraMatrix.mat4);
+    });
+  });
+
   suite('Helper Functions', function() {
     test('copy() returns a new p5.Camera object', function() {
       var newCam = myCam.copy();

--- a/test/unit/webgl/p5.Camera.js
+++ b/test/unit/webgl/p5.Camera.js
@@ -871,6 +871,58 @@ suite('p5.Camera', function() {
       myCam.slerp(cam0, cam1, 3/2);
       expectCameraMatricesAreClose(myCam, cam4);
     });
+    test('if viewpoints of cam0, cam1 are same, all the same.', function() {
+      myCam = myp5.createCamera();
+      const cam0 = myCam.copy();
+      cam0.camera(22, 37, 49, 0, 1, 2, 3, 4, -1);
+      const cam1 = myCam.copy();
+      cam1.camera(22, 37, 49, 2, 1, 0, 9, 8, 11);
+
+      // Run slerp() and compare viewpoints.
+      for (let i = 1; i < 100; i++) {
+        myCam.slerp(cam0, cam1, i * 0.01);
+        assert(myCam.eyeX === cam0.eyeX);
+        assert(myCam.eyeY === cam0.eyeY);
+        assert(myCam.eyeZ === cam0.eyeZ);
+      }
+    });
+    test('if center of cam0, cam1 are same, all the same.', function() {
+      myCam = myp5.createCamera();
+      const cam0 = myCam.copy();
+      cam0.camera(0, 1, 2, 22, 37, 49, 3, 4, -1);
+      const cam1 = myCam.copy();
+      cam1.camera(2, 1, 0, 22, 37, 49, 9, 8, 11);
+
+      // Run slerp() and compare centers.
+      for (let i = 1; i < 100; i++) {
+        myCam.slerp(cam0, cam1, i * 0.01);
+        assert(myCam.centerX === cam0.centerX);
+        assert(myCam.centerY === cam0.centerY);
+        assert(myCam.centerZ === cam0.centerZ);
+      }
+    });
+    test('if all camera is ortho, 0,5 component is interpolated', function() {
+      myCam = myp5.createCamera();
+      myCam.ortho(-50, 50, -50, 50, 0, 1000);
+      const cam0 = myCam.copy();
+      cam0.ortho(-20, 20, -20, 20, 0, 1000);
+      const cam1 = myCam.copy();
+      cam1.ortho(-100, 100, -100, 100, 0, 1000);
+
+      // interpolate cam0 and cam1
+      myCam.slerp(cam0, cam1, 0.3);
+
+      // Next, check the 0th and 5th entries of the projection matrix
+      // to make sure they are interpolated.
+      const p0_0 = cam0.projMatrix.mat4[0];
+      const p1_0 = cam1.projMatrix.mat4[0];
+      expect(myCam.projMatrix.mat4[0])
+        .to.be.closeTo(0.7 * p0_0 + 0.3 * p1_0, 0.0001);
+      const p0_5 = cam0.projMatrix.mat4[5];
+      const p1_5 = cam1.projMatrix.mat4[5];
+      expect(myCam.projMatrix.mat4[5])
+        .to.be.closeTo(0.7 * p0_5 + 0.3 * p1_5, 0.0001);
+    });
   });
 
   suite('Helper Functions', function() {

--- a/test/unit/webgl/p5.Camera.js
+++ b/test/unit/webgl/p5.Camera.js
@@ -881,9 +881,9 @@ suite('p5.Camera', function() {
       // Run slerp() and compare viewpoints.
       for (let i = 1; i < 100; i++) {
         myCam.slerp(cam0, cam1, i * 0.01);
-        assert(myCam.eyeX === cam0.eyeX);
-        assert(myCam.eyeY === cam0.eyeY);
-        assert(myCam.eyeZ === cam0.eyeZ);
+        assert.strictEqual(myCam.eyeX, cam0.eyeX);
+        assert.strictEqual(myCam.eyeY, cam0.eyeY);
+        assert.strictEqual(myCam.eyeZ, cam0.eyeZ);
       }
     });
     test('if center of cam0, cam1 are same, all the same.', function() {
@@ -896,9 +896,9 @@ suite('p5.Camera', function() {
       // Run slerp() and compare centers.
       for (let i = 1; i < 100; i++) {
         myCam.slerp(cam0, cam1, i * 0.01);
-        assert(myCam.centerX === cam0.centerX);
-        assert(myCam.centerY === cam0.centerY);
-        assert(myCam.centerZ === cam0.centerZ);
+        assert.strictEqual(myCam.centerX, cam0.centerX);
+        assert.strictEqual(myCam.centerY, cam0.centerY);
+        assert.strictEqual(myCam.centerZ, cam0.centerZ);
       }
     });
     test('if all camera is ortho, 0,5 component is interpolated', function() {

--- a/test/unit/webgl/p5.Matrix.js
+++ b/test/unit/webgl/p5.Matrix.js
@@ -266,13 +266,140 @@ suite('p5.Matrix', function() {
     });
   });
 
+
   suite('p5.Matrix3x3', function() {
-    test('copy3x3', function() {
-      const m = new p5.Matrix('mat3', [1,2,3,4,5,6,7,8,9]);
+    test('apply copy() to 3x3Matrix', function() {
+      const m = new p5.Matrix('mat3', [
+        1, 2, 3,
+        4, 5, 6,
+        7, 8, 9
+      ]);
       const mCopy = m.copy();
+
+      // The matrix created by copying is different from the original matrix
       assert.notEqual(m, mCopy);
       assert.notEqual(m.mat3, mCopy.mat3);
+
+      // The matrix created by copying has the same elements as the original matrix
       assert.deepEqual([].slice.call(m.mat3), [].slice.call(mCopy.mat3));
+    });
+    test('transpose3x3()', function() {
+      const m = new p5.Matrix('mat3', [
+        1, 2, 3,
+        4, 5, 6,
+        7, 8, 9
+      ]);
+      const mTp = new p5.Matrix('mat3', [
+        1, 4, 7,
+        2, 5, 8,
+        3, 6, 9
+      ]);
+
+      // If no arguments, transpose itself
+      m.transpose();
+      assert.deepEqual([].slice.call(m.mat3), [].slice.call(mTp.mat3));
+
+      // If there is an array of arguments, set it by transposing it
+      m.transpose([
+        1, 2, 3,
+        10, 20, 30,
+        100, 200, 300
+      ]);
+      assert.deepEqual([].slice.call(m.mat3), [
+        1, 10, 100,
+        2, 20, 200,
+        3, 30, 300
+      ]);
+    });
+    test('mult3x3()', function() {
+      const m = new p5.Matrix('mat3', [
+        1, 2, 3,
+        4, 5, 6,
+        7, 8, 9
+      ]);
+      const m1 = m.copy();
+      const m2 = m.copy();
+      const multMatrix = new p5.Matrix('mat3', [
+        1, 1, 1,
+        0, 1, 1,
+        1, 0, 1
+      ]);
+
+      // When taking a matrix as an argument
+      m.mult3x3(multMatrix);
+      assert.deepEqual([].slice.call(m.mat3), [
+         4,  3,  6,
+        10,  9, 15,
+        16, 15, 24
+      ]);
+
+      // if the argument is an array or an enumerated number
+      m1.mult3x3(1, 1, 1, 0, 1, 1, 1, 0, 1);
+      m2.mult3x3([1, 1, 1, 0, 1, 1, 1, 0, 1]);
+      assert.deepEqual([].slice.call(m.mat3), [].slice.call(m1.mat3));
+      assert.deepEqual([].slice.call(m.mat3), [].slice.call(m2.mat3));
+    });
+    test('column() and row()', function(){
+      const m = new p5.Matrix('mat3', [
+        1, 2, 3,
+        4, 5, 6,
+        7, 8, 9
+      ]);
+      const column0 = m.column(0);
+      const column1 = m.column(1);
+      const column2 = m.column(2);
+      assert.deepEqual(column0.array(), [1, 4, 7]);
+      assert.deepEqual(column1.array(), [2, 5, 8]);
+      assert.deepEqual(column2.array(), [3, 6, 9]);
+      const row0 = m.row(0);
+      const row1 = m.row(1);
+      const row2 = m.row(2);
+      assert.deepEqual(row0.array(), [1, 2, 3]);
+      assert.deepEqual(row1.array(), [4, 5, 6]);
+      assert.deepEqual(row2.array(), [7, 8, 9]);
+    });
+    test('diagonal()', function() {
+      const m = new p5.Matrix('mat3', [
+        1, 2, 3,
+        4, 5, 6,
+        7, 8, 9
+      ]);
+      const m4x4 = new p5.Matrix([
+        1, 2, 3, 4,
+        5, 6, 7, 8,
+        9, 10, 11, 12,
+        13, 14, 15, 16
+      ]);
+      assert.deepEqual(m.diagonal(), [1, 5, 9]);
+      assert.deepEqual(m4x4.diagonal(), [1, 6, 11, 16]);
+    });
+    test('multiplyVec3', function() {
+      const m = new p5.Matrix('mat3', [
+        1, 2, 3,
+        4, 5, 6,
+        7, 8, 9
+      ]);
+      const multVector = new p5.Vector(3, 2, 1);
+      const result = m.multiplyVec3(multVector);
+      assert.deepEqual(result.array(), [10, 28, 46]);
+    });
+    test('createSubMatrix3x3', function() {
+      const m4x4 = new p5.Matrix([
+        1, 2, 3, 4,
+        5, 6, 7, 8,
+        9, 10, 11, 12,
+        13, 14, 15, 16
+      ]);
+      const result = new p5.Matrix('mat3', [
+        1, 2, 3,
+        5, 6, 7,
+        9, 10, 11
+      ]);
+      const subMatrix3x3 = m4x4.createSubMatrix3x3();
+      assert.deepEqual(
+        [].slice.call(result.mat3),
+        [].slice.call(subMatrix3x3.mat3)
+      );
     });
   });
 });

--- a/test/unit/webgl/p5.Matrix.js
+++ b/test/unit/webgl/p5.Matrix.js
@@ -296,11 +296,11 @@ suite('p5.Matrix', function() {
       ]);
 
       // If no arguments, transpose itself
-      m.transpose();
+      m.transpose3x3();
       assert.deepEqual([].slice.call(m.mat3), [].slice.call(mTp.mat3));
 
       // If there is an array of arguments, set it by transposing it
-      m.transpose([
+      m.transpose3x3([
         1, 2, 3,
         10, 20, 30,
         100, 200, 300

--- a/test/unit/webgl/p5.Matrix.js
+++ b/test/unit/webgl/p5.Matrix.js
@@ -265,4 +265,14 @@ suite('p5.Matrix', function() {
       assert.deepEqual([].slice.call(m.mat4), rm);
     });
   });
+
+  suite('p5.Matrix3x3', function() {
+    test('copy3x3', function() {
+      const m = new p5.Matrix('mat3', [1,2,3,4,5,6,7,8,9]);
+      const mCopy = m.copy();
+      assert.notEqual(m, mCopy);
+      assert.notEqual(m.mat3, mCopy.mat3);
+      assert.deepEqual([].slice.call(m.mat3), [].slice.call(mCopy.mat3));
+    });
+  });
 });

--- a/test/unit/webgl/p5.Matrix.js
+++ b/test/unit/webgl/p5.Matrix.js
@@ -328,8 +328,8 @@ suite('p5.Matrix', function() {
       // When taking a matrix as an argument
       m.mult3x3(multMatrix);
       assert.deepEqual([].slice.call(m.mat3), [
-         4,  3,  6,
-        10,  9, 15,
+        4, 3, 6,
+        10, 9, 15,
         16, 15, 24
       ]);
 

--- a/test/unit/webgl/p5.Matrix.js
+++ b/test/unit/webgl/p5.Matrix.js
@@ -382,6 +382,10 @@ suite('p5.Matrix', function() {
       const multVector = new p5.Vector(3, 2, 1);
       const result = m.multiplyVec3(multVector);
       assert.deepEqual(result.array(), [10, 28, 46]);
+      // If there is a target, set result and return that.
+      const target = new p5.Vector();
+      m.multiplyVec3(multVector, target);
+      assert.deepEqual(target.array(), [10, 28, 46]);
     });
     test('createSubMatrix3x3', function() {
       const m4x4 = new p5.Matrix([


### PR DESCRIPTION
Resolves #6247

Introduces a new function, slerp(), to p5.Camera. It interpolates the views of the two camera arguments.

Interpolation is the so-called quaternion slerp() and is well known. However, since p5.js does not implement quaternions, it does interpolation directly using orthogonal matrix, which is effectively equivalent to quaternions.

However, when the so-called between-angle (corresponding to the difference of the orthonormal basis) is very small, linear interpolation is used instead. This is to avoid problems by classifying cases including that case because the unit matrix cannot take the axis. This is similar to quaternion interpolation, so I used it as a reference.

Besides that, I made a minor fix regarding orbitControl().

First, only uPMatrix is ​​updated when scaling ortho(), but this does not update the camera's projMatrix. This causes problems when interpolating between ortho() cameras, so I rewrote it to update projMatrix as well.

Also, mouseWheelY is used for the mouse wheel interaction, but since this value depends on the model, there is a concern that using the direct value may cause a significant difference of behavior depends on machine. Therefore, we changed the specification to use only the sign.

The main changes are as above. Here is an example:

## Example

[p5.Camera.slerp() for PR](https://editor.p5js.org/dark_fox/sketches/6r3hDs7Bz)

https://github.com/processing/p5.js/assets/39549290/edd6e278-8db4-47f6-ad1d-4953edb2d948

The main usage is to smoothly switch between multiple cameras, or smoothly restore the camera state changed by orbitControl().

#### PR Checklist
<!--
  To check any option, replace the "[ ]" with a "[x]". Be sure to check out how it looks in the Preview tab! Feel free to remove any portion of the template that is not relevant for your issue.
-->

- [x] `npm run lint` passes
- [x] [Inline documentation] is included / updated
- [x] [Unit tests] are included / updated

[Inline documentation]: https://github.com/processing/p5.js/blob/main/contributor_docs/inline_documentation.md
[Unit tests]: https://github.com/processing/p5.js/tree/main/contributor_docs#unit-tests
