### PR TITLE
Performance improvements for WebGL shape drawing

### DIFF
--- a/src/webgl/loading.js
+++ b/src/webgl/loading.js
@@ -474,6 +474,7 @@ p5.prototype.loadModel = function(path,options) {
           if (flipV) {
             model.flipV();
           }
+          model._makeTriangleEdges();
 
           self._decrementPreload();
           if (typeof successCallback === 'function') {
@@ -1117,11 +1118,6 @@ p5.prototype.model = function(model) {
   p5._validateParameters('model', arguments);
   if (model.vertices.length > 0) {
     if (!this._renderer.geometryInHash(model.gid)) {
-
-      if (model.edges.length === 0) {
-        model._makeTriangleEdges();
-      }
-
       model._edgesToVertices();
       this._renderer.createBuffers(model.gid, model);
     }
@@ -1292,6 +1288,8 @@ p5.prototype.createModel = function(modelString, fileType=' ', options) {
   if (flipV) {
     model.flipV();
   }
+
+  model._makeTriangleEdges();
 
   if (typeof successCallback === 'function') {
     successCallback(model);

--- a/src/webgl/p5.RendererGL.Immediate.js
+++ b/src/webgl/p5.RendererGL.Immediate.js
@@ -214,7 +214,7 @@ p5.RendererGL.prototype.endShape = function(
   if (this.immediateMode.geometry.vertices.length === 3 &&
       this.immediateMode.shapeMode === constants.TESS
   ) {
-    this.immediateMode.shapeMode === constants.TRIANGLES;
+    this.immediateMode.shapeMode = constants.TRIANGLES;
   }
 
   this.isProcessingVertices = true;


### PR DESCRIPTION
Resolves https://github.com/processing/p5.js/issues/7237

This makes two changes:
- We no longer create edges on models that don't have any, meaning if you never create strokes, you never have to incur the cost of calculating them.
- Fixes a shape drawing special case: we can draw individual triangles without tessellation, but what should have been an `=` was an `===` so it wasn't being applied, oops 😬 

I tested with this https://editor.p5js.org/davepagurek/sketches/vmiMgGi5s which makes a new geometry and draws it each frame. The perf I got was:

Chrome
- No stroke changes: 5fps
- Skip strokes: 11fps
- Add triangle check: 12fps

Firefox
- No changes: 4fps
- Skip strokes: 8fps
- Add triangle check: 9fps

I didn't make the other change requested in the issue to make `buildGeometry` update the line vertex data when you add a new shape. This is because when we add it, we have to transform every vertex anyway. This is probably not less work than just recreating it, and if you do any other operation (e.g. add this geometry into another geometry), you'd be doing more work overall by transforming twice.

#### PR Checklist
<!--
  To check any option, replace the "[ ]" with a "[x]". Be sure to check out how it looks in the Preview tab! Feel free to remove any portion of the template that is not relevant for your issue.
-->

- [x] `npm run lint` passes
- [ ] [Inline documentation] is included / updated
- [ ] [Unit tests] are included / updated

[Inline documentation]: https://github.com/processing/p5.js/blob/main/contributor_docs/inline_documentation.md
[Unit tests]: https://github.com/processing/p5.js/tree/main/contributor_docs#unit-tests
