### PR TITLE
Update accessibility references

### DIFF
--- a/src/accessibility/describe.js
+++ b/src/accessibility/describe.js
@@ -16,7 +16,7 @@ const labelTableId = '_labelTable'; //Label Table
 const labelTableElId = '_lte_'; //Label Table Element
 
 /**
- * Creates a screen reader-accessible description for the canvas.
+ * Creates a screen reader-accessible description of the canvas.
  *
  * The first parameter, `text`, is the description of the canvas.
  *
@@ -28,8 +28,8 @@ const labelTableElId = '_lte_'; //Label Table Element
  * visible to screen readers. This is the default mode.
  *
  * Read
- * <a href="/learn/labeling-canvases.html">How to label your p5.js code</a> to
- * learn more about making sketches accessible.
+ * <a href="/learn/accessible-labels.html">Writing accessible canvas descriptions</a>
+ * to learn more about making sketches accessible.
  *
  * @method describe
  * @param  {String} text        description of the canvas.
@@ -160,8 +160,10 @@ p5.prototype.describe = function(text, display) {
 };
 
 /**
- * Creates a screen reader-accessible description for elements in the canvas.
- * Elements are shapes or groups of shapes that create meaning together.
+ * Creates a screen reader-accessible description of elements in the canvas.
+ *
+ * Elements are shapes or groups of shapes that create meaning together. For
+ * example, a few overlapping circles could make an "eye" element.
  *
  * The first parameter, `name`, is the name of the element.
  *
@@ -177,8 +179,8 @@ p5.prototype.describe = function(text, display) {
  * mode.
  *
  * Read
- * <a href="/learn/labeling-canvases.html">How to label your p5.js code</a> to
- * learn more about making sketches accessible.
+ * <a href="/learn/accessible-labels.html">Writing accessible canvas descriptions</a>
+ * to learn more about making sketches accessible.
  *
  * @method describeElement
  * @param  {String} name        name of the element.

--- a/src/accessibility/outputs.js
+++ b/src/accessibility/outputs.js
@@ -8,12 +8,11 @@
 import p5 from '../core/main';
 
 /**
- * Creates a screen reader-accessible description for shapes on the canvas.
- * `textOutput()` adds a general description, list of shapes, and
- * table of shapes to the web page.
+ * Creates a screen reader-accessible description of shapes on the canvas.
  *
- * The general description includes the canvas size, canvas color, and number
- * of shapes. For example,
+ * `textOutput()` adds a general description, list of shapes, and
+ * table of shapes to the web page. The general description includes the
+ * canvas size, canvas color, and number of shapes. For example,
  * `Your output is a, 100 by 100 pixels, gray canvas containing the following 2 shapes:`.
  *
  * A list of shapes follows the general description. The list describes the
@@ -35,8 +34,8 @@ import p5 from '../core/main';
  * mode.
  *
  * Read
- * <a href="/learn/labeling-canvases.html">How to label your p5.js code</a> to
- * learn more about making sketches accessible.
+ * <a href="/learn/accessible-labels.html">Writing accessible canvas descriptions</a>
+ * to learn more about making sketches accessible.
  *
  * @method textOutput
  * @param  {Constant} [display] either FALLBACK or LABEL.
@@ -143,12 +142,11 @@ p5.prototype.textOutput = function(display) {
 };
 
 /**
- * Creates a screen reader-accessible description for shapes on the canvas.
- * `gridOutput()` adds a general description, table of shapes, and list of
- * shapes to the web page.
+ * Creates a screen reader-accessible description of shapes on the canvas.
  *
- * The general description includes the canvas size, canvas color, and number of
- * shapes. For example,
+ * `gridOutput()` adds a general description, table of shapes, and list of
+ * shapes to the web page. The general description includes the canvas size,
+ * canvas color, and number of shapes. For example,
  * `gray canvas, 100 by 100 pixels, contains 2 shapes:  1 circle 1 square`.
  *
  * `gridOutput()` uses its table of shapes as a grid. Each shape in the grid
@@ -171,8 +169,8 @@ p5.prototype.textOutput = function(display) {
  * mode.
  *
  * Read
- * <a href="/learn/labeling-canvases.html">How to label your p5.js code</a> to
- * learn more about making sketches accessible.
+ * <a href="/learn/accessible-labels.html">Writing accessible canvas descriptions</a>
+ * to learn more about making sketches accessible.
  *
  * @method gridOutput
  * @param  {Constant} [display] either FALLBACK or LABEL.


### PR DESCRIPTION
Preparing the following references for the new website:
- `describe()`
- `describeElement()`
- `textOutput()`
- `gridOutput()`

Also fixed links to Kathryn's tutorial.

#### PR Checklist

- [x] `npm run lint` passes
- [x] [Inline documentation] is included / updated

@Qianqianye @davepagurek @limzykenneth