### PR TITLE
fix clearStorage function to match expected behaviour

### DIFF
--- a/src/data/local_storage.js
+++ b/src/data/local_storage.js
@@ -194,8 +194,13 @@ p5.prototype.getItem = function(key) {
  * }
  * </code></div>
  */
-p5.prototype.clearStorage = function() {
-  localStorage.clear();
+p5.prototype.clearStorage = function () {
+  const keys = Object.keys(localStorage);
+  keys.forEach(key => {
+    if (key.endsWith('p5TypeID')) {
+      this.removeItem(key.replace('p5TypeID', ''));
+    }
+  });
 };
 
 /**

--- a/test/unit/data/local_storage.js
+++ b/test/unit/data/local_storage.js
@@ -105,4 +105,18 @@ suite('local storage', function() {
       checkRemoval('myVector');
     });
   });
+
+  suite('should be able to clear all items at once', function () {
+    test('should remove all items set by storeItem()', function () {
+      localStorage.setItem('extra', 'stuff');
+      myp5.clearStorage();
+      assert.deepEqual(myp5.getItem('myBoolean'), null);
+      assert.deepEqual(myp5.getItem('myNumber'), null);
+      assert.deepEqual(myp5.getItem('myObject'), null);
+      assert.deepEqual(myp5.getItem('myString'), null);
+      assert.deepEqual(myp5.getItem('myColor'), null);
+      assert.deepEqual(myp5.getItem('myVector'), null);
+      assert.deepEqual(myp5.getItem('extra'), 'stuff');
+    });
+  });
 });


### PR DESCRIPTION
Resolves #7003

Changes:
The `clearStorage()` function previously cleared the entire localStorage including the data set outside of p5.js. This is not the expected behaviour, the documentation states that only data set by the `storeItem()` will get cleared.
This fix checks which data has been set with `storeItem()` and only removes the relevant data.

- updated `clearStorage()` function
- added unit test

#### PR Checklist
- [x] `npm run lint` passes
- [x] [Inline documentation] is included / updated
- [x] [Unit tests] are included / updated
