### PR TITLE
Fix broken JsDoc comments

### DIFF
--- a/src/color/p5.Color.js
+++ b/src/color/p5.Color.js
@@ -705,7 +705,6 @@ p5.Color = class Color {
    * @param {Number} alpha the new alpha value.
    *
    * @example
-   * @example
    * <div>
    * <code>
    * function setup() {

--- a/src/math/random.js
+++ b/src/math/random.js
@@ -20,7 +20,7 @@ const c = 1013904223;
 let y2 = 0;
 
 // Linear Congruential Generator that stores its state at instance[stateProperty]
-p5.prototype._lcg = function (stateProperty) {
+p5.prototype._lcg = function(stateProperty) {
   // define the recurrence relationship
   this[stateProperty] = (a * this[stateProperty] + c) % m;
   // return a float in [0, 1)
@@ -28,7 +28,7 @@ p5.prototype._lcg = function (stateProperty) {
   return this[stateProperty] / m;
 };
 
-p5.prototype._lcgSetSeed = function (stateProperty, val) {
+p5.prototype._lcgSetSeed = function(stateProperty, val) {
   // pick a random seed if val is undefined or null
   // the >>> 0 casts the seed to an unsigned 32-bit integer
   this[stateProperty] = (val == null ? Math.random() * m : val) >>> 0;
@@ -78,7 +78,7 @@ p5.prototype._lcgSetSeed = function (stateProperty, val) {
  * </code>
  * </div>
  */
-p5.prototype.randomSeed = function (seed) {
+p5.prototype.randomSeed = function(seed) {
   this._lcgSetSeed(randomStateProp, seed);
   this._gaussian_previous = false;
 };
@@ -261,7 +261,7 @@ p5.prototype.randomSeed = function (seed) {
  * @param  {Array} choices   array to choose from.
  * @return {*} random element from the array.
  */
-p5.prototype.random = function (min, max) {
+p5.prototype.random = function(min, max) {
   p5._validateParameters('random', arguments);
   let rand;
 
@@ -351,7 +351,7 @@ p5.prototype.random = function (min, max) {
  * </code>
  * </div>
  */
-p5.prototype.randomGaussian = function (mean, sd = 1) {
+p5.prototype.randomGaussian = function(mean, sd = 1) {
   let y1, x1, x2, w;
   if (this._gaussian_previous) {
     y1 = y2;

--- a/src/math/random.js
+++ b/src/math/random.js
@@ -20,7 +20,7 @@ const c = 1013904223;
 let y2 = 0;
 
 // Linear Congruential Generator that stores its state at instance[stateProperty]
-p5.prototype._lcg = function(stateProperty) {
+p5.prototype._lcg = function (stateProperty) {
   // define the recurrence relationship
   this[stateProperty] = (a * this[stateProperty] + c) % m;
   // return a float in [0, 1)
@@ -28,7 +28,7 @@ p5.prototype._lcg = function(stateProperty) {
   return this[stateProperty] / m;
 };
 
-p5.prototype._lcgSetSeed = function(stateProperty, val) {
+p5.prototype._lcgSetSeed = function (stateProperty, val) {
   // pick a random seed if val is undefined or null
   // the >>> 0 casts the seed to an unsigned 32-bit integer
   this[stateProperty] = (val == null ? Math.random() * m : val) >>> 0;
@@ -78,7 +78,7 @@ p5.prototype._lcgSetSeed = function(stateProperty, val) {
  * </code>
  * </div>
  */
-p5.prototype.randomSeed = function(seed) {
+p5.prototype.randomSeed = function (seed) {
   this._lcgSetSeed(randomStateProp, seed);
   this._gaussian_previous = false;
 };
@@ -260,9 +260,8 @@ p5.prototype.randomSeed = function(seed) {
  * @method random
  * @param  {Array} choices   array to choose from.
  * @return {*} random element from the array.
- * @example
  */
-p5.prototype.random = function(min, max) {
+p5.prototype.random = function (min, max) {
   p5._validateParameters('random', arguments);
   let rand;
 
@@ -352,7 +351,7 @@ p5.prototype.random = function(min, max) {
  * </code>
  * </div>
  */
-p5.prototype.randomGaussian = function(mean, sd = 1) {
+p5.prototype.randomGaussian = function (mean, sd = 1) {
   let y1, x1, x2, w;
   if (this._gaussian_previous) {
     y1 = y2;

--- a/src/webgl/material.js
+++ b/src/webgl/material.js
@@ -2336,7 +2336,7 @@ p5.prototype.metalness = function (metallic) {
  * transparency internally, e.g. via vertex colors
  * @return {Number[]}  Normalized numbers array
  */
-p5.RendererGL.prototype._applyColorBlend = function (colors, hasTransparency) {
+p5.RendererGL.prototype._applyColorBlend = function(colors, hasTransparency) {
   const gl = this.GL;
 
   const isTexture = this.drawMode === constants.TEXTURE;

--- a/src/webgl/material.js
+++ b/src/webgl/material.js
@@ -2334,9 +2334,9 @@ p5.prototype.metalness = function (metallic) {
  * @param  {Number[]} color The currently set color, with values in 0-1 range
  * @param  {Boolean} [hasTransparency] Whether the shape being drawn has other
  * transparency internally, e.g. via vertex colors
- * @return {Number[]]}  Normalized numbers array
+ * @return {Number[]}  Normalized numbers array
  */
-p5.RendererGL.prototype._applyColorBlend = function(colors, hasTransparency) {
+p5.RendererGL.prototype._applyColorBlend = function (colors, hasTransparency) {
   const gl = this.GL;
 
   const isTexture = this.drawMode === constants.TEXTURE;

--- a/src/webgl/p5.Quat.js
+++ b/src/webgl/p5.Quat.js
@@ -36,8 +36,8 @@ p5.Quat = class {
      * @chainable
     */
   static fromAxisAngle(angle, x, y, z) {
-    const w = Math.cos(angle/2);
-    const vec = new p5.Vector(x, y, z).normalize().mult(Math.sin(angle/2));
+    const w = Math.cos(angle / 2);
+    const vec = new p5.Vector(x, y, z).normalize().mult(Math.sin(angle / 2));
     return new p5.Quat(w, vec.x, vec.y, vec.z);
   }
 
@@ -69,12 +69,11 @@ p5.Quat = class {
    * This was taken from the below stackexchange link
    * https://gamedev.stackexchange.com/questions/28395/rotating-vector3-by-a-quaternion/50545#50545
    * @param {p5.Vector} [p] vector to rotate on the axis quaternion
-   * @returns
    */
   rotateVector(p) {
-    return new p5.Vector.mult( p, this.w*this.w - this.vec.dot(this.vec) )
-      .add( p5.Vector.mult( this.vec, 2 * p.dot(this.vec) ) )
-      .add( p5.Vector.mult( this.vec, 2 * this.w ).cross( p ) )
+    return new p5.Vector.mult(p, this.w * this.w - this.vec.dot(this.vec))
+      .add(p5.Vector.mult(this.vec, 2 * p.dot(this.vec)))
+      .add(p5.Vector.mult(this.vec, 2 * this.w).cross(p))
       .clampToZero();
   }
 

--- a/src/webgl/p5.Quat.js
+++ b/src/webgl/p5.Quat.js
@@ -36,8 +36,8 @@ p5.Quat = class {
      * @chainable
     */
   static fromAxisAngle(angle, x, y, z) {
-    const w = Math.cos(angle / 2);
-    const vec = new p5.Vector(x, y, z).normalize().mult(Math.sin(angle / 2));
+    const w = Math.cos(angle/2);
+    const vec = new p5.Vector(x, y, z).normalize().mult(Math.sin(angle/2));
     return new p5.Quat(w, vec.x, vec.y, vec.z);
   }
 
@@ -71,9 +71,9 @@ p5.Quat = class {
    * @param {p5.Vector} [p] vector to rotate on the axis quaternion
    */
   rotateVector(p) {
-    return new p5.Vector.mult(p, this.w * this.w - this.vec.dot(this.vec))
-      .add(p5.Vector.mult(this.vec, 2 * p.dot(this.vec)))
-      .add(p5.Vector.mult(this.vec, 2 * this.w).cross(p))
+    return new p5.Vector.mult( p, this.w*this.w - this.vec.dot(this.vec) )
+      .add( p5.Vector.mult( this.vec, 2 * p.dot(this.vec) ) )
+      .add( p5.Vector.mult( this.vec, 2 * this.w ).cross( p ) )
       .clampToZero();
   }
 

--- a/src/webgl/p5.RendererGL.Immediate.js
+++ b/src/webgl/p5.RendererGL.Immediate.js
@@ -30,7 +30,7 @@ import './p5.RenderBuffer';
  *                       and TESS(WEBGL only)
  * @chainable
  */
-p5.RendererGL.prototype.beginShape = function(mode) {
+p5.RendererGL.prototype.beginShape = function (mode) {
   this.immediateMode.shapeMode =
     mode !== undefined ? mode : constants.TESS;
   this.immediateMode.geometry.reset();
@@ -46,7 +46,7 @@ const immediateBufferStrides = {
   uvs: 2
 };
 
-p5.RendererGL.prototype.beginContour = function() {
+p5.RendererGL.prototype.beginContour = function () {
   if (this.immediateMode.shapeMode !== constants.TESS) {
     throw new Error('WebGL mode can only use contours with beginShape(TESS).');
   }
@@ -65,7 +65,7 @@ p5.RendererGL.prototype.beginContour = function() {
  * @chainable
  * @TODO implement handling of <a href="#/p5.Vector">p5.Vector</a> args
  */
-p5.RendererGL.prototype.vertex = function(x, y) {
+p5.RendererGL.prototype.vertex = function (x, y) {
   // WebGL 1 doesn't support QUADS or QUAD_STRIP, so we duplicate data to turn
   // QUADS into TRIANGLES and QUAD_STRIP into TRIANGLE_STRIP. (There is no extra
   // work to convert QUAD_STRIP here, since the only difference is in how edges
@@ -139,7 +139,7 @@ p5.RendererGL.prototype.vertex = function(x, y) {
       this.userStrokeShader !== undefined ||
       this.userPointShader !== undefined
     ) {
-    // Do nothing if user-defined shaders are present
+      // Do nothing if user-defined shaders are present
     } else if (
       this._tex === null &&
       arguments.length >= 4
@@ -147,7 +147,7 @@ p5.RendererGL.prototype.vertex = function(x, y) {
       // Only throw this warning if custom uv's have  been provided
       console.warn(
         'You must first call texture() before using' +
-          ' vertex() with image based u and v coordinates'
+        ' vertex() with image based u and v coordinates'
       );
     }
   }
@@ -178,7 +178,7 @@ p5.RendererGL.prototype.vertex = function(x, y) {
  * @param  {Vector} v
  * @chainable
  */
-p5.RendererGL.prototype.normal = function(xorv, y, z) {
+p5.RendererGL.prototype.normal = function (xorv, y, z) {
   if (xorv instanceof p5.Vector) {
     this._currentNormal = xorv;
   } else {
@@ -192,7 +192,7 @@ p5.RendererGL.prototype.normal = function(xorv, y, z) {
  * End shape drawing and render vertices to screen.
  * @chainable
  */
-p5.RendererGL.prototype.endShape = function(
+p5.RendererGL.prototype.endShape = function (
   mode,
   isCurve,
   isBezier,
@@ -212,7 +212,7 @@ p5.RendererGL.prototype.endShape = function(
   // but in case of triangle we can skip the breaking into small triangle
   // this can optimize performance by skipping the step of breaking it into triangles
   if (this.immediateMode.geometry.vertices.length === 3 &&
-      this.immediateMode.shapeMode === constants.TESS
+    this.immediateMode.shapeMode === constants.TESS
   ) {
     this.immediateMode.shapeMode === constants.TRIANGLES;
   }
@@ -280,7 +280,7 @@ p5.RendererGL.prototype.endShape = function(
  *                       POINTS,LINES,LINE_STRIP,LINE_LOOP,TRIANGLES,
  *                       TRIANGLE_STRIP, TRIANGLE_FAN and TESS(WEBGL only)
  */
-p5.RendererGL.prototype._processVertices = function(mode) {
+p5.RendererGL.prototype._processVertices = function (mode) {
   if (this.immediateMode.geometry.vertices.length === 0) return;
 
   const calculateStroke = this._doStroke;
@@ -321,9 +321,9 @@ p5.RendererGL.prototype._processVertices = function(mode) {
  * Called from _processVertices(). This function calculates the stroke vertices for custom shapes and
  * tesselates shapes when applicable.
  * @private
- * @returns  {Array[Number]} indices for custom shape vertices indicating edges.
+ * @returns  {Number[]} indices for custom shape vertices indicating edges.
  */
-p5.RendererGL.prototype._calculateEdges = function(
+p5.RendererGL.prototype._calculateEdges = function (
   shapeMode,
   verts,
   shouldClose
@@ -409,7 +409,7 @@ p5.RendererGL.prototype._calculateEdges = function(
  * Called from _processVertices() when applicable. This function tesselates immediateMode.geometry.
  * @private
  */
-p5.RendererGL.prototype._tesselateShape = function() {
+p5.RendererGL.prototype._tesselateShape = function () {
   // TODO: handle non-TESS shape modes that have contours
   this.immediateMode.shapeMode = constants.TRIANGLES;
   const contours = [[]];
@@ -421,7 +421,7 @@ p5.RendererGL.prototype._tesselateShape = function() {
       this.immediateMode.contourIndices.shift();
       contours.push([]);
     }
-    contours[contours.length-1].push(
+    contours[contours.length - 1].push(
       this.immediateMode.geometry.vertices[i].x,
       this.immediateMode.geometry.vertices[i].y,
       this.immediateMode.geometry.vertices[i].z,
@@ -486,7 +486,7 @@ p5.RendererGL.prototype._tesselateShape = function() {
               const dX = orig.x - vert.x;
               const dY = orig.y - vert.y;
               const dZ = orig.z - vert.z;
-              const dist = dX*dX + dY*dY + dZ*dZ;
+              const dist = dX * dX + dY * dY + dZ * dZ;
               if (dist < closestDist) {
                 closestDist = dist;
                 closestIndex = i;
@@ -507,7 +507,7 @@ p5.RendererGL.prototype._tesselateShape = function() {
  * enabling all appropriate buffers, applying color blend, and drawing the fill geometry.
  * @private
  */
-p5.RendererGL.prototype._drawImmediateFill = function(count = 1) {
+p5.RendererGL.prototype._drawImmediateFill = function (count = 1) {
   const gl = this.GL;
   this._useVertexColor = (this.immediateMode.geometry.vertexColors.length > 0);
 
@@ -554,7 +554,7 @@ p5.RendererGL.prototype._drawImmediateFill = function(count = 1) {
  * enabling all appropriate buffers, applying color blend, and drawing the stroke geometry.
  * @private
  */
-p5.RendererGL.prototype._drawImmediateStroke = function() {
+p5.RendererGL.prototype._drawImmediateStroke = function () {
   const gl = this.GL;
 
   this._useLineColor =

--- a/src/webgl/p5.RendererGL.Immediate.js
+++ b/src/webgl/p5.RendererGL.Immediate.js
@@ -30,7 +30,7 @@ import './p5.RenderBuffer';
  *                       and TESS(WEBGL only)
  * @chainable
  */
-p5.RendererGL.prototype.beginShape = function (mode) {
+p5.RendererGL.prototype.beginShape = function(mode) {
   this.immediateMode.shapeMode =
     mode !== undefined ? mode : constants.TESS;
   this.immediateMode.geometry.reset();
@@ -46,7 +46,7 @@ const immediateBufferStrides = {
   uvs: 2
 };
 
-p5.RendererGL.prototype.beginContour = function () {
+p5.RendererGL.prototype.beginContour = function() {
   if (this.immediateMode.shapeMode !== constants.TESS) {
     throw new Error('WebGL mode can only use contours with beginShape(TESS).');
   }
@@ -65,7 +65,7 @@ p5.RendererGL.prototype.beginContour = function () {
  * @chainable
  * @TODO implement handling of <a href="#/p5.Vector">p5.Vector</a> args
  */
-p5.RendererGL.prototype.vertex = function (x, y) {
+p5.RendererGL.prototype.vertex = function(x, y) {
   // WebGL 1 doesn't support QUADS or QUAD_STRIP, so we duplicate data to turn
   // QUADS into TRIANGLES and QUAD_STRIP into TRIANGLE_STRIP. (There is no extra
   // work to convert QUAD_STRIP here, since the only difference is in how edges
@@ -139,7 +139,7 @@ p5.RendererGL.prototype.vertex = function (x, y) {
       this.userStrokeShader !== undefined ||
       this.userPointShader !== undefined
     ) {
-      // Do nothing if user-defined shaders are present
+    // Do nothing if user-defined shaders are present
     } else if (
       this._tex === null &&
       arguments.length >= 4
@@ -147,7 +147,7 @@ p5.RendererGL.prototype.vertex = function (x, y) {
       // Only throw this warning if custom uv's have  been provided
       console.warn(
         'You must first call texture() before using' +
-        ' vertex() with image based u and v coordinates'
+          ' vertex() with image based u and v coordinates'
       );
     }
   }
@@ -178,7 +178,7 @@ p5.RendererGL.prototype.vertex = function (x, y) {
  * @param  {Vector} v
  * @chainable
  */
-p5.RendererGL.prototype.normal = function (xorv, y, z) {
+p5.RendererGL.prototype.normal = function(xorv, y, z) {
   if (xorv instanceof p5.Vector) {
     this._currentNormal = xorv;
   } else {
@@ -192,7 +192,7 @@ p5.RendererGL.prototype.normal = function (xorv, y, z) {
  * End shape drawing and render vertices to screen.
  * @chainable
  */
-p5.RendererGL.prototype.endShape = function (
+p5.RendererGL.prototype.endShape = function(
   mode,
   isCurve,
   isBezier,
@@ -212,7 +212,7 @@ p5.RendererGL.prototype.endShape = function (
   // but in case of triangle we can skip the breaking into small triangle
   // this can optimize performance by skipping the step of breaking it into triangles
   if (this.immediateMode.geometry.vertices.length === 3 &&
-    this.immediateMode.shapeMode === constants.TESS
+      this.immediateMode.shapeMode === constants.TESS
   ) {
     this.immediateMode.shapeMode === constants.TRIANGLES;
   }
@@ -280,7 +280,7 @@ p5.RendererGL.prototype.endShape = function (
  *                       POINTS,LINES,LINE_STRIP,LINE_LOOP,TRIANGLES,
  *                       TRIANGLE_STRIP, TRIANGLE_FAN and TESS(WEBGL only)
  */
-p5.RendererGL.prototype._processVertices = function (mode) {
+p5.RendererGL.prototype._processVertices = function(mode) {
   if (this.immediateMode.geometry.vertices.length === 0) return;
 
   const calculateStroke = this._doStroke;
@@ -323,7 +323,7 @@ p5.RendererGL.prototype._processVertices = function (mode) {
  * @private
  * @returns  {Number[]} indices for custom shape vertices indicating edges.
  */
-p5.RendererGL.prototype._calculateEdges = function (
+p5.RendererGL.prototype._calculateEdges = function(
   shapeMode,
   verts,
   shouldClose
@@ -409,7 +409,7 @@ p5.RendererGL.prototype._calculateEdges = function (
  * Called from _processVertices() when applicable. This function tesselates immediateMode.geometry.
  * @private
  */
-p5.RendererGL.prototype._tesselateShape = function () {
+p5.RendererGL.prototype._tesselateShape = function() {
   // TODO: handle non-TESS shape modes that have contours
   this.immediateMode.shapeMode = constants.TRIANGLES;
   const contours = [[]];
@@ -421,7 +421,7 @@ p5.RendererGL.prototype._tesselateShape = function () {
       this.immediateMode.contourIndices.shift();
       contours.push([]);
     }
-    contours[contours.length - 1].push(
+    contours[contours.length-1].push(
       this.immediateMode.geometry.vertices[i].x,
       this.immediateMode.geometry.vertices[i].y,
       this.immediateMode.geometry.vertices[i].z,
@@ -486,7 +486,7 @@ p5.RendererGL.prototype._tesselateShape = function () {
               const dX = orig.x - vert.x;
               const dY = orig.y - vert.y;
               const dZ = orig.z - vert.z;
-              const dist = dX * dX + dY * dY + dZ * dZ;
+              const dist = dX*dX + dY*dY + dZ*dZ;
               if (dist < closestDist) {
                 closestDist = dist;
                 closestIndex = i;
@@ -507,7 +507,7 @@ p5.RendererGL.prototype._tesselateShape = function () {
  * enabling all appropriate buffers, applying color blend, and drawing the fill geometry.
  * @private
  */
-p5.RendererGL.prototype._drawImmediateFill = function (count = 1) {
+p5.RendererGL.prototype._drawImmediateFill = function(count = 1) {
   const gl = this.GL;
   this._useVertexColor = (this.immediateMode.geometry.vertexColors.length > 0);
 
@@ -554,7 +554,7 @@ p5.RendererGL.prototype._drawImmediateFill = function (count = 1) {
  * enabling all appropriate buffers, applying color blend, and drawing the stroke geometry.
  * @private
  */
-p5.RendererGL.prototype._drawImmediateStroke = function () {
+p5.RendererGL.prototype._drawImmediateStroke = function() {
   const gl = this.GL;
 
   this._useLineColor =


### PR DESCRIPTION
Background:

I want to write a p5.js Wrapper using the JSDocs for type definitions. I'm using [jsdoc-to-markdown](https://github.com/jsdoc2md/jsdoc-to-markdown) to parse the files. However, this only works if the files contain valid JsDoc annotations.

 Changes:
* `src/color/p5.Color.js` - removed duplicated `@example` annotation
* `src/math/random.js` - removed empty `@example` annotation
* `src/webgl/material.js` - removed additional `]`
* `src/webgl/p5.Quat.js` - removed empty `@returns` annotation
* `src/webgl/p5.RendererGL.Immediate.js` - replaced `Array[Number]` with `Number[]`

#### PR Checklist

- [x] `npm run lint` passes
- [x] [Inline documentation] is included / updated
- [x] [Unit tests] are included / updated