### PR TITLE
type the instance parameter in the `p5` constructor

### DIFF
--- a/src/core/main.js
+++ b/src/core/main.js
@@ -26,7 +26,7 @@ import * as constants from './constants';
  *
  * @class p5
  * @constructor
- * @param  {function}           sketch a closure that can set optional <a href="#/p5/preload">preload()</a>,
+ * @param  {function(p5)}       sketch a closure that can set optional <a href="#/p5/preload">preload()</a>,
  *                              <a href="#/p5/setup">setup()</a>, and/or <a href="#/p5/draw">draw()</a> properties on the
  *                              given p5 instance
  * @param  {HTMLElement}        [node] element to attach canvas to


### PR DESCRIPTION
<!--
  Thank you for contributing! Please use this pull request (PR) template.


 In the description field of this PR, include "resolves #XXXX" tagging the issue you are fixing. If this PR addresses the issue but doesn't completely resolve it (ie the issue should remain open after your PR is merged), write "addresses #XXXX".-->

 Changes:
<!-- Add here what changes were made in this pull request and if possible provide links showcasing the changes. -->
Adds a type annotation for the parameter of the `sketch` callback of the `p5` constructor.
The previous type was `function(...args: any[]): any`, and this changes it to be `function(p1: p5): any`, annotating that it takes a `p5` instance.

#### PR Checklist
<!--
  To check any option, replace the "[ ]" with a "[x]". Be sure to check out how it looks in the Preview tab! Feel free to remove any portion of the template that is not relevant for your issue.
-->

- [x] `npm run lint` passes
- [x] [Inline documentation] is included / updated
- [x] [Unit tests] are included / updated

[Inline documentation]: https://github.com/processing/p5.js/blob/main/contributor_docs/inline_documentation.md
[Unit tests]: https://github.com/processing/p5.js/tree/main/contributor_docs#unit-tests
