### PR TITLE
fix: framebuffer cameras uses the size from main canvas

### DIFF
--- a/src/webgl/p5.Camera.js
+++ b/src/webgl/p5.Camera.js
@@ -889,45 +889,36 @@ p5.Camera = class Camera {
  * two 3D boxes move back and forth along same plane, rotating as mouse is dragged.
  */
   ortho(left, right, bottom, top, near, far) {
-    if (left === undefined) left = -this._renderer.width / 2;
-    if (right === undefined) right = +this._renderer.width / 2;
-    if (bottom === undefined) bottom = -this._renderer.height / 2;
-    if (top === undefined) top = +this._renderer.height / 2;
+    const source = this.fbo||this._renderer;
+    if (left === undefined) left = -source.width / 2;
+    if (right === undefined) right = +source.width / 2;
+    if (bottom === undefined) bottom = -source.height / 2;
+    if (top === undefined) top = +source.height / 2;
     if (near === undefined) near = 0;
-    if (far === undefined)
-      far = Math.max(this._renderer.width, this._renderer.height)+800;
-
+    if (far === undefined) far = Math.max(source.width, source.height)+800;
     this.cameraNear = near;
     this.cameraFar = far;
-
     const w = right - left;
     const h = top - bottom;
     const d = far - near;
-
     const x = +2.0 / w;
     const y = +2.0 / h * this.yScale;
     const z = -2.0 / d;
-
     const tx = -(right + left) / w;
     const ty = -(top + bottom) / h;
     const tz = -(far + near) / d;
-
     this.projMatrix = p5.Matrix.identity();
-
     /* eslint-disable indent */
     this.projMatrix.set(  x,  0,  0,  0,
                           0, -y,  0,  0,
                           0,  0,  z,  0,
                           tx, ty, tz,  1);
     /* eslint-enable indent */
-
     if (this._isActive()) {
       this._renderer.uPMatrix.set(this.projMatrix);
     }
-
     this.cameraType = 'custom';
   }
-
   /**
  * Sets the camera's frustum.
  * Accepts the same parameters as the global


### PR DESCRIPTION

Resolves #7071

 Changes:

- Replaced the `this._renderer` with `(this.renderer||this.fbo)` to use either one of them.
- It will he fix the issue regarding the framebuffer camera using the size of the main canvas.

 Screenshots of the change:
![Screenshot 2024-05-29 171418](https://github.com/processing/p5.js/assets/35897449/a8ba4bd2-2282-4dc0-a2c3-b03990f715f4)

#### PR Checklist
<!--
  To check any option, replace the "[ ]" with a "[x]". Be sure to check out how it looks in the Preview tab! Feel free to remove any portion of the template that is not relevant for your issue.
-->

- [x] `npm run lint` passes

[Inline documentation]: https://github.com/processing/p5.js/blob/main/contributor_docs/inline_documentation.md
[Unit tests]: https://github.com/processing/p5.js/tree/main/contributor_docs#unit-tests
