### PR TITLE
Add draggable() feature to p5.Element

### DIFF
--- a/src/dom/dom.js
+++ b/src/dom/dom.js
@@ -2474,10 +2474,10 @@ p5.Element.prototype.draggable = function (elmnt = this.elt) {
     pos4 = 0;
   if (elmnt !== this.elt && elmnt.elt !== this.elt) {
     elmnt = elmnt.elt;
-    this.elt.onmousedown = dragMouseDown;
+    this.elt.addEventListener('mousedown', dragMouseDown, false);
     this.elt.style.cursor = 'move';
   } else {
-    elmnt.onmousedown = dragMouseDown;
+    elmnt.addEventListener('mousedown', dragMouseDown, false);
     elmnt.style.cursor = 'move';
   }
 
@@ -2485,8 +2485,8 @@ p5.Element.prototype.draggable = function (elmnt = this.elt) {
     e = e || window.event;
     pos3 = parseInt(e.clientX);
     pos4 = parseInt(e.clientY);
-    document.onmouseup = closeDragElement;
-    document.onmousemove = elementDrag;
+    document.addEventListener('mouseup', closeDragElement, false);
+    document.addEventListener('mousemove', elementDrag, false);
     return false;
   }
 
@@ -2501,8 +2501,8 @@ p5.Element.prototype.draggable = function (elmnt = this.elt) {
   }
 
   function closeDragElement() {
-    document.onmouseup = null;
-    document.onmousemove = null;
+    document.removeEventListener('mouseup', closeDragElement, false);
+    document.removeEventListener('mousemove', elementDrag, false);
   }
 
   return this;

--- a/src/dom/dom.js
+++ b/src/dom/dom.js
@@ -2422,10 +2422,10 @@ p5.Element.prototype.drop = function (callback, fxn) {
 };
 
 /**
- * Turns p5.Element into a draggable item with the mouse. If argument is given, it will drag a different p5.Element (parent container) instead, ie. for a GUI title bar.
+ * Turns p5.Element into a draggable item. If an argument is given, it will drag that p5.Element instead, ie. drag a entire GUI panel (parent container) with the panel's title bar.
  *
  * @method draggable
- * @param  {p5.Element} [elmnt]       pass a parent container
+ * @param  {p5.Element} [elmnt]       pass another p5.Element
  * @chainable
  *
  * @example
@@ -2467,42 +2467,69 @@ p5.Element.prototype.drop = function (callback, fxn) {
  * }
  * </code></div>
  */
-p5.Element.prototype.draggable = function (elmnt = this.elt) {
-  let pos1 = 0,
-    pos2 = 0,
-    pos3 = 0,
-    pos4 = 0;
-  if (elmnt !== this.elt && elmnt.elt !== this.elt) {
-    elmnt = elmnt.elt;
-    this.elt.addEventListener('mousedown', dragMouseDown, false);
-    this.elt.style.cursor = 'move';
-  } else {
-    elmnt.addEventListener('mousedown', dragMouseDown, false);
-    elmnt.style.cursor = 'move';
+p5.Element.prototype.draggable = function (elmMove) {
+  let isTouch = 'ontouchstart' in window;
+
+  let x = 0,
+    y = 0,
+    px = 0,
+    py = 0,
+    elmDrag,
+    dragMouseDownEvt = isTouch ? 'touchstart' : 'mousedown',
+    closeDragElementEvt = isTouch ? 'touchend' : 'mouseup',
+    elementDragEvt = isTouch ? 'touchmove' : 'mousemove';
+
+  if(elmMove === undefined){
+    elmMove = this.elt;
+    elmDrag = elmMove;
+  }else if(elmMove !== this.elt && elmMove.elt !== this.elt){
+    elmMove = elmMove.elt;
+    elmDrag = this.elt;
   }
+
+  elmDrag.addEventListener(dragMouseDownEvt, dragMouseDown, false);
+  elmDrag.style.cursor = 'move';
 
   function dragMouseDown(e) {
     e = e || window.event;
-    pos3 = parseInt(e.clientX);
-    pos4 = parseInt(e.clientY);
-    document.addEventListener('mouseup', closeDragElement, false);
-    document.addEventListener('mousemove', elementDrag, false);
+
+    if(isTouch){
+      const touches = e.changedTouches;
+      px = parseInt(touches[0].clientX);
+      py = parseInt(touches[0].clientY);
+    }else{
+      px = parseInt(e.clientX);
+      py = parseInt(e.clientY);
+    }
+
+    document.addEventListener(closeDragElementEvt, closeDragElement, false);
+    document.addEventListener(elementDragEvt, elementDrag, false);
     return false;
   }
 
   function elementDrag(e) {
     e = e || window.event;
-    pos1 = pos3 - parseInt(e.clientX);
-    pos2 = pos4 - parseInt(e.clientY);
-    pos3 = parseInt(e.clientX);
-    pos4 = parseInt(e.clientY);
-    elmnt.style.top = elmnt.offsetTop - pos2 + 'px';
-    elmnt.style.left = elmnt.offsetLeft - pos1 + 'px';
+
+    if(isTouch){
+      const touches = e.changedTouches;
+      x = px - parseInt(touches[0].clientX);
+      y = py - parseInt(touches[0].clientY);
+      px = parseInt(touches[0].clientX);
+      py = parseInt(touches[0].clientY);
+    }else{
+      x = px - parseInt(e.clientX);
+      y = py - parseInt(e.clientY);
+      px = parseInt(e.clientX);
+      py = parseInt(e.clientY);
+    }
+
+    elmMove.style.left = elmMove.offsetLeft - x + 'px';
+    elmMove.style.top = elmMove.offsetTop - y + 'px';
   }
 
   function closeDragElement() {
-    document.removeEventListener('mouseup', closeDragElement, false);
-    document.removeEventListener('mousemove', elementDrag, false);
+    document.removeEventListener(closeDragElementEvt, closeDragElement, false);
+    document.removeEventListener(elementDragEvt, elementDrag, false);
   }
 
   return this;

--- a/src/dom/dom.js
+++ b/src/dom/dom.js
@@ -2421,6 +2421,93 @@ p5.Element.prototype.drop = function (callback, fxn) {
   return this;
 };
 
+/**
+ * Turns p5.Element into a draggable item with the mouse. If argument is given, it will drag a different p5.Element (parent container) instead, ie. for a GUI title bar.
+ *
+ * @method draggable
+ * @param  {p5.Element} [elmnt]       pass a parent container
+ * @chainable
+ *
+ * @example
+ * <div><code>
+ * function setup() {
+ *   createCanvas(100, 100);
+ *   background(200);
+ *
+ *   createDiv('Post-It')
+ *     .position(5, 5)
+ *     .size(75, 20)
+ *     .style('font-size', '16px')
+ *     .style('background', 'yellow')
+ *     .style('color', '#000')
+ *     .style('border', '1px solid #aaaa00')
+ *     .style('padding', '5px')
+ *     .draggable();
+ *   // .style('cursor', 'help') // override cursor
+ *
+ *   let gui = createDiv('')
+ *     .position(5, 40)
+ *     .size(85, 50)
+ *     .style('font-size', '16px')
+ *     .style('background', 'yellow')
+ *     .style('z-index', '100')
+ *     .style('border', '1px solid #00aaaa');
+ *
+ *   createDiv('= PANEL =')
+ *     .parent(gui)
+ *     .style('background', 'cyan')
+ *     .style('padding', '2px')
+ *     .style('text-align', 'center')
+ *     .draggable(gui);
+ *
+ *   createSlider(0, 100, random(100))
+ *     .style('cursor', 'pointer')
+ *     .size(80, 5)
+ *     .parent(gui);
+ * }
+ * </code></div>
+ */
+p5.Element.prototype.draggable = function (elmnt = this.elt) {
+  let pos1 = 0,
+    pos2 = 0,
+    pos3 = 0,
+    pos4 = 0;
+  if (elmnt !== this.elt && elmnt.elt !== this.elt) {
+    elmnt = elmnt.elt;
+    this.elt.onmousedown = dragMouseDown;
+    this.elt.style.cursor = 'move';
+  } else {
+    elmnt.onmousedown = dragMouseDown;
+    elmnt.style.cursor = 'move';
+  }
+
+  function dragMouseDown(e) {
+    e = e || window.event;
+    pos3 = parseInt(e.clientX);
+    pos4 = parseInt(e.clientY);
+    document.onmouseup = closeDragElement;
+    document.onmousemove = elementDrag;
+    return false;
+  }
+
+  function elementDrag(e) {
+    e = e || window.event;
+    pos1 = pos3 - parseInt(e.clientX);
+    pos2 = pos4 - parseInt(e.clientY);
+    pos3 = parseInt(e.clientX);
+    pos4 = parseInt(e.clientY);
+    elmnt.style.top = elmnt.offsetTop - pos2 + 'px';
+    elmnt.style.left = elmnt.offsetLeft - pos1 + 'px';
+  }
+
+  function closeDragElement() {
+    document.onmouseup = null;
+    document.onmousemove = null;
+  }
+
+  return this;
+};
+
 /*** SCHEDULE EVENTS ***/
 
 // Cue inspired by JavaScript setTimeout, and the


### PR DESCRIPTION
Resolves #6248

 Changes:
As discussed, adds a very simple 'p5.js' way to make DOM elements draggable without the need for additional libraries. 
This works for both the element itself or using elm to move a parent container.

Basic example added to documentation) here:
[https://editor.p5js.org/ffd8/sketches/c-gRg5Rv-](https://editor.p5js.org/ffd8/sketches/c-gRg5Rv-)


#### PR Checklist
<!--
  To check any option, replace the "[ ]" with a "[x]". Be sure to check out how it looks in the Preview tab! Feel free to remove any portion of the template that is not relevant for your issue.
-->

- [x] `npm run lint` passes
- [x] [Inline documentation] is included / updated
- [ ] [Unit tests] are included / updated