### PR TITLE
Handle premultiplied alpha in filter(OPAQUE)

### DIFF
--- a/src/image/pixels.js
+++ b/src/image/pixels.js
@@ -298,7 +298,6 @@ p5.prototype._copyHelper = (
   dw,
   dh
 ) => {
-  srcImage.loadPixels();
   const s = srcImage.canvas.width / srcImage.width;
   // adjust coord system for 3D when renderer
   // ie top-left = -width/2, -height/2

--- a/src/webgl/shaders/filters/opaque.frag
+++ b/src/webgl/shaders/filters/opaque.frag
@@ -8,5 +8,5 @@ uniform sampler2D tex0;
 
 void main() {
   vec4 color = texture2D(tex0, vTexCoord);
-  gl_FragColor = vec4(color.rgb, 1.0);
+  gl_FragColor = vec4(color.rgb / color.a, 1.0);
 }

--- a/src/webgl/shaders/filters/posterize.frag
+++ b/src/webgl/shaders/filters/posterize.frag
@@ -23,7 +23,7 @@ vec3 quantize(vec3 color, float n) {
 void main() {
   vec4 color = texture2D(tex0, vTexCoord);
 
-  vec3 restrictedColor = quantize(color.rgb, filterParameter);
+  vec3 restrictedColor = quantize(color.rgb / color.a, filterParameter);
 
-  gl_FragColor = vec4(restrictedColor.rgb, color.a);
+  gl_FragColor = vec4(restrictedColor.rgb * color.a, color.a);
 }

--- a/src/webgl/shaders/filters/threshold.frag
+++ b/src/webgl/shaders/filters/threshold.frag
@@ -15,9 +15,9 @@ float luma(vec3 color) {
 
 void main() {
   vec4 color = texture2D(tex0, vTexCoord);
-  float gray = luma(color.rgb);
+  float gray = luma(color.rgb / color.a);
   // floor() used to match src/image/filters.js
   float threshold = floor(filterParameter * 255.0) / 255.0;
   float blackOrWhite = step(threshold, gray);
-  gl_FragColor = vec4(vec3(blackOrWhite), color.a);
+  gl_FragColor = vec4(vec3(blackOrWhite) * color.a, color.a);
 }


### PR DESCRIPTION
Resolves https://github.com/processing/p5.js/issues/6528

### Changes
- Handles the fact that filter input has its alpha channel premultiplied. It needs to be unmultiplied to not result in darker colors before changing the alpha.


### Screenshots of the change
https://editor.p5js.org/davepagurek/sketches/OXcL-h7ui

This sketch is now full red instead of dark red.

Before:
![image](https://github.com/processing/p5.js/assets/5315059/3783e6fd-c7b9-491a-ba00-52dbf52734a4)

After:
![image](https://github.com/processing/p5.js/assets/5315059/f0d047b0-b145-4c0c-a1fa-fcb550e8585c)


#### PR Checklist
- [x] `npm run lint` passes
- [ ] [Inline documentation] is included / updated
- [ ] [Unit tests] are included / updated
