### PR TITLE
Fix clipping bug with ellipses

### DIFF
--- a/src/core/p5.Renderer2D.js
+++ b/src/core/p5.Renderer2D.js
@@ -661,6 +661,7 @@ class Renderer2D extends p5.Renderer {
     if (!this._clipping) ctx.beginPath();
 
     ctx.ellipse(centerX, centerY, radiusX, radiusY, 0, 0, 2 * Math.PI);
+    ctx.closePath();
 
     if (!this._clipping && doFill) {
       ctx.fill();


### PR DESCRIPTION
<!--
  Thank you for contributing! Please use this pull request (PR) template.


 In the description field of this PR, include "resolves #XXXX" tagging the issue you are fixing. If this PR addresses the issue but doesn't completely resolve it (ie the issue should remain open after your PR is merged), write "addresses #XXXX".-->
Resolves #7158

 Changes:
<!-- Add here what changes were made in this pull request and if possible provide links showcasing the changes. -->
Added `ctx.closePath();` to the ellipse() function in p5.Renderer2D.js. This fixed weird behavior when using circles, ellipses, and arcs with a clipping mask.

View this sketch and comment/uncomment the src tags in HTML to view changes:
https://editor.p5js.org/jeanetteandrews/sketches/CMjMhM0fb

Recreate bug:
```
function setup() {
    createCanvas(400, 400);
    background(0);
    beginClip();
    circle(100, 100, 100);
    ellipse(300, 100, 100, 100);
    circle(100, 300, 100);
    arc(300, 300, 100, 100 , 0, 2*PI);
    endClip();
    background(255);
}
```
This behavior can also be recreated with the Canvas API. It's resolved by adding ctx.closePath(); after each shape.

```
const canvas = document.getElementById('myCanvas');
const ctx = canvas.getContext('2d');

ctx.ellipse(100, 100, 50, 50, 0, 0, 2 * Math.PI);  
// ctx.closePath(); 
ctx.ellipse(300, 100, 50, 50, 0, 0, 2 * Math.PI);  
// ctx.closePath(); 
ctx.ellipse(100, 300, 50, 50, 0, 0, 2 * Math.PI);  
// ctx.closePath(); 
ctx.arc(300, 300, 50, 50, 0, 2 * Math.PI);
// ctx.closePath(); 

ctx.fill(); 
```

 Screenshots of the change:
<!-- If applicable, add screenshots depicting the changes. -->
Clipping mask behavior before, and after

<img width="204" alt="Screenshot 2024-09-06 at 11 32 44 PM" src="https://github.com/user-attachments/assets/56284018-a51e-4639-9374-0b348b0eafee"> 
<img width="204" alt="Screenshot 2024-09-06 at 11 33 55 PM" src="https://github.com/user-attachments/assets/7e3ce73c-9f1b-4836-a7a4-93bae055c738">


#### PR Checklist
<!--
  To check any option, replace the "[ ]" with a "[x]". Be sure to check out how it looks in the Preview tab! Feel free to remove any portion of the template that is not relevant for your issue.
-->

- [X] `npm run lint` passes
- [X] [Unit tests] are included / updated (`npm test` passes)

[Inline documentation]: https://github.com/processing/p5.js/blob/main/contributor_docs/inline_documentation.md
[Unit tests]: https://github.com/processing/p5.js/tree/main/contributor_docs#unit-tests
