### PR TITLE
Fix typo in export path to fix dev mode

### DIFF
--- a/translations/dev.js
+++ b/translations/dev.js
@@ -2,7 +2,7 @@ export { default as en_translation } from './en/translation';
 export { default as es_translation } from './es/translation';
 export { default as ko_translation } from './ko/translation';
 export { default as zh_translation } from './zh/translation';
-export { default as hi_translation } from './hi/tranlation';
+export { default as hi_translation } from './hi/translation';
 
 /**
  * When adding a new language, add a new "export" statement above this.


### PR DESCRIPTION
<!--
  Thank you for contributing! Please use this pull request (PR) template.


 In the description field of this PR, include "resolves #XXXX" tagging the issue you are fixing. If this PR addresses the issue but doesn't completely resolve it (ie the issue should remain open after your PR is merged), write "addresses #XXXX".-->
Resolves [#6372](https://github.com/processing/p5.js/issues/6372)

 Changes:
<!-- Add here what changes were made in this pull request and if possible provide links showcasing the changes. -->
Fixes minor typo of an export path inside `translations/dev.js` to allow for building library in dev mode.

#### PR Checklist
<!--
  To check any option, replace the "[ ]" with a "[x]". Be sure to check out how it looks in the Preview tab! Feel free to remove any portion of the template that is not relevant for your issue.
-->

- [x] `npm run lint` passes

[Inline documentation]: https://github.com/processing/p5.js/blob/main/contributor_docs/inline_documentation.md
[Unit tests]: https://github.com/processing/p5.js/tree/main/contributor_docs#unit-tests
