### PR TITLE
Changed point class documentation description text

### DIFF
--- a/src/core/shape/2d_primitives.js
+++ b/src/core/shape/2d_primitives.js
@@ -737,7 +737,7 @@ p5.prototype.line = function(...args) {
  * can't be filled, so the <a href="#/p5/fill">fill()</a> function won't
  * affect the point's color.
  *
- * The version of `point()` with one parameter allows the point's location to
+ * The version of `point()` with two parameters allows the point's location to
  * be set with its x- and y-coordinates, as in `point(10, 20)`.
  *
  * The version of `point()` with three parameters allows the point to be drawn


### PR DESCRIPTION
<!--
  Thank you for contributing! Please use this pull request (PR) template.


 In the description field of this PR, include "resolves #7086" tagging the issue you are fixing. If this PR addresses the issue but doesn't completely resolve it (ie the issue should remain open after your PR is merged), write "addresses #XXXX".-->
Resolves #7086 

Changes:
Changed the description of the point method to clarify the number of parameters.

Previous Text:
The version of point() with `one parameter` allows the point's location to be set with its x- and y-coordinates, as in point(10, 20).

Updated Text:
The version of point() with `two parameters` allows the point's location to be set with its x- and y-coordinates, as in point(10, 20).

Reference:
As discussed in Issue #7086 .

 Screenshots of the change:
<!-- If applicable, add screenshots depicting the changes. -->

#### PR Checklist
<!--
  To check any option, replace the "[ ]" with a "[x]". Be sure to check out how it looks in the Preview tab! Feel free to remove any portion of the template that is not relevant for your issue.
-->

- [x] `npm run lint` passes
- [x] [Inline documentation] is included / updated

[Inline documentation]: https://github.com/processing/p5.js/blob/main/contributor_docs/inline_documentation.md
[Unit tests]: https://github.com/processing/p5.js/tree/main/contributor_docs#unit-tests
