### PR TITLE
fix documentation typo in src/math/random.js

### DIFF
--- a/src/math/random.js
+++ b/src/math/random.js
@@ -108,7 +108,7 @@ p5.prototype.randomSeed = function(seed) {
  * strokeWeight(5);
  * point(x, y);
  *
- * describe('A black dot appears in a random posiiton on a gray square.');
+ * describe('A black dot appears in a random position on a gray square.');
  * </code>
  * </div>
  *


### PR DESCRIPTION
Fix minor documentation typo in `src/math/random.js`.

#### PR Checklist
<!--
  To check any option, replace the "[ ]" with a "[x]". Be sure to check out how it looks in the Preview tab! Feel free to remove any portion of the template that is not relevant for your issue.
-->

- [x] `npm run lint` passes
- [x] [Inline documentation] is included / updated
- [x] [Unit tests] are included / updated

[Inline documentation]: https://github.com/processing/p5.js/blob/main/contributor_docs/inline_documentation.md
[Unit tests]: https://github.com/processing/p5.js/tree/main/contributor_docs#unit-tests
