### PR TITLE
Caps at beginning of curve

### DIFF
--- a/src/webgl/p5.Geometry.js
+++ b/src/webgl/p5.Geometry.js
@@ -657,6 +657,21 @@ p5.Geometry = class Geometry {
       if (dirOK) {
         this._addSegment(begin, end, fromColor, toColor, dir);
       }
+      // Check and add cap at the start of the stroke if not connected
+      if (i === 0 || !connected.has(currEdge[0])) {
+        const capInfo = potentialCaps.get(currEdge[0]) || {
+          point: begin,
+          dir: dir.copy().mult(-1),
+          color: fromColor
+        };
+        this._addCap(capInfo.point, capInfo.dir, capInfo.color);
+        potentialCaps.delete(currEdge[0]);
+        connected.add(currEdge[0]);
+      }else {
+        // If the vertex is already connected, remove its potential cap
+        potentialCaps.delete(currEdge[0]);
+      }
+
 
       if (i > 0 && prevEdge[1] === currEdge[0]) {
         if (!connected.has(currEdge[0])) {


### PR DESCRIPTION
<!--
  Thank you for contributing! Please use this pull request (PR) template.


 In the description field of this PR, include "resolves #XXXX" tagging the issue you are fixing. If this PR addresses the issue but doesn't completely resolve it (ie the issue should remain open after your PR is merged), write "addresses #XXXX".-->
Resolves #6816 
Work in progress.

 Changes:
<!-- Add here what changes were made in this pull request and if possible provide links showcasing the changes. -->
-Handles add cap at the start of the stroke if not connected

 Screenshots of the change:
<!-- If applicable, add screenshots depicting the changes. -->
sketch:
```js
function setup() {
  createCanvas(400, 400, WEBGL)
}

function draw() {
  background(255)
  stroke(0)
  strokeWeight(20)
  beginShape()
  vertex(-40, -40)
  bezierVertex(40, -40, -40, 40, 40, 40)
  endShape()
}
```
Before:
![image](https://github.com/processing/p5.js/assets/110971977/771b6d8e-558b-4dc4-a739-caf55df1fba7)
After:
![image](https://github.com/processing/p5.js/assets/110971977/20c4a671-1062-46c6-9ae5-5157567d9f8d)


sketch:
```
function setup() {
  createCanvas(400, 400, WEBGL);
  background(255)
  noFill()
  stroke(0)
  strokeWeight(20)
  translate(-width/2, -height/2)
  beginShape()
  vertex(20, 20)
  quadraticVertex(
    280, 200,
    100, 380
  )
  endShape()
}
```
output:
![image](https://github.com/processing/p5.js/assets/110971977/49faa175-6560-4f93-9093-157b8a0d45e3)



#### PR Checklist
<!--
  To check any option, replace the "[ ]" with a "[x]". Be sure to check out how it looks in the Preview tab! Feel free to remove any portion of the template that is not relevant for your issue.
-->

- [ ] `npm run lint` passes
- [ ] [Inline documentation] is included / updated
- [ ] [Unit tests] are included / updated

[Inline documentation]: https://github.com/processing/p5.js/blob/main/contributor_docs/inline_documentation.md
[Unit tests]: https://github.com/processing/p5.js/tree/main/contributor_docs#unit-tests
