### PR TITLE
Fix panorama()

### DIFF
--- a/src/webgl/p5.RendererGL.js
+++ b/src/webgl/p5.RendererGL.js
@@ -1727,7 +1727,7 @@ p5.RendererGL = class RendererGL extends p5.Renderer {
         sphereMapping
       );
     }
-    this.uNMatrix.inverseTranspose(this.uMVMatrix);
+    this.uNMatrix.inverseTranspose(this.uViewMatrix);
     this.uNMatrix.invert3x3(this.uNMatrix);
     this.sphereMapping.setUniform('uFovY', this._curCamera.cameraFOV);
     this.sphereMapping.setUniform('uAspect', this._curCamera.aspectRatio);


### PR DESCRIPTION
Super quick bug fix here!

After splitting up the model + view matrices, `panorama()` started breaking and showing weird stretching:

<img width="155" alt="Screenshot 2024-07-30 at 1 43 46 PM" src="https://github.com/user-attachments/assets/03f5ff3f-86f0-4b61-8455-58d590a9c417">

This is because it was accessing `uMVMatrix` before it gets set (now, it only gets set right before rendering, and the model and view matrices are instead the ones that get used everywhere.) I've updated it to use the view matrix instead:

<img width="134" alt="image" src="https://github.com/user-attachments/assets/9fb8294a-0ba0-4bd7-b81b-bdd1b9900d8e">
