### PR TITLE
Changed the definition of textBounds() in p5.Font.js

### DIFF
--- a/src/typography/p5.Font.js
+++ b/src/typography/p5.Font.js
@@ -187,7 +187,7 @@ p5.Font = class {
         opts,
         (glyph, gX, gY, gFontSize) => {
           const gm = glyph.getMetrics();
-          if (glyph.index === 0 || glyph.index === 10) {
+          if (glyph.index === 0) {
             lineCount += 1;
             xCoords[lineCount] = [];
           } else {


### PR DESCRIPTION
<!--
  Thank you for contributing! Please use this pull request (PR) template.


 In the description field of this PR, include "resolves #XXXX" tagging the issue you are fixing. If this PR addresses the issue but doesn't completely resolve it (ie the issue should remain open after your PR is merged), write "addresses #XXXX".-->
Resolves #6671

 Changes:
<!-- Add here what changes were made in this pull request and if possible provide links showcasing the changes. -->
Removed the check for `glyph.index === 10` from `if(glyph.index === 0 || glyph.index === 10)` in the definition of `p5.Font.textBounds()` (line 190 in `p5.Font.js`)

 Screenshots of the change:
<!-- If applicable, add screenshots depicting the changes. -->
![after](https://github.com/processing/p5.js/assets/148856416/85efa2f9-8f31-4152-bee1-734d457ac6e8)

#### PR Checklist
<!--
  To check any option, replace the "[ ]" with a "[x]". Be sure to check out how it looks in the Preview tab! Feel free to remove any portion of the template that is not relevant for your issue.
-->

- [x] `npm run lint` passes
- [ ] [Inline documentation] is included / updated
- [ ] [Unit tests] are included / updated

[Inline documentation]: https://github.com/processing/p5.js/blob/main/contributor_docs/inline_documentation.md
[Unit tests]: https://github.com/processing/p5.js/tree/main/contributor_docs#unit-tests
