### PR TITLE
Tie FES initialization to only run just before p5 init

### DIFF
--- a/src/core/friendly_errors/sketch_reader.js
+++ b/src/core/friendly_errors/sketch_reader.js
@@ -403,6 +403,6 @@ if (typeof IS_MINIFIED !== 'undefined') {
 
   p5._fesCodeReader = fesCodeReader;
 
-  window.addEventListener('load', p5._fesCodeReader);
+  window.addEventListener('p5Ready', p5._fesCodeReader);
 }
 export default p5;

--- a/src/core/init.js
+++ b/src/core/init.js
@@ -32,6 +32,8 @@ const _globalInit = () => {
         (window.draw && typeof window.draw === 'function')) &&
       !p5.instance
     ) {
+      const p5ReadyEvent = new Event('p5Ready');
+      window.dispatchEvent(p5ReadyEvent);
       new p5();
     }
   }

--- a/src/core/init.js
+++ b/src/core/init.js
@@ -25,6 +25,9 @@ const _globalInit = () => {
   }
 
   if (!window.mocha) {
+    const p5ReadyEvent = new Event('p5Ready');
+    window.dispatchEvent(p5ReadyEvent);
+
     // If there is a setup or draw function on the window
     // then instantiate p5 in "global" mode
     if (
@@ -32,8 +35,6 @@ const _globalInit = () => {
         (window.draw && typeof window.draw === 'function')) &&
       !p5.instance
     ) {
-      const p5ReadyEvent = new Event('p5Ready');
-      window.dispatchEvent(p5ReadyEvent);
       new p5();
     }
   }


### PR DESCRIPTION
<!--
  Thank you for contributing! Please use this pull request (PR) template.


 In the description field of this PR, include "resolves #XXXX" tagging the issue you are fixing. If this PR addresses the issue but doesn't completely resolve it (ie the issue should remain open after your PR is merged), write "addresses #XXXX".-->
Addresses #7168

 Changes:
<!-- Add here what changes were made in this pull request and if possible provide links showcasing the changes. -->
Create a custom event that will be triggered after both window load and translation load completes. FES init will listen to this event instead of the window load event to prevent the race condition. This is only a temporary quick fix with 2.0 going to have a reworked system overall.

Translated FES messages should work regardless of browser/editor setups after this.

#### PR Checklist
<!--
  To check any option, replace the "[ ]" with a "[x]". Be sure to check out how it looks in the Preview tab! Feel free to remove any portion of the template that is not relevant for your issue.
-->

- [x] `npm run lint` passes
- [ ] [Inline documentation] is included / updated
- [ ] [Unit tests] are included / updated

[Inline documentation]: https://github.com/processing/p5.js/blob/main/contributor_docs/inline_documentation.md
[Unit tests]: https://github.com/processing/p5.js/tree/main/contributor_docs#unit-tests
