### PR TITLE
Fix: Added unique group names for radio buttions

### DIFF
--- a/src/dom/dom.js
+++ b/src/dom/dom.js
@@ -1656,7 +1656,7 @@ p5.prototype.createRadio = function(...args) {
       labelElement = optionEl.parentElement;
     }
 
-    // Check if span element exists, else create it    
+    // Check if span element exists, else create it
     let spanElement;
     if (!isSpanElement(labelElement.lastElementChild)) {
       spanElement = document.createElement('span');
@@ -1665,7 +1665,7 @@ p5.prototype.createRadio = function(...args) {
       spanElement = labelElement.lastElementChild;
     }
 
-    // Set the innerHTML of span element as the label text    
+    // Set the innerHTML of span element as the label text
     spanElement.innerHTML = label === undefined ? value : label;
 
     // Append the label element, which includes option element and

--- a/src/dom/dom.js
+++ b/src/dom/dom.js
@@ -1580,6 +1580,9 @@ p5.prototype.createSelect = function(...args) {
  * @method createRadio
  * @return {p5.Element} new <a href="#/p5.Element">p5.Element</a> object.
  */
+
+//counter for unique names on radio button
+let counter = 0;
 p5.prototype.createRadio = function(...args) {
   // Creates a div, adds each option as an individual input inside it.
   // If already given with a containerEl, will search for all input[radio]
@@ -1613,7 +1616,7 @@ p5.prototype.createRadio = function(...args) {
   }
 
   // Generate a unique name for each radio group if not provided
-  self._name = name || `radioOption_${p5.prototype.createRadio.counter++}`;
+  self._name = name || `radioOption_${counter++}`;
   // setup member functions
   const isRadioInput = el =>
     el instanceof HTMLInputElement && el.type === 'radio';
@@ -1738,10 +1741,6 @@ p5.prototype.createRadio = function(...args) {
 
   return self;
 };
-
-// Initialize counter for unique radio group names
-p5.prototype.createRadio.counter = 0;
-
 
 /**
  * Creates a color picker element.

--- a/src/dom/dom.js
+++ b/src/dom/dom.js
@@ -1585,7 +1585,7 @@ p5.prototype.createRadio = function(...args) {
   let radioElement;
   let name;
   const arg0 = args[0];
-  
+
   if (
     arg0 instanceof p5.Element &&
     (arg0.elt instanceof HTMLDivElement || arg0.elt instanceof HTMLSpanElement)

--- a/src/dom/dom.js
+++ b/src/dom/dom.js
@@ -1631,6 +1631,7 @@ p5.prototype.createRadio = function(...args) {
   };
 
   self.option = function (value, label) {
+    // return an option with this value, create if not exists.
     let optionEl;
     for (const option of self._getOptionsArray()) {
       if (option.value === value) {

--- a/src/dom/dom.js
+++ b/src/dom/dom.js
@@ -1581,18 +1581,23 @@ p5.prototype.createSelect = function(...args) {
  * @return {p5.Element} new <a href="#/p5.Element">p5.Element</a> object.
  */
 p5.prototype.createRadio = function(...args) {
+  // Creates a div, adds each option as an individual input inside it.
+  // If already given with a containerEl, will search for all input[radio]
+  // it, create a p5.Element out of it, add options to it and return the p5.Element.
+
   let self;
   let radioElement;
   let name;
   const arg0 = args[0];
-
   if (
     arg0 instanceof p5.Element &&
     (arg0.elt instanceof HTMLDivElement || arg0.elt instanceof HTMLSpanElement)
   ) {
+    // If given argument is p5.Element of div/span type
     self = arg0;
     this.elt = arg0.elt;
   } else if (
+    // If existing radio Element is provided as argument 0
     arg0 instanceof HTMLDivElement ||
     arg0 instanceof HTMLSpanElement
   ) {
@@ -1609,7 +1614,7 @@ p5.prototype.createRadio = function(...args) {
 
   // Generate a unique name for each radio group if not provided
   self._name = name || `radioOption_${p5.prototype.createRadio.counter++}`;
-
+  // setup member functions
   const isRadioInput = el =>
     el instanceof HTMLInputElement && el.type === 'radio';
   const isLabelElement = el => el instanceof HTMLLabelElement;
@@ -1634,6 +1639,7 @@ p5.prototype.createRadio = function(...args) {
       }
     }
 
+    // Create a new option, add it to radioElement and return it.
     if (optionEl === undefined) {
       optionEl = document.createElement('input');
       optionEl.setAttribute('type', 'radio');
@@ -1641,6 +1647,7 @@ p5.prototype.createRadio = function(...args) {
     }
     optionEl.setAttribute('name', self._name);
 
+    // Check if label element exists, else create it
     let labelElement;
     if (!isLabelElement(optionEl.parentElement)) {
       labelElement = document.createElement('label');
@@ -1649,6 +1656,7 @@ p5.prototype.createRadio = function(...args) {
       labelElement = optionEl.parentElement;
     }
 
+    // Check if span element exists, else create it    
     let spanElement;
     if (!isSpanElement(labelElement.lastElementChild)) {
       spanElement = document.createElement('span');
@@ -1657,8 +1665,11 @@ p5.prototype.createRadio = function(...args) {
       spanElement = labelElement.lastElementChild;
     }
 
+    // Set the innerHTML of span element as the label text    
     spanElement.innerHTML = label === undefined ? value : label;
 
+    // Append the label element, which includes option element and
+    // span element to the radio container element
     this.elt.appendChild(labelElement);
 
     return optionEl;
@@ -1668,8 +1679,10 @@ p5.prototype.createRadio = function(...args) {
     for (const optionEl of self._getOptionsArray()) {
       if (optionEl.value === value) {
         if (isLabelElement(optionEl.parentElement)) {
+          // Remove parent label which also removes children elements
           optionEl.parentElement.remove();
         } else {
+          // Remove the option input if parent label does not exist
           optionEl.remove();
         }
         return;
@@ -1698,6 +1711,8 @@ p5.prototype.createRadio = function(...args) {
         }
       }
     } else {
+      // forEach loop to uncheck all radio buttons before
+      // setting any one as checked.
       self._getOptionsArray().forEach(option => {
         option.checked = false;
         option.removeAttribute('checked');

--- a/src/dom/dom.js
+++ b/src/dom/dom.js
@@ -1581,23 +1581,18 @@ p5.prototype.createSelect = function(...args) {
  * @return {p5.Element} new <a href="#/p5.Element">p5.Element</a> object.
  */
 p5.prototype.createRadio = function(...args) {
-  // Creates a div, adds each option as an individual input inside it.
-  // If already given with a containerEl, will search for all input[radio]
-  // it, create a p5.Element out of it, add options to it and return the p5.Element.
-
   let self;
   let radioElement;
   let name;
   const arg0 = args[0];
+  
   if (
     arg0 instanceof p5.Element &&
     (arg0.elt instanceof HTMLDivElement || arg0.elt instanceof HTMLSpanElement)
   ) {
-    // If given argument is p5.Element of div/span type
     self = arg0;
     this.elt = arg0.elt;
   } else if (
-    // If existing radio Element is provided as argument 0
     arg0 instanceof HTMLDivElement ||
     arg0 instanceof HTMLSpanElement
   ) {
@@ -1611,9 +1606,10 @@ p5.prototype.createRadio = function(...args) {
     self = addElement(radioElement, this);
     this.elt = radioElement;
   }
-  self._name = name || 'radioOption';
 
-  // setup member functions
+  // Generate a unique name for each radio group if not provided
+  self._name = name || `radioOption_${p5.prototype.createRadio.counter++}`;
+
   const isRadioInput = el =>
     el instanceof HTMLInputElement && el.type === 'radio';
   const isLabelElement = el => el instanceof HTMLLabelElement;
@@ -1630,7 +1626,6 @@ p5.prototype.createRadio = function(...args) {
   };
 
   self.option = function (value, label) {
-    // return an option with this value, create if not exists.
     let optionEl;
     for (const option of self._getOptionsArray()) {
       if (option.value === value) {
@@ -1639,7 +1634,6 @@ p5.prototype.createRadio = function(...args) {
       }
     }
 
-    // Create a new option, add it to radioElement and return it.
     if (optionEl === undefined) {
       optionEl = document.createElement('input');
       optionEl.setAttribute('type', 'radio');
@@ -1647,7 +1641,6 @@ p5.prototype.createRadio = function(...args) {
     }
     optionEl.setAttribute('name', self._name);
 
-    // Check if label element exists, else create it
     let labelElement;
     if (!isLabelElement(optionEl.parentElement)) {
       labelElement = document.createElement('label');
@@ -1656,7 +1649,6 @@ p5.prototype.createRadio = function(...args) {
       labelElement = optionEl.parentElement;
     }
 
-    // Check if span element exists, else create it
     let spanElement;
     if (!isSpanElement(labelElement.lastElementChild)) {
       spanElement = document.createElement('span');
@@ -1665,11 +1657,8 @@ p5.prototype.createRadio = function(...args) {
       spanElement = labelElement.lastElementChild;
     }
 
-    // Set the innerHTML of span element as the label text
     spanElement.innerHTML = label === undefined ? value : label;
 
-    // Append the label element, which includes option element and
-    // span element to the radio container element
     this.elt.appendChild(labelElement);
 
     return optionEl;
@@ -1679,10 +1668,8 @@ p5.prototype.createRadio = function(...args) {
     for (const optionEl of self._getOptionsArray()) {
       if (optionEl.value === value) {
         if (isLabelElement(optionEl.parentElement)) {
-          // Remove parent label which also removes children elements
           optionEl.parentElement.remove();
         } else {
-          // Remove the option input if parent label does not exist
           optionEl.remove();
         }
         return;
@@ -1711,8 +1698,6 @@ p5.prototype.createRadio = function(...args) {
         }
       }
     } else {
-      // forEach loop to uncheck all radio buttons before
-      // setting any one as checked.
       self._getOptionsArray().forEach(option => {
         option.checked = false;
         option.removeAttribute('checked');
@@ -1737,6 +1722,10 @@ p5.prototype.createRadio = function(...args) {
 
   return self;
 };
+
+// Initialize counter for unique radio group names
+p5.prototype.createRadio.counter = 0;
+
 
 /**
  * Creates a color picker element.


### PR DESCRIPTION
This PR ensures unique names for each radio button group in createRadio function
Resolves #6763 
<!--
  Thank you for contributing! Please use this pull request (PR) template.


 In the description field of this PR, include "resolves #XXXX" tagging the issue you are fixing. If this PR addresses the issue but doesn't completely resolve it (ie the issue should remain open after your PR is merged), write "addresses #XXXX".-->
Resolves #6763 

 Changes:
<!-- Add here what changes were made in this pull request and if possible provide links showcasing the changes. -->
- Added a Counter for Unique Radio button Names
- Modified the `self._name` Assignment


 Screenshots of the change:

https://github.com/user-attachments/assets/9da27258-29b3-4f2d-9515-0288d4be1305

<!-- If applicable, add screenshots depicting the changes. -->

#### PR Checklist
<!--
  To check any option, replace the "[ ]" with a "[x]". Be sure to check out how it looks in the Preview tab! Feel free to remove any portion of the template that is not relevant for your issue.
-->

- [x]  `npm run lint` passes
- [ ] [Inline documentation] is included / updated
- [ ] [Unit tests] are included / updated

[Inline documentation]: https://github.com/processing/p5.js/blob/main/contributor_docs/inline_documentation.md
[Unit tests]: https://github.com/processing/p5.js/tree/main/contributor_docs#unit-tests
