### PR TITLE
Add param geometry in freeGeometry function-docs

### DIFF
--- a/src/webgl/3d_primitives.js
+++ b/src/webgl/3d_primitives.js
@@ -174,7 +174,7 @@ p5.prototype.buildGeometry = function(callback) {
  * from <a href="#/p5/loadModel">loadModel()</a>.
  *
  * @method freeGeometry
- * @param {p5.Geometry} The geometry whose resources should be freed
+ * @param {p5.Geometry} geometry The geometry whose resources should be freed
  */
 p5.prototype.freeGeometry = function(geometry) {
   this._renderer._freeBuffers(geometry.gid);


### PR DESCRIPTION
<!--
  Thank you for contributing! Please use this pull request (PR) template.


 In the description field of this PR, include "resolves #XXXX" tagging the issue you are fixing. If this PR addresses the issue but doesn't completely resolve it (ie the issue should remain open after your PR is merged), write "addresses #XXXX".-->

When reading through the code just noticed that param geometry is missing in freeGeometry's function-docs 

 Changes:
- Added the `geometry` parameter to the documentation comments of the `freeGeometry` function.

<!-- Add here what changes were made in this pull request and if possible provide links showcasing the changes. -->


 Screenshots of the change:
<!-- If applicable, add screenshots depicting the changes. -->

#### PR Checklist
<!--
  To check any option, replace the "[ ]" with a "[x]". Be sure to check out how it looks in the Preview tab! Feel free to remove any portion of the template that is not relevant for your issue.
-->

- [ ] `npm run lint` passes
- [ ] [Inline documentation] is included / updated
- [ ] [Unit tests] are included / updated

[Inline documentation]: https://github.com/processing/p5.js/blob/main/contributor_docs/inline_documentation.md
[Unit tests]: https://github.com/processing/p5.js/tree/main/contributor_docs#unit-tests
