### PR TITLE
Fix rounding of values close to 0 when computing smooth normals

### DIFF
--- a/src/webgl/p5.Geometry.js
+++ b/src/webgl/p5.Geometry.js
@@ -291,8 +291,10 @@ p5.Geometry = class Geometry {
       const vertexIndices = {};
       const uniqueVertices = [];
 
+      const power = Math.pow(10, roundToPrecision);
+      const rounded = val => Math.round(val * power) / power;
       const getKey = vert =>
-        `${vert.x.toFixed(roundToPrecision)},${vert.y.toFixed(roundToPrecision)},${vert.z.toFixed(roundToPrecision)}`;
+        `${rounded(vert.x)},${rounded(vert.y)},${rounded(vert.z)}`;
 
       // loop through each vertex and add uniqueVertices
       for (let i = 0; i < vertices.length; i++) {


### PR DESCRIPTION
Resolves #6590

### Changes
I've updated the function to compute if vertices are the same to use rounding rather than `toFixed`.

Let's say you have two vertices, one at x=-1e-8 and one at x=1e-8. Previouisly, using `toFixed`, these values become `-0.000` and `0.000`, which are different strings, so they don't end up equal. After this change, both end up `0`.

### Screenshots of the change

Updated version of the sketch in the issue:
https://editor.p5js.org/davepagurek/sketches/WJ4DtuCcV

<img width="220" alt="image" src="https://github.com/processing/p5.js/assets/5315059/b5184c8b-8367-44b9-9797-e40cf3bf8689">


#### PR Checklist
<!--
  To check any option, replace the "[ ]" with a "[x]". Be sure to check out how it looks in the Preview tab! Feel free to remove any portion of the template that is not relevant for your issue.
-->

- [x] `npm run lint` passes
- [ ] [Inline documentation] is included / updated
- [ ] [Unit tests] are included / updated
