### PR TITLE
cleanup passing of mat4 arguments

### DIFF
--- a/src/webgl/interaction.js
+++ b/src/webgl/interaction.js
@@ -679,22 +679,7 @@ p5.prototype._grid = function(size, numDivs, xOff, yOff, zOff) {
       this._renderer.curStrokeColor[2] * 255
     );
     this._renderer.uMVMatrix.set(
-      this._renderer._curCamera.cameraMatrix.mat4[0],
-      this._renderer._curCamera.cameraMatrix.mat4[1],
-      this._renderer._curCamera.cameraMatrix.mat4[2],
-      this._renderer._curCamera.cameraMatrix.mat4[3],
-      this._renderer._curCamera.cameraMatrix.mat4[4],
-      this._renderer._curCamera.cameraMatrix.mat4[5],
-      this._renderer._curCamera.cameraMatrix.mat4[6],
-      this._renderer._curCamera.cameraMatrix.mat4[7],
-      this._renderer._curCamera.cameraMatrix.mat4[8],
-      this._renderer._curCamera.cameraMatrix.mat4[9],
-      this._renderer._curCamera.cameraMatrix.mat4[10],
-      this._renderer._curCamera.cameraMatrix.mat4[11],
-      this._renderer._curCamera.cameraMatrix.mat4[12],
-      this._renderer._curCamera.cameraMatrix.mat4[13],
-      this._renderer._curCamera.cameraMatrix.mat4[14],
-      this._renderer._curCamera.cameraMatrix.mat4[15]
+      ...this._renderer._curCamera.cameraMatrix.mat4.slice(0,16)
     );
 
     // Lines along X axis
