### PR TITLE
Fixed cursor image issue

### DIFF
--- a/src/core/environment.js
+++ b/src/core/environment.js
@@ -199,7 +199,7 @@ p5.prototype.focused = document.hasFocus();
  * strings: `'help'`, `'wait'`, `'crosshair'`, `'not-allowed'`, `'zoom-in'`,
  * and `'grab'`. If the path to an image is passed, as in
  * `cursor('assets/target.png')`, then the image will be used as the cursor.
- * Images must be in .cur, .gif, .jpg, .jpeg, or .png format and should be of 32 by 32 pixels dimensions.
+ * Images must be in .cur, .gif, .jpg, .jpeg, or .png format and should be <a href="https://developer.mozilla.org/en-US/docs/Web/CSS/cursor#icon_size_limits">at most 32 by 32 pixels large.</a>
  *
  * The parameters `x` and `y` are optional. If an image is used for the
  * cursor, `x` and `y` set the location pointed to within the image. They are

--- a/src/core/environment.js
+++ b/src/core/environment.js
@@ -199,7 +199,7 @@ p5.prototype.focused = document.hasFocus();
  * strings: `'help'`, `'wait'`, `'crosshair'`, `'not-allowed'`, `'zoom-in'`,
  * and `'grab'`. If the path to an image is passed, as in
  * `cursor('assets/target.png')`, then the image will be used as the cursor.
- * Images must be in .cur, .gif, .jpg, .jpeg, or .png format.
+ * Images must be in .cur, .gif, .jpg, .jpeg, or .png format and should be of 32 by 32 pixels dimensions.
  *
  * The parameters `x` and `y` are optional. If an image is used for the
  * cursor, `x` and `y` set the location pointed to within the image. They are


### PR DESCRIPTION
Resolves #6804


https://github.com/processing/p5.js/assets/104259212/890a427a-fea5-46e2-94de-a36f3a141a36

Hey @davepagurek, PR is ready for review. The only problem was that user did not know pixel size for image, that's why it was not rendering the cursor image. So I have updated the reference page of cursor.

<!--
  Thank you for contributing! Please use this pull request (PR) template.


 In the description field of this PR, include "resolves #XXXX" tagging the issue you are fixing. If this PR addresses the issue but doesn't completely resolve it (ie the issue should remain open after your PR is merged), write "addresses #XXXX".-->
Resolves #[Add issue number here]

 Changes:
<!-- Add here what changes were made in this pull request and if possible provide links showcasing the changes. -->


 Screenshots of the change:
<!-- If applicable, add screenshots depicting the changes. -->

#### PR Checklist
<!--
  To check any option, replace the "[ ]" with a "[x]". Be sure to check out how it looks in the Preview tab! Feel free to remove any portion of the template that is not relevant for your issue.
-->

- [x] `npm run lint` passes
- [x] [Inline documentation] is included / updated
- [x] [Unit tests] are included / updated

[Inline documentation]: https://github.com/processing/p5.js/blob/main/contributor_docs/inline_documentation.md
[Unit tests]: https://github.com/processing/p5.js/tree/main/contributor_docs#unit-tests
