### PR TITLE
Added WebGL text error and textFont documentation update

### DIFF
--- a/src/typography/loading_displaying.js
+++ b/src/typography/loading_displaying.js
@@ -366,8 +366,8 @@ p5.prototype.text = function(str, x, y, maxWidth, maxHeight) {
  * <code>
  * // WEBGL Example
  * function preload() {
- *  createCanvas(100, 100, WEBGL);
- *  textFont('Courier New'); // In WebGL textFont has to be executed in preload
+ *   createCanvas(100, 100, WEBGL);
+ *   textFont('Courier New'); // In WebGL textFont has to be executed in preload
  * }
  *
  * function setup() {

--- a/src/typography/loading_displaying.js
+++ b/src/typography/loading_displaying.js
@@ -364,6 +364,24 @@ p5.prototype.text = function(str, x, y, maxWidth, maxHeight) {
  *
  * <div>
  * <code>
+ * // WEBGL Example
+ * function preload() {
+ *  createCanvas(100, 100, WEBGL);
+ *  textFont('Courier New'); // In WebGL textFont has to be executed in preload
+ * }
+ *
+ * function setup() {
+ *   background(200);
+ *   textSize(24);
+ *   text('hi', 35, 55);
+ *
+ *   describe('The text "hi" written in a black, monospace font on a gray background.');
+ * }
+ * </code>
+ * </div>
+ *
+ * <div>
+ * <code>
  * function setup() {
  *   background('black');
  *   fill('palegreen');

--- a/src/webgl/text.js
+++ b/src/webgl/text.js
@@ -642,7 +642,8 @@ class FontInfo {
 p5.RendererGL.prototype._renderText = function(p, line, x, y, maxY) {
   if (!this._textFont || typeof this._textFont === 'string') {
     console.log(
-      'WEBGL: you must load and set a font before drawing text. See `loadFont` and `textFont` for more details.'
+      'WEBGL: you must load and set a font before drawing text. See `loadFont` and `textFont`' +
+      '(both of which have to be executed in preload() for WebGL mode) for more details.'
     );
     return;
   }

--- a/src/webgl/text.js
+++ b/src/webgl/text.js
@@ -643,7 +643,7 @@ p5.RendererGL.prototype._renderText = function(p, line, x, y, maxY) {
   if (!this._textFont || typeof this._textFont === 'string') {
     console.log(
       'WEBGL: you must load and set a font before drawing text. See `loadFont` and `textFont`' +
-      '(both of which have to be executed in preload() for WebGL mode) for more details.'
+      '(both of which have to be executed in preload() for WebGL mode when loading a new font) for more details.'
     );
     return;
   }


### PR DESCRIPTION
<!--
  Thank you for contributing! Please use this pull request (PR) template.


 In the description field of this PR, include "resolves #XXXX" tagging the issue you are fixing. If this PR addresses the issue but doesn't completely resolve it (ie the issue should remain open after your PR is merged), write "addresses #XXXX".-->
Resolves #7028

 Changes:
<!-- Add here what changes were made in this pull request and if possible provide links showcasing the changes. -->
Replaced the previously vague error:
```
WEBGL: you must load and set a font before drawing text. See `loadFont` and `textFont` for more details.
```
with
```
WEBGL: you must load and set a font before drawing text. See `loadFont` and `textFont` (both of which have to be executed in preload() for WebGL mode when loading a new font) for more details.
```

and updated `textFont()`'s page to have a WEBGL example:
```
// WEBGL Example
function preload() 
  createCanvas(100, 100, WEBGL); // In WebGL textFont has to be executed in preload
  textFont('Courier New');
}
 
function setup() {
  background(200);
  textSize(24);
  text('hi', 35, 55);

  describe('The text "hi" written in a black, monospace font on a gray background.');
}
```

 Screenshots of the change:
<!-- If applicable, add screenshots depicting the changes. -->

#### PR Checklist
<!--
  To check any option, replace the "[ ]" with a "[x]". Be sure to check out how it looks in the Preview tab! Feel free to remove any portion of the template that is not relevant for your issue.
-->

- [x] `npm run lint` passes
- [x] [Inline documentation] is included / updated
- [x] [Unit tests] are included / updated

[Inline documentation]: https://github.com/processing/p5.js/blob/main/contributor_docs/inline_documentation.md
[Unit tests]: https://github.com/processing/p5.js/tree/main/contributor_docs#unit-tests
