### PR TITLE
Made a new method to return Geometry with no internal colors.

### DIFF
--- a/src/webgl/3d_primitives.js
+++ b/src/webgl/3d_primitives.js
@@ -181,14 +181,6 @@ p5.prototype.freeGeometry = function(geometry) {
 };
 
 /**
- * Clears the internal Color of the Geometry.
- * @method clearColors
- */
-p5.prototype.clearColors = function () {
-  return this._renderer.clearColors();
-};
-
-/**
  * Draw a plane with given a width and height
  * @method plane
  * @param  {Number} [width]    width of the plane

--- a/src/webgl/3d_primitives.js
+++ b/src/webgl/3d_primitives.js
@@ -181,6 +181,14 @@ p5.prototype.freeGeometry = function(geometry) {
 };
 
 /**
+ * Clears the internal Color of the Geometry.
+ * @method clearColors
+ */
+p5.prototype.clearColors = function () {
+  return this._renderer.clearColors();
+};
+
+/**
  * Draw a plane with given a width and height
  * @method plane
  * @param  {Number} [width]    width of the plane

--- a/src/webgl/GeometryBuilder.js
+++ b/src/webgl/GeometryBuilder.js
@@ -126,21 +126,6 @@ class GeometryBuilder {
    */
   finish() {
     this.renderer._pInst.pop();
-
-    // If all vertices are the same color (no per-vertex colors were
-    // supplied), remove the vertex color data so that one may override the
-    // fill when drawing the geometry with `model()`
-    let allVertexColorsSame = true;
-    for (let i = 4; i < this.geometry.vertexColors.length; i++) {
-      if (this.geometry.vertexColors[i] !== this.geometry.vertexColors[i % 4]) {
-        allVertexColorsSame = false;
-        break;
-      }
-    }
-    if (allVertexColorsSame) {
-      this.geometry.vertexColors = [];
-    }
-
     return this.geometry;
   }
 }

