### PR TITLE
Fixes incorrect reference to constants in p5.Geometry.js

### DIFF
--- a/src/webgl/p5.Geometry.js
+++ b/src/webgl/p5.Geometry.js
@@ -9,7 +9,7 @@
 //some of the functions are adjusted from Three.js(http://threejs.org)
 
 import p5 from '../core/main';
-import * as constants from 'constants';
+import * as constants from '../core/constants';
 /**
  * p5 Geometry class
  * @class p5.Geometry


### PR DESCRIPTION
<!--
  Thank you for contributing! Please use this pull request (PR) template.


 In the description field of this PR, include "resolves #XXXX" tagging the issue you are fixing. If this PR addresses the issue but doesn't completely resolve it (ie the issue should remain open after your PR is merged), write "addresses #XXXX".-->
Resolves #6566

 Changes:
Updated the import statement in p5.Geometry.js to import constants from '../core/constants'.
<!-- Add here what changes were made in this pull request and if possible provide links showcasing the changes. -->


 

#### PR Checklist
<!--
  To check any option, replace the "[ ]" with a "[x]". Be sure to check out how it looks in the Preview tab! Feel free to remove any portion of the template that is not relevant for your issue.
-->

- [x] `npm run lint` passes
- [ ] [Inline documentation] is included / updated
- [ ] [Unit tests] are included / updated

[Inline documentation]: https://github.com/processing/p5.js/blob/main/contributor_docs/inline_documentation.md
[Unit tests]: https://github.com/processing/p5.js/tree/main/contributor_docs#unit-tests
