### PR TITLE
Fix camera flipping on framebuffers between push/pop calls

### DIFF
--- a/src/webgl/p5.Camera.js
+++ b/src/webgl/p5.Camera.js
@@ -1622,7 +1622,8 @@ p5.Camera = class Camera {
       'eyeX', 'eyeY', 'eyeZ',
       'centerX', 'centerY', 'centerZ',
       'upX', 'upY', 'upZ',
-      'cameraFOV', 'aspectRatio', 'cameraNear', 'cameraFar', 'cameraType'
+      'cameraFOV', 'aspectRatio', 'cameraNear', 'cameraFar', 'cameraType',
+      'yScale'
     ];
     for (const keyName of keyNamesOfThePropToCopy) {
       this[keyName] = cam[keyName];
@@ -2019,6 +2020,7 @@ p5.Camera = class Camera {
 
     _cam.cameraMatrix = this.cameraMatrix.copy();
     _cam.projMatrix = this.projMatrix.copy();
+    _cam.yScale = this.yScale;
 
     return _cam;
   }


### PR DESCRIPTION
Resolves https://github.com/processing/p5.js/issues/6470

### Changes
- Makes sure `yScale` is copied in `copy()` and `set()`


### Screenshots of the change
With the test sketch from the issue:
```js
let fbo
function setup() {
  createCanvas(400, 400, WEBGL)
  fbo = createFramebuffer()
}

function draw() {
  fbo.begin()
  background(100)
  push()
  ortho(-width/2, width/2, -height/2, height/2, 0.1, 2000)
  translate(0, -100)
  box()
  pop()
  fbo.end()
  
  imageMode(CENTER)
  image(fbo, 0, 0)
}
```

Before:
![image](https://github.com/processing/p5.js/assets/5315059/22978016-b711-40fd-b957-0aa994119cf2)

After:
![image](https://github.com/processing/p5.js/assets/5315059/439db663-1388-4575-a87a-677c9f59ae65)


Live: https://editor.p5js.org/davepagurek/sketches/g32vQiLIO

#### PR Checklist
- [x] `npm run lint` passes
- [ ] [Inline documentation] is included / updated
- [ ] [Unit tests] are included / updated
