### PR TITLE
Implement mirrored video feature for createCapture (#6441)

### DIFF
--- a/src/dom/dom.js
+++ b/src/dom/dom.js
@@ -2135,7 +2135,11 @@ if (navigator.mediaDevices.getUserMedia === undefined) {
  * W3C documentation</a> for possible properties. Different browsers support different
  * properties.
  *
- * The second parameter, `callback`, is optional. It's a function to call once
+ * The 'flipped' property is an optional property which can be set to `{flipped:true}`
+ * to mirror the video output.If it is true then it means that video will be mirrored
+ * or flipped and if nothing is mentioned then by default it will be `false`.
+ *
+ * The second parameter,`callback`, is optional. It's a function to call once
  * the capture is ready for use. The callback function should have one
  * parameter, `stream`, that's a
  * <a href="https://developer.mozilla.org/en-US/docs/Web/API/MediaStream" target="_blank">MediaStream</a> object.
@@ -2148,6 +2152,8 @@ if (navigator.mediaDevices.getUserMedia === undefined) {
  * @param  {String|Constant|Object}  [type] type of capture, either AUDIO or VIDEO,
  *                                   or a constraints object. Both video and audio
  *                                   audio streams are captured by default.
+ * @param  {Object}                  [flipped] flip the capturing video and mirror the output with `{flipped:true}`. By
+ *                                   default it is false.
  * @param  {Function}                [callback] function to call once the stream
  *                                   has loaded.
  * @return {p5.Element} new <a href="#/p5.Element">p5.Element</a> object.
@@ -2181,6 +2187,19 @@ if (navigator.mediaDevices.getUserMedia === undefined) {
  *   // Invert the colors in the stream.
  *   filter(INVERT);
  * }
+ * </code>
+ * </div>
+ * <div class='notest'>
+ * <code>
+ * let capture;
+ *
+ * function setup() {
+ *   // Create the video capture with mirrored output.
+ *   capture = createCapture(VIDEO,{ flipped:true });
+ *   capture.size(100,100);
+ *   describe('A video stream from the webcam with flipped or mirrored output.');
+ * }
+ *
  * </code>
  * </div>
  *
@@ -2227,11 +2246,12 @@ p5.prototype.createCapture = function(...args) {
     if (arg === p5.prototype.VIDEO) useAudio = false;
     else if (arg === p5.prototype.AUDIO) useVideo = false;
     else if (typeof arg === 'object') {
-      constraints = arg;
-      flipped = constraints.flipped || false;
-    }
-    else if (typeof arg === 'boolean') {
-      flipped = arg;
+      // Check if the argument is an object with a 'flipped' property
+      if (arg.flipped !== undefined) {
+        flipped = arg.flipped;
+      } else {
+        constraints = arg;
+      }
     }
     else if (typeof arg === 'function') {
       callback = arg;

--- a/src/dom/dom.js
+++ b/src/dom/dom.js
@@ -2275,7 +2275,7 @@ p5.prototype.createCapture = function(...args) {
 
     if (callback) callback(domElement.srcObject);
   });
-
+  videoEl.flipped=flipped;
   return videoEl;
 };
 
@@ -4393,7 +4393,6 @@ class MediaElement extends p5.Element {
   duration() {
     return this.elt.duration;
   }
-
   _ensureCanvas() {
     if (!this.canvas) {
       this.canvas = document.createElement('canvas');
@@ -4414,11 +4413,14 @@ class MediaElement extends p5.Element {
       }
 
       this.drawingContext.clearRect(
-        0,
-        0,
-        this.canvas.width,
-        this.canvas.height
-      );
+        0, 0, this.canvas.width, this.canvas.height);
+
+      if (this.flipped === true) {
+        this.drawingContext.save();
+        this.drawingContext.scale(-1, 1);
+        this.drawingContext.translate(-this.canvas.width, 0);
+      }
+
       this.drawingContext.drawImage(
         this.elt,
         0,
@@ -4426,6 +4428,11 @@ class MediaElement extends p5.Element {
         this.canvas.width,
         this.canvas.height
       );
+
+      if (this.flipped === true) {
+        this.drawingContext.restore();
+      }
+
       this.setModified(true);
       this._frameOnCanvas = this._pInst.frameCount;
     }

--- a/src/dom/dom.js
+++ b/src/dom/dom.js
@@ -2246,24 +2246,22 @@ p5.prototype.createCapture = function(...args) {
     if (arg === p5.prototype.VIDEO) useAudio = false;
     else if (arg === p5.prototype.AUDIO) useVideo = false;
     else if (typeof arg === 'object') {
-      // Check if the argument is an object with a 'flipped' property
       if (arg.flipped !== undefined) {
         flipped = arg.flipped;
-      } else {
-        constraints = arg;
+        delete arg.flipped;
       }
+      constraints = Object.assign({}, constraints, arg);
     }
     else if (typeof arg === 'function') {
       callback = arg;
     }
   }
 
-  if (!constraints) constraints = { video: useVideo, audio: useAudio };
-
+  const videoConstraints = { video: useVideo, audio: useAudio };
+  constraints = Object.assign({}, videoConstraints, constraints);
   const domElement = document.createElement('video');
   // required to work in iOS 11 & up:
   domElement.setAttribute('playsinline', '');
-
   navigator.mediaDevices.getUserMedia(constraints).then(function (stream) {
     try {
       if ('srcObject' in domElement) {
@@ -2271,10 +2269,11 @@ p5.prototype.createCapture = function(...args) {
       } else {
         domElement.src = window.URL.createObjectURL(stream);
       }
-    } catch (err) {
+    }
+    catch(err) {
       domElement.src = stream;
     }
-  }, console.log);
+  }, console.err);
 
   const videoEl = addElement(domElement, this, true);
   videoEl.loadedmetadata = false;

--- a/src/dom/dom.js
+++ b/src/dom/dom.js
@@ -2212,7 +2212,7 @@ if (navigator.mediaDevices.getUserMedia === undefined) {
 p5.prototype.createCapture = function(...args) {
   p5._validateParameters('createCapture', args);
 
-  // return if getUserMedia is not supported by browser
+  // return if getUserMedia is not supported by the browser
   if (!(navigator.mediaDevices && navigator.mediaDevices.getUserMedia)) {
     throw new DOMException('getUserMedia not supported in this browser');
   }
@@ -2221,12 +2221,23 @@ p5.prototype.createCapture = function(...args) {
   let useAudio = true;
   let constraints;
   let callback;
+  let flipped = false;
+
   for (const arg of args) {
     if (arg === p5.prototype.VIDEO) useAudio = false;
     else if (arg === p5.prototype.AUDIO) useVideo = false;
-    else if (typeof arg === 'object') constraints = arg;
-    else if (typeof arg === 'function') callback = arg;
+    else if (typeof arg === 'object') {
+      constraints = arg;
+      flipped = constraints.flipped || false;
+    }
+    else if (typeof arg === 'boolean') {
+      flipped = arg;
+    }
+    else if (typeof arg === 'function') {
+      callback = arg;
+    }
   }
+
   if (!constraints) constraints = { video: useVideo, audio: useAudio };
 
   const domElement = document.createElement('video');
@@ -2253,6 +2264,9 @@ p5.prototype.createCapture = function(...args) {
     if (domElement.width) {
       videoEl.width = domElement.width;
       videoEl.height = domElement.height;
+      if (flipped) {
+        videoEl.elt.style.transform = 'scaleX(-1)';
+      }
     } else {
       videoEl.width = videoEl.elt.width = domElement.videoWidth;
       videoEl.height = videoEl.elt.height = domElement.videoHeight;
@@ -2261,8 +2275,10 @@ p5.prototype.createCapture = function(...args) {
 
     if (callback) callback(domElement.srcObject);
   });
+
   return videoEl;
 };
+
 
 /**
  * Creates a new <a href="#/p5.Element">p5.Element</a> object.

--- a/src/dom/dom.js
+++ b/src/dom/dom.js
@@ -2273,7 +2273,7 @@ p5.prototype.createCapture = function(...args) {
     catch(err) {
       domElement.src = stream;
     }
-  }, console.err);
+  }, console.error);
 
   const videoEl = addElement(domElement, this, true);
   videoEl.loadedmetadata = false;


### PR DESCRIPTION
<!--
  Thank you for contributing! Please use this pull request (PR) template.


 In the description field of this PR, include "resolves #6441" tagging the issue you are fixing. If this PR addresses the issue but doesn't completely resolve it (ie the issue should remain open after your PR is merged), write "addresses #XXXX".-->
Resolves #6441

 Changes:

- Added a new feature to create a flipped video using `createCapture`.
- Modified the `createCapture` function to accept a boolean parameter for flipping the video.
 


 Screenshots of the change:
 
<img width="956" alt="Screenshot 2024-01-06 162132" src="https://github.com/processing/p5.js/assets/35897449/6eaa909b-72d0-4054-a47f-b4f831b8ce95">
<img width="953" alt="Screenshot 2024-01-05 234941" src="https://github.com/processing/p5.js/assets/35897449/f20c5514-f583-4684-81d1-15f445ee3a5c">


#### PR Checklist
<!--
  To check any option, replace the "[ ]" with a "[x]". Be sure to check out how it looks in the Preview tab! Feel free to remove any portion of the template that is not relevant for your issue.
-->

- [x] `npm run lint` passes
- [ ] [Inline documentation] is included / updated
- [ ] [Unit tests] are included / updated

