### PR TITLE
Fixed - Improve WebGL beginShape() performance when only drawing tria…

### DIFF
--- a/src/image/p5.Image.js
+++ b/src/image/p5.Image.js
@@ -223,6 +223,33 @@ p5.Image = class {
   /**
    * Helper function for animating GIF-based images with time
    */
+  /**
+   * Set the pixel density of the image.
+   *
+   * @method _setPixelDensity
+   * @param {Number} density - The pixel density to set.
+   * @example
+   * <div><code>
+   * let img = new p5.Image(100, 100);
+   * img._setPixelDensity(2);
+   * </code></div>
+   */
+  _setPixelDensity(density) {
+    if (density <= 0) {
+      console.error('Pixel density must be greater than 0.');
+      return;
+    }
+
+    this._pixelDensity = density;
+
+    // Adjust canvas dimensions based on pixel density
+    this.canvas.width = this.width * density;
+    this.canvas.height = this.height * density;
+
+    // Update the drawing context
+    this.drawingContext = this.canvas.getContext('2d');
+  }
+
   _animateGif(pInst) {
     const props = this.gifProperties;
     const curTime = pInst._lastRealFrameTime;
@@ -482,9 +509,9 @@ p5.Image = class {
       width = this.canvas.width;
       height = this.canvas.height;
     } else if (width === 0) {
-      width = this.canvas.width * height / this.canvas.height;
+      width = (this.canvas.width * height) / this.canvas.height;
     } else if (height === 0) {
-      height = this.canvas.height * width / this.canvas.width;
+      height = (this.canvas.height * width) / this.canvas.width;
     }
 
     width = Math.floor(width);
@@ -501,8 +528,8 @@ p5.Image = class {
         let pos = 0;
         for (let y = 0; y < dst.height; y++) {
           for (let x = 0; x < dst.width; x++) {
-            const srcX = Math.floor(x * src.width / dst.width);
-            const srcY = Math.floor(y * src.height / dst.height);
+            const srcX = Math.floor((x * src.width) / dst.width);
+            const srcY = Math.floor((y * src.height) / dst.height);
             let srcPos = (srcY * src.width + srcX) * 4;
             dst.data[pos++] = src.data[srcPos++]; // R
             dst.data[pos++] = src.data[srcPos++]; // G
@@ -521,11 +548,19 @@ p5.Image = class {
       }
     }
 
-    tempCanvas.getContext('2d').drawImage(
-      this.canvas,
-      0, 0, this.canvas.width, this.canvas.height,
-      0, 0, tempCanvas.width, tempCanvas.height
-    );
+    tempCanvas
+      .getContext('2d')
+      .drawImage(
+        this.canvas,
+        0,
+        0,
+        this.canvas.width,
+        this.canvas.height,
+        0,
+        0,
+        tempCanvas.width,
+        tempCanvas.height
+      );
 
     // Resize the original canvas, which will clear its contents
     this.canvas.width = this.width = width;
@@ -534,8 +569,14 @@ p5.Image = class {
     //Copy the image back
     this.drawingContext.drawImage(
       tempCanvas,
-      0, 0, width, height,
-      0, 0, width, height
+      0,
+      0,
+      width,
+      height,
+      0,
+      0,
+      width,
+      height
     );
 
     if (this.pixels.length > 0) {


### PR DESCRIPTION
…ngles #6440

<!--
  Thank you for contributing! Please use this pull request (PR) template.


 In the description field of this PR, include "resolves #XXXX" tagging the issue you are fixing. If this PR addresses the issue but doesn't completely resolve it (ie the issue should remain open after your PR is merged), write "addresses #XXXX".-->
Resolves #[6440]


 Changes:
<!-- Add here what changes were made in this pull request and if possible provide links showcasing the changes. -->
Added an if statement checking for the number of vertices and if vertices equal 3. then changed the shapemode to triangles.

 Screenshots of the change:
<!-- If applicable, add screenshots depicting the changes. -->

#### PR Checklist
<!--
  To check any option, replace the "[ ]" with a "[x]". Be sure to check out how it looks in the Preview tab! Feel free to remove any portion of the template that is not relevant for your issue.
-->

- [ x] `npm run lint` passes
- [ ] [Inline documentation] is included / updated
- [ ] [Unit tests] are included / updated

[Inline documentation]: https://github.com/processing/p5.js/blob/main/contributor_docs/inline_documentation.md
[Unit tests]: https://github.com/processing/p5.js/tree/main/contributor_docs#unit-tests
