### PR TITLE
Fix unnecessary console warnings when using smooth() on P2D Graphics objects

### DIFF
--- a/src/core/shape/attributes.js
+++ b/src/core/shape/attributes.js
@@ -375,11 +375,12 @@ p5.prototype.rectMode = function(m) {
  * </div>
  */
 p5.prototype.smooth = function() {
-  this.setAttributes('antialias', true);
   if (!this._renderer.isP3D) {
     if ('imageSmoothingEnabled' in this.drawingContext) {
       this.drawingContext.imageSmoothingEnabled = true;
     }
+  } else {
+    this.setAttributes('antialias', true);
   }
   return this;
 };


### PR DESCRIPTION
Changes:

Changed `smooth` implementation to match `noSmooth`. 
Previously `smooth` would call `setAttributes` regardless of whether or not the renderer is P2D or WebGL, on Graphics objects (to my knowledge, maybe on others too) when the renderer is P2D, this would cause unnecessary logs complaining about `setAttributes`'s use.
I have changed the `smooth` function to call `setAttributes` only if the renderer is WebGL.

I have not tested this extensively (I have though tested this change on one of my own projects using p5.js in which it functions perfectly fine),
but for such a minor change that takes from existing code I feel that it should work fine in all scenarios.
However feel free to close this pull request if there is a specific reason that the smooth function must be programmed this way

#### PR Checklist

- [x] `npm run lint` passes
- [ ] [Inline documentation] is included / updated
- [ ] [Unit tests] are included / updated

