### PR TITLE
lerpColor in HSL or HSB mode now can loop the color wheel if needed

### DIFF
--- a/src/color/creating_reading.js
+++ b/src/color/creating_reading.js
@@ -380,7 +380,7 @@ p5.prototype.hue = function(c) {
  * @method lerpColor
  * @param  {p5.Color} c1  interpolate from this color.
  * @param  {p5.Color} c2  interpolate to this color.
- * @param  {Number}       amt number between 0 and 1.
+ * @param  {Number}   amt number between 0 and 1.
  * @return {p5.Color}     interpolated color.
  *
  * @example
@@ -429,7 +429,7 @@ p5.prototype.lerpColor = function(c1, c2, amt) {
     fromArray = c1.hsla;
     toArray = c2.hsla;
   } else {
-    throw new Error(`${mode}cannot be used for interpolation.`);
+    throw new Error(`${mode} cannot be used for interpolation.`);
   }
 
   // Prevent extrapolation.
@@ -442,7 +442,22 @@ p5.prototype.lerpColor = function(c1, c2, amt) {
   }
 
   // Perform interpolation.
-  l0 = this.lerp(fromArray[0], toArray[0], amt);
+  if (mode === constants.RGB) {
+    l0 = this.lerp(fromArray[0], toArray[0], amt);
+  }
+  // l0 (hue) has to wrap around (and it's between 0 and 1)
+  else {
+    // find shortest path in the color wheel
+    if (Math.abs(fromArray[0] - toArray[0]) > 0.5) {
+      if (fromArray[0] > toArray[0]) {
+        toArray[0] += 1;
+      } else {
+        fromArray[0] += 1;
+      }
+    }
+    l0 = this.lerp(fromArray[0], toArray[0], amt);
+    if (l0 >= 1) { l0 -= 1; }
+  }
   l1 = this.lerp(fromArray[1], toArray[1], amt);
   l2 = this.lerp(fromArray[2], toArray[2], amt);
   l3 = this.lerp(fromArray[3], toArray[3], amt);

--- a/test/unit/color/creating_reading.js
+++ b/test/unit/color/creating_reading.js
@@ -159,15 +159,15 @@ suite('color/CreatingReading', function() {
       myp5.colorMode(myp5.HSL);
       var interA = myp5.lerpColor(fromColor, toColor, 0.33);
       var interB = myp5.lerpColor(fromColor, toColor, 0.66);
-      assert.deepEqual(interA.levels, [66, 190, 44, 255]);
-      assert.deepEqual(interB.levels, [53, 164, 161, 255]);
+      assert.deepEqual(interA.levels, [190, 44, 63, 255]);
+      assert.deepEqual(interB.levels, [122, 96, 103, 255] );
     });
     test('should correctly get lerp colors in HSB', function() {
       myp5.colorMode(myp5.HSB);
       var interA = myp5.lerpColor(fromColor, toColor, 0.33);
       var interB = myp5.lerpColor(fromColor, toColor, 0.66);
-      assert.deepEqual(interA.levels, [69, 192, 47, 255]);
-      assert.deepEqual(interB.levels, [56, 166, 163, 255]);
+      assert.deepEqual(interA.levels, [192, 47, 66, 255]);
+      assert.deepEqual(interB.levels, [166, 56, 164, 255]);
     });
     test('should not extrapolate', function() {
       var interA = myp5.lerpColor(fromColor, toColor, -0.5);
@@ -197,15 +197,15 @@ suite('color/CreatingReading', function() {
       myp5.colorMode(myp5.HSL);
       var interA = myp5.lerpColor(fromColor, toColor, 0.33);
       var interB = myp5.lerpColor(fromColor, toColor, 0.66);
-      assert.deepEqual(interA.levels, [66, 190, 44, 99]);
-      assert.deepEqual(interB.levels, [53, 164, 161, 149]);
+      assert.deepEqual(interA.levels, [190, 44, 63, 99]);
+      assert.deepEqual(interB.levels, [164, 53, 162, 149]);
     });
     test('should correctly get lerp colors in HSB with alpha', function() {
       myp5.colorMode(myp5.HSB);
       var interA = myp5.lerpColor(fromColor, toColor, 0.33);
       var interB = myp5.lerpColor(fromColor, toColor, 0.66);
-      assert.deepEqual(interA.levels, [69, 192, 47, 99]);
-      assert.deepEqual(interB.levels, [56, 166, 163, 149]);
+      assert.deepEqual(interA.levels, [192, 47, 66, 99]);
+      assert.deepEqual(interB.levels, [166, 56, 164, 149]);
     });
     test('should not extrapolate', function() {
       var interA = myp5.lerpColor(fromColor, toColor, -0.5);

--- a/test/unit/color/creating_reading.js
+++ b/test/unit/color/creating_reading.js
@@ -160,7 +160,7 @@ suite('color/CreatingReading', function() {
       var interA = myp5.lerpColor(fromColor, toColor, 0.33);
       var interB = myp5.lerpColor(fromColor, toColor, 0.66);
       assert.deepEqual(interA.levels, [190, 44, 63, 255]);
-      assert.deepEqual(interB.levels, [122, 96, 103, 255] );
+      assert.deepEqual(interB.levels, [164, 53, 162, 255]);
     });
     test('should correctly get lerp colors in HSB', function() {
       myp5.colorMode(myp5.HSB);


### PR DESCRIPTION
<!--
  Thank you for contributing! Please use this pull request (PR) template.


 In the description field of this PR, include "resolves #XXXX" tagging the issue you are fixing. If this PR addresses the issue but doesn't completely resolve it (ie the issue should remain open after your PR is merged), write "addresses #XXXX".-->
Resolves #6436 

 Changes:
<!-- Add here what changes were made in this pull request and if possible provide links showcasing the changes. -->
I modified p5.prototype.lerpColor in src/color/creating_reading.js. Now if the color mode is HSL or HSB the interpolation of the HUE value will proceed along the shortest path on the color wheel. So for example from hue 359 to hue 1 it will increase up to 360 then wrap at 0 and increase up to 1. I tried implementing this as suggested in the issue discussion (converting the color to vector and the using slerp), but I found another simpler solution that works. 

 Screenshots of the change:
Lerping from 340 to 20 before:
<img width="738" alt="Screenshot 2024-01-07 alle 15 12 57" src="https://github.com/processing/p5.js/assets/54026028/39ffc5f6-041e-43c2-82c6-a1868d80fb56">
Lerping from 340 to 20 now:
<img width="738" alt="Screenshot 2024-01-07 alle 15 14 31" src="https://github.com/processing/p5.js/assets/54026028/bc755ca8-f72b-42a5-8edb-55f92fa189dd">

#### PR Checklist
<!--
  To check any option, replace the "[ ]" with a "[x]". Be sure to check out how it looks in the Preview tab! Feel free to remove any portion of the template that is not relevant for your issue.
-->

- [x] `npm run lint` passes
- [x] [Inline documentation] is included / updated
- [x] [Unit tests] are included / updated

[Inline documentation]: https://github.com/processing/p5.js/blob/main/contributor_docs/inline_documentation.md
[Unit tests]: https://github.com/processing/p5.js/tree/main/contributor_docs#unit-tests
