### PR TITLE
Dev 2.0 - small changes to help people get the 2.0 branch running quickly

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,4 @@ yarn.lock
 docs/data.json
 analyzer/
 preview/
+__screenshots__/

--- a/lib/empty-example/index.html
+++ b/lib/empty-example/index.html
@@ -12,7 +12,7 @@
       background-color: #1b1b1b;
     }
   </style>
-  <script src="../p5.min.js"></script>
+  <script src="../p5.rollup.min.js"></script>
   <!-- <script src="../addons/p5.sound.js"></script> -->
   <script src="sketch.js"></script>
 </head>

--- a/src/color/p5.Color.js
+++ b/src/color/p5.Color.js
@@ -488,6 +488,10 @@ p5.Color = class Color {
       return to(this.color, 'hsl').coords[2] / 100 * this.maxes[this.mode][2];
     }
   }
+
+  get levels() {
+    return [...this.color.coords, this.color.alpha].map(v => v * 255);
+  }
 };
 
 export default p5.Color;

--- a/src/color/p5.Color.js
+++ b/src/color/p5.Color.js
@@ -492,6 +492,10 @@ p5.Color = class Color {
   get levels() {
     return [...this.color.coords, this.color.alpha].map(v => v * 255);
   }
+
+  get _array(){
+    return [...this.color.coords, this.color.alpha];
+  }
 };
 
 export default p5.Color;

--- a/utils/convert.js
+++ b/utils/convert.js
@@ -549,6 +549,10 @@ function buildParamDocs(docs) {
   out.end();
 }
 
+if (!fs.existsSync(path.join(__dirname, '../docs/reference'))) {
+  fs.mkdirSync(path.join(__dirname, '../docs/reference'));
+}
+
 fs.writeFileSync(path.join(__dirname, '../docs/reference/data.json'), JSON.stringify(converted, null, 2));
 fs.writeFileSync(path.join(__dirname, '../docs/reference/data.min.json'), JSON.stringify(converted));
 buildParamDocs(JSON.parse(JSON.stringify(converted)));


### PR DESCRIPTION
 Changes:
- [Add screenshots generated by `npm run build` to gitignore](https://github.com/lukeplowden/p5-attributes/commit/ffdbe2954f5f6b5fd39a981c97a99a42cbc577cc)
- [Change script reference in the empty example folder to match rollup build](https://github.com/lukeplowden/p5-attributes/commit/f6f878ee1d8f8a856b896fbacf3d61cbe440608d)
- Add temporary getters for properties absent on the color refactor which are referenced in the WebGL renderer API: [p5.Color.levels](https://github.com/lukeplowden/p5-attributes/commit/1ba649f7ca5370e96d239e0ee8c138a13df8ce28), [p5.Color._array](https://github.com/lukeplowden/p5-attributes/commit/9a808ed0790b0d94336e5ac4f6a6c6d4ecbd3b50)
- [Create the docs reference folder in case it doesn't exist](https://github.com/lukeplowden/p5-attributes/commit/265f9e7d72ce0a9458e2465f510e20eb5639b2cf)

#### PR Checklist
<!--
  To check any option, replace the "[ ]" with a "[x]". Be sure to check out how it looks in the Preview tab! Feel free to remove any portion of the template that is not relevant for your issue.
-->

- [ ] `npm run lint` passes
