### PR TITLE
Fix typo in touchStarted()

### DIFF
--- a/src/events/touch.js
+++ b/src/events/touch.js
@@ -163,7 +163,7 @@ function getTouchInfo(canvas, w, h, e, i = 0) {
  * On touchscreen devices, <a href="#/p5/mousePressed">mousePressed()</a> will
  * run when a user’s touch starts if `touchStarted()` isn’t declared. If
  * `touchStarted()` is declared, then `touchStarted()` will run when a user’s
- * touch ends and <a href="#/p5/mousePressed">mousePressed()</a> won’t.
+ * touch starts and <a href="#/p5/mousePressed">mousePressed()</a> won’t.
  *
  * Note: `touchStarted()`, <a href="#/p5/touchEnded">touchEnded()</a>, and
  * <a href="#/p5/touchMoved">touchMoved()</a> are all related.


### PR DESCRIPTION
Fixed a typo in `src/events/touch.js`.

#### PR Checklist
<!--
  To check any option, replace the "[ ]" with a "[x]". Be sure to check out how it looks in the Preview tab! Feel free to remove any portion of the template that is not relevant for your issue.
-->

- [x] `npm run lint` passes
- [x] [Inline documentation] is included / updated

@Qianqianye @limzykenneth @davepagurek
