### PR TITLE
Fix main canvas clipping getting applied to framebuffers

### DIFF
--- a/src/webgl/p5.Framebuffer.js
+++ b/src/webgl/p5.Framebuffer.js
@@ -849,6 +849,7 @@ class Framebuffer {
     this.target._renderer.uMVMatrix.set(
       this.target._renderer._curCamera.cameraMatrix
     );
+    this.target._renderer._applyStencilTestIfClipping();
   }
 
   /**

--- a/test/unit/webgl/p5.RendererGL.js
+++ b/test/unit/webgl/p5.RendererGL.js
@@ -2462,5 +2462,42 @@ suite('p5.RendererGL', function() {
         }
       }
     );
+
+    test(
+      'Main canvas masks do not apply to framebuffers',
+      function() {
+        myp5.createCanvas(50, 50, myp5.WEBGL);
+        const fbo = myp5.createFramebuffer({ antialias: false });
+        myp5.rectMode(myp5.CENTER);
+        myp5.background('red');
+        expect(myp5._renderer._stencilTestOn).to.equal(false);
+        myp5.push();
+        myp5.beginClip();
+        myp5.rect(-20, -20, 40, 40);
+        myp5.endClip();
+        expect(myp5._renderer._stencilTestOn).to.equal(true);
+
+        fbo.begin();
+        expect(myp5._renderer._stencilTestOn).to.equal(false);
+        myp5.noStroke();
+        myp5.fill('blue');
+        myp5.rect(0, 0, myp5.width, myp5.height);
+        fbo.end();
+
+        expect(myp5._renderer._stencilTestOn).to.equal(true);
+        myp5.pop();
+        expect(myp5._renderer._stencilTestOn).to.equal(false);
+
+        myp5.imageMode(myp5.CENTER);
+        myp5.image(fbo, 0, 0);
+
+        // In the middle of the canvas, the framebuffer's clip and the
+        // main canvas's clip intersect, so the blue should show through
+        assert.deepEqual(
+          myp5.get(myp5.width / 2, myp5.height / 2),
+          [0, 0, 255, 255]
+        );
+      }
+    );
   });
 });


### PR DESCRIPTION
<!--
  Thank you for contributing! Please use this pull request (PR) template.


 In the description field of this PR, include "resolves #XXXX" tagging the issue you are fixing. If this PR addresses the issue but doesn't completely resolve it (ie the issue should remain open after your PR is merged), write "addresses #XXXX".-->
Resolves #6989 

Changes:
- Makes sure the WebGL stencil check, which is what applies the clipping, is updated both when you *start* drawing to a framebuffer as well as when you stop (previously, it only did this when you stop)


Screenshots of the change:

The code in the issue now produces a red canvas in Chrome as expected:
![image](https://github.com/processing/p5.js/assets/5315059/341bf7ae-f2cb-4673-b349-f3f74eaa8d96)


#### PR Checklist

- [x] `npm run lint` passes
- [ ] [Inline documentation] is included / updated
- [x] [Unit tests] are included / updated
