### PR TITLE
Expand keyIsDown() to work with characters as arguments

### DIFF
--- a/src/events/keyboard.js
+++ b/src/events/keyboard.js
@@ -807,7 +807,8 @@ p5.prototype._onblur = function(e) {
  *
  * `keyIsDown()` can check for key presses using
  * <a href="#/p5/keyCode">keyCode</a> values, as in `keyIsDown(37)` or
- * `keyIsDown(LEFT_ARROW)`. Key codes can be found on websites such as
+ * `keyIsDown(LEFT_ARROW)` or an alphanumeric string value `keyIsDown('A')` or `keyIsDown('a')`
+ * Key codes can be found on websites such as
  * <a href="https://keycode.info" target="_blank">keycode.info</a>.
  *
  * @method keyIsDown
@@ -847,6 +848,50 @@ p5.prototype._onblur = function(e) {
  *   }
  *
  *   if (keyIsDown(DOWN_ARROW) === true) {
+ *     y += 1;
+ *   }
+ *
+ *   // Style the circle.
+ *   fill(0);
+ *
+ *   // Draw the circle.
+ *   circle(x, y, 5);
+ * }
+ * </code>
+ * </div>
+ *
+ * <div>
+ * <code>
+ * // Click on the canvas to begin detecting key presses.
+ *
+ * let x = 50;
+ * let y = 50;
+ *
+ * function setup() {
+ *   createCanvas(100, 100);
+ *
+ *   background(200);
+ *
+ *   describe(
+ *     'A gray square with a black circle at its center. The circle moves when the user presses "W", "A", "S", or "D". It leaves a trail as it moves.'
+ *   );
+ * }
+ *
+ * function draw() {
+ *   // Update x and y if "W", "A", "S", or "D" is pressed.
+ *   if (keyIsDown('A') === true) {
+ *     x -= 1;
+ *   }
+ *
+ *   if (keyIsDown('D') === true) {
+ *     x += 1;
+ *   }
+ *
+ *   if (keyIsDown('W') === true) {
+ *     y -= 1;
+ *   }
+ *
+ *   if (keyIsDown('S') === true) {
  *     y += 1;
  *   }
  *

--- a/src/events/keyboard.js
+++ b/src/events/keyboard.js
@@ -811,7 +811,7 @@ p5.prototype._onblur = function(e) {
  * <a href="https://keycode.info" target="_blank">keycode.info</a>.
  *
  * @method keyIsDown
- * @param {Number}          code key to check.
+ * @param {Number|String}         code key to check.
  * @return {Boolean}        whether the key is down or not.
  *
  * @example
@@ -905,11 +905,10 @@ p5.prototype._onblur = function(e) {
  */
 p5.prototype.keyIsDown = function(code) {
   p5._validateParameters('keyIsDown', arguments);
-  let keyCode = -1;
   if (typeof code === 'string' && code.length === 1) {
-    keyCode = code.charCodeAt(0);
+    code = code.toUpperCase().charCodeAt(0);
   }
-  return this._downKeys[code] || this._downKeys[keyCode] || false;
+  return this._downKeys[code] || false;
 };
 
 /**

--- a/src/events/keyboard.js
+++ b/src/events/keyboard.js
@@ -905,7 +905,11 @@ p5.prototype._onblur = function(e) {
  */
 p5.prototype.keyIsDown = function(code) {
   p5._validateParameters('keyIsDown', arguments);
-  return this._downKeys[code] || false;
+  let keyCode = -1;
+  if (typeof code === 'string' && code.length === 1) {
+    keyCode = code.charCodeAt(0);
+  }
+  return this._downKeys[code] || this._downKeys[keyCode] || false;
 };
 
 /**

--- a/test/unit/events/keyboard.js
+++ b/test/unit/events/keyboard.js
@@ -191,5 +191,9 @@ suite('Keyboard Events', function() {
     test('keyIsDown should return false if key is not down', function() {
       assert.strictEqual(myp5.keyIsDown(35), false);
     });
+
+    test('keyIsDown should return false if key has length more than 1', function() {
+      assert.strictEqual(myp5.keyIsDown('ab'), false);
+    });
   });
 });


### PR DESCRIPTION
<!--
  Thank you for contributing! Please use this pull request (PR) template.


 In the description field of this PR, include "resolves #XXXX" tagging the issue you are fixing. If this PR addresses the issue but doesn't completely resolve it (ie the issue should remain open after your PR is merged), write "addresses #XXXX".-->
Resolves #6798

 Changes:
<!-- Add here what changes were made in this pull request and if possible provide links showcasing the changes. -->

This is a working draft of this issue #6798 which allows for `keyIsDown()` to accept alphanumeric String params such as `'w'` or `'W'`. Regarding the confusing case of the int `4` versus string `'4'`, this implementation includes both where the string parameter e.g. `'4'` reflects the ASCII value of  `'4'` while the int parameter e.g. `4` reflects the ASCII code `4`.

The documentation is also updated to reflect the changes with examples now included for the new changes.
 
 Screenshots of the change:
<!-- If applicable, add screenshots depicting the changes. -->
<img width="635" alt="image" src="https://github.com/processing/p5.js/assets/116049361/c600b9e3-046a-4f81-812a-7069c77a40db">

#### PR Checklist
<!--
  To check any option, replace the "[ ]" with a "[x]". Be sure to check out how it looks in the Preview tab! Feel free to remove any portion of the template that is not relevant for your issue.
-->

- [x] `npm run lint` passes
- [x] [Inline documentation] is included / updated
- [ ] [Unit tests] are included / updated

[Inline documentation]: https://github.com/processing/p5.js/blob/main/contributor_docs/inline_documentation.md
[Unit tests]: https://github.com/processing/p5.js/tree/main/contributor_docs#unit-tests
