### PR TITLE
Fixed the shader in the `endShape()` example to make the boxes separated from one another

### DIFF
--- a/src/core/shape/vertex.js
+++ b/src/core/shape/vertex.js
@@ -647,12 +647,12 @@ p5.prototype.endContour = function() {
  *
  *   // gl_InstanceID represents a numeric value for each instance
  *   // using gl_InstanceID allows us to move each instance separately
- *   // here we move each instance horizontally by id * 375
- *   float xOffset = float(gl_InstanceID) * 375.0;
+ *   // here we move each instance horizontally by id * 23
+ *   float xOffset = float(gl_InstanceID) * 23.0;
  *
  *   // apply the offset to the final position
- *   gl_Position = uProjectionMatrix * uModelViewMatrix * positionVec4 -
- *     vec4(xOffset, 0.0, 0.0, 0.0);
+ *   gl_Position = uProjectionMatrix * uModelViewMatrix * (positionVec4 -
+ *     vec4(xOffset, 0.0, 0.0, 0.0));
  * }
  * `;
  * let fs = `#version 300 es

--- a/src/core/shape/vertex.js
+++ b/src/core/shape/vertex.js
@@ -647,8 +647,8 @@ p5.prototype.endContour = function() {
  *
  *   // gl_InstanceID represents a numeric value for each instance
  *   // using gl_InstanceID allows us to move each instance separately
- *   // here we move each instance horizontally by id * 40
- *   float xOffset = float(gl_InstanceID) * 40.0;
+ *   // here we move each instance horizontally by id * 375
+ *   float xOffset = float(gl_InstanceID) * 375.0;
  *
  *   // apply the offset to the final position
  *   gl_Position = uProjectionMatrix * uModelViewMatrix * positionVec4 -


### PR DESCRIPTION
The update to the camera locked the z at 800 which changed how the boxes are rendered in the example. This pull requests serves to divide them by changing the offset and making it so that the boxes are divided by per-pixel transformations in the shader.

<!--
  Thank you for contributing! Please use this pull request (PR) template.


 In the description field of this PR, include "resolves #XXXX" tagging the issue you are fixing. If this PR addresses the issue but doesn't completely resolve it (ie the issue should remain open after your PR is merged), write "addresses #XXXX".-->
Resolves #6655

 Changes:
<!-- Add here what changes were made in this pull request and if possible provide links showcasing the changes. -->
This changes the offset from *100 to *23 and makes it so that the offset is applied to the position before multiplication of the camera, and projection matrices with the position.

 Screenshots of the change:
<!-- If applicable, add screenshots depicting the changes. -->
Before:
![canvas](https://github.com/processing/p5.js/assets/83996185/aa18878e-71bf-4c6a-a8cd-bcca190c339a)
After:
![canvas](https://github.com/processing/p5.js/assets/83996185/d49cc262-9718-4913-972a-8e7257df8694)

#### PR Checklist
<!--
  To check any option, replace the "[ ]" with a "[x]". Be sure to check out how it looks in the Preview tab! Feel free to remove any portion of the template that is not relevant for your issue.
-->

- [x] `npm run lint` passes
- [x] [Inline documentation] is included / updated
- [x] [Unit tests] are included / updated

[Inline documentation]: https://github.com/processing/p5.js/blob/main/contributor_docs/inline_documentation.md
[Unit tests]: https://github.com/processing/p5.js/tree/main/contributor_docs#unit-tests
