### PR TITLE
Fix rotation properties being in degrees irrespective of angleMode

### DIFF
--- a/src/events/acceleration.js
+++ b/src/events/acceleration.js
@@ -656,60 +656,83 @@ p5.prototype._handleMotion = function() {
   }
 
   if (typeof context.deviceTurned === 'function') {
-    // The angles given by rotationX etc is from range -180 to 180.
-    // The following will convert them to 0 to 360 for ease of calculation
+    // The angles given by rotationX etc is from range [-180 to 180] or [-PI to PI].
+    // The following will convert them to [0 to 360] or [0 to 2*PI] for ease of calculation
     // of cases when the angles wrapped around.
     // _startAngleX will be converted back at the end and updated.
-    const wRX = this.rotationX + 180;
-    const wPRX = this.pRotationX + 180;
-    let wSAX = startAngleX + 180;
-    if ((wRX - wPRX > 0 && wRX - wPRX < 270) || wRX - wPRX < -270) {
+
+    // This is multiplied to all constant rotation values used in calculations
+    // to make the equations agnostic to the angleMode
+    let rotationMultipler = 1;
+    if(this._angleMode === constants.RADIANS) {
+      rotationMultipler = constants.DEG_TO_RAD;
+    }
+
+    const wRX = this.rotationX + (180 * rotationMultipler);
+    const wPRX = this.pRotationX + (180 * rotationMultipler);
+    let wSAX = startAngleX + (180 * rotationMultipler);
+    if (
+      (wRX - wPRX > 0 && wRX - wPRX < (270 * rotationMultipler)) ||
+      wRX - wPRX < (-270 * rotationMultipler)
+    ) {
       rotateDirectionX = 'clockwise';
-    } else if (wRX - wPRX < 0 || wRX - wPRX > 270) {
+    } else if (wRX - wPRX < 0 || wRX - wPRX > (270 * rotationMultipler)) {
       rotateDirectionX = 'counter-clockwise';
     }
     if (rotateDirectionX !== this.pRotateDirectionX) {
       wSAX = wRX;
     }
-    if (Math.abs(wRX - wSAX) > 90 && Math.abs(wRX - wSAX) < 270) {
+    if (
+      Math.abs(wRX - wSAX) > (90 * rotationMultipler) &&
+      Math.abs(wRX - wSAX) < (270 * rotationMultipler)
+    ) {
       wSAX = wRX;
       this._setProperty('turnAxis', 'X');
       context.deviceTurned();
     }
     this.pRotateDirectionX = rotateDirectionX;
-    startAngleX = wSAX - 180;
+    startAngleX = wSAX - (180 * rotationMultipler);
 
     // Y-axis is identical to X-axis except for changing some names.
-    const wRY = this.rotationY + 180;
-    const wPRY = this.pRotationY + 180;
-    let wSAY = startAngleY + 180;
-    if ((wRY - wPRY > 0 && wRY - wPRY < 270) || wRY - wPRY < -270) {
+    const wRY = this.rotationY + (180 * rotationMultipler);
+    const wPRY = this.pRotationY + (180 * rotationMultipler);
+    let wSAY = startAngleY + (180 * rotationMultipler);
+    if (
+      (wRY - wPRY > 0 && wRY - wPRY < (270 * rotationMultipler)) ||
+      wRY - wPRY < (-270 * rotationMultipler)
+    ) {
       rotateDirectionY = 'clockwise';
-    } else if (wRY - wPRY < 0 || wRY - this.pRotationY > 270) {
+    } else if (
+      wRY - wPRY < 0 ||
+      wRY - this.pRotationY > (270 * rotationMultipler)
+    ) {
       rotateDirectionY = 'counter-clockwise';
     }
     if (rotateDirectionY !== this.pRotateDirectionY) {
       wSAY = wRY;
     }
-    if (Math.abs(wRY - wSAY) > 90 && Math.abs(wRY - wSAY) < 270) {
+    if (
+      Math.abs(wRY - wSAY) > (90 * rotationMultipler) &&
+      Math.abs(wRY - wSAY) < (270 * rotationMultipler)
+    ) {
       wSAY = wRY;
       this._setProperty('turnAxis', 'Y');
       context.deviceTurned();
     }
     this.pRotateDirectionY = rotateDirectionY;
-    startAngleY = wSAY - 180;
+    startAngleY = wSAY - (180 * rotationMultipler);
 
     // Z-axis is already in the range 0 to 360
     // so no conversion is needed.
     if (
       (this.rotationZ - this.pRotationZ > 0 &&
-        this.rotationZ - this.pRotationZ < 270) ||
-      this.rotationZ - this.pRotationZ < -270
+        this.rotationZ - this.pRotationZ < (270 * rotationMultipler)) ||
+      this.rotationZ - this.pRotationZ < (-270 * rotationMultipler)
     ) {
       rotateDirectionZ = 'clockwise';
     } else if (
       this.rotationZ - this.pRotationZ < 0 ||
-      this.rotationZ - this.pRotationZ > 270
+      this.rotationZ - this.pRotationZ > (270 * rotationMultipler)
     ) {
       rotateDirectionZ = 'counter-clockwise';
     }
@@ -717,8 +740,8 @@ p5.prototype._handleMotion = function() {
       startAngleZ = this.rotationZ;
     }
     if (
-      Math.abs(this.rotationZ - startAngleZ) > 90 &&
-      Math.abs(this.rotationZ - startAngleZ) < 270
+      Math.abs(this.rotationZ - startAngleZ) > (90 * rotationMultipler) &&
+      Math.abs(this.rotationZ - startAngleZ) < (270 * rotationMultipler)
     ) {
       startAngleZ = this.rotationZ;
       this._setProperty('turnAxis', 'Z');

--- a/src/events/acceleration.js
+++ b/src/events/acceleration.js
@@ -619,7 +619,7 @@ p5.prototype.setShakeThreshold = function(val) {
 
 p5.prototype._ondeviceorientation = function(e) {
   this._updatePRotations();
-  if (this._angleMode === constants.radians) {
+  if (this._angleMode === constants.RADIANS) {
     e.beta = e.beta * (_PI / 180.0);
     e.gamma = e.gamma * (_PI / 180.0);
     e.alpha = e.alpha * (_PI / 180.0);

--- a/src/events/acceleration.js
+++ b/src/events/acceleration.js
@@ -619,14 +619,14 @@ p5.prototype.setShakeThreshold = function(val) {
 
 p5.prototype._ondeviceorientation = function(e) {
   this._updatePRotations();
+
+  let multiplier = 1;
   if (this._angleMode === constants.RADIANS) {
-    e.beta = e.beta * (_PI / 180.0);
-    e.gamma = e.gamma * (_PI / 180.0);
-    e.alpha = e.alpha * (_PI / 180.0);
+    multiplier = constants.PI / 180.0;
   }
-  this._setProperty('rotationX', e.beta);
-  this._setProperty('rotationY', e.gamma);
-  this._setProperty('rotationZ', e.alpha);
+  this._setProperty('rotationX', e.beta * multiplier);
+  this._setProperty('rotationY', e.gamma * multiplier);
+  this._setProperty('rotationZ', e.alpha * multiplier);
   this._handleMotion();
 };
 p5.prototype._ondevicemotion = function(e) {

--- a/src/math/trigonometry.js
+++ b/src/math/trigonometry.js
@@ -407,6 +407,25 @@ p5.prototype.angleMode = function(mode) {
   if (typeof mode === 'undefined') {
     return this._angleMode;
   } else if (mode === constants.DEGREES || mode === constants.RADIANS) {
+    const prevMode = this._angleMode;
+
+    // No change
+    if(mode === prevMode) return;
+
+    // Otherwise adjust pRotation according to new mode
+    // This is necessary for acceleration events to work properly
+    if(mode === constants.RADIANS) {
+      // Change pRotation to radians
+      this._setProperty('pRotationX', this.pRotationX * constants.DEG_TO_RAD);
+      this._setProperty('pRotationY', this.pRotationY * constants.DEG_TO_RAD);
+      this._setProperty('pRotationZ', this.pRotationZ * constants.DEG_TO_RAD);
+    } else {
+      // Change pRotation to degrees
+      this._setProperty('pRotationX', this.pRotationX * constants.RAD_TO_DEG);
+      this._setProperty('pRotationY', this.pRotationY * constants.RAD_TO_DEG);
+      this._setProperty('pRotationZ', this.pRotationZ * constants.RAD_TO_DEG);
+    }
+
     this._angleMode = mode;
   }
 };

--- a/src/math/trigonometry.js
+++ b/src/math/trigonometry.js
@@ -475,4 +475,19 @@ p5.prototype._fromRadians = function(angle) {
   return angle;
 };
 
+/**
+ * converts angles from DEGREES into the current angleMode
+ *
+ * @method _fromDegrees
+ * @private
+ * @param {Number} angle
+ * @returns {Number}
+ */
+p5.prototype._fromDegrees = function(angle) {
+  if (this._angleMode === constants.RADIANS) {
+    return angle * constants.DEG_TO_RAD;
+  }
+  return angle;
+};
+
 export default p5;

--- a/test/unit/events/acceleration.js
+++ b/test/unit/events/acceleration.js
@@ -75,15 +75,15 @@ suite('Acceleration Events', function() {
   suite('rotation', function() {
     test('rotationX should be 45', function() {
       window.dispatchEvent(deviceOrientationEvent1);
-      assert.strictEqual(myp5.rotationX, 45);
+      assert.strictEqual(myp5.rotationX, 45 * (Math.PI / 180.0));
     });
     test('rotationY should be 90', function() {
       window.dispatchEvent(deviceOrientationEvent1);
-      assert.strictEqual(myp5.rotationY, 90);
+      assert.strictEqual(myp5.rotationY, 90 * (Math.PI / 180.0));
     });
     test('rotationZ should be 10', function() {
       window.dispatchEvent(deviceOrientationEvent1);
-      assert.strictEqual(myp5.rotationZ, 10);
+      assert.strictEqual(myp5.rotationZ, 10 * (Math.PI / 180.0));
     });
   });
 
@@ -91,17 +91,17 @@ suite('Acceleration Events', function() {
     test('pRotationX should be 45', function() {
       window.dispatchEvent(deviceOrientationEvent1);
       window.dispatchEvent(deviceOrientationEvent2);
-      assert.strictEqual(myp5.pRotationX, 45);
+      assert.strictEqual(myp5.pRotationX, 45 * (Math.PI / 180.0));
     });
     test('pRotationY should be 90', function() {
       window.dispatchEvent(deviceOrientationEvent1);
       window.dispatchEvent(deviceOrientationEvent2);
-      assert.strictEqual(myp5.pRotationY, 90);
+      assert.strictEqual(myp5.pRotationY, 90 * (Math.PI / 180.0));
     });
     test('pRotationZ should be 10', function() {
       window.dispatchEvent(deviceOrientationEvent1);
       window.dispatchEvent(deviceOrientationEvent2);
-      assert.strictEqual(myp5.pRotationZ, 10);
+      assert.strictEqual(myp5.pRotationZ, 10 * (Math.PI / 180.0));
     });
   });
 


### PR DESCRIPTION
Resolves #6565

 Changes:  
 
1. Fixing the incorrectly lowercased reference to `constants.RADIANS` at
https://github.com/processing/p5.js/blob/773eb0d4aaee30238b15d53c955272ac6c53d806/src/events/acceleration.js#L622
This was also casuing rotation and pRotation properties being in degrees irrespective of the `_angleMode`.

2. Changes to `_handleMotion` function were made to make it work with both degree and radian values.

3. Changes in unit tests related to rotation were made as they expected degree values despite the default mode being radian.

4. The `angleMode` method in math/trigonometry.js was also changed to update pRotation properties when the mode is changed, this is needed because otherwise the units of rotation and pRotation could end up different, which may cause the `deviceTurned` event to fire incorrectly.

#### PR Checklist
- [x] `npm run lint` passes
- [ ] [Inline documentation] is included / updated
- [x] [Unit tests] are included / updated
