### PR TITLE
Fix 'Learn' and 'Get Started' links in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Learn more about [our community](https://p5js.org/community/) and read our commu
 
 ## Get Started
 
-Make your first sketch in the [p5.js Editor](https://editor.p5js.org/)! Learn more about sketching with p5.js on the [Get Started](https://p5js.org/get-started/) and find everything you can do in the [Reference](https://p5js.org/reference/).
+Make your first sketch in the [p5.js Editor](https://editor.p5js.org/)! Learn more about sketching with p5.js on the [Get Started](https://p5js.org/tutorials/get-started/) and find everything you can do in the [Reference](https://p5js.org/reference/).
 
 To get the complete p5.js library on your own computer, you can [download it here](https://p5js.org/download). If you are interested in the most recent, less stable version, or even simply in (**new!**) certain components of p5.js, you can clone this repository and run `grunt` from the command line to generate the library from source. See the [contributor docs](https://p5js.org/contribute/#docs) for more information about our build process.
 

--- a/README.md
+++ b/README.md
@@ -33,10 +33,10 @@ To get the complete p5.js library on your own computer, you can [download it her
 
 Check out [p5js.org](https://p5js.org) for lots more! Here are some quick-links to get started learning p5.js.
 
-* [Get Started](https://p5js.org/get-started): Create and run your first sketch!
+* [Get Started](https://p5js.org/tutorials/get-started): Create and run your first sketch!
 * [p5.js overview](https://github.com/processing/p5.js/wiki/p5.js-overview): An overview of the main features and functionality of p5.js
 * [Reference](https://p5js.org/reference): The functionality supported by p5.js
-* [Learn](https://p5js.org/learn): Tutorials and short, prototypical examples exploring the basics of p5.js
+* [Learn](https://p5js.org/tutorials): Tutorials and short, prototypical examples exploring the basics of p5.js
 * [Forum](https://discourse.processing.org/c/p5js): Ask and answer questions about how to make things with p5.js here
 * [Libraries](https://p5js.org/libraries): Extend p5 functionality to interact with HTML, manipulate sound, and more!
 * [The Coding Train p5.js Tutorials](https://thecodingtrain.com/beginners/p5js/): A huge trove of tutorials created by Dan Shiffman and friends


### PR DESCRIPTION
<!--
  Thank you for contributing! Please use this pull request (PR) template.


 In the description field of this PR, include "resolves #XXXX" tagging the issue you are fixing. If this PR addresses the issue but doesn't completely resolve it (ie the issue should remain open after your PR is merged), write "addresses #XXXX".-->
Resolves #7125 

 Changes:
Fixed the URLs for the "Learn" and "Get Started" links in the [Learning](https://github.com/processing/p5.js/blob/main/README.md#learning) section of the README to point to the relevant pages on the p5js.org site. 

Also fixed the URL for the "Get Started" link in the [Get Started](https://github.com/processing/p5.js/blob/main/README.md#get-started) section.
