### PR TITLE
Fixed uniform shader reset

### DIFF
--- a/src/webgl/p5.Shader.js
+++ b/src/webgl/p5.Shader.js
@@ -139,6 +139,7 @@ p5.Shader = class {
     this.uniforms = {};
     this._bound = false;
     this.samplers = [];
+    this.previousBindings = new Set();// Set to store previous bindings
   }
 
   /**
@@ -554,7 +555,10 @@ p5.Shader = class {
         // so we supply a default texture instead.
         tex = this._renderer._getEmptyTexture();
       }
-      gl.activeTexture(gl.TEXTURE0 + uniform.samplerIndex);
+      const textureUnit = gl.TEXTURE0 + uniform.samplerIndex;
+      gl.activeTexture(textureUnit);
+      const previousTexture = gl.getParameter(gl.TEXTURE_BINDING_2D);
+      this.previousBindings.add(textureUnit);
       tex.bindTexture();
       tex.update();
       gl.uniform1i(uniform.location, uniform.samplerIndex);
@@ -572,7 +576,9 @@ p5.Shader = class {
 
   unbindTextures() {
     for (const uniform of this.samplers) {
-      this.setUniform(uniform.name, this._renderer._getEmptyTexture());
+      if (this.previousBindings.has(textureUnit) === false){
+        this.setUniform(uniform.name, this._renderer._getEmptyTexture());
+       }
     }
   }
 

--- a/src/webgl/p5.Shader.js
+++ b/src/webgl/p5.Shader.js
@@ -557,7 +557,6 @@ p5.Shader = class {
       }
       const textureUnit = gl.TEXTURE0 + uniform.samplerIndex;
       gl.activeTexture(textureUnit);
-      const previousTexture = gl.getParameter(gl.TEXTURE_BINDING_2D);
       this.previousBindings.add(textureUnit);
       tex.bindTexture();
       tex.update();
@@ -578,7 +577,7 @@ p5.Shader = class {
     for (const uniform of this.samplers) {
       if (!this.previousBindings.has(textureUnit)){
         this.setUniform(uniform.name, this._renderer._getEmptyTexture());
-       }
+      }
     }
   }
 

--- a/src/webgl/p5.Shader.js
+++ b/src/webgl/p5.Shader.js
@@ -574,12 +574,14 @@ p5.Shader = class {
   }
 
   unbindTextures() {
+    const gl = this._renderer.GL;
     for (const uniform of this.samplers) {
       const textureUnit = gl.TEXTURE0 + uniform.samplerIndex;
       if (!this.previousBindings.has(textureUnit)){
         this.setUniform(uniform.name, this._renderer._getEmptyTexture());
       }
     }
+    this.previousBindings.clear();
   }
 
   _setMatrixUniforms() {

--- a/src/webgl/p5.Shader.js
+++ b/src/webgl/p5.Shader.js
@@ -576,7 +576,7 @@ p5.Shader = class {
 
   unbindTextures() {
     for (const uniform of this.samplers) {
-      if (this.previousBindings.has(textureUnit) === false){
+      if (!this.previousBindings.has(textureUnit)){
         this.setUniform(uniform.name, this._renderer._getEmptyTexture());
        }
     }

--- a/src/webgl/p5.Shader.js
+++ b/src/webgl/p5.Shader.js
@@ -575,6 +575,7 @@ p5.Shader = class {
 
   unbindTextures() {
     for (const uniform of this.samplers) {
+      const textureUnit = gl.TEXTURE0 + uniform.samplerIndex;
       if (!this.previousBindings.has(textureUnit)){
         this.setUniform(uniform.name, this._renderer._getEmptyTexture());
       }


### PR DESCRIPTION
Keeping track of bounded textures for later reuse thus , fixing uniform shader reset
<!--
  Thank you for contributing! Please use this pull request (PR) template.


 In the description field of this PR, include "resolves #XXXX" tagging the issue you are fixing. If this PR addresses the issue but doesn't completely resolve it (ie the issue should remain open after your PR is merged), write "addresses #XXXX".-->
Resolves #7030

 Changes:
<!-- Add here what changes were made in this pull request and if possible provide links showcasing the changes. -->


 Screenshots of the change:
<!-- If applicable, add screenshots depicting the changes. -->
Before:


https://github.com/user-attachments/assets/973a8c6d-7003-4bbc-ac5f-608823271261

After:


https://github.com/user-attachments/assets/9c11845b-1287-4bd1-b88d-449220014e07



#### PR Checklist
<!--
  To check any option, replace the "[ ]" with a "[x]". Be sure to check out how it looks in the Preview tab! Feel free to remove any portion of the template that is not relevant for your issue.
-->

- [x] `npm run lint` passes
- [ ] [Inline documentation] is included / updated
- [ ] [Unit tests] are included / updated

[Inline documentation]: https://github.com/processing/p5.js/blob/main/contributor_docs/inline_documentation.md
[Unit tests]: https://github.com/processing/p5.js/tree/main/contributor_docs#unit-tests
