### PR TITLE
Update default values in ortho() docs, use default args in example

### DIFF
--- a/src/webgl/p5.Camera.js
+++ b/src/webgl/p5.Camera.js
@@ -222,7 +222,6 @@ p5.prototype.perspective = function (...args) {
  * //there's no vanishing point
  * function setup() {
  *   createCanvas(100, 100, WEBGL);
- *   camera(0, 0, 50*sqrt(3), 0, 0, 0, 0, 1, 0);
  *   ortho();
  *   describe(
  *     'two 3D boxes move back and forth along same plane, rotating as mouse is dragged.'

--- a/src/webgl/p5.Camera.js
+++ b/src/webgl/p5.Camera.js
@@ -205,7 +205,7 @@ p5.prototype.perspective = function (...args) {
  * maximum z values.
  *
  * If no parameters are given, the following default is used:
- * ortho(-width/2, width/2, -height/2, height/2, 0, max(width, height)).
+ * ortho(-width/2, width/2, -height/2, height/2, 0, max(width, height) + 800).
  * @method  ortho
  * @for p5
  * @param  {Number} [left]   camera frustum left plane
@@ -223,7 +223,7 @@ p5.prototype.perspective = function (...args) {
  * function setup() {
  *   createCanvas(100, 100, WEBGL);
  *   camera(0, 0, 50*sqrt(3), 0, 0, 0, 0, 1, 0);
- *   ortho(-width / 2, width / 2, height / 2, -height / 2, 0, 500);
+ *   ortho();
  *   describe(
  *     'two 3D boxes move back and forth along same plane, rotating as mouse is dragged.'
  *   );


### PR DESCRIPTION
Resolves https://github.com/processing/p5.js/issues/6755

### Changes
- Updates the documentation to mention that the default `far` value adds 800
- Removes the args from `ortho` in the example:
  - Its default `far` value wasn't suitable when copy-and-pasted into a larger sketch
  - Its y values were flipped vertically, also probably unexpected when copy-and-pasting
- Removes the `camera(...)` call: with the updated `far` value, the camera does not need to be placed closer to the objects to make them visible and have them continue to be visible when zooming/rotating a bit with `orbitControl`


### Screenshots of the change
Before:
![image](https://github.com/processing/p5.js/assets/5315059/9e73232d-65b9-478f-88b0-7b8ca0a79a56)


After:
![image](https://github.com/processing/p5.js/assets/5315059/2f5cdaa9-8b56-4cdd-b078-74970a360b9a)



#### PR Checklist
<!--
  To check any option, replace the "[ ]" with a "[x]". Be sure to check out how it looks in the Preview tab! Feel free to remove any portion of the template that is not relevant for your issue.
-->

- [x] `npm run lint` passes
- [x] [Inline documentation] is included / updated
- [ ] [Unit tests] are included / updated

[Inline documentation]: https://github.com/processing/p5.js/blob/main/contributor_docs/inline_documentation.md
[Unit tests]: https://github.com/processing/p5.js/tree/main/contributor_docs#unit-tests
