### PR TITLE
Fix WebGL text not rendering when rotated 90 degrees

### DIFF
--- a/src/webgl/shaders/font.vert
+++ b/src/webgl/shaders/font.vert
@@ -17,9 +17,12 @@ void main() {
 
   // Expand glyph bounding boxes by 1px on each side to give a bit of room
   // for antialiasing
+  vec3 newOrigin = (uModelViewMatrix * vec4(0., 0., 0., 1.)).xyz;
+  vec3 newDX = (uModelViewMatrix * vec4(1., 0., 0., 1.)).xyz;
+  vec3 newDY = (uModelViewMatrix * vec4(0., 1., 0., 1.)).xyz;
   vec2 pixelScale = vec2(
-    1. / uModelViewMatrix[0][0],
-    1. / uModelViewMatrix[1][1]
+    1. / length(newOrigin - newDX),
+    1. / length(newOrigin - newDY)
   );
   vec2 offset = pixelScale * normalize(aTexCoord - vec2(0.5, 0.5)) * vec2(1., -1.);
   vec2 textureOffset = offset * (1. / vec2(


### PR DESCRIPTION
Resolves https://github.com/processing/p5.js/issues/6315

### Changes:
Uses a new method for checking the scale in the x and y axes. Rather than reading the diagonal of the transformation matrix (which will have 0s when rotated 90 degrees), it finds 3 points in world space, corresponding to (0, 0), (1, 0), and (0, 1) in model space. The difference between the latter two points and the first origin point will tell us how much each axis has been scaled by.


### Screenshots of the change
![image](https://github.com/processing/p5.js/assets/5315059/1a0d8a1b-c2fe-4fcc-add2-dcc3c2afa68f)

Live: https://editor.p5js.org/davepagurek/sketches/2gtvLy0Mx

#### PR Checklist

- [x] `npm run lint` passes
- [ ] [Inline documentation] is included / updated
- [ ] [Unit tests] are included / updated