### PR TITLE
Ask to disable printing when print() called with no arguments

### DIFF
--- a/src/core/environment.js
+++ b/src/core/environment.js
@@ -16,6 +16,7 @@ p5.prototype._lastFrameTime = window.performance.now();
 p5.prototype._targetFrameRate = 60;
 
 const _windowPrint = window.print;
+let windowPrintDisabled = false;
 
 /**
  * The <a href="#/p5/print">print()</a> function writes to the console area of
@@ -43,7 +44,16 @@ const _windowPrint = window.print;
  */
 p5.prototype.print = function(...args) {
   if (!args.length) {
-    _windowPrint();
+    if (!windowPrintDisabled) {
+      _windowPrint();
+      if (
+        window.confirm(
+          'You just tried to print the webpage. Do you want to prevent this from running again?'
+        )
+      ) {
+        windowPrintDisabled = true;
+      }
+    }
   } else {
     console.log(...args);
   }


### PR DESCRIPTION
Resolves https://github.com/processing/p5.js/issues/2765

### Changes
To address the issue where calling print() with no arguments in a loop effectively locks you out of a sketch, this asks for confirmation after each native window.print() call and gives the option to prevent future prints.

Live: https://editor.p5js.org/davepagurek/sketches/SRpbNUmzC

#### PR Checklist
- [x] `npm run lint` passes
- [ ] [Inline documentation] is included / updated
- [ ] [Unit tests] are included / updated
