### PR TITLE
Fix filter shaders when rectMode is applied; add tests

### DIFF
--- a/src/image/pixels.js
+++ b/src/image/pixels.js
@@ -307,6 +307,11 @@ p5.prototype._copyHelper = (
     syMod = srcImage.height / 2;
   }
   if (dstImage._renderer && dstImage._renderer.isP3D) {
+    dstImage.push();
+    dstImage.resetMatrix();
+    dstImage.noLights();
+    dstImage.blendMode(dstImage.BLEND);
+    dstImage.imageMode(dstImage.CORNER);
     p5.RendererGL.prototype.image.call(
       dstImage._renderer,
       srcImage,
@@ -319,6 +324,7 @@ p5.prototype._copyHelper = (
       dw,
       dh
     );
+    dstImage.pop();
   } else {
     dstImage.drawingContext.drawImage(
       srcImage.canvas,
@@ -613,7 +619,14 @@ p5.prototype.filter = function(...args) {
     filterGraphicsLayer.filter(...args);
 
     // copy secondary webgl renderer back to original p2d canvas
-    this._renderer._pInst.image(filterGraphicsLayer, 0, 0);
+    this.copy(
+      // src
+      filterGraphicsLayer._renderer,
+      // src coods
+      0, 0, this.width, this.height,
+      // dest coords
+      0, 0, this.width, this.height
+    );
     filterGraphicsLayer.clear(); // prevent feedback effects on p2d canvas
   }
 };

--- a/src/webgl/p5.Framebuffer.js
+++ b/src/webgl/p5.Framebuffer.js
@@ -175,6 +175,7 @@ class Framebuffer {
 
     const prevCam = this.target._renderer._curCamera;
     this.defaultCamera = this.createCamera();
+    this.filterCamera = this.createCamera();
     this.target._renderer._curCamera = prevCam;
 
     this.draw(() => this.target.clear());

--- a/src/webgl/p5.RendererGL.js
+++ b/src/webgl/p5.RendererGL.js
@@ -1064,10 +1064,6 @@ p5.RendererGL = class RendererGL extends p5.Renderer {
     // Resize the framebuffer 'fbo' and adjust its pixel density if it doesn't match the target.
     this.matchSize(fbo, target);
 
-    // Set filterCamera for framebuffers.
-    if (target !== this) {
-      this.filterCamera = this.getFilterLayer().createCamera();
-    }
     fbo.draw(() => this._pInst.clear()); // prevent undesirable feedback effects accumulating secretly.
 
     let texelSize = [
@@ -1084,6 +1080,7 @@ p5.RendererGL = class RendererGL extends p5.Renderer {
       // setup
       this._pInst.push();
       this._pInst.noStroke();
+      this._pInst.blendMode(constants.BLEND);
 
       // draw main to temp buffer
       this._pInst.shader(this.filterShader);
@@ -1098,8 +1095,7 @@ p5.RendererGL = class RendererGL extends p5.Renderer {
         this._pInst.clear();
         this._pInst.shader(this.filterShader);
         this._pInst.noLights();
-        this._pInst.rect(-target.width / 2,
-          -target.height / 2, target.width, target.height);
+        this._pInst.plane(target.width, target.height);
       });
 
       // Vert pass: draw `tmp` to `fbo`
@@ -1109,8 +1105,7 @@ p5.RendererGL = class RendererGL extends p5.Renderer {
         this._pInst.clear();
         this._pInst.shader(this.filterShader);
         this._pInst.noLights();
-        this._pInst.rect(-target.width / 2,
-          -target.height / 2, target.width, target.height);
+        this._pInst.plane(target.width, target.height);
       });
 
       this._pInst.pop();
@@ -1119,6 +1114,7 @@ p5.RendererGL = class RendererGL extends p5.Renderer {
     else {
       fbo.draw(() => {
         this._pInst.noStroke();
+        this._pInst.blendMode(constants.BLEND);
         this._pInst.shader(this.filterShader);
         this.filterShader.setUniform('tex0', target);
         this.filterShader.setUniform('texelSize', texelSize);
@@ -1127,8 +1123,7 @@ p5.RendererGL = class RendererGL extends p5.Renderer {
         // but shouldn't hurt to always set
         this.filterShader.setUniform('filterParameter', filterParameter);
         this._pInst.noLights();
-        this._pInst.rect(-target.width / 2, -target.height / 2,
-          target.width, target.height);
+        this._pInst.plane(target.width, target.height);
       });
 
     }
@@ -1139,8 +1134,8 @@ p5.RendererGL = class RendererGL extends p5.Renderer {
     this._pInst.push();
     this._pInst.imageMode(constants.CORNER);
     this._pInst.blendMode(constants.BLEND);
-    this.filterCamera._resize();
-    this._pInst.setCamera(this.filterCamera);
+    target.filterCamera._resize();
+    this._pInst.setCamera(target.filterCamera);
     this._pInst.resetMatrix();
     this._pInst.image(fbo, -this.width / 2, -this.height / 2,
       this.width, this.height);


### PR DESCRIPTION
<!--
  Thank you for contributing! Please use this pull request (PR) template.


 In the description field of this PR, include "resolves #XXXX" tagging the issue you are fixing. If this PR addresses the issue but doesn't completely resolve it (ie the issue should remain open after your PR is merged), write "addresses #XXXX".-->
Resolves #6602

### Changes:
- Uses `rect()` instead of `image()` to avoid `rectMode` compatibility issues
- Removes a test that was reliant on the `rect` implementation
- Added tests to make sure results look the same regardless of the renderer, rect mode, image mode, and blend mode
- Fixed some other minor bugs that came up in the test cases
- Small refactor to give framebuffers their own filter camera so we don't create a new camera every frame

### Screenshots of the change:
Before:
![image](https://github.com/processing/p5.js/assets/5315059/5cdbc019-0278-4b57-a89e-3bcd8d52eee4)

After:
![image](https://github.com/processing/p5.js/assets/5315059/ecef1cd0-a3f4-4188-9583-e6adcfd5dae6)


#### PR Checklist
<!--
  To check any option, replace the "[ ]" with a "[x]". Be sure to check out how it looks in the Preview tab! Feel free to remove any portion of the template that is not relevant for your issue.
-->

- [x] `npm run lint` passes
- [ ] [Inline documentation] is included / updated
- [x] [Unit tests] are included / updated

[Inline documentation]: https://github.com/processing/p5.js/blob/main/contributor_docs/inline_documentation.md
[Unit tests]: https://github.com/processing/p5.js/tree/main/contributor_docs#unit-tests
