### PR TITLE
Remove unused grunt task.

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -294,7 +294,6 @@ module.exports = grunt => {
   grunt.loadTasks('tasks/test');
 
   // Load the external libraries used.
-  grunt.loadNpmTasks('grunt-contrib-compress');
   grunt.loadNpmTasks('grunt-contrib-connect');
   grunt.loadNpmTasks('grunt-eslint');
   grunt.loadNpmTasks('grunt-contrib-watch');


### PR DESCRIPTION
When doing an `npm install` it always complained that `grunt-contrib-compress` wasn't installed, upon further inspection, it seems that `grunt-contrib-compress` is never used, so it is best if we remove this stale dependency.


#### PR Checklist
<!--
  To check any option, replace the "[ ]" with a "[x]". Be sure to check out how it looks in the Preview tab! Feel free to remove any portion of the template that is not relevant for your issue.
-->

- [x] `npm run lint` passes

