### PR TITLE
Added textAscent and textDescent functions on Webgl

### DIFF
--- a/src/webgl/text.js
+++ b/src/webgl/text.js
@@ -8,27 +8,13 @@ import './p5.RendererGL.Retained';
 p5.RendererGL.prototype._applyTextProperties = function() {
   //@TODO finish implementation
   //console.error('text commands not yet implemented in webgl');
+  this._setProperty('_textAscent', null);
+  this._setProperty('_textDescent', null);
 };
 
 p5.RendererGL.prototype.textWidth = function(s) {
   if (this._isOpenType()) {
     return this._textFont._textWidth(s, this._textSize);
-  }
-
-  return 0; // TODO: error
-};
-
-p5.RendererGL.prototype.textAscent = function(s) {
-  if (this._isOpenType()) {
-    return this._textFont._textAscent(this._textSize);
-  }
-
-  return 0; // TODO: error
-};
-
-p5.RendererGL.prototype.textDescent = function(s) {
-  if (this._isOpenType()) {
-    return this._textFont._textDescent(this._textSize);
   }
 
   return 0; // TODO: error

--- a/src/webgl/text.js
+++ b/src/webgl/text.js
@@ -18,6 +18,22 @@ p5.RendererGL.prototype.textWidth = function(s) {
   return 0; // TODO: error
 };
 
+p5.RendererGL.prototype.textAscent = function(s) {
+  if (this._isOpenType()) {
+    return this._textFont._textAscent(this._textSize);
+  }
+
+  return 0; // TODO: error
+};
+
+p5.RendererGL.prototype.textDescent = function(s) {
+  if (this._isOpenType()) {
+    return this._textFont._textDescent(this._textSize);
+  }
+
+  return 0; // TODO: error
+};
+
 // rendering constants
 
 // the number of rows/columns dividing each glyph


### PR DESCRIPTION
Added textAscent and textDescent functions on Webgl

<!--
  Thank you for contributing! Please use this pull request (PR) template.


 In the description field of this PR, include "resolves #XXXX" tagging the issue you are fixing. If this PR addresses the issue but doesn't completely resolve it (ie the issue should remain open after your PR is merged), write "addresses #XXXX".-->
Resolves #4958
 Changes:
<!-- Add here what changes were made in this pull request and if possible provide links showcasing the changes. -->


 Screenshots of the change:
<!-- If applicable, add screenshots depicting the changes. -->

Before :

![image](https://github.com/user-attachments/assets/caef32f6-7923-4c7a-9867-74de1b3c032a)

After :
![image](https://github.com/user-attachments/assets/afa50346-64df-44a1-85a9-a217492d1483)

example 
```js
let font;

function preload() {
  font = loadFont('consola_mono/ConsolaMono-Bold.ttf'); 
}

function setup() {
  createCanvas(900, 900, WEBGL);
  textFont(font); // Set the loaded font
}

function draw() {
  translate(-width/2, -height/2);
  background(0);
  fill('white');
  
  textSize(12);
  text('WEBGL : textAscent', 200, 20);
  text('12: ' + textAscent(), 20, 20);
  
  textSize(14);
  text('14: ' + textAscent(), 20, 40);
  
  textSize(16);
  text('16: ' + textAscent(), 20, 60);
  
  textSize(32);
  text('32: ' + textAscent(), 20, 100);
}
```

#### PR Checklist
<!--
  To check any option, replace the "[ ]" with a "[x]". Be sure to check out how it looks in the Preview tab! Feel free to remove any portion of the template that is not relevant for your issue.
-->

- [x] `npm run lint` passes
- [ ] [Inline documentation] is included / updated
- [ ] [Unit tests] are included / updated

[Inline documentation]: https://github.com/processing/p5.js/blob/main/contributor_docs/inline_documentation.md
[Unit tests]: https://github.com/processing/p5.js/tree/main/contributor_docs#unit-tests
