### PR TITLE
Fix bug in orbitControl() where scaling with the mouse wheel worked even outside the canvas.

### DIFF
--- a/src/webgl/interaction.js
+++ b/src/webgl/interaction.js
@@ -221,7 +221,7 @@ p5.prototype.orbitControl = function(
       if (pointersInCanvas) this._renderer.executeZoom = true;
     } else {
       // quit zoom when you stop wheeling.
-      this._renderer.zoomFlag = false;
+      this._renderer.executeZoom = false;
     }
     if (this.mouseIsPressed) {
       if (this.mouseButton === this.LEFT) {


### PR DESCRIPTION
I forgot to change the name, so I will change the name.

Resolves #6627

 Changes:
rename "zoomFlag" to "executeZoom".

 Screenshots of the change:

https://github.com/processing/p5.js/assets/39549290/49620044-1d61-477c-b42b-a5c20395e9e6

#### PR Checklist
<!--
  To check any option, replace the "[ ]" with a "[x]". Be sure to check out how it looks in the Preview tab! Feel free to remove any portion of the template that is not relevant for your issue.
-->

- [ ] `npm run lint` passes
- [ ] [Inline documentation] is included / updated
- [ ] [Unit tests] are included / updated

[Inline documentation]: https://github.com/processing/p5.js/blob/main/contributor_docs/inline_documentation.md
[Unit tests]: https://github.com/processing/p5.js/tree/main/contributor_docs#unit-tests
