### PR TITLE
fix triangle() orientation in webgl mode

### DIFF
--- a/src/webgl/3d_primitives.js
+++ b/src/webgl/3d_primitives.js
@@ -1070,10 +1070,11 @@ p5.RendererGL.prototype.triangle = function(args) {
   // origin appropriately.
   const uMVMatrix = this.uMVMatrix.copy();
   try {
+    const orientation = Math.sign(x1*y2-x2*y1 + x2*y3-x3*y2 + x3*y1-x1*y3);
     const mult = new p5.Matrix([
       x2 - x1, y2 - y1, 0, 0, // the resulting unit X-axis
       x3 - x1, y3 - y1, 0, 0, // the resulting unit Y-axis
-      0, 0, 1, 0,             // the resulting unit Z-axis (unchanged)
+      0, 0, orientation, 0,   // the resulting unit Z-axis (unchanged)
       x1, y1, 0, 1            // the resulting origin
     ]).mult(this.uMVMatrix);
 


### PR DESCRIPTION
Since the direction of triangle() is the front direction regardless of the order of specifying vertices, we make sure that the order of specifying vertices is properly reflected.

<!--
  Thank you for contributing! Please use this pull request (PR) template.


 In the description field of this PR, include "resolves #XXXX" tagging the issue you are fixing. If this PR addresses the issue but doesn't completely resolve it (ie the issue should remain open after your PR is merged), write "addresses #XXXX".-->
Resolves #6262

## Changes:
When calculating the matrix, by inserting the sign of the direction into the (3,3) component, to make sure that  the order of specifying the vertices will be reflected.

## Screenshots of the change:
[triangle()_debug](https://editor.p5js.org/dark_fox/sketches/Q8OHkjnO_)
```js
function setup() {
  createCanvas(400, 400, WEBGL);

  noStroke();
  pointLight(color("lime"), 0, 0, 50);

  // clockwise orientation. normal: (0, 0, 1)
  quad(-200, -200, 0, -200, 0, 0, -200, 0);
  // counter-clockwise orientation. normal: (0, 0, -1)
  quad(200, -200, 0, -200, 0, 0, 200, 0);

  // clockwise orientation. normal: (0, 0, 1)
  triangle(0, 0, 0, 200, -200, 200);
  // counter-clockwise orientation. normal: (0, 0, 1), the same.
  triangle(0, 0, 0, 200, 200, 200);
}
```
### before
![triquad](https://github.com/processing/p5.js/assets/39549290/ebb7263f-f723-487c-b499-328cc9681bbb)

### after
![true](https://github.com/processing/p5.js/assets/39549290/91fa47a2-f169-4e15-8c09-b2f67e722991)

#### PR Checklist
<!--
  To check any option, replace the "[ ]" with a "[x]". Be sure to check out how it looks in the Preview tab! Feel free to remove any portion of the template that is not relevant for your issue.
-->

- [ ] `npm run lint` passes
- [ ] [Inline documentation] is included / updated
- [ ] [Unit tests] are included / updated

[Inline documentation]: https://github.com/processing/p5.js/blob/main/contributor_docs/inline_documentation.md
[Unit tests]: https://github.com/processing/p5.js/tree/main/contributor_docs#unit-tests
