### PR TITLE
add unregisterMethod function

### DIFF
--- a/contributor_docs/creating_libraries.md
+++ b/contributor_docs/creating_libraries.md
@@ -73,17 +73,20 @@ p5.prototype.getData = function (callback) {
   return ret;
 };
 ```
-  
-### Use **registerMethod()** to register functions with _**p5**_ that should be called at various times.
+
+### Use **registerMethod()** and **unregisterMethod()** to register and unregister functions with _**p5**_ that should be called at various times
 
   ```js
   p5.prototype.doRemoveStuff = function () { 
     // library cleanup stuff
   };
   p5.prototype.registerMethod('remove', p5.prototype.doRemoveStuff);
+
+  // Unregister the method when it's no longer needed.
+  p5.prototype.unregisterMethod('remove', p5.prototype.doRemoveStuff);
   ```
-  
-Method names you can register include the following list. Note that you may need to define the function before you register it.
+
+Method names you can register and unregister include the following list. Note that you may need to define the function before you register it.
 
   * **pre** — Called at the beginning of `draw()`. It can affect drawing.
   * **post** — Called at the end of `draw()`.

--- a/contributor_docs/creating_libraries.md
+++ b/contributor_docs/creating_libraries.md
@@ -74,7 +74,7 @@ p5.prototype.getData = function (callback) {
 };
 ```
 
-### Use **registerMethod()** and **unregisterMethod()** to register and unregister functions with _**p5**_ that should be called at various times
+### Use **registerMethod()** and **unregisterMethod()** to register and unregister functions with _**p5**_ that should be called at various times.
 
   ```js
   p5.prototype.doRemoveStuff = function () { 

--- a/src/core/main.js
+++ b/src/core/main.js
@@ -628,6 +628,24 @@ class p5 {
     target._registeredMethods[name].push(m);
   }
 
+  unregisterMethod(name, m) {
+    const target = this || p5.prototype;
+    if (target._registeredMethods.hasOwnProperty(name)) {
+      const methods = target._registeredMethods[name];
+      const indexesToRemove = [];
+      // Find all indexes of the method `m` in the array of registered methods
+      for (let i = 0; i < methods.length; i++) {
+        if (methods[i] === m) {
+          indexesToRemove.push(i);
+        }
+      }
+      // Remove all instances of the method `m` from the array
+      for (let i = indexesToRemove.length - 1; i >= 0; i--) {
+        methods.splice(indexesToRemove[i], 1);
+      }
+    }
+  }
+
   // create a function which provides a standardized process for binding
   // globals; this is implemented as a factory primarily so that there's a
   // way to redefine what "global" means for the binding function so it


### PR DESCRIPTION
<!--
  Thank you for contributing! Please use this pull request (PR) template.


 In the description field of this PR, include "resolves #XXXX" tagging the issue you are fixing. If this PR addresses the issue but doesn't completely resolve it (ie the issue should remain open after your PR is merged), write "addresses #XXXX".-->
Addresses #[6422]

 Changes:
<!-- Add here what changes were made in this pull request and if possible provide links showcasing the changes. -->
adds a `unregisterMethod` function to remove all instances of method m for the given event name.

@davepagurek as you addressed in #6422. i know this is completely unfinished waiting for your feedback.

#### PR Checklist
<!--
  To check any option, replace the "[ ]" with a "[x]". Be sure to check out how it looks in the Preview tab! Feel free to remove any portion of the template that is not relevant for your issue.
-->

- [x] `npm run lint` passes
- [x] [Inline documentation] is included / updated
- [ ] [Unit tests] are included / updated

[Inline documentation]: https://github.com/processing/p5.js/blob/main/contributor_docs/inline_documentation.md
[Unit tests]: https://github.com/processing/p5.js/tree/main/contributor_docs#unit-tests
