### PR TITLE
Fix bug in ortho() where using it without arguements, drawing failed in some cases, resolved.

### DIFF
--- a/src/webgl/p5.Camera.js
+++ b/src/webgl/p5.Camera.js
@@ -912,7 +912,7 @@ p5.Camera = class Camera {
     if (top === undefined) top = +this._renderer.height / 2;
     if (near === undefined) near = 0;
     if (far === undefined)
-      far = Math.max(this._renderer.width, this._renderer.height);
+      far = Math.max(this._renderer.width, this._renderer.height)+800;
 
     this.cameraNear = near;
     this.cameraFar = far;

--- a/test/unit/webgl/p5.Camera.js
+++ b/test/unit/webgl/p5.Camera.js
@@ -650,12 +650,12 @@ suite('p5.Camera', function() {
         assert.deepEqual(myCam.projMatrix.mat4, expectedMatrix);
       });
 
-      test('ortho() with no parameters specified (sets default)', function() {
+      test('ortho() with no parameters specified (sets default with added far)', function() {
         var expectedMatrix = new Float32Array([
           0.019999999552965164, 0, 0, 0,
-          0, -0.019999999552965164, 0,0,
-          0,0,-0.019999999552965164,0,
-          -0,-0,-1,1
+          0, -0.019999999552965164, 0, 0,
+          0, 0, -0.002222222276031971, 0,
+          -0, -0, -1, 1
         ]);
         myCam.ortho();
         assert.deepEqual(myCam.projMatrix.mat4, expectedMatrix);


### PR DESCRIPTION
<!--
  Thank you for contributing! Please use this pull request (PR) template.


 In the description field of this PR, include "resolves #XXXX" tagging the issue you are fixing. If this PR addresses the issue but doesn't completely resolve it (ie the issue should remain open after your PR is merged), write "addresses #XXXX".-->
Resolves #6621 

 Changes:
In src/webgl/p5.Camera.js  :
`if (far === undefined)
      far = Math.max(this._renderer.width, this._renderer.height)+800;`


In test/unit/webgl/p5.Camera.js :
` var expectedMatrix = new Float32Array([
          0.019999999552965164, 0, 0, 0,
          0, -0.019999999552965164, 0, 0,
          0, 0, -0.002222222276031971, 0,
          -0, -0, -1, 1
        ]);`
<!-- Add here what changes were made in this pull request and if possible provide links showcasing the changes. -->


 Screenshots of the change:
<!-- If applicable, add screenshots depicting the changes. -->
Before:
![image](https://github.com/processing/p5.js/assets/110971977/5fbf0660-e3b2-428a-a127-5f519032599d)

```
function setup() {
  createCanvas(400, 400, WEBGL);
  ortho();
}

function draw() {
  background(220);
  box(100);
}
```
![image](https://github.com/processing/p5.js/assets/110971977/6440603a-a2a9-49c9-89a7-8f50f7af176a)


```
function setup() {
  createCanvas(100, 100, WEBGL);
  ortho();
}

function draw() {
  background(220);
  box(50);
}
```

![image](https://github.com/processing/p5.js/assets/110971977/e77fa554-ab46-4d35-a7b6-2cef770c9d82)


#### PR Checklist
<!--
  To check any option, replace the "[ ]" with a "[x]". Be sure to check out how it looks in the Preview tab! Feel free to remove any portion of the template that is not relevant for your issue.
-->

- [x] `npm run lint` passes
- [ ] [Inline documentation] is included / updated
- [x] [Unit tests] are included / updated

[Inline documentation]: https://github.com/processing/p5.js/blob/main/contributor_docs/inline_documentation.md
[Unit tests]: https://github.com/processing/p5.js/tree/main/contributor_docs#unit-tests
