### PR TITLE
Fixed the broken link on p5.js website page for "p5.js Web Accessibility"

### DIFF
--- a/contributor_docs/web_accessibility.md
+++ b/contributor_docs/web_accessibility.md
@@ -6,7 +6,7 @@ This document describes the structure of p5.js’ web accessibility features for
 
 If you want to make your sketches [screen reader](https://en.wikipedia.org/wiki/Screen_reader)-accessible, visit the How to label your p5.js code tutorial.
 
-If you want to use p5.js with a screen reader, visit the [Using p5.js with a Screen Reader tutorial](https://p5js.org/learn/p5-screen-reader.html).
+If you want to use p5.js with a screen reader, visit the [Using p5.js with a Screen Reader tutorial](https://p5js.org/tutorials/p5js-with-screen-reader).
 
 The canvas HTML element is a grid of pixels. It doesn’t provide any screen reader-accessible information about the shapes drawn on it. p5.js has several functions that make the canvas more accessible to screen readers by providing [fallback text](https://developer.mozilla.org/en-US/docs/Web/API/Canvas_API/Tutorial/Basic_usage#accessible_content) descriptions. I’ll describe some of the details around the implementation of these functions.
 


### PR DESCRIPTION
**Resolves Issue [#511](https://github.com/processing/p5.js-website/issues/511) of [p5.js-website](https://github.com/processing/p5.js-website) repo**

Updated broken link for "Using p5.js with a Screen Reader tutorial" to suggested link on [p5.js Web Accessibility](https://p5js.org/contribute/web_accessibility/) page.

![Screenshot 2024-09-08 161938](https://github.com/user-attachments/assets/db11ac98-35e2-4dbd-8d86-5fff9c51ac3a)


