### PR TITLE
fixed-Incorrect lines when applying a stroke to geometry built without initial stroke-#6318

### DIFF
--- a/src/webgl/GeometryBuilder.js
+++ b/src/webgl/GeometryBuilder.js
@@ -9,6 +9,7 @@ import * as constants from '../core/constants';
 class GeometryBuilder {
   constructor(renderer) {
     this.renderer = renderer;
+    renderer._doStroke = true;
     renderer._pInst.push();
     this.identityMatrix = new p5.Matrix();
     renderer.uMVMatrix = new p5.Matrix();


### PR DESCRIPTION



completely fixes the bug of issue https://github.com/processing/p5.js/issues/6318

Changes:
renderer._doStroke always true in  the constructor of GeometryBuilder Class within GeometryBuilder.js


Screenshot:

<img width="573" alt="Screenshot 2024-01-12 at 3 38 30 PM" src="https://github.com/processing/p5.js/assets/124163672/b6fb8d8e-b420-4863-baa9-2d43bde288f0">

#### PR Checklist
<!--
  To check any option, replace the "[ ]" with a "[x]". Be sure to check out how it looks in the Preview tab! Feel free to remove any portion of the template that is not relevant for your issue.
-->

- [x] `npm run lint` passes
- [ ] [Inline documentation] is included / updated
- [ ] [Unit tests] are included / updated

[Inline documentation]: https://github.com/processing/p5.js/blob/main/contributor_docs/inline_documentation.md
[Unit tests]: https://github.com/processing/p5.js/tree/main/contributor_docs#unit-tests
