### PR TITLE
Fix clip() on both the main canvas and framebuffers

### DIFF
--- a/src/webgl/p5.Framebuffer.js
+++ b/src/webgl/p5.Framebuffer.js
@@ -110,6 +110,8 @@ class Framebuffer {
     this.target = target;
     this.target._renderer.framebuffers.add(this);
 
+    this._isClipApplied = false;
+
     /**
      * A <a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference
      * /Global_Objects/Uint8ClampedArray' target='_blank'>Uint8ClampedArray</a>
@@ -960,12 +962,12 @@ class Framebuffer {
    */
   end() {
     const gl = this.gl;
+    this.target.pop();
     const fbo = this.target._renderer.activeFramebuffers.pop();
     if (fbo !== this) {
       throw new Error("It looks like you've called end() while another Framebuffer is active.");
     }
     this._beforeEnd();
-    this.target.pop();
     if (this.prevFramebuffer) {
       this.prevFramebuffer._beforeBegin();
     } else {
@@ -975,6 +977,7 @@ class Framebuffer {
         this.target._renderer._origViewport.height
       );
     }
+    this.target._renderer._applyStencilTestIfClipping();
   }
 
   /**

--- a/src/webgl/p5.RendererGL.js
+++ b/src/webgl/p5.RendererGL.js
@@ -423,7 +423,7 @@ p5.RendererGL = class RendererGL extends p5.Renderer {
     this._isErasing = false;
 
     // clipping
-    this._clipDepth = null;
+    this._clipDepths = [];
 
     // lights
     this._enableLighting = false;
@@ -1097,7 +1097,7 @@ p5.RendererGL = class RendererGL extends p5.Renderer {
 
     // Mark the depth at which the clip has been applied so that we can clear it
     // when we pop past this depth
-    this._clipDepth = this._pushPopDepth;
+    this._clipDepths.push(this._pushPopDepth);
 
     super.endClip();
   }
@@ -1105,7 +1105,9 @@ p5.RendererGL = class RendererGL extends p5.Renderer {
   _clearClip() {
     this.GL.clearStencil(1);
     this.GL.clear(this.GL.STENCIL_BUFFER_BIT);
-    this._clipDepth = null;
+    if (this._clipDepths.length > 0) {
+      this._clipDepths.pop();
+    }
   }
 
   /**
@@ -1453,9 +1455,14 @@ p5.RendererGL = class RendererGL extends p5.Renderer {
     return style;
   }
   pop(...args) {
-    if (this._pushPopDepth === this._clipDepth) {
+    if (
+      this._clipDepths.length > 0 &&
+      this._pushPopDepth === this._clipDepths[this._clipDepths.length - 1]
+    ) {
       this._clearClip();
-      this.GL.disable(this.GL.STENCIL_TEST);
+      if (this._clipDepths.length === 0) {
+        this.GL.disable(this.GL.STENCIL_TEST);
+      }
     }
     super.pop(...args);
   }

--- a/test/unit/webgl/p5.RendererGL.js
+++ b/test/unit/webgl/p5.RendererGL.js
@@ -2080,5 +2080,52 @@ suite('p5.RendererGL', function() {
       // Inside the clipped region should be red
       assert.deepEqual(getPixel(pixels, 15, 15), [255, 0, 0, 255]);
     });
+
+    test(
+      'It can mask a separate shape in a framebuffer from the main canvas',
+      function() {
+        myp5.createCanvas(50, 50, myp5.WEBGL);
+        const fbo = myp5.createFramebuffer({ antialias: false });
+        myp5.rectMode(myp5.CENTER);
+        myp5.background('red');
+        expect(myp5._renderer._clipDepths.length).to.equal(0);
+        myp5.push();
+        myp5.beginClip();
+        myp5.rect(-5, -5, 20, 20);
+        myp5.endClip();
+        expect(myp5._renderer._clipDepths.length).to.equal(1);
+
+        fbo.begin();
+        myp5.beginClip();
+        myp5.rect(5, 5, 20, 20);
+        myp5.endClip();
+        myp5.fill('blue');
+        myp5.rect(0, 0, myp5.width, myp5.height);
+        expect(myp5._renderer._clipDepths.length).to.equal(2);
+        fbo.end();
+        expect(myp5._renderer._clipDepths.length).to.equal(1);
+
+        myp5.imageMode(myp5.CENTER);
+        myp5.image(fbo, 0, 0);
+        myp5.pop();
+        expect(myp5._renderer._clipDepths.length).to.equal(0);
+
+        // In the middle of the canvas, the framebuffer's clip and the
+        // main canvas's clip intersect, so the blue should show through
+        assert.deepEqual(
+          myp5.get(myp5.width / 2, myp5.height / 2),
+          [0, 0, 255, 255]
+        );
+
+        // To either side of the center, nothing should be on top of
+        // the red background color
+        for (const side of [-1, 1]) {
+          assert.deepEqual(
+            myp5.get(myp5.width / 2 + side * 10, myp5.height / 2 + side * 10),
+            [255, 0, 0, 255]
+          );
+        }
+      }
+    );
   });
 });

--- a/test/unit/webgl/p5.RendererGL.js
+++ b/test/unit/webgl/p5.RendererGL.js
@@ -2102,8 +2102,13 @@ suite('p5.RendererGL', function() {
         myp5.fill('blue');
         myp5.rect(0, 0, myp5.width, myp5.height);
         expect(myp5._renderer._clipDepths.length).to.equal(2);
+        expect(myp5._renderer.drawTarget()).to.equal(fbo);
+        expect(fbo._isClipApplied).to.equal(true);
         fbo.end();
+        expect(fbo._isClipApplied).to.equal(false);
         expect(myp5._renderer._clipDepths.length).to.equal(1);
+        expect(myp5._renderer.drawTarget()).to.equal(myp5._renderer);
+        expect(myp5._renderer._isClipApplied).to.equal(true);
 
         myp5.imageMode(myp5.CENTER);
         myp5.image(fbo, 0, 0);


### PR DESCRIPTION
Resolves https://github.com/processing/p5.js/issues/6375

### Changes
Rather than storing just one clip depth in the push/pop stack, it now supports an array. While we still don't support multiple clips in one framebuffer/canvas, an array lets us keep track of a separate clip in each framebuffer within one WebGL context.

I also store on the renderer (for the main canvas) and on framebuffers whether or not a clip should be applied so that we can enable/disable stencil testing when we pop() to a potentially different draw target. We could leave it on all the time, but it'll be a bit faster not checking when we don't need to. I also store the current state of whether stencil testing is on rather than using `gl.isEnabled(gl.STENCIL_TEST)` because getting these parameters seems to be a big bottleneck in Firefox.

### Screenshots of the change
Live: https://editor.p5js.org/davepagurek/sketches/qsrIxUrKl

Before:
![image](https://github.com/processing/p5.js/assets/5315059/3a753886-b97e-4b40-bf51-bba65d9e2a87)


After:
![image](https://github.com/processing/p5.js/assets/5315059/e0d23cfe-f338-4f4b-9aef-ea79d6aa2f0c)


#### PR Checklist
<!--
  To check any option, replace the "[ ]" with a "[x]". Be sure to check out how it looks in the Preview tab! Feel free to remove any portion of the template that is not relevant for your issue.
-->

- [x] `npm run lint` passes
- [ ] [Inline documentation] is included / updated
- [x] [Unit tests] are included / updated
