### PR TITLE
bugfix #6653 vertexNormal() is not defined,replaces with normal

### DIFF
--- a/src/webgl/p5.RendererGL.Immediate.js
+++ b/src/webgl/p5.RendererGL.Immediate.js
@@ -167,13 +167,14 @@ p5.RendererGL.prototype.vertex = function(x, y) {
 
 /**
  * Sets the normal to use for subsequent vertices.
- * @method vertexNormal
+ * @private
+ * @method normal
  * @param  {Number} x
  * @param  {Number} y
  * @param  {Number} z
  * @chainable
  *
- * @method vertexNormal
+ * @method normal
  * @param  {Vector} v
  * @chainable
  */


### PR DESCRIPTION
<!--
  Thank you for contributing! Please use this pull request (PR) template.


 In the description field of this PR, include "resolves #XXXX" tagging the issue you are fixing. If this PR addresses the issue but doesn't completely resolve it (ie the issue should remain open after your PR is merged), write "addresses #XXXX".-->
Resolves #6653 

 Changes:
<!-- Add here what changes were made in this pull request and if possible provide links showcasing the changes. -->
 ```
* Sets the normal to use for subsequent vertices.
 * @private
 * @method normal
 * @param  {Number} x
 * @param  {Number} y
 * @param  {Number} z
 * @chainable
 *
 * @method normal
 * @param  {Vector} v
 * @chainable
 */
```

 Screenshots of the change:
<!-- If applicable, add screenshots depicting the changes. -->

#### PR Checklist
<!--
  To check any option, replace the "[ ]" with a "[x]". Be sure to check out how it looks in the Preview tab! Feel free to remove any portion of the template that is not relevant for your issue.
-->

- [x] `npm run lint` passes
- [x] [Inline documentation] is included / updated
- [x] [Unit tests] are included / updated

[Inline documentation]: https://github.com/processing/p5.js/blob/main/contributor_docs/inline_documentation.md
[Unit tests]: https://github.com/processing/p5.js/tree/main/contributor_docs#unit-tests
