### PR TITLE
Fix strokes on framebuffers with different aspect ratios

### DIFF
--- a/src/webgl/p5.Framebuffer.js
+++ b/src/webgl/p5.Framebuffer.js
@@ -911,9 +911,7 @@ class Framebuffer {
   _beforeBegin() {
     const gl = this.gl;
     gl.bindFramebuffer(gl.FRAMEBUFFER, this._framebufferToBind());
-    gl.viewport(
-      0,
-      0,
+    this.target._renderer.viewport(
       this.width * this.density,
       this.height * this.density
     );
@@ -972,7 +970,10 @@ class Framebuffer {
       this.prevFramebuffer._beforeBegin();
     } else {
       gl.bindFramebuffer(gl.FRAMEBUFFER, null);
-      gl.viewport(...this.target._renderer._viewport);
+      this.target._renderer.viewport(
+        this.target._renderer._origViewport.width,
+        this.target._renderer._origViewport.height
+      );
     }
   }
 

--- a/src/webgl/p5.RendererGL.js
+++ b/src/webgl/p5.RendererGL.js
@@ -1250,6 +1250,11 @@ p5.RendererGL = class RendererGL extends p5.Renderer {
     return this.retainedMode.geometry[gId] !== undefined;
   }
 
+  viewport(w, h) {
+    this._viewport = [0, 0, w, h];
+    this.GL.viewport(0, 0, w, h);
+  }
+
   /**
  * [resize description]
  * @private
@@ -1258,13 +1263,14 @@ p5.RendererGL = class RendererGL extends p5.Renderer {
  */
   resize(w, h) {
     p5.Renderer.prototype.resize.call(this, w, h);
-    this.GL.viewport(
-      0,
-      0,
-      this.GL.drawingBufferWidth,
-      this.GL.drawingBufferHeight
+    this._origViewport = {
+      width: this.GL.drawingBufferWidth,
+      height: this.GL.drawingBufferHeight
+    };
+    this.viewport(
+      this._origViewport.width,
+      this._origViewport.height
     );
-    this._viewport = this.GL.getParameter(this.GL.VIEWPORT);
 
     this._curCamera._resize();
 


### PR DESCRIPTION
Resolves https://github.com/processing/p5.js/issues/6338

### Changes:
- Previously, `_renderer._viewport` was being used to position strokes correctly, but it was not getting updated when the viewport changes when rendering to a framebuffer
- I've added a `_renderer.viewport(w, h)` method that both sets the viewport and also updated the `_viewport` property to keep the stroke shader up to date


### Screenshots of the change:

Before:
<img width="391" alt="image" src="https://github.com/processing/p5.js/assets/5315059/87c2acfd-597d-4bc7-af9d-dd55d68b0efc">

After:
<img width="387" alt="image" src="https://github.com/processing/p5.js/assets/5315059/0ee47e19-7fa8-48da-88fd-863adfd78827">

Live: https://editor.p5js.org/davepagurek/sketches/IiLXSdjZ-

#### PR Checklist
- [x] `npm run lint` passes
- [ ] [Inline documentation] is included / updated
- [ ] [Unit tests] are included / updated

[Inline documentation]: https://github.com/processing/p5.js/blob/main/contributor_docs/inline_documentation.md
[Unit tests]: https://github.com/processing/p5.js/tree/main/contributor_docs#unit-tests
