### PR TITLE
Refactor arc and rect to use canvas methods rather than curves

### DIFF
--- a/src/core/p5.Renderer2D.js
+++ b/src/core/p5.Renderer2D.js
@@ -548,7 +548,7 @@ class Renderer2D extends p5.Renderer {
       radiusY = h / 2;
 
     // Determines whether to add a line to the center, which should be done
-    // when the mode is PIE or default, as well as when the start and end
+    // when the mode is PIE or default; as well as when the start and end
     // angles do not form a full circle.
     const createPieSlice = ! (
       mode === constants.CHORD ||
@@ -600,7 +600,7 @@ class Renderer2D extends p5.Renderer {
       radiusX = w / 2,
       radiusY = h / 2;
     if (!this._clipping) ctx.beginPath();
-    
+
     ctx.ellipse(centerX, centerY, radiusX, radiusY, 0, 0, 2 * Math.PI);
 
     if (!this._clipping && doFill) {
@@ -745,14 +745,7 @@ class Renderer2D extends p5.Renderer {
         bl = hh;
       }
 
-      // Draw shape
-      if (!this._clipping) ctx.beginPath();
-      ctx.moveTo(x + tl, y);
-      ctx.arcTo(x + w, y, x + w, y + h, tr);
-      ctx.arcTo(x + w, y + h, x, y + h, br);
-      ctx.arcTo(x, y + h, x, y, bl);
-      ctx.arcTo(x, y, x + w, y, tl);
-      ctx.closePath();
+      ctx.roundRect(x, y, w, h, [tl, tr, br, bl]);
     }
     if (!this._clipping && this._doFill) {
       ctx.fill();

--- a/src/core/p5.Renderer2D.js
+++ b/src/core/p5.Renderer2D.js
@@ -532,42 +532,6 @@ class Renderer2D extends p5.Renderer {
   // SHAPE | 2D Primitives
   //////////////////////////////////////////////
 
-  /**
- * Generate a cubic Bezier representing an arc on the unit circle of total
- * angle `size` radians, beginning `start` radians above the x-axis. Up to
- * four of these curves are combined to make a full arc.
- *
- * See ecridge.com/bezier.pdf for an explanation of the method.
- */
-  _acuteArcToBezier(
-    start,
-    size
-  ) {
-    // Evaluate constants.
-    const alpha = size / 2.0,
-      cos_alpha = Math.cos(alpha),
-      sin_alpha = Math.sin(alpha),
-      cot_alpha = 1.0 / Math.tan(alpha),
-      // This is how far the arc needs to be rotated.
-      phi = start + alpha,
-      cos_phi = Math.cos(phi),
-      sin_phi = Math.sin(phi),
-      lambda = (4.0 - cos_alpha) / 3.0,
-      mu = sin_alpha + (cos_alpha - lambda) * cot_alpha;
-
-    // Return rotated waypoints.
-    return {
-      ax: Math.cos(start).toFixed(7),
-      ay: Math.sin(start).toFixed(7),
-      bx: (lambda * cos_phi + mu * sin_phi).toFixed(7),
-      by: (lambda * sin_phi - mu * cos_phi).toFixed(7),
-      cx: (lambda * cos_phi - mu * sin_phi).toFixed(7),
-      cy: (lambda * sin_phi + mu * cos_phi).toFixed(7),
-      dx: Math.cos(start + size).toFixed(7),
-      dy: Math.sin(start + size).toFixed(7)
-    };
-  }
-
   /*
  * This function requires that:
  *
@@ -577,64 +541,41 @@ class Renderer2D extends p5.Renderer {
  */
   arc(x, y, w, h, start, stop, mode) {
     const ctx = this.drawingContext;
-    const rx = w / 2.0;
-    const ry = h / 2.0;
-    const epsilon = 0.00001; // Smallest visible angle on displays up to 4K.
-    let arcToDraw = 0;
-    const curves = [];
 
-    x += rx;
-    y += ry;
+    const centerX = x + w / 2,
+      centerY = y + h / 2,
+      radiusX = w / 2,
+      radiusY = h / 2;
 
-    // Create curves
-    while (stop - start >= epsilon) {
-      arcToDraw = Math.min(stop - start, constants.HALF_PI);
-      curves.push(this._acuteArcToBezier(start, arcToDraw));
-      start += arcToDraw;
-    }
+    // Determines whether to add a line to the center, which should be done
+    // when the mode is PIE or default, as well as when the start and end
+    // angles do not form a full circle.
+    const createPieSlice = ! (
+      mode === constants.CHORD ||
+      mode === constants.OPEN ||
+      (stop - start) % constants.TWO_PI === 0
+    );
 
-    // Fill curves
+    // Fill
     if (this._doFill) {
       if (!this._clipping) ctx.beginPath();
-      curves.forEach((curve, index) => {
-        if (index === 0) {
-          ctx.moveTo(x + curve.ax * rx, y + curve.ay * ry);
-        }
-        /* eslint-disable indent */
-        ctx.bezierCurveTo(x + curve.bx * rx, y + curve.by * ry,
-          x + curve.cx * rx, y + curve.cy * ry,
-          x + curve.dx * rx, y + curve.dy * ry);
-        /* eslint-enable indent */
-      });
-      if (mode === constants.PIE || mode == null) {
-        ctx.lineTo(x, y);
-      }
+      ctx.ellipse(centerX, centerY, radiusX, radiusY, 0, start, stop);
+      if (createPieSlice) ctx.lineTo(centerX, centerY);
       ctx.closePath();
       if (!this._clipping) ctx.fill();
     }
 
-    // Stroke curves
+    // Stroke
     if (this._doStroke) {
       if (!this._clipping) ctx.beginPath();
-      curves.forEach((curve, index) => {
-        if (index === 0) {
-          ctx.moveTo(x + curve.ax * rx, y + curve.ay * ry);
-        }
-        /* eslint-disable indent */
-        ctx.bezierCurveTo(x + curve.bx * rx, y + curve.by * ry,
-          x + curve.cx * rx, y + curve.cy * ry,
-          x + curve.dx * rx, y + curve.dy * ry);
-        /* eslint-enable indent */
-      });
-      if (mode === constants.PIE) {
-        ctx.lineTo(x, y);
-        ctx.closePath();
-      } else if (mode === constants.CHORD) {
-        ctx.closePath();
-      }
+      ctx.ellipse(centerX, centerY, radiusX, radiusY, 0, start, stop);
+      if (createPieSlice) ctx.lineTo(centerX, centerY);
+      if (mode !== constants.OPEN) ctx.closePath();
       if (!this._clipping) ctx.stroke();
     }
+
     return this;
+
   }
 
   ellipse(args) {
@@ -659,7 +600,7 @@ class Renderer2D extends p5.Renderer {
       radiusX = w / 2,
       radiusY = h / 2;
     if (!this._clipping) ctx.beginPath();
-
+    
     ctx.ellipse(centerX, centerY, radiusX, radiusY, 0, 0, 2 * Math.PI);
 
     if (!this._clipping && doFill) {

--- a/src/core/p5.Renderer2D.js
+++ b/src/core/p5.Renderer2D.js
@@ -569,8 +569,18 @@ class Renderer2D extends p5.Renderer {
     if (this._doStroke) {
       if (!this._clipping) ctx.beginPath();
       ctx.ellipse(centerX, centerY, radiusX, radiusY, 0, start, stop);
-      if (createPieSlice) ctx.lineTo(centerX, centerY);
-      if (mode !== constants.OPEN) ctx.closePath();
+
+      if (mode === constants.PIE && createPieSlice) {
+        // In PIE mode, stroke is added to the center and back to path,
+        // unless the pie forms a complete ellipse (see: createPieSlice)
+        ctx.lineTo(centerX, centerY);
+      }
+
+      if (mode === constants.PIE || mode === constants.CHORD) {
+        // Stroke connects back to path begin for both PIE and CHORD
+        ctx.closePath();
+      }
+
       if (!this._clipping) ctx.stroke();
     }
 


### PR DESCRIPTION
Resolves #6485 

Changes:

* in Renderer2D `arc`, use canvas `ellipse`, removing the need for `_acuteArcToBezier`
* in Renderer2D `rect`, use canvas `roundRect` when there are rounded corners, rater than `ArcTo`

 Screenshots of the change:

<img width="709" alt="image" src="https://github.com/user-attachments/assets/960ea3a1-1ee8-4ba2-a623-ca638f44adac">

SCREENSHOT: Same code running with current p5 (left) and locally (right) demonstrating visual equivalence for `rect` with different rounded corners, one of them clipped.

#### PR Checklist

- [x] `npm run lint` passes
- [x] [Inline documentation] is included / updated
- [ ] [Unit tests] are included / updated

No additional unit tests have been included*. Manual testing was done with all the standard examples from the p5 documentation on both `arc` and `rect` as well as some additional edge cases, like too-big corner radii (as in the screenshot above) and arc start/end values outside of `(0, TWO_PI)` range (this is currently not breaking usage and so should not become breaking usage).

Where out-of-domain parameters to canvas rendering context method is the source of the error, the error provided by p5 will reflect the different function usage:

<img width="1070" alt="image" src="https://github.com/user-attachments/assets/657d63bc-0ac2-4d7b-bfea-cf9107b5ac55">

SCREENSHOT: ~Same code running with current p5 (left) and locally (right) demonstrating difference between bad `rect` input of negative radius. The p5 error provides the canvas error, which is different due to refactor, and the new error is not caught correctly. I am not sure where to update the corresponding code.~ Edited to add: sorry, the nice error is just in the p5 editor. In plain browser, both errors are equally uncaught, just the name of the function is different.

*There is an idea in the original issue discussion to use visual automated tests (https://github.com/processing/p5.js/issues/6485#issuecomment-1783671690: "...the idea is to run sample input through p5's current implementation of ellipse and create an image from that. Let's call this the base image. Then, you run the same input through your implementation and create another image. Let's call that the compare image. The test does a pixel-by-pixel comparison of the base image and the compare image. If there's a difference, the test fails.") which I think would be really good, and I would be happy to work on that, but it seems like a separate Issue/PR for workflow enhancement.