### PR TITLE
Fix Broken README Link

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ function draw() {
 </tr>
 </table>
 
-[Get Started](https://p5js.org/get-started) — [Reference](https://p5js.org/reference) — [Tutorials](https://p5js.org/tutorials) — [Examples](https://p5js.org/examples/) — [Libraries](https://p5js.org/libraries) — [Forum](https://discourse.processing.org/c/p5js) — [Discord](https://discord.gg/SHQ8dH25r9)
+[Get Started](https://p5js.org/tutorials/get-started/) — [Reference](https://p5js.org/reference) — [Tutorials](https://p5js.org/tutorials) — [Examples](https://p5js.org/examples/) — [Libraries](https://p5js.org/libraries) — [Forum](https://discourse.processing.org/c/p5js) — [Discord](https://discord.gg/SHQ8dH25r9)
 
 ## About
 


### PR DESCRIPTION
- Getting started link now links to this page (https://p5js.org/tutorials/get-started/) 
- Was broken before