### PR TITLE
Update WebGL blur filter to match CPU blur more

### DIFF
--- a/src/webgl/p5.RendererGL.js
+++ b/src/webgl/p5.RendererGL.js
@@ -1075,7 +1075,7 @@ p5.RendererGL = class RendererGL extends p5.Renderer {
 
       pg.shader(this.filterShader);
       this.filterShader.setUniform('texelSize', [1/this.width, 1/this.height]);
-      this.filterShader.setUniform('steps', Math.max(1, filterParameter));
+      this.filterShader.setUniform('radius', Math.max(1, filterParameter));
 
       // horiz pass
       this.filterShader.setUniform('direction', [1, 0]);

--- a/src/webgl/shaders/filters/blur.frag
+++ b/src/webgl/shaders/filters/blur.frag
@@ -11,11 +11,6 @@ uniform vec2 direction;
 uniform vec2 canvasSize;
 uniform float radius;
 
-float random2 (vec2 st) {
-  return fract(sin(dot(st.xy, vec2(12.9898,78.233))) *
-      43758.5453123);
-}
-
 float random(vec2 p) {
   vec3 p3  = fract(vec3(p.xyx) * .1031);
   p3 += dot(p3, p3.yzx + 33.33);


### PR DESCRIPTION
Resolves https://github.com/processing/p5.js/issues/6397

Changes:
- Uses a quadratic blur weight instead of a box blur to better match the CPU blue


Screenshots of the change:
<img width="397" alt="image" src="https://github.com/processing/p5.js/assets/5315059/3d3a3f34-e4e4-40b7-bba3-67b9c4a39489">


Live: https://editor.p5js.org/davepagurek/sketches/7WXweF7iI

#### PR Checklist
- [x] `npm run lint` passes
- [ ] [Inline documentation] is included / updated
- [ ] [Unit tests] are included / updated