### PR TITLE
Fix for fill artifact in WebGL mode when rendering in LINE mode using beginShape

### DIFF
--- a/src/webgl/p5.RendererGL.Immediate.js
+++ b/src/webgl/p5.RendererGL.Immediate.js
@@ -223,11 +223,13 @@ p5.RendererGL.prototype.endShape = function(
 
   // LINE_STRIP and LINES are not used for rendering, instead
   // they only indicate a way to modify vertices during the _processVertices() step
+  let is_line = false;
   if (
     this.immediateMode.shapeMode === constants.LINE_STRIP ||
     this.immediateMode.shapeMode === constants.LINES
   ) {
     this.immediateMode.shapeMode = constants.TRIANGLE_FAN;
+    is_line = true;
   }
 
   // WebGL doesn't support the QUADS and QUAD_STRIP modes, so we
@@ -239,7 +241,7 @@ p5.RendererGL.prototype.endShape = function(
     this.immediateMode.shapeMode = constants.TRIANGLE_STRIP;
   }
 
-  if (this._doFill) {
+  if (this._doFill && !is_line) {
     if (
       !this.geometryBuilder &&
       this.immediateMode.geometry.vertices.length >= 3


### PR DESCRIPTION
<!--
  Thank you for contributing! Please use this pull request (PR) template.


 In the description field of this PR, include "resolves #XXXX" tagging the issue you are fixing. If this PR addresses the issue but doesn't completely resolve it (ie the issue should remain open after your PR is merged), write "addresses #XXXX".-->
Resolves #6826

 Changes:
<!-- Add here what changes were made in this pull request and if possible provide links showcasing the changes. -->
Adds a local variable called `is_line` within `p5.RendererGL.prototype.endShape` and uses that to check whether or not to apply fill.

 Screenshots of the change:
<!-- If applicable, add screenshots depicting the changes. -->
Here's the sketch demonstrating the issue (This is using the unfixed version of p5.js, but if you'd like to use the fixed version just comment out the default import for the `p5.min.js` import)
https://editor.p5js.org/PotatoBoy/sketches/XOezf6_IR
Without the fix:
![image](https://github.com/processing/p5.js/assets/83996185/a0f6c97d-3b31-4ded-98e3-eaaa273ca56d)
With the fix:
![image](https://github.com/processing/p5.js/assets/83996185/0f9c8ae2-26bb-483f-9439-b192273110e4)


#### PR Checklist
<!--
  To check any option, replace the "[ ]" with a "[x]". Be sure to check out how it looks in the Preview tab! Feel free to remove any portion of the template that is not relevant for your issue.
-->

- [x] `npm run lint` passes
- [x] [Inline documentation] is included / updated
- [x] [Unit tests] are included / updated

[Inline documentation]: https://github.com/processing/p5.js/blob/main/contributor_docs/inline_documentation.md
[Unit tests]: https://github.com/processing/p5.js/tree/main/contributor_docs#unit-tests
