### PR TITLE
Fix Typos from multiple sections in Docs

### DIFF
--- a/src/README.md
+++ b/src/README.md
@@ -1,27 +1,27 @@
 # Organization
 
-The p5.js source code is organized into subdirectories which are roughly conceptually equivalent to third-party addons, except that these "addons" are actually just shipped as part of the p5.js library because the functionality they provide is so useful and central to p5's goal of building art projects for the web.
+The p5.js source code is organized into subdirectories which are roughly conceptually equivalent to third-party add-ons, except that these "add-ons" are actually just shipped as part of the p5.js library because the functionality they provide is so useful and central to p5's goal of building art projects for the web.
 
-The `src/core` directory is the primary exception to this. It contains most of the internal logic of p5.js — the code which orchestrates everything else. It is possible to create optimized minimalist [custom builds](/contributor_docs/custom_p5_build.md) of the p5.js library which only include specific desired modules. In such a custom build, the contents of the core directory would be the only hard requirement, and everything else would be optional.
+The `src/core` directory is the primary exception to this. It contains most of the internal logic of p5.js — the code that orchestrates everything else. It is possible to create optimized minimalist [custom builds](/contributor_docs/custom_p5_build.md) of the p5.js library which only includes specific desired modules. In such a custom build, the contents of the core directory would be the only hard requirement, and everything else would be optional.
 
