### PR TITLE
Fix broken test

### DIFF
--- a/test/unit/image/p5.Image.js
+++ b/test/unit/image/p5.Image.js
@@ -123,12 +123,13 @@ suite('p5.Image', function() {
       myp5.createCanvas(10,10);
       myp5.pixelDensity(2);
       let img = myp5.createGraphics(10,10);
+      img.noStroke();
       img.rect(0,0,10,10);
-      img.background(0);
-      let mask = createGraphics(10,10);
+      let mask = myp5.createGraphics(10,10);
+      mask.noStroke();
       mask.rect(0,0,5,5);
       let masked = img.get();
-      masked.mask( mask.get() );
+      masked.mask(mask.get());
 
       for (let i = 0; i < masked.width; i++) {
         for (let j = 0; j < masked.height; j++) {

--- a/test/unit/visual/cases/typography.js
+++ b/test/unit/visual/cases/typography.js
@@ -17,4 +17,4 @@ visualSuite('Typography', function() {
       screenshot();
     });
   });
-}, { focus: true });
+});


### PR DESCRIPTION
Resolves https://github.com/processing/p5.js/issues/7008

Removes a focused test case, and fixes a broken test that got merged in because of that.

I looked into adding `mocha.setup({ ui: 'tdd', forbidOnly: true })` into `mocha_setup.js` to see if we could catch these in CI, but I couldn't get it to actually fail on usage of `.only` locally. Any idea what I might be missing @limzykenneth?