### PR TITLE
add friendly error to createCapture()

### DIFF
--- a/src/dom/dom.js
+++ b/src/dom/dom.js
@@ -2438,7 +2438,15 @@ p5.prototype.createCapture = function(...args) {
     catch(err) {
       domElement.src = stream;
     }
-  }, console.error);
+  }).catch(e => {
+    
+    if (e.name === 'NotFoundError')
+      p5._friendlyError('No webcam found on this device', 'createCapture');
+    if (e.name === 'NotAllowedError')
+      p5._friendlyError('Access to the camera was denied', 'createCapture');
+
+    console.error(e);
+  });
 
   const videoEl = addElement(domElement, this, true);
   videoEl.loadedmetadata = false;


### PR DESCRIPTION
Resolves #6402

 Changes:
One small change to add friendly errors when using createCapture(). Handle errors when there is no webcam or the webcam access is denied. 


#### PR Checklist

- [x] `npm run lint` passes
- [ ] [Inline documentation] is included / updated
- [ ] [Unit tests] are included / updated

[Inline documentation]: https://github.com/processing/p5.js/blob/main/contributor_docs/inline_documentation.md
[Unit tests]: https://github.com/processing/p5.js/tree/main/contributor_docs#unit-tests
