### PR TITLE
Fix for touchEnded triggers twice among other issues with touchEnded/mouseReleased on mobile

### DIFF
--- a/src/core/main.js
+++ b/src/core/main.js
@@ -205,6 +205,7 @@ class p5 {
     };
     this._millisStart = -1;
     this._recording = false;
+    this.touchend = false;
 
     // States used in the custom random generators
     this._lcg_random_state = null;

--- a/src/events/mouse.js
+++ b/src/events/mouse.js
@@ -732,6 +732,7 @@ p5.prototype._onmouseup = function(e) {
   let executeDefault;
   this._setProperty('mouseIsPressed', false);
 
+  // _ontouchend triggers first and sets this.touchend
   if (this.touchend) {
     return;
   }

--- a/src/events/mouse.js
+++ b/src/events/mouse.js
@@ -731,11 +731,11 @@ p5.prototype._onmouseup = function(e) {
   const context = this._isGlobal ? window : this;
   let executeDefault;
   this._setProperty('mouseIsPressed', false);
-  
+
   if (this.touchend) {
     return;
   }
-  
+
   if (typeof context.mouseReleased === 'function') {
     executeDefault = context.mouseReleased(e);
     if (executeDefault === false) {

--- a/src/events/mouse.js
+++ b/src/events/mouse.js
@@ -731,6 +731,11 @@ p5.prototype._onmouseup = function(e) {
   const context = this._isGlobal ? window : this;
   let executeDefault;
   this._setProperty('mouseIsPressed', false);
+  
+  if (this.touchend) {
+    return;
+  }
+  
   if (typeof context.mouseReleased === 'function') {
     executeDefault = context.mouseReleased(e);
     if (executeDefault === false) {
@@ -742,6 +747,7 @@ p5.prototype._onmouseup = function(e) {
       e.preventDefault();
     }
   }
+  this.touchend = false;
 };
 
 p5.prototype._ondragend = p5.prototype._onmouseup;

--- a/src/events/touch.js
+++ b/src/events/touch.js
@@ -282,11 +282,7 @@ p5.prototype._ontouchend = function(e) {
     if (executeDefault === false) {
       e.preventDefault();
     }
-  } else if (typeof context.mouseReleased === 'function') {
-    executeDefault = context.mouseReleased(e);
-    if (executeDefault === false) {
-      e.preventDefault();
-    }
+    this.touchend = true;
   }
 };
 


### PR DESCRIPTION
<!--
  Thank you for contributing! Please use this pull request (PR) template.


 In the description field of this PR, include "resolves #XXXX" tagging the issue you are fixing. If this PR addresses the issue but doesn't completely resolve it (ie the issue should remain open after your PR is merged), write "addresses #XXXX".-->
Resolves #6737

 Changes:
<!-- Add here what changes were made in this pull request and if possible provide links showcasing the changes. -->
Adds an instance variable called touchend to p5 and changed p5.prototype._ontouchend & p5.prototype._onmouseup to function as documented.

On touchscreen
- mouseReleased and touchEnded no longer both trigger if they're both present (same for mouseReleased)
- If either is without the other it doesn't triggers twice anymore

#### PR Checklist
<!--
  To check any option, replace the "[ ]" with a "[x]". Be sure to check out how it looks in the Preview tab! Feel free to remove any portion of the template that is not relevant for your issue.
-->

- [x] `npm run lint` passes
- [x] [Inline documentation] is included / updated
- [x] [Unit tests] are included / updated

[Inline documentation]: https://github.com/processing/p5.js/blob/main/contributor_docs/inline_documentation.md
[Unit tests]: https://github.com/processing/p5.js/tree/main/contributor_docs#unit-tests
