### PR TITLE
A fix to the formatting of the documentation for endShape's instancing example

### DIFF
--- a/src/core/shape/vertex.js
+++ b/src/core/shape/vertex.js
@@ -647,8 +647,8 @@ p5.prototype.endContour = function() {
  *
  *   // gl_InstanceID represents a numeric value for each instance
  *   // using gl_InstanceID allows us to move each instance separately
- *   // here we move each instance horizontally by id * 100
- *   float xOffset = float(gl_InstanceID) * 100.0;
+ *   // here we move each instance horizontally by id * 40
+ *   float xOffset = float(gl_InstanceID) * 40.0;
  *
  *   // apply the offset to the final position
  *   gl_Position = uProjectionMatrix * uModelViewMatrix * positionVec4 -
@@ -676,7 +676,7 @@ p5.prototype.endContour = function() {
  * `;
  *
  * function setup() {
- *   createCanvas(400, 400, WEBGL);
+ *   createCanvas(100, 100, WEBGL);
  *   fx = createShader(vs, fs);
  * }
  *
@@ -687,12 +687,16 @@ p5.prototype.endContour = function() {
  *   shader(fx);
  *   fx.setUniform('numInstances', 4);
  *
+ *   // this doesn't have to do with instancing, this is just for centering the squares
+ *   translate(25, -10);
+ *
+ *   // here we draw the squares we want to instance
  *   beginShape();
- *   vertex(30, 20);
- *   vertex(85, 20);
- *   vertex(85, 75);
- *   vertex(30, 75);
- *   vertex(30, 20);
+ *   vertex(0, 0);
+ *   vertex(0, 20);
+ *   vertex(20, 20);
+ *   vertex(20, 0);
+ *   vertex(0, 0);
  *   endShape(CLOSE, 4);
  *
  *   resetShader();


### PR DESCRIPTION
<!--
  Thank you for contributing! Please use this pull request (PR) template.


 In the description field of this PR, include "resolves #XXXX" tagging the issue you are fixing. If this PR addresses the issue but doesn't completely resolve it (ie the issue should remain open after your PR is merged), write "addresses #XXXX".-->
Resolves an issue with the formatting of the instancing example for endShape()

 Changes:
<!-- Add here what changes were made in this pull request and if possible provide links showcasing the changes. -->
This decreases the size of the canvas so that the example code can be formatted properly, and centers the squares used in the example to make it look nicer.

 Screenshots of the change:
<!-- If applicable, add screenshots depicting the changes. -->
Here's what it currently looks like (400x400 canvas is used for the example):
![current-formatting](https://github.com/processing/p5.js/assets/83996185/fdf87fcd-0862-45bb-ba9e-f202d387ab5f)
Here's how the new 100x100 canvas which will fix the formatting:
![new-canvas](https://github.com/processing/p5.js/assets/83996185/357e8cec-40aa-4e38-8d28-61d59dc2ad23)

#### PR Checklist
<!--
  To check any option, replace the "[ ]" with a "[x]". Be sure to check out how it looks in the Preview tab! Feel free to remove any portion of the template that is not relevant for your issue.
-->

- [x] `npm run lint` passes
- [x] [Inline documentation] is included / updated
- [x] [Unit tests] are included / updated

[Inline documentation]: https://github.com/processing/p5.js/blob/main/contributor_docs/inline_documentation.md
[Unit tests]: https://github.com/processing/p5.js/tree/main/contributor_docs#unit-tests
