### PR TITLE
Handle missing exact edge vertices in buildGeometry

### DIFF
--- a/src/webgl/p5.RendererGL.Immediate.js
+++ b/src/webgl/p5.RendererGL.Immediate.js
@@ -447,12 +447,36 @@ p5.RendererGL.prototype._tesselateShape = function() {
       this.immediateMode.geometry.edges.map(edge => edge.map(origIdx => {
         if (!newIndex.has(origIdx)) {
           const orig = originalVertices[origIdx];
-          newIndex.set(origIdx, this.immediateMode.geometry.vertices.findIndex(
+          let newVertIndex = this.immediateMode.geometry.vertices.findIndex(
             v =>
               orig.x === v.x &&
               orig.y === v.y &&
               orig.z === v.z
-          ));
+          );
+          if (newVertIndex === -1) {
+            // The tesselation process didn't output a vertex with the exact
+            // coordinate as before, potentially due to numerical issues. This
+            // doesn't happen often, but in this case, pick the closest point
+            let closestDist = Infinity;
+            let closestIndex = 0;
+            for (
+              let i = 0;
+              i < this.immediateMode.geometry.vertices.length;
+              i++
+            ) {
+              const vert = this.immediateMode.geometry.vertices[i];
+              const dX = orig.x - vert.x;
+              const dY = orig.y - vert.y;
+              const dZ = orig.z - vert.z;
+              const dist = dX*dX + dY*dY + dZ*dZ;
+              if (dist < closestDist) {
+                closestDist = dist;
+                closestIndex = i;
+              }
+            }
+            newVertIndex = closestIndex;
+          }
+          newIndex.set(origIdx, newVertIndex);
         }
         return newIndex.get(origIdx);
       }));


### PR DESCRIPTION
Resolves #6319

### Changes:
- When trying to finding what TESS output vertices original edge vertices corresponds to, sometimes we don't find an index and get -1
- We now handle this case and find the index of the closest point
  - I suspect this is caused by having points very close together, so libtess merges some

Live version of the sketch in the issue, but with this fix applied: https://editor.p5js.org/davepagurek/sketches/a4yT6jJta

#### PR Checklist
<!--
  To check any option, replace the "[ ]" with a "[x]". Be sure to check out how it looks in the Preview tab! Feel free to remove any portion of the template that is not relevant for your issue.
-->

- [x] `npm run lint` passes
- [ ] [Inline documentation] is included / updated
- [ ] [Unit tests] are included / updated