### PR TITLE
fix link in documentation_style_guide.md

### DIFF
--- a/contributor_docs/documentation_style_guide.md
+++ b/contributor_docs/documentation_style_guide.md
@@ -80,7 +80,7 @@ function drawFractal(c, radius, maxIter) {
 }
 ```
 
-Communicate the current way of doing things, both explicitly and implicitly. Use the idioms recommended in this guide. Reorder sections to emphasize favored approaches if needed. The documentation should be a model for best practices and approachable for beginners.
+Communicate the current way of doing things, both explicitly and implicitly. Use the idioms recommended in [this guide.](https://github.com/processing/p5.js/blob/main/contributor_docs/contributing_to_the_p5.js_reference.md) Reorder sections to emphasize favored approaches if needed. The documentation should be a model for best practices and approachable for beginners.
 
 Documentation has to be brief but comprehensive. Explore and document edge cases. What happens for each combination of arguments? What bugs are most likely to appear in a beginner's code?
 


### PR DESCRIPTION

### Resolves #7050

### Changes:
Added the missing link in the sentence:
'Use the idioms recommended in this guide.'

Now links to:
https://github.com/processing/p5.js/blob/main/contributor_docs/contributing_to_the_p5.js_reference.md

### Screenshots of the change:
**Before**
![Screenshot (43)](https://github.com/processing/p5.js/assets/76125564/fe7625a1-eb04-42ea-906d-e11056c5e125)
**After**
![image](https://github.com/processing/p5.js/assets/76125564/0d963e9f-87de-448a-a888-4c9236f1beb5)


