### PR TITLE
Add missing backtick

### DIFF
--- a/src/webgl/loading.js
+++ b/src/webgl/loading.js
@@ -22,7 +22,7 @@ import './p5.Geometry';
  *
  * The first parameter, `path`, is always a `String` with the path to the
  * file. Paths to local files should be relative, as in
- * `loadModel('assets/model.obj'). URLs such as
+ * `loadModel('assets/model.obj')`. URLs such as
  * `'https://example.com/model.obj'` may be blocked due to browser security.
  *
  * The first way to call `loadModel()` has three optional parameters after the


### PR DESCRIPTION
There was a missing backtick, causing a code block to not end correctly

<!--
  Thank you for contributing! Please use this pull request (PR) template.


 In the description field of this PR, include "resolves #XXXX" tagging the issue you are fixing. If this PR addresses the issue but doesn't completely resolve it (ie the issue should remain open after your PR is merged), write "addresses #XXXX".-->
Resolves #6995

 Changes:
<!-- Add here what changes were made in this pull request and if possible provide links showcasing the changes. -->
I added the missing backtick.

 Screenshots of the change:
Before:

Paths to local files should be relative, as in `loadModel('assets/model.obj'). URLs such as `'https://example.com/model.obj'` may be blocked due to browser security.

After:

Paths to local files should be relative, as in `loadModel('assets/model.obj')`. URLs such as `'https://example.com/model.obj'` may be blocked due to browser security.

#### PR Checklist
<!--
  To check any option, replace the "[ ]" with a "[x]". Be sure to check out how it looks in the Preview tab! Feel free to remove any portion of the template that is not relevant for your issue.
-->

- [ ] `npm run lint` passes
- [ ] [Inline documentation] is included / updated
- [ ] [Unit tests] are included / updated

[Inline documentation]: https://github.com/processing/p5.js/blob/main/contributor_docs/inline_documentation.md
[Unit tests]: https://github.com/processing/p5.js/tree/main/contributor_docs#unit-tests
