### PR TITLE
Line.vert fix for small units

### DIFF
--- a/src/webgl/shaders/line.vert
+++ b/src/webgl/shaders/line.vert
@@ -90,13 +90,33 @@ void main() {
 
   // Moving vertices slightly toward the camera
   // to avoid depth-fighting with the fill triangles.
-  // This prevents popping effects due to half of
+  // A mix of scaling and offsetting is used based on distance
+  // Discussion here:
+  // https://github.com/processing/p5.js/issues/7200 
+
+  // using a scale <1 moves the lines towards nearby camera
+  // in order to prevent popping effects due to half of
   // the line disappearing behind the geometry faces.
+  float zDistance = -posp.z; 
+  float distanceFactor = smoothstep(0.0, 800.0, zDistance); 
   
+  // Discussed here:
+  // http://www.opengl.org/discussion_boards/ubbthreads.php?ubb=showflat&Number=252848  
+  float scale = mix(1., 0.995, facingCamera);
+  float dynamicScale = mix(scale, 1.0, distanceFactor); // Closer = more scale, farther = less
+
+  posp.xyz = posp.xyz * dynamicScale;
+  posqIn.xyz = posqIn.xyz * dynamicScale;
+  posqOut.xyz = posqOut.xyz * dynamicScale;
+
+  // Moving vertices slightly toward camera when far away 
+  // https://github.com/processing/p5.js/issues/6956 
   float zOffset = mix(-0.00045, -1., facingCamera);
-  posp.z -= zOffset;
-  posqIn.z -= zOffset;
-  posqOut.z -= zOffset;
+  float dynamicZAdjustment = mix(0.0, zOffset, distanceFactor); // Closer = less zAdjustment, farther = more
+
+  posp.z -= dynamicZAdjustment;
+  posqIn.z -= dynamicZAdjustment;
+  posqOut.z -= dynamicZAdjustment;
   
   vec4 p = uProjectionMatrix * posp;
   vec4 qIn = uProjectionMatrix * posqIn;


### PR DESCRIPTION
Resolves #7200

<!--
  Thank you for contributing! Please use this pull request (PR) template.


 In the description field of this PR, include "resolves #XXXX" tagging the issue you are fixing. If this PR addresses the issue but doesn't completely resolve it (ie the issue should remain open after your PR is merged), write "addresses #XXXX".-->
Resolves #[Add issue number here]

 Changes:
<!-- Add here what changes were made in this pull request and if possible provide links showcasing the changes. -->


 Screenshots of the change:
<!-- If applicable, add screenshots depicting the changes. -->

#### PR Checklist
<!--
  To check any option, replace the "[ ]" with a "[x]". Be sure to check out how it looks in the Preview tab! Feel free to remove any portion of the template that is not relevant for your issue.
-->

- [ ] `npm run lint` passes
- [ ] [Inline documentation] is included / updated
- [ ] [Unit tests] are included / updated

[Inline documentation]: https://github.com/processing/p5.js/blob/main/contributor_docs/inline_documentation.md
[Unit tests]: https://github.com/processing/p5.js/tree/main/contributor_docs#unit-tests
