### PR TITLE
Updated docs for p5.Shader.js

### DIFF
--- a/src/webgl/p5.Shader.js
+++ b/src/webgl/p5.Shader.js
@@ -215,7 +215,7 @@ p5.Shader = class {
       );
       uniform.size = uniformInfo.size;
       let uniformName = uniformInfo.name;
-      //uniforms thats are arrays have their name returned as
+      //uniforms that are arrays have their name returned as
       //someUniform[0] which is a bit silly so we trim it
       //off here. The size property tells us that its an array
       //so we dont lose any information by doing this
@@ -382,7 +382,7 @@ p5.Shader = class {
    * @param {String} uniformName the name of the uniform.
    * Must correspond to the name used in the vertex and fragment shaders
    * @param {Boolean|Number|Number[]|p5.Image|p5.Graphics|p5.MediaElement|p5.Texture}
-   * data the data to associate with the uniform. The type can be
+   * data The value to assign to the uniform. This can be
    * a boolean (true/false), a number, an array of numbers, or
    * an image (p5.Image, p5.Graphics, p5.MediaElement, p5.Texture)
    *


### PR DESCRIPTION

- [x] `npm run lint` passes
- [x] [Inline documentation] is included / updated
- [ ] [Unit tests] are included / updated

[Inline documentation]: https://github.com/processing/p5.js/blob/main/contributor_docs/inline_documentation.md
[Unit tests]: https://github.com/processing/p5.js/tree/main/contributor_docs#unit-tests
