### PR TITLE
Update fes_reference_dev_notes.md

### DIFF
--- a/contributor_docs/fes_reference_dev_notes.md
+++ b/contributor_docs/fes_reference_dev_notes.md
@@ -6,7 +6,7 @@ Main functions for generating the friendly error messages are:
 * `_friendlyFileLoadError()`
 * `_friendlyError()`
 * `helpForMisusedAtTopLevelCode()`
-* `_fesErrorMontitor()`
+* `_fesErrorMonitor()`
 
 These functions are located throughout the `core/friendly_errors/` folder.
 * `fes_core.js` contains the core as well as miscellaneous functionality of the FES.


### PR DESCRIPTION

 Changes:
Corrected spellings of _fesErrorMonitor() in fes_reference_dev_notes.md



#### PR Checklist


- [ ] `npm run lint` passes
- [x] [Inline documentation] is included / updated
- [ ] [Unit tests] are included / updated

[Inline documentation]: https://github.com/processing/p5.js/blob/main/contributor_docs/inline_documentation.md
[Unit tests]: https://github.com/processing/p5.js/tree/main/contributor_docs#unit-tests