-[JSDoc](https://jsdoc.app/) [module](https://jsdoc.app/tags-module.html) annotations are used throughout the codebase, but they primarily organize the public-facing [p5 reference manual](https://p5js.org/reference/), which is built automatically from the source code. These annotations structure the *expressive and creative API* of p5, and consequently they might not always align exactly with the *source code structure*.
+[JSDoc](https://jsdoc.app/) [module](https://jsdoc.app/tags-module.html) annotations are used throughout the codebase, but they primarily organize the public-facing [p5 reference manual](https://p5js.org/reference/), which is built automatically from the source code. These annotations structure the *expressive and creative API* of p5, and consequently, they might not always align exactly with the *source code structure*.
 
-The `app.js` file is simply an index of all the other modules which exports the p5 constructor function.
+The `app.js` file is simply an index of all the other modules which export the p5 constructor function.
 
 # APIs
 
-p5.js seeks to create a toolkit for working with the web technologies that are most valuable for building art projects. For both expressive and pedagogical reasons, p5.js values (but does not necessarily always achieve lol!) clarity in its APIs. These are guidelines, and in practice there may be occasional exceptions.
+p5.js seeks to create a toolkit for working with the web technologies that are most valuable for building art projects. For both expressive and pedagogical reasons, p5.js values (but does not necessarily always achieve lol!) clarity in its APIs. These are guidelines, and in practice, there may be occasional exceptions.
 
 ## Public
 
-Public APIs which are exposed to users of the p5.js library during the course of working on sketches and projects should use short, clear, declarative function names. `circle()` is preferable to `new Circle()`. If the name of a public API function is longer than one or two words, it may be worth carefully considering whether the API should be restructured into something more creative, expressive, or intuitive.
+Public APIs that are exposed to users of the p5.js library during the course of working on sketches and projects should use short, clear, declarative function names. `circle()` is preferable to `new Circle()`. If the name of a public API function is longer than one or two words, it may be worth carefully considering whether the API should be restructured into something more creative, expressive, or intuitive.
 
 ## Native
 
 Native APIs provided by the browser can sometimes be aliased in the style of public APIs to provide a more creative, expressive, or intuitive interface than the native implementation. For example, `print()` is easier to explain than `console.log()`. Idiomatic JavaScript is generally preferable, so aliasing in this manner needs to have tremendous creative or pedagogical benefits.
 
-Native browser functionality is also often aliased with properties on the `p5` object. This allows the library to consistently point toward the same reference, but in most cases this practice should not be considered part of the public API even though those properties are exposed to the user.
+Native browser functionality is also often aliased with properties on the `p5` object. This allows the library to consistently point toward the same reference, but in most cases, this practice should not be considered part of the public API even though those properties are exposed to the user.
 
 ## Internal
 
-Internal APIs which are not exposed to the user but are used for coordination within the library should generally take the form of constructor functions which can be exported across module boundaries. Those constructors are often attached to the `p5` constructor as a form of namespacing, but otherwise do not meaningfully act as methods that reference the host object. In cases where a `p5` object is needed inside a constructor, an instance will be explicitly passed as an input argument.
+Internal APIs which are not exposed to the user but are used for coordination within the library should generally take the form of constructor functions that can be exported across module boundaries. Those constructors are often attached to the `p5` constructor as a form of namespacing, but otherwise do not meaningfully act as methods that reference the host object. In cases where a `p5` object is needed inside a constructor, an instance will be explicitly passed as an input argument.

--- a/src/accessibility/describe.js
+++ b/src/accessibility/describe.js
@@ -28,7 +28,7 @@ const labelTableElId = '_lte_'; //Label Table Element
  * visible to screen readers. This is the default mode.
  *
  * Read
- * <a href="/learn/labeling-canvases.html">How to label your p5.js code</a> to
+ * <a href="/learn/labeling-canvases.html">How to Label your p5.js code</a> to
  * learn more about making sketches accessible.
  *
  * @method describe
@@ -177,7 +177,7 @@ p5.prototype.describe = function(text, display) {
  * mode.
  *
  * Read
- * <a href="/learn/labeling-canvases.html">How to label your p5.js code</a> to
+ * <a href="/learn/labeling-canvases.html">How to Label your p5.js code</a> to
  * learn more about making sketches accessible.
  *
  * @method describeElement

--- a/src/accessibility/outputs.js
+++ b/src/accessibility/outputs.js
@@ -8,8 +8,8 @@
 import p5 from '../core/main';
 
 /**
- * Creates a screen reader-accessible description for shapes on the canvas.
- * `textOutput()` adds a general description, list of shapes, and
+* Creates a screen reader-accessible description for shapes on the canvas.
+ * `textOutput()` adds a general description, a list of shapes, and
  * table of shapes to the web page.
  *
  * The general description includes the canvas size, canvas color, and number
@@ -18,7 +18,7 @@ import p5 from '../core/main';
  *
  * A list of shapes follows the general description. The list describes the
  * color, location, and area of each shape. For example,
- * `a red circle at middle covering 3% of the canvas`. Each shape can be
+ * a red circle in the middle covering 3% of the canvas`. Each shape can be
  * selected to get more details.
  *
  * `textOutput()` uses its table of shapes as a list. The table describes the
@@ -35,7 +35,7 @@ import p5 from '../core/main';
  * mode.
  *
  * Read
- * <a href="/learn/labeling-canvases.html">How to label your p5.js code</a> to
+ * <a href="/learn/labeling-canvases.html">How to Label your p5.js code</a> to
  * learn more about making sketches accessible.
  *
  * @method textOutput
@@ -153,7 +153,7 @@ p5.prototype.textOutput = function(display) {
  *
  * `gridOutput()` uses its table of shapes as a grid. Each shape in the grid
  * is placed in a cell whose row and column correspond to the shape's location
- * on the canvas. The grid cells describe the color and type of shape at that
+ * on the canvas. The grid cells describe the color and type of shape of that
  * location. For example, `red circle`. These descriptions can be selected
  * individually to get more details. This is different from
  * <a href="#/p5/textOutput">textOutput()</a>, which uses its table as a list.
@@ -171,7 +171,7 @@ p5.prototype.textOutput = function(display) {
  * mode.
  *
  * Read
- * <a href="/learn/labeling-canvases.html">How to label your p5.js code</a> to
+ * <a href="/learn/labeling-canvases.html">How to Label your p5.js code</a> to
  * learn more about making sketches accessible.
  *
  * @method gridOutput

--- a/src/color/color_conversion.js
+++ b/src/color/color_conversion.js
@@ -122,7 +122,7 @@ p5.ColorConversion = {
   /**
    * Convert an HSLA array to RGBA.
    *
-   * We need to change basis from HSLA to something that can be more easily be
+   * We need to change the basis from HSLA to something that can more easily be
    * projected onto RGBA. We will choose hue and brightness as our first two
    * components, and pick a convenient third one ('zest') so that we don't need
    * to calculate formal HSBA saturation.

--- a/src/color/creating_reading.js
+++ b/src/color/creating_reading.js
@@ -123,7 +123,7 @@ p5.prototype.brightness = function(c) {
  * return a bright yellow color. The way these parameters are interpreted may
  * be changed with the <a href="#/p5/colorMode">colorMode()</a> function.
  *
- * The version of `color()` with one parameter interprets the value one of two
+ * The version of `color()` with one parameter interprets the value as one of two
  * ways. If the parameter is a number, it's interpreted as a grayscale value.
  * If the parameter is a string, it's interpreted as a CSS color string.
  *
@@ -329,7 +329,7 @@ p5.prototype.green = function(c) {
 
 /**
  * Extracts the hue value from a
- * <a href="#/p5.Color">p5.Color</a> object, array of color components, or
+ * <a href="#/p5.Color">p5.Color</a> object, an array of color components, or
  * CSS color string.
  *
  * Hue exists in both HSB and HSL. It describes a color's position on the

--- a/src/color/p5.Color.js
+++ b/src/color/p5.Color.js
@@ -328,7 +328,7 @@ const colorPatterns = {
  * are sent to the renderer.
  *
  * When different color representations are calculated, the results are cached
- * for performance. These values are normalized, floating-point numbers.
+ * for performance. These values are normalized floating-point numbers.
  *
  * <a href="#/p5/color">color()</a> is the recommended way to create an instance
  * of this class.

--- a/src/core/constants.js
+++ b/src/core/constants.js
@@ -22,21 +22,21 @@ export const VERSION =
  */
 export const P2D = 'p2d';
 /**
- * One of the two render modes in p5.js, used for computationally intensive tasks like 3D rendering and shaders.
+ * One of the two render modes in p5.js is used for computationally intensive tasks like 3D rendering and shaders.
  *
  * `WEBGL` differs from the default <a href="/reference/#/p5/P2D">`P2D`</a> renderer in the following ways:
  *
  * - **Coordinate System** - When drawing in `WEBGL` mode, the origin point (0,0,0) is located at the center of the screen, not the top-left corner. See <a href="https://p5js.org/learn/getting-started-in-webgl-coords-and-transform.html">the learn page about coordinates and transformations</a>.
  * - **3D Shapes** - `WEBGL` mode can be used to draw 3-dimensional shapes like <a href="/reference/#/p5/box">box()</a>, <a href="/reference/#/p5/sphere">sphere()</a>, <a href="/reference/#/p5/cone">cone()</a>, and <a href="/#Shape3D%20Primitives">more</a>. See <a href="https://p5js.org/learn/getting-started-in-webgl-custom-geometry.html">the learn page about custom geometry</a> to make more complex objects.
- * - **Shape Detail** - When drawing in `WEBGL` mode, you can specify how smooth curves should be drawn by using a `detail` parameter. See <a href="https://github.com/processing/p5.js/wiki/Getting-started-with-WebGL-in-p5#3d-primitives-shapes">the wiki section about shapes</a> for a more information and an example.
+ * - **Shape Detail** - When drawing in `WEBGL` mode, you can specify how smooth curves should be drawn by using a `detail` parameter. See <a href="https://github.com/processing/p5.js/wiki/Getting-started-with-WebGL-in-p5#3d-primitives-shapes">the wiki section about shapes</a> for more information and an example.
  * - **Textures** - A texture is like a skin that wraps onto a shape. See <a href="https://github.com/processing/p5.js/wiki/Getting-started-with-WebGL-in-p5#textures">the wiki section about textures</a> for examples of mapping images onto surfaces with textures.
  * - **Materials and Lighting** - `WEBGL` offers different types of lights like <a href="/reference/#/p5/ambientLight">ambientLight()</a> to place around a scene. Materials like <a href="/reference/#/p5/specularMaterial">specularMaterial()</a> reflect the lighting to convey shape and depth. See <a href="https://p5js.org/learn/getting-started-in-webgl-appearance.html">the learn page for styling and appearance</a> to experiment with different combinations.
  * - **Camera** - The viewport of a `WEBGL` sketch can be adjusted by changing camera attributes. See <a href="https://p5js.org/learn/getting-started-in-webgl-appearance.html#camera">the learn page section about cameras</a> for an explanation of camera controls.
  * - **Text** - `WEBGL` requires opentype/truetype font files to be preloaded using <a href="/reference/#/p5/loadFont">loadFont()</a>. See <a href="https://github.com/processing/p5.js/wiki/Getting-started-with-WebGL-in-p5#text">the wiki section about text</a> for details, along with a workaround.
- * - **Shaders** - Shaders are hardware accelerated programs that can be used for a variety of effects and graphics. See the <a href="https://p5js.org/learn/getting-started-in-webgl-shaders.html">introduction to shaders</a> to get started with shaders in p5.js.
- * - **Graphics Acceleration** - `WEBGL` mode uses the graphics card instead of the CPU, so it may help boost the performance of your sketch (example: drawing more shapes on the screen at once).
+ * - **Shaders** - Shaders are hardware-accelerated programs that can be used for a variety of effects and graphics. See the <a href="https://p5js.org/learn/getting-started-in-webgl-shaders.html">introduction to shaders</a> to get started with shaders in p5.js.
+ * - **Graphics Acceleration** - `WEBGL` mode uses the graphics card instead of the CPU, so it may help boost the performance of your sketch (for example: drawing more shapes on the screen at once).
  *
- * To learn more about WEBGL mode, check out <a href="https://p5js.org/learn/#:~:text=Getting%20Started%20in%20WebGL">all the interactive WEBGL tutorials</a> in the "Learn" section of this website, or read the wiki article <a href="https://github.com/processing/p5.js/wiki/Getting-started-with-WebGL-in-p5">"Getting started with WebGL in p5"</a>.
+ * To learn more about WebGL mode, check out <a href="https://p5js.org/learn/#:~:text=Getting%20Started%20in%20WebGL">all the interactive WebGL tutorials</a> in the "Learn" section of this website, or read the wiki article <a href="https://github.com/processing/p5.js/wiki/Getting-started-with-WebGL-in-p5">"Getting started with WebGL in p5"</a>.
  *
  * @property {String} WEBGL
  * @final

--- a/src/core/reference.js
+++ b/src/core/reference.js
@@ -410,19 +410,19 @@
  * section of code multiple times.
  *
  * A 'for loop' consists of three different expressions inside of a parenthesis,
- * all of which are optional.These expressions are used to control the number of
- * times the loop is run.The first expression is a statement that is used to set
- * the initial state for the loop.The second expression is a condition that you
+ * all of which are optional. These expressions are used to control the number of
+ * times the loop is run. The first expression is a statement that is used to set
+ * the initial state for the loop. The second expression is a condition that you
  * would like to check before each loop. If this expression returns false then
- * the loop will exit.The third expression is executed at the end of each loop.
- * These expression are separated by ; (semi-colon).In case of an empty expression,
+ * the loop will exit. The third expression is executed at the end of each loop.
+ * These expression are separated by ; (semi-colon).In the case of an empty expression,
  * only a semi-colon is written.
  *
  * The code inside of the loop body (in between the curly braces) is executed between the evaluation of the second
  * and third expression.
  *
  * As with any loop, it is important to ensure that the loop can 'exit', or that
- * the test condition will eventually evaluate to false. The test condition with a <a href="#/p5/for">for</a> loop
+ * The test condition will eventually evaluate as false. The test condition with a <a href="#/p5/for">for</a> loop
  * is the second expression detailed above. Ensuring that this expression can eventually
  * become false ensures that your loop doesn't attempt to run an infinite amount of times,
  * which can crash your browser.

--- a/src/core/rendering.js
+++ b/src/core/rendering.js
@@ -22,7 +22,7 @@ const defaultClass = 'p5Canvas';
  *
  * Important note: in 2D mode (i.e. when `p5.Renderer` is not set) the origin (0,0)
  * is positioned at the top left of the screen. In 3D mode (i.e. when `p5.Renderer`
- * is set to `WEBGL`), the origin is positioned at the center of the canvas.
+ * is set to `WEBGL`), and the origin is positioned at the center of the canvas.
  * See [this issue](https://github.com/processing/p5.js/issues/1545) for more information.
  *
  * A WebGL canvas will use a WebGL2 context if it is supported by the browser.
@@ -309,7 +309,7 @@ p5.prototype.createGraphics = function(w, h, ...args) {
  *
  * Options can include:
  * - `format`: The data format of the texture, either `UNSIGNED_BYTE`, `FLOAT`, or `HALF_FLOAT`. The default is `UNSIGNED_BYTE`.
- * - `channels`: What color channels to store, either `RGB` or `RGBA`. The default is to match the channels in the main canvas (with alpha unless disabled with `setAttributes`.)
+ * - `channels`: What color channels to store, either `RGB` or `RGBA`? The default is to match the channels in the main canvas (with alpha unless disabled with `setAttributes`.)
  * - `depth`: A boolean, whether or not to include a depth buffer. Defaults to true.
  * - `depthFormat`: The data format for depth information, either `UNSIGNED_INT` or `FLOAT`. The default is `FLOAT` if available, or `UNSIGNED_INT` otherwise.
  * - `stencil`: A boolean, whether or not to include a stencil buffer, which can be used for masking. This may only be used if also using a depth buffer. Defaults to the value of `depth`, which is true if not provided.
@@ -320,7 +320,7 @@ p5.prototype.createGraphics = function(w, h, ...args) {
  * - `textureFiltering`: Either `LINEAR` (nearby pixels will be interpolated when reading values from the color texture) or `NEAREST` (no interpolation.) Generally, use `LINEAR` when using the texture as an image, and use `NEAREST` if reading the texture as data. Defaults to `LINEAR`.
  *
  * If `width`, `height`, or `density` are specified, then the framebuffer will
- * keep that size until manually changed. Otherwise, it will be autosized, and
+ * keep that size until manually changed. Otherwise, it will be auto-sized, and
  * it will update to match the main canvas's size and density when the main
  * canvas changes.
  *

--- a/src/core/shape/2d_primitives.js
+++ b/src/core/shape/2d_primitives.js
@@ -21,8 +21,8 @@ import '../friendly_errors/validate_params';
  *          0 <= start < TWO_PI ;    start <= stop < start + TWO_PI
  *
  *      This means that the arc rendering functions don't have to be concerned
- *      with what happens if stop is smaller than start, or if the arc 'goes
- *      round more than once', etc.: they can just start at start and increase
+ *      with what happens if the stop is smaller than the start, or if the arc 'goes
+ *      round more than once, etc.: they can just start at the start and increase
  *      until stop and the correct arc will be drawn.
  *
  *   2. Optionally adjusts the angles within each quadrant to counter the naive
@@ -601,10 +601,10 @@ p5.prototype.quad = function(...args) {
 };
 
 /**
- * Draws a rectangle to the canvas. A rectangle is a four-sided polygon with
+ * Draw a rectangle on the canvas. A rectangle is a four-sided polygon with
  * every angle at ninety degrees. By default, the first two parameters set the
- * location of the rectangle's upper-left corner. The third and fourth set the
- * shape's the width and height, respectively. The way these parameters are
+ * location of the rectangle's upper-left corner. The third and fourth sets the
+ * shape the width and height, respectively. The way these parameters are
  * interpreted may be changed with the <a href="#/p5/rectMode">rectMode()</a>
  * function.
  *
@@ -669,7 +669,7 @@ p5.prototype.rect = function(...args) {
 };
 
 /**
- * Draws a square to the canvas. A square is a four-sided polygon with every
+ * Draws a square on the canvas. A square is a four-sided polygon with every
  * angle at ninety degrees and equal side lengths. By default, the first two
  * parameters set the location of the square's upper-left corner. The third
  * parameter sets its side size. The way these parameters are interpreted may

--- a/src/core/shape/attributes.js
+++ b/src/core/shape/attributes.js
@@ -11,12 +11,12 @@ import * as constants from '../constants';
 
 /**
  * Modifies the location from which ellipses, circles, and arcs are drawn. By default, the
- * first two parameters are the x- and y-coordinates of the shape's center. The next
+ * first two parameters are the x and y coordinates of the shape's center. The next
  * parameters are its width and height. This is equivalent to calling `ellipseMode(CENTER)`.
  *
  * `ellipseMode(RADIUS)` also uses the first two parameters to set the x- and y-coordinates
  * of the shape's center. The next parameters are half of the shapes's width and height.
- * Calling `ellipse(0, 0, 10, 15)` draws a shape with a width of 20 and height of 30.
+ * Calling `ellipse(0, 0, 10, 15)` draws a shape with a width of 20 and a height of 30.
  *
  * `ellipseMode(CORNER)` uses the first two parameters as the upper-left corner of the
  * shape. The next parameters are its width and height.
@@ -107,7 +107,7 @@ p5.prototype.noSmooth = function() {
 
 /**
  * Modifies the location from which rectangles and squares are drawn. By default,
- * the first two parameters are the x- and y-coordinates of the shape's upper-left
+ * the first two parameters are the x and y coordinates of the shape's upper-left
  * corner. The next parameters are its width and height. This is equivalent to
  * calling `rectMode(CORNER)`.
  *
@@ -115,10 +115,10 @@ p5.prototype.noSmooth = function() {
  * the corners. The third and fourth parameters are the location of the opposite
  * corner.
  *
- * `rectMode(CENTER)` uses the first two parameters as the x- and y-coordinates of
+ * `rectMode(CENTER)` uses the first two parameters as the x and y coordinates of
  * the shape's center. The next parameters are its width and height.
  *
- * `rectMode(RADIUS)` also uses the first two parameters as the x- and y-coordinates
+ * `rectMode(RADIUS)` also uses the first two parameters as the x and y coordinates
  * of the shape's center. The next parameters are half of the shape's width and
  * height.
  *

--- a/src/core/shape/curves.js
+++ b/src/core/shape/curves.js
@@ -14,8 +14,8 @@ import '../friendly_errors/validate_params';
  * Draws a cubic Bezier curve on the screen. These curves are defined by a
  * series of anchor and control points. The first two parameters specify
  * the first anchor point and the last two parameters specify the other
- * anchor point, which become the first and last points on the curve. The
- * middle parameters specify the two control points which define the shape
+ * anchor point, which becomes the first and last point on the curve. The
+ * middle parameters specify the two control points that define the shape
  * of the curve. Approximately speaking, control points "pull" the curve
  * towards them.
  *
@@ -129,10 +129,10 @@ p5.prototype.bezierDetail = function(d) {
 };
 
 /**
- * Given the x or y co-ordinate values of control and anchor points of a bezier
+ * Given the x or y coordinate values of control and anchor points of a bezier
  * curve, it evaluates the x or y coordinate of the bezier at position t. The
- * parameters a and d are the x or y coordinates of first and last points on the
- * curve while b and c are of the control points.The final parameter t is the
+ * parameters a and d are the x or y coordinates of the first and last points on the
+ * curve while b and c are the control points. The final parameter t is the
  * position of the resultant point which is given between 0 and 1.
  * This can be done once with the x coordinates and a second time
  * with the y coordinates to get the location of a bezier curve at t.
@@ -264,7 +264,7 @@ p5.prototype.bezierTangent = function(a, b, c, d, t) {
 
 /**
  * Draws a curved line on the screen between two points, given as the
- * middle four parameters. The first two parameters are a control point, as
+ * middle four parameters. The first two parameters are control point, as
  * if the curve came from this point even though it's not drawn. The last
  * two parameters similarly describe the other control point. <br /><br />
  * Longer curves can be created by putting a series of <a href="#/p5/curve">curve()</a> functions

--- a/src/core/shape/vertex.js
+++ b/src/core/shape/vertex.js
@@ -257,16 +257,16 @@ p5.prototype.beginContour = function() {
  * </div>
  *
  * @alt
- * white square-shape with black outline in middle-right of canvas.
- * 4 black points in a square shape in middle-right of canvas.
- * 2 horizontal black lines. In the top-right and bottom-right of canvas.
- * 3 line shape with horizontal on top, vertical in middle and horizontal bottom.
- * square line shape in middle-right of canvas.
+ * white square shape with a black outline in the middle right of the canvas.
+ * 4 black points in a square shape in the middle right of the canvas.
+ * 2 horizontal black lines. In the top-right and bottom-right of the canvas.
+ * 3 line shape with horizontal on the top, vertical in the middle and horizontal bottom.
+ * square line shape in the middle-right of the canvas.
  * 2 white triangle shapes mid-right canvas. left one pointing up and right down.
  * 5 horizontal interlocking and alternating white triangles in mid-right canvas.
  * 4 interlocking white triangles in 45 degree rotated square-shape.
  * 2 white rectangle shapes in mid-right canvas. Both 20×55.
- * 3 side-by-side white rectangles center rect is smaller in mid-right canvas.
+ * 3 side-by-side white rectangles center rect is smaller in the mid-right canvas.
  * Thick white l-shape with black outline mid-top-left of canvas.
  */
 p5.prototype.beginShape = function(kind) {
@@ -425,10 +425,10 @@ p5.prototype.bezierVertex = function(...args) {
  *
  * The first and last points in a series of curveVertex() lines will be used to
  * guide the beginning and end of the curve. A minimum of four
- * points is required to draw a tiny curve between the second and
+ * points are required to draw a tiny curve between the second and
  * third points. Adding a fifth point with curveVertex() will draw
  * the curve between the second, third, and fourth points. The
- * curveVertex() function is an implementation of Catmull-Rom
+ * curveVertex() function is an implementation of the Catmull-Rom
  * splines.
  *
  * @method curveVertex

--- a/src/image/filters.js
+++ b/src/image/filters.js
@@ -148,13 +148,13 @@ const Filters = {
  * The difference between this and the actual filter functions defined below
  * is that the filter functions generally modify the pixel buffer but do
  * not actually put that data back to the canvas (where it would actually
- * update what is visible). By contrast this method does make the changes
+ * update what is visible). By contrast, this method does make the changes
  * actually visible in the canvas.
  *
  * The apply method is the method that callers of this module would generally
  * use. It has been separated from the actual filters to support an advanced
  * use case of creating a filter chain that executes without actually updating
- * the canvas in between everystep.
+ * the canvas in between every step.
  *
  * @private
  * @param  {HTMLCanvasElement} canvas The input canvas to apply the filter on.

--- a/src/image/loading_displaying.js
+++ b/src/image/loading_displaying.js
@@ -18,7 +18,7 @@ import '../core/friendly_errors/fes_core';
 /**
  * Loads an image to create a <a href="#/p5.Image">p5.Image</a> object.
  *
- * `loadImage()` interprets the first parameter one of three ways. If the path
+ * `loadImage()` interprets the first parameter in one of three ways. If the path
  * to an image file is provided, `loadImage()` will load it. Paths to local
  * files should be relative, such as `'assets/thundercat.jpg'`. URLs such as
  * `'https://example.com/thundercat.jpg'` may be blocked due to browser
@@ -830,7 +830,7 @@ function _sAssign(sVal, iVal) {
 }
 
 /**
- * Draws a source image to the canvas.
+ * Draws a source image on the canvas.
  *
  * The first parameter, `img`, is the source image to be drawn. The second and
  * third parameters, `dx` and `dy`, set the coordinates of the destination
@@ -855,13 +855,13 @@ function _sAssign(sVal, iVal) {
  * (`sx`, `sy`) and extends to the edges of the source image.
  *
  * The ninth parameter, `fit`, is also optional. It enables a subsection of
- * the source image to be drawn without affecting its aspect ratio. If
+ * the source image is to be drawn without affecting its aspect ratio. If
  * `CONTAIN` is passed, the full subsection will appear within the destination
  * rectangle. If `COVER` is passed, the subsection will completely cover the
  * destination rectangle. This may have the effect of zooming into the
  * subsection.
  *
- * The tenth and eleventh paremeters, `xAlign` and `yAlign`, are also
+ * The tenth and eleventh parameters, `xAlign` and `yAlign`, are also
  * optional. They determine how to align the fitted subsection. `xAlign` can
  * be set to either `LEFT`, `RIGHT`, or `CENTER`. `yAlign` can be set to
  * either `TOP`, `BOTTOM`, or `CENTER`. By default, both `xAlign` and `yAlign`

--- a/src/image/pixels.js
+++ b/src/image/pixels.js
@@ -23,7 +23,7 @@ import '../color/p5.Color';
  *
  * Some displays use several smaller pixels to set the color at a single
  * point. The <a href="#/p5/pixelDensity">pixelDensity()</a> function returns
- * the pixel density of the canvas. High density displays often have a
+ * the pixel density of the canvas. High-density displays often have a
  * <a href="#/p5/pixelDensity">pixelDensity()</a> of 2. On such a display, the
  * `pixels` array for a 100&times;100 canvas has 200 &times; 200 &times; 4 =
  * 160,000 elements.

--- a/src/io/files.js
+++ b/src/io/files.js
@@ -577,8 +577,8 @@ function makeObject(row, headers) {
  * If the name of the file is used as the parameter, as in the above example,
  * the file must be located in the sketch directory/folder.
  *
- * Alternatively, the file maybe be loaded from anywhere on the local
- * computer using an absolute path (something that starts with / on Unix and
+ * Alternatively, the file may be loaded from anywhere on the local
+ * computer using an absolute path (something that starts with/on Unix and
  * Linux, or a drive letter on Windows), or the filename parameter can be a
  * URL for a file found on a network.
  *

--- a/src/math/math.js
+++ b/src/math/math.js
@@ -15,7 +15,7 @@ import p5 from '../core/main';
  *
  * <a href="#/p5.Vector">p5.Vector</a> objects are often used to program
  * motion because they simplify the math. For example, a moving ball has a
- * position and a velocity. Position describes where the ball is in space. The
+ * position and velocity. Position describes where the ball is in space. The
  * ball's position vector extends from the origin to the ball's center.
  * Velocity describes the ball's speed and the direction it's moving. If the
  * ball is moving straight up, its velocity vector points straight up. Adding

--- a/src/webgl/interaction.js
+++ b/src/webgl/interaction.js
@@ -10,20 +10,20 @@ import * as constants from '../core/constants';
 
 /**
  * Allows movement around a 3D sketch using a mouse or trackpad or touch.
- * Left-clicking and dragging or swipe motion will rotate the camera position
+ * Left-clicking and dragging or swiping motion will rotate the camera position
  * about the center of the sketch, right-clicking and dragging or multi-swipe
  * will pan the camera position without rotation, and using the mouse wheel
  * (scrolling) or pinch in/out will move the camera further or closer
  * from the center of the sketch. This function can be called with parameters
  * dictating sensitivity to mouse/touch movement along the X and Y axes.
  * Calling this function without parameters is equivalent to calling
- * orbitControl(1,1). To reverse direction of movement in either axis,
+ * orbitControl(1,1). To reverse the direction of movement in either axis,
  * enter a negative number for sensitivity.
  * @method orbitControl
  * @for p5
  * @param  {Number} [sensitivityX] sensitivity to mouse movement along X axis
  * @param  {Number} [sensitivityY] sensitivity to mouse movement along Y axis
- * @param  {Number} [sensitivityZ] sensitivity to scroll movement along Z axis
+ * @param  {Number} [sensitivityZ] sensitivity to scroll movement along the Z axis
  * @param  {Object} [options] An optional object that can contain additional settings,
  * disableTouchActions - Boolean, default value is true.
  * Setting this to true makes mobile interactions smoother by preventing
@@ -33,7 +33,7 @@ import * as constants from '../core/constants';
  * By default, horizontal movement of the mouse or touch pointer rotates the camera
  * around the y-axis, and vertical movement rotates the camera around the x-axis.
  * But if setting this option to true, the camera always rotates in the direction
- * the pointer is moving. For zoom and move, the behavior is the same regardless of
+ * the pointer is moving. For Zoom and Move, the behavior is the same regardless of
  * true/false.
  * @chainable
  * @example

--- a/src/webgl/p5.RendererGL.Immediate.js
+++ b/src/webgl/p5.RendererGL.Immediate.js
@@ -8,7 +8,7 @@
  * It differs from p5.js' default, Retained Mode, which caches
  * geometries and buffers on the CPU to reduce the number of webgl
  * draw calls. Retained mode is more efficient & performative,
- * however, Immediate Mode is useful for sketching quick
+ * However, Immediate Mode is useful for sketching quick
  * geometric ideas.
  */
 import p5 from '../core/main';

--- a/src/webgl/p5.RendererGL.js
+++ b/src/webgl/p5.RendererGL.js
@@ -123,7 +123,7 @@ const filterShaderVert = readFileSync(join(__dirname, '/shaders/filters/default.
  * The available attributes are:
  * <br>
  * alpha - indicates if the canvas contains an alpha buffer
- * default is true
+ * Default is true
  *
  * depth - indicates whether the drawing buffer has a depth buffer
  * of at least 16 bits - default is true
@@ -132,20 +132,20 @@ const filterShaderVert = readFileSync(join(__dirname, '/shaders/filters/default.
  * of at least 8 bits
  *
  * antialias - indicates whether or not to perform anti-aliasing
- * default is false (true in Safari)
+ * Default is false (true in Safari)
  *
  * premultipliedAlpha - indicates that the page compositor will assume
  * the drawing buffer contains colors with pre-multiplied alpha
- * default is true
+ * Default is true
  *
  * preserveDrawingBuffer - if true the buffers will not be cleared and
  * and will preserve their values until cleared or overwritten by author
- * (note that p5 clears automatically on draw loop)
- * default is true
+ * (note that p5 clears automatically on the draw loop)
+ * Default is true
  *
  * perPixelLighting - if true, per-pixel lighting will be used in the
  * lighting shader otherwise per-vertex lighting is used.
- * default is true.
+ * Default is true.
  *
  * version - either 1 or 2, to specify which WebGL version to ask for. By
  * default, WebGL 2 will be requested. If WebGL2 is not available, it will


### PR DESCRIPTION
Signed-off-by: nikhilkalburgi <nikhilkalburgi19@gmail.com>

####Changes:

Identified and resolved typos, punctuation errors in Docs


#### PR Checklist

- [x] `npm run lint` passes
- [x] [Inline documentation] is included / updated
- [ ] [Unit tests] are included / updated