@@ -743,22 +728,7 @@ p5.prototype._axesIcon = function(size, xOff, yOff, zOff) {
   return function() {
     this.push();
     this._renderer.uMVMatrix.set(
-      this._renderer._curCamera.cameraMatrix.mat4[0],
-      this._renderer._curCamera.cameraMatrix.mat4[1],
-      this._renderer._curCamera.cameraMatrix.mat4[2],
-      this._renderer._curCamera.cameraMatrix.mat4[3],
-      this._renderer._curCamera.cameraMatrix.mat4[4],
-      this._renderer._curCamera.cameraMatrix.mat4[5],
-      this._renderer._curCamera.cameraMatrix.mat4[6],
-      this._renderer._curCamera.cameraMatrix.mat4[7],
-      this._renderer._curCamera.cameraMatrix.mat4[8],
-      this._renderer._curCamera.cameraMatrix.mat4[9],
-      this._renderer._curCamera.cameraMatrix.mat4[10],
-      this._renderer._curCamera.cameraMatrix.mat4[11],
-      this._renderer._curCamera.cameraMatrix.mat4[12],
-      this._renderer._curCamera.cameraMatrix.mat4[13],
-      this._renderer._curCamera.cameraMatrix.mat4[14],
-      this._renderer._curCamera.cameraMatrix.mat4[15]
+      ...this._renderer._curCamera.cameraMatrix.mat4.slice(0,16)
     );
 
     // X axis

--- a/src/webgl/interaction.js
+++ b/src/webgl/interaction.js
@@ -678,9 +678,7 @@ p5.prototype._grid = function(size, numDivs, xOff, yOff, zOff) {
       this._renderer.curStrokeColor[1] * 255,
       this._renderer.curStrokeColor[2] * 255
     );
-    this._renderer.uMVMatrix.set(
-      ...this._renderer._curCamera.cameraMatrix.mat4.slice(0,16)
-    );
+    this._renderer.uMVMatrix.set(this._renderer._curCamera.cameraMatrix);
 
     // Lines along X axis
     for (let q = 0; q <= numDivs; q++) {
@@ -727,9 +725,7 @@ p5.prototype._axesIcon = function(size, xOff, yOff, zOff) {
 
   return function() {
     this.push();
-    this._renderer.uMVMatrix.set(
-      ...this._renderer._curCamera.cameraMatrix.mat4.slice(0,16)
-    );
+    this._renderer.uMVMatrix.set(this._renderer._curCamera.cameraMatrix);
 
     // X axis
     this.strokeWeight(2);

--- a/src/webgl/p5.Camera.js
+++ b/src/webgl/p5.Camera.js
@@ -832,22 +832,7 @@ p5.Camera = class Camera {
 
     if (this._isActive()) {
       this._renderer.uPMatrix.set(
-        this.projMatrix.mat4[0],
-        this.projMatrix.mat4[1],
-        this.projMatrix.mat4[2],
-        this.projMatrix.mat4[3],
-        this.projMatrix.mat4[4],
-        this.projMatrix.mat4[5],
-        this.projMatrix.mat4[6],
-        this.projMatrix.mat4[7],
-        this.projMatrix.mat4[8],
-        this.projMatrix.mat4[9],
-        this.projMatrix.mat4[10],
-        this.projMatrix.mat4[11],
-        this.projMatrix.mat4[12],
-        this.projMatrix.mat4[13],
-        this.projMatrix.mat4[14],
-        this.projMatrix.mat4[15]
+        ...this.projMatrix.mat4.slice(0,16)
       );
     }
   }
@@ -930,22 +915,7 @@ p5.Camera = class Camera {
 
     if (this._isActive()) {
       this._renderer.uPMatrix.set(
-        this.projMatrix.mat4[0],
-        this.projMatrix.mat4[1],
-        this.projMatrix.mat4[2],
-        this.projMatrix.mat4[3],
-        this.projMatrix.mat4[4],
-        this.projMatrix.mat4[5],
-        this.projMatrix.mat4[6],
-        this.projMatrix.mat4[7],
-        this.projMatrix.mat4[8],
-        this.projMatrix.mat4[9],
-        this.projMatrix.mat4[10],
-        this.projMatrix.mat4[11],
-        this.projMatrix.mat4[12],
-        this.projMatrix.mat4[13],
-        this.projMatrix.mat4[14],
-        this.projMatrix.mat4[15]
+        ...this.projMatrix.mat4.slice(0,16)
       );
     }
 
@@ -1028,22 +998,7 @@ p5.Camera = class Camera {
 
     if (this._isActive()) {
       this._renderer.uPMatrix.set(
-        this.projMatrix.mat4[0],
-        this.projMatrix.mat4[1],
-        this.projMatrix.mat4[2],
-        this.projMatrix.mat4[3],
-        this.projMatrix.mat4[4],
-        this.projMatrix.mat4[5],
-        this.projMatrix.mat4[6],
-        this.projMatrix.mat4[7],
-        this.projMatrix.mat4[8],
-        this.projMatrix.mat4[9],
-        this.projMatrix.mat4[10],
-        this.projMatrix.mat4[11],
-        this.projMatrix.mat4[12],
-        this.projMatrix.mat4[13],
-        this.projMatrix.mat4[14],
-        this.projMatrix.mat4[15]
+        ...this.projMatrix.mat4.slice(0,16)
       );
     }
 
@@ -1425,22 +1380,7 @@ p5.Camera = class Camera {
 
     if (this._isActive()) {
       this._renderer.uMVMatrix.set(
-        this.cameraMatrix.mat4[0],
-        this.cameraMatrix.mat4[1],
-        this.cameraMatrix.mat4[2],
-        this.cameraMatrix.mat4[3],
-        this.cameraMatrix.mat4[4],
-        this.cameraMatrix.mat4[5],
-        this.cameraMatrix.mat4[6],
-        this.cameraMatrix.mat4[7],
-        this.cameraMatrix.mat4[8],
-        this.cameraMatrix.mat4[9],
-        this.cameraMatrix.mat4[10],
-        this.cameraMatrix.mat4[11],
-        this.cameraMatrix.mat4[12],
-        this.cameraMatrix.mat4[13],
-        this.cameraMatrix.mat4[14],
-        this.cameraMatrix.mat4[15]
+        ...this.cameraMatrix.mat4.slice(0,16)
       );
     }
     return this;
@@ -2328,22 +2268,7 @@ p5.prototype.setCamera = function (cam) {
 
   // set the projection matrix (which is not normally updated each frame)
   this._renderer.uPMatrix.set(
-    cam.projMatrix.mat4[0],
-    cam.projMatrix.mat4[1],
-    cam.projMatrix.mat4[2],
-    cam.projMatrix.mat4[3],
-    cam.projMatrix.mat4[4],
-    cam.projMatrix.mat4[5],
-    cam.projMatrix.mat4[6],
-    cam.projMatrix.mat4[7],
-    cam.projMatrix.mat4[8],
-    cam.projMatrix.mat4[9],
-    cam.projMatrix.mat4[10],
-    cam.projMatrix.mat4[11],
-    cam.projMatrix.mat4[12],
-    cam.projMatrix.mat4[13],
-    cam.projMatrix.mat4[14],
-    cam.projMatrix.mat4[15]
+    ...cam.projMatrix.mat4.slice(0,16)
   );
 };
 

--- a/src/webgl/p5.Camera.js
+++ b/src/webgl/p5.Camera.js
@@ -831,9 +831,7 @@ p5.Camera = class Camera {
     /* eslint-enable indent */
 
     if (this._isActive()) {
-      this._renderer.uPMatrix.set(
-        ...this.projMatrix.mat4.slice(0,16)
-      );
+      this._renderer.uPMatrix.set(this.projMatrix);
     }
   }
 
@@ -914,9 +912,7 @@ p5.Camera = class Camera {
     /* eslint-enable indent */
 
     if (this._isActive()) {
-      this._renderer.uPMatrix.set(
-        ...this.projMatrix.mat4.slice(0,16)
-      );
+      this._renderer.uPMatrix.set(this.projMatrix);
     }
 
     this.cameraType = 'custom';
@@ -997,9 +993,7 @@ p5.Camera = class Camera {
     /* eslint-enable indent */
 
     if (this._isActive()) {
-      this._renderer.uPMatrix.set(
-        ...this.projMatrix.mat4.slice(0,16)
-      );
+      this._renderer.uPMatrix.set(this.projMatrix);
     }
 
     this.cameraType = 'custom';
@@ -1379,9 +1373,7 @@ p5.Camera = class Camera {
     this.cameraMatrix.translate([tx, ty, tz]);
 
     if (this._isActive()) {
-      this._renderer.uMVMatrix.set(
-        ...this.cameraMatrix.mat4.slice(0,16)
-      );
+      this._renderer.uMVMatrix.set(this.cameraMatrix);
     }
     return this;
   }
@@ -2267,9 +2259,7 @@ p5.prototype.setCamera = function (cam) {
   this._renderer._curCamera = cam;
 
   // set the projection matrix (which is not normally updated each frame)
-  this._renderer.uPMatrix.set(
-    ...cam.projMatrix.mat4.slice(0,16)
-  );
+  this._renderer.uPMatrix.set(cam.projMatrix);
 };
 
 export default p5.Camera;

--- a/src/webgl/p5.Framebuffer.js
+++ b/src/webgl/p5.Framebuffer.js
@@ -843,7 +843,7 @@ class Framebuffer {
     // it only sets the camera.
     this.target.setCamera(this.defaultCamera);
     this.target._renderer.uMVMatrix.set(
-      ...this.target._renderer._curCamera.cameraMatrix.mat4.slice(0,16)
+      this.target._renderer._curCamera.cameraMatrix
     );
   }
 

--- a/src/webgl/p5.Framebuffer.js
+++ b/src/webgl/p5.Framebuffer.js
@@ -843,22 +843,7 @@ class Framebuffer {
     // it only sets the camera.
     this.target.setCamera(this.defaultCamera);
     this.target._renderer.uMVMatrix.set(
-      this.target._renderer._curCamera.cameraMatrix.mat4[0],
-      this.target._renderer._curCamera.cameraMatrix.mat4[1],
-      this.target._renderer._curCamera.cameraMatrix.mat4[2],
-      this.target._renderer._curCamera.cameraMatrix.mat4[3],
-      this.target._renderer._curCamera.cameraMatrix.mat4[4],
-      this.target._renderer._curCamera.cameraMatrix.mat4[5],
-      this.target._renderer._curCamera.cameraMatrix.mat4[6],
-      this.target._renderer._curCamera.cameraMatrix.mat4[7],
-      this.target._renderer._curCamera.cameraMatrix.mat4[8],
-      this.target._renderer._curCamera.cameraMatrix.mat4[9],
-      this.target._renderer._curCamera.cameraMatrix.mat4[10],
-      this.target._renderer._curCamera.cameraMatrix.mat4[11],
-      this.target._renderer._curCamera.cameraMatrix.mat4[12],
-      this.target._renderer._curCamera.cameraMatrix.mat4[13],
-      this.target._renderer._curCamera.cameraMatrix.mat4[14],
-      this.target._renderer._curCamera.cameraMatrix.mat4[15]
+      ...this.target._renderer._curCamera.cameraMatrix.mat4.slice(0,16)
     );
   }
 

--- a/src/webgl/p5.Matrix.js
+++ b/src/webgl/p5.Matrix.js
@@ -48,8 +48,10 @@ p5.Matrix = class {
   }
 
   /**
- * Sets the x, y, and z component of the vector using two or three separate
- * variables, the data from a p5.Matrix, or the values from a float array.
+ * Replace the entire contents of a 4x4 matrix.
+ * If providing an array or a p5.Matrix, the values will be copied without
+ * referencing the source object.
+ * Can also provide 16 numbers as individual arguments.
  *
  * @method set
  * @param {p5.Matrix|Float32Array|Number[]} [inMatrix] the input p5.Matrix or
@@ -63,29 +65,21 @@ p5.Matrix = class {
  * @chainable
  */
   set(inMatrix) {
+    let refArray = arguments;
     if (inMatrix instanceof p5.Matrix) {
-      this.mat4 = inMatrix.mat4;
-      return this;
+      refArray = inMatrix.mat4;
     } else if (isMatrixArray(inMatrix)) {
-      this.mat4 = inMatrix;
+      refArray = inMatrix;
+    }
+    if (refArray.length !== 16) {
+      p5._friendlyError(
+        `Expected 16 values but received ${refArray.length}.`,
+        'p5.Matrix.set'
+      );
       return this;
-    } else if (arguments.length === 16) {
-      this.mat4[0] = arguments[0];
-      this.mat4[1] = arguments[1];
-      this.mat4[2] = arguments[2];
-      this.mat4[3] = arguments[3];
-      this.mat4[4] = arguments[4];
-      this.mat4[5] = arguments[5];
-      this.mat4[6] = arguments[6];
-      this.mat4[7] = arguments[7];
-      this.mat4[8] = arguments[8];
-      this.mat4[9] = arguments[9];
-      this.mat4[10] = arguments[10];
-      this.mat4[11] = arguments[11];
-      this.mat4[12] = arguments[12];
-      this.mat4[13] = arguments[13];
-      this.mat4[14] = arguments[14];
-      this.mat4[15] = arguments[15];
+    }
+    for (let i = 0; i < 16; i++) {
+      this.mat4[i] = refArray[i];
     }
     return this;
   }

--- a/src/webgl/p5.RendererGL.js
+++ b/src/webgl/p5.RendererGL.js
@@ -850,9 +850,7 @@ p5.RendererGL = class RendererGL extends p5.Renderer {
   _update() {
     // reset model view and apply initial camera transform
     // (containing only look at info; no projection).
-    this.uMVMatrix.set(
-      ...this._curCamera.cameraMatrix.mat4.slice(0,16)
-    );
+    this.uMVMatrix.set(this._curCamera.cameraMatrix);
 
     // reset light data for new frame.
 
@@ -1634,9 +1632,7 @@ p5.RendererGL = class RendererGL extends p5.Renderer {
     }
   }
   resetMatrix() {
-    this.uMVMatrix.set(
-      ...this._curCamera.cameraMatrix.mat4.slice(0,16)
-    );
+    this.uMVMatrix.set(this._curCamera.cameraMatrix);
     return this;
   }
 

--- a/src/webgl/p5.RendererGL.js
+++ b/src/webgl/p5.RendererGL.js
@@ -851,22 +851,7 @@ p5.RendererGL = class RendererGL extends p5.Renderer {
     // reset model view and apply initial camera transform
     // (containing only look at info; no projection).
     this.uMVMatrix.set(
-      this._curCamera.cameraMatrix.mat4[0],
-      this._curCamera.cameraMatrix.mat4[1],
-      this._curCamera.cameraMatrix.mat4[2],
-      this._curCamera.cameraMatrix.mat4[3],
-      this._curCamera.cameraMatrix.mat4[4],
-      this._curCamera.cameraMatrix.mat4[5],
-      this._curCamera.cameraMatrix.mat4[6],
-      this._curCamera.cameraMatrix.mat4[7],
-      this._curCamera.cameraMatrix.mat4[8],
-      this._curCamera.cameraMatrix.mat4[9],
-      this._curCamera.cameraMatrix.mat4[10],
-      this._curCamera.cameraMatrix.mat4[11],
-      this._curCamera.cameraMatrix.mat4[12],
-      this._curCamera.cameraMatrix.mat4[13],
-      this._curCamera.cameraMatrix.mat4[14],
-      this._curCamera.cameraMatrix.mat4[15]
+      ...this._curCamera.cameraMatrix.mat4.slice(0,16)
     );
 
     // reset light data for new frame.
@@ -1650,22 +1635,7 @@ p5.RendererGL = class RendererGL extends p5.Renderer {
   }
   resetMatrix() {
     this.uMVMatrix.set(
-      this._curCamera.cameraMatrix.mat4[0],
-      this._curCamera.cameraMatrix.mat4[1],
-      this._curCamera.cameraMatrix.mat4[2],
-      this._curCamera.cameraMatrix.mat4[3],
-      this._curCamera.cameraMatrix.mat4[4],
-      this._curCamera.cameraMatrix.mat4[5],
-      this._curCamera.cameraMatrix.mat4[6],
-      this._curCamera.cameraMatrix.mat4[7],
-      this._curCamera.cameraMatrix.mat4[8],
-      this._curCamera.cameraMatrix.mat4[9],
-      this._curCamera.cameraMatrix.mat4[10],
-      this._curCamera.cameraMatrix.mat4[11],
-      this._curCamera.cameraMatrix.mat4[12],
-      this._curCamera.cameraMatrix.mat4[13],
-      this._curCamera.cameraMatrix.mat4[14],
-      this._curCamera.cameraMatrix.mat4[15]
+      ...this._curCamera.cameraMatrix.mat4.slice(0,16)
     );
     return this;
   }


### PR DESCRIPTION
#### Background:
This is just a code cleanup and should not change any behaviors.  There is a big block of code for passing the arguments of a 4x4 matrix.  It is excessively verbose and it's repeated in 10 different places!
https://github.com/processing/p5.js/blob/fb70e98ee6bd317d91d0ad2c2bc30dedafa90abf/src/webgl/p5.Camera.js#L1427-L1444

These blocks are one of many issues brought up by @RandomGamingDev in [this comment](https://github.com/processing/p5.js/issues/6527#issuecomment-1793477773) on #6527.

#### Changes:
Simplifies these blocks of code to:
```
this._renderer.uMVMatrix.set( 
   ...this.cameraMatrix.mat4.slice(0,16)
)
```
Using:
- `slice(0,16)` to access the first 16 element of the array (indices 0 through 15)
- `...` ([spread syntax](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Spread_syntax)) to pass the elements of the array as individual arguments.

#### Questions:
- Are there every fewer than 16 elements in these arrays?  If so then there **would** be a behavior change because this approach will only pass as many arguments as there are in the array.  The current code would pad with `undefined` in that situation.  It's the difference between calling `func(a, b, undefined, undefined)` and `func(a, b)`.
- Are there always exactly 16 elements in these arrays?  If so, the `.slice(0,16)` is not necessary.
- It seems like the `Matrix.set()` method accepts an array, in addition to accepting individual numbers.  Should I drop the `...` and call with the array directly? (But keeping the `.slice()` to clone it).  Or use the `.copy()` method, as suggested by @RandomGamingDev?

#### PR Checklist
<!--
  To check any option, replace the "[ ]" with a "[x]". Be sure to check out how it looks in the Preview tab! Feel free to remove any portion of the template that is not relevant for your issue.
-->

- [ ] `npm run lint` passes
- [ ] [Inline documentation] is included / updated
- [ ] [Unit tests] are included / updated

[Inline documentation]: https://github.com/processing/p5.js/blob/main/contributor_docs/inline_documentation.md
[Unit tests]: https://github.com/processing/p5.js/tree/main/contributor_docs#unit-tests
