### PR TITLE
Remove references to non-existant constant

### DIFF
--- a/src/core/p5.Renderer2D.js
+++ b/src/core/p5.Renderer2D.js
@@ -854,7 +854,7 @@ class Renderer2D extends p5.Renderer{
     }
     let i, j;
     const numVerts = vertices.length;
-    if (isCurve && (shapeKind === constants.POLYGON || shapeKind === null)) {
+    if (isCurve && shapeKind === null) {
       if (numVerts > 3) {
         const b = [],
           s = 1 - this._curveTightness;
@@ -890,7 +890,7 @@ class Renderer2D extends p5.Renderer{
       }
     } else if (
       isBezier &&
-    (shapeKind === constants.POLYGON || shapeKind === null)
+      shapeKind === null
     ) {
       if (!this._clipping) this.drawingContext.beginPath();
       for (i = 0; i < numVerts; i++) {
@@ -914,7 +914,7 @@ class Renderer2D extends p5.Renderer{
       this._doFillStrokeClose(closeShape);
     } else if (
       isQuadratic &&
-    (shapeKind === constants.POLYGON || shapeKind === null)
+      shapeKind === null
     ) {
       if (!this._clipping) this.drawingContext.beginPath();
       for (i = 0; i < numVerts; i++) {


### PR DESCRIPTION
<!--
  Thank you for contributing! Please use this pull request (PR) template.


 In the description field of this PR, include "resolves #XXXX" tagging the issue you are fixing. If this PR addresses the issue but doesn't completely resolve it (ie the issue should remain open after your PR is merged), write "addresses #XXXX".-->
Resolves #6565

 Changes:
Removed references to undeclared constant `constants.POLYGON` in core/p5.renderer2D.js as it had no effect on the code

#### PR Checklist
<!--
  To check any option, replace the "[ ]" with a "[x]". Be sure to check out how it looks in the Preview tab! Feel free to remove any portion of the template that is not relevant for your issue.
-->

- [x] `npm run lint` passes
- [ ] [Inline documentation] is included / updated
- [ ] [Unit tests] are included / updated