### PR TITLE
Update clearDepth() example to restore trails

### DIFF
--- a/src/core/rendering.js
+++ b/src/core/rendering.js
@@ -664,7 +664,7 @@ p5.prototype.createFramebuffer = function(options) {
  *   createCanvas(100, 100, WEBGL);
  *
  *   // Create the p5.Framebuffer objects.
- *   prev = createFramebuffer({ format: FLOAT });
+ *   previous = createFramebuffer({ format: FLOAT });
  *   current = createFramebuffer({ format: FLOAT });
  *
  *   describe(
@@ -673,9 +673,9 @@ p5.prototype.createFramebuffer = function(options) {
  * }
  *
  * function draw() {
- *   // Set the previous p5.Framebuffer to the
+ *   // Swap the previous p5.Framebuffer and the
  *   // current one so it can be used as a texture.
- *   previous = current;
+ *   [previous, current] = [current, previous];
  *
  *   // Start drawing to the current p5.Framebuffer.
  *   current.begin();


### PR DESCRIPTION
Resolves https://github.com/processing/p5.js/issues/7094

### Changes:
- Fixes variable names
- Fixes swapping between framebuffers


### Screenshots of the change:
![image](https://github.com/processing/p5.js/assets/5315059/46296ad4-2572-44bf-a780-17a7050ba35d)


#### PR Checklist
<!--
  To check any option, replace the "[ ]" with a "[x]". Be sure to check out how it looks in the Preview tab! Feel free to remove any portion of the template that is not relevant for your issue.
-->

- [ ] `npm run lint` passes
- [ ] [Inline documentation] is included / updated
- [ ] [Unit tests] are included / updated

[Inline documentation]: https://github.com/processing/p5.js/blob/main/contributor_docs/inline_documentation.md
[Unit tests]: https://github.com/processing/p5.js/tree/main/contributor_docs#unit-tests
