### PR TITLE
Caps at the beginning of the curve

### DIFF
--- a/src/webgl/3d_primitives.js
+++ b/src/webgl/3d_primitives.js
@@ -2984,7 +2984,7 @@ p5.RendererGL.prototype.bezierVertex = function(...args) {
       this._lookUpTableBezier = [];
       this._lutBezierDetail = this._pInst._curveDetail;
       const step = 1 / this._lutBezierDetail;
-      let start = 0;
+      let start = step;
       let end = 1;
       let j = 0;
       while (start < 1) {
@@ -3144,7 +3144,7 @@ p5.RendererGL.prototype.quadraticVertex = function(...args) {
       this._lookUpTableQuadratic = [];
       this._lutQuadraticDetail = this._pInst._curveDetail;
       const step = 1 / this._lutQuadraticDetail;
-      let start = 0;
+      let start = step;
       let end = 1;
       let j = 0;
       while (start < 1) {
@@ -3288,7 +3288,7 @@ p5.RendererGL.prototype.curveVertex = function(...args) {
     this._lookUpTableBezier = [];
     this._lutBezierDetail = this._pInst._curveDetail;
     const step = 1 / this._lutBezierDetail;
-    let start = 0;
+    let start = step;
     let end = 1;
     let j = 0;
     while (start < 1) {


### PR DESCRIPTION
<!--
  Thank you for contributing! Please use this pull request (PR) template.


 In the description field of this PR, include "resolves #XXXX" tagging the issue you are fixing. If this PR addresses the issue but doesn't completely resolve it (ie the issue should remain open after your PR is merged), write "addresses #XXXX".-->
Resolves #6816 

 Changes:
Sets `let start=step;` instead of `let start=0;` .
Added fix for both quadratic vertex segment and bezier vertex.


 Screenshots of the change:
Before:
![image](https://github.com/user-attachments/assets/7e9975ab-dfcc-4b89-ac76-c09c1b529c45)

After:
![image](https://github.com/user-attachments/assets/d6584407-ca1e-4336-a2f2-3d22131ff340)

sketch
```
function setup() {
  createCanvas(400, 400, WEBGL);
  background(255)
  noFill()
  stroke(0)
  strokeWeight(20)
  translate(-width/2, -height/2)
  beginShape()
  vertex(20, 20)
  quadraticVertex(
    280, 200,
    100, 380
  )
  endShape()
}
```

#### PR Checklist
<!--
  To check any option, replace the "[ ]" with a "[x]". Be sure to check out how it looks in the Preview tab! Feel free to remove any portion of the template that is not relevant for your issue.
-->

- [x] `npm run lint` passes
- [x] [Inline documentation] is included / updated
- [x] [Unit tests] are included / updated

[Inline documentation]: https://github.com/processing/p5.js/blob/main/contributor_docs/inline_documentation.md
[Unit tests]: https://github.com/processing/p5.js/tree/main/contributor_docs#unit-tests
