### PR TITLE
Use requestAnimationFrame timestamp for less noise in deltaTime

### DIFF
--- a/src/core/main.js
+++ b/src/core/main.js
@@ -391,8 +391,8 @@ class p5 {
       this.callRegisteredHooksFor('afterSetup');
     };
 
-    this._draw = () => {
-      const now = window.performance.now();
+    this._draw = requestAnimationFrameTimestamp => {
+      const now = requestAnimationFrameTimestamp || window.performance.now();
       const time_since_last = now - this._lastTargetFrameTime;
       const target_time_between_frames = 1000 / this._targetFrameRate;
 


### PR DESCRIPTION
Related to https://github.com/processing/p5.js/issues/5354 (but does not fully solve it)

### Changes
This uses the timestamp passed into `requestAnimationFrame` callbacks instead of `window.performance.now()` if it's available.

This refers to the time when the browser starts calling callbacks, as opposed to the time the callback gets run. The rate between frames should be the same on average: this basically just offsets in time the point at which we measure, but not the time between samples.

The main difference is just that there's less noise in when the browser starts running RAF callbacks compared to when the browser actually runs each. This means that the *variance* in `deltaTime` goes down, and `deltaTime` values fluctuate less around their average. Previously, I was seeing a variance of around ~0.3, and after, I see a variance of around ~0.1.

Some implications:
- If you're doing physics simulations with the step size based on `deltaTime`, your step size will be more consistent each frame.
- Since the time the frame is actually drawn at still may vary, `deltaTime` may become slightly less accurate in measuring exactly how much time has elapsed since the last `draw` call.

So whether or not this is useful essentially boils down to whether or not we want frames to look like they're taking even steps even though they may not *actually be drawn* at quite so even steps. I think my gut feeling is that this actually produces perceptually smoother motion: at least personally, I perceive the time discrepancy less than the space discrepancy.

To compare:
- Current behaviour: https://editor.p5js.org/davepagurek/sketches/aPcxzwE-J
- Updated behaviour: https://editor.p5js.org/davepagurek/sketches/STFSi5YUB

Does this make sense to you all too?

#### PR Checklist
<!--
  To check any option, replace the "[ ]" with a "[x]". Be sure to check out how it looks in the Preview tab! Feel free to remove any portion of the template that is not relevant for your issue.
-->

- [x] `npm run lint` passes
- [ ] [Inline documentation] is included / updated
- [ ] [Unit tests] are included / updated

[Inline documentation]: https://github.com/processing/p5.js/blob/main/contributor_docs/inline_documentation.md
[Unit tests]: https://github.com/processing/p5.js/tree/main/contributor_docs#unit-tests
