### PR TITLE
Fix syntax error re: `new p5.Vector.cross`

### DIFF
--- a/src/webgl/p5.Camera.js
+++ b/src/webgl/p5.Camera.js
@@ -2110,9 +2110,9 @@ p5.Camera = class Camera {
     // up vector. normalized camera's up vector.
     const up = new p5.Vector(this.upX, this.upY, this.upZ).normalize(); // y-axis
     // side vector. Right when viewed from the front
-    const side = new p5.Vector.cross(up, front).normalize(); // x-axis
+    const side = p5.Vector.cross(up, front).normalize(); // x-axis
     // vertical vector. normalized vector of projection of front vector.
-    const vertical = new p5.Vector.cross(side, up); // z-axis
+    const vertical = p5.Vector.cross(side, up); // z-axis
 
     // update camRadius
     camRadius *= Math.pow(10, dRadius);
@@ -2180,9 +2180,9 @@ p5.Camera = class Camera {
     // up vector. camera's up vector.
     const up = new p5.Vector(this.upX, this.upY, this.upZ);
     // side vector. Right when viewed from the front. (like x-axis)
-    const side = new p5.Vector.cross(up, front).normalize();
+    const side = p5.Vector.cross(up, front).normalize();
     // down vector. Bottom when viewed from the front. (like y-axis)
-    const down = new p5.Vector.cross(front, side);
+    const down = p5.Vector.cross(front, side);
 
     // side vector and down vector are no longer used as-is.
     // Create a vector representing the direction of rotation
@@ -2195,7 +2195,7 @@ p5.Camera = class Camera {
     const rotAngle = Math.sqrt(dx*dx + dy*dy);
     // The vector that is orthogonal to both the front vector and
     // the rotation direction vector is the rotation axis vector.
-    const axis = new p5.Vector.cross(front, side);
+    const axis = p5.Vector.cross(front, side);
 
     // update camRadius
     camRadius *= Math.pow(10, dRadius);


### PR DESCRIPTION
Fixes the failing tests explained in [this comment](https://github.com/processing/p5.js/issues/6633#issuecomment-1859300727_):
> All of the tests related to the camera `_orbit` method fail with `TypeError: _main.default.Vector.cross is not a constructor` because the code uses improper syntax `new p5.Vector.cross(up, front)`.  `cross` is a `static` method so there shouldn't be a `new` there.

 Changes:
* Replace syntax `new p5.Vector.cross(a, b)` with `p5.Vector.cross(a, b)` in a few places in the `p5.Camera` class.
* A bunch of tests which were failing before will pass now.

#### PR Checklist
<!--
  To check any option, replace the "[ ]" with a "[x]". Be sure to check out how it looks in the Preview tab! Feel free to remove any portion of the template that is not relevant for your issue.
-->

- [x] `npm run lint` passes
- [ ] [Inline documentation] is included / updated
- [ ] [Unit tests] are included / updated

[Inline documentation]: https://github.com/processing/p5.js/blob/main/contributor_docs/inline_documentation.md
[Unit tests]: https://github.com/processing/p5.js/tree/main/contributor_docs#unit-tests
