### PR TITLE
Made change in this.ingredients.shapes[f] !== [include] to  this.ingredients.shapes[f].length !== include.length so it does not return true everytime in  (Bug#6660)

### DIFF
--- a/src/accessibility/outputs.js
+++ b/src/accessibility/outputs.js
@@ -494,7 +494,8 @@ p5.prototype._accsOutput = function(f, args) {
   if (!this.ingredients.shapes[f]) {
     this.ingredients.shapes[f] = [include];
     //if other shapes of this type have been created
-  } else if (this.ingredients.shapes[f] !== [include]) {
+  } else if (this.ingredients.shapes[f].length !== include.length ||
+    !this.ingredients.shapes[f].every((val, index) => val === include[index])) {
     //for every shape of this type
     for (let y in this.ingredients.shapes[f]) {
       //compare it with current shape and if it already exists make add false


### PR DESCRIPTION



<!--
  Thank you for contributing! Please use this pull request (PR) template.
I have made a change in accessibility/output.js when i change this.ingredients.shapes[f] !== [include] to  this.ingredients.shapes[f].length !== include.length ||
    !this.ingredients.shapes[f].every((val, index) => val === include[index])
and this is not giving true value every time 

 Changes:
<!-- Add here what changes were made in this pull request and if possible provide links showcasing the changes. -->
change this.ingredients.shapes[f] !== [include] to  this.ingredients.shapes[f].length !== include.length ||
    !this.ingredients.shapes[f].every((val, index) => val === include[index])


 Screenshots of the change:
<!-- If applicable, add screenshots depicting the changes. -->
 
![Screenshot (36)](https://github.com/processing/p5.js/assets/122914867/ae8009a6-8078-49a8-90a0-721e3e524d70)
#### PR Checklist
<!--
  To check any option, replace the "[ ]" with a "[x]". Be sure to check out how it looks in the Preview tab! Feel free to remove any portion of the template that is not relevant for your issue.
-->

- [ ] `npm run lint` passes
- [ ] [Inline documentation] is included / updated
- [ ] [Unit tests] are included / updated

[Inline documentation]: https://github.com/processing/p5.js/blob/main/contributor_docs/inline_documentation.md
[Unit tests]: https://github.com/processing/p5.js/tree/main/contributor_docs#unit-tests
