### PR TITLE
fixed textpoint alignment

### DIFF
--- a/src/typography/p5.Font.js
+++ b/src/typography/p5.Font.js
@@ -344,7 +344,8 @@ p5.Font = class {
   textToPoints(txt, x, y, fontSize, options) {
     const xOriginal = x;
     const result = [];
-
+    const p = this.parent;
+    let pos;
     let lines = txt.split(/\r?\n|\r|\n/g);
     fontSize = fontSize || this.parent._renderer._textSize;
 
@@ -376,6 +377,14 @@ p5.Font = class {
 
             for (let l = 0; l < pts.length; l++) {
               pts[l].x += xoff;
+              pos = this._handleAlignment(
+                p._renderer,
+                line,
+                pts[l].x,
+                pts[l].y
+              );
+              pts[l].x = pos.x;
+              pts[l].y = pos.y;
               result.push(pts[l]);
             }
           }
@@ -386,7 +395,6 @@ p5.Font = class {
 
       y = y + this.parent._renderer._textLeading;
     }
-
     return result;
   }
 


### PR DESCRIPTION
<!--
  Thank you for contributing! Please use this pull request (PR) template.


 In the description field of this PR, include "resolves #XXXX" tagging the issue you are fixing. If this PR addresses the issue but doesn't completely resolve it (ie the issue should remain open after your PR is merged), write "addresses #XXXX".-->
Resolves #6893 

 Changes:
<!-- Add here what changes were made in this pull request and if possible provide links showcasing the changes. -->
Added the ```_handleAlignment``` function in ```p5.Font.js``` to ```textToPoints```, so that it also follows the renderer's current alignment.

 Screenshots of the change:
<!-- If applicable, add screenshots depicting the changes. -->
When ```textAlign(CENTER, BASELINE);``` was called, the text points and the normal text would be misaligned. 

Before the change: 
![error](https://github.com/processing/p5.js/assets/112679001/f9e443be-57c6-43c1-8f34-69c2f1fa882e)


After the change:
![fixed](https://github.com/processing/p5.js/assets/112679001/3d8d0ee5-b553-461d-8067-926cf2c298fe)



#### PR Checklist
<!--
  To check any option, replace the "[ ]" with a "[x]". Be sure to check out how it looks in the Preview tab! Feel free to remove any portion of the template that is not relevant for your issue.
-->

- [x ] `npm run lint` passes

[Inline documentation]: https://github.com/processing/p5.js/blob/main/contributor_docs/inline_documentation.md
[Unit tests]: https://github.com/processing/p5.js/tree/main/contributor_docs#unit-tests
