### PR TITLE
Add list support for `lerpColor` like other color functions

### DIFF
--- a/src/color/creating_reading.js
+++ b/src/color/creating_reading.js
@@ -960,8 +960,8 @@ p5.prototype.hue = function(c) {
  * <a href="#/colorMode">colorMode()</a>.
  *
  * @method lerpColor
- * @param  {p5.Color} c1  interpolate from this color.
- * @param  {p5.Color} c2  interpolate to this color.
+ * @param  {p5.Color|Number[]} c1  interpolate from this color.
+ * @param  {p5.Color|Number[]} c2  interpolate to this color.
  * @param  {Number}   amt number between 0 and 1.
  * @return {p5.Color}     interpolated color.
  *
@@ -1007,6 +1007,14 @@ p5.prototype.hue = function(c) {
  */
 p5.prototype.lerpColor = function(c1, c2, amt) {
   p5._validateParameters('lerpColor', arguments);
+
+  if (Array.isArray(c1)) {
+    c1 = color(c1);
+  }
+  if (Array.isArray(c2)) {
+    c2 = color(c2);
+  }
+
   const mode = this._colorMode;
   const maxes = this._colorMaxes;
   let l0, l1, l2, l3;

--- a/src/color/creating_reading.js
+++ b/src/color/creating_reading.js
@@ -960,8 +960,8 @@ p5.prototype.hue = function(c) {
  * <a href="#/colorMode">colorMode()</a>.
  *
  * @method lerpColor
- * @param  {p5.Color|Number[]} c1  interpolate from this color.
- * @param  {p5.Color|Number[]} c2  interpolate to this color.
+ * @param  {p5.Color} c1  interpolate from this color (any value created by the color() function).
+ * @param  {p5.Color} c2  interpolate to this color (any value created by the color() function).
  * @param  {Number}   amt number between 0 and 1.
  * @return {p5.Color}     interpolated color.
  *

--- a/src/color/creating_reading.js
+++ b/src/color/creating_reading.js
@@ -1008,10 +1008,10 @@ p5.prototype.hue = function(c) {
 p5.prototype.lerpColor = function(c1, c2, amt) {
   p5._validateParameters('lerpColor', arguments);
 
-  if (Array.isArray(c1)) {
+  if (!(c1 instanceof p5.Color)) {
     c1 = color(c1);
   }
-  if (Array.isArray(c2)) {
+  if (!(c2 instanceof p5.Color)) {
     c2 = color(c2);
   }
 


### PR DESCRIPTION
<!--
  Thank you for contributing! Please use this pull request (PR) template.


 In the description field of this PR, include "resolves #XXXX" tagging the issue you are fixing. If this PR addresses the issue but doesn't completely resolve it (ie the issue should remain open after your PR is merged), write "addresses #XXXX".-->
Resolves #6953

 Changes:
<!-- Add here what changes were made in this pull request and if possible provide links showcasing the changes. -->
Adds list support to the `lerpColor` like other color functions. 
(I understand why this function doesn't support string based colors since you should know the actual value of the color when lerping between them, but adding list support is still definitely something that would be useful as seen in the referenced issue. However, if anyone thinks that adding string based color support to `lerpColor` as well would be preferred I'll add that to the PR.)

 Screenshots of the change:
<!-- If applicable, add screenshots depicting the changes. -->
```js
const red = [255, 0, 0];
const blue = [0, 255, 0];

function setup() {
  // These always worked
  fill(red);
  fill(blue);
  // This works now!
  lerpColor(red, blue, 0.5);
}
```

#### PR Checklist
<!--
  To check any option, replace the "[ ]" with a "[x]". Be sure to check out how it looks in the Preview tab! Feel free to remove any portion of the template that is not relevant for your issue.
-->

- [x] `npm run lint` passes
- [x] [Inline documentation] is included / updated
- [x] [Unit tests] are included / updated

[Inline documentation]: https://github.com/processing/p5.js/blob/main/contributor_docs/inline_documentation.md
[Unit tests]: https://github.com/processing/p5.js/tree/main/contributor_docs#unit-tests
