### PR TITLE
Fix incorrect pixel offset in updatePixels()

### DIFF
--- a/src/core/p5.Renderer2D.js
+++ b/src/core/p5.Renderer2D.js
@@ -525,7 +525,7 @@ class Renderer2D extends p5.Renderer {
         pixelsState.imageData;
     }
 
-    this.drawingContext.putImageData(pixelsState.imageData, x, y, 0, 0, w, h);
+    this.drawingContext.putImageData(pixelsState.imageData, 0, 0, x, y, w, h);
   }
 
   //////////////////////////////////////////////


### PR DESCRIPTION
<!--
  Thank you for contributing! Please use this pull request (PR) template.


 In the description field of this PR, include "resolves #XXXX" tagging the issue you are fixing. If this PR addresses the issue but doesn't completely resolve it (ie the issue should remain open after your PR is merged), write "addresses #XXXX".-->
Resolves #7139

 Changes:
<!-- Add here what changes were made in this pull request and if possible provide links showcasing the changes. -->


 Screenshots of the change:
<!-- If applicable, add screenshots depicting the changes. -->

Before:
![image](https://github.com/user-attachments/assets/c915f875-0705-4360-bbae-912bd225ae1a)

After :

![image](https://github.com/user-attachments/assets/ef082928-f909-42a4-9edc-2c8f5589d9a9)

#### PR Checklist
<!--
  To check any option, replace the "[ ]" with a "[x]". Be sure to check out how it looks in the Preview tab! Feel free to remove any portion of the template that is not relevant for your issue.
-->

- [x] `npm run lint` passes
- [ ] [Inline documentation] is included / updated
- [ ] [Unit tests] are included / updated

[Inline documentation]: https://github.com/processing/p5.js/blob/main/contributor_docs/inline_documentation.md
[Unit tests]: https://github.com/processing/p5.js/tree/main/contributor_docs#unit-tests

example usage 

```js
function setup() {
  createCanvas(400, 400);
}

function draw() {
  background(220);

  set(0, 0, [255, 0, 0, 255]); // red pixel at (0, 0)
  set(2, 2, [0, 0, 255, 255]); // blue pixel at (2, 2)
  updatePixels(2, 2, 1, 1);    // FIX : pixel at  (2, 2) is blue as expected
}
```
