### PR TITLE
update all contributors setup

### DIFF
--- a/.all-contributorsrc
+++ b/.all-contributorsrc
@@ -4,7 +4,8 @@
   "files": [
     "README.md"
   ],
-  "imageSize": 100,
+  "imageSize": 120,
+  "contributorsPerLine": 6,
   "commit": true,
   "contributors": [
     {
@@ -3853,7 +3854,6 @@
   ],
   "repoType": "github",
   "repoHost": "https://github.com",
-  "contributorsPerLine": 7,
   "skipCi": true,
   "commitConvention": "angular",
   "commitType": "docs"

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -1,13 +1,3 @@
-/**
- *  Please see the contributor docs for usage of the build steps.
- *  This header will only describe some of the more obscure tasks.
- *
- *  Contributors list can be updated using all-contributors-cli:
- *  https://www.npmjs.com/package/all-contributors-cli
- *
- *  all-contributors generate - Generates new contributors list for README
- */
-
 // these requires allow us to use es6 features such as
 // `import`/`export` and `async`/`await` in the Grunt tasks
 // we load from other files (`tasks/`)


### PR DESCRIPTION
Resolves #6337

Changes:

- remove obsolete note from Gruntfile.js
- chore: update all-contributors configuration to only render 6 images per row

#### PR Checklist

<!--
  To check any option, replace the "[ ]" with a "[x]". Be sure to check out how it looks in the Preview tab! Feel free to remove any portion of the template that is not relevant for your issue.
-->

- [ ] `npm run lint` passes
- [ ] [Inline documentation] is included / updated
- [ ] [Unit tests] are included / updated

[Inline documentation]: https://github.com/processing/p5.js/blob/main/contributor_docs/inline_documentation.md
[Unit tests]: https://github.com/processing/p5.js/tree/main/contributor_docs#unit-tests
