### PR TITLE
Fixed textfont() to work for multi-word fonts

### DIFF
--- a/src/core/p5.Renderer2D.js
+++ b/src/core/p5.Renderer2D.js
@@ -1329,7 +1329,7 @@ class Renderer2D extends p5.Renderer {
     }
 
     this.drawingContext.font = `${this._textStyle || 'normal'} ${this._textSize ||
-      12}px ${font || 'sans-serif'}`;
+      12}px "${font || 'sans-serif'}"`;
 
     this.drawingContext.textAlign = this._textAlign;
     if (this._textBaseline === constants.CENTER) {


### PR DESCRIPTION
fixes #6652 


Changes:
added changes as mentioned in the issue 6652, created a PR as suggested by @dhowe in issue #6652 to fix "drawingContext.font" property.


 Screenshots of the change:

#### PR Checklist

- [x] `npm run lint` passes
- [x] [Inline documentation] is included / updated
- [x] [Unit tests] are included / updated

[Inline documentation]: https://github.com/processing/p5.js/blob/main/contributor_docs/inline_documentation.md
[Unit tests]: https://github.com/processing/p5.js/tree/main/contributor_docs#unit-tests
