### PR TITLE
Fix for gif not animating when drawing to p5.graphics

### DIFF
--- a/src/image/p5.Image.js
+++ b/src/image/p5.Image.js
@@ -344,7 +344,7 @@ p5.Image = class {
    */
   _animateGif(pInst) {
     const props = this.gifProperties;
-    const curTime = pInst._lastRealFrameTime;
+    const curTime = pInst._lastRealFrameTime || window.performance.now();
     if (props.lastChangeTime === 0) {
       props.lastChangeTime = curTime;
     }


### PR DESCRIPTION
<!--
  Thank you for contributing! Please use this pull request (PR) template.


 In the description field of this PR, include "resolves #XXXX" tagging the issue you are fixing. If this PR addresses the issue but doesn't completely resolve it (ie the issue should remain open after your PR is merged), write "addresses #XXXX".-->
Resolves #6925 

 Changes:
<!-- Add here what changes were made in this pull request and if possible provide links showcasing the changes. -->

From:
`const curTime = pInst._lastRealFrameTime`
To:
`const curTime = pInst._lastRealFrameTime || window.performance.now();`
In /image/p5.Image.js under the  _animateGif(pInst) helper function

_lastRealFrameTime in main.js is set to window.performance.now() which starts the browser timer, however like the issue poster mentioned pInst._lastRealFrameTime exists on the main canvas but not graphics if you attach a gif to a graphic like below then only the first frame of the gif will animate since the helper function sets curTime to pInst._lastRealFrameTime.

`let cnv;
function preload() {
  gif = loadImage('test.gif)
}

function setup() {
  createCanvas(100, 100);
  cnv = createGraphics(100, 100);
}

function draw() {
  cnv.background(255);
  cnv.image(gif, 0, 0);
  image(cnv, 0, 0);
}`

In /image/p5.Image.js  then under the  _animateGif(pInst)  `curTime` which is set to `pInst._lastRealFrameTime` will not exist (undefined) thus adding  `|| window.performance.now();` will start the timer again allowing the gif to animate beyond the first frame. 

 Screenshots of the change:
<!-- If applicable, add screenshots depicting the changes. -->

![image](https://github.com/processing/p5.js/assets/82423742/3e958685-841a-48b4-b34e-7572e5a81cd9)
![image](https://github.com/processing/p5.js/assets/82423742/a5b5a5e8-1ea8-46be-96a5-47da6f636ab3)

#### PR Checklist
<!--
  To check any option, replace the "[ ]" with a "[x]". Be sure to check out how it looks in the Preview tab! Feel free to remove any portion of the template that is not relevant for your issue.
-->

- [x] `npm run lint` passes
- [] [Inline documentation] is included / updated
- [] [Unit tests] are included / updated

[Inline documentation]: https://github.com/processing/p5.js/blob/main/contributor_docs/inline_documentation.md
[Unit tests]: https://github.com/processing/p5.js/tree/main/contributor_docs#unit-tests
