### PR TITLE
Added window size check upon p5 instantiation

### DIFF
--- a/src/core/environment.js
+++ b/src/core/environment.js
@@ -675,7 +675,7 @@ p5.prototype.displayHeight = screen.height;
  * @alt
  * This example does not render anything.
  */
-p5.prototype.windowWidth = getWindowWidth();
+p5.prototype.windowWidth = 0;
 
 /**
  * A `Number` variable that stores the height of the browser's viewport.
@@ -703,7 +703,7 @@ p5.prototype.windowWidth = getWindowWidth();
  * @alt
  * This example does not render anything.
  */
-p5.prototype.windowHeight = getWindowHeight();
+p5.prototype.windowHeight = 0;
 
 /**
  * A function that's called when the browser window is resized.
@@ -799,6 +799,15 @@ function getWindowHeight() {
     0
   );
 }
+
+/**
+ * Called upon each p5 instantiation instead of module import due to the
+ * possibility of the window being resized when no sketch is active.
+ */
+p5.prototype._updateWindowSize = function() {
+  this._setProperty('windowWidth', getWindowWidth());
+  this._setProperty('windowHeight', getWindowHeight());
+};
 
 /**
  * A `Number` variable that stores the width of the canvas in pixels.

--- a/src/core/main.js
+++ b/src/core/main.js
@@ -344,8 +344,6 @@ class p5 {
       this._events.devicemotion = null;
     }
 
-    this.registerMethod('init', this._updateWindowSize);
-
     // Function to invoke registered hooks before or after events such as preload, setup, and pre/post draw.
     p5.prototype.callRegisteredHooksFor = function (hookName) {
       const target = this || p5.prototype;
@@ -659,6 +657,9 @@ class p5 {
         p5.instance = null;
       }
     };
+
+    // ensure correct reporting of window dimensions
+    this._updateWindowSize();
 
     // call any registered init functions
     this._registeredMethods.init.forEach(function(f) {

--- a/src/core/main.js
+++ b/src/core/main.js
@@ -344,6 +344,8 @@ class p5 {
       this._events.devicemotion = null;
     }
 
+    this.registerMethod('init', this._updateWindowSize);
+
     // Function to invoke registered hooks before or after events such as preload, setup, and pre/post draw.
     p5.prototype.callRegisteredHooksFor = function (hookName) {
       const target = this || p5.prototype;


### PR DESCRIPTION
Resolves #7133


 Changes:
Adds a function called upon p5 initialisation which fixes a bug where `windowWidth` and `windowHeight` would represent the correct values when the window was resized and no p5 sketch was active


 Video of the before:
https://github.com/user-attachments/assets/82ebad21-5d55-4203-870b-184f9b8775e8


#### PR Checklist
<!--
  To check any option, replace the "[ ]" with a "[x]". Be sure to check out how it looks in the Preview tab! Feel free to remove any portion of the template that is not relevant for your issue.
-->

- [x] `npm run lint` passes
- [x] [Inline documentation] is included / updated

[Inline documentation]: https://github.com/processing/p5.js/blob/main/contributor_docs/inline_documentation.md
[Unit tests]: https://github.com/processing/p5.js/tree/main/contributor_docs#unit-tests
