### PR TITLE
Adds Error message for when there are no screenshots

### DIFF
--- a/contributor_docs/unit_testing.md
+++ b/contributor_docs/unit_testing.md
@@ -139,3 +139,31 @@ If you need to add a new test file, add it to that folder, then add the filename
 When you add a new test, running `npm test` will generate new screenshots for any visual tests that do not yet have them. Those screenshots will then be used as a reference the next time tests run to make sure the sketch looks the same. If a test intentionally needs to look different, you can delete the folder matching the test name in the `test/unit/visual/screenshots` folder, and then re-run `npm test` to generate a new one.
 
 To manually inspect all visual tests, run `grunt yui:dev` to launch a local server, then go to http://127.0.0.1:9001/test/visual.html to see a list of all test cases.
+
+
+The visual test environment is set up to execute your commands sequentially rather than running a preload or draw function that you provide.
+In continuous integration (CI) environments, it's crucial to keep tests running as quickly as possible. Running a full `preload/draw` cycle as in a regular p5.js sketch can significantly slow down the testing process.
+When testing features like 3D model rendering, you might encounter scenarios where you need to load a model before performing assertions. Here's an example of how you can handle Sequential Command Execution and Asynchronous Operations in your visual tests:
+
+
+```js
+visualSuite('3D Model rendering', function() {
+  visualTest('OBJ model is displayed correctly', function(p5, screenshot) {
+    // Return a Promise to ensure the test runner waits for the asynchronous operation to complete
+    return new Promise(resolve => {
+      p5.createCanvas(50, 50, p5.WEBGL);
+      // Load the model asynchronously
+      p5.loadModel('unit/assets/teapot.obj', model => {
+        p5.background(200);
+        p5.rotateX(10 * 0.01);
+        p5.rotateY(10 * 0.01);
+        p5.model(model);
+        // Take a screenshot for visual comparison
+        screenshot();
+        // Resolve the Promise to indicate completion
+        resolve();
+      });
+    });
+  });
+});
+```

--- a/contributor_docs/unit_testing.md
+++ b/contributor_docs/unit_testing.md
@@ -141,10 +141,8 @@ When you add a new test, running `npm test` will generate new screenshots for an
 To manually inspect all visual tests, run `grunt yui:dev` to launch a local server, then go to http://127.0.0.1:9001/test/visual.html to see a list of all test cases.
 
 
-The visual test environment is set up to execute your commands sequentially rather than running a preload or draw function that you provide.
-In continuous integration (CI) environments, it's crucial to keep tests running as quickly as possible. Running a full `preload/draw` cycle as in a regular p5.js sketch can significantly slow down the testing process.
-When testing features like 3D model rendering, you might encounter scenarios where you need to load a model before performing assertions. Here's an example of how you can handle Sequential Command Execution and Asynchronous Operations in your visual tests:
-
+In a continuous integration (CI) environment, optimizing test speed is essential. It is advantageous to keep the code concise, avoid unnecessary frames, minimize canvas size, and load assets only when essential for the specific functionality under test.
+To address scenarios involving operations like asynchronous 3D model rendering, consider returning a promise that resolves upon completing all the necessary tests, ensuring efficiency in your visual testing approach. Here's an example of how you can asynchronous 3D model rendering in your visual tests:
 
 ```js
 visualSuite('3D Model rendering', function() {

--- a/test/unit/visual/visualTest.js
+++ b/test/unit/visual/visualTest.js
@@ -153,10 +153,8 @@ window.visualTest = function(
 
 
       if (actual.length === 0) {
-        throw new Error('No screenshots were generated. Check if your test generates screenshots correctly.If the test includes asynchronous operations, ensure they complete before the test ends.');
+        throw new Error('No screenshots were generated. Check if your test generates screenshots correctly. If the test includes asynchronous operations, ensure they complete before the test ends.');
       }
-
-
       if (expectedScreenshots && actual.length !== expectedScreenshots) {
         throw new Error(
           `Expected ${expectedScreenshots} screenshot(s) but generated ${actual.length}`

--- a/test/unit/visual/visualTest.js
+++ b/test/unit/visual/visualTest.js
@@ -151,6 +151,12 @@ window.visualTest = function(
         actual.push(myp5.get());
       });
 
+
+      if (actual.length === 0) {
+        throw new Error('No screenshots were generated. Check if your test generates screenshots correctly.If the test includes asynchronous operations, ensure they complete before the test ends.');
+      }
+
+
       if (expectedScreenshots && actual.length !== expectedScreenshots) {
         throw new Error(
           `Expected ${expectedScreenshots} screenshot(s) but generated ${actual.length}`


### PR DESCRIPTION
<!--
  Thank you for contributing! Please use this pull request (PR) template.


 In the description field of this PR, include "resolves #XXXX" tagging the issue you are fixing. If this PR addresses the issue but doesn't completely resolve it (ie the issue should remain open after your PR is merged), write "addresses #XXXX".-->
Resolves #6772 

 Changes:
<!-- Add here what changes were made in this pull request and if possible provide links showcasing the changes. -->

- In `test/unit/visual/visualTest.js` if `actual.length===0` added error handling to throw an Error indicating lack of screenshots or if the developer needs to wait for asynchronous tasks to complete before the test ends.


 Screenshots of the change:
<!-- If applicable, add screenshots depicting the changes. -->

#### PR Checklist
<!--
  To check any option, replace the "[ ]" with a "[x]". Be sure to check out how it looks in the Preview tab! Feel free to remove any portion of the template that is not relevant for your issue.
-->

- [x] `npm run lint` passes
- [ ] [Inline documentation] is included / updated
- [x] [Unit tests] are included / updated

[Inline documentation]: https://github.com/processing/p5.js/blob/main/contributor_docs/inline_documentation.md
[Unit tests]: https://github.com/processing/p5.js/tree/main/contributor_docs#unit-tests
