### PR TITLE
Fix width/height not matching after get()

### DIFF
--- a/src/core/p5.Renderer.js
+++ b/src/core/p5.Renderer.js
@@ -159,7 +159,7 @@ class Renderer extends p5.Element {
     }
 
     const region = new p5.Image(w*pd, h*pd);
-    region._pixelDensity = pd;
+    region.pixelDensity(pd);
     region.canvas
       .getContext('2d')
       .drawImage(canvas, x, y, w * pd, h * pd, 0, 0, w*pd, h*pd);

--- a/test/unit/image/p5.Image.js
+++ b/test/unit/image/p5.Image.js
@@ -122,4 +122,23 @@ suite('p5.Image', function() {
       });
     });
   });
+
+  suite('p5.Graphics.get()', function() {
+    for (const density of [1, 2]) {
+      test(`width and height match at pixel density ${density}`, function() {
+        const g = myp5.createGraphics(10, 10);
+        g.pixelDensity(density);
+        g.rect(2, 2, 5, 5);
+
+        const img = g.get();
+        assert.equal(g.width, img.width);
+        assert.equal(g.height, img.height);
+        assert.equal(g.pixelDensity(), img.pixelDensity());
+
+        g.loadPixels();
+        img.loadPixels();
+        assert.deepEqual([...g.pixels], [...img.pixels]);
+      });
+    }
+  });
 });


### PR DESCRIPTION
<!--
  Thank you for contributing! Please use this pull request (PR) template.


 In the description field of this PR, include "resolves #XXXX" tagging the issue you are fixing. If this PR addresses the issue but doesn't completely resolve it (ie the issue should remain open after your PR is merged), write "addresses #XXXX".-->
Resolves https://github.com/processing/p5.js/issues/6540

### Changes
- Calls `pixelDensity()` on images created via `get()` rather than setting an internal property


### Screenshots of the change
https://editor.p5js.org/davepagurek/sketches/6VuOKHnPv

#### PR Checklist
<!--
  To check any option, replace the "[ ]" with a "[x]". Be sure to check out how it looks in the Preview tab! Feel free to remove any portion of the template that is not relevant for your issue.
-->

- [x] `npm run lint` passes
- [x] [Inline documentation] is included / updated
- [x] [Unit tests] are included / updated
