### PR TITLE
fixed texture filtering bug in p5.Framebuffer

### DIFF
--- a/src/webgl/p5.Framebuffer.js
+++ b/src/webgl/p5.Framebuffer.js
@@ -533,8 +533,8 @@ class Framebuffer {
       this.target._renderer,
       this.color,
       {
-        glMinFilter: filter,
-        glMagFilter: filter
+        minFilter: filter,
+        magFilter: filter
       }
     );
     this.target._renderer.textures.set(this.color, this.colorP5Texture);

--- a/test/unit/webgl/p5.Framebuffer.js
+++ b/test/unit/webgl/p5.Framebuffer.js
@@ -541,4 +541,34 @@ suite('p5.Framebuffer', function() {
       });
     }
   });
+
+  suite('texture filtering', function() {
+    test('can create a framebuffer that uses NEAREST texture filtering',
+      function() {
+        myp5.createCanvas(10, 10, myp5.WEBGL);
+        const fbo = myp5.createFramebuffer({
+          textureFiltering: myp5.NEAREST
+        });
+
+        assert.equal(
+          fbo.color.framebuffer.colorP5Texture.glMinFilter, fbo.gl.NEAREST
+        );
+        assert.equal(
+          fbo.color.framebuffer.colorP5Texture.glMagFilter, fbo.gl.NEAREST
+        );
+      });
+    test('can create a framebuffer that uses LINEAR texture filtering',
+      function() {
+        myp5.createCanvas(10, 10, myp5.WEBGL);
+        // LINEAR should be the default
+        const fbo = myp5.createFramebuffer({});
+
+        assert.equal(
+          fbo.color.framebuffer.colorP5Texture.glMinFilter, fbo.gl.LINEAR
+        );
+        assert.equal(
+          fbo.color.framebuffer.colorP5Texture.glMagFilter, fbo.gl.LINEAR
+        );
+      });
+  });
 });


### PR DESCRIPTION
<!--
  Thank you for contributing! Please use this pull request (PR) template.

In the description field of this PR, include "resolves #XXXX" tagging the issue you are fixing. If this PR addresses the issue but doesn't completely resolve it (ie the issue should remain open after your PR is merged), write "addresses #XXXX".-->
Resolves #6408

Changes:
<!-- Add here what changes were made in this pull request and if possible provide links showcasing the changes. -->
When constructing color textures, `p5.Framebuffer` was using the wrong property names in the `p5.Texture` constructor's settings object. As a result, changing `textureFiltering` option of `createFramebuffer` had no effect. This PR corrects the property names, and fixes the bug.

#### PR Checklist
<!--
  To check any option, replace the "[ ]" with a "[x]". Be sure to check out how it looks in the Preview tab! Feel free to remove any portion of the template that is not relevant for your issue.
-->

- [x] `npm run lint` passes
- [x] [Unit tests] are included / updated

[Inline documentation]: https://github.com/processing/p5.js/blob/main/contributor_docs/inline_documentation.md
[Unit tests]: https://github.com/processing/p5.js/tree/main/contributor_docs#unit-tests
