### PR TITLE
Clears MediaElement canvas at the beginning of every frame

### DIFF
--- a/src/dom/dom.js
+++ b/src/dom/dom.js
@@ -3213,6 +3213,12 @@ class MediaElement extends p5.Element {
         this.height = this.canvas.height;
       }
 
+      this.drawingContext.clearRect(
+        0,
+        0,
+        this.canvas.width,
+        this.canvas.height
+      );
       this.drawingContext.drawImage(
         this.elt,
         0,


### PR DESCRIPTION
<!--
  Thank you for contributing! Please use this pull request (PR) template.


 In the description field of this PR, include "resolves #XXXX" tagging the issue you are fixing. If this PR addresses the issue but doesn't completely resolve it (ie the issue should remain open after your PR is merged), write "addresses #XXXX".-->
Resolves #6258

 Changes:
<!-- Add here what changes were made in this pull request and if possible provide links showcasing the changes. -->
Added `drawingContext.clearRect` inside `_ensureCanvas` for `p5.MediaElement` before every draw loop. This is done so to ensure previous frames are cleared from canvas, as some `webm` media files could contain transparency.

 Screenshots of the change:
<!-- If applicable, add screenshots depicting the changes. -->
![ezgif-3-d998b6f0eb](https://github.com/processing/p5.js/assets/65828128/e7ca5488-824b-487f-9847-2b47ee30aa61)

#### PR Checklist
<!--
  To check any option, replace the "[ ]" with a "[x]". Be sure to check out how it looks in the Preview tab! Feel free to remove any portion of the template that is not relevant for your issue.
-->

- [x] `npm run lint` passes
- [ ] [Inline documentation] is included / updated
- [ ] [Unit tests] are included / updated

[Inline documentation]: https://github.com/processing/p5.js/blob/main/contributor_docs/inline_documentation.md
[Unit tests]: https://github.com/processing/p5.js/tree/main/contributor_docs#unit-tests
