### PR TITLE
Support for .mtl Files with Textures

### DIFF
--- a/src/webgl/p5.Geometry.js
+++ b/src/webgl/p5.Geometry.js
@@ -62,6 +62,11 @@ p5.Geometry = class Geometry {
     // One color per vertex representing the stroke color at that vertex
     this.vertexStrokeColors = [];
 
+    // Map storing the textures and faces for each texture
+    this.textures = {};
+
+    this.hasTextures = false;
+
     // One color per line vertex, generated automatically based on
     // vertexStrokeColors in _edgesToVertices()
     this.lineVertexColors = new p5.DataArray();
@@ -707,10 +712,18 @@ p5.Geometry = class Geometry {
   _makeTriangleEdges() {
     this.edges.length = 0;
 
+    const _addEdge = face => {
+      this.edges.push([face[0], face[1]]);
+      this.edges.push([face[1], face[2]]);
+      this.edges.push([face[2], face[0]]);
+    };
+
     for (let j = 0; j < this.faces.length; j++) {
-      this.edges.push([this.faces[j][0], this.faces[j][1]]);
-      this.edges.push([this.faces[j][1], this.faces[j][2]]);
-      this.edges.push([this.faces[j][2], this.faces[j][0]]);
+      _addEdge(this.faces[j]);
+    }
+
+    for (let material of Object.keys(this.textures)) {
+      this.textures[material].faces.map(face => _addEdge(face));
     }
 
     return this;
@@ -1002,6 +1015,19 @@ p5.Geometry = class Geometry {
       }
     }
     return this;
+  }
+
+  /**
+   * When using textures each material contains all the face indices for that texture.
+   * this function collects all the faces mapped to different textures in a single array
+   * @method collectFaces
+  */
+  collectFaces() {
+    const faces = [];
+    for (let materialName of Object.keys(this.textures)) {
+      faces.push(this.textures[materialName]['faces']);
+    }
+    return faces.flat();
   }
 };
 export default p5.Geometry;


### PR DESCRIPTION
<!--
  Thank you for contributing! Please use this pull request (PR) template.

 In the description field of this PR, include "resolves #XXXX" tagging the issue you are fixing. If this PR addresses the issue but doesn't completely resolve it (ie the issue should remain open after your PR is merged), write "addresses #XXXX".-->
Resolves #6924 

 Changes:
This change allows to render diffuse textures specified in the .mtl files while rendering the model. To implement this, a JS object has been added to the Geometry class which maps each material name to a texture (p5.Img object) and the faces to which the texture has to be applied. While rendering the model first it is checked if the model has textures, if it does then for each texture the index buffer is updated with face indices for that texture and rendered. This runs in a loop until all the textures have been rendered. 

I have moved out from the logic for creating and updating indexBuffer from the createBuffers function to updateIndexBuffer function because I only wanted to update the index buffer again and again without deleting and initializing other buffers. 

 Screenshots of the change:

<img width="298" alt="Screenshot 2024-05-28 at 1 12 59 PM" src="https://github.com/processing/p5.js/assets/19673968/be82b7d1-e87b-420d-be11-eee6f31b01a3">

<img width="298" alt="Screenshot 2024-05-28 at 1 14 40 PM" src="https://github.com/processing/p5.js/assets/19673968/f0742f11-45cd-49ab-a944-9b55a63f0201">

<img width="298" alt="Screenshot 2024-05-28 at 12 39 29 PM" src="https://github.com/processing/p5.js/assets/19673968/087c31f6-42a5-46a7-94a4-156eb425f981">

<img width="298" alt="Screenshot 2024-05-28 at 2 25 03 PM" src="https://github.com/processing/p5.js/assets/19673968/efb5c3f0-acec-4a6e-9db0-8523eb01a797">





###
The mario obj file in the sample [sketch](https://aijs.io/editor?user=sableraph&project=multiTextureMaterial_test) specified in the issue  have negative texture coordinates. Due to that it does not render correctly. Only when V coordinate is not [inversed](https://github.com/processing/p5.js/blob/main/src/webgl/loading.js#L602) and texture wrapping mode is changed from clamp to repeat the model renders correctly. Now I am not sure exactly why this is working. For wrapping modes I understand why repeat mode should work but I am not sure how, not inversing the V coordinate is fixing the problem. 

#### PR Checklist
<!--
  To check any option, replace the "[ ]" with a "[x]". Be sure to check out how it looks in the Preview tab! Feel free to remove any portion of the template that is not relevant for your issue.
-->

- [x] `npm run lint` passes
- [ ] [Inline documentation] is included / updated
- [ ] [Unit tests] are included / updated

[Inline documentation]: https://github.com/processing/p5.js/blob/main/contributor_docs/inline_documentation.md
[Unit tests]: https://github.com/processing/p5.js/tree/main/contributor_docs#unit-tests

PS: I am not sure if this was the exepcted implementation. If this looks fine I will add unit tests for this.