### PR TITLE
Update friendly_error_system.md

### DIFF
--- a/contributor_docs/friendly_error_system.md
+++ b/contributor_docs/friendly_error_system.md
@@ -129,7 +129,7 @@ You can find the translation files used by the `translator()` inside:
 These functions are mainly responsible for catching errors and generating FES messages:
 * [`_friendlyFileLoadError()`] catches file loading errors.
 * [`_validateParameters()`] checks a p5.js function’s input parameters based on inline documents.
-* [`_fesErrorMontitor()`] handles global errors.
+* [`_fesErrorMonitor()`] handles global errors.
 
 For full reference, please see our [Dev Notes].
 


### PR DESCRIPTION
Changes:
Corrected the _fesMonitor() spellings in friendly_error_system.md file.

#### PR Checklist

- [ ] `npm run lint` passes
- [x] [Inline documentation] is included / updated
- [ ] [Unit tests] are included / updated

[Inline documentation]: https://github.com/processing/p5.js/blob/main/contributor_docs/inline_documentation.md
[Unit tests]: https://github.com/processing/p5.js/tree/main/contributor_docs#unit-tests
