### PR TITLE
Fix orphan canvas when sketch is removed before canvas creation

### DIFF
--- a/src/core/main.js
+++ b/src/core/main.js
@@ -9,7 +9,6 @@ import './shim';
 
 // Core needs the PVariables object
 import * as constants from './constants';
-
 /**
  * This is the p5 instance constructor.
  *
@@ -178,6 +177,7 @@ class p5 {
     this._preloadCount = 0;
     this._isGlobal = false;
     this._loop = true;
+    this._startListener = null;
     this._initializeInstanceVariables();
     this._defaultCanvasSize = {
       width: 100,
@@ -452,6 +452,10 @@ class p5 {
      *
      */
     this.remove = () => {
+      // Remove start listener to prevent orphan canvas being created
+      if(this._startListener){
+        window.removeEventListener('load', this._startListener, false);
+      }
       const loadingScreen = document.getElementById(this._loadingScreenId);
       if (loadingScreen) {
         loadingScreen.parentNode.removeChild(loadingScreen);
@@ -586,7 +590,8 @@ class p5 {
     if (document.readyState === 'complete') {
       this._start();
     } else {
-      window.addEventListener('load', this._start.bind(this), false);
+      this._startListener = this._start.bind(this);
+      window.addEventListener('load', this._startListener, false);
     }
   }
 


### PR DESCRIPTION
<!--
  Thank you for contributing! Please use this pull request (PR) template.


 In the description field of this PR, include "resolves #XXXX" tagging the issue you are fixing. If this PR addresses the issue but doesn't completely resolve it (ie the issue should remain open after your PR is merged), write "addresses #XXXX".-->
Resolves #6311

Changes:
<!-- Add here what changes were made in this pull request and if possible provide links showcasing the changes. -->
The current implementation will have the start up function (including setup and default canvas creation) run on window `load` event and this event listener is not removed when the sketch is removed with the `remove()` function. 

The event listener should now be removed accordingly. There is a more synchronous version of the start up that runs after the `load` event has already fired (when `window.readyState === 'complete'`), this should not cause the original issue as it is synchronousand so shouldn't ever get in between initialization and a call to `remove()`.

This is one of those changes that may have unforeseen side effects so anyone can test it out first would be really helpful.


#### PR Checklist
<!--
  To check any option, replace the "[ ]" with a "[x]". Be sure to check out how it looks in the Preview tab! Feel free to remove any portion of the template that is not relevant for your issue.
-->

- [x] `npm run lint` passes
- [ ] [Inline documentation] is included / updated
- [ ] [Unit tests] are included / updated

[Inline documentation]: https://github.com/processing/p5.js/blob/main/contributor_docs/inline_documentation.md
[Unit tests]: https://github.com/processing/p5.js/tree/main/contributor_docs#unit-tests
