### PR TITLE
Fix Camera.eyeX comment

### DIFF
--- a/src/webgl/p5.Camera.js
+++ b/src/webgl/p5.Camera.js
@@ -849,9 +849,9 @@ p5.Camera = class Camera {
     this.yScale = 1;
   }
   /**
- * The camera’s y-coordinate.
+ * The camera’s x-coordinate.
  *
- * By default, the camera’s y-coordinate is set to 0 in "world" space.
+ * By default, the camera’s x-coordinate is set to 0 in "world" space.
  *
  * @property {Number} eyeX
  * @readonly


### PR DESCRIPTION
There is no issue for this.

 Changes:
The comment said y-coordinate instead of x-coordinate

 Screenshots of the change:
No, not really

#### PR Checklist
<!--
  To check any option, replace the "[ ]" with a "[x]". Be sure to check out how it looks in the Preview tab! Feel free to remove any portion of the template that is not relevant for your issue.
-->

- [x] `npm run lint` passes
- [x] [Inline documentation] is included / updated
- [x] [Unit tests] are included / updated

[Inline documentation]: https://github.com/processing/p5.js/blob/main/contributor_docs/inline_documentation.md
[Unit tests]: https://github.com/processing/p5.js/tree/main/contributor_docs#unit-tests
