### PR TITLE
Add support for beginContour() and endContour() in Webgl mode

### DIFF
--- a/src/core/p5.Renderer2D.js
+++ b/src/core/p5.Renderer2D.js
@@ -1016,6 +1016,7 @@ class Renderer2D extends p5.Renderer{
           v = vertices[i];
           if (v.isVert) {
             if (v.moveTo) {
+              if (closeShape) this.drawingContext.closePath();
               this.drawingContext.moveTo(v[0], v[1]);
             } else {
               this.drawingContext.lineTo(v[0], v[1]);

--- a/src/core/shape/vertex.js
+++ b/src/core/shape/vertex.js
@@ -59,8 +59,12 @@ let isFirstContour = true;
  * white rect and smaller grey rect with red outlines in center of canvas.
  */
 p5.prototype.beginContour = function() {
-  contourVertices = [];
-  isContour = true;
+  if (this._renderer.isP3D) {
+    this._renderer.beginContour();
+  } else {
+    contourVertices = [];
+    isContour = true;
+  }
   return this;
 };
 
@@ -563,6 +567,10 @@ p5.prototype.curveVertex = function(...args) {
  * white rect and smaller grey rect with red outlines in center of canvas.
  */
 p5.prototype.endContour = function() {
+  if (this._renderer.isP3D) {
+    return this;
+  }
+
   const vert = contourVertices[0].slice(); // copy all data
   vert.isVert = contourVertices[0].isVert;
   vert.moveTo = false;

--- a/src/webgl/p5.Geometry.js
+++ b/src/webgl/p5.Geometry.js
@@ -266,10 +266,8 @@ p5.Geometry = class  {
     this.lineTangentsOut.length = 0;
     this.lineSides.length = 0;
 
-    const closed =
-    this.edges.length > 1 &&
-    this.edges[0][0] === this.edges[this.edges.length - 1][1];
-    let addedStartingCap = false;
+    const potentialCaps = new Map();
+    const connected = new Set();
     let lastValidDir;
     for (let i = 0; i < this.edges.length; i++) {
       const prevEdge = this.edges[i - 1];
@@ -298,52 +296,89 @@ p5.Geometry = class  {
       }
 
       if (i > 0 && prevEdge[1] === currEdge[0]) {
-      // Add a join if this segment shares a vertex with the previous. Skip
-      // actually adding join vertices if either the previous segment or this
-      // one has a length of 0.
-      //
-      // Don't add a join if the tangents point in the same direction, which
-      // would mean the edges line up exactly, and there is no need for a join.
-        if (lastValidDir && dirOK && dir.dot(lastValidDir) < 1 - 1e-8) {
-          this._addJoin(begin, lastValidDir, dir, fromColor);
-        }
-        if (dirOK && !addedStartingCap && !closed) {
-          this._addCap(begin, dir.copy().mult(-1), fromColor);
-          addedStartingCap = true;
+        if (!connected.has(currEdge[0])) {
+          connected.add(currEdge[0]);
+          potentialCaps.delete(currEdge[0]);
+          // Add a join if this segment shares a vertex with the previous. Skip
+          // actually adding join vertices if either the previous segment or this
+          // one has a length of 0.
+          //
+          // Don't add a join if the tangents point in the same direction, which
+          // would mean the edges line up exactly, and there is no need for a join.
+          if (lastValidDir && dirOK && dir.dot(lastValidDir) < 1 - 1e-8) {
+            this._addJoin(begin, lastValidDir, dir, fromColor);
+          }
         }
       } else {
-        addedStartingCap = false;
         // Start a new line
-        if (dirOK && (!closed || i > 0)) {
-          this._addCap(begin, dir.copy().mult(-1), fromColor);
-          addedStartingCap = true;
+        if (dirOK && !connected.has(currEdge[0])) {
+          const existingCap = potentialCaps.get(currEdge[0]);
+          if (existingCap) {
+            this._addJoin(
+              begin,
+              existingCap.dir,
+              dir,
+              fromColor
+            );
+            potentialCaps.delete(currEdge[0]);
+            connected.add(currEdge[0]);
+          } else {
+            potentialCaps.set(currEdge[0], {
+              point: begin,
+              dir: dir.copy().mult(-1),
+              color: fromColor
+            });
+          }
         }
-        if (lastValidDir && (!closed || i < this.edges.length - 1)) {
-        // Close off the last segment with a cap
-          this._addCap(this.vertices[prevEdge[1]], lastValidDir, fromColor);
+        if (lastValidDir && !connected.has(prevEdge[1])) {
+          const existingCap = potentialCaps.get(prevEdge[1]);
+          if (existingCap) {
+            this._addJoin(
+              this.vertices[prevEdge[1]],
+              lastValidDir,
+              existingCap.dir.copy().mult(-1),
+              fromColor
+            );
+            potentialCaps.delete(prevEdge[1]);
+            connected.add(prevEdge[1]);
+          } else {
+            // Close off the last segment with a cap
+            potentialCaps.set(prevEdge[1], {
+              point: this.vertices[prevEdge[1]],
+              dir: lastValidDir,
+              color: fromColor
+            });
+          }
           lastValidDir = undefined;
         }
       }
 
-      if (i === this.edges.length - 1) {
-        if (closed) {
+      if (i === this.edges.length - 1 && !connected.has(currEdge[1])) {
+        const existingCap = potentialCaps.get(currEdge[1]);
+        if (existingCap) {
           this._addJoin(
             end,
             dir,
-            this.vertices[this.edges[0][1]]
-              .copy()
-              .sub(end)
-              .normalize(),
+            existingCap.dir.copy().mult(-1),
             toColor
           );
+          potentialCaps.delete(currEdge[1]);
+          connected.add(currEdge[1]);
         } else {
-          this._addCap(end, dir, toColor);
+          potentialCaps.set(currEdge[1], {
+            point: end,
+            dir,
+            color: toColor
+          });
         }
       }
 
       if (dirOK) {
         lastValidDir = dir;
       }
+    }
+    for (const { point, dir, color } of potentialCaps.values()) {
+      this._addCap(point, dir, color);
     }
     return this;
   }

--- a/src/webgl/p5.RendererGL.js
+++ b/src/webgl/p5.RendererGL.js
@@ -543,6 +543,7 @@ p5.RendererGL = class RendererGL extends p5.Renderer {
     this.immediateMode = {
       geometry: new p5.Geometry(),
       shapeMode: constants.TRIANGLE_FAN,
+      contourIndices: [],
       _bezierVertex: [],
       _quadraticVertex: [],
       _curveVertex: [],
@@ -1763,6 +1764,10 @@ p5.RendererGL = class RendererGL extends p5.Renderer {
     tessy.gluTessCallback(libtess.gluEnum.GLU_TESS_ERROR, errorcallback);
     tessy.gluTessCallback(libtess.gluEnum.GLU_TESS_COMBINE, combinecallback);
     tessy.gluTessCallback(libtess.gluEnum.GLU_TESS_EDGE_FLAG, edgeCallback);
+    tessy.gluTessProperty(
+      libtess.gluEnum.GLU_TESS_WINDING_RULE,
+      libtess.windingRule.GLU_TESS_WINDING_NONZERO
+    );
 
     return tessy;
   }

--- a/test/unit/webgl/p5.RendererGL.js
+++ b/test/unit/webgl/p5.RendererGL.js
@@ -118,6 +118,41 @@ suite('p5.RendererGL', function() {
     });
   });
 
+  test('contours match 2D', function() {
+    const getColors = function(mode) {
+      myp5.createCanvas(50, 50, mode);
+      myp5.pixelDensity(1);
+      myp5.background(200);
+      myp5.strokeCap(myp5.SQUARE);
+      myp5.strokeJoin(myp5.MITER);
+      if (mode === myp5.WEBGL) {
+        myp5.translate(-myp5.width/2, -myp5.height/2);
+      }
+      myp5.stroke('black');
+      myp5.strokeWeight(1);
+      myp5.translate(25, 25);
+      myp5.beginShape();
+      // Exterior part of shape, clockwise winding
+      myp5.vertex(-20, -20);
+      myp5.vertex(20, -20);
+      myp5.vertex(20, 20);
+      myp5.vertex(-20, 20);
+      // Interior part of shape, counter-clockwise winding
+      myp5.beginContour();
+      myp5.vertex(-10, -10);
+      myp5.vertex(-10, 10);
+      myp5.vertex(10, 10);
+      myp5.vertex(10, -10);
+      myp5.endContour();
+      myp5.endShape(myp5.CLOSE);
+      console.log(myp5._renderer.elt.toDataURL());
+      myp5.loadPixels();
+      return [...myp5.pixels];
+    };
+
+    assert.deepEqual(getColors(myp5.P2D), getColors(myp5.WEBGL));
+  });
+
   suite('text shader', function() {
     test('rendering looks the same in WebGL1 and 2', function(done) {
       myp5.loadFont('manual-test-examples/p5.Font/Inconsolata-Bold.ttf', function(font) {

--- a/test/unit/webgl/p5.RendererGL.js
+++ b/test/unit/webgl/p5.RendererGL.js
@@ -129,7 +129,7 @@ suite('p5.RendererGL', function() {
         myp5.translate(-myp5.width/2, -myp5.height/2);
       }
       myp5.stroke('black');
-      myp5.strokeWeight(1);
+      myp5.strokeWeight(2);
       myp5.translate(25, 25);
       myp5.beginShape();
       // Exterior part of shape, clockwise winding
@@ -145,7 +145,6 @@ suite('p5.RendererGL', function() {
       myp5.vertex(10, -10);
       myp5.endContour();
       myp5.endShape(myp5.CLOSE);
-      console.log(myp5._renderer.elt.toDataURL());
       myp5.loadPixels();
       return [...myp5.pixels];
     };


### PR DESCRIPTION
Resolves #5946 

### Changes

1. This implements contours in WebGL TESS mode (the default mode.) This involves:
    - Recording the indices of breaks between contours
    - Taking the vertex data array that we were passing into libtess before and splitting it into multiple arrays at the 
contour indices
    - Updating our TESS edge algorithm to not connect vertices across contour boundaries
    - Making libtess use nonzero winding order like 2D mode (its default is evenodd)
3. Updating the WebGL stroke cap/join algorithm to handle multiple contours better.
    - Previously, only back-to-back edges in the array could get a join between them
    - Now, every time we see an edge not connected with the previous, we check to see if we previously thought it was 
a cap, and turn it into a join
    - I stress tested this on a complicated shape and the performance is within 1FPS difference of before (33FPS with https://github.com/processing/p5.js/pull/6230 also merged in):
      ![image](https://github.com/processing/p5.js/assets/5315059/68d54f15-12b1-4c8e-9534-204b584e25f3)
5. Fixes a bug in 2D mode where `endShape(CLOSE)`, when used with contours, does not add a stroke join between the end of the stroke and the start. Note the gap in the top left corner of this modified version of the `beginContour()` reference example (it was less visible before with the default round caps, which look very similar to a round join):
  ![image](https://github.com/processing/p5.js/assets/5315059/0d975a96-c6ac-4237-8e95-60030066eb18)

Performance 

### Screenshots
![image](https://github.com/processing/p5.js/assets/5315059/86bdb55c-a4c3-4b2e-a638-3a0424896398)
Live: https://editor.p5js.org/davepagurek/sketches/qYp33OFnY

#### PR Checklist
<!--
  To check any option, replace the "[ ]" with a "[x]". Be sure to check out how it looks in the Preview tab! Feel free to remove any portion of the template that is not relevant for your issue.
-->

- [x] `npm run lint` passes
- [ ] [Inline documentation] is included / updated
- [x] [Unit tests] are included / updated

[Inline documentation]: https://github.com/processing/p5.js/blob/main/contributor_docs/inline_documentation.md
[Unit tests]: https://github.com/processing/p5.js/tree/main/contributor_docs#unit-tests
