### PR TITLE
Fix typo in JSDoc of the createVector method #6569

### DIFF
--- a/src/math/math.js
+++ b/src/math/math.js
@@ -21,7 +21,7 @@ import p5 from '../core/main';
  * ball is moving straight up, its velocity vector points straight up. Adding
  * the ball's velocity vector to its position vector moves it, as in
  * `pos.add(vel)`. Vector math relies on methods inside the
- * <a href="#/p5.Vector">p5.Vector</a>` class.
+ * <a href="#/p5.Vector">p5.Vector</a> class.
  *
  * @method createVector
  * @param {Number} [x] x component of the vector.


### PR DESCRIPTION
<!--
  Thank you for contributing! Please use this pull request (PR) template.


 In the description field of this PR, include "resolves #XXXX" tagging the issue you are fixing. If this PR addresses the issue but doesn't completely resolve it (ie the issue should remain open after your PR is merged), write "addresses #XXXX".-->
Resolves #6569

 Changes:
<!-- Add here what changes were made in this pull request and if possible provide links showcasing the changes. -->

- Remove unnecessary backquote from JSDoc of the createVector description in src/math/math.js

 Screenshots of the change:
<!-- If applicable, add screenshots depicting the changes. -->

- Omitting screenshot because it's not related to visual change.

#### PR Checklist
<!--
  To check any option, replace the "[ ]" with a "[x]". Be sure to check out how it looks in the Preview tab! Feel free to remove any portion of the template that is not relevant for your issue.
-->

- [x] `npm run lint` passes
- [x] [Inline documentation] is included / updated
- [ ] [Unit tests] are included / updated

[Inline documentation]: https://github.com/processing/p5.js/blob/main/contributor_docs/inline_documentation.md
[Unit tests]: https://github.com/processing/p5.js/tree/main/contributor_docs#unit-tests
