### PR TITLE
max and min now evaluates correctly

### DIFF
--- a/src/math/calculation.js
+++ b/src/math/calculation.js
@@ -473,7 +473,7 @@ p5.prototype.max = function(...args) {
   const findMax = arr => {
     let max = -Infinity;
     for (let x of arr) {
-      max = x > max ? x : max;
+      max = Math.max(max, x);
     }
     return max;
   };
@@ -551,7 +551,7 @@ p5.prototype.min = function(...args) {
   const findMin = arr => {
     let min = Infinity;
     for (let x of arr) {
-      min = x < min ? x : min;
+      min = Math.min(min, x);
     }
     return min;
   };


### PR DESCRIPTION
max and min now evaluates correctly  even on numbers in strings

Resolves #6728

 Changes:
used built in Math.min and Math.max for better evaluation.


 Screenshots of the change:
![Screenshot 2024-01-12 112052](https://github.com/processing/p5.js/assets/153272518/fab2f599-ba0d-4238-a79c-36a8c544b680)

- [x] `npm run lint` passes
- [x] [Inline documentation] is included / updated
- [x] [Unit tests] are included / updated