### PR TITLE
fixed second example in the reference page for `acos()` 

### DIFF
--- a/src/math/trigonometry.js
+++ b/src/math/trigonometry.js
@@ -42,14 +42,14 @@ p5.prototype._angleMode = constants.RADIANS;
  *
  * <div>
  * <code>
- * let a = PI-QUARTER_PI;
+ * let a = PI + QUARTER_PI;
  * let c = cos(a);
  * let ac = acos(c);
  * text(`${round(a, 3)}`, 35, 25);
  * text(`${round(c, 3)}`, 35, 50);
  * text(`${round(ac, 3)}`, 35, 75);
  *
- * describe('The numbers 2.356, -0.707, and 2.356 written on separate rows.');
+ * describe('The numbers 3.927, -0.707, and 2.356 written on separate rows.');
  * </code>
  * </div>
  */

--- a/src/math/trigonometry.js
+++ b/src/math/trigonometry.js
@@ -42,14 +42,14 @@ p5.prototype._angleMode = constants.RADIANS;
  *
  * <div>
  * <code>
- * let a = PI;
+ * let a = PI-QUARTER_PI;
  * let c = cos(a);
  * let ac = acos(c);
  * text(`${round(a, 3)}`, 35, 25);
  * text(`${round(c, 3)}`, 35, 50);
  * text(`${round(ac, 3)}`, 35, 75);
  *
- * describe('The numbers 3.927, -0.707, and 2.356 written on separate rows.');
+ * describe('The numbers 2.356, -0.707, and 2.356 written on separate rows.');
  * </code>
  * </div>
  */


### PR DESCRIPTION
<!--
  Thank you for contributing! Please use this pull request (PR) template.


 In the description field of this PR, include "resolves #XXXX" tagging the issue you are fixing. If this PR addresses the issue but doesn't completely resolve it (ie the issue should remain open after your PR is merged), write "addresses #XXXX".-->
Resolves #6696 

 Changes:
<!-- Add here what changes were made in this pull request and if possible provide links showcasing the changes. -->
Changed the value of `a` from `PI` to `PI-QUARTER_PI` in the second example in reference for `acos()` (in file `src/math/trigonometry.js` ). Also changed `3.927` to `2.356` in `describe` in this example.

 Screenshots of the change:
<!-- If applicable, add screenshots depicting the changes. -->
![change](https://github.com/processing/p5.js/assets/148856416/8dee50e5-95b9-4f6f-a5df-5bdbae976a57)

#### PR Checklist
<!--
  To check any option, replace the "[ ]" with a "[x]". Be sure to check out how it looks in the Preview tab! Feel free to remove any portion of the template that is not relevant for your issue.
-->

- [x] `npm run lint` passes
- [ ] [Inline documentation] is included / updated
- [ ] [Unit tests] are included / updated

[Inline documentation]: https://github.com/processing/p5.js/blob/main/contributor_docs/inline_documentation.md
[Unit tests]: https://github.com/processing/p5.js/tree/main/contributor_docs#unit-tests
