### PR TITLE
Fix clipped multiline font rendering

### DIFF
--- a/src/typography/p5.Font.js
+++ b/src/typography/p5.Font.js
@@ -532,7 +532,7 @@ p5.Font = class {
       pdata = this._getPath(line, x, y, options).commands;
     }
 
-    ctx.beginPath();
+    if (!pg._clipping) ctx.beginPath();
 
     for (const cmd of pdata) {
       if (cmd.type === 'M') {


### PR DESCRIPTION
Resolves https://github.com/processing/p5.js/issues/7108

Changes:
- Doesn't start a new path if currently creating a clipping mask

Screenshots of the change:

<img width="393" alt="image" src="https://github.com/processing/p5.js/assets/5315059/177b268d-fe9b-43d5-a708-2e636c0b4144">


https://editor.p5js.org/davepagurek/sketches/ojjIs2--Q


#### PR Checklist
<!--
  To check any option, replace the "[ ]" with a "[x]". Be sure to check out how it looks in the Preview tab! Feel free to remove any portion of the template that is not relevant for your issue.
-->

- [x] `npm run lint` passes
- [ ] [Inline documentation] is included / updated
- [ ] [Unit tests] are included / updated
