### PR TITLE
fix camera slerp() BUG

### DIFF
--- a/src/webgl/p5.Camera.js
+++ b/src/webgl/p5.Camera.js
@@ -1818,10 +1818,10 @@ p5.Camera = class Camera {
     const rotMat1 = cam1.cameraMatrix.createSubMatrix3x3();
 
     // get front and up vector from local-coordinate-system.
-    const front0 = rotMat0.column(2);
-    const front1 = rotMat1.column(2);
-    const up0 = rotMat0.column(1);
-    const up1 = rotMat1.column(1);
+    const front0 = rotMat0.row(2);
+    const front1 = rotMat1.row(2);
+    const up0 = rotMat0.row(1);
+    const up1 = rotMat1.row(1);
 
     // prepare new vectors.
     const newFront = new p5.Vector();

--- a/test/unit/webgl/p5.Camera.js
+++ b/test/unit/webgl/p5.Camera.js
@@ -923,6 +923,21 @@ suite('p5.Camera', function() {
       expect(myCam.projMatrix.mat4[5])
         .to.be.closeTo(p0_5 * Math.pow(p1_5 / p0_5, 0.3), 0.00001);
     });
+    test('Preventing bugs from occurring by changes in slerp spec', function() {
+      myCam = myp5.createCamera();
+      const cam0 = myp5.createCamera();
+      const cam1 = myp5.createCamera();
+      cam0.camera(100, 763, 1073, 100, 480, 380, 0, 1, 2);
+      cam1.camera(300, 400, 700, 0, 0, 0, 2, 3, 1);
+      myCam.slerp(cam0, cam1, 0.1);
+      const expectedSlerpedMatrix = new Float32Array([
+        0.9983342289924622, 0.04771510139107704, 0.03243450075387955, 0,
+        -0.056675542145967484, 0.9162729382514954, 0.39652466773986816, 0,
+        -0.010798640549182892, -0.3977023959159851, 0.9174509048461914, 0,
+        -66.60199737548828, -260.3179016113281, -1242.9371337890625, 1
+      ]);
+      assert.deepEqual(myCam.cameraMatrix.mat4, expectedSlerpedMatrix);
+    });
   });
 
   suite('Helper Functions', function() {


### PR DESCRIPTION
fix column() to row().

<!--
  Thank you for contributing! Please use this pull request (PR) template.


 In the description field of this PR, include "resolves #XXXX" tagging the issue you are fixing. If this PR addresses the issue but doesn't completely resolve it (ie the issue should remain open after your PR is merged), write "addresses #XXXX".-->
Resolves #6508

## Changes:
<!-- Add here what changes were made in this pull request and if possible provide links showcasing the changes. -->
A bug occurred in camera's slerp() due to a change in the specifications of column() and row().
So I'll fix that.

[CAMERA_SLERP_BUG](https://editor.p5js.org/dark_fox/sketches/6zhKfTckZ)

### before
```js
  // BUG IS HERE.

  var front0 = rotMat0.column(2);
  var front1 = rotMat1.column(2);
  var up0 = rotMat0.column(1);
  var up1 = rotMat1.column(1);
```
### after
```js
  // The specifications of column() and row() have been reversed, so column() must be rewritten as row().
  var front0 = rotMat0.row(2);
  var front1 = rotMat1.row(2);
  var up0 = rotMat0.row(1);
  var up1 = rotMat1.row(1); // prepare new vectors.
```

#### PR Checklist
<!--
  To check any option, replace the "[ ]" with a "[x]". Be sure to check out how it looks in the Preview tab! Feel free to remove any portion of the template that is not relevant for your issue.
-->

- [x] `npm run lint` passes
- [ ] [Inline documentation] is included / updated
- [x] [Unit tests] are included / updated

[Inline documentation]: https://github.com/processing/p5.js/blob/main/contributor_docs/inline_documentation.md
[Unit tests]: https://github.com/processing/p5.js/tree/main/contributor_docs#unit-tests
