### PR TITLE
fix/Local Npm module 'grunt-contrib-compress' not found

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
     "grunt": "^1.6.1",
     "grunt-cli": "^1.4.3",
     "grunt-contrib-clean": "^2.0.1",
+    "grunt-contrib-compress": "^2.0.0",
     "grunt-contrib-connect": "^3.0.0",
     "grunt-contrib-uglify": "^5.2.2",
     "grunt-contrib-watch": "^1.1.0",


### PR DESCRIPTION
Resolves #6706

**Changes:**
Added 'grunt-contrib-compress' as a dev-dependency to resolve the "Local Npm module 'grunt-contrib-compress' not found" issue.

#### PR Checklist

- [X] `npm run lint` passes
- [X] [Inline documentation] is included / updated
- [X] [Unit tests] are included / updated
