### PR TITLE
Fixed typing errors in validate_params.js file's documentation

### DIFF
--- a/src/core/friendly_errors/validate_params.js
+++ b/src/core/friendly_errors/validate_params.js
@@ -153,7 +153,7 @@ if (typeof IS_MINIFIED !== 'undefined') {
           return obj;
         }
       }
-      // nothing worked, put the type as is
+      // nothing worked, put the type as it is
       obj = obj[type] || (obj[type] = {});
     }
 
@@ -256,7 +256,7 @@ if (typeof IS_MINIFIED !== 'undefined') {
 
           let lowerType = type.toLowerCase();
 
-          // contant
+          // constant
           if (lowerType === 'constant') {
             let constant;
             if (mapConstants.hasOwnProperty(format.name)) {
@@ -694,7 +694,7 @@ if (typeof IS_MINIFIED !== 'undefined') {
    * @example:
    *  const a;
    *  ellipse(10,10,a,5);
-   * console ouput:
+   * console output:
    *  "It looks like ellipse received an empty variable in spot #2."
    *
    * @example:


### PR DESCRIPTION

 Changes:
Fixed typing errors in validate_params.js file's documentation
Link to the changes made: src/core/friendly_errors/validate_params.js
https://github.com/Garima3110/p5.js/commit/6f666890df159957dad4e216fd0b54aae9217550#diff-ccdec9d10ce9805d2cf552e45993bd7884cc57d4473c168f16d07909984c4068


 Screenshots of the change:
<img width="941" alt="image" src="https://github.com/processing/p5.js/assets/110815240/7d8b1b8f-2e0e-4382-8f06-cccbed3d3965">


#### PR Checklist
<!--
  To check any option, replace the "[ ]" with a "[x]". Be sure to check out how it looks in the Preview tab! Feel free to remove any portion of the template that is not relevant for your issue.
-->

- [ ] `npm run lint` passes
- [x] [Inline documentation] is included / updated
- [ ] [Unit tests] are included / updated

[Inline documentation]: https://github.com/processing/p5.js/blob/main/contributor_docs/inline_documentation.md
[Unit tests]: https://github.com/processing/p5.js/tree/main/contributor_docs#unit-tests
