### PR TITLE
Fix webgl erase. Resolves #6523

### DIFF
--- a/src/webgl/p5.RendererGL.js
+++ b/src/webgl/p5.RendererGL.js
@@ -1183,7 +1183,6 @@ p5.RendererGL = class RendererGL extends p5.Renderer {
       this._cachedBlendMode = this.curBlendMode;
       this._isErasing = true;
       this.blendMode(constants.REMOVE);
-      this._applyBlendMode();
       this._cachedFillStyle = this.curFillColor.slice();
       this.curFillColor = [1, 1, 1, opacityFill / 255];
       this._cachedStrokeStyle = this.curStrokeColor.slice();

--- a/src/webgl/p5.RendererGL.js
+++ b/src/webgl/p5.RendererGL.js
@@ -1180,7 +1180,9 @@ p5.RendererGL = class RendererGL extends p5.Renderer {
 
   erase(opacityFill, opacityStroke) {
     if (!this._isErasing) {
-      this._applyBlendMode(constants.REMOVE);
+      this.currentBlendMode = this._cachedBlendMode;
+      this.blendMode(constants.REMOVE);
+      this._applyBlendMode();
       this._isErasing = true;
 
       this._cachedFillStyle = this.curFillColor.slice();
@@ -1196,7 +1198,7 @@ p5.RendererGL = class RendererGL extends p5.Renderer {
       this._isErasing = false;
       this.curFillColor = this._cachedFillStyle.slice();
       this.curStrokeColor = this._cachedStrokeStyle.slice();
-      this.blendMode(this._cachedBlendMode);
+      this.blendMode(this.currentBlendMode);
     }
   }
 

--- a/src/webgl/p5.RendererGL.js
+++ b/src/webgl/p5.RendererGL.js
@@ -1180,14 +1180,12 @@ p5.RendererGL = class RendererGL extends p5.Renderer {
 
   erase(opacityFill, opacityStroke) {
     if (!this._isErasing) {
-      this.currentBlendMode = this._cachedBlendMode;
+      this._cachedBlendMode = this.curBlendMode;
+      this._isErasing = true;
       this.blendMode(constants.REMOVE);
       this._applyBlendMode();
-      this._isErasing = true;
-
       this._cachedFillStyle = this.curFillColor.slice();
       this.curFillColor = [1, 1, 1, opacityFill / 255];
-
       this._cachedStrokeStyle = this.curStrokeColor.slice();
       this.curStrokeColor = [1, 1, 1, opacityStroke / 255];
     }
@@ -1195,10 +1193,14 @@ p5.RendererGL = class RendererGL extends p5.Renderer {
 
   noErase() {
     if (this._isErasing) {
-      this._isErasing = false;
       this.curFillColor = this._cachedFillStyle.slice();
       this.curStrokeColor = this._cachedStrokeStyle.slice();
-      this.blendMode(this.currentBlendMode);
+      // It's necessary to restore post-erase state. Needs rework
+      let temp = this.curBlendMode;
+      this.blendMode(this._cachedBlendMode);
+      this._cachedBlendMode = temp; // If we don't do this, appleBlendMode() returns null
+      this._isErasing = false;
+      this._applyBlendMode(); // This sets _cachedBlendMode back to the original blendmode
     }
   }
 

--- a/src/webgl/p5.RendererGL.js
+++ b/src/webgl/p5.RendererGL.js
@@ -1198,7 +1198,7 @@ p5.RendererGL = class RendererGL extends p5.Renderer {
       // It's necessary to restore post-erase state. Needs rework
       let temp = this.curBlendMode;
       this.blendMode(this._cachedBlendMode);
-      this._cachedBlendMode = temp; // If we don't do this, appleBlendMode() returns null
+      this._cachedBlendMode = temp; // If we don't do this, applyBlendMode() returns null
       this._isErasing = false;
       this._applyBlendMode(); // This sets _cachedBlendMode back to the original blendmode
     }


### PR DESCRIPTION

Resolves #6523

Changes:
Changes to the erase() and noErase() functions in the webgl renderer.
In the erase() function
- Activate isErasing at the beginning
- Update _cachedBlendMode with current BlendMode (if omitted, it does not pass npm test)
- Change blendMode to constants.REMOVE mode

In the noErase() function
- Store currentBlendMode in temp
- Change blendMode back to the original (cached)
- Set cached to temp. If we don't do this, when applying the new blendmode (applyBlendMode()), the function returns null
- Apply original blendMode and set cached again to the original (to pass npm test)

This is all very confusing, but it's the only way of making it work without refactoring the whole thing.

#### PR Checklist
- [x] `npm run lint` passes