### PR TITLE
Fix 'p5.Vector.sub()' documentation mistakenly referencing 'add'ing

### DIFF
--- a/src/math/p5.Vector.js
+++ b/src/math/p5.Vector.js
@@ -640,7 +640,7 @@ p5.Vector = class {
  * of numbers, as in `v.sub([1, 2, 3])`.
  *
  * If a value isn't provided for a component, it won't change. For
- * example, `v.sub(4, 5)` adds 4 to `v.x`, 5 to `v.y`, and 0 to `v.z`.
+ * example, `v.sub(4, 5)` subtracts 4 from `v.x`, 5 from `v.y`, and 0 from `v.z`.
  * Calling `sub()` with no arguments, as in `v.sub()`, has no effect.
  *
  * The static version of `sub()`, as in `p5.Vector.sub(v2, v1)`, returns a new


### PR DESCRIPTION
Resolves #7023 

 Changes:
Edited reference documentation for vector `sub()` that seems to just be an exact copy/paste of vector `add()` on line 290.

#### PR Checklist
- [ ] `npm run lint` passes
- [ ] [Inline documentation] is included / updated
- [ ] [Unit tests] are included / updated

[Inline documentation]: https://github.com/processing/p5.js/blob/main/contributor_docs/inline_documentation.md
[Unit tests]: https://github.com/processing/p5.js/tree/main/contributor_docs#unit-tests
