### PR TITLE
Fix #6847: Update mouseButton value when one mouse button is released

### DIFF
--- a/src/events/mouse.js
+++ b/src/events/mouse.js
@@ -341,7 +341,7 @@ p5.prototype.pwinMouseY = 0;
 /**
  * p5 automatically tracks if the mouse button is pressed and which
  * button is pressed. The value of the system variable mouseButton is either
- * LEFT, RIGHT, or CENTER depending on which button was pressed last.
+ * LEFT, RIGHT, or CENTER depending on which button was pressed/released last.
  * Warning: different browsers may track mouseButton differently.
  *
  * @property {Constant} mouseButton
@@ -734,6 +734,7 @@ p5.prototype._onmouseup = function(e) {
   const context = this._isGlobal ? window : this;
   let executeDefault;
   this._setProperty('mouseIsPressed', false);
+  this._setMouseButton(e);
 
   // _ontouchend triggers first and sets this.touchend
   if (this.touchend) {

--- a/test/unit/events/mouse.js
+++ b/test/unit/events/mouse.js
@@ -365,6 +365,14 @@ suite('Mouse Events', function() {
       assert.deepEqual(count, 1);
     });
 
+    test('mouseButton should be "left" on left mouse button release', async function() {
+      // both mouse buttons pressed
+      window.dispatchEvent(new MouseEvent('mousedown', { button: 0 }));
+      window.dispatchEvent(new MouseEvent('mousedown', { button: 2 }));
+      window.dispatchEvent(new MouseEvent('mouseup', { button: 0 }));
+      assert.strictEqual(myp5.mouseButton, 'left');
+    });
+
     test('mouseReleased functions on multiple instances must run once', async function() {
       let sketchFn = function(sketch, resolve, reject) {
         let count = 0;


### PR DESCRIPTION
Resolves #6847 

 Changes:
- Modified src/events/mouse.js to correctly update the mouseButton value upon releasing one mouse button.
- Updated documentation in src/events/mouse.js accordingly.
- Added unit test in test/unit/events/mouse.js to cover scenario described in the issue.
- Now mouseButton should have the value corresponding to the last mouse button pressed/released


 Screenshots of the change:
(no screenshots)

#### PR Checklist

- [ x ] `npm run lint` passes
- [ x ] [Inline documentation] is included / updated
- [ x ] [Unit tests] are included / updated

[Inline documentation]: https://github.com/processing/p5.js/blob/main/contributor_docs/inline_documentation.md
[Unit tests]: https://github.com/processing/p5.js/tree/main/contributor_docs#unit-tests
