### PR TITLE
Skip out of canvas shapes for gridOutput() table

### DIFF
--- a/src/accessibility/gridOutput.js
+++ b/src/accessibility/gridOutput.js
@@ -62,19 +62,26 @@ function _gridMap(idT, ingredients) {
           ingredients[x][y].color
         } ${x} midpoint</a>`;
       }
-      //if empty cell of location of shape is undefined
-      if (!cells[ingredients[x][y].loc.locY][ingredients[x][y].loc.locX]) {
-        //fill it with shape info
-        cells[ingredients[x][y].loc.locY][ingredients[x][y].loc.locX] = fill;
-        //if a shape is already in that location
-      } else {
-        //add it
-        cells[ingredients[x][y].loc.locY][ingredients[x][y].loc.locX] =
-          cells[ingredients[x][y].loc.locY][ingredients[x][y].loc.locX] +
-          '  ' +
-          fill;
+
+      // Check if shape is in canvas, skip if not
+      if(
+        ingredients[x][y].loc.locY < cells.length &&
+        ingredients[x][y].loc.locX < cells[ingredients[x][y].loc.locY].length
+      ){
+        //if empty cell of location of shape is undefined
+        if (!cells[ingredients[x][y].loc.locY][ingredients[x][y].loc.locX]) {
+          //fill it with shape info
+          cells[ingredients[x][y].loc.locY][ingredients[x][y].loc.locX] = fill;
+          //if a shape is already in that location
+        } else {
+          //add it
+          cells[ingredients[x][y].loc.locY][ingredients[x][y].loc.locX] =
+            cells[ingredients[x][y].loc.locY][ingredients[x][y].loc.locX] +
+            '  ' +
+            fill;
+        }
+        shapeNumber++;
       }
-      shapeNumber++;
     }
   }
   //make table based on array


### PR DESCRIPTION
<!--
  Thank you for contributing! Please use this pull request (PR) template.


 In the description field of this PR, include "resolves #XXXX" tagging the issue you are fixing. If this PR addresses the issue but doesn't completely resolve it (ie the issue should remain open after your PR is merged), write "addresses #XXXX".-->
Resolves #7130

 Changes:
<!-- Add here what changes were made in this pull request and if possible provide links showcasing the changes. -->
Add a check to see if the shape being iterated by `gridOutput()` is within the bounds of the canvas. If it is out of the canvas it won't be added to the table generated by `gridOutput()` (which only has entries for things within the canvas bounds).

#### PR Checklist
<!--
  To check any option, replace the "[ ]" with a "[x]". Be sure to check out how it looks in the Preview tab! Feel free to remove any portion of the template that is not relevant for your issue.
-->

- [x] `npm run lint` passes
- [ ] [Inline documentation] is included / updated
- [ ] [Unit tests] are included / updated

[Inline documentation]: https://github.com/processing/p5.js/blob/main/contributor_docs/inline_documentation.md
[Unit tests]: https://github.com/processing/p5.js/tree/main/contributor_docs#unit-tests
