### PR TITLE
lights()  and specularMaterial() support on framebuffer block when filter is applied inside the block.

### DIFF
--- a/src/webgl/p5.Geometry.js
+++ b/src/webgl/p5.Geometry.js
@@ -103,7 +103,7 @@ p5.Geometry = class Geometry {
    * let points = [];
    *
    * function setup() {
-   *   createCanvas(600, 600, WEBGL);
+   *   createCanvas(100, 100, WEBGL);
    *   points.push(new p5.Vector(-1, -1, 0), new p5.Vector(-1, 1, 0),
    *     new p5.Vector(1, -1, 0), new p5.Vector(-1, -1, 0));
    *   buildShape01();

--- a/src/webgl/p5.RendererGL.js
+++ b/src/webgl/p5.RendererGL.js
@@ -1095,6 +1095,7 @@ p5.RendererGL = class RendererGL extends p5.Renderer {
         this.filterShader.setUniform('tex0', target);
         this._pInst.clear();
         this._pInst.shader(this.filterShader);
+        this._pInst.noLights();
         this._pInst.rect(-target.width / 2,
           -target.height / 2, target.width, target.height);
       });
@@ -1105,6 +1106,7 @@ p5.RendererGL = class RendererGL extends p5.Renderer {
         this.filterShader.setUniform('tex0', tmp);
         this._pInst.clear();
         this._pInst.shader(this.filterShader);
+        this._pInst.noLights();
         this._pInst.rect(-target.width / 2,
           -target.height / 2, target.width, target.height);
       });
@@ -1122,6 +1124,7 @@ p5.RendererGL = class RendererGL extends p5.Renderer {
         // filterParameter uniform only used for POSTERIZE, and THRESHOLD
         // but shouldn't hurt to always set
         this.filterShader.setUniform('filterParameter', filterParameter);
+        this._pInst.noLights();
         this._pInst.rect(-target.width / 2, -target.height / 2,
           target.width, target.height);
       });


### PR DESCRIPTION
<!--
  Thank you for contributing! Please use this pull request (PR) template.


 In the description field of this PR, include "resolves  #6595 " tagging the issue you are fixing. If this PR addresses the issue but doesn't completely resolve it (ie the issue should remain open after your PR is merged), write "addresses #6595 ".-->
Resolves #6595 

 Changes:

This pull request addresses the inconsistency observed when using lights() and specularmaterial() within the framebuffer block, specifically when the filter() function is applied internally. The proposed changes ensure that lights and materials behave as expected within the framebuffer block, enhancing overall rendering consistency.

 Screenshots of the change:
before:- 
![fixes-blur](https://github.com/processing/p5.js/assets/127239756/e3df5b92-69ba-4715-bbf6-960e7713233e)
after:-
![fixes-after](https://github.com/processing/p5.js/assets/127239756/32e8fbfb-1798-4309-a3f5-59cecda8f223)



#### PR Checklist
<!--
  To check any option, replace the "[ ]" with a "[x]". Be sure to check out how it looks in the Preview tab! Feel free to remove any portion of the template that is not relevant for your issue.
-->

- [x] `npm run lint` passes
- [ ] [Inline documentation] is included / updated
- [ ] [Unit tests] are included / updated

[Inline documentation]: https://github.com/processing/p5.js/blob/main/contributor_docs/inline_documentation.md
[Unit tests]: https://github.com/processing/p5.js/tree/main/contributor_docs#unit-tests
