### PR TITLE
Corrects the circle() description

### DIFF
--- a/src/core/shape/2d_primitives.js
+++ b/src/core/shape/2d_primitives.js
@@ -492,7 +492,8 @@ p5.prototype.ellipse = function(x, y, w, h, detailX) {
  *
  * A circle is a round shape defined by the `x`, `y`, and `d` parameters.
  * `x` and `y` set the location of its center. `d` sets its width and height (diameter).
- * Every point on the circle's edge is half the distance, `d`, from its center (radius = diameter/2).
+ * Every point on the circle's edge is the same distance, `0.5 * d`, from its center.
+ * `0.5 * d` (half the diameter) is the circle's radius.
  * See <a href="#/p5/ellipseMode">ellipseMode()</a> for other ways to set its position.
  *
  * @method circle

--- a/src/core/shape/2d_primitives.js
+++ b/src/core/shape/2d_primitives.js
@@ -490,12 +490,10 @@ p5.prototype.ellipse = function(x, y, w, h, detailX) {
 /**
  * Draws a circle.
  *
- * A circle is a round shape defined by the `x`, `y`, and `d`
- * parameters. `x` and `y` set the location of its center. `d` sets its
- * width and height (diameter). Every point on the circle's edge is the
- * same distance, `d`, from its center. See
- * <a href="#/p5/ellipseMode">ellipseMode()</a> for other ways to set
- * its position.
+ * A circle is a round shape defined by the `x`, `y`, and `d` parameters.
+ * `x` and `y` set the location of its center. `d` sets its width and height (diameter).
+ * Every point on the circle's edge is half the distance, `d`, from its center (radius = diameter/2).
+ * See <a href="#/p5/ellipseMode">ellipseMode()</a> for other ways to set its position.
  *
  * @method circle
  * @param  {Number} x  x-coordinate of the center of the circle.


### PR DESCRIPTION
<!--
  Thank you for contributing! Please use this pull request (PR) template.


 In the description field of this PR, include "resolves #XXXX" tagging the issue you are fixing. If this PR addresses the issue but doesn't completely resolve it (ie the issue should remain open after your PR is merged), write "addresses #XXXX".-->
 Changes:

 This clarifies that each point on the edge of the circle is half its diameter.

<!-- Add here what changes were made in this pull request and if possible provide links showcasing the changes. -->


<!-- If applicable, add screenshots depicting the changes. -->

#### PR Checklist
<!--
  To check any option, replace the "[ ]" with a "[x]". Be sure to check out how it looks in the Preview tab! Feel free to remove any portion of the template that is not relevant for your issue.
-->

- [ ] `npm run lint` passes
- [x] [Inline documentation] is included / updated
- [ ] [Unit tests] are included / updated

[Inline documentation]: https://github.com/processing/p5.js/blob/main/contributor_docs/inline_documentation.md
[Unit tests]: https://github.com/processing/p5.js/tree/main/contributor_docs#unit-tests
