### PR TITLE
fixed the doubleClicked() in offline docs 

### DIFF
--- a/docs/yuidoc-p5-theme/assets/js/render.js
+++ b/docs/yuidoc-p5-theme/assets/js/render.js
@@ -194,7 +194,7 @@ var renderCode = function(exampleName) {
 
       var s = function( p ) {
         var fxns = ['setup', 'draw', 'preload', 'mousePressed', 'mouseReleased',
-          'mouseMoved', 'mouseDragged', 'mouseClicked', 'mouseWheel',
+          'mouseMoved', 'mouseDragged', 'mouseClicked','doubleClicked','mouseWheel',
           'touchStarted', 'touchMoved', 'touchEnded',
           'keyPressed', 'keyReleased', 'keyTyped'];
         var _found = [];


### PR DESCRIPTION

  
 completely fixes the bug of issue #6252

 Changes:
doubleClicked was not called within the fxn in render.js



 Screenshots of the change:
<img width="637" alt="Screenshot 2024-01-01 at 7 45 24 PM" src="https://github.com/processing/p5.js/assets/124163672/32a6da3a-eb3d-4059-842f-fa8f65c79e95">



https://github.com/processing/p5.js/assets/124163672/0924dddc-57e0-4029-ac03-268a9f33677a




#### PR Checklist

- [x] `npm run lint` passes
- [ ] [Inline documentation] is included / updated
- [ ] [Unit tests] are included / updated

[Inline documentation]: https://github.com/processing/p5.js/blob/main/contributor_docs/inline_documentation.md
[Unit tests]: https://github.com/processing/p5.js/tree/main/contributor_docs#unit-tests
