### PR TITLE
Fix: Misleading error message when NaN passed

### DIFF
--- a/src/core/friendly_errors/validate_params.js
+++ b/src/core/friendly_errors/validate_params.js
@@ -569,7 +569,7 @@ if (typeof IS_MINIFIED !== 'undefined') {
         const argType =
           arg instanceof Array
             ? 'array'
-            : arg === null ? 'null' : arg.name || typeof arg;
+            : arg === null ? 'null' : isNaN(arg) ? 'NaN' : arg.name || typeof arg;
 
         translationObj = {
           func,

--- a/src/core/friendly_errors/validate_params.js
+++ b/src/core/friendly_errors/validate_params.js
@@ -569,7 +569,7 @@ if (typeof IS_MINIFIED !== 'undefined') {
         const argType =
           arg instanceof Array
             ? 'array'
-            : arg === null ? 'null' : typeof arg === 'number' && isNaN(arg) ? 'NaN' : arg.name || typeof arg;
+            : arg === null ? 'null' : arg === undefined ? 'undefined' : typeof arg === 'number' && isNaN(arg) ? 'NaN' : arg.name || typeof arg;
 
         translationObj = {
           func,

--- a/src/core/friendly_errors/validate_params.js
+++ b/src/core/friendly_errors/validate_params.js
@@ -569,7 +569,7 @@ if (typeof IS_MINIFIED !== 'undefined') {
         const argType =
           arg instanceof Array
             ? 'array'
-            : arg === null ? 'null' : isNaN(arg) ? 'NaN' : arg.name || typeof arg;
+            : arg === null ? 'null' : typeof arg === 'number' && isNaN(arg) ? 'NaN' : arg.name || typeof arg;
 
         translationObj = {
           func,


### PR DESCRIPTION
<!--
  Thank you for contributing! Please use this pull request (PR) template.


 In the description field of this PR, include "resolves #XXXX" tagging the issue you are fixing. If this PR addresses the issue but doesn't completely resolve it (ie the issue should remain open after your PR is merged), write "addresses #XXXX".-->
Resolves #6463

 Changes:
<!-- Add here what changes were made in this pull request and if possible provide links showcasing the changes. -->

```js
function setup() {
  createCanvas(400, 400);
  let i = 0, j = 0;
  point(i/j,10);
}
```
whenever a NaN is passed it gives error message:
> 🌸 p5.js says: [sketch.js, line 4] point() was expecting Number for the first parameter, received number instead. (http://p5js.org/reference/#/p5/point) 

where it is supposed to give:
> 🌸 p5.js says: [sketch.js, line 4] point() was expecting Number for the first parameter, received NaN instead. (http://p5js.org/reference/#/p5/point) 

I have updated the code in validate_params.js for `_friendlyParamError` function under the switch case "WRONG_TYPE" to include an additional check using `isNaN(arg)` to detect NaN values.

<!-- If applicable, add screenshots depicting the changes. -->

#### PR Checklist
<!--
  To check any option, replace the "[ ]" with a "[x]". Be sure to check out how it looks in the Preview tab! Feel free to remove any portion of the template that is not relevant for your issue.
-->

- [x] `npm run lint` passes
- [ ] [Inline documentation] is included / updated
- [ ] [Unit tests] are included / updated

[Inline documentation]: https://github.com/processing/p5.js/blob/main/contributor_docs/inline_documentation.md
[Unit tests]: https://github.com/processing/p5.js/tree/main/contributor_docs#unit-tests
