### PR TITLE
Fix stroke rendering when drawing to framebuffers

### DIFF
--- a/src/webgl/shaders/line.vert
+++ b/src/webgl/shaders/line.vert
@@ -137,8 +137,10 @@ void main() {
     // Perspective ---
     // convert from world to clip by multiplying with projection scaling factor
     // to get the right thickness (see https://github.com/processing/processing/issues/5182)
-    // invert Y, projections in Processing invert Y
-    curPerspScale = (uProjectionMatrix * vec4(1, -1, 0, 0)).xy;
+
+    // The y value of the projection matrix may be flipped if rendering to a Framebuffer.
+    // Multiplying again by its sign here negates the flip to get just the scale.
+    curPerspScale = (uProjectionMatrix * vec4(1, sign(uProjectionMatrix[1][1]), 0, 0)).xy;
   } else {
     // No Perspective ---
     // multiply by W (to cancel out division by W later in the pipeline) and

--- a/test/unit/webgl/p5.Framebuffer.js
+++ b/test/unit/webgl/p5.Framebuffer.js
@@ -452,4 +452,36 @@ suite('p5.Framebuffer', function() {
       assert.deepEqual(myp5.get(0, 0), [0, 0, 255, 255]);
     }
   );
+
+  test('Strokes work on and off of framebuffers', function() {
+    myp5.createCanvas(20, 20, myp5.WEBGL);
+    const fbo = myp5.createFramebuffer();
+
+    const drawCircle = () => {
+      myp5.clear();
+      myp5.noFill();
+      myp5.stroke(0);
+      myp5.strokeWeight(20);
+      myp5.beginShape();
+      for (let i = 0; i < 20; i++) {
+        const angle = i/20*myp5.TWO_PI;
+        myp5.vertex(
+          100 * myp5.cos(angle),
+          // Add an offset to make sure results don't get flipped
+          100 * myp5.sin(angle) - 50
+        );
+      }
+      myp5.endShape(myp5.CLOSE);
+    };
+
+    fbo.draw(drawCircle);
+    fbo.loadPixels();
+    const fboPixels = [...fbo.pixels];
+
+    drawCircle();
+    myp5.loadPixels();
+    const mainPixels = [...myp5.pixels];
+
+    assert.deepEqual(fboPixels, mainPixels);
+  });
 });


### PR DESCRIPTION
Resolves #6303

When we draw to framebuffers, we invert the y axis of the camera so that users do not need to flip the content a second time when drawing a framebuffer to the screen. However, inside the stroke shader, we try to get the scaling factor of a stroke due to perspective, and end up with a negative scale when drawing to framebuffers, which produces weird visual artifacts.

This updates the stroke shader to handle a potentially pre-flipped y axis so that strokes render the same on framebuffers as the main canvas.

### Screenshots of the change:
Before:
<img width="267" alt="image" src="https://github.com/processing/p5.js/assets/5315059/9056b889-7089-455a-89b6-c8aea74587ff">

After:
<img width="273" alt="image" src="https://github.com/processing/p5.js/assets/5315059/823e4396-2bf8-4ecf-b2f9-b13044856000">

Live: https://editor.p5js.org/davepagurek/sketches/V1240zcre

#### PR Checklist
- [x] `npm run lint` passes
- [ ] [Inline documentation] is included / updated
- [x] [Unit tests] are included / updated
