### PR TITLE
Fix textureMode(IMAGE) + beginShape(TESS)

### DIFF
--- a/src/webgl/p5.RendererGL.Immediate.js
+++ b/src/webgl/p5.RendererGL.Immediate.js
@@ -128,14 +128,13 @@ p5.RendererGL.prototype.vertex = function(x, y) {
     lineVertexColor[3]
   );
 
-  if (this.textureMode === constants.IMAGE) {
+  if (this.textureMode === constants.IMAGE && !this.isProcessingVertices) {
     if (this._tex !== null) {
       if (this._tex.width > 0 && this._tex.height > 0) {
         u /= this._tex.width;
         v /= this._tex.height;
       }
     } else if (
-      !this.isProcessingVertices &&
       this._tex === null &&
       arguments.length >= 4
     ) {

--- a/test/unit/webgl/p5.RendererGL.js
+++ b/test/unit/webgl/p5.RendererGL.js
@@ -1364,6 +1364,31 @@ suite('p5.RendererGL', function() {
       done();
     });
 
+    test('TESS does not affect texture coordinates', function(done) {
+      var renderer = myp5.createCanvas(10, 10, myp5.WEBGL);
+      const texture = new p5.Image(25, 25);
+
+      myp5.textureMode(myp5.IMAGE);
+      myp5.texture(texture);
+      renderer.beginShape(myp5.TESS);
+      myp5.noFill();
+      renderer.vertex(-10, -10, 0, 0);
+      renderer.vertex(10, -10, 25, 0);
+      renderer.vertex(10, 10, 25, 25);
+      renderer.vertex(-10, 10, 0, 25);
+      renderer.endShape(myp5.CLOSE);
+
+      // UVs are correctly translated through tessy
+      assert.deepEqual(renderer.immediateMode.geometry.uvs, [
+        0, 0,
+        1, 0,
+        1, 1,
+        0, 1
+      ]);
+
+      done();
+    });
+
     test('TESS interpolates vertex data at intersections', function(done) {
       var renderer = myp5.createCanvas(10, 10, myp5.WEBGL);
 


### PR DESCRIPTION
Resolves https://github.com/processing/p5.js/issues/6365

### Changes
Previously, whenever we call `vertex()`, if the texture mode is `IMAGE`, we divide texture coordinates by the texture's width and height. However, if you use `beginShape()` with no mode or by explicitly using the `TESS` mode (both are equivalent), `vertex()` ends up being called twice per vertex: once when the user calls it, and a second time for the output vertices of tesselation. This was causing texture coordinates to get divided twice.

This changes `vertex()` to only divide when called directly by the user.


### Screenshots of the change
<img width="493" alt="image" src="https://github.com/processing/p5.js/assets/5315059/5cb253ea-7d63-4f26-a8a2-ca7bca4f2614">

Live: https://editor.p5js.org/davepagurek/sketches/FXRtf9vRv

#### PR Checklist

- [x] `npm run lint` passes
- [ ] [Inline documentation] is included / updated
- [x] [Unit tests] are included / updated
