### PR TITLE
Fix vector reflect() mutating surface normal arg (#7088)

### DIFF
--- a/src/math/p5.Vector.js
+++ b/src/math/p5.Vector.js
@@ -2972,8 +2972,8 @@ p5.Vector = class {
  * </div>
  */
   reflect(surfaceNormal) {
-    surfaceNormal.normalize();
-    return this.sub(surfaceNormal.mult(2 * this.dot(surfaceNormal)));
+    const surfaceNormalCopy = p5.Vector.normalize(surfaceNormal);
+    return this.sub(surfaceNormalCopy.mult(2 * this.dot(surfaceNormalCopy)));
   }
 
   /**

--- a/test/unit/math/p5.Vector.js
+++ b/test/unit/math/p5.Vector.js
@@ -1646,6 +1646,21 @@ suite('p5.Vector', function() {
           0.01
         );
       });
+      test('should not update surface normal', function() {
+        const tolerance = 0.001;
+        assert.closeTo(x_normal.x, 3, tolerance);
+        assert.closeTo(x_normal.y, 0, tolerance);
+        assert.closeTo(x_normal.z, 0, tolerance);
+
+        assert.closeTo(y_normal.x, 0, tolerance);
+        assert.closeTo(y_normal.y, 3, tolerance);
+        assert.closeTo(y_normal.z, 0, tolerance);
+
+        assert.closeTo(z_normal.x, 0, tolerance);
+        assert.closeTo(z_normal.y, 0, tolerance);
+        assert.closeTo(z_normal.z, 3, tolerance);
+      });
+
     });
 
     suite('p5.Vector.reflect() [CLASS]', function() {
@@ -1695,6 +1710,22 @@ suite('p5.Vector', function() {
         expect(y_bounce_incoming).to.not.equal(y_bounce_outgoing);
         expect(z_bounce_incoming).to.not.equal(z_bounce_outgoing);
       });
+
+      test('should not update surface normal', function() {
+        const tolerance = 0.001;
+        assert.closeTo(x_normal.x, 3, tolerance);
+        assert.closeTo(x_normal.y, 0, tolerance);
+        assert.closeTo(x_normal.z, 0, tolerance);
+
+        assert.closeTo(y_normal.x, 0, tolerance);
+        assert.closeTo(y_normal.y, 3, tolerance);
+        assert.closeTo(y_normal.z, 0, tolerance);
+
+        assert.closeTo(z_normal.x, 0, tolerance);
+        assert.closeTo(z_normal.y, 0, tolerance);
+        assert.closeTo(z_normal.z, 3, tolerance);
+      });
+
 
       test('should update target', function() {
         assert.equal(x_target, x_bounce_outgoing);


### PR DESCRIPTION
Resolves #7088

 Changes:

Added unit tests to check the reflect functions (static and instance) don't alter the given surfaceNormal vector.

Changed the common p5.Vector reflect function so that the given surfaceNormal vector is not mutated unexpectedly.

Did so by making a local copy of the input vector:

```js
reflect(surfaceNormal) {
    const surfaceNormalCopy = p5.Vector.normalize(surfaceNormal);
    return this.sub(surfaceNormalCopy.mult(2 * this.dot(surfaceNormalCopy)));
}
```

 Screenshots of the change:
 n/a

#### PR Checklist

- [x] `npm run lint` passes
- [ ] [Inline documentation] is included / updated - n/a (bugfix)
- [x] [Unit tests] are included / updated

Note: eslint passes but emits one warning.
```
p5.js/src/core/reference.js:0:0: File ignored because of a matching ignore pattern. Use "--no-ignore" to override. [Warning]
```


#### misc implementation notes

Also considered this alternative implementation using the static methods to avoid a local copy of the vector, but I think it turns out harder to read, and requires the normalisation calculation happen twice.
 
```js
reflect(surfaceNormal) {
    return this.sub(
      p5.Vector.mult(
        p5.Vector.normalize(surfaceNormal),
        2 * this.dot(p5.Vector.normalize(surfaceNormal))
      )
    );
  }
```

