### PR TITLE
Final changes for parameter validation

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,8 +27,7 @@
     "gifenc": "^1.0.3",
     "libtess": "^1.2.2",
     "omggif": "^1.0.10",
-    "opentype.js": "^1.3.1",
-    "zod-validation-error": "^3.3.1"
+    "opentype.js": "^1.3.1"
   },
   "devDependencies": {
     "@rollup/plugin-commonjs": "^25.0.7",

--- a/src/core/friendly_errors/param_validator.js
+++ b/src/core/friendly_errors/param_validator.js
@@ -112,6 +112,18 @@ function validateParams(p5, fn) {
    * @returns {z.ZodSchema} Zod schema
    */
   function generateZodSchemasForFunc(func) {
+    // A special case for `p5.Color.paletteLerp`, which has an unusual and
+    // complicated function signature not shared by any other function in p5.
+    if (func === 'p5.Color.paletteLerp') {
+      return z.tuple([
+        z.array(z.tuple([
+          z.instanceof(p5.Color),
+          z.number()
+        ])),
+        z.number()
+      ]);
+    }
+
     // Expect global functions like `sin` and class methods like `p5.Vector.add`
     const ichDot = func.lastIndexOf('.');
     const funcName = func.slice(ichDot + 1);

--- a/src/core/friendly_errors/param_validator.js
+++ b/src/core/friendly_errors/param_validator.js
@@ -84,6 +84,10 @@ function validateParams(p5, fn) {
   // Add web API schemas to the schema map.
   Object.assign(schemaMap, webAPISchemas);
 
+  // For mapping 0-indexed parameters to their ordinal representation, e.g.
+  // "first" for 0, "second" for 1, "third" for 2, etc.
+  const ordinals = ["first", "second", "third", "fourth", "fifth", "sixth", "seventh", "eighth", "ninth", "tenth"];
+
   /**
    * This is a helper function that generates Zod schemas for a function based on
    * the parameter data from `docs/parameterData.json`.
@@ -101,12 +105,6 @@ function validateParams(p5, fn) {
       }
    * Where each array in `overloads` represents a set of valid overloaded
    * parameters, and `?` is a shorthand for `Optional`.
-   *
-   * TODO:
-   * - [ ] Support for p5 constructors
-   * - [ ] Support for more obscure types, such as `lerpPalette` and optional
-   * objects in `p5.Geometry.computeNormals()`
-   * (see https://github.com/processing/p5.js/pull/7186#discussion_r1724983249)
    *
    * @param {String} func - Name of the function.
    * @returns {z.ZodSchema} Zod schema
@@ -152,9 +150,7 @@ function validateParams(p5, fn) {
       }
       // All p5 objects start with `p5` in the documentation, i.e. `p5.Camera`.
       else if (baseType.startsWith('p5')) {
-        console.log('type', baseType);
         const className = baseType.substring(baseType.indexOf('.') + 1);
-        console.log('className', p5Constructors[className]);
         typeSchema = z.instanceof(p5Constructors[className]);
       }
       // For primitive types and web API objects.
@@ -244,7 +240,6 @@ function validateParams(p5, fn) {
 
   /**
    * This is a helper function to print out the Zod schema in a readable format.
-   * This is for debugging purposes only and will be removed in the future.
    *
    * @param {z.ZodSchema} schema - Zod schema.
    * @param {number} indent - Indentation level.
@@ -289,14 +284,27 @@ function validateParams(p5, fn) {
     // Helper function that scores how close the input arguments are to a schema.
     // Lower score means closer match.
     const scoreSchema = schema => {
+      let score = Infinity;
       if (!(schema instanceof z.ZodTuple)) {
         console.warn('Schema below is not a tuple: ');
         printZodSchema(schema);
-        return Infinity;
+        return score;
       }
 
+      const numArgs = args.length;
       const schemaItems = schema.items;
-      let score = Math.abs(schemaItems.length - args.length) * 2;
+      const numSchemaItems = schemaItems.length;
+      const numRequiredSchemaItems = schemaItems.filter(item => !item.isOptional()).length;
+
+      if (numArgs >= numRequiredSchemaItems && numArgs <= numSchemaItems) {
+        score = 0;
+      }
+
+      else {
+        score = Math.abs(
+          numArgs < numRequiredSchemaItems ? numRequiredSchemaItems - numArgs : numArgs - numSchemaItems
+        ) * 4;
+      }
 
       for (let i = 0; i < Math.min(schemaItems.length, args.length); i++) {
         const paramSchema = schemaItems[i];
@@ -326,6 +334,97 @@ function validateParams(p5, fn) {
   }
 
   /**
+   * Prints a friendly error message after parameter validation, if validation
+   * has failed.
+   * 
+   * @method _friendlyParamError
+   * @private
+   * @param {z.ZodError} zodErrorObj - The Zod error object containing validation errors.
+   * @returns {String} The friendly error message.
+   */
+  p5._friendlyParamError = function (zodErrorObj) {
+    let message;
+    // The `zodErrorObj` might contain multiple errors of equal importance
+    // (after scoring the schema closeness in `findClosestSchema`). Here, we
+    // always print the first error so that user can work through the errors
+    // one by one.
+    let currentError = zodErrorObj.errors[0];
+
+    // Helper function to build a type mismatch message.
+    const buildTypeMismatchMessage = (actualType, expectedTypeStr, position) => {
+      const positionStr = position ? `at the ${ordinals[position]} parameter` : '';
+      const actualTypeStr = actualType ? `, but received ${actualType}` : '';
+      return `Expected ${expectedTypeStr} ${positionStr}${actualTypeStr}.`;
+    }
+
+    // Union errors occur when a parameter can be of multiple types but is not
+    // of any of them. In this case, aggregate all possible types and print
+    // a friendly error message that indicates what the expected types are at
+    // which position (position is not 0-indexed, for accessibility reasons).
+    const processUnionError = (error) => {
+      const expectedTypes = new Set();
+      let actualType;
+
+      error.unionErrors.forEach(err => {
+        const issue = err.issues[0];
+        if (issue) {
+          if (!actualType) {
+            actualType = issue.received;
+          }
+
+          if (issue.code === 'invalid_type') {
+            expectedTypes.add(issue.expected);
+          }
+          // The case for constants. Since we don't want to print out the actual
+          // constant values in the error message, the error message will
+          // direct users to the documentation.
+          else if (issue.code === 'invalid_literal') {
+            expectedTypes.add("constant (please refer to documentation for allowed values)");
+          } else if (issue.code === 'custom') {
+            const match = issue.message.match(/Input not instance of (\w+)/);
+            if (match) expectedTypes.add(match[1]);
+          }
+        }
+      });
+
+      if (expectedTypes.size > 0) {
+        const expectedTypesStr = Array.from(expectedTypes).join(' or ');
+        const position = error.path.join('.');
+
+        message = buildTypeMismatchMessage(actualType, expectedTypesStr, position);
+      }
+
+      return message;
+    }
+
+    switch (currentError.code) {
+      case 'invalid_union': {
+        processUnionError(currentError);
+        break;
+      }
+      case 'too_small': {
+        const minArgs = currentError.minimum;
+        message = `Expected at least ${minArgs} argument${minArgs > 1 ? 's' : ''}, but received fewer. Please add more arguments!`;
+        break;
+      }
+      case 'invalid_type': {
+        message = buildTypeMismatchMessage(currentError.received, currentError.expected, currentError.path.join('.'));
+        break;
+      }
+      case 'too_big': {
+        const maxArgs = currentError.maximum;
+        message = `Expected at most ${maxArgs} argument${maxArgs > 1 ? 's' : ''}, but received more. Please delete some arguments!`;
+        break;
+      }
+      default: {
+        console.log('Zod error object', currentError);
+      }
+    }
+
+    return message;
+  }
+
+  /**
    * Runs parameter validation by matching the input parameters to Zod schemas
    * generated from the parameter data from `docs/parameterData.json`.
    *
@@ -334,7 +433,7 @@ function validateParams(p5, fn) {
    * @returns {Object} The validation result.
    * @returns {Boolean} result.success - Whether the validation was successful.
    * @returns {any} [result.data] - The parsed data if validation was successful.
-   * @returns {import('zod-validation-error').ZodValidationError} [result.error] - The validation error if validation failed.
+   * @returns {String} [result.error] - The validation error message if validation has failed.
    */
   fn._validateParams = function (func, args) {
     if (p5.disableFriendlyErrors) {
@@ -346,12 +445,11 @@ function validateParams(p5, fn) {
     // user intended to call the function with non-undefined arguments. Skip
     // regular workflow and return a friendly error message right away.
     if (Array.isArray(args) && args.every(arg => arg === undefined)) {
-      const undefinedError = new Error(`All arguments for function ${func} are undefined. There is likely an error in the code.`);
-      const zodUndefinedError = fromError(undefinedError);
+      const undefinedErrorMessage = `All arguments for function ${func} are undefined. There is likely an error in the code.`;
 
       return {
         success: false,
-        error: zodUndefinedError
+        error: undefinedErrorMessage
       };
     }
 
@@ -368,11 +466,12 @@ function validateParams(p5, fn) {
       };
     } catch (error) {
       const closestSchema = findClosestSchema(funcSchemas, args);
-      const validationError = fromError(closestSchema.safeParse(args).error);
+      const zodError = closestSchema.safeParse(args).error;
+      const errorMessage = p5._friendlyParamError(zodError);
 
       return {
         success: false,
-        error: validationError
+        error: errorMessage
       };
     }
   };

--- a/test/js/chai_helpers.js
+++ b/test/js/chai_helpers.js
@@ -1,5 +1,4 @@
 import p5 from '../../src/app.js';
-import { ValidationError } from 'zod-validation-error';
 
 // Setup chai
 var expect = chai.expect;

--- a/test/js/chai_helpers.js
+++ b/test/js/chai_helpers.js
@@ -12,7 +12,7 @@ assert.arrayApproximately = function (arr1, arr2, delta, desc) {
   }
 }
 
-assert.deepCloseTo = function(actual, expected, digits = 4) {
+assert.deepCloseTo = function (actual, expected, digits = 4) {
   expect(actual.length).toBe(expected.length);
   for (let i = 0; i < actual.length; i++) {
     expect(actual[i]).withContext(`[${i}]`).toBeCloseTo(expected[i], digits);
@@ -26,15 +26,5 @@ assert.validationError = function (fn) {
     assert.throws(fn, p5.ValidationError);
   } else {
     assert.doesNotThrow(fn, Error, 'got unwanted exception');
-  }
-};
-
-// A custom assertion for validation results for the new parameter validation
-// system.
-assert.validationResult = function (result, expectSuccess) {
-  if (expectSuccess) {
-    assert.isTrue(result.success);
-  } else {
-    assert.instanceOf(result.error, ValidationError);
   }
 };

--- a/test/unit/core/param_errors.js
+++ b/test/unit/core/param_errors.js
@@ -88,7 +88,7 @@ suite('Validate Params', function () {
     });
 
     const invalidInputs = [
-      { name: 'missing required arc parameters #4, #5', input: [200, 100, 100, 80], msg: 'Expected at least 6 arguments, but received fewer. Please add more arguments!' },
+      { name: 'missing required arc parameters #4, #5', input: [200, 100, 100, 80], msg: 'Expected at least 6 arguments, but received fewer. Please add more arguments! For more information, see https://p5js.org/reference/p5/arc.' },
       { name: 'missing required param #0', input: [undefined, 100, 100, 80, 0, Math.PI, constants.PIE, 30], msg: 'Expected number at the first parameter, but received undefined.' },
       { name: 'missing required param #4', input: [200, 100, 100, 80, undefined, 0], msg: 'Expected number at the fifth parameter, but received undefined.' },
       { name: 'missing optional param #5', input: [200, 100, 100, 80, 0, undefined, Math.PI], msg: 'Expected number at the sixth parameter, but received undefined.' },
@@ -116,7 +116,7 @@ suite('Validate Params', function () {
       { fn: 'color', name: 'superfluous parameter', input: [[0, 0, 0], 0], msg: 'Expected number at the first parameter, but received array.' },
       { fn: 'color', name: 'wrong element types', input: [['A', 'B', 'C']], msg: 'Expected number at the first parameter, but received array.' },
       { fn: 'rect', name: 'null, non-trailing, optional parameter', input: [0, 0, 0, 0, null, 0, 0, 0], msg: 'Expected number at the fifth parameter, but received null.' },
-      { fn: 'color', name: 'too many args + wrong types too', input: ['A', 'A', 0, 0, 0, 0, 0, 0, 0, 0], msg: 'Expected at most 4 arguments, but received more. Please delete some arguments!' },
+      { fn: 'color', name: 'too many args + wrong types too', input: ['A', 'A', 0, 0, 0, 0, 0, 0, 0, 0], msg: 'Expected at most 4 arguments, but received more. Please delete some arguments! For more information, see https://p5js.org/reference/p5/color.' },
       { fn: 'line', name: 'null string given', input: [1, 2, 4, 'null'], msg: 'Expected number at the fourth parameter, but received string.' },
       { fn: 'line', name: 'NaN value given', input: [1, 2, 4, NaN], msg: 'Expected number at the fourth parameter, but received nan.' }
     ];
@@ -164,7 +164,7 @@ suite('Validate Params', function () {
       { name: 'optional parameter, incorrect type', input: [65, 100, 100, 'a'], msg: 'Expected number at the fourth parameter, but received string.' },
       { name: 'extra parameter', input: [[65, 100, 100], 100], msg: 'Expected number at the first parameter, but received array.' },
       { name: 'incorrect element type', input: ['A', 'B', 'C'], msg: 'Expected number at the first parameter, but received string.' },
-      { name: 'incorrect parameter count', input: ['A', 'A', 0, 0, 0, 0, 0, 0], msg: 'Expected at most 4 arguments, but received more. Please delete some arguments!' }
+      { name: 'incorrect parameter count', input: ['A', 'A', 0, 0, 0, 0, 0, 0], msg: 'Expected at most 4 arguments, but received more. Please delete some arguments! For more information, see https://p5js.org/reference/p5/color.' }
     ];
 
     invalidInputs.forEach(({ name, input, msg }) => {

--- a/test/unit/core/param_errors.js
+++ b/test/unit/core/param_errors.js
@@ -197,4 +197,16 @@ suite('Validate Params', function () {
       });
     });
   });
+
+  suite('validateParams: paletteLerp', function () {
+    test('paletteLerp(): no firendly-err-msg', function () {
+      const colorStops = [
+        [new mockP5.Color(), 0.2],
+        [new mockP5.Color(), 0.8],
+        [new mockP5.Color(), 0.5]
+      ];
+      const result = mockP5Prototype._validateParams('p5.Color.paletteLerp', [colorStops, 0.5]);
+      assert.isTrue(result.success);
+    })
+  })
 });

--- a/test/unit/core/param_errors.js
+++ b/test/unit/core/param_errors.js
@@ -12,7 +12,7 @@ suite('Validate Params', function () {
 
   beforeAll(function () {
     validateParams(mockP5, mockP5Prototype);
-    mockP5Prototype._loadP5Constructors();
+    mockP5Prototype.loadP5Constructors();
   });
 
   afterAll(function () {
@@ -27,7 +27,7 @@ suite('Validate Params', function () {
       ];
 
       validInputs.forEach(({ input }) => {
-        const result = mockP5Prototype._validateParams('saturation', input);
+        const result = mockP5Prototype.validate('saturation', input);
         assert.isTrue(result.success);
       });
     });
@@ -41,7 +41,7 @@ suite('Validate Params', function () {
       ];
 
       invalidInputs.forEach(({ input }) => {
-        const result = mockP5Prototype._validateParams('p5.saturation', input);
+        const result = mockP5Prototype.validate('p5.saturation', input);
         assert.isTrue(result.error.startsWith("Expected Color or array or string at the first parameter, but received"));
       });
     });
@@ -55,7 +55,7 @@ suite('Validate Params', function () {
 
     validInputs.forEach(({ name, input }) => {
       test(`blendMode(): ${name}`, () => {
-        const result = mockP5Prototype._validateParams('p5.blendMode', [input]);
+        const result = mockP5Prototype.validate('p5.blendMode', [input]);
         assert.isTrue(result.success);
       });
     });
@@ -68,8 +68,8 @@ suite('Validate Params', function () {
 
     invalidInputs.forEach(({ name, input }) => {
       test(`blendMode(): ${name}`, () => {
-        const result = mockP5Prototype._validateParams('p5.blendMode', [input]);
-        const expectedError = "Expected constant (please refer to documentation for allowed values) at the first parameter, but received " + input + ".";
+        const result = mockP5Prototype.validate('p5.blendMode', [input]);
+        const expectedError = "Expected constant (please refer to documentation for allowed values) at the first parameter, but received " + input + " in p5.blendMode().";
         assert.equal(result.error, expectedError);
       });
     });
@@ -82,22 +82,22 @@ suite('Validate Params', function () {
     ];
     validInputs.forEach(({ name, input }) => {
       test(`arc(): ${name}`, () => {
-        const result = mockP5Prototype._validateParams('p5.arc', input);
+        const result = mockP5Prototype.validate('p5.arc', input);
         assert.isTrue(result.success);
       });
     });
 
     const invalidInputs = [
-      { name: 'missing required arc parameters #4, #5', input: [200, 100, 100, 80], msg: 'Expected at least 6 arguments, but received fewer. Please add more arguments! For more information, see https://p5js.org/reference/p5/arc.' },
-      { name: 'missing required param #0', input: [undefined, 100, 100, 80, 0, Math.PI, constants.PIE, 30], msg: 'Expected number at the first parameter, but received undefined.' },
-      { name: 'missing required param #4', input: [200, 100, 100, 80, undefined, 0], msg: 'Expected number at the fifth parameter, but received undefined.' },
-      { name: 'missing optional param #5', input: [200, 100, 100, 80, 0, undefined, Math.PI], msg: 'Expected number at the sixth parameter, but received undefined.' },
-      { name: 'wrong param type at #0', input: ['a', 100, 100, 80, 0, Math.PI, constants.PIE, 30], msg: 'Expected number at the first parameter, but received string.' }
+      { name: 'missing required arc parameters #4, #5', input: [200, 100, 100, 80], msg: 'Expected at least 6 arguments, but received fewer in p5.arc(). For more information, see https://p5js.org/reference/p5/arc.' },
+      { name: 'missing required param #0', input: [undefined, 100, 100, 80, 0, Math.PI, constants.PIE, 30], msg: 'Expected number at the first parameter, but received undefined in p5.arc().' },
+      { name: 'missing required param #4', input: [200, 100, 100, 80, undefined, 0], msg: 'Expected number at the fifth parameter, but received undefined in p5.arc().' },
+      { name: 'missing optional param #5', input: [200, 100, 100, 80, 0, undefined, Math.PI], msg: 'Expected number at the sixth parameter, but received undefined in p5.arc().' },
+      { name: 'wrong param type at #0', input: ['a', 100, 100, 80, 0, Math.PI, constants.PIE, 30], msg: 'Expected number at the first parameter, but received string in p5.arc().' }
     ];
 
     invalidInputs.forEach(({ name, input, msg }) => {
       test(`arc(): ${name}`, () => {
-        const result = mockP5Prototype._validateParams('p5.arc', input);
+        const result = mockP5Prototype.validate('p5.arc', input);
         assert.equal(result.error, msg);
       });
     });
@@ -105,25 +105,25 @@ suite('Validate Params', function () {
 
   suite('validateParams: class, multi-types + optional numbers', function () {
     test('ambientLight(): no firendly-err-msg', function () {
-      const result = mockP5Prototype._validateParams('p5.ambientLight', [new mockP5.Color()]);
+      const result = mockP5Prototype.validate('p5.ambientLight', [new mockP5.Color()]);
       assert.isTrue(result.success);
     })
   })
 
   suite('validateParams: a few edge cases', function () {
     const invalidInputs = [
-      { fn: 'color', name: 'wrong type for optional parameter', input: [0, 0, 0, 'A'], msg: 'Expected number at the fourth parameter, but received string.' },
-      { fn: 'color', name: 'superfluous parameter', input: [[0, 0, 0], 0], msg: 'Expected number at the first parameter, but received array.' },
-      { fn: 'color', name: 'wrong element types', input: [['A', 'B', 'C']], msg: 'Expected number at the first parameter, but received array.' },
-      { fn: 'rect', name: 'null, non-trailing, optional parameter', input: [0, 0, 0, 0, null, 0, 0, 0], msg: 'Expected number at the fifth parameter, but received null.' },
-      { fn: 'color', name: 'too many args + wrong types too', input: ['A', 'A', 0, 0, 0, 0, 0, 0, 0, 0], msg: 'Expected at most 4 arguments, but received more. Please delete some arguments! For more information, see https://p5js.org/reference/p5/color.' },
-      { fn: 'line', name: 'null string given', input: [1, 2, 4, 'null'], msg: 'Expected number at the fourth parameter, but received string.' },
-      { fn: 'line', name: 'NaN value given', input: [1, 2, 4, NaN], msg: 'Expected number at the fourth parameter, but received nan.' }
+      { fn: 'color', name: 'wrong type for optional parameter', input: [0, 0, 0, 'A'], msg: 'Expected number at the fourth parameter, but received string in p5.color().' },
+      { fn: 'color', name: 'superfluous parameter', input: [[0, 0, 0], 0], msg: 'Expected number at the first parameter, but received array in p5.color().' },
+      { fn: 'color', name: 'wrong element types', input: [['A', 'B', 'C']], msg: 'Expected number at the first parameter, but received array in p5.color().' },
+      { fn: 'rect', name: 'null, non-trailing, optional parameter', input: [0, 0, 0, 0, null, 0, 0, 0], msg: 'Expected number at the fifth parameter, but received null in p5.rect().' },
+      { fn: 'color', name: 'too many args + wrong types too', input: ['A', 'A', 0, 0, 0, 0, 0, 0, 0, 0], msg: 'Expected at most 4 arguments, but received more in p5.color(). For more information, see https://p5js.org/reference/p5/color.' },
+      { fn: 'line', name: 'null string given', input: [1, 2, 4, 'null'], msg: 'Expected number at the fourth parameter, but received string in p5.line().' },
+      { fn: 'line', name: 'NaN value given', input: [1, 2, 4, NaN], msg: 'Expected number at the fourth parameter, but received nan in p5.line().' }
     ];
 
     invalidInputs.forEach(({ name, input, fn, msg }) => {
       test(`${fn}(): ${name}`, () => {
-        const result = mockP5Prototype._validateParams(`p5.${fn}`, input);
+        const result = mockP5Prototype.validate(`p5.${fn}`, input);
         assert.equal(result.error, msg);
       });
     });
@@ -131,17 +131,17 @@ suite('Validate Params', function () {
 
   suite('validateParams: trailing undefined arguments', function () {
     const invalidInputs = [
-      { fn: 'color', name: 'missing params #1, #2', input: [12, undefined, undefined], msg: 'Expected number at the second parameter, but received undefined.' },
+      { fn: 'color', name: 'missing params #1, #2', input: [12, undefined, undefined], msg: 'Expected number at the second parameter, but received undefined in p5.color().' },
       // Even though the undefined arguments are technically allowed for
       // optional parameters, it is more likely that the user wanted to call
       // the function with meaningful arguments.
-      { fn: 'random', name: 'missing params #0, #1', input: [undefined, undefined], msg: 'All arguments for function p5.random are undefined. There is likely an error in the code.' },
-      { fn: 'circle', name: 'missing compulsory parameter #2', input: [5, 5, undefined], msg: 'Expected number at the third parameter, but received undefined.' }
+      { fn: 'random', name: 'missing params #0, #1', input: [undefined, undefined], msg: 'All arguments for p5.random() are undefined. There is likely an error in the code.' },
+      { fn: 'circle', name: 'missing compulsory parameter #2', input: [5, 5, undefined], msg: 'Expected number at the third parameter, but received undefined in p5.circle().' }
     ];
 
     invalidInputs.forEach(({ fn, name, input, msg }) => {
       test(`${fn}(): ${name}`, () => {
-        const result = mockP5Prototype._validateParams(`p5.${fn}`, input);
+        const result = mockP5Prototype.validate(`p5.${fn}`, input);
         assert.equal(result.error, msg);
       });
     });
@@ -155,21 +155,22 @@ suite('Validate Params', function () {
     ];
     validInputs.forEach(({ name, input }) => {
       test(`color(): ${name}`, () => {
-        const result = mockP5Prototype._validateParams('p5.color', input);
+        const result = mockP5Prototype.validate('p5.color', input);
         assert.isTrue(result.success);
       });
     });
 
     const invalidInputs = [
-      { name: 'optional parameter, incorrect type', input: [65, 100, 100, 'a'], msg: 'Expected number at the fourth parameter, but received string.' },
-      { name: 'extra parameter', input: [[65, 100, 100], 100], msg: 'Expected number at the first parameter, but received array.' },
-      { name: 'incorrect element type', input: ['A', 'B', 'C'], msg: 'Expected number at the first parameter, but received string.' },
-      { name: 'incorrect parameter count', input: ['A', 'A', 0, 0, 0, 0, 0, 0], msg: 'Expected at most 4 arguments, but received more. Please delete some arguments! For more information, see https://p5js.org/reference/p5/color.' }
+      { name: 'optional parameter, incorrect type', input: [65, 100, 100, 'a'], msg: 'Expected number at the fourth parameter, but received string in p5.color().' },
+      { name: 'extra parameter', input: [[65, 100, 100], 100], msg: 'Expected number at the first parameter, but received array in p5.color().' },
+      { name: 'incorrect element type', input: ['A', 'B', 'C'], msg: 'Expected number at the first parameter, but received string in p5.color().' },
+      { name: 'incorrect parameter count', input: ['A', 'A', 0, 0, 0, 0, 0, 0], msg: 'Expected at most 4 arguments, but received more in p5.color(). For more information, see https://p5js.org/reference/p5/color.' }
     ];
 
     invalidInputs.forEach(({ name, input, msg }) => {
       test(`color(): ${name}`, () => {
-        const result = mockP5Prototype._validateParams('p5.color', input);
+        const result = mockP5Prototype.validate('p5.color', input);
+
         assert.equal(result.error, msg);
       });
     });
@@ -183,14 +184,14 @@ suite('Validate Params', function () {
     ];
     validInputs.forEach(({ name, input }) => {
       test(`${name}`, function () {
-        const result = mockP5Prototype._validateParams('p5.set', input);
+        const result = mockP5Prototype.validate('p5.set', input);
         assert.isTrue(result.success);
       });
     });
 
     test(`set() with Boolean (invalid)`, function () {
-      const result = mockP5Prototype._validateParams('p5.set', [0, 0, true]);
-      assert.equal(result.error, 'Expected number or array or object at the third parameter, but received boolean.');
+      const result = mockP5Prototype.validate('p5.set', [0, 0, true]);
+      assert.equal(result.error, 'Expected number or array or object at the third parameter, but received boolean in p5.set().');
     });
   });
 
@@ -205,7 +206,7 @@ suite('Validate Params', function () {
 
     testCases.forEach(({ fn, name, input }) => {
       test(`${fn}(): ${name}`, function () {
-        const result = mockP5Prototype._validateParams(fn, input);
+        const result = mockP5Prototype.validate(fn, input);
         assert.isTrue(result.success);
       });
     });
@@ -218,7 +219,7 @@ suite('Validate Params', function () {
         [new mockP5.Color(), 0.8],
         [new mockP5.Color(), 0.5]
       ];
-      const result = mockP5Prototype._validateParams('p5.Color.paletteLerp', [colorStops, 0.5]);
+      const result = mockP5Prototype.validate('p5.Color.paletteLerp', [colorStops, 0.5]);
       assert.isTrue(result.success);
     })
   })


### PR DESCRIPTION
<!--
  Thank you for contributing! Please use this pull request (PR) template.


 In the description field of this PR, include "resolves #XXXX" tagging the issue you are fixing. If this PR addresses the issue but doesn't completely resolve it (ie the issue should remain open after your PR is merged), write "addresses #XXXX".-->
Addresses https://github.com/processing/p5.js/issues/7178

 Changes:
<!-- Add here what changes were made in this pull request and if possible provide links showcasing the changes. -->

- Added parameter validation support for `paletteLerp`, see https://github.com/processing/p5.js/pull/6960
- Instead of using `zod-validation-error` library, prints error messages with custom logic catered towards beginners, and modified the tests accordingly.
- Updated `convert.js`, to 1) ignore false duplicated definitions (i.e. what happened with `createAudio`), and 2) dedup when overloads of the same types exist
- Some code cleanups, including deleting the outstanding TODO items that have been completed, deleting function `printZodSchema` that's only for debugging purposes, etc.

 Screenshots of the change:
<!-- If applicable, add screenshots depicting the changes. -->

#### PR Checklist
<!--
  To check any option, replace the "[ ]" with a "[x]". Be sure to check out how it looks in the Preview tab! Feel free to remove any portion of the template that is not relevant for your issue.
-->

- [x] `npm run lint` passes
- [x] [Inline documentation] is included / updated
- [x] [Unit tests] are included / updated

[Inline documentation]: https://github.com/processing/p5.js/blob/main/contributor_docs/inline_documentation.md
[Unit tests]: https://github.com/processing/p5.js/tree/main/contributor_docs#unit-tests