--- a/src/webgl/p5.Geometry.js
+++ b/src/webgl/p5.Geometry.js
@@ -90,7 +90,7 @@ p5.Geometry = class Geometry {
   /**
    * Removes the internal Colors of p5.Geometry
    * Using clearColors, you can use 'fill()' to supply new colors before drawing each shape.
-   * If clearColors() is not used, the shapes will use their internal colors.
+   * If clearColors() is not used, the shapes will use their internal colors by ignoring 'fill()'.
    *
    * @method clearColors
    *

--- a/src/webgl/p5.Geometry.js
+++ b/src/webgl/p5.Geometry.js
@@ -87,10 +87,7 @@ p5.Geometry = class Geometry {
 
     this.dirtyFlags = {};
   }
-/**
-   * @method clearColors
-   * @chainable
-   */
+
   clearColors() {
     this.vertexColors = [];
     return this;

--- a/src/webgl/p5.Geometry.js
+++ b/src/webgl/p5.Geometry.js
@@ -89,7 +89,7 @@ p5.Geometry = class Geometry {
   }
   /**
    * Removes the internal Colors of p5.Geometry
-   * Using clearColors you can use the `fill()` to supply new colors before drawing each shape. 
+   * Using clearColors, you can use 'fill()' to supply new colors before drawing each shape.
    * If clearColors() is not used, the shapes will use their internal colors.
    *
    * @method clearColors

--- a/src/webgl/p5.Geometry.js
+++ b/src/webgl/p5.Geometry.js
@@ -88,9 +88,9 @@ p5.Geometry = class Geometry {
     this.dirtyFlags = {};
   }
   /**
-   * Removes the internal Colors of p5.Geometry
-   * Using clearColors, you can use 'fill()' to supply new colors before drawing each shape.
-   * If clearColors() is not used, the shapes will use their internal colors by ignoring 'fill()'.
+   * Removes the internal Colors of p5.Geometry.
+   * Using clearColors, you can use `fill()` to supply new colors before drawing each shape.
+   * If clearColors() is not used, the shapes will use their internal colors by ignoring `fill()`.
    *
    * @method clearColors
    *

--- a/src/webgl/p5.Geometry.js
+++ b/src/webgl/p5.Geometry.js
@@ -101,24 +101,23 @@ p5.Geometry = class Geometry {
    *
    * function setup() {
    *   renderer = createCanvas(600, 600, WEBGL);
-   *   points.push(new p5.Vector(-1, -1, 0), new p5.Vector(-1, 1, 0), new p5.Vector(1, -1, 0), new p5.Vector(-1, -1, 0));
+   *   points.push(new p5.Vector(-1, -1, 0), new p5.Vector(-1, 1, 0),
+   *     new p5.Vector(1, -1, 0), new p5.Vector(-1, -1, 0));
    *   buildShape01();
    *   buildShape02();
    * }
    * function draw() {
    *   background(0);
-   *
-   *   fill("pink"); // shape01 retains its internal blue color, so it won't turn pink.
+   *   fill('pink'); // shape01 retains its internal blue color, so it won't turn pink.
    *   model(shape01);
-   *
    *   shape02.clearColors(); // Resets shape02's colors.
-   *   fill("yellow"); // Now, shape02 is yellow.
+   *   fill('yellow'); // Now, shape02 is yellow.
    *   model(shape02);
    * }
    *
    * function buildShape01() {
    *   beginGeometry();
-   *   fill("blue"); // shape01's color is blue because its internal colors remain.
+   *   fill('blue'); // shape01's color is blue because its internal colors remain.
    *   beginShape();
    *   for (let vec of points) vertex(vec.x * 100, vec.y * 100, vec.z * 100);
    *   endShape(CLOSE);
@@ -127,7 +126,7 @@ p5.Geometry = class Geometry {
    *
    * function buildShape02() {
    *   beginGeometry();
-   *   fill("red");  // shape02.clearColors() removes its internal colors. Now, shape02 is red.
+   *   fill('red');  // shape02.clearColors() removes its internal colors. Now, shape02 is red.
    *   beginShape();
    *   for (let vec of points) vertex(vec.x * 200, vec.y * 200, vec.z * 200);
    *   endShape(CLOSE);

--- a/src/webgl/p5.Geometry.js
+++ b/src/webgl/p5.Geometry.js
@@ -87,7 +87,56 @@ p5.Geometry = class Geometry {
 
     this.dirtyFlags = {};
   }
-
+  /**
+   * Removes the internal Colors of p5.Geometry
+   *
+   * @method clearColors
+   *
+   * @example
+   * <div>
+   * <code>
+   * let shape01;
+   * let shape02;
+   * let points = [];
+   *
+   * function setup() {
+   *   renderer = createCanvas(600, 600, WEBGL);
+   *   points.push(new p5.Vector(-1, -1, 0), new p5.Vector(-1, 1, 0), new p5.Vector(1, -1, 0), new p5.Vector(-1, -1, 0));
+   *   buildShape01();
+   *   buildShape02();
+   * }
+   * function draw() {
+   *   background(0);
+   *
+   *   fill("pink"); // shape01 retains its internal blue color, so it won't turn pink.
+   *   model(shape01);
+   *
+   *   shape02.clearColors(); // Resets shape02's colors.
+   *   fill("yellow"); // Now, shape02 is yellow.
+   *   model(shape02);
+   * }
+   *
+   * function buildShape01() {
+   *   beginGeometry();
+   *   fill("blue"); // shape01's color is blue because its internal colors remain.
+   *   beginShape();
+   *   for (let vec of points) vertex(vec.x * 100, vec.y * 100, vec.z * 100);
+   *   endShape(CLOSE);
+   *   shape01 = endGeometry();
+   * }
+   *
+   * function buildShape02() {
+   *   beginGeometry();
+   *   fill("red");  // shape02.clearColors() removes its internal colors. Now, shape02 is red.
+   *   beginShape();
+   *   for (let vec of points) vertex(vec.x * 200, vec.y * 200, vec.z * 200);
+   *   endShape(CLOSE);
+   *   shape02 = endGeometry();
+   *   // You can also call shape02.clearColors() here.
+   * }
+   * </code>
+   * </div>
+   */
   clearColors() {
     this.vertexColors = [];
     return this;

--- a/src/webgl/p5.Geometry.js
+++ b/src/webgl/p5.Geometry.js
@@ -88,9 +88,9 @@ p5.Geometry = class Geometry {
     this.dirtyFlags = {};
   }
   /**
-   * Removes the internal Colors of p5.Geometry.
-   * Using clearColors, you can use `fill()` to supply new colors before drawing each shape.
-   * If clearColors() is not used, the shapes will use their internal colors by ignoring `fill()`.
+   * Removes the internal colors of p5.Geometry.
+   * Using `clearColors()`, you can use `fill()` to supply new colors before drawing each shape.
+   * If `clearColors()` is not used, the shapes will use their internal colors by ignoring `fill()`.
    *
    * @method clearColors
    *

--- a/src/webgl/p5.Geometry.js
+++ b/src/webgl/p5.Geometry.js
@@ -87,7 +87,14 @@ p5.Geometry = class Geometry {
 
     this.dirtyFlags = {};
   }
-
+/**
+   * @method clearColors
+   * @chainable
+   */
+  clearColors() {
+    this.vertexColors = [];
+    return this;
+  }
   /**
  * computes faces for geometry objects based on the vertices.
  * @method computeFaces

--- a/src/webgl/p5.Geometry.js
+++ b/src/webgl/p5.Geometry.js
@@ -89,6 +89,8 @@ p5.Geometry = class Geometry {
   }
   /**
    * Removes the internal Colors of p5.Geometry
+   * Using clearColors you can use the `fill()` to supply new colors before drawing each shape. 
+   * If clearColors() is not used, the shapes will use their internal colors.
    *
    * @method clearColors
    *
@@ -100,7 +102,7 @@ p5.Geometry = class Geometry {
    * let points = [];
    *
    * function setup() {
-   *   renderer = createCanvas(600, 600, WEBGL);
+   *   createCanvas(600, 600, WEBGL);
    *   points.push(new p5.Vector(-1, -1, 0), new p5.Vector(-1, 1, 0),
    *     new p5.Vector(1, -1, 0), new p5.Vector(-1, -1, 0));
    *   buildShape01();
@@ -110,7 +112,6 @@ p5.Geometry = class Geometry {
    *   background(0);
    *   fill('pink'); // shape01 retains its internal blue color, so it won't turn pink.
    *   model(shape01);
-   *   shape02.clearColors(); // Resets shape02's colors.
    *   fill('yellow'); // Now, shape02 is yellow.
    *   model(shape02);
    * }
@@ -131,7 +132,7 @@ p5.Geometry = class Geometry {
    *   for (let vec of points) vertex(vec.x * 200, vec.y * 200, vec.z * 200);
    *   endShape(CLOSE);
    *   shape02 = endGeometry();
-   *   // You can also call shape02.clearColors() here.
+   *   shape02.clearColors(); // Resets shape02's colors.
    * }
    * </code>
    * </div>

--- a/src/webgl/p5.Geometry.js
+++ b/src/webgl/p5.Geometry.js
@@ -18,9 +18,9 @@ import p5 from '../core/main';
  * @param {function} [callback] function to call upon object instantiation.
  */
 p5.Geometry = class Geometry {
-  constructor(detailX, detailY, callback){
-  //an array containing every vertex
-  //@type [p5.Vector]
+  constructor(detailX, detailY, callback) {
+    //an array containing every vertex
+    //@type [p5.Vector]
     this.vertices = [];
 
     //an array containing every vertex for stroke drawing
@@ -164,7 +164,7 @@ p5.Geometry = class Geometry {
   }
 
   _getFaceNormal(faceId) {
-  //This assumes that vA->vB->vC is a counter-clockwise ordering
+    //This assumes that vA->vB->vC is a counter-clockwise ordering
     const face = this.faces[faceId];
     const vA = this.vertices[face[0]];
     const vB = this.vertices[face[1]];
@@ -249,7 +249,7 @@ p5.Geometry = class Geometry {
  * @chainable
  */
   averagePoleNormals() {
-  //average the north pole
+    //average the north pole
     let sum = new p5.Vector(0, 0, 0);
     for (let i = 0; i < this.detailX; i++) {
       sum.add(this.vertexNormals[i]);
@@ -560,7 +560,7 @@ p5.Geometry = class Geometry {
  */
   normalize() {
     if (this.vertices.length > 0) {
-    // Find the corners of our bounding box
+      // Find the corners of our bounding box
       const maxPosition = this.vertices[0].copy();
       const minPosition = this.vertices[0].copy();
 


### PR DESCRIPTION
<!--
  Thank you for contributing! Please use this pull request (PR) template.


 In the description field of this PR, include "resolves #6384 " tagging the issue you are fixing. If this PR addresses the issue but doesn't completely resolve it (ie the issue should remain open after your PR is merged), write "addresses #6384 ".-->
Resolves #6384 

 Changes:

https://github.com/processing/p5.js/assets/127239756/36d5714b-d94c-4e21-9e31-82ef2047204a

Description:


let shap01;
function setup() {
  renderer = createCanvas(600, 600, WEBGL);
  buildShape02();
}
function draw() {
  background(0);
  fill("yellow");
  model(shape02);
}

function buildShape02() {
  beginGeometry();
  fill("red"); //The box is red
  box(50);
  shape02 = endGeometry();
  shape02.clearColors(); //After calling this the box becomes yellow as it removes internal colors.
}


#### PR Checklist
<!--
  To check any option, replace the "[ ]" with a "[x]". Be sure to check out how it looks in the Preview tab! Feel free to remove any portion of the template that is not relevant for your issue.
-->

- [x] `npm run lint` passes
- [x] [Inline documentation] is included / updated
- [x] [Unit tests] are included / updated

[Inline documentation]: https://github.com/processing/p5.js/blob/main/contributor_docs/inline_documentation.md
[Unit tests]: https://github.com/processing/p5.js/tree/main/contributor_docs#unit-tests
