### PR TITLE
Fix issue where nf with 0 'right' parameter returns undefined in string

### DIFF
--- a/src/utilities/string_functions.js
+++ b/src/utilities/string_functions.js
@@ -210,7 +210,11 @@ function doNf(num, left, right) {
     let roundedOff = num.toFixed(right);
     [leftPart, rightPart] = roundedOff.toString().split('.');
     leftPart = leftPart.padStart(left, '0');
-    return leftPart + '.' + rightPart;
+    if(typeof rightPart === 'undefined'){
+      return leftPart;
+    }else{
+      return leftPart + '.' + rightPart;
+    }
   }
 }
 

--- a/test/unit/utilities/string_functions.js
+++ b/test/unit/utilities/string_functions.js
@@ -105,6 +105,12 @@ suite('String functions', function() {
       result = myp5.nf(num, '3', '4'); // automatic conversion?
       assert.equal(result, '31415160.0000');
     });
+
+    test('should return correct string', function() {
+      var num = 123.45;
+      result = myp5.nf(num, 3, 0);
+      assert.equal(result, '123');
+    });
   });
 
   suite('p5.prototype.nfc', function() {


### PR DESCRIPTION
<!--
  Thank you for contributing! Please use this pull request (PR) template.


 In the description field of this PR, include "resolves #XXXX" tagging the issue you are fixing. If this PR addresses the issue but doesn't completely resolve it (ie the issue should remain open after your PR is merged), write "addresses #XXXX".-->
Resolves #6273

Changes:
<!-- Add here what changes were made in this pull request and if possible provide links showcasing the changes. -->
@e-coucou Just to confirm expected behaviour here, when called as `nf(123.45, 0, 0)` is the expectation for it to return `"123"`?

This PR implements the above behaviour but do chime in if that's not what's expected. I believe Processing have different behaviour for this but we don't have to match it, just what fits intuition.


#### PR Checklist
<!--
  To check any option, replace the "[ ]" with a "[x]". Be sure to check out how it looks in the Preview tab! Feel free to remove any portion of the template that is not relevant for your issue.
-->

- [x] `npm run lint` passes
- [ ] [Inline documentation] is included / updated
- [x] [Unit tests] are included / updated

[Inline documentation]: https://github.com/processing/p5.js/blob/main/contributor_docs/inline_documentation.md
[Unit tests]: https://github.com/processing/p5.js/tree/main/contributor_docs#unit-tests
