### PR TITLE
Fix links and typos

### DIFF
--- a/src/color/p5.Color.js
+++ b/src/color/p5.Color.js
@@ -571,7 +571,7 @@ p5.Color = class Color {
   /**
    * Sets the red component of a color.
    *
-   * The range depends on the <a href="#/colorMode">colorMode()</a>. In the
+   * The range depends on the <a href="#/p5/colorMode">colorMode()</a>. In the
    * default RGB mode it's between 0 and 255.
    *
    * @method setRed
@@ -613,7 +613,7 @@ p5.Color = class Color {
   /**
    * Sets the green component of a color.
    *
-   * The range depends on the <a href="#/colorMode">colorMode()</a>. In the
+   * The range depends on the <a href="#/p5/colorMode">colorMode()</a>. In the
    * default RGB mode it's between 0 and 255.
    *
    * @method setGreen
@@ -655,7 +655,7 @@ p5.Color = class Color {
   /**
    * Sets the blue component of a color.
    *
-   * The range depends on the <a href="#/colorMode">colorMode()</a>. In the
+   * The range depends on the <a href="#/p5/colorMode">colorMode()</a>. In the
    * default RGB mode it's between 0 and 255.
    *
    * @method setBlue
@@ -698,7 +698,7 @@ p5.Color = class Color {
    * Sets the alpha (transparency) value of a color.
    *
    * The range depends on the
-   * <a href="#/colorMode">colorMode()</a>. In the default RGB mode it's
+   * <a href="#/p5/colorMode">colorMode()</a>. In the default RGB mode it's
    * between 0 and 255.
    *
    * @method setAlpha

--- a/src/core/transform.js
+++ b/src/core/transform.js
@@ -266,7 +266,7 @@ p5.prototype.applyMatrix = function(...args) {
  *   // Translate the origin to the center.
  *   translate(50, 50);
  *
- *   // Draw a red circle at the coordinates (25, 25).
+ *   // Draw a blue circle at the coordinates (25, 25).
  *   fill('blue');
  *   circle(25, 25, 20);
  *
@@ -274,7 +274,7 @@ p5.prototype.applyMatrix = function(...args) {
  *   // The origin is now at the top-left corner.
  *   resetMatrix();
  *
- *   // Draw a blue circle at the coordinates (25, 25).
+ *   // Draw a red circle at the coordinates (25, 25).
  *   fill('red');
  *   circle(25, 25, 20);
  * }
@@ -317,9 +317,8 @@ p5.prototype.resetMatrix = function() {
  * shapes to spin.
  *
  * @method rotate
- * @param  {Number} angle the angle of rotation, specified in radians
- *                        or degrees, depending on current angleMode
- * @param  {p5.Vector|Number[]} [axis] (in 3d) the axis to rotate around
+ * @param  {Number} angle angle of rotation in the current <a href="#/p5/angleMode">angleMode()</a>.
+ * @param  {p5.Vector|Number[]} [axis] axis to rotate about in 3D.
  * @chainable
  *
  * @example


### PR DESCRIPTION
Fixed a few links in `p5.Color` and a typo in `resetMatrix()`.

#### PR Checklist
<!--
  To check any option, replace the "[ ]" with a "[x]". Be sure to check out how it looks in the Preview tab! Feel free to remove any portion of the template that is not relevant for your issue.
-->

- [x] `npm run lint` passes
- [x] [Inline documentation] is included / updated

@Qianqianye @davepagurek @limzykenneth