### PR TITLE
Set interapolation to nearest when used in WebGL mode for noSmooth()

### DIFF
--- a/src/core/shape/attributes.js
+++ b/src/core/shape/attributes.js
@@ -100,6 +100,13 @@ p5.prototype.noSmooth = function() {
       this.drawingContext.imageSmoothingEnabled = false;
     }
   } else {
+    // Get the WebGL context
+    var gl = this._renderer.GL;
+
+    // Set texture interpolation to NEAREST
+    gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MIN_FILTER, gl.NEAREST);
+    gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MAG_FILTER, gl.NEAREST);
+
     this.setAttributes('antialias', false);
   }
   return this;


### PR DESCRIPTION
<!--
  Thank you for contributing! Please use this pull request (PR) template.


 In the description field of this PR, include "resolves #XXXX" tagging the issue you are fixing. If this PR addresses the issue but doesn't completely resolve it (ie the issue should remain open after your PR is merged), write "addresses #XXXX".-->
Addresses #6554 

 Changes:
<!-- Add here what changes were made in this pull request and if possible provide links showcasing the changes. -->
I have set interapolation to nearest for noSmooth() when used in WebGL Mode

 Screenshots of the change:
<!-- If applicable, add screenshots depicting the changes. -->

#### PR Checklist
<!--
  To check any option, replace the "[ ]" with a "[x]". Be sure to check out how it looks in the Preview tab! Feel free to remove any portion of the template that is not relevant for your issue.
-->

- [x] `npm run lint` passes
- [x] [Inline documentation] is included / updated
- [ ] [Unit tests] are included / updated

[Inline documentation]: https://github.com/processing/p5.js/blob/main/contributor_docs/inline_documentation.md
[Unit tests]: https://github.com/processing/p5.js/tree/main/contributor_docs#unit-tests
