### PR TITLE
fixed parameters for normal() method

### DIFF
--- a/src/core/shape/vertex.js
+++ b/src/core/shape/vertex.js
@@ -2117,7 +2117,7 @@ p5.prototype.vertex = function(x, y, moveTo, u, v) {
  * </code>
  *
  * @method normal
- * @param  {Vector} vector vertex normal as a <a href="#/p5.Vector">p5.Vector</a> object.
+ * @param  {p5.Vector} vector vertex normal as a <a href="#/p5.Vector">p5.Vector</a> object.
  * @chainable
  *
  * @example


### PR DESCRIPTION
<!--
  Thank you for contributing! Please use this pull request (PR) template.


In the description field of this PR, include "resolves #XXXX" tagging the issue you are fixing. If this PR addresses the issue but doesn't completely resolve it (ie the issue should remain open after your PR is merged), write "addresses #XXXX".-->
Resolves #6982

 Changes:
<!-- Add here what changes were made in this pull request and if possible provide links showcasing the changes. -->
It seems that in `src\core\shape\vertex.js` for the `normal()` method the documentation was written as `@param  {Vector} vector `and since `Vector `isn't a native JS class when the FES couldn't use `instanceOf` to check and `typeOf `checked the e.g. example `let n = createVector(-0.4, -0.4, 0.8); ` which would return object since Vector is not a native JS class.

A quick and easy fix would be to change `@param  {Vector} vector` to `@param  {p5.Vector} vector` so FES can correctly check the parameter.

 Screenshots of the change:
<!-- If applicable, add screenshots depicting the changes. -->
![image](https://github.com/processing/p5.js/assets/82423742/9438c837-7271-4ff2-a719-cdea8ae3ae94)

#### PR Checklist
<!--
  To check any option, replace the "[ ]" with a "[x]". Be sure to check out how it looks in the Preview tab! Feel free to remove any portion of the template that is not relevant for your issue.
-->

- [x] `npm run lint` passes
- [x] [Inline documentation] is included / updated
- [x] [Unit tests] are included / updated

[Inline documentation]: https://github.com/processing/p5.js/blob/main/contributor_docs/inline_documentation.md
[Unit tests]: https://github.com/processing/p5.js/tree/main/contributor_docs#unit-tests
