### PR TITLE
Update computeNormals() to support smooth shading for buildGeometry() outputs

### DIFF
--- a/src/core/constants.js
+++ b/src/core/constants.js
@@ -709,6 +709,18 @@ export const CLAMP = 'clamp';
  */
 export const MIRROR = 'mirror';
 
+// WEBGL GEOMETRY SHADING
+/**
+ * @property {String} FLAT
+ * @final
+ */
+export const FLAT = 'flat';
+/**
+ * @property {String} SMOOTH
+ * @final
+ */
+export const SMOOTH = 'smooth';
+
 // DEVICE-ORIENTATION
 /**
  * @property {String} LANDSCAPE

--- a/src/webgl/p5.Geometry.js
+++ b/src/webgl/p5.Geometry.js
@@ -188,8 +188,8 @@ p5.Geometry = class Geometry {
    * computes smooth normals per vertex as an average of each
    * face.
    * @method computeNormals
-   * @param {String} [shadingType] (optional) To specify the shading type ('FLAT' for flat shading or 'SMOOTH' for smooth shading).
-   * @param {Object} [settings={ roundToPrecision: 3 }] (optional) Additional settings object with the precision for rounding vertex coordinates (optional).
+   * @param {String} [shadingType] (optional) Shading type ('FLAT' for flat shading or 'SMOOTH' for smooth shading) for buildGeometry() outputs.
+   * @param {Object} [settings={ roundToPrecision: 3 }] (optional) Additional settings object with rounding precision for vertex coordinates when shadingType is 'SMOOTH'.
    * @chainable
    */
   computeNormals(shadingType = 'FLAT', { roundToPrecision = 3 } = {}) {

--- a/src/webgl/p5.Geometry.js
+++ b/src/webgl/p5.Geometry.js
@@ -186,13 +186,13 @@ p5.Geometry = class Geometry {
   }
   /**
    * This function calculates normals for each face, where each vertex's normal is the average of the normals of all faces it's connected to.
-   * i.e computes smooth normals per vertex as an average of each face.
-   * When using 'FLAT' shading, vertices are disconnected/duplicated i.e each face has its own copy of vertices.
-   * When using 'SMOOTH' shading, vertices are connected/deduplicated i.e each face has its vertices shared with other faces.
+   * i.e computes smooth normals per vertex as an average of each face.<br>
+   * When using 'FLAT' shading, vertices are disconnected/duplicated i.e each face has its own copy of vertices.<br>
+   * When using 'SMOOTH' shading, vertices are connected/deduplicated i.e each face has its vertices shared with other faces.<br>
    *
    * @method computeNormals
-   * @param {String} [shadingType] (optional) shading type ('FLAT' for flat shading or 'SMOOTH' for smooth shading) for buildGeometry() outputs.
-   * @param {Object} [options] (optional) object with roundToPrecision property.
+   * @param {String} [shadingType] shading type ('FLAT' for flat shading or 'SMOOTH' for smooth shading) for buildGeometry() outputs.
+   * @param {Object} [options] object with roundToPrecision property.
    * @chainable
    *
    * @example
@@ -297,13 +297,23 @@ p5.Geometry = class Geometry {
         }
       }
 
-      // update face indices to use the new deduplicated vertex indices
+      // update face indices to use the deduplicated vertex indices
       faces.forEach(face => {
         for (let fv = 0; fv < 3; ++fv) {
           const originalVertexIndex = face[fv];
           const originalVertex = vertices[originalVertexIndex];
           const key = getKey(originalVertex);
           face[fv] = vertexIndices[key];
+        }
+      });
+
+      // update edge indices to use the deduplicated vertex indices
+      this.edges.forEach(edge => {
+        for (let ev = 0; ev < 2; ++ev) {
+          const originalVertexIndex = edge[ev];
+          const originalVertex = vertices[originalVertexIndex];
+          const key = getKey(originalVertex);
+          edge[ev] = vertexIndices[key];
         }
       });
 

--- a/src/webgl/p5.Geometry.js
+++ b/src/webgl/p5.Geometry.js
@@ -185,11 +185,13 @@ p5.Geometry = class Geometry {
     return n.mult(Math.asin(sinAlpha) / ln);
   }
   /**
- * computes smooth normals per vertex as an average of each
- * face.
- * @method computeNormals
- * @chainable
- */
+   * computes smooth normals per vertex as an average of each
+   * face.
+   * @method computeNormals
+   * @param {String} [shadingType] (optional) To specify the shading type ('FLAT' for flat shading or 'SMOOTH' for smooth shading).
+   * @param {Object} [settings={ roundToPrecision: 3 }] (optional) Additional settings object with the precision for rounding vertex coordinates (optional).
+   * @chainable
+   */
   computeNormals(shadingType = 'FLAT', { roundToPrecision = 3 } = {}) {
     const vertexNormals = this.vertexNormals;
     let vertices = this.vertices;

--- a/src/webgl/p5.Geometry.js
+++ b/src/webgl/p5.Geometry.js
@@ -190,11 +190,39 @@ p5.Geometry = class Geometry {
  * @method computeNormals
  * @chainable
  */
-  computeNormals() {
+  computeNormals(shadingType = 'FLAT', { roundToPrecision = 3 } = {}) {
     const vertexNormals = this.vertexNormals;
-    const vertices = this.vertices;
+    let vertices = this.vertices;
     const faces = this.faces;
     let iv;
+
+    if (shadingType === 'SMOOTH') {
+      const vertexIndices = {};
+      const uniqueVertices = [];
+
+      // loop through each vertex and add uniqueVertices
+      for (let i = 0; i < vertices.length; i++) {
+        const vertex = vertices[i];
+        const key = `${vertex.x.toFixed(roundToPrecision)},${vertex.y.toFixed(roundToPrecision)},${vertex.z.toFixed(roundToPrecision)}`;
+        if (vertexIndices[key] === undefined) {
+          vertexIndices[key] = uniqueVertices.length;
+          uniqueVertices.push(vertex);
+        }
+      }
+
+      // update face indices to use the new deduplicated vertex indices
+      faces.forEach(face => {
+        for (let fv = 0; fv < 3; ++fv) {
+          const originalVertexIndex = face[fv];
+          const originalVertex = vertices[originalVertexIndex];
+          const key = `${originalVertex.x.toFixed(roundToPrecision)},${originalVertex.y.toFixed(roundToPrecision)},${originalVertex.z.toFixed(roundToPrecision)}`;
+          face[fv] = vertexIndices[key];
+        }
+      });
+
+      // update the deduplicated vertices
+      vertices = uniqueVertices;
+    }
 
     // initialize the vertexNormals array with empty vectors
     vertexNormals.length = 0;

--- a/src/webgl/p5.Geometry.js
+++ b/src/webgl/p5.Geometry.js
@@ -9,6 +9,7 @@
 //some of the functions are adjusted from Three.js(http://threejs.org)
 
 import p5 from '../core/main';
+import * as constants from 'constants';
 /**
  * p5 Geometry class
  * @class p5.Geometry
@@ -186,13 +187,17 @@ p5.Geometry = class Geometry {
   }
   /**
    * This function calculates normals for each face, where each vertex's normal is the average of the normals of all faces it's connected to.
-   * i.e computes smooth normals per vertex as an average of each face.<br>
-   * When using 'FLAT' shading, vertices are disconnected/duplicated i.e each face has its own copy of vertices.<br>
-   * When using 'SMOOTH' shading, vertices are connected/deduplicated i.e each face has its vertices shared with other faces.<br>
+   * i.e computes smooth normals per vertex as an average of each face.
+   *
+   * When using `FLAT` shading, vertices are disconnected/duplicated i.e each face has its own copy of vertices.
+   * When using `SMOOTH` shading, vertices are connected/deduplicated i.e each face has its vertices shared with other faces.
+   *
+   * Options can include:
+   * - `roundToPrecision`: Precision value for rounding computations. Defaults to 3.
    *
    * @method computeNormals
-   * @param {String} [shadingType] shading type ('FLAT' for flat shading or 'SMOOTH' for smooth shading) for buildGeometry() outputs.
-   * @param {Object} [options] object with roundToPrecision property.
+   * @param {String} [shadingType] shading type (`FLAT` for flat shading or `SMOOTH` for smooth shading) for buildGeometry() outputs. Defaults to `FLAT`.
+   * @param {Object} [options] An optional object with configuration.
    * @chainable
    *
    * @example
@@ -206,11 +211,11 @@ p5.Geometry = class Geometry {
    *   helix = buildGeometry(() => {
    *     beginShape();
    *
-   *     for (let i = 0; i < TWO_PI * 3; i += 0.1) {
+   *     for (let i = 0; i < TWO_PI * 3; i += 0.6) {
    *       let radius = 20;
    *       let x = cos(i) * radius;
    *       let y = sin(i) * radius;
-   *       let z = i * 10;
+   *       let z = map(i, 0, TWO_PI * 3, -30, 30);
    *       vertex(x, y, z);
    *     }
    *     endShape();
@@ -222,6 +227,7 @@ p5.Geometry = class Geometry {
    *   stroke(0);
    *   fill(150, 200, 250);
    *   lights();
+   *   rotateX(PI*0.2);
    *   orbitControl();
    *   model(helix);
    * }
@@ -229,7 +235,7 @@ p5.Geometry = class Geometry {
    * </div>
    *
    * @alt
-   * A 3D helix using the computeNormals() function by default uses 'FLAT' to create a flat shading effect on the helix.
+   * A 3D helix using the computeNormals() function by default uses `FLAT` to create a flat shading effect on the helix.
    *
    * @example
    * <div>
@@ -257,13 +263,14 @@ p5.Geometry = class Geometry {
    *     }
    *     endShape(CLOSE);
    *   });
-   *   star.computeNormals('SMOOTH');
+   *   star.computeNormals(SMOOTH);
    * }
    * function draw() {
    *   background(255);
    *   stroke(0);
    *   fill(150, 200, 250);
    *   lights();
+   *   rotateX(PI*0.2);
    *   orbitControl();
    *   model(star);
    * }
@@ -271,16 +278,16 @@ p5.Geometry = class Geometry {
    * </div>
    *
    * @alt
-   * A star-like geometry, here the computeNormals('SMOOTH') is applied for a smooth shading effect.
+   * A star-like geometry, here the computeNormals(SMOOTH) is applied for a smooth shading effect.
    * This helps to avoid the faceted appearance that can occur with flat shading.
    */
-  computeNormals(shadingType = 'FLAT', { roundToPrecision = 3 } = {}) {
+  computeNormals(shadingType = constants.FLAT, { roundToPrecision = 3 } = {}) {
     const vertexNormals = this.vertexNormals;
     let vertices = this.vertices;
     const faces = this.faces;
     let iv;
 
-    if (shadingType === 'SMOOTH') {
+    if (shadingType === constants.SMOOTH) {
       const vertexIndices = {};
       const uniqueVertices = [];
 


### PR DESCRIPTION
<!--
  Thank you for contributing! Please use this pull request (PR) template.


 In the description field of this PR, include "resolves #XXXX" tagging the issue you are fixing. If this PR addresses the issue but doesn't completely resolve it (ie the issue should remain open after your PR is merged), write "addresses #XXXX".-->
Resolves #6494

Update `computeNormals` to support smooth shading feature for `buildGeometry` outputs by incorporating vertex deduplication. Additionally, a new setting object, roundToPrecision, to enable rounding of vertex coordinates, addressing potential slight differences in calculations. 

Changes:

- Added support to smooth shading for buildGeometry() outputs by vertex deduplication.
- Introduced the roundToPrecision setting for precise vertex coordinate rounding.
- Updated inline function docs for the both shadingType and settings object params


<!-- Add here what changes were made in this pull request and if possible provide links showcasing the changes. -->

<!-- If applicable, add screenshots depicting the changes. -->

#### PR Checklist
<!--
  To check any option, replace the "[ ]" with a "[x]". Be sure to check out how it looks in the Preview tab! Feel free to remove any portion of the template that is not relevant for your issue.
-->

- [x] `npm run lint` passes
- [x] [Inline documentation] is included / updated
- [ ] [Unit tests] are included / updated

[Inline documentation]: https://github.com/processing/p5.js/blob/main/contributor_docs/inline_documentation.md
[Unit tests]: https://github.com/processing/p5.js/tree/main/contributor_docs#unit-tests
