### PR TITLE
Fix reading between nested active framebuffers

### DIFF
--- a/src/webgl/p5.Framebuffer.js
+++ b/src/webgl/p5.Framebuffer.js
@@ -882,9 +882,10 @@ class Framebuffer {
   }
 
   /**
-   * When setting up a framebuffer to be written to, which WebGL framebuffer
-   * should be active. Antialiased framebuffers first write to a multisampled
-   * renderbuffer, which other framebuffers can write directly to their main
+   * When making a p5.Framebuffer active so that it may be drawn to, this method
+   * returns the underlying WebGL framebuffer that needs to be active to
+   * support this. Antialiased framebuffers first write to a multisampled
+   * renderbuffer, while other framebuffers can write directly to their main
    * framebuffers.
    *
    * @method _framebufferToBind

--- a/src/webgl/p5.RendererGL.js
+++ b/src/webgl/p5.RendererGL.js
@@ -579,6 +579,8 @@ p5.RendererGL = class RendererGL extends p5.Renderer {
 
     // set of framebuffers in use
     this.framebuffers = new Set();
+    // stack of active framebuffers
+    this.activeFramebuffers = [];
 
     this.textureMode = constants.IMAGE;
     // default wrap settings
@@ -1572,6 +1574,16 @@ p5.RendererGL = class RendererGL extends p5.Renderer {
     const tex = new p5.Texture(this, src);
     this.textures.set(src, tex);
     return tex;
+  }
+
+  /**
+   * @method activeFramebuffer
+   * @private
+   * @returns {p5.Framebuffer|null} The currently active framebuffer, or null if
+   * the main canvas is the current draw target.
+   */
+  activeFramebuffer() {
+    return this.activeFramebuffers[this.activeFramebuffers.length - 1] || null;
   }
 
   createFramebuffer(options) {


### PR DESCRIPTION
Resolves https://github.com/processing/p5.js/issues/6313

### Changes:
- Keeps track of the stack of `p5.Framebuffer`s, not just the previous WebGL framebuffer, so we can tell the previous one to draw its antialiased content to its main framebuffer if it needs to
- While we're at it, this stops using `gl.getParameter` so much, as the CPU/GPU communication can be a bit of a bottleneck


Live version of the example in the issue, now fixed: https://editor.p5js.org/davepagurek/sketches/q1kSBVIRk

#### PR Checklist

- [x] `npm run lint` passes
- [x] [Inline documentation] is included / updated
- [x] [Unit tests] are included / updated
