### PR TITLE
Add required parameters in _flipPixels function

### DIFF
--- a/src/image/loading_displaying.js
+++ b/src/image/loading_displaying.js
@@ -375,7 +375,7 @@ p5.prototype.saveGif = async function(
         pixels
       );
 
-      data = _flipPixels(pixels);
+      data = _flipPixels(pixels, this.width, this.height);
     } else {
       data = this.drawingContext.getImageData(0, 0, this.width, this.height)
         .data;
@@ -507,7 +507,7 @@ p5.prototype.saveGif = async function(
   p5.prototype.downloadFile(blob, fileName, extension);
 };
 
-function _flipPixels(pixels) {
+function _flipPixels(pixels, width, height) {
   // extracting the pixels using readPixels returns
   // an upside down image. we have to flip it back
   // first. this solution is proposed by gman on


### PR DESCRIPTION
<!--
  Thank you for contributing! Please use this pull request (PR) template.


 In the description field of this PR, include "resolves #XXXX" tagging the issue you are fixing. If this PR addresses the issue but doesn't completely resolve it (ie the issue should remain open after your PR is merged), write "addresses #XXXX".-->
Resolves #6724 

 Changes:
<!-- Add here what changes were made in this pull request and if possible provide links showcasing the changes. -->
The flipPixels function don't has access to width and height so it will give undefined error whenever we call it.


 Screenshots of the change:
<!-- If applicable, add screenshots depicting the changes. -->

#### PR Checklist
<!--
  To check any option, replace the "[ ]" with a "[x]". Be sure to check out how it looks in the Preview tab! Feel free to remove any portion of the template that is not relevant for your issue.
-->

- [x] `npm run lint` passes
- [x] [Inline documentation] is included / updated
- [ ] [Unit tests] are included / updated

[Inline documentation]: https://github.com/processing/p5.js/blob/main/contributor_docs/inline_documentation.md
[Unit tests]: https://github.com/processing/p5.js/tree/main/contributor_docs#unit-tests
