### PR TITLE
Fix mistake in p5.Vector.rotate() documentation

### DIFF
--- a/src/math/p5.Vector.js
+++ b/src/math/p5.Vector.js
@@ -1766,7 +1766,7 @@ p5.Vector = class {
  *
  *   drawArrow(v0, v1, 'black');
  *
- *   describe('A black arrow extends from the center of a gray square. The arrow rotates counterclockwise.');
+ *   describe('A black arrow extends from the center of a gray square. The arrow rotates clockwise.');
  * }
  *
  * function drawArrow(base, vec, myColor) {


### PR DESCRIPTION
One of the examples in the p5.Vector.rotate() documentation incorrectly states that the arrow rotates counterclockwise. Fixed it to say it rotates clockwise.

#### PR Checklist
<!--
  To check any option, replace the "[ ]" with a "[x]". Be sure to check out how it looks in the Preview tab! Feel free to remove any portion of the template that is not relevant for your issue.
-->

- [ ] `npm run lint` passes
- [x] [Inline documentation] is included / updated
- [ ] [Unit tests] are included / updated

[Inline documentation]: https://github.com/processing/p5.js/blob/main/contributor_docs/inline_documentation.md
[Unit tests]: https://github.com/processing/p5.js/tree/main/contributor_docs#unit-tests
