### PR TITLE
Fix map example

### DIFF
--- a/src/math/calculation.js
+++ b/src/math/calculation.js
@@ -574,7 +574,7 @@ p5.prototype.mag = function(x, y) {
  *   let x = map(mouseX, 0, 100, 0, 50);
  *
  *   // Draw the bottom line.
- *   line(0, 75, 0, x);
+ *   line(0, 75, x, 75);
  * }
  * </code>
  * </div>


### PR DESCRIPTION
Fixing the example of `map` function. The bottom line was drown vertical instad of horizontal, as the example try to show.

```
'Two horizontal lines. The top line grows horizontally as the mouse moves to the right. The bottom line also grows horizontally but is scaled to stay on the left half of the canvas.'
```