### PR TITLE
Stores the width and height values before any adjustments are made, Solves #6581

### DIFF
--- a/src/dom/dom.js
+++ b/src/dom/dom.js
@@ -3254,7 +3254,6 @@ p5.Element.prototype.size = function (w, h) {
     let aW = w;
     let aH = h;
     const AUTO = p5.prototype.AUTO;
-    
     if (aW !== AUTO || aH !== AUTO) {
       if (aW === AUTO) {
         aW = h * this.width / this.height;
@@ -3273,7 +3272,6 @@ p5.Element.prototype.size = function (w, h) {
         this.elt.setAttribute('height', aH * this._pInst._pixelDensity);
         this.elt.style.width = aW + 'px';
         this.elt.style.height = aH + 'px';
-        
         this._pInst.scale(this._pInst._pixelDensity, this._pInst._pixelDensity);
         for (prop in j) {
           this.elt.getContext('2d')[prop] = j[prop];
@@ -3284,11 +3282,8 @@ p5.Element.prototype.size = function (w, h) {
         this.elt.width = aW;
         this.elt.height = aH;
       }
-
-      
       this.width = aW;
       this.height = aH;
-
       if (this._pInst && this._pInst._curElement) {
         // main canvas associated with p5 instance
         if (this._pInst._curElement.elt === this.elt) {

--- a/src/dom/dom.js
+++ b/src/dom/dom.js
@@ -3254,6 +3254,8 @@ p5.Element.prototype.size = function (w, h) {
     let aW = w;
     let aH = h;
     const AUTO = p5.prototype.AUTO;
+    let originalWidth = aW;
+    let originalHeight = aH;
     if (aW !== AUTO || aH !== AUTO) {
       if (aW === AUTO) {
         aW = h * this.width / this.height;
@@ -3283,14 +3285,14 @@ p5.Element.prototype.size = function (w, h) {
         this.elt.height = aH;
       }
 
-      this.width = this.elt.offsetWidth;
-      this.height = this.elt.offsetHeight;
+      originalWidth = aW;
+      originalHeight = aH;
 
       if (this._pInst && this._pInst._curElement) {
         // main canvas associated with p5 instance
         if (this._pInst._curElement.elt === this.elt) {
-          this._pInst._setProperty('width', this.elt.offsetWidth);
-          this._pInst._setProperty('height', this.elt.offsetHeight);
+          this._pInst._setProperty('width', originalWidth);
+          this._pInst._setProperty('height', originalHeight);
         }
       }
     }

--- a/src/dom/dom.js
+++ b/src/dom/dom.js
@@ -3254,8 +3254,8 @@ p5.Element.prototype.size = function (w, h) {
     let aW = w;
     let aH = h;
     const AUTO = p5.prototype.AUTO;
-    let originalWidth = aW;
-    let originalHeight = aH;
+    let styleWidth= null;
+    let styleHeight = null;
     if (aW !== AUTO || aH !== AUTO) {
       if (aW === AUTO) {
         aW = h * this.width / this.height;
@@ -3274,25 +3274,31 @@ p5.Element.prototype.size = function (w, h) {
         this.elt.setAttribute('height', aH * this._pInst._pixelDensity);
         this.elt.style.width = aW + 'px';
         this.elt.style.height = aH + 'px';
+        this.elt.style.width = styleWidth;
+        this.elt.style.height = styleHeight;
         this._pInst.scale(this._pInst._pixelDensity, this._pInst._pixelDensity);
         for (prop in j) {
           this.elt.getContext('2d')[prop] = j[prop];
         }
       } else {
+        styleWidth = aW + 'px';
+        styleHeight = aH + 'px';
         this.elt.style.width = aW + 'px';
         this.elt.style.height = aH + 'px';
-        this.elt.width = aW;
-        this.elt.height = aH;
       }
 
-      originalWidth = aW;
-      originalHeight = aH;
+      this.elt.width = styleWidth; // Set elt.width to the recorded value
+      this.elt.height = styleHeight; // Set elt.height to the recorded value
+
+      
+      this.width = aW;
+      this.height = aH;
 
       if (this._pInst && this._pInst._curElement) {
         // main canvas associated with p5 instance
         if (this._pInst._curElement.elt === this.elt) {
-          this._pInst._setProperty('width', originalWidth);
-          this._pInst._setProperty('height', originalHeight);
+          this._pInst._setProperty('width', aW);
+          this._pInst._setProperty('height', aH);
         }
       }
     }

--- a/src/dom/dom.js
+++ b/src/dom/dom.js
@@ -3254,8 +3254,7 @@ p5.Element.prototype.size = function (w, h) {
     let aW = w;
     let aH = h;
     const AUTO = p5.prototype.AUTO;
-    let styleWidth= null;
-    let styleHeight = null;
+    
     if (aW !== AUTO || aH !== AUTO) {
       if (aW === AUTO) {
         aW = h * this.width / this.height;
@@ -3274,21 +3273,17 @@ p5.Element.prototype.size = function (w, h) {
         this.elt.setAttribute('height', aH * this._pInst._pixelDensity);
         this.elt.style.width = aW + 'px';
         this.elt.style.height = aH + 'px';
-        this.elt.style.width = styleWidth;
-        this.elt.style.height = styleHeight;
+        
         this._pInst.scale(this._pInst._pixelDensity, this._pInst._pixelDensity);
         for (prop in j) {
           this.elt.getContext('2d')[prop] = j[prop];
         }
       } else {
-        styleWidth = aW + 'px';
-        styleHeight = aH + 'px';
         this.elt.style.width = aW + 'px';
         this.elt.style.height = aH + 'px';
+        this.elt.width = aW;
+        this.elt.height = aH;
       }
-
-      this.elt.width = styleWidth; // Set elt.width to the recorded value
-      this.elt.height = styleHeight; // Set elt.height to the recorded value
 
       
       this.width = aW;


### PR DESCRIPTION

<!--
  Thank you for contributing! Please use this pull request (PR) template.


 In the description field of this PR, include "resolves #XXXX" tagging the issue you are fixing. If this PR addresses the issue but doesn't completely resolve it (ie the issue should remain open after your PR is merged), write "addresses #XXXX".-->
Resolves #6581 

 Changes:
<!-- Add here what changes were made in this pull request and if possible provide links showcasing the changes. -->
In this modification, I added `originalWidth` and `originalHeight` variables to store the width and height values before any adjustments are made. Later in the function, when setting the canvas width and height, I use these original values to update the canvas dimensions. This prevents the issue where the width and height are evaluated as 0 when the element is hidden. The snippet works just fine after the change.


 Snippet:
```
let movie;

function preload() {
	// my video is 640 x 360
	movie = createVideo("flyboard.mp4");
    movie.volume(0);
}

function setup() {
	createCanvas(640, 360);
	pixelDensity(1);
  
	movie.play();
    // Commenting this out makes it work
	movie.hide();
}

function draw() {
	background(220);
    // Commenting this out makes it work
    // (or moving it to setup it seems)
    movie.size(width, height);
    debugger
	image(movie, 0, 0);
}
```

<!-- If applicable, add screenshots depicting the changes. -->



#### PR Checklist
<!--
  To check any option, replace the "[ ]" with a "[x]". Be sure to check out how it looks in the Preview tab! Feel free to remove any portion of the template that is not relevant for your issue.
-->

- [x] `npm run lint` passes
- [ ] [Inline documentation] is included / updated
- [ ] [Unit tests] are included / updated

[Inline documentation]: https://github.com/processing/p5.js/blob/main/contributor_docs/inline_documentation.md
[Unit tests]: https://github.com/processing/p5.js/tree/main/contributor_docs#unit-tests
