### PR TITLE
Fix Web Accessibility output not tracking background color changes

### DIFF
--- a/src/accessibility/outputs.js
+++ b/src/accessibility/outputs.js
@@ -300,7 +300,8 @@ p5.prototype._createOutput = function(type, display) {
     this.ingredients = {
       shapes: {},
       colors: { background: 'white', fill: 'white', stroke: 'black' },
-      pShapes: ''
+      pShapes: '',
+      pBackground: ''
     };
   }
   //if there is no dummyDOM create it
@@ -396,7 +397,10 @@ p5.prototype._createOutput = function(type, display) {
 p5.prototype._updateAccsOutput = function() {
   let cnvId = this.canvas.id;
   //if the shapes are not the same as before
-  if (JSON.stringify(this.ingredients.shapes) !== this.ingredients.pShapes) {
+  if (
+    JSON.stringify(this.ingredients.shapes) !== this.ingredients.pShapes ||
+    this.ingredients.colors.background !== this.ingredients.pBackground
+  ) {
     //save current shapes as string in pShapes
     this.ingredients.pShapes = JSON.stringify(this.ingredients.shapes);
     if (this._accessibleOutputs.text) {
@@ -419,6 +423,7 @@ p5.prototype._updateAccsOutput = function() {
 p5.prototype._accsBackground = function(args) {
   //save current shapes as string in pShapes
   this.ingredients.pShapes = JSON.stringify(this.ingredients.shapes);
+  this.ingredients.pBackground = this.ingredients.colors.background;
   //empty shapes JSON
   this.ingredients.shapes = {};
   //update background different


### PR DESCRIPTION
<!--
  Thank you for contributing! Please use this pull request (PR) template.


 In the description field of this PR, include "resolves #XXXX" tagging the issue you are fixing. If this PR addresses the issue but doesn't completely resolve it (ie the issue should remain open after your PR is merged), write "addresses #XXXX".-->
Resolves #6610

 Changes:
<!-- Add here what changes were made in this pull request and if possible provide links showcasing the changes. -->
The text in `textOutput` and `gridOutput` previously only updates when there are changes on the canvas relating to shapes but it won't update if the background color changes while the shapes on the canvas stays the same, resulting in potentially incorrect background color being reported.

This fix adds an additional property to the web accessibility `ingredients` object that keep tracks of background color changes `pBackground` plus a check that will re-render the background color when necessary. 

#### PR Checklist
<!--
  To check any option, replace the "[ ]" with a "[x]". Be sure to check out how it looks in the Preview tab! Feel free to remove any portion of the template that is not relevant for your issue.
-->

- [x] `npm run lint` passes
- [ ] [Inline documentation] is included / updated
- [ ] [Unit tests] are included / updated

[Inline documentation]: https://github.com/processing/p5.js/blob/main/contributor_docs/inline_documentation.md
[Unit tests]: https://github.com/processing/p5.js/tree/main/contributor_docs#unit-tests
