### PR TITLE
Textures support to mtl files

### DIFF
--- a/src/webgl/p5.Geometry.js
+++ b/src/webgl/p5.Geometry.js
@@ -664,6 +664,10 @@ p5.Geometry = class Geometry {
     // One color per vertex representing the stroke color at that vertex
     this.vertexStrokeColors = [];
 
+    // Map storing the textures and faces for each texture
+    this.textures = {};
+    this.hasTextures = false;
+
     // One color per line vertex, generated automatically based on
     // vertexStrokeColors in _edgesToVertices()
     this.lineVertexColors = new p5.DataArray();
@@ -922,6 +926,11 @@ p5.Geometry = class Geometry {
    */
   clearColors() {
     this.vertexColors = [];
+    return this;
+  }
+
+  clearTextures() {
+    this.textures = {};
     return this;
   }
 
@@ -1955,11 +1964,20 @@ p5.Geometry = class Geometry {
   _makeTriangleEdges() {
     this.edges.length = 0;
 
+    const _addEdge = face => {
+      this.edges.push([face[0], face[1]]);
+      this.edges.push([face[1], face[2]]);
+      this.edges.push([face[2], face[0]]);
+    };
+
     for (let j = 0; j < this.faces.length; j++) {
-      this.edges.push([this.faces[j][0], this.faces[j][1]]);
-      this.edges.push([this.faces[j][1], this.faces[j][2]]);
-      this.edges.push([this.faces[j][2], this.faces[j][0]]);
+      _addEdge(this.faces[j]);
     }
+
+    for (let material of Object.keys(this.textures)) {
+      this.textures[material].faces.map(face => _addEdge(face));
+    }
+
 
     return this;
   }
@@ -2299,6 +2317,7 @@ p5.Geometry = class Geometry {
     }
     return this;
   }
+
 };
 export default p5.Geometry;
 

--- a/src/webgl/p5.RendererGL.Retained.js
+++ b/src/webgl/p5.RendererGL.Retained.js
@@ -64,6 +64,30 @@ p5.RendererGL.prototype._freeBuffers = function(gId) {
   freeBuffers(this.retainedMode.buffers.fill);
 };
 
+p5.RendererGL.prototype.updateIndexBuffer = function(gId, faces) {
+  const gl = this.GL;
+  const buffers = this.retainedMode.geometry[gId];
+  let indexBuffer = buffers.indexBuffer;
+
+  if (!indexBuffer) indexBuffer = buffers.indexBuffer = gl.createBuffer();
+  const vals = p5.RendererGL.prototype._flatten(faces);
+
+  // If any face references a vertex with an index greater than the maximum
+  // un-singed 16 bit integer, then we need to use a Uint32Array instead of a
+  // Uint16Array
+
+  const hasVertexIndicesOverMaxUInt16 = vals.some(v => v > 65535);
+  let type = hasVertexIndicesOverMaxUInt16 ? Uint32Array : Uint16Array;
+  this._bindBuffer(indexBuffer, gl.ELEMENT_ARRAY_BUFFER, vals, type);
+  buffers.indexBufferType = hasVertexIndicesOverMaxUInt16
+    ? gl.UNSIGNED_INT
+    : gl.UNSIGNED_SHORT;
+
+  // the vertex count is based on the number of faces
+  buffers.vertexCount = faces.length * 3;
+};
+
+
 /**
  * creates a buffers object that holds the WebGL render buffers
  * for a geometry.
@@ -80,26 +104,7 @@ p5.RendererGL.prototype.createBuffers = function(gId, model) {
   let indexBuffer = buffers.indexBuffer;
 
   if (model.faces.length) {
-    // allocate space for faces
-    if (!indexBuffer) indexBuffer = buffers.indexBuffer = gl.createBuffer();
-    const vals = p5.RendererGL.prototype._flatten(model.faces);
-
-    // If any face references a vertex with an index greater than the maximum
-    // un-singed 16 bit integer, then we need to use a Uint32Array instead of a
-    // Uint16Array
-    const hasVertexIndicesOverMaxUInt16 = vals.some(v => v > 65535);
-    let type = hasVertexIndicesOverMaxUInt16 ? Uint32Array : Uint16Array;
-    this._bindBuffer(indexBuffer, gl.ELEMENT_ARRAY_BUFFER, vals, type);
-
-    // If we're using a Uint32Array for our indexBuffer we will need to pass a
-    // different enum value to WebGL draw triangles. This happens in
-    // the _drawElements function.
-    buffers.indexBufferType = hasVertexIndicesOverMaxUInt16
-      ? gl.UNSIGNED_INT
-      : gl.UNSIGNED_SHORT;
-
-    // the vertex count is based on the number of faces
-    buffers.vertexCount = model.faces.length * 3;
+    this.updateIndexBuffer(gId, model.faces);
   } else {
     // the index buffer is unused, remove it
     if (indexBuffer) {


### PR DESCRIPTION
<!--
  Thank you for contributing! Please use this pull request (PR) template.


 In the description field of this PR, include "resolves #XXXX" tagging the issue you are fixing. If this PR addresses the issue but doesn't completely resolve it (ie the issue should remain open after your PR is merged), write "addresses #XXXX".-->
Resolves #6924

Thanks to @rohanjulka19 for his prior work.
This PR is work in progress.

 Changes:
- Error handling in loading texture image.
- `clearTextures()` as a draft.

Description:
These are some of the things that I'm not too sure about and would love to get some suggestions:
- Should the class design of  `p5.Geometry` be decoupled?
I am not too sure but I think there should be some separation between `p5.Geometry` or multiple objects and their properties such as material properties, diffuse colors, textures, etc.
- The `clearTextures()`  might not be what we desire but it's just the idea of having it here. (ToDo)

Seperation of Concerns in the `p5.Geometry` class:

**Class**: `p5.Geometry` 
 Focuses solely on the geometric data of the 3D object.

- Properties: 
  - `vertices`
  - `normals`
  - ` faces`
  - `texCoords`, etc.

and methods for the geometry data.

**Class**: `p5.Material`
Manages material properties, colors, texture, mtl properties, etc.
Methods  like: applyMaterial(`fill()`), `clearColors()`, `clearTextures()`, etc.

A Grouping Structure:
**Class:** `p5.Group` : Combines multiple `p5.Geometry`, `p5.Material` and transform (global transformation on the entire group) and methods.


#### PR Checklist
<!--
  To check any option, replace the "[ ]" with a "[x]". Be sure to check out how it looks in the Preview tab! Feel free to remove any portion of the template that is not relevant for your issue.
-->

- [x] `npm run lint` passes
- [ ] [Inline documentation] is included / updated
- [ ] [Unit tests] are included / updated

[Inline documentation]: https://github.com/processing/p5.js/blob/main/contributor_docs/inline_documentation.md
[Unit tests]: https://github.com/processing/p5.js/tree/main/contributor_docs#unit-tests
