### PR TITLE
fixed the example in the reference page for lightFalloff()

### DIFF
--- a/src/webgl/light.js
+++ b/src/webgl/light.js
@@ -672,8 +672,7 @@ p5.prototype.lights = function() {
  *   );
  * }
  * function draw() {
- *   ortho();
- *   background(0);
+ *   background(125);
  *
  *   let locX = mouseX - width / 2;
  *   let locY = mouseY - height / 2;


### PR DESCRIPTION
<!--
  Thank you for contributing! Please use this pull request (PR) template.


 In the description field of this PR, include "resolves #XXXX" tagging the issue you are fixing. If this PR addresses the issue but doesn't completely resolve it (ie the issue should remain open after your PR is merged), write "addresses #XXXX".-->
Resolves #6789

 Changes:
<!-- Add here what changes were made in this pull request and if possible provide links showcasing the changes. -->
Removed `ortho()` from the example in the reference page for `lightFalloff()`. Also changed `background(0)` to `background(125)` in the same example.

 
Screenshots of the change:
<!-- If applicable, add screenshots depicting the changes. -->
![Screenshot from 2024-02-04 17-05-50](https://github.com/processing/p5.js/assets/148856416/53f49f6d-5ce3-4a02-9115-18620c231759)


#### PR Checklist
<!--
  To check any option, replace the "[ ]" with a "[x]". Be sure to check out how it looks in the Preview tab! Feel free to remove any portion of the template that is not relevant for your issue.
-->

- [x] `npm run lint` passes
- [ ] [Inline documentation] is included / updated
- [ ] [Unit tests] are included / updated

[Inline documentation]: https://github.com/processing/p5.js/blob/main/contributor_docs/inline_documentation.md
[Unit tests]: https://github.com/processing/p5.js/tree/main/contributor_docs#unit-tests
