### PR TITLE
Fixed mousePressed() Example Error

### DIFF
--- a/src/events/mouse.js
+++ b/src/events/mouse.js
@@ -621,7 +621,7 @@ p5.prototype._onmousemove = function(e) {
  *   describe('black 50-by-50 rect turns white with mouse click/press.');
  * }
  * function mousePressed() {
- *   if (value === 0) {
+ *   if (colorValue === 0) {
  *     colorValue = 255;
  *   } else {
  *     colorValue = 0;


### PR DESCRIPTION
## Descriptiion 
The example code at: https://p5js.org/reference/#/p5/mousePressed does not function, no response when key is pressed. This is due to an error in the variable names. So I have changed the variable name ```value``` to ```colorValue``` in the function ```mousePressed()```

Resolves # [1415](https://github.com/processing/p5.js-website/issues/1415) : mousePressed() Example Error

 Changes:
<!-- Add here what changes were made in this pull request and if possible provide links showcasing the changes. -->
![Screenshot (222)](https://github.com/processing/p5.js/assets/88283012/f0ead96c-9032-4892-b9aa-9636654d954e)

Screenshot of Changes:
![Screenshot (223)](https://github.com/processing/p5.js/assets/88283012/8ce1420e-8b20-4a16-848c-08d66b853aeb)

Additional Description:
I don't know why css is not working on local machine. That's why page is looking different