### PR TITLE
Fix default z value in p5.Camera::camera() docs

### DIFF
--- a/src/webgl/p5.Camera.js
+++ b/src/webgl/p5.Camera.js
@@ -2721,7 +2721,7 @@ p5.Camera = class Camera {
  * @for p5.Camera
  * @param  {Number} [x]        x-coordinate of the camera. Defaults to 0.
  * @param  {Number} [y]        y-coordinate of the camera. Defaults to 0.
- * @param  {Number} [z]        z-coordinate of the camera. Defaults to 0.
+ * @param  {Number} [z]        z-coordinate of the camera. Defaults to 800.
  * @param  {Number} [centerX]  x-coordinate of the point the camera faces. Defaults to 0.
  * @param  {Number} [centerY]  y-coordinate of the point the camera faces. Defaults to 0.
  * @param  {Number} [centerZ]  z-coordinate of the point the camera faces. Defaults to 0.


### PR DESCRIPTION
It was discovered in https://github.com/processing/p5.js-website/pull/312 that in the `p5.Camera::camera()` method, the default value for `z` was described as 0 when it should be 800 (and is correctly documented as such in the global `camera()` method and other places.) This PR changes the value in the docs to 800.

I'll also make a change in the website repo directly so that we don't need a full release of p5 to get this updated on the site.
