### PR TITLE
Expand keyIsDown() to work with characters as arguments

### DIFF
--- a/src/events/keyboard.js
+++ b/src/events/keyboard.js
@@ -307,7 +307,7 @@ p5.prototype._onblur = function(e) {
  * <a href="http://p5js.org/reference/#p5/keyCode">here</a>.
  *
  * @method keyIsDown
- * @param {Number}          code The key to check for.
+ * @param {Number|String}          code The key to check for.
  * @return {Boolean}        whether key is down or not
  * @example
  * <div><code>
@@ -371,6 +371,9 @@ p5.prototype._onblur = function(e) {
  */
 p5.prototype.keyIsDown = function(code) {
   p5._validateParameters('keyIsDown', arguments);
+  if (typeof code === 'string' && code.length === 1) {
+    code = code.toUpperCase().charCodeAt(0);
+  }
   return this._downKeys[code] || false;
 };
 

--- a/src/events/keyboard.js
+++ b/src/events/keyboard.js
@@ -344,6 +344,39 @@ p5.prototype._onblur = function(e) {
  * </code></div>
  *
  * <div><code>
+ * let x = 100;
+ * let y = 100;
+ *
+ * function setup() {
+ *   createCanvas(512, 512);
+ *   fill(255, 0, 0);
+ * }
+ *
+ * function draw() {
+ *   if (keyIsDown('A')) {
+ *     x -= 5;
+ *   }
+ *
+ *   if (keyIsDown('D')) {
+ *     x += 5;
+ *   }
+ *
+ *   if (keyIsDown('W')) {
+ *     y -= 5;
+ *   }
+ *
+ *   if (keyIsDown('S')) {
+ *     y += 5;
+ *   }
+ *
+ *   clear();
+ *   ellipse(x, y, 50, 50);
+ *   describe(`50-by-50 red ellipse moves left, right, up, and
+ *     down with 'W', 'A', 'S', and 'D' pressed.`);
+ * }
+ * </code></div>
+ *
+ * <div><code>
  * let diameter = 50;
  *
  * function setup() {


### PR DESCRIPTION
<!--
  Thank you for contributing! Please use this pull request (PR) template.


 In the description field of this PR, include "resolves #XXXX" tagging the issue you are fixing. If this PR addresses the issue but doesn't completely resolve it (ie the issue should remain open after your PR is merged), write "addresses #XXXX".-->
Resolves #6798 

 Changes:
<!-- Add here what changes were made in this pull request and if possible provide links showcasing the changes. -->
This is a working draft of this issue #6798 which allows for `keyIsDown()` to accept alphanumeric String params such as `'w'` or `'W'`. Regarding the confusing case of the int `4` versus string `'4'`, this implementation includes both where the string parameter e.g. `'4'` reflects the ASCII value of  `'4'` while the int parameter e.g. `4` reflects the ASCII code `4`.

The documentation is also updated to reflect the changes with examples now included for the new changes.
 
 Screenshots of the change:
<!-- If applicable, add screenshots depicting the changes. -->
<img width="635" alt="image" src="https://github.com/processing/p5.js/assets/116049361/c600b9e3-046a-4f81-812a-7069c77a40db">

#### PR Checklist
<!--
  To check any option, replace the "[ ]" with a "[x]". Be sure to check out how it looks in the Preview tab! Feel free to remove any portion of the template that is not relevant for your issue.
-->

- [ ] `npm run lint` passes
- [x] [Inline documentation] is included / updated
- [ ] [Unit tests] are included / updated

[Inline documentation]: https://github.com/processing/p5.js/blob/main/contributor_docs/inline_documentation.md
[Unit tests]: https://github.com/processing/p5.js/tree/main/contributor_docs#unit-tests
