### PR TITLE
Check the element type before calling `createRadio` from `select()`

### DIFF
--- a/src/dom/dom.js
+++ b/src/dom/dom.js
@@ -229,7 +229,8 @@ p5.prototype._wrapElement = function (elt) {
     children.length > 0 &&
     children.every(function (c) {
       return c.tagName === 'INPUT' || c.tagName === 'LABEL';
-    })
+    }) &&
+    (elt.tagName === 'DIV' || elt.tagName === 'SPAN')
   ) {
     return this.createRadio(new p5.Element(elt, this));
   } else {


### PR DESCRIPTION
Only call `createRadio` from `select()` if the element is a valid radio parent (span or div)

Resolves #6836 

 Changes:
Adds a check `(elt.tagName === 'DIV' || elt.tagName === 'SPAN')` before calling `createRadio`.  Other element types will just get a normal `p5.Element`.

I chose the `elt.tagName ===` syntax because that is what is used in the lines above this.  Note that `createRadio` uses an `instanceof ` check (`arg0.elt instanceof HTMLDivElement || arg0.elt instanceof HTMLSpanElement`), but the result should be the same.

#### PR Checklist
<!--
  To check any option, replace the "[ ]" with a "[x]". Be sure to check out how it looks in the Preview tab! Feel free to remove any portion of the template that is not relevant for your issue.
-->

- [x] `npm run lint` passes
- [ ] [Inline documentation] is included / updated
- [ ] [Unit tests] are included / updated

[Inline documentation]: https://github.com/processing/p5.js/blob/main/contributor_docs/inline_documentation.md
[Unit tests]: https://github.com/processing/p5.js/tree/main/contributor_docs#unit-tests
