### PR TITLE
textWrap() parameter validation uses FES instead of throwing error

### DIFF
--- a/src/typography/attributes.js
+++ b/src/typography/attributes.js
@@ -539,9 +539,8 @@ p5.prototype._updateTextMetrics = function() {
  * </div>
  */
 p5.prototype.textWrap = function(wrapStyle) {
-  if (wrapStyle !== 'WORD' && wrapStyle !== 'CHAR') {
-    throw 'Error: textWrap accepts only WORD or CHAR';
-  }
+  p5._validateParameters('textWrap', [wrapStyle]);
+
   return this._renderer.textWrap(wrapStyle);
 };
 

--- a/test/unit/typography/attributes.js
+++ b/test/unit/typography/attributes.js
@@ -113,11 +113,6 @@ suite('Typography Attributes', function() {
   });
 
   suite('p5.prototype.textWrap', function() {
-    test('should throw error for non-constant input', function() {
-      expect(function() {
-        myp5.textWrap('NO-WRAP');
-      }).to.throw('Error: textWrap accepts only WORD or CHAR');
-    });
     test('returns textWrap text attribute', function() {
       assert.strictEqual(myp5.textWrap(myp5.WORD), myp5.WORD);
     });


### PR DESCRIPTION
<!--
  Thank you for contributing! Please use this pull request (PR) template.


 In the description field of this PR, include "resolves #XXXX" tagging the issue you are fixing. If this PR addresses the issue but doesn't completely resolve it (ie the issue should remain open after your PR is merged), write "addresses #XXXX".-->
Resolves #6997

 Changes:
<!-- Add here what changes were made in this pull request and if possible provide links showcasing the changes. -->
In the `textWrap()` function for parameter type checking, use FES `p5._validateParameters()` instead of manual checking and throwing error for a more recoverable state overall.

Also removed unit test that expects the function to throw an error on incorrect argument type. 


#### PR Checklist
<!--
  To check any option, replace the "[ ]" with a "[x]". Be sure to check out how it looks in the Preview tab! Feel free to remove any portion of the template that is not relevant for your issue.
-->

- [x] `npm run lint` passes
- [ ] [Inline documentation] is included / updated
- [x] [Unit tests] are included / updated

[Inline documentation]: https://github.com/processing/p5.js/blob/main/contributor_docs/inline_documentation.md
[Unit tests]: https://github.com/processing/p5.js/tree/main/contributor_docs#unit-tests
