### PR TITLE
fix textbound invalid input

### DIFF
--- a/src/typography/p5.Font.js
+++ b/src/typography/p5.Font.js
@@ -76,6 +76,10 @@ p5.Font = class {
   // Check cache for existing bounds. Take into consideration the text alignment
   // settings. Default alignment should match opentype's origin: left-aligned &
   // alphabetic baseline.
+    if (typeof str !== 'string') {
+      console.error('Error: Text parameter must be a string.');
+      return null;
+    }
     const p = (opts && opts.renderer && opts.renderer._pInst) || this.parent;
 
     const ctx = p._renderer.drawingContext;

--- a/test/unit/typography/p5.Font.js
+++ b/test/unit/typography/p5.Font.js
@@ -34,6 +34,35 @@ suite('p5.Font', function() {
       assert.property(bbox, 'w');
       assert.property(bbox, 'h');
     });
+
+    test('returns null and logs an error when a number is passed instead of text', async function() {
+      const errorLog = await promisedSketch(function(sketch, resolve, reject){
+        let _font;
+        let invalidText = 10;
+        sketch.preload = function() {
+          _font = sketch.loadFont('path/to/valid/font.ttf', function() {}, reject);
+        };
+        sketch.setup = function() {
+          console.error = function(message) {
+            // Check if the error message contains the expected substring
+            if (message.includes('Error: Text parameter must be a string.')) {
+              resolve(true);
+            } else {
+              resolve(false);
+            }
+          };
+
+          let _bbox = _font.textBounds(invalidText, 0, 0, 12);
+          if (_bbox === null) {
+            resolve(false);
+          } else {
+            resolve(false);
+          }
+        };
+      });
+
+      assert.isTrue(errorLog, 'Error was logged for invalid text parameter');
+    });
   });
 
   suite('p5.Font.prototype.textToPoints', function() {


### PR DESCRIPTION
Resolves #6298 

 Changes:
Added an additional check for invalid input. Also I have written test for the same

- [x] `npm run lint` passes
- [x] [Inline documentation] is included / updated
- [x] [Unit tests] are included / updated

[Inline documentation]: https://github.com/processing/p5.js/blob/main/contributor_docs/inline_documentation.md
[Unit tests]: https://github.com/processing/p5.js/tree/main/contributor_docs#unit-tests
