### PR TITLE
Refactor vertex functions for composite paths

### DIFF
--- a/src/core/p5.Renderer2D.js
+++ b/src/core/p5.Renderer2D.js
@@ -867,266 +867,33 @@ class Renderer2D extends p5.Renderer {
 
   endShape(
     mode,
-    vertices,
     isCurve,
     isBezier,
     isQuadratic,
     isContour,
-    shapeKind
+    shapeKind,
+    allVertsObj,
+    currentContour,
+    closeShape
   ) {
-    if (vertices.length === 0) {
-      return this;
+    let initialVertex = allVertsObj[0];
+    allVertsObj.currentCoordinates = initialVertex.coordinates;
+    this.drawingContext.moveTo(...allVertsObj.currentCoordinates);
+
+    for (const vert of allVertsObj) {
+      vert.addToCanvasPath(this.drawingContext);
+      allVertsObj.currentCoordinates = vert.coordinates;
     }
-    if (!this._doStroke && !this._doFill) {
-      return this;
-    }
-    const closeShape = mode === constants.CLOSE;
-    let v;
-    if (closeShape && !isContour) {
-      vertices.push(vertices[0]);
-    }
-    let i, j;
-    const numVerts = vertices.length;
-    if (isCurve && shapeKind === null) {
-      if (numVerts > 3) {
-        const b = [],
-          s = 1 - this._curveTightness;
-        if (!this._clipping) this.drawingContext.beginPath();
-        this.drawingContext.moveTo(vertices[1][0], vertices[1][1]);
-        for (i = 1; i + 2 < numVerts; i++) {
-          v = vertices[i];
-          b[0] = [v[0], v[1]];
-          b[1] = [
-            v[0] + (s * vertices[i + 1][0] - s * vertices[i - 1][0]) / 6,
-            v[1] + (s * vertices[i + 1][1] - s * vertices[i - 1][1]) / 6
-          ];
-          b[2] = [
-            vertices[i + 1][0] +
-            (s * vertices[i][0] - s * vertices[i + 2][0]) / 6,
-            vertices[i + 1][1] +
-            (s * vertices[i][1] - s * vertices[i + 2][1]) / 6
-          ];
-          b[3] = [vertices[i + 1][0], vertices[i + 1][1]];
-          this.drawingContext.bezierCurveTo(
-            b[1][0],
-            b[1][1],
-            b[2][0],
-            b[2][1],
-            b[3][0],
-            b[3][1]
-          );
-        }
-        if (closeShape) {
-          this.drawingContext.lineTo(vertices[i + 1][0], vertices[i + 1][1]);
-        }
-        this._doFillStrokeClose(closeShape);
-      }
-    } else if (
-      isBezier &&
-      shapeKind === null
-    ) {
-      if (!this._clipping) this.drawingContext.beginPath();
-      for (i = 0; i < numVerts; i++) {
-        if (vertices[i].isVert) {
-          if (vertices[i].moveTo) {
-            this.drawingContext.moveTo(vertices[i][0], vertices[i][1]);
-          } else {
-            this.drawingContext.lineTo(vertices[i][0], vertices[i][1]);
-          }
-        } else {
-          this.drawingContext.bezierCurveTo(
-            vertices[i][0],
-            vertices[i][1],
-            vertices[i][2],
-            vertices[i][3],
-            vertices[i][4],
-            vertices[i][5]
-          );
-        }
-      }
-      this._doFillStrokeClose(closeShape);
-    } else if (
-      isQuadratic &&
-      shapeKind === null
-    ) {
-      if (!this._clipping) this.drawingContext.beginPath();
-      for (i = 0; i < numVerts; i++) {
-        if (vertices[i].isVert) {
-          if (vertices[i].moveTo) {
-            this.drawingContext.moveTo(vertices[i][0], vertices[i][1]);
-          } else {
-            this.drawingContext.lineTo(vertices[i][0], vertices[i][1]);
-          }
-        } else {
-          this.drawingContext.quadraticCurveTo(
-            vertices[i][0],
-            vertices[i][1],
-            vertices[i][2],
-            vertices[i][3]
-          );
-        }
-      }
-      this._doFillStrokeClose(closeShape);
-    } else {
-      if (shapeKind === constants.POINTS) {
-        for (i = 0; i < numVerts; i++) {
-          v = vertices[i];
-          if (this._doStroke) {
-            this._pInst.stroke(v[6]);
-          }
-          this._pInst.point(v[0], v[1]);
-        }
-      } else if (shapeKind === constants.LINES) {
-        for (i = 0; i + 1 < numVerts; i += 2) {
-          v = vertices[i];
-          if (this._doStroke) {
-            this._pInst.stroke(vertices[i + 1][6]);
-          }
-          this._pInst.line(v[0], v[1], vertices[i + 1][0], vertices[i + 1][1]);
-        }
-      } else if (shapeKind === constants.TRIANGLES) {
-        for (i = 0; i + 2 < numVerts; i += 3) {
-          v = vertices[i];
-          if (!this._clipping) this.drawingContext.beginPath();
-          this.drawingContext.moveTo(v[0], v[1]);
-          this.drawingContext.lineTo(vertices[i + 1][0], vertices[i + 1][1]);
-          this.drawingContext.lineTo(vertices[i + 2][0], vertices[i + 2][1]);
-          this.drawingContext.closePath();
-          if (!this._clipping && this._doFill) {
-            this._pInst.fill(vertices[i + 2][5]);
-            this.drawingContext.fill();
-          }
-          if (!this._clipping && this._doStroke) {
-            this._pInst.stroke(vertices[i + 2][6]);
-            this.drawingContext.stroke();
-          }
-        }
-      } else if (shapeKind === constants.TRIANGLE_STRIP) {
-        for (i = 0; i + 1 < numVerts; i++) {
-          v = vertices[i];
-          if (!this._clipping) this.drawingContext.beginPath();
-          this.drawingContext.moveTo(vertices[i + 1][0], vertices[i + 1][1]);
-          this.drawingContext.lineTo(v[0], v[1]);
-          if (!this._clipping && this._doStroke) {
-            this._pInst.stroke(vertices[i + 1][6]);
-          }
-          if (!this._clipping && this._doFill) {
-            this._pInst.fill(vertices[i + 1][5]);
-          }
-          if (i + 2 < numVerts) {
-            this.drawingContext.lineTo(vertices[i + 2][0], vertices[i + 2][1]);
-            if (!this._clipping && this._doStroke) {
-              this._pInst.stroke(vertices[i + 2][6]);
-            }
-            if (!this._clipping && this._doFill) {
-              this._pInst.fill(vertices[i + 2][5]);
-            }
-          }
-          this._doFillStrokeClose(closeShape);
-        }
-      } else if (shapeKind === constants.TRIANGLE_FAN) {
-        if (numVerts > 2) {
-          // For performance reasons, try to batch as many of the
-          // fill and stroke calls as possible.
-          if (!this._clipping) this.drawingContext.beginPath();
-          for (i = 2; i < numVerts; i++) {
-            v = vertices[i];
-            this.drawingContext.moveTo(vertices[0][0], vertices[0][1]);
-            this.drawingContext.lineTo(vertices[i - 1][0], vertices[i - 1][1]);
-            this.drawingContext.lineTo(v[0], v[1]);
-            this.drawingContext.lineTo(vertices[0][0], vertices[0][1]);
-            // If the next colour is going to be different, stroke / fill now
-            if (i < numVerts - 1) {
-              if (
-                (this._doFill && v[5] !== vertices[i + 1][5]) ||
-                (this._doStroke && v[6] !== vertices[i + 1][6])
-              ) {
-                if (!this._clipping && this._doFill) {
-                  this._pInst.fill(v[5]);
-                  this.drawingContext.fill();
-                  this._pInst.fill(vertices[i + 1][5]);
-                }
-                if (!this._clipping && this._doStroke) {
-                  this._pInst.stroke(v[6]);
-                  this.drawingContext.stroke();
-                  this._pInst.stroke(vertices[i + 1][6]);
-                }
-                this.drawingContext.closePath();
-                if (!this._clipping) this.drawingContext.beginPath(); // Begin the next one
-              }
-            }
-          }
-          this._doFillStrokeClose(closeShape);
-        }
-      } else if (shapeKind === constants.QUADS) {
-        for (i = 0; i + 3 < numVerts; i += 4) {
-          v = vertices[i];
-          if (!this._clipping) this.drawingContext.beginPath();
-          this.drawingContext.moveTo(v[0], v[1]);
-          for (j = 1; j < 4; j++) {
-            this.drawingContext.lineTo(vertices[i + j][0], vertices[i + j][1]);
-          }
-          this.drawingContext.lineTo(v[0], v[1]);
-          if (!this._clipping && this._doFill) {
-            this._pInst.fill(vertices[i + 3][5]);
-          }
-          if (!this._clipping && this._doStroke) {
-            this._pInst.stroke(vertices[i + 3][6]);
-          }
-          this._doFillStrokeClose(closeShape);
-        }
-      } else if (shapeKind === constants.QUAD_STRIP) {
-        if (numVerts > 3) {
-          for (i = 0; i + 1 < numVerts; i += 2) {
-            v = vertices[i];
-            if (!this._clipping) this.drawingContext.beginPath();
-            if (i + 3 < numVerts) {
-              this.drawingContext.moveTo(
-                vertices[i + 2][0], vertices[i + 2][1]);
-              this.drawingContext.lineTo(v[0], v[1]);
-              this.drawingContext.lineTo(
-                vertices[i + 1][0], vertices[i + 1][1]);
-              this.drawingContext.lineTo(
-                vertices[i + 3][0], vertices[i + 3][1]);
-              if (!this._clipping && this._doFill) {
-                this._pInst.fill(vertices[i + 3][5]);
-              }
-              if (!this._clipping && this._doStroke) {
-                this._pInst.stroke(vertices[i + 3][6]);
-              }
-            } else {
-              this.drawingContext.moveTo(v[0], v[1]);
-              this.drawingContext.lineTo(
-                vertices[i + 1][0], vertices[i + 1][1]);
-            }
-            this._doFillStrokeClose(closeShape);
-          }
-        }
-      } else {
-        if (!this._clipping) this.drawingContext.beginPath();
-        this.drawingContext.moveTo(vertices[0][0], vertices[0][1]);
-        for (i = 1; i < numVerts; i++) {
-          v = vertices[i];
-          if (v.isVert) {
-            if (v.moveTo) {
-              if (closeShape) this.drawingContext.closePath();
-              this.drawingContext.moveTo(v[0], v[1]);
-            } else {
-              this.drawingContext.lineTo(v[0], v[1]);
-            }
-          }
-        }
-        this._doFillStrokeClose(closeShape);
-      }
-    }
+    this._doFillStrokeClose(closeShape);
+
     isCurve = false;
     isBezier = false;
     isQuadratic = false;
     isContour = false;
-    if (closeShape) {
-      vertices.pop();
-    }
 
+    if (closeShape) {
+      currentContour.segmentss.pop();
+    }
     return this;
   }
   //////////////////////////////////////////////

--- a/src/core/shape/shape.js
+++ b/src/core/shape/shape.js
@@ -1,0 +1,158 @@
+export class Shape {
+  constructor() {
+    this.contours = [];
+  }
+
+  addContour(c) {
+    this.contours.push(c);
+  }
+
+  get contourss() {
+    return this.contours;
+  }
+}
+
+export class Contour {
+  constructor(firstVertex = null) {
+    this.firstVertex = firstVertex;
+    //contourVertices/Segments
+    this.segments = [];
+  }
+
+  get segmentss() {
+    return this.segments;
+  }
+
+  get firstSegment() {
+    return this.segments[0];
+  }
+
+  addSegment(segment) {
+    this.segments.push(segment);
+  }
+}
+
+export class ContourSegment {
+  constructor() {
+    // this.index = index;
+  }
+
+  getStartVertex() {
+    // logic to retrieve start vertex
+  }
+
+  getEndVertex() {
+    // logic to retrieve end vertex
+  }
+
+  accept(visitor) {
+    // logic to accept a visitor
+  }
+}
+
+export class ContourSegment2D extends ContourSegment {
+  constructor() {
+    super();
+    this.vertices = [];
+  }
+  addVertex(vertex) {
+    this.vertices.push(vertex);
+  }
+  get verticess() {
+    return this.vertices;
+  }
+}
+
+export class Vertex {
+  constructor(vert) {
+    this.data = vert;
+  }
+
+  get coordinates() {
+    return [this.data[0], this.data[1]];
+  }
+
+  addToCanvasPath(drawingContext) {
+    drawingContext.lineTo(this.data[0], this.data[1]);
+  }
+}
+
+
+export class BezierVertex {
+  constructor(vert) {
+    this.data = vert;
+  }
+
+  get coordinates() {
+    return this.data.slice(-2);
+  }
+
+  addToCanvasPath(drawingContext) {
+    drawingContext.bezierCurveTo(...this.data);
+  }
+}
+
+export class QuadraticVertex {
+  constructor(vert) {
+    this.data = vert;
+  }
+
+  get coordinates() {
+    return this.data.slice(-2);
+  }
+
+  addToCanvasPath(drawingContext) {
+    drawingContext.quadraticCurveTo(...this.data);
+  }
+}
+
+
+export class CurveVertex {
+  constructor(x, y) {
+    this.data = [x, y];
+    this.type = 'curveVertex';
+  }
+
+  get coordinates() {
+    let isComplete = this.data.length >= 8;
+    let secondToLastPoint = this.data.slice(-4, -2);
+
+    if(isComplete) {
+      return secondToLastPoint;
+    }
+    else {
+      return null;
+    }
+  }
+
+  addToCanvasPath(drawingContext) {
+    let bezierArrays = catmullRomToBezier(this.data, 0);
+    for (const arr of bezierArrays) {
+      drawingContext.bezierCurveTo(...arr);
+    }
+  }
+}
+
+function catmullRomToBezier(vertices, tightness) {
+  let X0, Y0, X1, Y1, X2, Y2, X3, Y3;
+  let s = 1 - tightness;
+  let bezX1, bezY1, bezX2, bezY2, bezX3, bezY3;
+  let bezArrays = [];
+
+  for (let i = 2; i + 4 < vertices.length; i+= 2) {
+    [X0, Y0, X1, Y1, X2, Y2, X3, Y3] = vertices.slice(i - 2, i + 6);
+
+    bezX1 = X1 + (s * X2 - s * X0) / 6;
+    bezY1 = Y1 + (s * Y2 - s * Y0) / 6;
+
+    bezX2 = X2 + (s * X1 - s * X3) / 6;
+    bezY2 = Y2 + (s * Y1 - s * Y3) / 6;
+
+    bezX3 = X2;
+    bezY3 = Y2;
+
+    bezArrays.push([bezX1, bezY1, bezX2, bezY2, bezX3, bezY3]);
+  }
+  return bezArrays;
+}
+


### PR DESCRIPTION
<!--
  Thank you for contributing! Please use this pull request (PR) template.


 In the description field of this PR, include "resolves #XXXX" tagging the issue you are fixing. If this PR addresses the issue but doesn't completely resolve it (ie the issue should remain open after your PR is merged), write "addresses #XXXX".-->
Addresses  #6560
This PR introduces the suggested way (as discussed in #6560 by @davepagurek and @gregstanton ) to refactor endShape to enable it for composite paths for 2D.
 Changes:
 - Vertex functions now uses vertex class objects (`Vertex`, `BezierVertex`, `QuadraticVertex`, `CurveVertex`)
 - Rendering them sequentially in `endShape` by looping through the vertex objects.
 - Classes `Shape`, `Contour`, `ContourSegment` to organize the construction and manipulation of the vertex objects.
<!-- Add here what changes were made in this pull request and if possible provide links showcasing the changes. -->


 Screenshots of the change:
<!-- If applicable, add screenshots depicting the changes. -->

#### PR Checklist
<!--
  To check any option, replace the "[ ]" with a "[x]". Be sure to check out how it looks in the Preview tab! Feel free to remove any portion of the template that is not relevant for your issue.
-->

- [x] `npm run lint` passes
- [ ] [Inline documentation] is included / updated
- [ ] [Unit tests] are included / updated

[Inline documentation]: https://github.com/processing/p5.js/blob/main/contributor_docs/inline_documentation.md
[Unit tests]: https://github.com/processing/p5.js/tree/main/contributor_docs#unit-tests
