### PR TITLE
add non-code contributions to contrib guidelines readme

### DIFF
--- a/contributor_docs/README.md
+++ b/contributor_docs/README.md
@@ -38,8 +38,18 @@ Most of the time we will stick with this workflow quite strictly and, especially
 
 **We see contributing to p5.js as a learning opportunity** and we don't measure sucess by only looking at the volume of contributions we received. There is no time limit on how long it takes you to complete a contribution, so take your time and work at your own pace (we may check in after a long period of inactivity). Ask for help from any of the stewards or maintainers if you need them and we'll try our best to support you.
 
-## Non-source code contribution
-There are many more ways to contribute to p5.js through non-source code contribution than can be exhaustively listed here, some of the ways may also involve working with some of the p5.js repositories (such as adding examples, writing tutorials for the website, etc.). Depending on what the planned contribution is, we may be able to support you in different ways so do reach out to us via any channel available to you (email, social media, [Discourse forum](https://discourse.processing.org/c/p5js/10), Discord, etc).
-
 ## [Stewards and maintainers](./steward_guidelines.md)
 For information related to area stewards or general maintenance of p5.js GitHub repository, please check out the [steward guidelines](./steward_guidelines.md).
+
+## Non-source code contribution
+There are many more ways to contribute to p5.js through non-source code contribution than can be exhaustively listed here. Some of the ways may also involve working with some of the p5.js repositories (such as adding examples, writing tutorials for the website, etc.). Depending on what the planned contribution is, we may be able to support you in different ways so do reach out to us via any channel available to you (email, social media, [Discourse forum](https://discourse.processing.org/c/p5js/10), Discord, etc). Here are just some ways you can contribute:
+
+**Create.** Inspire others with your sketches. p5.js is looking for designers, artists, coders, and programmers to showcase their creative, amazing work on the community sketch gallery. Don’t forget to tag @p5xjs on [Instagram](https://www.instagram.com/p5xjs/) and [X](https://twitter.com/p5xjs/), and we will do our best to share what you're doing.
+
+**Teach.** Teach a workshop, a class, a friend, or a collaborator! Share a syllabus, video tutorials, or other teaching materials with the community.
+
+**Organize.** Host p5.js events. Curate a p5.js exhibition. Activate your local p5.js community.
+
+**Donate.** p5.js is an open-source project made for and by artists, supported by a dedicated community of volunteers. It is and will always remain free to all, without restrictions. If p5.js has made an impact in your life, and you're in a position to give back, please consider making a donation to the Processing Foundation. Your donations directly fund the development of new features, better community support, improved documentation, and more. Thank you for your support.
+
+p5.js is designed to be inclusive and welcomes contributions from everyone, regardless of their background, resources, or level of experience. If you thought of another way you'd like to contribute that you don’t see here, [let us know](mailto:hello@p5js.org)! Your participation is important and contributes to the lively community that is p5.js.

--- a/contributor_docs/README.md
+++ b/contributor_docs/README.md
@@ -1,8 +1,8 @@
 # 🌸 Welcome! 🌺
 
-Thanks for your interest in contributing to p5.js! Our community values contributions of all forms and seeks to expand the meaning of the word "contributor" as far and wide as possible. It includes documentation, teaching, writing code, making art, writing, design, activism, organizing, curating, or anything else you might imagine. [Our community page](https://p5js.org/community/#contribute) gives an overview of some different ways to get involved and contribute.
+Thanks for your interest in contributing to p5.js! p5.js is a collaborative project with contributions from many volunteers. Our community is always looking for contributors and appreciates involvement in all forms. We acknowledge that not everyone has the capacity, time, or financial means to participate actively or in the same ways. We want to expand the meaning of the word “contributor.” Whether you're an experienced developer or just starting out, we value your involvement. Your unique perspectives, skills, and experiences enrich our community, and we encourage you to get involved in a way that works for you. It includes documentation, teaching, writing code, making art, writing, design, activism, organizing, curating, or anything else you might imagine. Our [contribute page](https://p5js.org/contributor-docs/#/) gives an overview of different ways to get involved and contribute.
 
-This project follows the [all-contributors](https://github.com/kentcdodds/all-contributors) specification. We use the @all-contributors bot to handle adding people to the README.md file. You can ask @all-contributors bot to add you in an issue or PR comment like so:
+p5.js project follows the [all-contributors](https://github.com/kentcdodds/all-contributors) specification. We use the @all-contributors bot to handle adding people to the README.md file. You can ask @all-contributors bot to add you in an issue or PR comment like so:
 ```
 @all-contributors please add @[your GitHub handle] for [your contribution type]
 ```
@@ -17,8 +17,8 @@ Next, we are currently prioritizing work that expands access (inclusion and acce
 
 # Get Started
 Now you are ready to start contributing to p5.js! There are many ways to get started with contributing to p5.js and many reasons to do so. For the purpose of this documentation, we will split contributions roughly into two categories.
-- Contributions that directly deals with the source code (including documentation)
-- Contributions that directly deals with the source code very little or not at all
+- Source code contribution (including documentation)
+- Non-source code contribution
 
 Depending on what kind of contribution you are making to p5.js, please read on to the relevant section of this documentation.
 
@@ -36,10 +36,7 @@ Head over to [this link](./contributor_guidelines.md) where you will be guided o
 
 Most of the time we will stick with this workflow quite strictly and, especially if you have contributed to other projects before, it may feel like there are too many hoops to jump through for what may be a simple contribution. However, the steps above are aimed to make it easy for you as a contributor and for stewards/maintainers to contribute meaningfully, while also making sure that you won't be spending time working on things that may not be accepted for various reasons. The steps above will help ensure that any proposals or fixes are adequately discussed and considered before any work begin, and often this will actually save you (and the steward/maintainer) time because the PR that would need additional fixing after review, or outright not accepted, would happen less often as a result.
 
-**We see contributing to p5.js as a learning opportunity** and we don't measure sucess by only looking at the volume of contributions we received. There is no time limit on how long it takes you to complete a contribution, so take your time and work at your own pace (we may check in after a long period of inactivity). Ask for help from any of the stewards or maintainers if you need them and we'll try our best to support you.
-
-## [Stewards and maintainers](./steward_guidelines.md)
-For information related to area stewards or general maintenance of p5.js GitHub repository, please check out the [steward guidelines](./steward_guidelines.md).
+**We see contributing to p5.js as a learning opportunity** and we don't measure sucess by only looking at the volume of contributions we received. There is no time limit on how long it takes you to complete a contribution, so take your time and work at your own pace (we may check in after a long period of inactivity). Ask for help from any of the stewards or maintainers if you need them and we'll try our best to support you. For information related to area stewards or general maintenance of p5.js GitHub repository, please check out the [steward guidelines](./steward_guidelines.md).
 
 ## Non-source code contribution
 There are many more ways to contribute to p5.js through non-source code contribution than can be exhaustively listed here. Some of the ways may also involve working with some of the p5.js repositories (such as adding examples, writing tutorials for the website, etc.). Depending on what the planned contribution is, we may be able to support you in different ways so do reach out to us via any channel available to you (email, social media, [Discourse forum](https://discourse.processing.org/c/p5js/10), Discord, etc). Here are just some ways you can contribute:


### PR DESCRIPTION
Requested by Q and Ken, inserted edited text for non-code ways to contribute at bottom of README.md

@all-contributors please add @sarahciston for [doc]