### PR TITLE
[p5.js 2.0] WebGL module syntax

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,8 +14,7 @@
         "gifenc": "^1.0.3",
         "libtess": "^1.2.2",
         "omggif": "^1.0.10",
-        "opentype.js": "^1.3.1",
-        "zod-validation-error": "^3.3.1"
+        "opentype.js": "^1.3.1"
       },
       "devDependencies": {
         "@rollup/plugin-commonjs": "^25.0.7",
@@ -11606,19 +11605,9 @@
       "version": "3.23.8",
       "resolved": "https://registry.npmjs.org/zod/-/zod-3.23.8.tgz",
       "integrity": "sha512-XBx9AXhXktjUqnepgTiE5flcKIYWi/rme0Eaj+5Y0lftuGBq+jyRu/md4WnuxqgP1ubdpNCsYEYPxrzVHD8d6g==",
+      "dev": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
-      }
-    },
-    "node_modules/zod-validation-error": {
-      "version": "3.3.1",
-      "resolved": "https://registry.npmjs.org/zod-validation-error/-/zod-validation-error-3.3.1.tgz",
-      "integrity": "sha512-uFzCZz7FQis256dqw4AhPQgD6f3pzNca/Zh62RNELavlumQB3nDIUFbF5JQfFLcMbO1s02Q7Xg/gpcOBlEnYZA==",
-      "engines": {
-        "node": ">=18.0.0"
-      },
-      "peerDependencies": {
-        "zod": "^3.18.0"
       }
     },
     "node_modules/zwitch": {

--- a/src/app.js
+++ b/src/app.js
@@ -70,24 +70,10 @@ utilities(p5);
 // webgl
 import webgl from './webgl';
 webgl(p5);
-// import './webgl/3d_primitives';
-// import './webgl/interaction';
-// import './webgl/light';
-// import './webgl/loading';
-// import './webgl/material';
-// import './webgl/p5.Camera';
-// import './webgl/p5.DataArray';
-// import './webgl/p5.Geometry';
-// import './webgl/p5.Matrix';
-// import './webgl/p5.Quat';
 import './webgl/p5.RendererGL.Immediate';
 import './webgl/p5.RendererGL';
 import './webgl/p5.RendererGL.Retained';
-// import './webgl/p5.Framebuffer';
-// import './webgl/p5.Shader';
-// import './webgl/p5.RenderBuffer';
 import './webgl/p5.Texture';
-// import './webgl/text';
 
 import './core/init';
 

--- a/src/app.js
+++ b/src/app.js
@@ -68,24 +68,26 @@ import utilities from './utilities';
 utilities(p5);
 
 // webgl
-import './webgl/3d_primitives';
-import './webgl/interaction';
-import './webgl/light';
-import './webgl/loading';
-import './webgl/material';
-import './webgl/p5.Camera';
-import './webgl/p5.DataArray';
-import './webgl/p5.Geometry';
-import './webgl/p5.Matrix';
-import './webgl/p5.Quat';
+import webgl from './webgl';
+webgl(p5);
+// import './webgl/3d_primitives';
+// import './webgl/interaction';
+// import './webgl/light';
+// import './webgl/loading';
+// import './webgl/material';
+// import './webgl/p5.Camera';
+// import './webgl/p5.DataArray';
+// import './webgl/p5.Geometry';
+// import './webgl/p5.Matrix';
+// import './webgl/p5.Quat';
 import './webgl/p5.RendererGL.Immediate';
 import './webgl/p5.RendererGL';
 import './webgl/p5.RendererGL.Retained';
-import './webgl/p5.Framebuffer';
-import './webgl/p5.Shader';
-import './webgl/p5.RenderBuffer';
+// import './webgl/p5.Framebuffer';
+// import './webgl/p5.Shader';
+// import './webgl/p5.RenderBuffer';
 import './webgl/p5.Texture';
-import './webgl/text';
+// import './webgl/text';
 
 import './core/init';
 

--- a/src/webgl/3d_primitives.js
+++ b/src/webgl/3d_primitives.js
@@ -6,2679 +6,2619 @@
  * @requires p5.Geometry
  */
 
-import p5 from '../core/main';
-import './p5.Geometry';
 import * as constants from '../core/constants';
 
-/**
- * Begins adding shapes to a new
- * <a href="#/p5.Geometry">p5.Geometry</a> object.
- *
- * The `beginGeometry()` and <a href="#/p5/endGeometry">endGeometry()</a>
- * functions help with creating complex 3D shapes from simpler ones such as
- * <a href="#/p5/sphere">sphere()</a>. `beginGeometry()` begins adding shapes
- * to a custom <a href="#/p5.Geometry">p5.Geometry</a> object and
- * <a href="#/p5/endGeometry">endGeometry()</a> stops adding them.
- *
- * `beginGeometry()` and <a href="#/p5/endGeometry">endGeometry()</a> can help
- * to make sketches more performant. For example, if a complex 3D shape
- * doesn’t change while a sketch runs, then it can be created with
- * `beginGeometry()` and <a href="#/p5/endGeometry">endGeometry()</a>.
- * Creating a <a href="#/p5.Geometry">p5.Geometry</a> object once and then
- * drawing it will run faster than repeatedly drawing the individual pieces.
- *
- * See <a href="#/p5/buildGeometry">buildGeometry()</a> for another way to
- * build 3D shapes.
- *
- * Note: `beginGeometry()` can only be used in WebGL mode.
- *
- * @method beginGeometry
- *
- * @example
- * <div>
- * <code>
- * // Click and drag the mouse to view the scene from different angles.
- *
- * let shape;
- *
- * function setup() {
- *   createCanvas(100, 100, WEBGL);
- *
- *   // Start building the p5.Geometry object.
- *   beginGeometry();
- *
- *   // Add a cone.
- *   cone();
- *
- *   // Stop building the p5.Geometry object.
- *   shape = endGeometry();
- *
- *   describe('A white cone drawn on a gray background.');
- * }
- *
- * function draw() {
- *   background(50);
- *
- *   // Enable orbiting with the mouse.
- *   orbitControl();
- *
- *   // Turn on the lights.
- *   lights();
- *
- *   // Style the p5.Geometry object.
- *   noStroke();
- *
- *   // Draw the p5.Geometry object.
- *   model(shape);
- * }
- * </code>
- * </div>
- *
- * <div>
- * <code>
- * // Click and drag the mouse to view the scene from different angles.
- *
- * let shape;
- *
- * function setup() {
- *   createCanvas(100, 100, WEBGL);
- *
- *   // Create the p5.Geometry object.
- *   createArrow();
- *
- *   describe('A white arrow drawn on a gray background.');
- * }
- *
- * function draw() {
- *   background(50);
- *
- *   // Enable orbiting with the mouse.
- *   orbitControl();
- *
- *   // Turn on the lights.
- *   lights();
- *
- *   // Style the p5.Geometry object.
- *   noStroke();
- *
- *   // Draw the p5.Geometry object.
- *   model(shape);
- * }
- *
- * function createArrow() {
- *   // Start building the p5.Geometry object.
- *   beginGeometry();
- *
- *   // Add shapes.
- *   push();
- *   rotateX(PI);
- *   cone(10);
- *   translate(0, -10, 0);
- *   cylinder(3, 20);
- *   pop();
- *
- *   // Stop building the p5.Geometry object.
- *   shape = endGeometry();
- * }
- * </code>
- * </div>
- *
- * <div>
- * <code>
- * // Click and drag the mouse to view the scene from different angles.
- *
- * let blueArrow;
- * let redArrow;
- *
- * function setup() {
- *   createCanvas(100, 100, WEBGL);
- *
- *   // Create the arrows.
- *   redArrow = createArrow('red');
- *   blueArrow = createArrow('blue');
- *
- *   describe('A red arrow and a blue arrow drawn on a gray background. The blue arrow rotates slowly.');
- * }
- *
- * function draw() {
- *   background(200);
- *
- *   // Enable orbiting with the mouse.
- *   orbitControl();
- *
- *   // Turn on the lights.
- *   lights();
- *
- *   // Style the arrows.
- *   noStroke();
- *
- *   // Draw the red arrow.
- *   model(redArrow);
- *
- *   // Translate and rotate the coordinate system.
- *   translate(30, 0, 0);
- *   rotateZ(frameCount * 0.01);
- *
- *   // Draw the blue arrow.
- *   model(blueArrow);
- * }
- *
- * function createArrow(fillColor) {
- *   // Start building the p5.Geometry object.
- *   beginGeometry();
- *
- *   fill(fillColor);
- *
- *   // Add shapes to the p5.Geometry object.
- *   push();
- *   rotateX(PI);
- *   cone(10);
- *   translate(0, -10, 0);
- *   cylinder(3, 20);
- *   pop();
- *
- *   // Stop building the p5.Geometry object.
- *   let shape = endGeometry();
- *
- *   return shape;
- * }
- * </code>
- * </div>
- *
- * <div>
- * <code>
- * // Click and drag the mouse to view the scene from different angles.
- *
- * let button;
- * let particles;
- *
- * function setup() {
- *   createCanvas(100, 100, WEBGL);
- *
- *   // Create a button to reset the particle system.
- *   button = createButton('Reset');
- *
- *   // Call resetModel() when the user presses the button.
- *   button.mousePressed(resetModel);
- *
- *   // Add the original set of particles.
- *   resetModel();
- * }
- *
- * function draw() {
- *   background(50);
- *
- *   // Enable orbiting with the mouse.
- *   orbitControl();
- *
- *   // Turn on the lights.
- *   lights();
- *
- *   // Style the particles.
- *   noStroke();
- *
- *   // Draw the particles.
- *   model(particles);
- * }
- *
- * function resetModel() {
- *   // If the p5.Geometry object has already been created,
- *   // free those resources.
- *   if (particles) {
- *     freeGeometry(particles);
- *   }
- *
- *   // Create a new p5.Geometry object with random spheres.
- *   particles = createParticles();
- * }
- *
- * function createParticles() {
- *   // Start building the p5.Geometry object.
- *   beginGeometry();
- *
- *   // Add shapes.
- *   for (let i = 0; i < 60; i += 1) {
- *     // Calculate random coordinates.
- *     let x = randomGaussian(0, 20);
- *     let y = randomGaussian(0, 20);
- *     let z = randomGaussian(0, 20);
- *
- *     push();
- *     // Translate to the particle's coordinates.
- *     translate(x, y, z);
- *     // Draw the particle.
- *     sphere(5);
- *     pop();
- *   }
- *
- *   // Stop building the p5.Geometry object.
- *   let shape = endGeometry();
- *
- *   return shape;
- * }
- * </code>
- * </div>
- */
-p5.prototype.beginGeometry = function() {
-  return this._renderer.beginGeometry();
-};
-
-/**
- * Stops adding shapes to a new
- * <a href="#/p5.Geometry">p5.Geometry</a> object and returns the object.
- *
- * The `beginGeometry()` and <a href="#/p5/endGeometry">endGeometry()</a>
- * functions help with creating complex 3D shapes from simpler ones such as
- * <a href="#/p5/sphere">sphere()</a>. `beginGeometry()` begins adding shapes
- * to a custom <a href="#/p5.Geometry">p5.Geometry</a> object and
- * <a href="#/p5/endGeometry">endGeometry()</a> stops adding them.
- *
- * `beginGeometry()` and <a href="#/p5/endGeometry">endGeometry()</a> can help
- * to make sketches more performant. For example, if a complex 3D shape
- * doesn’t change while a sketch runs, then it can be created with
- * `beginGeometry()` and <a href="#/p5/endGeometry">endGeometry()</a>.
- * Creating a <a href="#/p5.Geometry">p5.Geometry</a> object once and then
- * drawing it will run faster than repeatedly drawing the individual pieces.
- *
- * See <a href="#/p5/buildGeometry">buildGeometry()</a> for another way to
- * build 3D shapes.
- *
- * Note: `endGeometry()` can only be used in WebGL mode.
- *
- * @method endGeometry
- * @returns {p5.Geometry} new 3D shape.
- *
- * @example
- * <div>
- * <code>
- * // Click and drag the mouse to view the scene from different angles.
- *
- * let shape;
- *
- * function setup() {
- *   createCanvas(100, 100, WEBGL);
- *
- *   // Start building the p5.Geometry object.
- *   beginGeometry();
- *
- *   // Add a cone.
- *   cone();
- *
- *   // Stop building the p5.Geometry object.
- *   shape = endGeometry();
- *
- *   describe('A white cone drawn on a gray background.');
- * }
- *
- * function draw() {
- *   background(50);
- *
- *   // Enable orbiting with the mouse.
- *   orbitControl();
- *
- *   // Turn on the lights.
- *   lights();
- *
- *   // Style the p5.Geometry object.
- *   noStroke();
- *
- *   // Draw the p5.Geometry object.
- *   model(shape);
- * }
- * </code>
- * </div>
- *
- * <div>
- * <code>
- * // Click and drag the mouse to view the scene from different angles.
- *
- * let shape;
- *
- * function setup() {
- *   createCanvas(100, 100, WEBGL);
- *
- *   // Create the p5.Geometry object.
- *   createArrow();
- *
- *   describe('A white arrow drawn on a gray background.');
- * }
- *
- * function draw() {
- *   background(50);
- *
- *   // Enable orbiting with the mouse.
- *   orbitControl();
- *
- *   // Turn on the lights.
- *   lights();
- *
- *   // Style the p5.Geometry object.
- *   noStroke();
- *
- *   // Draw the p5.Geometry object.
- *   model(shape);
- * }
- *
- * function createArrow() {
- *   // Start building the p5.Geometry object.
- *   beginGeometry();
- *
- *   // Add shapes.
- *   push();
- *   rotateX(PI);
- *   cone(10);
- *   translate(0, -10, 0);
- *   cylinder(3, 20);
- *   pop();
- *
- *   // Stop building the p5.Geometry object.
- *   shape = endGeometry();
- * }
- * </code>
- * </div>
- *
- * <div>
- * <code>
- * // Click and drag the mouse to view the scene from different angles.
- *
- * let blueArrow;
- * let redArrow;
- *
- * function setup() {
- *   createCanvas(100, 100, WEBGL);
- *
- *   // Create the arrows.
- *   redArrow = createArrow('red');
- *   blueArrow = createArrow('blue');
- *
- *   describe('A red arrow and a blue arrow drawn on a gray background. The blue arrow rotates slowly.');
- * }
- *
- * function draw() {
- *   background(200);
- *
- *   // Enable orbiting with the mouse.
- *   orbitControl();
- *
- *   // Turn on the lights.
- *   lights();
- *
- *   // Style the arrows.
- *   noStroke();
- *
- *   // Draw the red arrow.
- *   model(redArrow);
- *
- *   // Translate and rotate the coordinate system.
- *   translate(30, 0, 0);
- *   rotateZ(frameCount * 0.01);
- *
- *   // Draw the blue arrow.
- *   model(blueArrow);
- * }
- *
- * function createArrow(fillColor) {
- *   // Start building the p5.Geometry object.
- *   beginGeometry();
- *
- *   fill(fillColor);
- *
- *   // Add shapes to the p5.Geometry object.
- *   push();
- *   rotateX(PI);
- *   cone(10);
- *   translate(0, -10, 0);
- *   cylinder(3, 20);
- *   pop();
- *
- *   // Stop building the p5.Geometry object.
- *   let shape = endGeometry();
- *
- *   return shape;
- * }
- * </code>
- * </div>
- *
- * <div>
- * <code>
- * // Click and drag the mouse to view the scene from different angles.
- *
- * let button;
- * let particles;
- *
- * function setup() {
- *   createCanvas(100, 100, WEBGL);
- *
- *   // Create a button to reset the particle system.
- *   button = createButton('Reset');
- *
- *   // Call resetModel() when the user presses the button.
- *   button.mousePressed(resetModel);
- *
- *   // Add the original set of particles.
- *   resetModel();
- * }
- *
- * function draw() {
- *   background(50);
- *
- *   // Enable orbiting with the mouse.
- *   orbitControl();
- *
- *   // Turn on the lights.
- *   lights();
- *
- *   // Style the particles.
- *   noStroke();
- *
- *   // Draw the particles.
- *   model(particles);
- * }
- *
- * function resetModel() {
- *   // If the p5.Geometry object has already been created,
- *   // free those resources.
- *   if (particles) {
- *     freeGeometry(particles);
- *   }
- *
- *   // Create a new p5.Geometry object with random spheres.
- *   particles = createParticles();
- * }
- *
- * function createParticles() {
- *   // Start building the p5.Geometry object.
- *   beginGeometry();
- *
- *   // Add shapes.
- *   for (let i = 0; i < 60; i += 1) {
- *     // Calculate random coordinates.
- *     let x = randomGaussian(0, 20);
- *     let y = randomGaussian(0, 20);
- *     let z = randomGaussian(0, 20);
- *
- *     push();
- *     // Translate to the particle's coordinates.
- *     translate(x, y, z);
- *     // Draw the particle.
- *     sphere(5);
- *     pop();
- *   }
- *
- *   // Stop building the p5.Geometry object.
- *   let shape = endGeometry();
- *
- *   return shape;
- * }
- * </code>
- * </div>
- */
-p5.prototype.endGeometry = function() {
-  return this._renderer.endGeometry();
-};
-
-/**
- * Creates a custom <a href="#/p5.Geometry">p5.Geometry</a> object from
- * simpler 3D shapes.
- *
- * `buildGeometry()` helps with creating complex 3D shapes from simpler ones
- * such as <a href="#/p5/sphere">sphere()</a>. It can help to make sketches
- * more performant. For example, if a complex 3D shape doesn’t change while a
- * sketch runs, then it can be created with `buildGeometry()`. Creating a
- * <a href="#/p5.Geometry">p5.Geometry</a> object once and then drawing it
- * will run faster than repeatedly drawing the individual pieces.
- *
- * The parameter, `callback`, is a function with the drawing instructions for
- * the new <a href="#/p5.Geometry">p5.Geometry</a> object. It will be called
- * once to create the new 3D shape.
- *
- * See <a href="#/p5/beginGeometry">beginGeometry()</a> and
- * <a href="#/p5/endGeometry">endGeometry()</a> for another way to build 3D
- * shapes.
- *
- * Note: `buildGeometry()` can only be used in WebGL mode.
- *
- * @method buildGeometry
- * @param {Function} callback function that draws the shape.
- * @returns {p5.Geometry} new 3D shape.
- *
- * @example
- * <div>
- * <code>
- * // Click and drag the mouse to view the scene from different angles.
- *
- * let shape;
- *
- * function setup() {
- *   createCanvas(100, 100, WEBGL);
- *
- *   // Create the p5.Geometry object.
- *   shape = buildGeometry(createShape);
- *
- *   describe('A white cone drawn on a gray background.');
- * }
- *
- * function draw() {
- *   background(50);
- *
- *   // Enable orbiting with the mouse.
- *   orbitControl();
- *
- *   // Turn on the lights.
- *   lights();
- *
- *   // Style the p5.Geometry object.
- *   noStroke();
- *
- *   // Draw the p5.Geometry object.
- *   model(shape);
- * }
- *
- * // Create p5.Geometry object from a single cone.
- * function createShape() {
- *   cone();
- * }
- * </code>
- * </div>
- *
- * <div>
- * <code>
- * // Click and drag the mouse to view the scene from different angles.
- *
- * let shape;
- *
- * function setup() {
- *   createCanvas(100, 100, WEBGL);
- *
- *   // Create the arrow.
- *   shape = buildGeometry(createArrow);
- *
- *   describe('A white arrow drawn on a gray background.');
- * }
- *
- * function draw() {
- *   background(50);
- *
- *   // Enable orbiting with the mouse.
- *   orbitControl();
- *
- *   // Turn on the lights.
- *   lights();
- *
- *   // Style the arrow.
- *   noStroke();
- *
- *   // Draw the arrow.
- *   model(shape);
- * }
- *
- * function createArrow() {
- *   // Add shapes to the p5.Geometry object.
- *   push();
- *   rotateX(PI);
- *   cone(10);
- *   translate(0, -10, 0);
- *   cylinder(3, 20);
- *   pop();
- * }
- * </code>
- * </div>
- *
- * <div>
- * <code>
- * // Click and drag the mouse to view the scene from different angles.
- *
- * let shape;
- *
- * function setup() {
- *   createCanvas(100, 100, WEBGL);
- *
- *   // Create the p5.Geometry object.
- *   shape = buildGeometry(createArrow);
- *
- *   describe('Two white arrows drawn on a gray background. The arrow on the right rotates slowly.');
- * }
- *
- * function draw() {
- *   background(50);
- *
- *   // Enable orbiting with the mouse.
- *   orbitControl();
- *
- *   // Turn on the lights.
- *   lights();
- *
- *   // Style the arrows.
- *   noStroke();
- *
- *   // Draw the p5.Geometry object.
- *   model(shape);
- *
- *   // Translate and rotate the coordinate system.
- *   translate(30, 0, 0);
- *   rotateZ(frameCount * 0.01);
- *
- *   // Draw the p5.Geometry object again.
- *   model(shape);
- * }
- *
- * function createArrow() {
- *   // Add shapes to the p5.Geometry object.
- *   push();
- *   rotateX(PI);
- *   cone(10);
- *   translate(0, -10, 0);
- *   cylinder(3, 20);
- *   pop();
- * }
- * </code>
- * </div>
- *
- * <div>
- * <code>
- * // Click and drag the mouse to view the scene from different angles.
- *
- * let button;
- * let particles;
- *
- * function setup() {
- *   createCanvas(100, 100, WEBGL);
- *
- *   // Create a button to reset the particle system.
- *   button = createButton('Reset');
- *
- *   // Call resetModel() when the user presses the button.
- *   button.mousePressed(resetModel);
- *
- *   // Add the original set of particles.
- *   resetModel();
- *
- *   describe('A set of white spheres on a gray background. The spheres are positioned randomly. Their positions reset when the user presses the Reset button.');
- * }
- *
- * function draw() {
- *   background(50);
- *
- *   // Enable orbiting with the mouse.
- *   orbitControl();
- *
- *   // Turn on the lights.
- *   lights();
- *
- *   // Style the particles.
- *   noStroke();
- *
- *   // Draw the particles.
- *   model(particles);
- * }
- *
- * function resetModel() {
- *   // If the p5.Geometry object has already been created,
- *   // free those resources.
- *   if (particles) {
- *     freeGeometry(particles);
- *   }
- *
- *   // Create a new p5.Geometry object with random spheres.
- *   particles = buildGeometry(createParticles);
- * }
- *
- * function createParticles() {
- *   for (let i = 0; i < 60; i += 1) {
- *     // Calculate random coordinates.
- *     let x = randomGaussian(0, 20);
- *     let y = randomGaussian(0, 20);
- *     let z = randomGaussian(0, 20);
- *
- *     push();
- *     // Translate to the particle's coordinates.
- *     translate(x, y, z);
- *     // Draw the particle.
- *     sphere(5);
- *     pop();
- *   }
- * }
- * </code>
- * </div>
- */
-p5.prototype.buildGeometry = function(callback) {
-  return this._renderer.buildGeometry(callback);
-};
-
-/**
- * Clears a <a href="#/p5.Geometry">p5.Geometry</a> object from the graphics
- * processing unit (GPU) memory.
- *
- * <a href="#/p5.Geometry">p5.Geometry</a> objects can contain lots of data
- * about their vertices, surface normals, colors, and so on. Complex 3D shapes
- * can use lots of memory which is a limited resource in many GPUs. Calling
- * `freeGeometry()` can improve performance by freeing a
- * <a href="#/p5.Geometry">p5.Geometry</a> object’s resources from GPU memory.
- * `freeGeometry()` works with <a href="#/p5.Geometry">p5.Geometry</a> objects
- * created with <a href="#/p5/beginGeometry">beginGeometry()</a> and
- * <a href="#/p5/endGeometry">endGeometry()</a>,
- * <a href="#/p5/buildGeometry">buildGeometry()</a>, and
- * <a href="#/p5/loadModel">loadModel()</a>.
- *
- * The parameter, `geometry`, is the <a href="#/p5.Geometry">p5.Geometry</a>
- * object to be freed.
- *
- * Note: A <a href="#/p5.Geometry">p5.Geometry</a> object can still be drawn
- * after its resources are cleared from GPU memory. It may take longer to draw
- * the first time it’s redrawn.
- *
- * Note: `freeGeometry()` can only be used in WebGL mode.
- *
- * @method freeGeometry
- * @param {p5.Geometry} geometry 3D shape whose resources should be freed.
- *
- * @example
- * <div>
- * <code>
- * function setup() {
- *   createCanvas(100, 100, WEBGL);
- *
- *   background(200);
- *
- *   // Create a p5.Geometry object.
- *   beginGeometry();
- *   cone();
- *   let shape = endGeometry();
- *
- *   // Draw the shape.
- *   model(shape);
- *
- *   // Free the shape's resources.
- *   freeGeometry(shape);
- * }
- * </code>
- * </div>
- *
- * <div>
- * <code>
- * // Click and drag the mouse to view the scene from different angles.
- *
- * let button;
- * let particles;
- *
- * function setup() {
- *   createCanvas(100, 100, WEBGL);
- *
- *   // Create a button to reset the particle system.
- *   button = createButton('Reset');
- *
- *   // Call resetModel() when the user presses the button.
- *   button.mousePressed(resetModel);
- *
- *   // Add the original set of particles.
- *   resetModel();
- * }
- *
- * function draw() {
- *   background(50);
- *
- *   // Enable orbiting with the mouse.
- *   orbitControl();
- *
- *   // Turn on the lights.
- *   lights();
- *
- *   // Style the particles.
- *   noStroke();
- *
- *   // Draw the particles.
- *   model(particles);
- * }
- *
- * function resetModel() {
- *   // If the p5.Geometry object has already been created,
- *   // free those resources.
- *   if (particles) {
- *     freeGeometry(particles);
- *   }
- *
- *   // Create a new p5.Geometry object with random spheres.
- *   particles = buildGeometry(createParticles);
- * }
- *
- * function createParticles() {
- *   for (let i = 0; i < 60; i += 1) {
- *     // Calculate random coordinates.
- *     let x = randomGaussian(0, 20);
- *     let y = randomGaussian(0, 20);
- *     let z = randomGaussian(0, 20);
- *
- *     push();
- *     // Translate to the particle's coordinates.
- *     translate(x, y, z);
- *     // Draw the particle.
- *     sphere(5);
- *     pop();
- *   }
- * }
- * </code>
- * </div>
- */
-p5.prototype.freeGeometry = function(geometry) {
-  this._renderer._freeBuffers(geometry.gid);
-};
-
-/**
- * Draws a plane.
- *
- * A plane is a four-sided, flat shape with every angle measuring 90˚. It’s
- * similar to a rectangle and offers advanced drawing features in WebGL mode.
- *
- * The first parameter, `width`, is optional. If a `Number` is passed, as in
- * `plane(20)`, it sets the plane’s width and height. By default, `width` is
- * 50.
- *
- * The second parameter, `height`, is also optional. If a `Number` is passed,
- * as in `plane(20, 30)`, it sets the plane’s height. By default, `height` is
- * set to the plane’s `width`.
- *
- * The third parameter, `detailX`, is also optional. If a `Number` is passed,
- * as in `plane(20, 30, 5)` it sets the number of triangle subdivisions to use
- * along the x-axis. All 3D shapes are made by connecting triangles to form
- * their surfaces. By default, `detailX` is 1.
- *
- * The fourth parameter, `detailY`, is also optional. If a `Number` is passed,
- * as in `plane(20, 30, 5, 7)` it sets the number of triangle subdivisions to
- * use along the y-axis. All 3D shapes are made by connecting triangles to
- * form their surfaces. By default, `detailY` is 1.
- *
- * Note: `plane()` can only be used in WebGL mode.
- *
- * @method plane
- * @param  {Number} [width]    width of the plane.
- * @param  {Number} [height]   height of the plane.
- * @param  {Integer} [detailX] number of triangle subdivisions along the x-axis.
- * @param {Integer} [detailY]  number of triangle subdivisions along the y-axis.
- * @chainable
- *
- * @example
- * <div>
- * <code>
- * // Click and drag the mouse to view the scene from different angles.
- *
- * function setup() {
- *   createCanvas(100, 100, WEBGL);
- *
- *   describe('A white plane on a gray background.');
- * }
- *
- * function draw() {
- *   background(200);
- *
- *   // Enable orbiting with the mouse.
- *   orbitControl();
- *
- *   // Draw the plane.
- *   plane();
- * }
- * </code>
- * </div>
- *
- * <div>
- * <code>
- * // Click and drag the mouse to view the scene from different angles.
- *
- * function setup() {
- *   createCanvas(100, 100, WEBGL);
- *
- *   describe('A white plane on a gray background.');
- * }
- *
- * function draw() {
- *   background(200);
- *
- *   // Enable orbiting with the mouse.
- *   orbitControl();
- *
- *   // Draw the plane.
- *   // Set its width and height to 30.
- *   plane(30);
- * }
- * </code>
- * </div>
- *
- * <div>
- * <code>
- * // Click and drag the mouse to view the scene from different angles.
- *
- * function setup() {
- *   createCanvas(100, 100, WEBGL);
- *
- *   describe('A white plane on a gray background.');
- * }
- *
- * function draw() {
- *   background(200);
- *
- *   // Enable orbiting with the mouse.
- *   orbitControl();
- *
- *   // Draw the plane.
- *   // Set its width to 30 and height to 50.
- *   plane(30, 50);
- * }
- * </code>
- * </div>
- */
-p5.prototype.plane = function(
-  width = 50,
-  height = width,
-  detailX = 1,
-  detailY = 1
-) {
-  this._assert3d('plane');
-  p5._validateParameters('plane', arguments);
-
-  const gId = `plane|${detailX}|${detailY}`;
-
-  if (!this._renderer.geometryInHash(gId)) {
-    const _plane = function() {
-      let u, v, p;
-      for (let i = 0; i <= this.detailY; i++) {
-        v = i / this.detailY;
-        for (let j = 0; j <= this.detailX; j++) {
-          u = j / this.detailX;
-          p = new p5.Vector(u - 0.5, v - 0.5, 0);
-          this.vertices.push(p);
-          this.uvs.push(u, v);
-        }
-      }
-    };
-    const planeGeom = new p5.Geometry(detailX, detailY, _plane);
-    planeGeom.computeFaces().computeNormals();
-    if (detailX <= 1 && detailY <= 1) {
-      planeGeom._makeTriangleEdges()._edgesToVertices();
-    } else if (this._renderer.states.doStroke) {
-      console.log(
-        'Cannot draw stroke on plane objects with more' +
-        ' than 1 detailX or 1 detailY'
-      );
-    }
-    this._renderer.createBuffers(gId, planeGeom);
-  }
-
-  this._renderer.drawBuffersScaled(gId, width, height, 1);
-  return this;
-};
-
-/**
- * Draws a box (rectangular prism).
- *
- * A box is a 3D shape with six faces. Each face makes a 90˚ with four
- * neighboring faces.
- *
- * The first parameter, `width`, is optional. If a `Number` is passed, as in
- * `box(20)`, it sets the box’s width and height. By default, `width` is 50.
- *
- * The second parameter, `height`, is also optional. If a `Number` is passed,
- * as in `box(20, 30)`, it sets the box’s height. By default, `height` is set
- * to the box’s `width`.
- *
- * The third parameter, `depth`, is also optional. If a `Number` is passed, as
- * in `box(20, 30, 40)`, it sets the box’s depth. By default, `depth` is set
- * to the box’s `height`.
- *
- * The fourth parameter, `detailX`, is also optional. If a `Number` is passed,
- * as in `box(20, 30, 40, 5)`, it sets the number of triangle subdivisions to
- * use along the x-axis. All 3D shapes are made by connecting triangles to
- * form their surfaces. By default, `detailX` is 1.
- *
- * The fifth parameter, `detailY`, is also optional. If a number is passed, as
- * in `box(20, 30, 40, 5, 7)`, it sets the number of triangle subdivisions to
- * use along the y-axis. All 3D shapes are made by connecting triangles to
- * form their surfaces. By default, `detailY` is 1.
- *
- * Note: `box()` can only be used in WebGL mode.
- *
- * @method  box
- * @param  {Number} [width]     width of the box.
- * @param  {Number} [height]    height of the box.
- * @param  {Number} [depth]     depth of the box.
- * @param {Integer} [detailX]   number of triangle subdivisions along the x-axis.
- * @param {Integer} [detailY]   number of triangle subdivisions along the y-axis.
- * @chainable
- *
- * @example
- * <div>
- * <code>
- * // Click and drag the mouse to view the scene from different angles.
- *
- * function setup() {
- *   createCanvas(100, 100, WEBGL);
- *
- *   describe('A white box on a gray background.');
- * }
- *
- * function draw() {
- *   background(200);
- *
- *   // Enable orbiting with the mouse.
- *   orbitControl();
- *
- *   // Draw the box.
- *   box();
- * }
- * </code>
- * </div>
- *
- * <div>
- * <code>
- * // Click and drag the mouse to view the scene from different angles.
- *
- * function setup() {
- *   createCanvas(100, 100, WEBGL);
- *
- *   describe('A white box on a gray background.');
- * }
- *
- * function draw() {
- *   background(200);
- *
- *   // Enable orbiting with the mouse.
- *   orbitControl();
- *
- *   // Draw the box.
- *   // Set its width and height to 30.
- *   box(30);
- * }
- * </code>
- * </div>
- *
- * <div>
- * <code>
- * // Click and drag the mouse to view the scene from different angles.
- *
- * function setup() {
- *   createCanvas(100, 100, WEBGL);
- *
- *   describe('A white box on a gray background.');
- * }
- *
- * function draw() {
- *   background(200);
- *
- *   // Enable orbiting with the mouse.
- *   orbitControl();
- *
- *   // Draw the box.
- *   // Set its width to 30 and height to 50.
- *   box(30, 50);
- * }
- * </code>
- * </div>
- *
- * <div>
- * <code>
- * // Click and drag the mouse to view the scene from different angles.
- *
- * function setup() {
- *   createCanvas(100, 100, WEBGL);
- *
- *   describe('A white box on a gray background.');
- * }
- *
- * function draw() {
- *   background(200);
- *
- *   // Enable orbiting with the mouse.
- *   orbitControl();
- *
- *   // Draw the box.
- *   // Set its width to 30, height to 50, and depth to 10.
- *   box(30, 50, 10);
- * }
- * </code>
- * </div>
- */
-p5.prototype.box = function(width, height, depth, detailX, detailY) {
-  this._assert3d('box');
-  p5._validateParameters('box', arguments);
-  if (typeof width === 'undefined') {
-    width = 50;
-  }
-  if (typeof height === 'undefined') {
-    height = width;
-  }
-  if (typeof depth === 'undefined') {
-    depth = height;
-  }
-
-  const perPixelLighting =
-    this._renderer.attributes && this._renderer.attributes.perPixelLighting;
-  if (typeof detailX === 'undefined') {
-    detailX = perPixelLighting ? 1 : 4;
-  }
-  if (typeof detailY === 'undefined') {
-    detailY = perPixelLighting ? 1 : 4;
-  }
-
-  const gId = `box|${detailX}|${detailY}`;
-  if (!this._renderer.geometryInHash(gId)) {
-    const _box = function() {
-      const cubeIndices = [
-        [0, 4, 2, 6], // -1, 0, 0],// -x
-        [1, 3, 5, 7], // +1, 0, 0],// +x
-        [0, 1, 4, 5], // 0, -1, 0],// -y
-        [2, 6, 3, 7], // 0, +1, 0],// +y
-        [0, 2, 1, 3], // 0, 0, -1],// -z
-        [4, 5, 6, 7] // 0, 0, +1] // +z
-      ];
-      //using custom edges
-      //to avoid diagonal stroke lines across face of box
-      this.edges = [
-        [0, 1],
-        [1, 3],
-        [3, 2],
-        [6, 7],
-        [8, 9],
-        [9, 11],
-        [14, 15],
-        [16, 17],
-        [17, 19],
-        [18, 19],
-        [20, 21],
-        [22, 23]
-      ];
-
-      cubeIndices.forEach((cubeIndex, i) => {
-        const v = i * 4;
-        for (let j = 0; j < 4; j++) {
-          const d = cubeIndex[j];
-          //inspired by lightgl:
-          //https://github.com/evanw/lightgl.js
-          //octants:https://en.wikipedia.org/wiki/Octant_(solid_geometry)
-          const octant = new p5.Vector(
-            ((d & 1) * 2 - 1) / 2,
-            ((d & 2) - 1) / 2,
-            ((d & 4) / 2 - 1) / 2
-          );
-          this.vertices.push(octant);
-          this.uvs.push(j & 1, (j & 2) / 2);
-        }
-        this.faces.push([v, v + 1, v + 2]);
-        this.faces.push([v + 2, v + 1, v + 3]);
-      });
-    };
-    const boxGeom = new p5.Geometry(detailX, detailY, _box);
-    boxGeom.computeNormals();
-    if (detailX <= 4 && detailY <= 4) {
-      boxGeom._edgesToVertices();
-    } else if (this._renderer.states.doStroke) {
-      console.log(
-        'Cannot draw stroke on box objects with more' +
-        ' than 4 detailX or 4 detailY'
-      );
-    }
-    //initialize our geometry buffer with
-    //the key val pair:
-    //geometry Id, Geom object
-    this._renderer.createBuffers(gId, boxGeom);
-  }
-  this._renderer.drawBuffersScaled(gId, width, height, depth);
-
-  return this;
-};
-
-/**
- * Draws a sphere.
- *
- * A sphere is a 3D shape with triangular faces that connect to form a round
- * surface. Spheres with few faces look like crystals. Spheres with many faces
- * have smooth surfaces and look like balls.
- *
- * The first parameter, `radius`, is optional. If a `Number` is passed, as in
- * `sphere(20)`, it sets the radius of the sphere. By default, `radius` is 50.
- *
- * The second parameter, `detailX`, is also optional. If a `Number` is passed,
- * as in `sphere(20, 5)`, it sets the number of triangle subdivisions to use
- * along the x-axis. All 3D shapes are made by connecting triangles to form
- * their surfaces. By default, `detailX` is 24.
- *
- * The third parameter, `detailY`, is also optional. If a `Number` is passed,
- * as in `sphere(20, 5, 2)`, it sets the number of triangle subdivisions to
- * use along the y-axis. All 3D shapes are made by connecting triangles to
- * form their surfaces. By default, `detailY` is 16.
- *
- * Note: `sphere()` can only be used in WebGL mode.
- *
- * @method sphere
- * @param  {Number} [radius]   radius of the sphere. Defaults to 50.
- * @param  {Integer} [detailX] number of triangle subdivisions along the x-axis. Defaults to 24.
- * @param  {Integer} [detailY] number of triangle subdivisions along the y-axis. Defaults to 16.
- *
- * @chainable
- * @example
- * <div>
- * <code>
- * // Click and drag the mouse to view the scene from different angles.
- *
- * function setup() {
- *   createCanvas(100, 100, WEBGL);
- *
- *   describe('A white sphere on a gray background.');
- * }
- *
- * function draw() {
- *   background(200);
- *
- *   // Enable orbiting with the mouse.
- *   orbitControl();
- *
- *   // Draw the sphere.
- *   sphere();
- * }
- * </code>
- * </div>
- *
- * <div>
- * <code>
- * // Click and drag the mouse to view the scene from different angles.
- *
- * function setup() {
- *   createCanvas(100, 100, WEBGL);
- *
- *   describe('A white sphere on a gray background.');
- * }
- *
- * function draw() {
- *   background(200);
- *
- *   // Enable orbiting with the mouse.
- *   orbitControl();
- *
- *   // Draw the sphere.
- *   // Set its radius to 30.
- *   sphere(30);
- * }
- * </code>
- * </div>
- *
- * <div>
- * <code>
- * // Click and drag the mouse to view the scene from different angles.
- *
- * function setup() {
- *   createCanvas(100, 100, WEBGL);
- *
- *   describe('A white sphere on a gray background.');
- * }
- *
- * function draw() {
- *   background(200);
- *
- *   // Enable orbiting with the mouse.
- *   orbitControl();
- *
- *   // Draw the sphere.
- *   // Set its radius to 30.
- *   // Set its detailX to 6.
- *   sphere(30, 6);
- * }
- * </code>
- * </div>
- *
- * <div>
- * <code>
- * // Click and drag the mouse to view the scene from different angles.
- *
- * function setup() {
- *   createCanvas(100, 100, WEBGL);
- *
- *   describe('A white sphere on a gray background.');
- * }
- *
- * function draw() {
- *   background(200);
- *
- *   // Enable orbiting with the mouse.
- *   orbitControl();
- *
- *   // Draw the sphere.
- *   // Set its radius to 30.
- *   // Set its detailX to 24.
- *   // Set its detailY to 4.
- *   sphere(30, 24, 4);
- * }
- * </code>
- * </div>
- */
-p5.prototype.sphere = function(radius = 50, detailX = 24, detailY = 16) {
-  this._assert3d('sphere');
-  p5._validateParameters('sphere', arguments);
-
-  this.ellipsoid(radius, radius, radius, detailX, detailY);
-
-  return this;
-};
-
-/**
- * @private
- * Helper function for creating both cones and cylinders
- * Will only generate well-defined geometry when bottomRadius, height > 0
- * and topRadius >= 0
- * If topRadius == 0, topCap should be false
- */
-const _truncatedCone = function(
-  bottomRadius,
-  topRadius,
-  height,
-  detailX,
-  detailY,
-  bottomCap,
-  topCap
-) {
-  bottomRadius = bottomRadius <= 0 ? 1 : bottomRadius;
-  topRadius = topRadius < 0 ? 0 : topRadius;
-  height = height <= 0 ? bottomRadius : height;
-  detailX = detailX < 3 ? 3 : detailX;
-  detailY = detailY < 1 ? 1 : detailY;
-  bottomCap = bottomCap === undefined ? true : bottomCap;
-  topCap = topCap === undefined ? topRadius !== 0 : topCap;
-  const start = bottomCap ? -2 : 0;
-  const end = detailY + (topCap ? 2 : 0);
-  //ensure constant slant for interior vertex normals
-  const slant = Math.atan2(bottomRadius - topRadius, height);
-  const sinSlant = Math.sin(slant);
-  const cosSlant = Math.cos(slant);
-  let yy, ii, jj;
-  for (yy = start; yy <= end; ++yy) {
-    let v = yy / detailY;
-    let y = height * v;
-    let ringRadius;
-    if (yy < 0) {
-      //for the bottomCap edge
-      y = 0;
-      v = 0;
-      ringRadius = bottomRadius;
-    } else if (yy > detailY) {
-      //for the topCap edge
-      y = height;
-      v = 1;
-      ringRadius = topRadius;
-    } else {
-      //for the middle
-      ringRadius = bottomRadius + (topRadius - bottomRadius) * v;
-    }
-    if (yy === -2 || yy === detailY + 2) {
-      //center of bottom or top caps
-      ringRadius = 0;
-    }
-
-    y -= height / 2; //shift coordiate origin to the center of object
-    for (ii = 0; ii < detailX; ++ii) {
-      const u = ii / (detailX - 1);
-      const ur = 2 * Math.PI * u;
-      const sur = Math.sin(ur);
-      const cur = Math.cos(ur);
-
-      //VERTICES
-      this.vertices.push(new p5.Vector(sur * ringRadius, y, cur * ringRadius));
-
-      //VERTEX NORMALS
-      let vertexNormal;
-      if (yy < 0) {
-        vertexNormal = new p5.Vector(0, -1, 0);
-      } else if (yy > detailY && topRadius) {
-        vertexNormal = new p5.Vector(0, 1, 0);
-      } else {
-        vertexNormal = new p5.Vector(sur * cosSlant, sinSlant, cur * cosSlant);
-      }
-      this.vertexNormals.push(vertexNormal);
-      //UVs
-      this.uvs.push(u, v);
-    }
-  }
-
-  let startIndex = 0;
-  if (bottomCap) {
-    for (jj = 0; jj < detailX; ++jj) {
-      const nextjj = (jj + 1) % detailX;
-      this.faces.push([
-        startIndex + jj,
-        startIndex + detailX + nextjj,
-        startIndex + detailX + jj
-      ]);
-    }
-    startIndex += detailX * 2;
-  }
-  for (yy = 0; yy < detailY; ++yy) {
-    for (ii = 0; ii < detailX; ++ii) {
-      const nextii = (ii + 1) % detailX;
-      this.faces.push([
-        startIndex + ii,
-        startIndex + nextii,
-        startIndex + detailX + nextii
-      ]);
-      this.faces.push([
-        startIndex + ii,
-        startIndex + detailX + nextii,
-        startIndex + detailX + ii
-      ]);
-    }
-    startIndex += detailX;
-  }
-  if (topCap) {
-    startIndex += detailX;
-    for (ii = 0; ii < detailX; ++ii) {
-      this.faces.push([
-        startIndex + ii,
-        startIndex + (ii + 1) % detailX,
-        startIndex + detailX
-      ]);
-    }
-  }
-};
-
-/**
- * Draws a cylinder.
- *
- * A cylinder is a 3D shape with triangular faces that connect a flat bottom
- * to a flat top. Cylinders with few faces look like boxes. Cylinders with
- * many faces have smooth surfaces.
- *
- * The first parameter, `radius`, is optional. If a `Number` is passed, as in
- * `cylinder(20)`, it sets the radius of the cylinder’s base. By default,
- * `radius` is 50.
- *
- * The second parameter, `height`, is also optional. If a `Number` is passed,
- * as in `cylinder(20, 30)`, it sets the cylinder’s height. By default,
- * `height` is set to the cylinder’s `radius`.
- *
- * The third parameter, `detailX`, is also optional. If a `Number` is passed,
- * as in `cylinder(20, 30, 5)`, it sets the number of edges used to form the
- * cylinder's top and bottom. Using more edges makes the top and bottom look
- * more like circles. By default, `detailX` is 24.
- *
- * The fourth parameter, `detailY`, is also optional. If a `Number` is passed,
- * as in `cylinder(20, 30, 5, 2)`, it sets the number of triangle subdivisions
- * to use along the y-axis, between cylinder's the top and bottom. All 3D
- * shapes are made by connecting triangles to form their surfaces. By default,
- * `detailY` is 1.
- *
- * The fifth parameter, `bottomCap`, is also optional. If a `false` is passed,
- * as in `cylinder(20, 30, 5, 2, false)` the cylinder’s bottom won’t be drawn.
- * By default, `bottomCap` is `true`.
- *
- * The sixth parameter, `topCap`, is also optional. If a `false` is passed, as
- * in `cylinder(20, 30, 5, 2, false, false)` the cylinder’s top won’t be
- * drawn. By default, `topCap` is `true`.
- *
- * Note: `cylinder()` can only be used in WebGL mode.
- *
- * @method cylinder
- * @param  {Number}  [radius]    radius of the cylinder. Defaults to 50.
- * @param  {Number}  [height]    height of the cylinder. Defaults to the value of `radius`.
- * @param  {Integer} [detailX]   number of edges along the top and bottom. Defaults to 24.
- * @param  {Integer} [detailY]   number of triangle subdivisions along the y-axis. Defaults to 1.
- * @param  {Boolean} [bottomCap] whether to draw the cylinder's bottom. Defaults to `true`.
- * @param  {Boolean} [topCap]    whether to draw the cylinder's top. Defaults to `true`.
- * @chainable
- *
- * @example
- * <div>
- * <code>
- * // Click and drag the mouse to view the scene from different angles.
- *
- * function setup() {
- *   createCanvas(100, 100, WEBGL);
- *
- *   describe('A white cylinder on a gray background.');
- * }
- *
- * function draw() {
- *   background(200);
- *
- *   // Enable orbiting with the mouse.
- *   orbitControl();
- *
- *   // Draw the cylinder.
- *   cylinder();
- * }
- * </code>
- * </div>
- *
- * <div>
- * <code>
- * // Click and drag the mouse to view the scene from different angles.
- *
- * function setup() {
- *   createCanvas(100, 100, WEBGL);
- *
- *   describe('A white cylinder on a gray background.');
- * }
- *
- * function draw() {
- *   background(200);
- *
- *   // Enable orbiting with the mouse.
- *   orbitControl();
- *
- *   // Draw the cylinder.
- *   // Set its radius and height to 30.
- *   cylinder(30);
- * }
- * </code>
- * </div>
- *
- * <div>
- * <code>
- * // Click and drag the mouse to view the scene from different angles.
- *
- * function setup() {
- *   createCanvas(100, 100, WEBGL);
- *
- *   describe('A white cylinder on a gray background.');
- * }
- *
- * function draw() {
- *   background(200);
- *
- *   // Enable orbiting with the mouse.
- *   orbitControl();
- *
- *   // Draw the cylinder.
- *   // Set its radius to 30 and height to 50.
- *   cylinder(30, 50);
- * }
- * </code>
- * </div>
- *
- * <div>
- * <code>
- * // Click and drag the mouse to view the scene from different angles.
- *
- * function setup() {
- *   createCanvas(100, 100, WEBGL);
- *
- *   describe('A white box on a gray background.');
- * }
- *
- * function draw() {
- *   background(200);
- *
- *   // Enable orbiting with the mouse.
- *   orbitControl();
- *
- *   // Draw the cylinder.
- *   // Set its radius to 30 and height to 50.
- *   // Set its detailX to 5.
- *   cylinder(30, 50, 5);
- * }
- * </code>
- * </div>
- *
- * <div>
- * <code>
- * // Click and drag the mouse to view the scene from different angles.
- *
- * function setup() {
- *   createCanvas(100, 100, WEBGL);
- *
- *   describe('A white cylinder on a gray background.');
- * }
- *
- * function draw() {
- *   background(200);
- *
- *   // Enable orbiting with the mouse.
- *   orbitControl();
- *
- *   // Draw the cylinder.
- *   // Set its radius to 30 and height to 50.
- *   // Set its detailX to 24 and detailY to 2.
- *   cylinder(30, 50, 24, 2);
- * }
- * </code>
- * </div>
- *
- * <div>
- * <code>
- * // Click and drag the mouse to view the scene from different angles.
- *
- * function setup() {
- *   createCanvas(100, 100, WEBGL);
- *
- *   describe('A white cylinder on a gray background. Its top is missing.');
- * }
- *
- * function draw() {
- *   background(200);
- *
- *   // Enable orbiting with the mouse.
- *   orbitControl();
- *
- *   // Draw the cylinder.
- *   // Set its radius to 30 and height to 50.
- *   // Set its detailX to 24 and detailY to 1.
- *   // Don't draw its bottom.
- *   cylinder(30, 50, 24, 1, false);
- * }
- * </code>
- * </div>
- *
- * <div>
- * <code>
- * // Click and drag the mouse to view the scene from different angles.
- *
- * function setup() {
- *   createCanvas(100, 100, WEBGL);
- *
- *   describe('A white cylinder on a gray background. Its top and bottom are missing.');
- * }
- *
- * function draw() {
- *   background(200);
- *
- *   // Enable orbiting with the mouse.
- *   orbitControl();
- *
- *   // Draw the cylinder.
- *   // Set its radius to 30 and height to 50.
- *   // Set its detailX to 24 and detailY to 1.
- *   // Don't draw its bottom or top.
- *   cylinder(30, 50, 24, 1, false, false);
- * }
- * </code>
- * </div>
- */
-p5.prototype.cylinder = function(
-  radius = 50,
-  height = radius,
-  detailX = 24,
-  detailY = 1,
-  bottomCap = true,
-  topCap = true
-) {
-  this._assert3d('cylinder');
-  p5._validateParameters('cylinder', arguments);
-
-  const gId = `cylinder|${detailX}|${detailY}|${bottomCap}|${topCap}`;
-  if (!this._renderer.geometryInHash(gId)) {
-    const cylinderGeom = new p5.Geometry(detailX, detailY);
-    _truncatedCone.call(
-      cylinderGeom,
-      1,
-      1,
-      1,
-      detailX,
-      detailY,
-      bottomCap,
-      topCap
-    );
-    // normals are computed in call to _truncatedCone
-    if (detailX <= 24 && detailY <= 16) {
-      cylinderGeom._makeTriangleEdges()._edgesToVertices();
-    } else if (this._renderer.states.doStroke) {
-      console.log(
-        'Cannot draw stroke on cylinder objects with more' +
-        ' than 24 detailX or 16 detailY'
-      );
-    }
-    this._renderer.createBuffers(gId, cylinderGeom);
-  }
-
-  this._renderer.drawBuffersScaled(gId, radius, height, radius);
-
-  return this;
-};
-
-/**
- * Draws a cone.
- *
- * A cone is a 3D shape with triangular faces that connect a flat bottom to a
- * single point. Cones with few faces look like pyramids. Cones with many
- * faces have smooth surfaces.
- *
- * The first parameter, `radius`, is optional. If a `Number` is passed, as in
- * `cone(20)`, it sets the radius of the cone’s base. By default, `radius` is
- * 50.
- *
- * The second parameter, `height`, is also optional. If a `Number` is passed,
- * as in `cone(20, 30)`, it sets the cone’s height. By default, `height` is
- * set to the cone’s `radius`.
- *
- * The third parameter, `detailX`, is also optional. If a `Number` is passed,
- * as in `cone(20, 30, 5)`, it sets the number of edges used to form the
- * cone's base. Using more edges makes the base look more like a circle. By
- * default, `detailX` is 24.
- *
- * The fourth parameter, `detailY`, is also optional. If a `Number` is passed,
- * as in `cone(20, 30, 5, 7)`, it sets the number of triangle subdivisions to
- * use along the y-axis connecting the base to the tip. All 3D shapes are made
- * by connecting triangles to form their surfaces. By default, `detailY` is 1.
- *
- * The fifth parameter, `cap`, is also optional. If a `false` is passed, as
- * in `cone(20, 30, 5, 7, false)` the cone’s base won’t be drawn. By default,
- * `cap` is `true`.
- *
- * Note: `cone()` can only be used in WebGL mode.
- *
- * @method cone
- * @param  {Number}  [radius]  radius of the cone's base. Defaults to 50.
- * @param  {Number}  [height]  height of the cone. Defaults to the value of `radius`.
- * @param  {Integer} [detailX] number of edges used to draw the base. Defaults to 24.
- * @param  {Integer} [detailY] number of triangle subdivisions along the y-axis. Defaults to 1.
- * @param  {Boolean} [cap]     whether to draw the cone's base.  Defaults to `true`.
- * @chainable
- *
- * @example
- * <div>
- * <code>
- * // Click and drag the mouse to view the scene from different angles.
- *
- * function setup() {
- *   createCanvas(100, 100, WEBGL);
- *
- *   describe('A white cone on a gray background.');
- * }
- *
- * function draw() {
- *   background(200);
- *
- *   // Enable orbiting with the mouse.
- *   orbitControl();
- *
- *   // Draw the cone.
- *   cone();
- * }
- * </code>
- * </div>
- *
- * <div>
- * <code>
- * // Click and drag the mouse to view the scene from different angles.
- *
- * function setup() {
- *   createCanvas(100, 100, WEBGL);
- *
- *   describe('A white cone on a gray background.');
- * }
- *
- * function draw() {
- *   background(200);
- *
- *   // Enable orbiting with the mouse.
- *   orbitControl();
- *
- *   // Draw the cone.
- *   // Set its radius and height to 30.
- *   cone(30);
- * }
- * </code>
- * </div>
- *
- * <div>
- * <code>
- * // Click and drag the mouse to view the scene from different angles.
- *
- * function setup() {
- *   createCanvas(100, 100, WEBGL);
- *
- *   describe('A white cone on a gray background.');
- * }
- *
- * function draw() {
- *   background(200);
- *
- *   // Enable orbiting with the mouse.
- *   orbitControl();
- *
- *   // Draw the cone.
- *   // Set its radius to 30 and height to 50.
- *   cone(30, 50);
- * }
- * </code>
- * </div>
- *
- * <div>
- * <code>
- * // Click and drag the mouse to view the scene from different angles.
- *
- * function setup() {
- *   createCanvas(100, 100, WEBGL);
- *
- *   describe('A white cone on a gray background.');
- * }
- *
- * function draw() {
- *   background(200);
- *
- *   // Enable orbiting with the mouse.
- *   orbitControl();
- *
- *   // Draw the cone.
- *   // Set its radius to 30 and height to 50.
- *   // Set its detailX to 5.
- *   cone(30, 50, 5);
- * }
- * </code>
- * </div>
- *
- * <div>
- * <code>
- * // Click and drag the mouse to view the scene from different angles.
- *
- * function setup() {
- *   createCanvas(100, 100, WEBGL);
- *
- *   describe('A white pyramid on a gray background.');
- * }
- *
- * function draw() {
- *   background(200);
- *
- *   // Enable orbiting with the mouse.
- *   orbitControl();
- *
- *   // Draw the cone.
- *   // Set its radius to 30 and height to 50.
- *   // Set its detailX to 5.
- *   cone(30, 50, 5);
- * }
- * </code>
- * </div>
- *
- * <div>
- * <code>
- * // Click and drag the mouse to view the scene from different angles.
- *
- * function setup() {
- *   createCanvas(100, 100, WEBGL);
- *
- *   describe('A white cone on a gray background.');
- * }
- *
- * function draw() {
- *   background(200);
- *
- *   // Enable orbiting with the mouse.
- *   orbitControl();
- *
- *   // Draw the cone.
- *   // Set its radius to 30 and height to 50.
- *   // Set its detailX to 24 and detailY to 2.
- *   cone(30, 50, 24, 2);
- * }
- * </code>
- * </div>
- *
- * <div>
- * <code>
- * // Click and drag the mouse to view the scene from different angles.
- *
- * function setup() {
- *   createCanvas(100, 100, WEBGL);
- *
- *   describe('A white cone on a gray background. Its base is missing.');
- * }
- *
- * function draw() {
- *   background(200);
- *
- *   // Enable orbiting with the mouse.
- *   orbitControl();
- *
- *   // Draw the cone.
- *   // Set its radius to 30 and height to 50.
- *   // Set its detailX to 24 and detailY to 1.
- *   // Don't draw its base.
- *   cone(30, 50, 24, 1, false);
- * }
- * </code>
- * </div>
- */
-p5.prototype.cone = function(
-  radius = 50,
-  height = radius,
-  detailX = 24,
-  detailY = 1,
-  cap = true
-) {
-  this._assert3d('cone');
-  p5._validateParameters('cone', arguments);
-
-  const gId = `cone|${detailX}|${detailY}|${cap}`;
-  if (!this._renderer.geometryInHash(gId)) {
-    const coneGeom = new p5.Geometry(detailX, detailY);
-    _truncatedCone.call(coneGeom, 1, 0, 1, detailX, detailY, cap, false);
-    if (detailX <= 24 && detailY <= 16) {
-      coneGeom._makeTriangleEdges()._edgesToVertices();
-    } else if (this._renderer.states.doStroke) {
-      console.log(
-        'Cannot draw stroke on cone objects with more' +
-        ' than 24 detailX or 16 detailY'
-      );
-    }
-    this._renderer.createBuffers(gId, coneGeom);
-  }
-
-  this._renderer.drawBuffersScaled(gId, radius, height, radius);
-
-  return this;
-};
-
-/**
- * Draws an ellipsoid.
- *
- * An ellipsoid is a 3D shape with triangular faces that connect to form a
- * round surface. Ellipsoids with few faces look like crystals. Ellipsoids
- * with many faces have smooth surfaces and look like eggs. `ellipsoid()`
- * defines a shape by its radii. This is different from
- * <a href="#/p5/ellipse">ellipse()</a> which uses diameters
- * (width and height).
- *
- * The first parameter, `radiusX`, is optional. If a `Number` is passed, as in
- * `ellipsoid(20)`, it sets the radius of the ellipsoid along the x-axis. By
- * default, `radiusX` is 50.
- *
- * The second parameter, `radiusY`, is also optional. If a `Number` is passed,
- * as in `ellipsoid(20, 30)`, it sets the ellipsoid’s radius along the y-axis.
- * By default, `radiusY` is set to the ellipsoid’s `radiusX`.
- *
- * The third parameter, `radiusZ`, is also optional. If a `Number` is passed,
- * as in `ellipsoid(20, 30, 40)`, it sets the ellipsoid’s radius along the
- * z-axis. By default, `radiusZ` is set to the ellipsoid’s `radiusY`.
- *
- * The fourth parameter, `detailX`, is also optional. If a `Number` is passed,
- * as in `ellipsoid(20, 30, 40, 5)`, it sets the number of triangle
- * subdivisions to use along the x-axis. All 3D shapes are made by connecting
- * triangles to form their surfaces. By default, `detailX` is 24.
- *
- * The fifth parameter, `detailY`, is also optional. If a `Number` is passed,
- * as in `ellipsoid(20, 30, 40, 5, 7)`, it sets the number of triangle
- * subdivisions to use along the y-axis. All 3D shapes are made by connecting
- * triangles to form their surfaces. By default, `detailY` is 16.
- *
- * Note: `ellipsoid()` can only be used in WebGL mode.
- *
- * @method ellipsoid
- * @param  {Number} [radiusX]  radius of the ellipsoid along the x-axis. Defaults to 50.
- * @param  {Number} [radiusY]  radius of the ellipsoid along the y-axis. Defaults to `radiusX`.
- * @param  {Number} [radiusZ]  radius of the ellipsoid along the z-axis. Defaults to `radiusY`.
- * @param  {Integer} [detailX] number of triangle subdivisions along the x-axis. Defaults to 24.
- * @param  {Integer} [detailY] number of triangle subdivisions along the y-axis. Defaults to 16.
- * @chainable
- *
- * @example
- * <div>
- * <code>
- * // Click and drag the mouse to view the scene from different angles.
- *
- * function setup() {
- *   createCanvas(100, 100, WEBGL);
- *
- *   describe('A white sphere on a gray background.');
- * }
- *
- * function draw() {
- *   background(200);
- *
- *   // Enable orbiting with the mouse.
- *   orbitControl();
- *
- *   // Draw the ellipsoid.
- *   // Set its radiusX to 30.
- *   ellipsoid(30);
- * }
- * </code>
- * </div>
- *
- * <div>
- * <code>
- * // Click and drag the mouse to view the scene from different angles.
- *
- * function setup() {
- *   createCanvas(100, 100, WEBGL);
- *
- *   describe('A white ellipsoid on a gray background.');
- * }
- *
- * function draw() {
- *   background(200);
- *
- *   // Enable orbiting with the mouse.
- *   orbitControl();
- *
- *   // Draw the ellipsoid.
- *   // Set its radiusX to 30.
- *   // Set its radiusY to 40.
- *   ellipsoid(30, 40);
- * }
- * </code>
- * </div>
- *
- * <div>
- * <code>
- * // Click and drag the mouse to view the scene from different angles.
- *
- * function setup() {
- *   createCanvas(100, 100, WEBGL);
- *
- *   describe('A white ellipsoid on a gray background.');
- * }
- *
- * function draw() {
- *   background(200);
- *
- *   // Enable orbiting with the mouse.
- *   orbitControl();
- *
- *   // Draw the ellipsoid.
- *   // Set its radiusX to 30.
- *   // Set its radiusY to 40.
- *   // Set its radiusZ to 50.
- *   ellipsoid(30, 40, 50);
- * }
- * </code>
- * </div>
- *
- * <div>
- * <code>
- * // Click and drag the mouse to view the scene from different angles.
- *
- * function setup() {
- *   createCanvas(100, 100, WEBGL);
- *
- *   describe('A white ellipsoid on a gray background.');
- * }
- *
- * function draw() {
- *   background(200);
- *
- *   // Enable orbiting with the mouse.
- *   orbitControl();
- *
- *   // Draw the ellipsoid.
- *   // Set its radiusX to 30.
- *   // Set its radiusY to 40.
- *   // Set its radiusZ to 50.
- *   // Set its detailX to 4.
- *   ellipsoid(30, 40, 50, 4);
- * }
- * </code>
- * </div>
- *
- * <div>
- * <code>
- * // Click and drag the mouse to view the scene from different angles.
- *
- * function setup() {
- *   createCanvas(100, 100, WEBGL);
- *
- *   describe('A white ellipsoid on a gray background.');
- * }
- *
- * function draw() {
- *   background(200);
- *
- *   // Enable orbiting with the mouse.
- *   orbitControl();
- *
- *   // Draw the ellipsoid.
- *   // Set its radiusX to 30.
- *   // Set its radiusY to 40.
- *   // Set its radiusZ to 50.
- *   // Set its detailX to 4.
- *   // Set its detailY to 3.
- *   ellipsoid(30, 40, 50, 4, 3);
- * }
- * </code>
- * </div>
- */
-p5.prototype.ellipsoid = function(
-  radiusX = 50,
-  radiusY = radiusX,
-  radiusZ = radiusX,
-  detailX = 24,
-  detailY = 16
-) {
-  this._assert3d('ellipsoid');
-  p5._validateParameters('ellipsoid', arguments);
-
-  const gId = `ellipsoid|${detailX}|${detailY}`;
-
-  if (!this._renderer.geometryInHash(gId)) {
-    const _ellipsoid = function() {
-      for (let i = 0; i <= this.detailY; i++) {
-        const v = i / this.detailY;
-        const phi = Math.PI * v - Math.PI / 2;
-        const cosPhi = Math.cos(phi);
-        const sinPhi = Math.sin(phi);
-
-        for (let j = 0; j <= this.detailX; j++) {
-          const u = j / this.detailX;
-          const theta = 2 * Math.PI * u;
-          const cosTheta = Math.cos(theta);
-          const sinTheta = Math.sin(theta);
-          const p = new p5.Vector(cosPhi * sinTheta, sinPhi, cosPhi * cosTheta);
-          this.vertices.push(p);
-          this.vertexNormals.push(p);
-          this.uvs.push(u, v);
-        }
-      }
-    };
-    const ellipsoidGeom = new p5.Geometry(detailX, detailY, _ellipsoid);
-    ellipsoidGeom.computeFaces();
-    if (detailX <= 24 && detailY <= 24) {
-      ellipsoidGeom._makeTriangleEdges()._edgesToVertices();
-    } else if (this._renderer.states.doStroke) {
-      console.log(
-        'Cannot draw stroke on ellipsoids with more' +
-        ' than 24 detailX or 24 detailY'
-      );
-    }
-    this._renderer.createBuffers(gId, ellipsoidGeom);
-  }
-
-  this._renderer.drawBuffersScaled(gId, radiusX, radiusY, radiusZ);
-
-  return this;
-};
-
-/**
- * Draws a torus.
- *
- * A torus is a 3D shape with triangular faces that connect to form a ring.
- * Toruses with few faces look flattened. Toruses with many faces have smooth
- * surfaces.
- *
- * The first parameter, `radius`, is optional. If a `Number` is passed, as in
- * `torus(30)`, it sets the radius of the ring. By default, `radius` is 50.
- *
- * The second parameter, `tubeRadius`, is also optional. If a `Number` is
- * passed, as in `torus(30, 15)`, it sets the radius of the tube. By default,
- * `tubeRadius` is 10.
- *
- * The third parameter, `detailX`, is also optional. If a `Number` is passed,
- * as in `torus(30, 15, 5)`, it sets the number of edges used to draw the hole
- * of the torus. Using more edges makes the hole look more like a circle. By
- * default, `detailX` is 24.
- *
- * The fourth parameter, `detailY`, is also optional. If a `Number` is passed,
- * as in `torus(30, 15, 5, 7)`, it sets the number of triangle subdivisions to
- * use while filling in the torus’ height. By default, `detailY` is 16.
- *
- * Note: `torus()` can only be used in WebGL mode.
- *
- * @method torus
- * @param  {Number} [radius]      radius of the torus. Defaults to 50.
- * @param  {Number} [tubeRadius]  radius of the tube. Defaults to 10.
- * @param  {Integer} [detailX]    number of edges that form the hole. Defaults to 24.
- * @param  {Integer} [detailY]    number of triangle subdivisions along the y-axis. Defaults to 16.
- * @chainable
- *
- * @example
- * <div>
- * <code>
- * // Click and drag the mouse to view the scene from different angles.
- *
- * function setup() {
- *   createCanvas(100, 100, WEBGL);
- *
- *   describe('A white torus on a gray background.');
- * }
- *
- * function draw() {
- *   background(200);
- *
- *   // Enable orbiting with the mouse.
- *   orbitControl();
- *
- *   // Draw the torus.
- *   torus();
- * }
- * </code>
- * </div>
- *
- * <div>
- * <code>
- * // Click and drag the mouse to view the scene from different angles.
- *
- * function setup() {
- *   createCanvas(100, 100, WEBGL);
- *
- *   describe('A white torus on a gray background.');
- * }
- *
- * function draw() {
- *   background(200);
- *
- *   // Enable orbiting with the mouse.
- *   orbitControl();
- *
- *   // Draw the torus.
- *   // Set its radius to 30.
- *   torus(30);
- * }
- * </code>
- * </div>
- *
- * <div>
- * <code>
- * // Click and drag the mouse to view the scene from different angles.
- *
- * function setup() {
- *   createCanvas(100, 100, WEBGL);
- *
- *   describe('A white torus on a gray background.');
- * }
- *
- * function draw() {
- *   background(200);
- *
- *   // Enable orbiting with the mouse.
- *   orbitControl();
- *
- *   // Draw the torus.
- *   // Set its radius to 30 and tubeRadius to 15.
- *   torus(30, 15);
- * }
- * </code>
- * </div>
- *
- * <div>
- * <code>
- * // Click and drag the mouse to view the scene from different angles.
- *
- * function setup() {
- *   createCanvas(100, 100, WEBGL);
- *
- *   describe('A white torus on a gray background.');
- * }
- *
- * function draw() {
- *   background(200);
- *
- *   // Enable orbiting with the mouse.
- *   orbitControl();
- *
- *   // Draw the torus.
- *   // Set its radius to 30 and tubeRadius to 15.
- *   // Set its detailX to 5.
- *   torus(30, 15, 5);
- * }
- * </code>
- * </div>
- *
- * <div>
- * <code>
- * // Click and drag the mouse to view the scene from different angles.
- *
- * function setup() {
- *   createCanvas(100, 100, WEBGL);
- *
- *   describe('A white torus on a gray background.');
- * }
- *
- * function draw() {
- *   background(200);
- *
- *   // Enable orbiting with the mouse.
- *   orbitControl();
- *
- *   // Draw the torus.
- *   // Set its radius to 30 and tubeRadius to 15.
- *   // Set its detailX to 5.
- *   // Set its detailY to 3.
- *   torus(30, 15, 5, 3);
- * }
- * </code>
- * </div>
- */
-p5.prototype.torus = function(radius, tubeRadius, detailX, detailY) {
-  this._assert3d('torus');
-  p5._validateParameters('torus', arguments);
-  if (typeof radius === 'undefined') {
-    radius = 50;
-  } else if (!radius) {
-    return; // nothing to draw
-  }
-
-  if (typeof tubeRadius === 'undefined') {
-    tubeRadius = 10;
-  } else if (!tubeRadius) {
-    return; // nothing to draw
-  }
-
-  if (typeof detailX === 'undefined') {
-    detailX = 24;
-  }
-  if (typeof detailY === 'undefined') {
-    detailY = 16;
-  }
-
-  const tubeRatio = (tubeRadius / radius).toPrecision(4);
-  const gId = `torus|${tubeRatio}|${detailX}|${detailY}`;
-
-  if (!this._renderer.geometryInHash(gId)) {
-    const _torus = function() {
-      for (let i = 0; i <= this.detailY; i++) {
-        const v = i / this.detailY;
-        const phi = 2 * Math.PI * v;
-        const cosPhi = Math.cos(phi);
-        const sinPhi = Math.sin(phi);
-        const r = 1 + tubeRatio * cosPhi;
-
-        for (let j = 0; j <= this.detailX; j++) {
-          const u = j / this.detailX;
-          const theta = 2 * Math.PI * u;
-          const cosTheta = Math.cos(theta);
-          const sinTheta = Math.sin(theta);
-
-          const p = new p5.Vector(
-            r * cosTheta,
-            r * sinTheta,
-            tubeRatio * sinPhi
-          );
-
-          const n = new p5.Vector(cosPhi * cosTheta, cosPhi * sinTheta, sinPhi);
-
-          this.vertices.push(p);
-          this.vertexNormals.push(n);
-          this.uvs.push(u, v);
-        }
-      }
-    };
-    const torusGeom = new p5.Geometry(detailX, detailY, _torus);
-    torusGeom.computeFaces();
-    if (detailX <= 24 && detailY <= 16) {
-      torusGeom._makeTriangleEdges()._edgesToVertices();
-    } else if (this._renderer.states.doStroke) {
-      console.log(
-        'Cannot draw strokes on torus object with more' +
-        ' than 24 detailX or 16 detailY'
-      );
-    }
-    this._renderer.createBuffers(gId, torusGeom);
-  }
-  this._renderer.drawBuffersScaled(gId, radius, radius, radius);
-
-  return this;
-};
-
-///////////////////////
-/// 2D primitives
-/////////////////////////
-//
-// Note: Documentation is not generated on the p5.js website for functions on
-// the p5.RendererGL prototype.
-
-/**
- * Draws a point, a coordinate in space at the dimension of one pixel,
- * given x, y and z coordinates. The color of the point is determined
- * by the current stroke, while the point size is determined by current
- * stroke weight.
- * @private
- * @param {Number} x x-coordinate of point
- * @param {Number} y y-coordinate of point
- * @param {Number} z z-coordinate of point
- * @chainable
- * @example
- * <div>
- * <code>
- * function setup() {
- *   createCanvas(100, 100, WEBGL);
- * }
- *
- * function draw() {
- *   background(50);
- *   stroke(255);
- *   strokeWeight(4);
- *   point(25, 0);
- *   strokeWeight(3);
- *   point(-25, 0);
- *   strokeWeight(2);
- *   point(0, 25);
- *   strokeWeight(1);
- *   point(0, -25);
- * }
- * </code>
- * </div>
- */
-p5.RendererGL.prototype.point = function(x, y, z = 0) {
-
-  const _vertex = [];
-  _vertex.push(new p5.Vector(x, y, z));
-  this._drawPoints(_vertex, this.immediateMode.buffers.point);
-
-  return this;
-};
-
-p5.RendererGL.prototype.triangle = function(args) {
-  const x1 = args[0],
-    y1 = args[1];
-  const x2 = args[2],
-    y2 = args[3];
-  const x3 = args[4],
-    y3 = args[5];
-
-  const gId = 'tri';
-  if (!this.geometryInHash(gId)) {
-    const _triangle = function() {
-      const vertices = [];
-      vertices.push(new p5.Vector(0, 0, 0));
-      vertices.push(new p5.Vector(1, 0, 0));
-      vertices.push(new p5.Vector(0, 1, 0));
-      this.edges = [[0, 1], [1, 2], [2, 0]];
-      this.vertices = vertices;
-      this.faces = [[0, 1, 2]];
-      this.uvs = [0, 0, 1, 0, 1, 1];
-    };
-    const triGeom = new p5.Geometry(1, 1, _triangle);
-    triGeom._edgesToVertices();
-    triGeom.computeNormals();
-    this.createBuffers(gId, triGeom);
-  }
-
-  // only one triangle is cached, one point is at the origin, and the
-  // two adjacent sides are tne unit vectors along the X & Y axes.
-  //
-  // this matrix multiplication transforms those two unit vectors
-  // onto the required vector prior to rendering, and moves the
-  // origin appropriately.
-  const uModelMatrix = this.states.uModelMatrix.copy();
-  try {
-    // triangle orientation.
-    const orientation = Math.sign(x1*y2-x2*y1 + x2*y3-x3*y2 + x3*y1-x1*y3);
-    const mult = new p5.Matrix([
-      x2 - x1, y2 - y1, 0, 0, // the resulting unit X-axis
-      x3 - x1, y3 - y1, 0, 0, // the resulting unit Y-axis
-      0, 0, orientation, 0,   // the resulting unit Z-axis (Reflect the specified order of vertices)
-      x1, y1, 0, 1            // the resulting origin
-    ]).mult(this.states.uModelMatrix);
-
-    this.states.uModelMatrix = mult;
-
-    this.drawBuffers(gId);
-  } finally {
-    this.states.uModelMatrix = uModelMatrix;
-  }
-
-  return this;
-};
-
-p5.RendererGL.prototype.ellipse = function(args) {
-  this.arc(
-    args[0],
-    args[1],
-    args[2],
-    args[3],
-    0,
-    constants.TWO_PI,
-    constants.OPEN,
-    args[4]
-  );
-};
-
-p5.RendererGL.prototype.arc = function(...args) {
-  const x = args[0];
-  const y = args[1];
-  const width = args[2];
-  const height = args[3];
-  const start = args[4];
-  const stop = args[5];
-  const mode = args[6];
-  const detail = args[7] || 25;
-
-  let shape;
-  let gId;
-
-  // check if it is an ellipse or an arc
-  if (Math.abs(stop - start) >= constants.TWO_PI) {
-    shape = 'ellipse';
-    gId = `${shape}|${detail}|`;
-  } else {
-    shape = 'arc';
-    gId = `${shape}|${start}|${stop}|${mode}|${detail}|`;
-  }
-
-  if (!this.geometryInHash(gId)) {
-    const _arc = function() {
-
-      // if the start and stop angles are not the same, push vertices to the array
-      if (start.toFixed(10) !== stop.toFixed(10)) {
-        // if the mode specified is PIE or null, push the mid point of the arc in vertices
-        if (mode === constants.PIE || typeof mode === 'undefined') {
-          this.vertices.push(new p5.Vector(0.5, 0.5, 0));
-          this.uvs.push([0.5, 0.5]);
-        }
-
-        // vertices for the perimeter of the circle
-        for (let i = 0; i <= detail; i++) {
-          const u = i / detail;
-          const theta = (stop - start) * u + start;
-
-          const _x = 0.5 + Math.cos(theta) / 2;
-          const _y = 0.5 + Math.sin(theta) / 2;
-
-          this.vertices.push(new p5.Vector(_x, _y, 0));
-          this.uvs.push([_x, _y]);
-
-          if (i < detail - 1) {
-            this.faces.push([0, i + 1, i + 2]);
-            this.edges.push([i + 1, i + 2]);
-          }
-        }
-
-        // check the mode specified in order to push vertices and faces, different for each mode
-        switch (mode) {
-          case constants.PIE:
-            this.faces.push([
-              0,
-              this.vertices.length - 2,
-              this.vertices.length - 1
-            ]);
-            this.edges.push([0, 1]);
-            this.edges.push([
-              this.vertices.length - 2,
-              this.vertices.length - 1
-            ]);
-            this.edges.push([0, this.vertices.length - 1]);
-            break;
-
-          case constants.CHORD:
-            this.edges.push([0, 1]);
-            this.edges.push([0, this.vertices.length - 1]);
-            break;
-
-          case constants.OPEN:
-            this.edges.push([0, 1]);
-            break;
-
-          default:
-            this.faces.push([
-              0,
-              this.vertices.length - 2,
-              this.vertices.length - 1
-            ]);
-            this.edges.push([
-              this.vertices.length - 2,
-              this.vertices.length - 1
-            ]);
-        }
-      }
-    };
-
-    const arcGeom = new p5.Geometry(detail, 1, _arc);
-    arcGeom.computeNormals();
-
-    if (detail <= 50) {
-      arcGeom._edgesToVertices(arcGeom);
-    } else if (this.states.doStroke) {
-      console.log(
-        `Cannot apply a stroke to an ${shape} with more than 50 detail`
-      );
-    }
-
-    this.createBuffers(gId, arcGeom);
-  }
-
-  const uModelMatrix = this.states.uModelMatrix.copy();
-
-  try {
-    this.states.uModelMatrix.translate([x, y, 0]);
-    this.states.uModelMatrix.scale(width, height, 1);
-
-    this.drawBuffers(gId);
-  } finally {
-    this.states.uModelMatrix = uModelMatrix;
-  }
-
-  return this;
-};
-
-p5.RendererGL.prototype.rect = function(args) {
-  const x = args[0];
-  const y = args[1];
-  const width = args[2];
-  const height = args[3];
-
-  if (typeof args[4] === 'undefined') {
-    // Use the retained mode for drawing rectangle,
-    // if args for rounding rectangle is not provided by user.
-    const perPixelLighting = this._pInst._glAttributes.perPixelLighting;
-    const detailX = args[4] || (perPixelLighting ? 1 : 24);
-    const detailY = args[5] || (perPixelLighting ? 1 : 16);
-    const gId = `rect|${detailX}|${detailY}`;
-    if (!this.geometryInHash(gId)) {
-      const _rect = function() {
+function primitives3D(p5, fn){
+  /**
+   * Begins adding shapes to a new
+   * <a href="#/p5.Geometry">p5.Geometry</a> object.
+   *
+   * The `beginGeometry()` and <a href="#/p5/endGeometry">endGeometry()</a>
+   * functions help with creating complex 3D shapes from simpler ones such as
+   * <a href="#/p5/sphere">sphere()</a>. `beginGeometry()` begins adding shapes
+   * to a custom <a href="#/p5.Geometry">p5.Geometry</a> object and
+   * <a href="#/p5/endGeometry">endGeometry()</a> stops adding them.
+   *
+   * `beginGeometry()` and <a href="#/p5/endGeometry">endGeometry()</a> can help
+   * to make sketches more performant. For example, if a complex 3D shape
+   * doesn’t change while a sketch runs, then it can be created with
+   * `beginGeometry()` and <a href="#/p5/endGeometry">endGeometry()</a>.
+   * Creating a <a href="#/p5.Geometry">p5.Geometry</a> object once and then
+   * drawing it will run faster than repeatedly drawing the individual pieces.
+   *
+   * See <a href="#/p5/buildGeometry">buildGeometry()</a> for another way to
+   * build 3D shapes.
+   *
+   * Note: `beginGeometry()` can only be used in WebGL mode.
+   *
+   * @method beginGeometry
+   *
+   * @example
+   * <div>
+   * <code>
+   * // Click and drag the mouse to view the scene from different angles.
+   *
+   * let shape;
+   *
+   * function setup() {
+   *   createCanvas(100, 100, WEBGL);
+   *
+   *   // Start building the p5.Geometry object.
+   *   beginGeometry();
+   *
+   *   // Add a cone.
+   *   cone();
+   *
+   *   // Stop building the p5.Geometry object.
+   *   shape = endGeometry();
+   *
+   *   describe('A white cone drawn on a gray background.');
+   * }
+   *
+   * function draw() {
+   *   background(50);
+   *
+   *   // Enable orbiting with the mouse.
+   *   orbitControl();
+   *
+   *   // Turn on the lights.
+   *   lights();
+   *
+   *   // Style the p5.Geometry object.
+   *   noStroke();
+   *
+   *   // Draw the p5.Geometry object.
+   *   model(shape);
+   * }
+   * </code>
+   * </div>
+   *
+   * <div>
+   * <code>
+   * // Click and drag the mouse to view the scene from different angles.
+   *
+   * let shape;
+   *
+   * function setup() {
+   *   createCanvas(100, 100, WEBGL);
+   *
+   *   // Create the p5.Geometry object.
+   *   createArrow();
+   *
+   *   describe('A white arrow drawn on a gray background.');
+   * }
+   *
+   * function draw() {
+   *   background(50);
+   *
+   *   // Enable orbiting with the mouse.
+   *   orbitControl();
+   *
+   *   // Turn on the lights.
+   *   lights();
+   *
+   *   // Style the p5.Geometry object.
+   *   noStroke();
+   *
+   *   // Draw the p5.Geometry object.
+   *   model(shape);
+   * }
+   *
+   * function createArrow() {
+   *   // Start building the p5.Geometry object.
+   *   beginGeometry();
+   *
+   *   // Add shapes.
+   *   push();
+   *   rotateX(PI);
+   *   cone(10);
+   *   translate(0, -10, 0);
+   *   cylinder(3, 20);
+   *   pop();
+   *
+   *   // Stop building the p5.Geometry object.
+   *   shape = endGeometry();
+   * }
+   * </code>
+   * </div>
+   *
+   * <div>
+   * <code>
+   * // Click and drag the mouse to view the scene from different angles.
+   *
+   * let blueArrow;
+   * let redArrow;
+   *
+   * function setup() {
+   *   createCanvas(100, 100, WEBGL);
+   *
+   *   // Create the arrows.
+   *   redArrow = createArrow('red');
+   *   blueArrow = createArrow('blue');
+   *
+   *   describe('A red arrow and a blue arrow drawn on a gray background. The blue arrow rotates slowly.');
+   * }
+   *
+   * function draw() {
+   *   background(200);
+   *
+   *   // Enable orbiting with the mouse.
+   *   orbitControl();
+   *
+   *   // Turn on the lights.
+   *   lights();
+   *
+   *   // Style the arrows.
+   *   noStroke();
+   *
+   *   // Draw the red arrow.
+   *   model(redArrow);
+   *
+   *   // Translate and rotate the coordinate system.
+   *   translate(30, 0, 0);
+   *   rotateZ(frameCount * 0.01);
+   *
+   *   // Draw the blue arrow.
+   *   model(blueArrow);
+   * }
+   *
+   * function createArrow(fillColor) {
+   *   // Start building the p5.Geometry object.
+   *   beginGeometry();
+   *
+   *   fill(fillColor);
+   *
+   *   // Add shapes to the p5.Geometry object.
+   *   push();
+   *   rotateX(PI);
+   *   cone(10);
+   *   translate(0, -10, 0);
+   *   cylinder(3, 20);
+   *   pop();
+   *
+   *   // Stop building the p5.Geometry object.
+   *   let shape = endGeometry();
+   *
+   *   return shape;
+   * }
+   * </code>
+   * </div>
+   *
+   * <div>
+   * <code>
+   * // Click and drag the mouse to view the scene from different angles.
+   *
+   * let button;
+   * let particles;
+   *
+   * function setup() {
+   *   createCanvas(100, 100, WEBGL);
+   *
+   *   // Create a button to reset the particle system.
+   *   button = createButton('Reset');
+   *
+   *   // Call resetModel() when the user presses the button.
+   *   button.mousePressed(resetModel);
+   *
+   *   // Add the original set of particles.
+   *   resetModel();
+   * }
+   *
+   * function draw() {
+   *   background(50);
+   *
+   *   // Enable orbiting with the mouse.
+   *   orbitControl();
+   *
+   *   // Turn on the lights.
+   *   lights();
+   *
+   *   // Style the particles.
+   *   noStroke();
+   *
+   *   // Draw the particles.
+   *   model(particles);
+   * }
+   *
+   * function resetModel() {
+   *   // If the p5.Geometry object has already been created,
+   *   // free those resources.
+   *   if (particles) {
+   *     freeGeometry(particles);
+   *   }
+   *
+   *   // Create a new p5.Geometry object with random spheres.
+   *   particles = createParticles();
+   * }
+   *
+   * function createParticles() {
+   *   // Start building the p5.Geometry object.
+   *   beginGeometry();
+   *
+   *   // Add shapes.
+   *   for (let i = 0; i < 60; i += 1) {
+   *     // Calculate random coordinates.
+   *     let x = randomGaussian(0, 20);
+   *     let y = randomGaussian(0, 20);
+   *     let z = randomGaussian(0, 20);
+   *
+   *     push();
+   *     // Translate to the particle's coordinates.
+   *     translate(x, y, z);
+   *     // Draw the particle.
+   *     sphere(5);
+   *     pop();
+   *   }
+   *
+   *   // Stop building the p5.Geometry object.
+   *   let shape = endGeometry();
+   *
+   *   return shape;
+   * }
+   * </code>
+   * </div>
+   */
+  fn.beginGeometry = function() {
+    return this._renderer.beginGeometry();
+  };
+
+  /**
+   * Stops adding shapes to a new
+   * <a href="#/p5.Geometry">p5.Geometry</a> object and returns the object.
+   *
+   * The `beginGeometry()` and <a href="#/p5/endGeometry">endGeometry()</a>
+   * functions help with creating complex 3D shapes from simpler ones such as
+   * <a href="#/p5/sphere">sphere()</a>. `beginGeometry()` begins adding shapes
+   * to a custom <a href="#/p5.Geometry">p5.Geometry</a> object and
+   * <a href="#/p5/endGeometry">endGeometry()</a> stops adding them.
+   *
+   * `beginGeometry()` and <a href="#/p5/endGeometry">endGeometry()</a> can help
+   * to make sketches more performant. For example, if a complex 3D shape
+   * doesn’t change while a sketch runs, then it can be created with
+   * `beginGeometry()` and <a href="#/p5/endGeometry">endGeometry()</a>.
+   * Creating a <a href="#/p5.Geometry">p5.Geometry</a> object once and then
+   * drawing it will run faster than repeatedly drawing the individual pieces.
+   *
+   * See <a href="#/p5/buildGeometry">buildGeometry()</a> for another way to
+   * build 3D shapes.
+   *
+   * Note: `endGeometry()` can only be used in WebGL mode.
+   *
+   * @method endGeometry
+   * @returns {p5.Geometry} new 3D shape.
+   *
+   * @example
+   * <div>
+   * <code>
+   * // Click and drag the mouse to view the scene from different angles.
+   *
+   * let shape;
+   *
+   * function setup() {
+   *   createCanvas(100, 100, WEBGL);
+   *
+   *   // Start building the p5.Geometry object.
+   *   beginGeometry();
+   *
+   *   // Add a cone.
+   *   cone();
+   *
+   *   // Stop building the p5.Geometry object.
+   *   shape = endGeometry();
+   *
+   *   describe('A white cone drawn on a gray background.');
+   * }
+   *
+   * function draw() {
+   *   background(50);
+   *
+   *   // Enable orbiting with the mouse.
+   *   orbitControl();
+   *
+   *   // Turn on the lights.
+   *   lights();
+   *
+   *   // Style the p5.Geometry object.
+   *   noStroke();
+   *
+   *   // Draw the p5.Geometry object.
+   *   model(shape);
+   * }
+   * </code>
+   * </div>
+   *
+   * <div>
+   * <code>
+   * // Click and drag the mouse to view the scene from different angles.
+   *
+   * let shape;
+   *
+   * function setup() {
+   *   createCanvas(100, 100, WEBGL);
+   *
+   *   // Create the p5.Geometry object.
+   *   createArrow();
+   *
+   *   describe('A white arrow drawn on a gray background.');
+   * }
+   *
+   * function draw() {
+   *   background(50);
+   *
+   *   // Enable orbiting with the mouse.
+   *   orbitControl();
+   *
+   *   // Turn on the lights.
+   *   lights();
+   *
+   *   // Style the p5.Geometry object.
+   *   noStroke();
+   *
+   *   // Draw the p5.Geometry object.
+   *   model(shape);
+   * }
+   *
+   * function createArrow() {
+   *   // Start building the p5.Geometry object.
+   *   beginGeometry();
+   *
+   *   // Add shapes.
+   *   push();
+   *   rotateX(PI);
+   *   cone(10);
+   *   translate(0, -10, 0);
+   *   cylinder(3, 20);
+   *   pop();
+   *
+   *   // Stop building the p5.Geometry object.
+   *   shape = endGeometry();
+   * }
+   * </code>
+   * </div>
+   *
+   * <div>
+   * <code>
+   * // Click and drag the mouse to view the scene from different angles.
+   *
+   * let blueArrow;
+   * let redArrow;
+   *
+   * function setup() {
+   *   createCanvas(100, 100, WEBGL);
+   *
+   *   // Create the arrows.
+   *   redArrow = createArrow('red');
+   *   blueArrow = createArrow('blue');
+   *
+   *   describe('A red arrow and a blue arrow drawn on a gray background. The blue arrow rotates slowly.');
+   * }
+   *
+   * function draw() {
+   *   background(200);
+   *
+   *   // Enable orbiting with the mouse.
+   *   orbitControl();
+   *
+   *   // Turn on the lights.
+   *   lights();
+   *
+   *   // Style the arrows.
+   *   noStroke();
+   *
+   *   // Draw the red arrow.
+   *   model(redArrow);
+   *
+   *   // Translate and rotate the coordinate system.
+   *   translate(30, 0, 0);
+   *   rotateZ(frameCount * 0.01);
+   *
+   *   // Draw the blue arrow.
+   *   model(blueArrow);
+   * }
+   *
+   * function createArrow(fillColor) {
+   *   // Start building the p5.Geometry object.
+   *   beginGeometry();
+   *
+   *   fill(fillColor);
+   *
+   *   // Add shapes to the p5.Geometry object.
+   *   push();
+   *   rotateX(PI);
+   *   cone(10);
+   *   translate(0, -10, 0);
+   *   cylinder(3, 20);
+   *   pop();
+   *
+   *   // Stop building the p5.Geometry object.
+   *   let shape = endGeometry();
+   *
+   *   return shape;
+   * }
+   * </code>
+   * </div>
+   *
+   * <div>
+   * <code>
+   * // Click and drag the mouse to view the scene from different angles.
+   *
+   * let button;
+   * let particles;
+   *
+   * function setup() {
+   *   createCanvas(100, 100, WEBGL);
+   *
+   *   // Create a button to reset the particle system.
+   *   button = createButton('Reset');
+   *
+   *   // Call resetModel() when the user presses the button.
+   *   button.mousePressed(resetModel);
+   *
+   *   // Add the original set of particles.
+   *   resetModel();
+   * }
+   *
+   * function draw() {
+   *   background(50);
+   *
+   *   // Enable orbiting with the mouse.
+   *   orbitControl();
+   *
+   *   // Turn on the lights.
+   *   lights();
+   *
+   *   // Style the particles.
+   *   noStroke();
+   *
+   *   // Draw the particles.
+   *   model(particles);
+   * }
+   *
+   * function resetModel() {
+   *   // If the p5.Geometry object has already been created,
+   *   // free those resources.
+   *   if (particles) {
+   *     freeGeometry(particles);
+   *   }
+   *
+   *   // Create a new p5.Geometry object with random spheres.
+   *   particles = createParticles();
+   * }
+   *
+   * function createParticles() {
+   *   // Start building the p5.Geometry object.
+   *   beginGeometry();
+   *
+   *   // Add shapes.
+   *   for (let i = 0; i < 60; i += 1) {
+   *     // Calculate random coordinates.
+   *     let x = randomGaussian(0, 20);
+   *     let y = randomGaussian(0, 20);
+   *     let z = randomGaussian(0, 20);
+   *
+   *     push();
+   *     // Translate to the particle's coordinates.
+   *     translate(x, y, z);
+   *     // Draw the particle.
+   *     sphere(5);
+   *     pop();
+   *   }
+   *
+   *   // Stop building the p5.Geometry object.
+   *   let shape = endGeometry();
+   *
+   *   return shape;
+   * }
+   * </code>
+   * </div>
+   */
+  fn.endGeometry = function() {
+    return this._renderer.endGeometry();
+  };
+
+  /**
+   * Creates a custom <a href="#/p5.Geometry">p5.Geometry</a> object from
+   * simpler 3D shapes.
+   *
+   * `buildGeometry()` helps with creating complex 3D shapes from simpler ones
+   * such as <a href="#/p5/sphere">sphere()</a>. It can help to make sketches
+   * more performant. For example, if a complex 3D shape doesn’t change while a
+   * sketch runs, then it can be created with `buildGeometry()`. Creating a
+   * <a href="#/p5.Geometry">p5.Geometry</a> object once and then drawing it
+   * will run faster than repeatedly drawing the individual pieces.
+   *
+   * The parameter, `callback`, is a function with the drawing instructions for
+   * the new <a href="#/p5.Geometry">p5.Geometry</a> object. It will be called
+   * once to create the new 3D shape.
+   *
+   * See <a href="#/p5/beginGeometry">beginGeometry()</a> and
+   * <a href="#/p5/endGeometry">endGeometry()</a> for another way to build 3D
+   * shapes.
+   *
+   * Note: `buildGeometry()` can only be used in WebGL mode.
+   *
+   * @method buildGeometry
+   * @param {Function} callback function that draws the shape.
+   * @returns {p5.Geometry} new 3D shape.
+   *
+   * @example
+   * <div>
+   * <code>
+   * // Click and drag the mouse to view the scene from different angles.
+   *
+   * let shape;
+   *
+   * function setup() {
+   *   createCanvas(100, 100, WEBGL);
+   *
+   *   // Create the p5.Geometry object.
+   *   shape = buildGeometry(createShape);
+   *
+   *   describe('A white cone drawn on a gray background.');
+   * }
+   *
+   * function draw() {
+   *   background(50);
+   *
+   *   // Enable orbiting with the mouse.
+   *   orbitControl();
+   *
+   *   // Turn on the lights.
+   *   lights();
+   *
+   *   // Style the p5.Geometry object.
+   *   noStroke();
+   *
+   *   // Draw the p5.Geometry object.
+   *   model(shape);
+   * }
+   *
+   * // Create p5.Geometry object from a single cone.
+   * function createShape() {
+   *   cone();
+   * }
+   * </code>
+   * </div>
+   *
+   * <div>
+   * <code>
+   * // Click and drag the mouse to view the scene from different angles.
+   *
+   * let shape;
+   *
+   * function setup() {
+   *   createCanvas(100, 100, WEBGL);
+   *
+   *   // Create the arrow.
+   *   shape = buildGeometry(createArrow);
+   *
+   *   describe('A white arrow drawn on a gray background.');
+   * }
+   *
+   * function draw() {
+   *   background(50);
+   *
+   *   // Enable orbiting with the mouse.
+   *   orbitControl();
+   *
+   *   // Turn on the lights.
+   *   lights();
+   *
+   *   // Style the arrow.
+   *   noStroke();
+   *
+   *   // Draw the arrow.
+   *   model(shape);
+   * }
+   *
+   * function createArrow() {
+   *   // Add shapes to the p5.Geometry object.
+   *   push();
+   *   rotateX(PI);
+   *   cone(10);
+   *   translate(0, -10, 0);
+   *   cylinder(3, 20);
+   *   pop();
+   * }
+   * </code>
+   * </div>
+   *
+   * <div>
+   * <code>
+   * // Click and drag the mouse to view the scene from different angles.
+   *
+   * let shape;
+   *
+   * function setup() {
+   *   createCanvas(100, 100, WEBGL);
+   *
+   *   // Create the p5.Geometry object.
+   *   shape = buildGeometry(createArrow);
+   *
+   *   describe('Two white arrows drawn on a gray background. The arrow on the right rotates slowly.');
+   * }
+   *
+   * function draw() {
+   *   background(50);
+   *
+   *   // Enable orbiting with the mouse.
+   *   orbitControl();
+   *
+   *   // Turn on the lights.
+   *   lights();
+   *
+   *   // Style the arrows.
+   *   noStroke();
+   *
+   *   // Draw the p5.Geometry object.
+   *   model(shape);
+   *
+   *   // Translate and rotate the coordinate system.
+   *   translate(30, 0, 0);
+   *   rotateZ(frameCount * 0.01);
+   *
+   *   // Draw the p5.Geometry object again.
+   *   model(shape);
+   * }
+   *
+   * function createArrow() {
+   *   // Add shapes to the p5.Geometry object.
+   *   push();
+   *   rotateX(PI);
+   *   cone(10);
+   *   translate(0, -10, 0);
+   *   cylinder(3, 20);
+   *   pop();
+   * }
+   * </code>
+   * </div>
+   *
+   * <div>
+   * <code>
+   * // Click and drag the mouse to view the scene from different angles.
+   *
+   * let button;
+   * let particles;
+   *
+   * function setup() {
+   *   createCanvas(100, 100, WEBGL);
+   *
+   *   // Create a button to reset the particle system.
+   *   button = createButton('Reset');
+   *
+   *   // Call resetModel() when the user presses the button.
+   *   button.mousePressed(resetModel);
+   *
+   *   // Add the original set of particles.
+   *   resetModel();
+   *
+   *   describe('A set of white spheres on a gray background. The spheres are positioned randomly. Their positions reset when the user presses the Reset button.');
+   * }
+   *
+   * function draw() {
+   *   background(50);
+   *
+   *   // Enable orbiting with the mouse.
+   *   orbitControl();
+   *
+   *   // Turn on the lights.
+   *   lights();
+   *
+   *   // Style the particles.
+   *   noStroke();
+   *
+   *   // Draw the particles.
+   *   model(particles);
+   * }
+   *
+   * function resetModel() {
+   *   // If the p5.Geometry object has already been created,
+   *   // free those resources.
+   *   if (particles) {
+   *     freeGeometry(particles);
+   *   }
+   *
+   *   // Create a new p5.Geometry object with random spheres.
+   *   particles = buildGeometry(createParticles);
+   * }
+   *
+   * function createParticles() {
+   *   for (let i = 0; i < 60; i += 1) {
+   *     // Calculate random coordinates.
+   *     let x = randomGaussian(0, 20);
+   *     let y = randomGaussian(0, 20);
+   *     let z = randomGaussian(0, 20);
+   *
+   *     push();
+   *     // Translate to the particle's coordinates.
+   *     translate(x, y, z);
+   *     // Draw the particle.
+   *     sphere(5);
+   *     pop();
+   *   }
+   * }
+   * </code>
+   * </div>
+   */
+  fn.buildGeometry = function(callback) {
+    return this._renderer.buildGeometry(callback);
+  };
+
+  /**
+   * Clears a <a href="#/p5.Geometry">p5.Geometry</a> object from the graphics
+   * processing unit (GPU) memory.
+   *
+   * <a href="#/p5.Geometry">p5.Geometry</a> objects can contain lots of data
+   * about their vertices, surface normals, colors, and so on. Complex 3D shapes
+   * can use lots of memory which is a limited resource in many GPUs. Calling
+   * `freeGeometry()` can improve performance by freeing a
+   * <a href="#/p5.Geometry">p5.Geometry</a> object’s resources from GPU memory.
+   * `freeGeometry()` works with <a href="#/p5.Geometry">p5.Geometry</a> objects
+   * created with <a href="#/p5/beginGeometry">beginGeometry()</a> and
+   * <a href="#/p5/endGeometry">endGeometry()</a>,
+   * <a href="#/p5/buildGeometry">buildGeometry()</a>, and
+   * <a href="#/p5/loadModel">loadModel()</a>.
+   *
+   * The parameter, `geometry`, is the <a href="#/p5.Geometry">p5.Geometry</a>
+   * object to be freed.
+   *
+   * Note: A <a href="#/p5.Geometry">p5.Geometry</a> object can still be drawn
+   * after its resources are cleared from GPU memory. It may take longer to draw
+   * the first time it’s redrawn.
+   *
+   * Note: `freeGeometry()` can only be used in WebGL mode.
+   *
+   * @method freeGeometry
+   * @param {p5.Geometry} geometry 3D shape whose resources should be freed.
+   *
+   * @example
+   * <div>
+   * <code>
+   * function setup() {
+   *   createCanvas(100, 100, WEBGL);
+   *
+   *   background(200);
+   *
+   *   // Create a p5.Geometry object.
+   *   beginGeometry();
+   *   cone();
+   *   let shape = endGeometry();
+   *
+   *   // Draw the shape.
+   *   model(shape);
+   *
+   *   // Free the shape's resources.
+   *   freeGeometry(shape);
+   * }
+   * </code>
+   * </div>
+   *
+   * <div>
+   * <code>
+   * // Click and drag the mouse to view the scene from different angles.
+   *
+   * let button;
+   * let particles;
+   *
+   * function setup() {
+   *   createCanvas(100, 100, WEBGL);
+   *
+   *   // Create a button to reset the particle system.
+   *   button = createButton('Reset');
+   *
+   *   // Call resetModel() when the user presses the button.
+   *   button.mousePressed(resetModel);
+   *
+   *   // Add the original set of particles.
+   *   resetModel();
+   * }
+   *
+   * function draw() {
+   *   background(50);
+   *
+   *   // Enable orbiting with the mouse.
+   *   orbitControl();
+   *
+   *   // Turn on the lights.
+   *   lights();
+   *
+   *   // Style the particles.
+   *   noStroke();
+   *
+   *   // Draw the particles.
+   *   model(particles);
+   * }
+   *
+   * function resetModel() {
+   *   // If the p5.Geometry object has already been created,
+   *   // free those resources.
+   *   if (particles) {
+   *     freeGeometry(particles);
+   *   }
+   *
+   *   // Create a new p5.Geometry object with random spheres.
+   *   particles = buildGeometry(createParticles);
+   * }
+   *
+   * function createParticles() {
+   *   for (let i = 0; i < 60; i += 1) {
+   *     // Calculate random coordinates.
+   *     let x = randomGaussian(0, 20);
+   *     let y = randomGaussian(0, 20);
+   *     let z = randomGaussian(0, 20);
+   *
+   *     push();
+   *     // Translate to the particle's coordinates.
+   *     translate(x, y, z);
+   *     // Draw the particle.
+   *     sphere(5);
+   *     pop();
+   *   }
+   * }
+   * </code>
+   * </div>
+   */
+  fn.freeGeometry = function(geometry) {
+    this._renderer._freeBuffers(geometry.gid);
+  };
+
+  /**
+   * Draws a plane.
+   *
+   * A plane is a four-sided, flat shape with every angle measuring 90˚. It’s
+   * similar to a rectangle and offers advanced drawing features in WebGL mode.
+   *
+   * The first parameter, `width`, is optional. If a `Number` is passed, as in
+   * `plane(20)`, it sets the plane’s width and height. By default, `width` is
+   * 50.
+   *
+   * The second parameter, `height`, is also optional. If a `Number` is passed,
+   * as in `plane(20, 30)`, it sets the plane’s height. By default, `height` is
+   * set to the plane’s `width`.
+   *
+   * The third parameter, `detailX`, is also optional. If a `Number` is passed,
+   * as in `plane(20, 30, 5)` it sets the number of triangle subdivisions to use
+   * along the x-axis. All 3D shapes are made by connecting triangles to form
+   * their surfaces. By default, `detailX` is 1.
+   *
+   * The fourth parameter, `detailY`, is also optional. If a `Number` is passed,
+   * as in `plane(20, 30, 5, 7)` it sets the number of triangle subdivisions to
+   * use along the y-axis. All 3D shapes are made by connecting triangles to
+   * form their surfaces. By default, `detailY` is 1.
+   *
+   * Note: `plane()` can only be used in WebGL mode.
+   *
+   * @method plane
+   * @param  {Number} [width]    width of the plane.
+   * @param  {Number} [height]   height of the plane.
+   * @param  {Integer} [detailX] number of triangle subdivisions along the x-axis.
+   * @param {Integer} [detailY]  number of triangle subdivisions along the y-axis.
+   * @chainable
+   *
+   * @example
+   * <div>
+   * <code>
+   * // Click and drag the mouse to view the scene from different angles.
+   *
+   * function setup() {
+   *   createCanvas(100, 100, WEBGL);
+   *
+   *   describe('A white plane on a gray background.');
+   * }
+   *
+   * function draw() {
+   *   background(200);
+   *
+   *   // Enable orbiting with the mouse.
+   *   orbitControl();
+   *
+   *   // Draw the plane.
+   *   plane();
+   * }
+   * </code>
+   * </div>
+   *
+   * <div>
+   * <code>
+   * // Click and drag the mouse to view the scene from different angles.
+   *
+   * function setup() {
+   *   createCanvas(100, 100, WEBGL);
+   *
+   *   describe('A white plane on a gray background.');
+   * }
+   *
+   * function draw() {
+   *   background(200);
+   *
+   *   // Enable orbiting with the mouse.
+   *   orbitControl();
+   *
+   *   // Draw the plane.
+   *   // Set its width and height to 30.
+   *   plane(30);
+   * }
+   * </code>
+   * </div>
+   *
+   * <div>
+   * <code>
+   * // Click and drag the mouse to view the scene from different angles.
+   *
+   * function setup() {
+   *   createCanvas(100, 100, WEBGL);
+   *
+   *   describe('A white plane on a gray background.');
+   * }
+   *
+   * function draw() {
+   *   background(200);
+   *
+   *   // Enable orbiting with the mouse.
+   *   orbitControl();
+   *
+   *   // Draw the plane.
+   *   // Set its width to 30 and height to 50.
+   *   plane(30, 50);
+   * }
+   * </code>
+   * </div>
+   */
+  fn.plane = function(
+    width = 50,
+    height = width,
+    detailX = 1,
+    detailY = 1
+  ) {
+    this._assert3d('plane');
+    p5._validateParameters('plane', arguments);
+
+    const gId = `plane|${detailX}|${detailY}`;
+
+    if (!this._renderer.geometryInHash(gId)) {
+      const _plane = function() {
+        let u, v, p;
         for (let i = 0; i <= this.detailY; i++) {
-          const v = i / this.detailY;
+          v = i / this.detailY;
           for (let j = 0; j <= this.detailX; j++) {
-            const u = j / this.detailX;
-            const p = new p5.Vector(u, v, 0);
+            u = j / this.detailX;
+            p = new p5.Vector(u - 0.5, v - 0.5, 0);
             this.vertices.push(p);
             this.uvs.push(u, v);
           }
         }
-        // using stroke indices to avoid stroke over face(s) of rectangle
-        if (detailX > 0 && detailY > 0) {
-          this.edges = [
-            [0, detailX],
-            [detailX, (detailX + 1) * (detailY + 1) - 1],
-            [(detailX + 1) * (detailY + 1) - 1, (detailX + 1) * detailY],
-            [(detailX + 1) * detailY, 0]
-          ];
-        }
       };
-      const rectGeom = new p5.Geometry(detailX, detailY, _rect);
-      rectGeom
-        .computeFaces()
-        .computeNormals()
-        ._edgesToVertices();
-      this.createBuffers(gId, rectGeom);
+      const planeGeom = new p5.Geometry(detailX, detailY, _plane);
+      planeGeom.computeFaces().computeNormals();
+      if (detailX <= 1 && detailY <= 1) {
+        planeGeom._makeTriangleEdges()._edgesToVertices();
+      } else if (this._renderer.states.doStroke) {
+        console.log(
+          'Cannot draw stroke on plane objects with more' +
+          ' than 1 detailX or 1 detailY'
+        );
+      }
+      this._renderer.createBuffers(gId, planeGeom);
     }
 
-    // only a single rectangle (of a given detail) is cached: a square with
-    // opposite corners at (0,0) & (1,1).
+    this._renderer.drawBuffersScaled(gId, width, height, 1);
+    return this;
+  };
+
+  /**
+   * Draws a box (rectangular prism).
+   *
+   * A box is a 3D shape with six faces. Each face makes a 90˚ with four
+   * neighboring faces.
+   *
+   * The first parameter, `width`, is optional. If a `Number` is passed, as in
+   * `box(20)`, it sets the box’s width and height. By default, `width` is 50.
+   *
+   * The second parameter, `height`, is also optional. If a `Number` is passed,
+   * as in `box(20, 30)`, it sets the box’s height. By default, `height` is set
+   * to the box’s `width`.
+   *
+   * The third parameter, `depth`, is also optional. If a `Number` is passed, as
+   * in `box(20, 30, 40)`, it sets the box’s depth. By default, `depth` is set
+   * to the box’s `height`.
+   *
+   * The fourth parameter, `detailX`, is also optional. If a `Number` is passed,
+   * as in `box(20, 30, 40, 5)`, it sets the number of triangle subdivisions to
+   * use along the x-axis. All 3D shapes are made by connecting triangles to
+   * form their surfaces. By default, `detailX` is 1.
+   *
+   * The fifth parameter, `detailY`, is also optional. If a number is passed, as
+   * in `box(20, 30, 40, 5, 7)`, it sets the number of triangle subdivisions to
+   * use along the y-axis. All 3D shapes are made by connecting triangles to
+   * form their surfaces. By default, `detailY` is 1.
+   *
+   * Note: `box()` can only be used in WebGL mode.
+   *
+   * @method  box
+   * @param  {Number} [width]     width of the box.
+   * @param  {Number} [height]    height of the box.
+   * @param  {Number} [depth]     depth of the box.
+   * @param {Integer} [detailX]   number of triangle subdivisions along the x-axis.
+   * @param {Integer} [detailY]   number of triangle subdivisions along the y-axis.
+   * @chainable
+   *
+   * @example
+   * <div>
+   * <code>
+   * // Click and drag the mouse to view the scene from different angles.
+   *
+   * function setup() {
+   *   createCanvas(100, 100, WEBGL);
+   *
+   *   describe('A white box on a gray background.');
+   * }
+   *
+   * function draw() {
+   *   background(200);
+   *
+   *   // Enable orbiting with the mouse.
+   *   orbitControl();
+   *
+   *   // Draw the box.
+   *   box();
+   * }
+   * </code>
+   * </div>
+   *
+   * <div>
+   * <code>
+   * // Click and drag the mouse to view the scene from different angles.
+   *
+   * function setup() {
+   *   createCanvas(100, 100, WEBGL);
+   *
+   *   describe('A white box on a gray background.');
+   * }
+   *
+   * function draw() {
+   *   background(200);
+   *
+   *   // Enable orbiting with the mouse.
+   *   orbitControl();
+   *
+   *   // Draw the box.
+   *   // Set its width and height to 30.
+   *   box(30);
+   * }
+   * </code>
+   * </div>
+   *
+   * <div>
+   * <code>
+   * // Click and drag the mouse to view the scene from different angles.
+   *
+   * function setup() {
+   *   createCanvas(100, 100, WEBGL);
+   *
+   *   describe('A white box on a gray background.');
+   * }
+   *
+   * function draw() {
+   *   background(200);
+   *
+   *   // Enable orbiting with the mouse.
+   *   orbitControl();
+   *
+   *   // Draw the box.
+   *   // Set its width to 30 and height to 50.
+   *   box(30, 50);
+   * }
+   * </code>
+   * </div>
+   *
+   * <div>
+   * <code>
+   * // Click and drag the mouse to view the scene from different angles.
+   *
+   * function setup() {
+   *   createCanvas(100, 100, WEBGL);
+   *
+   *   describe('A white box on a gray background.');
+   * }
+   *
+   * function draw() {
+   *   background(200);
+   *
+   *   // Enable orbiting with the mouse.
+   *   orbitControl();
+   *
+   *   // Draw the box.
+   *   // Set its width to 30, height to 50, and depth to 10.
+   *   box(30, 50, 10);
+   * }
+   * </code>
+   * </div>
+   */
+  fn.box = function(width, height, depth, detailX, detailY) {
+    this._assert3d('box');
+    p5._validateParameters('box', arguments);
+    if (typeof width === 'undefined') {
+      width = 50;
+    }
+    if (typeof height === 'undefined') {
+      height = width;
+    }
+    if (typeof depth === 'undefined') {
+      depth = height;
+    }
+
+    const perPixelLighting =
+      this._renderer.attributes && this._renderer.attributes.perPixelLighting;
+    if (typeof detailX === 'undefined') {
+      detailX = perPixelLighting ? 1 : 4;
+    }
+    if (typeof detailY === 'undefined') {
+      detailY = perPixelLighting ? 1 : 4;
+    }
+
+    const gId = `box|${detailX}|${detailY}`;
+    if (!this._renderer.geometryInHash(gId)) {
+      const _box = function() {
+        const cubeIndices = [
+          [0, 4, 2, 6], // -1, 0, 0],// -x
+          [1, 3, 5, 7], // +1, 0, 0],// +x
+          [0, 1, 4, 5], // 0, -1, 0],// -y
+          [2, 6, 3, 7], // 0, +1, 0],// +y
+          [0, 2, 1, 3], // 0, 0, -1],// -z
+          [4, 5, 6, 7] // 0, 0, +1] // +z
+        ];
+        //using custom edges
+        //to avoid diagonal stroke lines across face of box
+        this.edges = [
+          [0, 1],
+          [1, 3],
+          [3, 2],
+          [6, 7],
+          [8, 9],
+          [9, 11],
+          [14, 15],
+          [16, 17],
+          [17, 19],
+          [18, 19],
+          [20, 21],
+          [22, 23]
+        ];
+
+        cubeIndices.forEach((cubeIndex, i) => {
+          const v = i * 4;
+          for (let j = 0; j < 4; j++) {
+            const d = cubeIndex[j];
+            //inspired by lightgl:
+            //https://github.com/evanw/lightgl.js
+            //octants:https://en.wikipedia.org/wiki/Octant_(solid_geometry)
+            const octant = new p5.Vector(
+              ((d & 1) * 2 - 1) / 2,
+              ((d & 2) - 1) / 2,
+              ((d & 4) / 2 - 1) / 2
+            );
+            this.vertices.push(octant);
+            this.uvs.push(j & 1, (j & 2) / 2);
+          }
+          this.faces.push([v, v + 1, v + 2]);
+          this.faces.push([v + 2, v + 1, v + 3]);
+        });
+      };
+      const boxGeom = new p5.Geometry(detailX, detailY, _box);
+      boxGeom.computeNormals();
+      if (detailX <= 4 && detailY <= 4) {
+        boxGeom._edgesToVertices();
+      } else if (this._renderer.states.doStroke) {
+        console.log(
+          'Cannot draw stroke on box objects with more' +
+          ' than 4 detailX or 4 detailY'
+        );
+      }
+      //initialize our geometry buffer with
+      //the key val pair:
+      //geometry Id, Geom object
+      this._renderer.createBuffers(gId, boxGeom);
+    }
+    this._renderer.drawBuffersScaled(gId, width, height, depth);
+
+    return this;
+  };
+
+  /**
+   * Draws a sphere.
+   *
+   * A sphere is a 3D shape with triangular faces that connect to form a round
+   * surface. Spheres with few faces look like crystals. Spheres with many faces
+   * have smooth surfaces and look like balls.
+   *
+   * The first parameter, `radius`, is optional. If a `Number` is passed, as in
+   * `sphere(20)`, it sets the radius of the sphere. By default, `radius` is 50.
+   *
+   * The second parameter, `detailX`, is also optional. If a `Number` is passed,
+   * as in `sphere(20, 5)`, it sets the number of triangle subdivisions to use
+   * along the x-axis. All 3D shapes are made by connecting triangles to form
+   * their surfaces. By default, `detailX` is 24.
+   *
+   * The third parameter, `detailY`, is also optional. If a `Number` is passed,
+   * as in `sphere(20, 5, 2)`, it sets the number of triangle subdivisions to
+   * use along the y-axis. All 3D shapes are made by connecting triangles to
+   * form their surfaces. By default, `detailY` is 16.
+   *
+   * Note: `sphere()` can only be used in WebGL mode.
+   *
+   * @method sphere
+   * @param  {Number} [radius]   radius of the sphere. Defaults to 50.
+   * @param  {Integer} [detailX] number of triangle subdivisions along the x-axis. Defaults to 24.
+   * @param  {Integer} [detailY] number of triangle subdivisions along the y-axis. Defaults to 16.
+   *
+   * @chainable
+   * @example
+   * <div>
+   * <code>
+   * // Click and drag the mouse to view the scene from different angles.
+   *
+   * function setup() {
+   *   createCanvas(100, 100, WEBGL);
+   *
+   *   describe('A white sphere on a gray background.');
+   * }
+   *
+   * function draw() {
+   *   background(200);
+   *
+   *   // Enable orbiting with the mouse.
+   *   orbitControl();
+   *
+   *   // Draw the sphere.
+   *   sphere();
+   * }
+   * </code>
+   * </div>
+   *
+   * <div>
+   * <code>
+   * // Click and drag the mouse to view the scene from different angles.
+   *
+   * function setup() {
+   *   createCanvas(100, 100, WEBGL);
+   *
+   *   describe('A white sphere on a gray background.');
+   * }
+   *
+   * function draw() {
+   *   background(200);
+   *
+   *   // Enable orbiting with the mouse.
+   *   orbitControl();
+   *
+   *   // Draw the sphere.
+   *   // Set its radius to 30.
+   *   sphere(30);
+   * }
+   * </code>
+   * </div>
+   *
+   * <div>
+   * <code>
+   * // Click and drag the mouse to view the scene from different angles.
+   *
+   * function setup() {
+   *   createCanvas(100, 100, WEBGL);
+   *
+   *   describe('A white sphere on a gray background.');
+   * }
+   *
+   * function draw() {
+   *   background(200);
+   *
+   *   // Enable orbiting with the mouse.
+   *   orbitControl();
+   *
+   *   // Draw the sphere.
+   *   // Set its radius to 30.
+   *   // Set its detailX to 6.
+   *   sphere(30, 6);
+   * }
+   * </code>
+   * </div>
+   *
+   * <div>
+   * <code>
+   * // Click and drag the mouse to view the scene from different angles.
+   *
+   * function setup() {
+   *   createCanvas(100, 100, WEBGL);
+   *
+   *   describe('A white sphere on a gray background.');
+   * }
+   *
+   * function draw() {
+   *   background(200);
+   *
+   *   // Enable orbiting with the mouse.
+   *   orbitControl();
+   *
+   *   // Draw the sphere.
+   *   // Set its radius to 30.
+   *   // Set its detailX to 24.
+   *   // Set its detailY to 4.
+   *   sphere(30, 24, 4);
+   * }
+   * </code>
+   * </div>
+   */
+  fn.sphere = function(radius = 50, detailX = 24, detailY = 16) {
+    this._assert3d('sphere');
+    p5._validateParameters('sphere', arguments);
+
+    this.ellipsoid(radius, radius, radius, detailX, detailY);
+
+    return this;
+  };
+
+  /**
+   * @private
+   * Helper function for creating both cones and cylinders
+   * Will only generate well-defined geometry when bottomRadius, height > 0
+   * and topRadius >= 0
+   * If topRadius == 0, topCap should be false
+   */
+  const _truncatedCone = function(
+    bottomRadius,
+    topRadius,
+    height,
+    detailX,
+    detailY,
+    bottomCap,
+    topCap
+  ) {
+    bottomRadius = bottomRadius <= 0 ? 1 : bottomRadius;
+    topRadius = topRadius < 0 ? 0 : topRadius;
+    height = height <= 0 ? bottomRadius : height;
+    detailX = detailX < 3 ? 3 : detailX;
+    detailY = detailY < 1 ? 1 : detailY;
+    bottomCap = bottomCap === undefined ? true : bottomCap;
+    topCap = topCap === undefined ? topRadius !== 0 : topCap;
+    const start = bottomCap ? -2 : 0;
+    const end = detailY + (topCap ? 2 : 0);
+    //ensure constant slant for interior vertex normals
+    const slant = Math.atan2(bottomRadius - topRadius, height);
+    const sinSlant = Math.sin(slant);
+    const cosSlant = Math.cos(slant);
+    let yy, ii, jj;
+    for (yy = start; yy <= end; ++yy) {
+      let v = yy / detailY;
+      let y = height * v;
+      let ringRadius;
+      if (yy < 0) {
+        //for the bottomCap edge
+        y = 0;
+        v = 0;
+        ringRadius = bottomRadius;
+      } else if (yy > detailY) {
+        //for the topCap edge
+        y = height;
+        v = 1;
+        ringRadius = topRadius;
+      } else {
+        //for the middle
+        ringRadius = bottomRadius + (topRadius - bottomRadius) * v;
+      }
+      if (yy === -2 || yy === detailY + 2) {
+        //center of bottom or top caps
+        ringRadius = 0;
+      }
+
+      y -= height / 2; //shift coordiate origin to the center of object
+      for (ii = 0; ii < detailX; ++ii) {
+        const u = ii / (detailX - 1);
+        const ur = 2 * Math.PI * u;
+        const sur = Math.sin(ur);
+        const cur = Math.cos(ur);
+
+        //VERTICES
+        this.vertices.push(new p5.Vector(sur * ringRadius, y, cur * ringRadius));
+
+        //VERTEX NORMALS
+        let vertexNormal;
+        if (yy < 0) {
+          vertexNormal = new p5.Vector(0, -1, 0);
+        } else if (yy > detailY && topRadius) {
+          vertexNormal = new p5.Vector(0, 1, 0);
+        } else {
+          vertexNormal = new p5.Vector(sur * cosSlant, sinSlant, cur * cosSlant);
+        }
+        this.vertexNormals.push(vertexNormal);
+        //UVs
+        this.uvs.push(u, v);
+      }
+    }
+
+    let startIndex = 0;
+    if (bottomCap) {
+      for (jj = 0; jj < detailX; ++jj) {
+        const nextjj = (jj + 1) % detailX;
+        this.faces.push([
+          startIndex + jj,
+          startIndex + detailX + nextjj,
+          startIndex + detailX + jj
+        ]);
+      }
+      startIndex += detailX * 2;
+    }
+    for (yy = 0; yy < detailY; ++yy) {
+      for (ii = 0; ii < detailX; ++ii) {
+        const nextii = (ii + 1) % detailX;
+        this.faces.push([
+          startIndex + ii,
+          startIndex + nextii,
+          startIndex + detailX + nextii
+        ]);
+        this.faces.push([
+          startIndex + ii,
+          startIndex + detailX + nextii,
+          startIndex + detailX + ii
+        ]);
+      }
+      startIndex += detailX;
+    }
+    if (topCap) {
+      startIndex += detailX;
+      for (ii = 0; ii < detailX; ++ii) {
+        this.faces.push([
+          startIndex + ii,
+          startIndex + (ii + 1) % detailX,
+          startIndex + detailX
+        ]);
+      }
+    }
+  };
+
+  /**
+   * Draws a cylinder.
+   *
+   * A cylinder is a 3D shape with triangular faces that connect a flat bottom
+   * to a flat top. Cylinders with few faces look like boxes. Cylinders with
+   * many faces have smooth surfaces.
+   *
+   * The first parameter, `radius`, is optional. If a `Number` is passed, as in
+   * `cylinder(20)`, it sets the radius of the cylinder’s base. By default,
+   * `radius` is 50.
+   *
+   * The second parameter, `height`, is also optional. If a `Number` is passed,
+   * as in `cylinder(20, 30)`, it sets the cylinder’s height. By default,
+   * `height` is set to the cylinder’s `radius`.
+   *
+   * The third parameter, `detailX`, is also optional. If a `Number` is passed,
+   * as in `cylinder(20, 30, 5)`, it sets the number of edges used to form the
+   * cylinder's top and bottom. Using more edges makes the top and bottom look
+   * more like circles. By default, `detailX` is 24.
+   *
+   * The fourth parameter, `detailY`, is also optional. If a `Number` is passed,
+   * as in `cylinder(20, 30, 5, 2)`, it sets the number of triangle subdivisions
+   * to use along the y-axis, between cylinder's the top and bottom. All 3D
+   * shapes are made by connecting triangles to form their surfaces. By default,
+   * `detailY` is 1.
+   *
+   * The fifth parameter, `bottomCap`, is also optional. If a `false` is passed,
+   * as in `cylinder(20, 30, 5, 2, false)` the cylinder’s bottom won’t be drawn.
+   * By default, `bottomCap` is `true`.
+   *
+   * The sixth parameter, `topCap`, is also optional. If a `false` is passed, as
+   * in `cylinder(20, 30, 5, 2, false, false)` the cylinder’s top won’t be
+   * drawn. By default, `topCap` is `true`.
+   *
+   * Note: `cylinder()` can only be used in WebGL mode.
+   *
+   * @method cylinder
+   * @param  {Number}  [radius]    radius of the cylinder. Defaults to 50.
+   * @param  {Number}  [height]    height of the cylinder. Defaults to the value of `radius`.
+   * @param  {Integer} [detailX]   number of edges along the top and bottom. Defaults to 24.
+   * @param  {Integer} [detailY]   number of triangle subdivisions along the y-axis. Defaults to 1.
+   * @param  {Boolean} [bottomCap] whether to draw the cylinder's bottom. Defaults to `true`.
+   * @param  {Boolean} [topCap]    whether to draw the cylinder's top. Defaults to `true`.
+   * @chainable
+   *
+   * @example
+   * <div>
+   * <code>
+   * // Click and drag the mouse to view the scene from different angles.
+   *
+   * function setup() {
+   *   createCanvas(100, 100, WEBGL);
+   *
+   *   describe('A white cylinder on a gray background.');
+   * }
+   *
+   * function draw() {
+   *   background(200);
+   *
+   *   // Enable orbiting with the mouse.
+   *   orbitControl();
+   *
+   *   // Draw the cylinder.
+   *   cylinder();
+   * }
+   * </code>
+   * </div>
+   *
+   * <div>
+   * <code>
+   * // Click and drag the mouse to view the scene from different angles.
+   *
+   * function setup() {
+   *   createCanvas(100, 100, WEBGL);
+   *
+   *   describe('A white cylinder on a gray background.');
+   * }
+   *
+   * function draw() {
+   *   background(200);
+   *
+   *   // Enable orbiting with the mouse.
+   *   orbitControl();
+   *
+   *   // Draw the cylinder.
+   *   // Set its radius and height to 30.
+   *   cylinder(30);
+   * }
+   * </code>
+   * </div>
+   *
+   * <div>
+   * <code>
+   * // Click and drag the mouse to view the scene from different angles.
+   *
+   * function setup() {
+   *   createCanvas(100, 100, WEBGL);
+   *
+   *   describe('A white cylinder on a gray background.');
+   * }
+   *
+   * function draw() {
+   *   background(200);
+   *
+   *   // Enable orbiting with the mouse.
+   *   orbitControl();
+   *
+   *   // Draw the cylinder.
+   *   // Set its radius to 30 and height to 50.
+   *   cylinder(30, 50);
+   * }
+   * </code>
+   * </div>
+   *
+   * <div>
+   * <code>
+   * // Click and drag the mouse to view the scene from different angles.
+   *
+   * function setup() {
+   *   createCanvas(100, 100, WEBGL);
+   *
+   *   describe('A white box on a gray background.');
+   * }
+   *
+   * function draw() {
+   *   background(200);
+   *
+   *   // Enable orbiting with the mouse.
+   *   orbitControl();
+   *
+   *   // Draw the cylinder.
+   *   // Set its radius to 30 and height to 50.
+   *   // Set its detailX to 5.
+   *   cylinder(30, 50, 5);
+   * }
+   * </code>
+   * </div>
+   *
+   * <div>
+   * <code>
+   * // Click and drag the mouse to view the scene from different angles.
+   *
+   * function setup() {
+   *   createCanvas(100, 100, WEBGL);
+   *
+   *   describe('A white cylinder on a gray background.');
+   * }
+   *
+   * function draw() {
+   *   background(200);
+   *
+   *   // Enable orbiting with the mouse.
+   *   orbitControl();
+   *
+   *   // Draw the cylinder.
+   *   // Set its radius to 30 and height to 50.
+   *   // Set its detailX to 24 and detailY to 2.
+   *   cylinder(30, 50, 24, 2);
+   * }
+   * </code>
+   * </div>
+   *
+   * <div>
+   * <code>
+   * // Click and drag the mouse to view the scene from different angles.
+   *
+   * function setup() {
+   *   createCanvas(100, 100, WEBGL);
+   *
+   *   describe('A white cylinder on a gray background. Its top is missing.');
+   * }
+   *
+   * function draw() {
+   *   background(200);
+   *
+   *   // Enable orbiting with the mouse.
+   *   orbitControl();
+   *
+   *   // Draw the cylinder.
+   *   // Set its radius to 30 and height to 50.
+   *   // Set its detailX to 24 and detailY to 1.
+   *   // Don't draw its bottom.
+   *   cylinder(30, 50, 24, 1, false);
+   * }
+   * </code>
+   * </div>
+   *
+   * <div>
+   * <code>
+   * // Click and drag the mouse to view the scene from different angles.
+   *
+   * function setup() {
+   *   createCanvas(100, 100, WEBGL);
+   *
+   *   describe('A white cylinder on a gray background. Its top and bottom are missing.');
+   * }
+   *
+   * function draw() {
+   *   background(200);
+   *
+   *   // Enable orbiting with the mouse.
+   *   orbitControl();
+   *
+   *   // Draw the cylinder.
+   *   // Set its radius to 30 and height to 50.
+   *   // Set its detailX to 24 and detailY to 1.
+   *   // Don't draw its bottom or top.
+   *   cylinder(30, 50, 24, 1, false, false);
+   * }
+   * </code>
+   * </div>
+   */
+  fn.cylinder = function(
+    radius = 50,
+    height = radius,
+    detailX = 24,
+    detailY = 1,
+    bottomCap = true,
+    topCap = true
+  ) {
+    this._assert3d('cylinder');
+    p5._validateParameters('cylinder', arguments);
+
+    const gId = `cylinder|${detailX}|${detailY}|${bottomCap}|${topCap}`;
+    if (!this._renderer.geometryInHash(gId)) {
+      const cylinderGeom = new p5.Geometry(detailX, detailY);
+      _truncatedCone.call(
+        cylinderGeom,
+        1,
+        1,
+        1,
+        detailX,
+        detailY,
+        bottomCap,
+        topCap
+      );
+      // normals are computed in call to _truncatedCone
+      if (detailX <= 24 && detailY <= 16) {
+        cylinderGeom._makeTriangleEdges()._edgesToVertices();
+      } else if (this._renderer.states.doStroke) {
+        console.log(
+          'Cannot draw stroke on cylinder objects with more' +
+          ' than 24 detailX or 16 detailY'
+        );
+      }
+      this._renderer.createBuffers(gId, cylinderGeom);
+    }
+
+    this._renderer.drawBuffersScaled(gId, radius, height, radius);
+
+    return this;
+  };
+
+  /**
+   * Draws a cone.
+   *
+   * A cone is a 3D shape with triangular faces that connect a flat bottom to a
+   * single point. Cones with few faces look like pyramids. Cones with many
+   * faces have smooth surfaces.
+   *
+   * The first parameter, `radius`, is optional. If a `Number` is passed, as in
+   * `cone(20)`, it sets the radius of the cone’s base. By default, `radius` is
+   * 50.
+   *
+   * The second parameter, `height`, is also optional. If a `Number` is passed,
+   * as in `cone(20, 30)`, it sets the cone’s height. By default, `height` is
+   * set to the cone’s `radius`.
+   *
+   * The third parameter, `detailX`, is also optional. If a `Number` is passed,
+   * as in `cone(20, 30, 5)`, it sets the number of edges used to form the
+   * cone's base. Using more edges makes the base look more like a circle. By
+   * default, `detailX` is 24.
+   *
+   * The fourth parameter, `detailY`, is also optional. If a `Number` is passed,
+   * as in `cone(20, 30, 5, 7)`, it sets the number of triangle subdivisions to
+   * use along the y-axis connecting the base to the tip. All 3D shapes are made
+   * by connecting triangles to form their surfaces. By default, `detailY` is 1.
+   *
+   * The fifth parameter, `cap`, is also optional. If a `false` is passed, as
+   * in `cone(20, 30, 5, 7, false)` the cone’s base won’t be drawn. By default,
+   * `cap` is `true`.
+   *
+   * Note: `cone()` can only be used in WebGL mode.
+   *
+   * @method cone
+   * @param  {Number}  [radius]  radius of the cone's base. Defaults to 50.
+   * @param  {Number}  [height]  height of the cone. Defaults to the value of `radius`.
+   * @param  {Integer} [detailX] number of edges used to draw the base. Defaults to 24.
+   * @param  {Integer} [detailY] number of triangle subdivisions along the y-axis. Defaults to 1.
+   * @param  {Boolean} [cap]     whether to draw the cone's base.  Defaults to `true`.
+   * @chainable
+   *
+   * @example
+   * <div>
+   * <code>
+   * // Click and drag the mouse to view the scene from different angles.
+   *
+   * function setup() {
+   *   createCanvas(100, 100, WEBGL);
+   *
+   *   describe('A white cone on a gray background.');
+   * }
+   *
+   * function draw() {
+   *   background(200);
+   *
+   *   // Enable orbiting with the mouse.
+   *   orbitControl();
+   *
+   *   // Draw the cone.
+   *   cone();
+   * }
+   * </code>
+   * </div>
+   *
+   * <div>
+   * <code>
+   * // Click and drag the mouse to view the scene from different angles.
+   *
+   * function setup() {
+   *   createCanvas(100, 100, WEBGL);
+   *
+   *   describe('A white cone on a gray background.');
+   * }
+   *
+   * function draw() {
+   *   background(200);
+   *
+   *   // Enable orbiting with the mouse.
+   *   orbitControl();
+   *
+   *   // Draw the cone.
+   *   // Set its radius and height to 30.
+   *   cone(30);
+   * }
+   * </code>
+   * </div>
+   *
+   * <div>
+   * <code>
+   * // Click and drag the mouse to view the scene from different angles.
+   *
+   * function setup() {
+   *   createCanvas(100, 100, WEBGL);
+   *
+   *   describe('A white cone on a gray background.');
+   * }
+   *
+   * function draw() {
+   *   background(200);
+   *
+   *   // Enable orbiting with the mouse.
+   *   orbitControl();
+   *
+   *   // Draw the cone.
+   *   // Set its radius to 30 and height to 50.
+   *   cone(30, 50);
+   * }
+   * </code>
+   * </div>
+   *
+   * <div>
+   * <code>
+   * // Click and drag the mouse to view the scene from different angles.
+   *
+   * function setup() {
+   *   createCanvas(100, 100, WEBGL);
+   *
+   *   describe('A white cone on a gray background.');
+   * }
+   *
+   * function draw() {
+   *   background(200);
+   *
+   *   // Enable orbiting with the mouse.
+   *   orbitControl();
+   *
+   *   // Draw the cone.
+   *   // Set its radius to 30 and height to 50.
+   *   // Set its detailX to 5.
+   *   cone(30, 50, 5);
+   * }
+   * </code>
+   * </div>
+   *
+   * <div>
+   * <code>
+   * // Click and drag the mouse to view the scene from different angles.
+   *
+   * function setup() {
+   *   createCanvas(100, 100, WEBGL);
+   *
+   *   describe('A white pyramid on a gray background.');
+   * }
+   *
+   * function draw() {
+   *   background(200);
+   *
+   *   // Enable orbiting with the mouse.
+   *   orbitControl();
+   *
+   *   // Draw the cone.
+   *   // Set its radius to 30 and height to 50.
+   *   // Set its detailX to 5.
+   *   cone(30, 50, 5);
+   * }
+   * </code>
+   * </div>
+   *
+   * <div>
+   * <code>
+   * // Click and drag the mouse to view the scene from different angles.
+   *
+   * function setup() {
+   *   createCanvas(100, 100, WEBGL);
+   *
+   *   describe('A white cone on a gray background.');
+   * }
+   *
+   * function draw() {
+   *   background(200);
+   *
+   *   // Enable orbiting with the mouse.
+   *   orbitControl();
+   *
+   *   // Draw the cone.
+   *   // Set its radius to 30 and height to 50.
+   *   // Set its detailX to 24 and detailY to 2.
+   *   cone(30, 50, 24, 2);
+   * }
+   * </code>
+   * </div>
+   *
+   * <div>
+   * <code>
+   * // Click and drag the mouse to view the scene from different angles.
+   *
+   * function setup() {
+   *   createCanvas(100, 100, WEBGL);
+   *
+   *   describe('A white cone on a gray background. Its base is missing.');
+   * }
+   *
+   * function draw() {
+   *   background(200);
+   *
+   *   // Enable orbiting with the mouse.
+   *   orbitControl();
+   *
+   *   // Draw the cone.
+   *   // Set its radius to 30 and height to 50.
+   *   // Set its detailX to 24 and detailY to 1.
+   *   // Don't draw its base.
+   *   cone(30, 50, 24, 1, false);
+   * }
+   * </code>
+   * </div>
+   */
+  fn.cone = function(
+    radius = 50,
+    height = radius,
+    detailX = 24,
+    detailY = 1,
+    cap = true
+  ) {
+    this._assert3d('cone');
+    p5._validateParameters('cone', arguments);
+
+    const gId = `cone|${detailX}|${detailY}|${cap}`;
+    if (!this._renderer.geometryInHash(gId)) {
+      const coneGeom = new p5.Geometry(detailX, detailY);
+      _truncatedCone.call(coneGeom, 1, 0, 1, detailX, detailY, cap, false);
+      if (detailX <= 24 && detailY <= 16) {
+        coneGeom._makeTriangleEdges()._edgesToVertices();
+      } else if (this._renderer.states.doStroke) {
+        console.log(
+          'Cannot draw stroke on cone objects with more' +
+          ' than 24 detailX or 16 detailY'
+        );
+      }
+      this._renderer.createBuffers(gId, coneGeom);
+    }
+
+    this._renderer.drawBuffersScaled(gId, radius, height, radius);
+
+    return this;
+  };
+
+  /**
+   * Draws an ellipsoid.
+   *
+   * An ellipsoid is a 3D shape with triangular faces that connect to form a
+   * round surface. Ellipsoids with few faces look like crystals. Ellipsoids
+   * with many faces have smooth surfaces and look like eggs. `ellipsoid()`
+   * defines a shape by its radii. This is different from
+   * <a href="#/p5/ellipse">ellipse()</a> which uses diameters
+   * (width and height).
+   *
+   * The first parameter, `radiusX`, is optional. If a `Number` is passed, as in
+   * `ellipsoid(20)`, it sets the radius of the ellipsoid along the x-axis. By
+   * default, `radiusX` is 50.
+   *
+   * The second parameter, `radiusY`, is also optional. If a `Number` is passed,
+   * as in `ellipsoid(20, 30)`, it sets the ellipsoid’s radius along the y-axis.
+   * By default, `radiusY` is set to the ellipsoid’s `radiusX`.
+   *
+   * The third parameter, `radiusZ`, is also optional. If a `Number` is passed,
+   * as in `ellipsoid(20, 30, 40)`, it sets the ellipsoid’s radius along the
+   * z-axis. By default, `radiusZ` is set to the ellipsoid’s `radiusY`.
+   *
+   * The fourth parameter, `detailX`, is also optional. If a `Number` is passed,
+   * as in `ellipsoid(20, 30, 40, 5)`, it sets the number of triangle
+   * subdivisions to use along the x-axis. All 3D shapes are made by connecting
+   * triangles to form their surfaces. By default, `detailX` is 24.
+   *
+   * The fifth parameter, `detailY`, is also optional. If a `Number` is passed,
+   * as in `ellipsoid(20, 30, 40, 5, 7)`, it sets the number of triangle
+   * subdivisions to use along the y-axis. All 3D shapes are made by connecting
+   * triangles to form their surfaces. By default, `detailY` is 16.
+   *
+   * Note: `ellipsoid()` can only be used in WebGL mode.
+   *
+   * @method ellipsoid
+   * @param  {Number} [radiusX]  radius of the ellipsoid along the x-axis. Defaults to 50.
+   * @param  {Number} [radiusY]  radius of the ellipsoid along the y-axis. Defaults to `radiusX`.
+   * @param  {Number} [radiusZ]  radius of the ellipsoid along the z-axis. Defaults to `radiusY`.
+   * @param  {Integer} [detailX] number of triangle subdivisions along the x-axis. Defaults to 24.
+   * @param  {Integer} [detailY] number of triangle subdivisions along the y-axis. Defaults to 16.
+   * @chainable
+   *
+   * @example
+   * <div>
+   * <code>
+   * // Click and drag the mouse to view the scene from different angles.
+   *
+   * function setup() {
+   *   createCanvas(100, 100, WEBGL);
+   *
+   *   describe('A white sphere on a gray background.');
+   * }
+   *
+   * function draw() {
+   *   background(200);
+   *
+   *   // Enable orbiting with the mouse.
+   *   orbitControl();
+   *
+   *   // Draw the ellipsoid.
+   *   // Set its radiusX to 30.
+   *   ellipsoid(30);
+   * }
+   * </code>
+   * </div>
+   *
+   * <div>
+   * <code>
+   * // Click and drag the mouse to view the scene from different angles.
+   *
+   * function setup() {
+   *   createCanvas(100, 100, WEBGL);
+   *
+   *   describe('A white ellipsoid on a gray background.');
+   * }
+   *
+   * function draw() {
+   *   background(200);
+   *
+   *   // Enable orbiting with the mouse.
+   *   orbitControl();
+   *
+   *   // Draw the ellipsoid.
+   *   // Set its radiusX to 30.
+   *   // Set its radiusY to 40.
+   *   ellipsoid(30, 40);
+   * }
+   * </code>
+   * </div>
+   *
+   * <div>
+   * <code>
+   * // Click and drag the mouse to view the scene from different angles.
+   *
+   * function setup() {
+   *   createCanvas(100, 100, WEBGL);
+   *
+   *   describe('A white ellipsoid on a gray background.');
+   * }
+   *
+   * function draw() {
+   *   background(200);
+   *
+   *   // Enable orbiting with the mouse.
+   *   orbitControl();
+   *
+   *   // Draw the ellipsoid.
+   *   // Set its radiusX to 30.
+   *   // Set its radiusY to 40.
+   *   // Set its radiusZ to 50.
+   *   ellipsoid(30, 40, 50);
+   * }
+   * </code>
+   * </div>
+   *
+   * <div>
+   * <code>
+   * // Click and drag the mouse to view the scene from different angles.
+   *
+   * function setup() {
+   *   createCanvas(100, 100, WEBGL);
+   *
+   *   describe('A white ellipsoid on a gray background.');
+   * }
+   *
+   * function draw() {
+   *   background(200);
+   *
+   *   // Enable orbiting with the mouse.
+   *   orbitControl();
+   *
+   *   // Draw the ellipsoid.
+   *   // Set its radiusX to 30.
+   *   // Set its radiusY to 40.
+   *   // Set its radiusZ to 50.
+   *   // Set its detailX to 4.
+   *   ellipsoid(30, 40, 50, 4);
+   * }
+   * </code>
+   * </div>
+   *
+   * <div>
+   * <code>
+   * // Click and drag the mouse to view the scene from different angles.
+   *
+   * function setup() {
+   *   createCanvas(100, 100, WEBGL);
+   *
+   *   describe('A white ellipsoid on a gray background.');
+   * }
+   *
+   * function draw() {
+   *   background(200);
+   *
+   *   // Enable orbiting with the mouse.
+   *   orbitControl();
+   *
+   *   // Draw the ellipsoid.
+   *   // Set its radiusX to 30.
+   *   // Set its radiusY to 40.
+   *   // Set its radiusZ to 50.
+   *   // Set its detailX to 4.
+   *   // Set its detailY to 3.
+   *   ellipsoid(30, 40, 50, 4, 3);
+   * }
+   * </code>
+   * </div>
+   */
+  fn.ellipsoid = function(
+    radiusX = 50,
+    radiusY = radiusX,
+    radiusZ = radiusX,
+    detailX = 24,
+    detailY = 16
+  ) {
+    this._assert3d('ellipsoid');
+    p5._validateParameters('ellipsoid', arguments);
+
+    const gId = `ellipsoid|${detailX}|${detailY}`;
+
+    if (!this._renderer.geometryInHash(gId)) {
+      const _ellipsoid = function() {
+        for (let i = 0; i <= this.detailY; i++) {
+          const v = i / this.detailY;
+          const phi = Math.PI * v - Math.PI / 2;
+          const cosPhi = Math.cos(phi);
+          const sinPhi = Math.sin(phi);
+
+          for (let j = 0; j <= this.detailX; j++) {
+            const u = j / this.detailX;
+            const theta = 2 * Math.PI * u;
+            const cosTheta = Math.cos(theta);
+            const sinTheta = Math.sin(theta);
+            const p = new p5.Vector(cosPhi * sinTheta, sinPhi, cosPhi * cosTheta);
+            this.vertices.push(p);
+            this.vertexNormals.push(p);
+            this.uvs.push(u, v);
+          }
+        }
+      };
+      const ellipsoidGeom = new p5.Geometry(detailX, detailY, _ellipsoid);
+      ellipsoidGeom.computeFaces();
+      if (detailX <= 24 && detailY <= 24) {
+        ellipsoidGeom._makeTriangleEdges()._edgesToVertices();
+      } else if (this._renderer.states.doStroke) {
+        console.log(
+          'Cannot draw stroke on ellipsoids with more' +
+          ' than 24 detailX or 24 detailY'
+        );
+      }
+      this._renderer.createBuffers(gId, ellipsoidGeom);
+    }
+
+    this._renderer.drawBuffersScaled(gId, radiusX, radiusY, radiusZ);
+
+    return this;
+  };
+
+  /**
+   * Draws a torus.
+   *
+   * A torus is a 3D shape with triangular faces that connect to form a ring.
+   * Toruses with few faces look flattened. Toruses with many faces have smooth
+   * surfaces.
+   *
+   * The first parameter, `radius`, is optional. If a `Number` is passed, as in
+   * `torus(30)`, it sets the radius of the ring. By default, `radius` is 50.
+   *
+   * The second parameter, `tubeRadius`, is also optional. If a `Number` is
+   * passed, as in `torus(30, 15)`, it sets the radius of the tube. By default,
+   * `tubeRadius` is 10.
+   *
+   * The third parameter, `detailX`, is also optional. If a `Number` is passed,
+   * as in `torus(30, 15, 5)`, it sets the number of edges used to draw the hole
+   * of the torus. Using more edges makes the hole look more like a circle. By
+   * default, `detailX` is 24.
+   *
+   * The fourth parameter, `detailY`, is also optional. If a `Number` is passed,
+   * as in `torus(30, 15, 5, 7)`, it sets the number of triangle subdivisions to
+   * use while filling in the torus’ height. By default, `detailY` is 16.
+   *
+   * Note: `torus()` can only be used in WebGL mode.
+   *
+   * @method torus
+   * @param  {Number} [radius]      radius of the torus. Defaults to 50.
+   * @param  {Number} [tubeRadius]  radius of the tube. Defaults to 10.
+   * @param  {Integer} [detailX]    number of edges that form the hole. Defaults to 24.
+   * @param  {Integer} [detailY]    number of triangle subdivisions along the y-axis. Defaults to 16.
+   * @chainable
+   *
+   * @example
+   * <div>
+   * <code>
+   * // Click and drag the mouse to view the scene from different angles.
+   *
+   * function setup() {
+   *   createCanvas(100, 100, WEBGL);
+   *
+   *   describe('A white torus on a gray background.');
+   * }
+   *
+   * function draw() {
+   *   background(200);
+   *
+   *   // Enable orbiting with the mouse.
+   *   orbitControl();
+   *
+   *   // Draw the torus.
+   *   torus();
+   * }
+   * </code>
+   * </div>
+   *
+   * <div>
+   * <code>
+   * // Click and drag the mouse to view the scene from different angles.
+   *
+   * function setup() {
+   *   createCanvas(100, 100, WEBGL);
+   *
+   *   describe('A white torus on a gray background.');
+   * }
+   *
+   * function draw() {
+   *   background(200);
+   *
+   *   // Enable orbiting with the mouse.
+   *   orbitControl();
+   *
+   *   // Draw the torus.
+   *   // Set its radius to 30.
+   *   torus(30);
+   * }
+   * </code>
+   * </div>
+   *
+   * <div>
+   * <code>
+   * // Click and drag the mouse to view the scene from different angles.
+   *
+   * function setup() {
+   *   createCanvas(100, 100, WEBGL);
+   *
+   *   describe('A white torus on a gray background.');
+   * }
+   *
+   * function draw() {
+   *   background(200);
+   *
+   *   // Enable orbiting with the mouse.
+   *   orbitControl();
+   *
+   *   // Draw the torus.
+   *   // Set its radius to 30 and tubeRadius to 15.
+   *   torus(30, 15);
+   * }
+   * </code>
+   * </div>
+   *
+   * <div>
+   * <code>
+   * // Click and drag the mouse to view the scene from different angles.
+   *
+   * function setup() {
+   *   createCanvas(100, 100, WEBGL);
+   *
+   *   describe('A white torus on a gray background.');
+   * }
+   *
+   * function draw() {
+   *   background(200);
+   *
+   *   // Enable orbiting with the mouse.
+   *   orbitControl();
+   *
+   *   // Draw the torus.
+   *   // Set its radius to 30 and tubeRadius to 15.
+   *   // Set its detailX to 5.
+   *   torus(30, 15, 5);
+   * }
+   * </code>
+   * </div>
+   *
+   * <div>
+   * <code>
+   * // Click and drag the mouse to view the scene from different angles.
+   *
+   * function setup() {
+   *   createCanvas(100, 100, WEBGL);
+   *
+   *   describe('A white torus on a gray background.');
+   * }
+   *
+   * function draw() {
+   *   background(200);
+   *
+   *   // Enable orbiting with the mouse.
+   *   orbitControl();
+   *
+   *   // Draw the torus.
+   *   // Set its radius to 30 and tubeRadius to 15.
+   *   // Set its detailX to 5.
+   *   // Set its detailY to 3.
+   *   torus(30, 15, 5, 3);
+   * }
+   * </code>
+   * </div>
+   */
+  fn.torus = function(radius, tubeRadius, detailX, detailY) {
+    this._assert3d('torus');
+    p5._validateParameters('torus', arguments);
+    if (typeof radius === 'undefined') {
+      radius = 50;
+    } else if (!radius) {
+      return; // nothing to draw
+    }
+
+    if (typeof tubeRadius === 'undefined') {
+      tubeRadius = 10;
+    } else if (!tubeRadius) {
+      return; // nothing to draw
+    }
+
+    if (typeof detailX === 'undefined') {
+      detailX = 24;
+    }
+    if (typeof detailY === 'undefined') {
+      detailY = 16;
+    }
+
+    const tubeRatio = (tubeRadius / radius).toPrecision(4);
+    const gId = `torus|${tubeRatio}|${detailX}|${detailY}`;
+
+    if (!this._renderer.geometryInHash(gId)) {
+      const _torus = function() {
+        for (let i = 0; i <= this.detailY; i++) {
+          const v = i / this.detailY;
+          const phi = 2 * Math.PI * v;
+          const cosPhi = Math.cos(phi);
+          const sinPhi = Math.sin(phi);
+          const r = 1 + tubeRatio * cosPhi;
+
+          for (let j = 0; j <= this.detailX; j++) {
+            const u = j / this.detailX;
+            const theta = 2 * Math.PI * u;
+            const cosTheta = Math.cos(theta);
+            const sinTheta = Math.sin(theta);
+
+            const p = new p5.Vector(
+              r * cosTheta,
+              r * sinTheta,
+              tubeRatio * sinPhi
+            );
+
+            const n = new p5.Vector(cosPhi * cosTheta, cosPhi * sinTheta, sinPhi);
+
+            this.vertices.push(p);
+            this.vertexNormals.push(n);
+            this.uvs.push(u, v);
+          }
+        }
+      };
+      const torusGeom = new p5.Geometry(detailX, detailY, _torus);
+      torusGeom.computeFaces();
+      if (detailX <= 24 && detailY <= 16) {
+        torusGeom._makeTriangleEdges()._edgesToVertices();
+      } else if (this._renderer.states.doStroke) {
+        console.log(
+          'Cannot draw strokes on torus object with more' +
+          ' than 24 detailX or 16 detailY'
+        );
+      }
+      this._renderer.createBuffers(gId, torusGeom);
+    }
+    this._renderer.drawBuffersScaled(gId, radius, radius, radius);
+
+    return this;
+  };
+
+  ///////////////////////
+  /// 2D primitives
+  /////////////////////////
+  //
+  // Note: Documentation is not generated on the p5.js website for functions on
+  // the p5.RendererGL prototype.
+
+  /**
+   * Draws a point, a coordinate in space at the dimension of one pixel,
+   * given x, y and z coordinates. The color of the point is determined
+   * by the current stroke, while the point size is determined by current
+   * stroke weight.
+   * @private
+   * @param {Number} x x-coordinate of point
+   * @param {Number} y y-coordinate of point
+   * @param {Number} z z-coordinate of point
+   * @chainable
+   * @example
+   * <div>
+   * <code>
+   * function setup() {
+   *   createCanvas(100, 100, WEBGL);
+   * }
+   *
+   * function draw() {
+   *   background(50);
+   *   stroke(255);
+   *   strokeWeight(4);
+   *   point(25, 0);
+   *   strokeWeight(3);
+   *   point(-25, 0);
+   *   strokeWeight(2);
+   *   point(0, 25);
+   *   strokeWeight(1);
+   *   point(0, -25);
+   * }
+   * </code>
+   * </div>
+   */
+  p5.RendererGL.prototype.point = function(x, y, z = 0) {
+
+    const _vertex = [];
+    _vertex.push(new p5.Vector(x, y, z));
+    this._drawPoints(_vertex, this.immediateMode.buffers.point);
+
+    return this;
+  };
+
+  p5.RendererGL.prototype.triangle = function(args) {
+    const x1 = args[0],
+      y1 = args[1];
+    const x2 = args[2],
+      y2 = args[3];
+    const x3 = args[4],
+      y3 = args[5];
+
+    const gId = 'tri';
+    if (!this.geometryInHash(gId)) {
+      const _triangle = function() {
+        const vertices = [];
+        vertices.push(new p5.Vector(0, 0, 0));
+        vertices.push(new p5.Vector(1, 0, 0));
+        vertices.push(new p5.Vector(0, 1, 0));
+        this.edges = [[0, 1], [1, 2], [2, 0]];
+        this.vertices = vertices;
+        this.faces = [[0, 1, 2]];
+        this.uvs = [0, 0, 1, 0, 1, 1];
+      };
+      const triGeom = new p5.Geometry(1, 1, _triangle);
+      triGeom._edgesToVertices();
+      triGeom.computeNormals();
+      this.createBuffers(gId, triGeom);
+    }
+
+    // only one triangle is cached, one point is at the origin, and the
+    // two adjacent sides are tne unit vectors along the X & Y axes.
     //
-    // before rendering, this square is scaled & moved to the required location.
+    // this matrix multiplication transforms those two unit vectors
+    // onto the required vector prior to rendering, and moves the
+    // origin appropriately.
     const uModelMatrix = this.states.uModelMatrix.copy();
+    try {
+      // triangle orientation.
+      const orientation = Math.sign(x1*y2-x2*y1 + x2*y3-x3*y2 + x3*y1-x1*y3);
+      const mult = new p5.Matrix([
+        x2 - x1, y2 - y1, 0, 0, // the resulting unit X-axis
+        x3 - x1, y3 - y1, 0, 0, // the resulting unit Y-axis
+        0, 0, orientation, 0,   // the resulting unit Z-axis (Reflect the specified order of vertices)
+        x1, y1, 0, 1            // the resulting origin
+      ]).mult(this.states.uModelMatrix);
+
+      this.states.uModelMatrix = mult;
+
+      this.drawBuffers(gId);
+    } finally {
+      this.states.uModelMatrix = uModelMatrix;
+    }
+
+    return this;
+  };
+
+  p5.RendererGL.prototype.ellipse = function(args) {
+    this.arc(
+      args[0],
+      args[1],
+      args[2],
+      args[3],
+      0,
+      constants.TWO_PI,
+      constants.OPEN,
+      args[4]
+    );
+  };
+
+  p5.RendererGL.prototype.arc = function(...args) {
+    const x = args[0];
+    const y = args[1];
+    const width = args[2];
+    const height = args[3];
+    const start = args[4];
+    const stop = args[5];
+    const mode = args[6];
+    const detail = args[7] || 25;
+
+    let shape;
+    let gId;
+
+    // check if it is an ellipse or an arc
+    if (Math.abs(stop - start) >= constants.TWO_PI) {
+      shape = 'ellipse';
+      gId = `${shape}|${detail}|`;
+    } else {
+      shape = 'arc';
+      gId = `${shape}|${start}|${stop}|${mode}|${detail}|`;
+    }
+
+    if (!this.geometryInHash(gId)) {
+      const _arc = function() {
+
+        // if the start and stop angles are not the same, push vertices to the array
+        if (start.toFixed(10) !== stop.toFixed(10)) {
+          // if the mode specified is PIE or null, push the mid point of the arc in vertices
+          if (mode === constants.PIE || typeof mode === 'undefined') {
+            this.vertices.push(new p5.Vector(0.5, 0.5, 0));
+            this.uvs.push([0.5, 0.5]);
+          }
+
+          // vertices for the perimeter of the circle
+          for (let i = 0; i <= detail; i++) {
+            const u = i / detail;
+            const theta = (stop - start) * u + start;
+
+            const _x = 0.5 + Math.cos(theta) / 2;
+            const _y = 0.5 + Math.sin(theta) / 2;
+
+            this.vertices.push(new p5.Vector(_x, _y, 0));
+            this.uvs.push([_x, _y]);
+
+            if (i < detail - 1) {
+              this.faces.push([0, i + 1, i + 2]);
+              this.edges.push([i + 1, i + 2]);
+            }
+          }
+
+          // check the mode specified in order to push vertices and faces, different for each mode
+          switch (mode) {
+            case constants.PIE:
+              this.faces.push([
+                0,
+                this.vertices.length - 2,
+                this.vertices.length - 1
+              ]);
+              this.edges.push([0, 1]);
+              this.edges.push([
+                this.vertices.length - 2,
+                this.vertices.length - 1
+              ]);
+              this.edges.push([0, this.vertices.length - 1]);
+              break;
+
+            case constants.CHORD:
+              this.edges.push([0, 1]);
+              this.edges.push([0, this.vertices.length - 1]);
+              break;
+
+            case constants.OPEN:
+              this.edges.push([0, 1]);
+              break;
+
+            default:
+              this.faces.push([
+                0,
+                this.vertices.length - 2,
+                this.vertices.length - 1
+              ]);
+              this.edges.push([
+                this.vertices.length - 2,
+                this.vertices.length - 1
+              ]);
+          }
+        }
+      };
+
+      const arcGeom = new p5.Geometry(detail, 1, _arc);
+      arcGeom.computeNormals();
+
+      if (detail <= 50) {
+        arcGeom._edgesToVertices(arcGeom);
+      } else if (this.states.doStroke) {
+        console.log(
+          `Cannot apply a stroke to an ${shape} with more than 50 detail`
+        );
+      }
+
+      this.createBuffers(gId, arcGeom);
+    }
+
+    const uModelMatrix = this.states.uModelMatrix.copy();
+
     try {
       this.states.uModelMatrix.translate([x, y, 0]);
       this.states.uModelMatrix.scale(width, height, 1);
@@ -2687,295 +2627,784 @@ p5.RendererGL.prototype.rect = function(args) {
     } finally {
       this.states.uModelMatrix = uModelMatrix;
     }
-  } else {
-    // Use Immediate mode to round the rectangle corner,
-    // if args for rounding corners is provided by user
-    let tl = args[4];
-    let tr = typeof args[5] === 'undefined' ? tl : args[5];
-    let br = typeof args[6] === 'undefined' ? tr : args[6];
-    let bl = typeof args[7] === 'undefined' ? br : args[7];
 
-    let a = x;
-    let b = y;
-    let c = width;
-    let d = height;
+    return this;
+  };
 
-    c += a;
-    d += b;
+  p5.RendererGL.prototype.rect = function(args) {
+    const x = args[0];
+    const y = args[1];
+    const width = args[2];
+    const height = args[3];
 
-    if (a > c) {
-      const temp = a;
-      a = c;
-      c = temp;
-    }
+    if (typeof args[4] === 'undefined') {
+      // Use the retained mode for drawing rectangle,
+      // if args for rounding rectangle is not provided by user.
+      const perPixelLighting = this._pInst._glAttributes.perPixelLighting;
+      const detailX = args[4] || (perPixelLighting ? 1 : 24);
+      const detailY = args[5] || (perPixelLighting ? 1 : 16);
+      const gId = `rect|${detailX}|${detailY}`;
+      if (!this.geometryInHash(gId)) {
+        const _rect = function() {
+          for (let i = 0; i <= this.detailY; i++) {
+            const v = i / this.detailY;
+            for (let j = 0; j <= this.detailX; j++) {
+              const u = j / this.detailX;
+              const p = new p5.Vector(u, v, 0);
+              this.vertices.push(p);
+              this.uvs.push(u, v);
+            }
+          }
+          // using stroke indices to avoid stroke over face(s) of rectangle
+          if (detailX > 0 && detailY > 0) {
+            this.edges = [
+              [0, detailX],
+              [detailX, (detailX + 1) * (detailY + 1) - 1],
+              [(detailX + 1) * (detailY + 1) - 1, (detailX + 1) * detailY],
+              [(detailX + 1) * detailY, 0]
+            ];
+          }
+        };
+        const rectGeom = new p5.Geometry(detailX, detailY, _rect);
+        rectGeom
+          .computeFaces()
+          .computeNormals()
+          ._edgesToVertices();
+        this.createBuffers(gId, rectGeom);
+      }
 
-    if (b > d) {
-      const temp = b;
-      b = d;
-      d = temp;
-    }
+      // only a single rectangle (of a given detail) is cached: a square with
+      // opposite corners at (0,0) & (1,1).
+      //
+      // before rendering, this square is scaled & moved to the required location.
+      const uModelMatrix = this.states.uModelMatrix.copy();
+      try {
+        this.states.uModelMatrix.translate([x, y, 0]);
+        this.states.uModelMatrix.scale(width, height, 1);
 
-    const maxRounding = Math.min((c - a) / 2, (d - b) / 2);
-    if (tl > maxRounding) tl = maxRounding;
-    if (tr > maxRounding) tr = maxRounding;
-    if (br > maxRounding) br = maxRounding;
-    if (bl > maxRounding) bl = maxRounding;
-
-    let x1 = a;
-    let y1 = b;
-    let x2 = c;
-    let y2 = d;
-
-    this.beginShape();
-    if (tr !== 0) {
-      this.vertex(x2 - tr, y1);
-      this.quadraticVertex(x2, y1, x2, y1 + tr);
+        this.drawBuffers(gId);
+      } finally {
+        this.states.uModelMatrix = uModelMatrix;
+      }
     } else {
-      this.vertex(x2, y1);
+      // Use Immediate mode to round the rectangle corner,
+      // if args for rounding corners is provided by user
+      let tl = args[4];
+      let tr = typeof args[5] === 'undefined' ? tl : args[5];
+      let br = typeof args[6] === 'undefined' ? tr : args[6];
+      let bl = typeof args[7] === 'undefined' ? br : args[7];
+
+      let a = x;
+      let b = y;
+      let c = width;
+      let d = height;
+
+      c += a;
+      d += b;
+
+      if (a > c) {
+        const temp = a;
+        a = c;
+        c = temp;
+      }
+
+      if (b > d) {
+        const temp = b;
+        b = d;
+        d = temp;
+      }
+
+      const maxRounding = Math.min((c - a) / 2, (d - b) / 2);
+      if (tl > maxRounding) tl = maxRounding;
+      if (tr > maxRounding) tr = maxRounding;
+      if (br > maxRounding) br = maxRounding;
+      if (bl > maxRounding) bl = maxRounding;
+
+      let x1 = a;
+      let y1 = b;
+      let x2 = c;
+      let y2 = d;
+
+      this.beginShape();
+      if (tr !== 0) {
+        this.vertex(x2 - tr, y1);
+        this.quadraticVertex(x2, y1, x2, y1 + tr);
+      } else {
+        this.vertex(x2, y1);
+      }
+      if (br !== 0) {
+        this.vertex(x2, y2 - br);
+        this.quadraticVertex(x2, y2, x2 - br, y2);
+      } else {
+        this.vertex(x2, y2);
+      }
+      if (bl !== 0) {
+        this.vertex(x1 + bl, y2);
+        this.quadraticVertex(x1, y2, x1, y2 - bl);
+      } else {
+        this.vertex(x1, y2);
+      }
+      if (tl !== 0) {
+        this.vertex(x1, y1 + tl);
+        this.quadraticVertex(x1, y1, x1 + tl, y1);
+      } else {
+        this.vertex(x1, y1);
+      }
+
+      this.immediateMode.geometry.uvs.length = 0;
+      for (const vert of this.immediateMode.geometry.vertices) {
+        const u = (vert.x - x1) / width;
+        const v = (vert.y - y1) / height;
+        this.immediateMode.geometry.uvs.push(u, v);
+      }
+
+      this.endShape(constants.CLOSE);
     }
-    if (br !== 0) {
-      this.vertex(x2, y2 - br);
-      this.quadraticVertex(x2, y2, x2 - br, y2);
-    } else {
-      this.vertex(x2, y2);
-    }
-    if (bl !== 0) {
-      this.vertex(x1 + bl, y2);
-      this.quadraticVertex(x1, y2, x1, y2 - bl);
-    } else {
-      this.vertex(x1, y2);
-    }
-    if (tl !== 0) {
-      this.vertex(x1, y1 + tl);
-      this.quadraticVertex(x1, y1, x1 + tl, y1);
-    } else {
-      this.vertex(x1, y1);
-    }
+    return this;
+  };
 
-    this.immediateMode.geometry.uvs.length = 0;
-    for (const vert of this.immediateMode.geometry.vertices) {
-      const u = (vert.x - x1) / width;
-      const v = (vert.y - y1) / height;
-      this.immediateMode.geometry.uvs.push(u, v);
-    }
+  /* eslint-disable max-len */
+  p5.RendererGL.prototype.quad = function(x1, y1, z1, x2, y2, z2, x3, y3, z3, x4, y4, z4, detailX=2, detailY=2) {
+    /* eslint-enable max-len */
 
-    this.endShape(constants.CLOSE);
-  }
-  return this;
-};
+    const gId =
+      `quad|${x1}|${y1}|${z1}|${x2}|${y2}|${z2}|${x3}|${y3}|${z3}|${x4}|${y4}|${z4}|${detailX}|${detailY}`;
 
-/* eslint-disable max-len */
-p5.RendererGL.prototype.quad = function(x1, y1, z1, x2, y2, z2, x3, y3, z3, x4, y4, z4, detailX=2, detailY=2) {
-  /* eslint-enable max-len */
+    if (!this.geometryInHash(gId)) {
+      const quadGeom = new p5.Geometry(detailX, detailY, function() {
+        //algorithm adapted from c++ to js
+        //https://stackoverflow.com/questions/16989181/whats-the-correct-way-to-draw-a-distorted-plane-in-opengl/16993202#16993202
+        let xRes = 1.0 / (this.detailX - 1);
+        let yRes = 1.0 / (this.detailY - 1);
+        for (let y = 0; y < this.detailY; y++) {
+          for (let x = 0; x < this.detailX; x++) {
+            let pctx = x * xRes;
+            let pcty = y * yRes;
 
-  const gId =
-    `quad|${x1}|${y1}|${z1}|${x2}|${y2}|${z2}|${x3}|${y3}|${z3}|${x4}|${y4}|${z4}|${detailX}|${detailY}`;
+            let linePt0x = (1 - pcty) * x1 + pcty * x4;
+            let linePt0y = (1 - pcty) * y1 + pcty * y4;
+            let linePt0z = (1 - pcty) * z1 + pcty * z4;
+            let linePt1x = (1 - pcty) * x2 + pcty * x3;
+            let linePt1y = (1 - pcty) * y2 + pcty * y3;
+            let linePt1z = (1 - pcty) * z2 + pcty * z3;
 
-  if (!this.geometryInHash(gId)) {
-    const quadGeom = new p5.Geometry(detailX, detailY, function() {
-      //algorithm adapted from c++ to js
-      //https://stackoverflow.com/questions/16989181/whats-the-correct-way-to-draw-a-distorted-plane-in-opengl/16993202#16993202
-      let xRes = 1.0 / (this.detailX - 1);
-      let yRes = 1.0 / (this.detailY - 1);
-      for (let y = 0; y < this.detailY; y++) {
-        for (let x = 0; x < this.detailX; x++) {
-          let pctx = x * xRes;
-          let pcty = y * yRes;
+            let ptx = (1 - pctx) * linePt0x + pctx * linePt1x;
+            let pty = (1 - pctx) * linePt0y + pctx * linePt1y;
+            let ptz = (1 - pctx) * linePt0z + pctx * linePt1z;
 
-          let linePt0x = (1 - pcty) * x1 + pcty * x4;
-          let linePt0y = (1 - pcty) * y1 + pcty * y4;
-          let linePt0z = (1 - pcty) * z1 + pcty * z4;
-          let linePt1x = (1 - pcty) * x2 + pcty * x3;
-          let linePt1y = (1 - pcty) * y2 + pcty * y3;
-          let linePt1z = (1 - pcty) * z2 + pcty * z3;
+            this.vertices.push(new p5.Vector(ptx, pty, ptz));
+            this.uvs.push([pctx, pcty]);
+          }
+        }
+      });
 
-          let ptx = (1 - pctx) * linePt0x + pctx * linePt1x;
-          let pty = (1 - pctx) * linePt0y + pctx * linePt1y;
-          let ptz = (1 - pctx) * linePt0z + pctx * linePt1z;
-
-          this.vertices.push(new p5.Vector(ptx, pty, ptz));
-          this.uvs.push([pctx, pcty]);
+      quadGeom.faces = [];
+      for(let y = 0; y < detailY-1; y++){
+        for(let x = 0; x < detailX-1; x++){
+          let pt0 = x + y * detailX;
+          let pt1 = (x + 1) + y * detailX;
+          let pt2 = (x + 1) + (y + 1) * detailX;
+          let pt3 = x + (y + 1) * detailX;
+          quadGeom.faces.push([pt0, pt1, pt2]);
+          quadGeom.faces.push([pt0, pt2, pt3]);
         }
       }
-    });
+      quadGeom.computeNormals();
+      quadGeom.edges.length = 0;
+      const vertexOrder = [0, 2, 3, 1];
+      for (let i = 0; i < vertexOrder.length; i++) {
+        const startVertex = vertexOrder[i];
+        const endVertex = vertexOrder[(i + 1) % vertexOrder.length];
+        quadGeom.edges.push([startVertex, endVertex]);
+      }
+      quadGeom._edgesToVertices();
+      this.createBuffers(gId, quadGeom);
+    }
+    this.drawBuffers(gId);
+    return this;
+  };
 
-    quadGeom.faces = [];
-    for(let y = 0; y < detailY-1; y++){
-      for(let x = 0; x < detailX-1; x++){
-        let pt0 = x + y * detailX;
-        let pt1 = (x + 1) + y * detailX;
-        let pt2 = (x + 1) + (y + 1) * detailX;
-        let pt3 = x + (y + 1) * detailX;
-        quadGeom.faces.push([pt0, pt1, pt2]);
-        quadGeom.faces.push([pt0, pt2, pt3]);
+  //this implementation of bezier curve
+  //is based on Bernstein polynomial
+  // pretier-ignore
+  p5.RendererGL.prototype.bezier = function(
+    x1,
+    y1,
+    z1, // x2
+    x2, // y2
+    y2, // x3
+    z2, // y3
+    x3, // x4
+    y3, // y4
+    z3,
+    x4,
+    y4,
+    z4
+  ) {
+    if (arguments.length === 8) {
+      y4 = y3;
+      x4 = x3;
+      y3 = z2;
+      x3 = y2;
+      y2 = x2;
+      x2 = z1;
+      z1 = z2 = z3 = z4 = 0;
+    }
+    const bezierDetail = this._pInst._bezierDetail || 20; //value of Bezier detail
+    this.beginShape();
+    for (let i = 0; i <= bezierDetail; i++) {
+      const c1 = Math.pow(1 - i / bezierDetail, 3);
+      const c2 = 3 * (i / bezierDetail) * Math.pow(1 - i / bezierDetail, 2);
+      const c3 = 3 * Math.pow(i / bezierDetail, 2) * (1 - i / bezierDetail);
+      const c4 = Math.pow(i / bezierDetail, 3);
+      this.vertex(
+        x1 * c1 + x2 * c2 + x3 * c3 + x4 * c4,
+        y1 * c1 + y2 * c2 + y3 * c3 + y4 * c4,
+        z1 * c1 + z2 * c2 + z3 * c3 + z4 * c4
+      );
+    }
+    this.endShape();
+    return this;
+  };
+
+  // pretier-ignore
+  p5.RendererGL.prototype.curve = function(
+    x1,
+    y1,
+    z1, // x2
+    x2, // y2
+    y2, // x3
+    z2, // y3
+    x3, // x4
+    y3, // y4
+    z3,
+    x4,
+    y4,
+    z4
+  ) {
+    if (arguments.length === 8) {
+      x4 = x3;
+      y4 = y3;
+      x3 = y2;
+      y3 = x2;
+      x2 = z1;
+      y2 = x2;
+      z1 = z2 = z3 = z4 = 0;
+    }
+    const curveDetail = this._pInst._curveDetail;
+    this.beginShape();
+    for (let i = 0; i <= curveDetail; i++) {
+      const c1 = Math.pow(i / curveDetail, 3) * 0.5;
+      const c2 = Math.pow(i / curveDetail, 2) * 0.5;
+      const c3 = i / curveDetail * 0.5;
+      const c4 = 0.5;
+      const vx =
+        c1 * (-x1 + 3 * x2 - 3 * x3 + x4) +
+        c2 * (2 * x1 - 5 * x2 + 4 * x3 - x4) +
+        c3 * (-x1 + x3) +
+        c4 * (2 * x2);
+      const vy =
+        c1 * (-y1 + 3 * y2 - 3 * y3 + y4) +
+        c2 * (2 * y1 - 5 * y2 + 4 * y3 - y4) +
+        c3 * (-y1 + y3) +
+        c4 * (2 * y2);
+      const vz =
+        c1 * (-z1 + 3 * z2 - 3 * z3 + z4) +
+        c2 * (2 * z1 - 5 * z2 + 4 * z3 - z4) +
+        c3 * (-z1 + z3) +
+        c4 * (2 * z2);
+      this.vertex(vx, vy, vz);
+    }
+    this.endShape();
+    return this;
+  };
+
+  /**
+   * Draw a line given two points
+   * @private
+   * @param {Number} x0 x-coordinate of first vertex
+   * @param {Number} y0 y-coordinate of first vertex
+   * @param {Number} z0 z-coordinate of first vertex
+   * @param {Number} x1 x-coordinate of second vertex
+   * @param {Number} y1 y-coordinate of second vertex
+   * @param {Number} z1 z-coordinate of second vertex
+   * @chainable
+   * @example
+   * <div>
+   * <code>
+   * //draw a line
+   * function setup() {
+   *   createCanvas(100, 100, WEBGL);
+   * }
+   *
+   * function draw() {
+   *   background(200);
+   *   rotateX(frameCount * 0.01);
+   *   rotateY(frameCount * 0.01);
+   *   // Use fill instead of stroke to change the color of shape.
+   *   fill(255, 0, 0);
+   *   line(10, 10, 0, 60, 60, 20);
+   * }
+   * </code>
+   * </div>
+   */
+  p5.RendererGL.prototype.line = function(...args) {
+    if (args.length === 6) {
+      this.beginShape(constants.LINES);
+      this.vertex(args[0], args[1], args[2]);
+      this.vertex(args[3], args[4], args[5]);
+      this.endShape();
+    } else if (args.length === 4) {
+      this.beginShape(constants.LINES);
+      this.vertex(args[0], args[1], 0);
+      this.vertex(args[2], args[3], 0);
+      this.endShape();
+    }
+    return this;
+  };
+
+  p5.RendererGL.prototype.bezierVertex = function(...args) {
+    if (this.immediateMode._bezierVertex.length === 0) {
+      throw Error('vertex() must be used once before calling bezierVertex()');
+    } else {
+      let w_x = [];
+      let w_y = [];
+      let w_z = [];
+      let t, _x, _y, _z, i, k, m;
+      // variable i for bezierPoints, k for components, and m for anchor points.
+      const argLength = args.length;
+
+      t = 0;
+
+      if (
+        this._lookUpTableBezier.length === 0 ||
+        this._lutBezierDetail !== this._pInst._curveDetail
+      ) {
+        this._lookUpTableBezier = [];
+        this._lutBezierDetail = this._pInst._curveDetail;
+        const step = 1 / this._lutBezierDetail;
+        let start = 0;
+        let end = 1;
+        let j = 0;
+        while (start < 1) {
+          t = parseFloat(start.toFixed(6));
+          this._lookUpTableBezier[j] = this._bezierCoefficients(t);
+          if (end.toFixed(6) === step.toFixed(6)) {
+            t = parseFloat(end.toFixed(6)) + parseFloat(start.toFixed(6));
+            ++j;
+            this._lookUpTableBezier[j] = this._bezierCoefficients(t);
+            break;
+          }
+          start += step;
+          end -= step;
+          ++j;
+        }
+      }
+
+      const LUTLength = this._lookUpTableBezier.length;
+      const immediateGeometry = this.immediateMode.geometry;
+
+      // fillColors[0]: start point color
+      // fillColors[1],[2]: control point color
+      // fillColors[3]: end point color
+      const fillColors = [];
+      for (m = 0; m < 4; m++) fillColors.push([]);
+      fillColors[0] = immediateGeometry.vertexColors.slice(-4);
+      fillColors[3] = this.states.curFillColor.slice();
+
+      // Do the same for strokeColor.
+      const strokeColors = [];
+      for (m = 0; m < 4; m++) strokeColors.push([]);
+      strokeColors[0] = immediateGeometry.vertexStrokeColors.slice(-4);
+      strokeColors[3] = this.states.curStrokeColor.slice();
+
+      // Do the same for custom vertex properties
+      const userVertexProperties = {};
+      for (const propName in immediateGeometry.userVertexProperties){
+        const prop = immediateGeometry.userVertexProperties[propName];
+        const size = prop.getDataSize();
+        userVertexProperties[propName] = [];
+        for (m = 0; m < 4; m++) userVertexProperties[propName].push([]);
+        userVertexProperties[propName][0] = prop.getSrcArray().slice(-size);
+        userVertexProperties[propName][3] = prop.getCurrentData();
+      }
+
+      if (argLength === 6) {
+        this.isBezier = true;
+
+        w_x = [this.immediateMode._bezierVertex[0], args[0], args[2], args[4]];
+        w_y = [this.immediateMode._bezierVertex[1], args[1], args[3], args[5]];
+        // The ratio of the distance between the start point, the two control-
+        // points, and the end point determines the intermediate color.
+        let d0 = Math.hypot(w_x[0]-w_x[1], w_y[0]-w_y[1]);
+        let d1 = Math.hypot(w_x[1]-w_x[2], w_y[1]-w_y[2]);
+        let d2 = Math.hypot(w_x[2]-w_x[3], w_y[2]-w_y[3]);
+        const totalLength = d0 + d1 + d2;
+        d0 /= totalLength;
+        d2 /= totalLength;
+        for (k = 0; k < 4; k++) {
+          fillColors[1].push(
+            fillColors[0][k] * (1-d0) + fillColors[3][k] * d0
+          );
+          fillColors[2].push(
+            fillColors[0][k] * d2 + fillColors[3][k] * (1-d2)
+          );
+          strokeColors[1].push(
+            strokeColors[0][k] * (1-d0) + strokeColors[3][k] * d0
+          );
+          strokeColors[2].push(
+            strokeColors[0][k] * d2 + strokeColors[3][k] * (1-d2)
+          );
+        }
+        for (const propName in immediateGeometry.userVertexProperties){
+          const size = immediateGeometry.userVertexProperties[propName].getDataSize();
+          for (k = 0; k < size; k++){
+            userVertexProperties[propName][1].push(
+              userVertexProperties[propName][0][k] * (1-d0) + userVertexProperties[propName][3][k] * d0
+            );
+            userVertexProperties[propName][2].push(
+              userVertexProperties[propName][0][k] * (1-d2) + userVertexProperties[propName][3][k] * d2
+            );
+          }
+        }
+
+        for (let i = 0; i < LUTLength; i++) {
+          // Interpolate colors using control points
+          this.states.curFillColor = [0, 0, 0, 0];
+          this.states.curStrokeColor = [0, 0, 0, 0];
+          _x = _y = 0;
+          for (let m = 0; m < 4; m++) {
+            for (let k = 0; k < 4; k++) {
+              this.states.curFillColor[k] +=
+                this._lookUpTableBezier[i][m] * fillColors[m][k];
+              this.states.curStrokeColor[k] +=
+                this._lookUpTableBezier[i][m] * strokeColors[m][k];
+            }
+            _x += w_x[m] * this._lookUpTableBezier[i][m];
+            _y += w_y[m] * this._lookUpTableBezier[i][m];
+          }
+          for (const propName in immediateGeometry.userVertexProperties){
+            const prop = immediateGeometry.userVertexProperties[propName];
+            const size = prop.getDataSize();
+            let newValues = Array(size).fill(0);
+            for (let m = 0; m < 4; m++){
+              for (let k = 0; k < size; k++){
+                newValues[k] += this._lookUpTableBezier[i][m] * userVertexProperties[propName][m][k];
+              }
+            }
+            prop.setCurrentData(newValues);
+          }
+          this.vertex(_x, _y);
+        }
+        // so that we leave currentColor with the last value the user set it to
+        this.states.curFillColor = fillColors[3];
+        this.states.curStrokeColor = strokeColors[3];
+        for (const propName in immediateGeometry.userVertexProperties) {
+          const prop = immediateGeometry.userVertexProperties[propName];
+          prop.setCurrentData(userVertexProperties[propName][2]);
+        }
+        this.immediateMode._bezierVertex[0] = args[4];
+        this.immediateMode._bezierVertex[1] = args[5];
+      } else if (argLength === 9) {
+        this.isBezier = true;
+
+        w_x = [this.immediateMode._bezierVertex[0], args[0], args[3], args[6]];
+        w_y = [this.immediateMode._bezierVertex[1], args[1], args[4], args[7]];
+        w_z = [this.immediateMode._bezierVertex[2], args[2], args[5], args[8]];
+        // The ratio of the distance between the start point, the two control-
+        // points, and the end point determines the intermediate color.
+        let d0 = Math.hypot(w_x[0]-w_x[1], w_y[0]-w_y[1], w_z[0]-w_z[1]);
+        let d1 = Math.hypot(w_x[1]-w_x[2], w_y[1]-w_y[2], w_z[1]-w_z[2]);
+        let d2 = Math.hypot(w_x[2]-w_x[3], w_y[2]-w_y[3], w_z[2]-w_z[3]);
+        const totalLength = d0 + d1 + d2;
+        d0 /= totalLength;
+        d2 /= totalLength;
+        for (let k = 0; k < 4; k++) {
+          fillColors[1].push(
+            fillColors[0][k] * (1-d0) + fillColors[3][k] * d0
+          );
+          fillColors[2].push(
+            fillColors[0][k] * d2 + fillColors[3][k] * (1-d2)
+          );
+          strokeColors[1].push(
+            strokeColors[0][k] * (1-d0) + strokeColors[3][k] * d0
+          );
+          strokeColors[2].push(
+            strokeColors[0][k] * d2 + strokeColors[3][k] * (1-d2)
+          );
+        }
+        for (const propName in immediateGeometry.userVertexProperties){
+          const size = immediateGeometry.userVertexProperties[propName].getDataSize();
+          for (k = 0; k < size; k++){
+            userVertexProperties[propName][1].push(
+              userVertexProperties[propName][0][k] * (1-d0) + userVertexProperties[propName][3][k] * d0
+            );
+            userVertexProperties[propName][2].push(
+              userVertexProperties[propName][0][k] * (1-d2) + userVertexProperties[propName][3][k] * d2
+            );
+          }
+        }
+        for (let i = 0; i < LUTLength; i++) {
+          // Interpolate colors using control points
+          this.states.curFillColor = [0, 0, 0, 0];
+          this.states.curStrokeColor = [0, 0, 0, 0];
+          _x = _y = _z = 0;
+          for (m = 0; m < 4; m++) {
+            for (k = 0; k < 4; k++) {
+              this.states.curFillColor[k] +=
+                this._lookUpTableBezier[i][m] * fillColors[m][k];
+              this.states.curStrokeColor[k] +=
+                this._lookUpTableBezier[i][m] * strokeColors[m][k];
+            }
+            _x += w_x[m] * this._lookUpTableBezier[i][m];
+            _y += w_y[m] * this._lookUpTableBezier[i][m];
+            _z += w_z[m] * this._lookUpTableBezier[i][m];
+          }
+          for (const propName in immediateGeometry.userVertexProperties){
+            const prop = immediateGeometry.userVertexProperties[propName];
+            const size = prop.getDataSize();
+            let newValues = Array(size).fill(0);
+            for (let m = 0; m < 4; m++){
+              for (let k = 0; k < size; k++){
+                newValues[k] += this._lookUpTableBezier[i][m] * userVertexProperties[propName][m][k];
+              }
+            }
+            prop.setCurrentData(newValues);
+          }
+          this.vertex(_x, _y, _z);
+        }
+        // so that we leave currentColor with the last value the user set it to
+        this.states.curFillColor = fillColors[3];
+        this.states.curStrokeColor = strokeColors[3];
+        for (const propName in immediateGeometry.userVertexProperties) {
+          const prop = immediateGeometry.userVertexProperties[propName];
+          prop.setCurrentData(userVertexProperties[propName][2]);
+        }
+        this.immediateMode._bezierVertex[0] = args[6];
+        this.immediateMode._bezierVertex[1] = args[7];
+        this.immediateMode._bezierVertex[2] = args[8];
       }
     }
-    quadGeom.computeNormals();
-    quadGeom.edges.length = 0;
-    const vertexOrder = [0, 2, 3, 1];
-    for (let i = 0; i < vertexOrder.length; i++) {
-      const startVertex = vertexOrder[i];
-      const endVertex = vertexOrder[(i + 1) % vertexOrder.length];
-      quadGeom.edges.push([startVertex, endVertex]);
+  };
+
+  p5.RendererGL.prototype.quadraticVertex = function(...args) {
+    if (this.immediateMode._quadraticVertex.length === 0) {
+      throw Error('vertex() must be used once before calling quadraticVertex()');
+    } else {
+      let w_x = [];
+      let w_y = [];
+      let w_z = [];
+      let t, _x, _y, _z, i, k, m;
+      // variable i for bezierPoints, k for components, and m for anchor points.
+      const argLength = args.length;
+
+      t = 0;
+
+      if (
+        this._lookUpTableQuadratic.length === 0 ||
+        this._lutQuadraticDetail !== this._pInst._curveDetail
+      ) {
+        this._lookUpTableQuadratic = [];
+        this._lutQuadraticDetail = this._pInst._curveDetail;
+        const step = 1 / this._lutQuadraticDetail;
+        let start = 0;
+        let end = 1;
+        let j = 0;
+        while (start < 1) {
+          t = parseFloat(start.toFixed(6));
+          this._lookUpTableQuadratic[j] = this._quadraticCoefficients(t);
+          if (end.toFixed(6) === step.toFixed(6)) {
+            t = parseFloat(end.toFixed(6)) + parseFloat(start.toFixed(6));
+            ++j;
+            this._lookUpTableQuadratic[j] = this._quadraticCoefficients(t);
+            break;
+          }
+          start += step;
+          end -= step;
+          ++j;
+        }
+      }
+
+      const LUTLength = this._lookUpTableQuadratic.length;
+      const immediateGeometry = this.immediateMode.geometry;
+
+      // fillColors[0]: start point color
+      // fillColors[1]: control point color
+      // fillColors[2]: end point color
+      const fillColors = [];
+      for (m = 0; m < 3; m++) fillColors.push([]);
+      fillColors[0] = immediateGeometry.vertexColors.slice(-4);
+      fillColors[2] = this.states.curFillColor.slice();
+
+      // Do the same for strokeColor.
+      const strokeColors = [];
+      for (m = 0; m < 3; m++) strokeColors.push([]);
+      strokeColors[0] = immediateGeometry.vertexStrokeColors.slice(-4);
+      strokeColors[2] = this.states.curStrokeColor.slice();
+
+      // Do the same for user defined vertex properties
+      const userVertexProperties = {};
+      for (const propName in immediateGeometry.userVertexProperties){
+        const prop = immediateGeometry.userVertexProperties[propName];
+        const size = prop.getDataSize();
+        userVertexProperties[propName] = [];
+        for (m = 0; m < 3; m++) userVertexProperties[propName].push([]);
+        userVertexProperties[propName][0] = prop.getSrcArray().slice(-size);
+        userVertexProperties[propName][2] = prop.getCurrentData();
+      }
+
+      if (argLength === 4) {
+        this.isQuadratic = true;
+
+        w_x = [this.immediateMode._quadraticVertex[0], args[0], args[2]];
+        w_y = [this.immediateMode._quadraticVertex[1], args[1], args[3]];
+
+        // The ratio of the distance between the start point, the control-
+        // point, and the end point determines the intermediate color.
+        let d0 = Math.hypot(w_x[0]-w_x[1], w_y[0]-w_y[1]);
+        let d1 = Math.hypot(w_x[1]-w_x[2], w_y[1]-w_y[2]);
+        const totalLength = d0 + d1;
+        d0 /= totalLength;
+        for (let k = 0; k < 4; k++) {
+          fillColors[1].push(
+            fillColors[0][k] * (1-d0) + fillColors[2][k] * d0
+          );
+          strokeColors[1].push(
+            strokeColors[0][k] * (1-d0) + strokeColors[2][k] * d0
+          );
+        }
+        for (const propName in immediateGeometry.userVertexProperties){
+          const prop = immediateGeometry.userVertexProperties[propName];
+          const size = prop.getDataSize();
+          for (let k = 0; k < size; k++){
+            userVertexProperties[propName][1].push(
+              userVertexProperties[propName][0][k] * (1-d0) + userVertexProperties[propName][2][k] * d0
+            );
+          }
+        }
+
+        for (let i = 0; i < LUTLength; i++) {
+          // Interpolate colors using control points
+          this.states.curFillColor = [0, 0, 0, 0];
+          this.states.curStrokeColor = [0, 0, 0, 0];
+          _x = _y = 0;
+          for (let m = 0; m < 3; m++) {
+            for (let k = 0; k < 4; k++) {
+              this.states.curFillColor[k] +=
+                this._lookUpTableQuadratic[i][m] * fillColors[m][k];
+              this.states.curStrokeColor[k] +=
+                this._lookUpTableQuadratic[i][m] * strokeColors[m][k];
+            }
+            _x += w_x[m] * this._lookUpTableQuadratic[i][m];
+            _y += w_y[m] * this._lookUpTableQuadratic[i][m];
+          }
+
+          for (const propName in immediateGeometry.userVertexProperties) {
+            const prop = immediateGeometry.userVertexProperties[propName];
+            const size = prop.getDataSize();
+            let newValues = Array(size).fill(0);
+            for (let m = 0; m < 3; m++){
+              for (let k = 0; k < size; k++){
+                newValues[k] += this._lookUpTableQuadratic[i][m] * userVertexProperties[propName][m][k];
+              }
+            }
+            prop.setCurrentData(newValues);
+          }
+          this.vertex(_x, _y);
+        }
+
+        // so that we leave currentColor with the last value the user set it to
+        this.states.curFillColor = fillColors[2];
+        this.states.curStrokeColor = strokeColors[2];
+        for (const propName in immediateGeometry.userVertexProperties) {
+          const prop = immediateGeometry.userVertexProperties[propName];
+          prop.setCurrentData(userVertexProperties[propName][2]);
+        }
+        this.immediateMode._quadraticVertex[0] = args[2];
+        this.immediateMode._quadraticVertex[1] = args[3];
+      } else if (argLength === 6) {
+        this.isQuadratic = true;
+
+        w_x = [this.immediateMode._quadraticVertex[0], args[0], args[3]];
+        w_y = [this.immediateMode._quadraticVertex[1], args[1], args[4]];
+        w_z = [this.immediateMode._quadraticVertex[2], args[2], args[5]];
+
+        // The ratio of the distance between the start point, the control-
+        // point, and the end point determines the intermediate color.
+        let d0 = Math.hypot(w_x[0]-w_x[1], w_y[0]-w_y[1], w_z[0]-w_z[1]);
+        let d1 = Math.hypot(w_x[1]-w_x[2], w_y[1]-w_y[2], w_z[1]-w_z[2]);
+        const totalLength = d0 + d1;
+        d0 /= totalLength;
+        for (k = 0; k < 4; k++) {
+          fillColors[1].push(
+            fillColors[0][k] * (1-d0) + fillColors[2][k] * d0
+          );
+          strokeColors[1].push(
+            strokeColors[0][k] * (1-d0) + strokeColors[2][k] * d0
+          );
+        }
+
+        for (const propName in immediateGeometry.userVertexProperties){
+          const prop = immediateGeometry.userVertexProperties[propName];
+          const size = prop.getDataSize();
+          for (let k = 0; k < size; k++){
+            userVertexProperties[propName][1].push(
+              userVertexProperties[propName][0][k] * (1-d0) + userVertexProperties[propName][2][k] * d0
+            );
+          }
+        }
+
+        for (i = 0; i < LUTLength; i++) {
+          // Interpolate colors using control points
+          this.states.curFillColor = [0, 0, 0, 0];
+          this.states.curStrokeColor = [0, 0, 0, 0];
+          _x = _y = _z = 0;
+          for (m = 0; m < 3; m++) {
+            for (k = 0; k < 4; k++) {
+              this.states.curFillColor[k] +=
+                this._lookUpTableQuadratic[i][m] * fillColors[m][k];
+              this.states.curStrokeColor[k] +=
+                this._lookUpTableQuadratic[i][m] * strokeColors[m][k];
+            }
+            _x += w_x[m] * this._lookUpTableQuadratic[i][m];
+            _y += w_y[m] * this._lookUpTableQuadratic[i][m];
+            _z += w_z[m] * this._lookUpTableQuadratic[i][m];
+          }
+          for (const propName in immediateGeometry.userVertexProperties) {
+            const prop = immediateGeometry.userVertexProperties[propName];
+            const size = prop.getDataSize();
+            let newValues = Array(size).fill(0);
+            for (let m = 0; m < 3; m++){
+              for (let k = 0; k < size; k++){
+                newValues[k] += this._lookUpTableQuadratic[i][m] * userVertexProperties[propName][m][k];
+              }
+            }
+            prop.setCurrentData(newValues);
+          }
+          this.vertex(_x, _y, _z);
+        }
+
+        // so that we leave currentColor with the last value the user set it to
+        this.states.curFillColor = fillColors[2];
+        this.states.curStrokeColor = strokeColors[2];
+        for (const propName in immediateGeometry.userVertexProperties) {
+          const prop = immediateGeometry.userVertexProperties[propName];
+          prop.setCurrentData(userVertexProperties[propName][2]);
+        }
+        this.immediateMode._quadraticVertex[0] = args[3];
+        this.immediateMode._quadraticVertex[1] = args[4];
+        this.immediateMode._quadraticVertex[2] = args[5];
+      }
     }
-    quadGeom._edgesToVertices();
-    this.createBuffers(gId, quadGeom);
-  }
-  this.drawBuffers(gId);
-  return this;
-};
+  };
 
-//this implementation of bezier curve
-//is based on Bernstein polynomial
-// pretier-ignore
-p5.RendererGL.prototype.bezier = function(
-  x1,
-  y1,
-  z1, // x2
-  x2, // y2
-  y2, // x3
-  z2, // y3
-  x3, // x4
-  y3, // y4
-  z3,
-  x4,
-  y4,
-  z4
-) {
-  if (arguments.length === 8) {
-    y4 = y3;
-    x4 = x3;
-    y3 = z2;
-    x3 = y2;
-    y2 = x2;
-    x2 = z1;
-    z1 = z2 = z3 = z4 = 0;
-  }
-  const bezierDetail = this._pInst._bezierDetail || 20; //value of Bezier detail
-  this.beginShape();
-  for (let i = 0; i <= bezierDetail; i++) {
-    const c1 = Math.pow(1 - i / bezierDetail, 3);
-    const c2 = 3 * (i / bezierDetail) * Math.pow(1 - i / bezierDetail, 2);
-    const c3 = 3 * Math.pow(i / bezierDetail, 2) * (1 - i / bezierDetail);
-    const c4 = Math.pow(i / bezierDetail, 3);
-    this.vertex(
-      x1 * c1 + x2 * c2 + x3 * c3 + x4 * c4,
-      y1 * c1 + y2 * c2 + y3 * c3 + y4 * c4,
-      z1 * c1 + z2 * c2 + z3 * c3 + z4 * c4
-    );
-  }
-  this.endShape();
-  return this;
-};
-
-// pretier-ignore
-p5.RendererGL.prototype.curve = function(
-  x1,
-  y1,
-  z1, // x2
-  x2, // y2
-  y2, // x3
-  z2, // y3
-  x3, // x4
-  y3, // y4
-  z3,
-  x4,
-  y4,
-  z4
-) {
-  if (arguments.length === 8) {
-    x4 = x3;
-    y4 = y3;
-    x3 = y2;
-    y3 = x2;
-    x2 = z1;
-    y2 = x2;
-    z1 = z2 = z3 = z4 = 0;
-  }
-  const curveDetail = this._pInst._curveDetail;
-  this.beginShape();
-  for (let i = 0; i <= curveDetail; i++) {
-    const c1 = Math.pow(i / curveDetail, 3) * 0.5;
-    const c2 = Math.pow(i / curveDetail, 2) * 0.5;
-    const c3 = i / curveDetail * 0.5;
-    const c4 = 0.5;
-    const vx =
-      c1 * (-x1 + 3 * x2 - 3 * x3 + x4) +
-      c2 * (2 * x1 - 5 * x2 + 4 * x3 - x4) +
-      c3 * (-x1 + x3) +
-      c4 * (2 * x2);
-    const vy =
-      c1 * (-y1 + 3 * y2 - 3 * y3 + y4) +
-      c2 * (2 * y1 - 5 * y2 + 4 * y3 - y4) +
-      c3 * (-y1 + y3) +
-      c4 * (2 * y2);
-    const vz =
-      c1 * (-z1 + 3 * z2 - 3 * z3 + z4) +
-      c2 * (2 * z1 - 5 * z2 + 4 * z3 - z4) +
-      c3 * (-z1 + z3) +
-      c4 * (2 * z2);
-    this.vertex(vx, vy, vz);
-  }
-  this.endShape();
-  return this;
-};
-
-/**
- * Draw a line given two points
- * @private
- * @param {Number} x0 x-coordinate of first vertex
- * @param {Number} y0 y-coordinate of first vertex
- * @param {Number} z0 z-coordinate of first vertex
- * @param {Number} x1 x-coordinate of second vertex
- * @param {Number} y1 y-coordinate of second vertex
- * @param {Number} z1 z-coordinate of second vertex
- * @chainable
- * @example
- * <div>
- * <code>
- * //draw a line
- * function setup() {
- *   createCanvas(100, 100, WEBGL);
- * }
- *
- * function draw() {
- *   background(200);
- *   rotateX(frameCount * 0.01);
- *   rotateY(frameCount * 0.01);
- *   // Use fill instead of stroke to change the color of shape.
- *   fill(255, 0, 0);
- *   line(10, 10, 0, 60, 60, 20);
- * }
- * </code>
- * </div>
- */
-p5.RendererGL.prototype.line = function(...args) {
-  if (args.length === 6) {
-    this.beginShape(constants.LINES);
-    this.vertex(args[0], args[1], args[2]);
-    this.vertex(args[3], args[4], args[5]);
-    this.endShape();
-  } else if (args.length === 4) {
-    this.beginShape(constants.LINES);
-    this.vertex(args[0], args[1], 0);
-    this.vertex(args[2], args[3], 0);
-    this.endShape();
-  }
-  return this;
-};
-
-p5.RendererGL.prototype.bezierVertex = function(...args) {
-  if (this.immediateMode._bezierVertex.length === 0) {
-    throw Error('vertex() must be used once before calling bezierVertex()');
-  } else {
+  p5.RendererGL.prototype.curveVertex = function(...args) {
     let w_x = [];
     let w_y = [];
     let w_z = [];
-    let t, _x, _y, _z, i, k, m;
-    // variable i for bezierPoints, k for components, and m for anchor points.
-    const argLength = args.length;
-
+    let t, _x, _y, _z, i;
     t = 0;
+    const argLength = args.length;
 
     if (
       this._lookUpTableBezier.length === 0 ||
@@ -3003,575 +3432,150 @@ p5.RendererGL.prototype.bezierVertex = function(...args) {
     }
 
     const LUTLength = this._lookUpTableBezier.length;
-    const immediateGeometry = this.immediateMode.geometry;
 
-    // fillColors[0]: start point color
-    // fillColors[1],[2]: control point color
-    // fillColors[3]: end point color
-    const fillColors = [];
-    for (m = 0; m < 4; m++) fillColors.push([]);
-    fillColors[0] = immediateGeometry.vertexColors.slice(-4);
-    fillColors[3] = this.states.curFillColor.slice();
-
-    // Do the same for strokeColor.
-    const strokeColors = [];
-    for (m = 0; m < 4; m++) strokeColors.push([]);
-    strokeColors[0] = immediateGeometry.vertexStrokeColors.slice(-4);
-    strokeColors[3] = this.states.curStrokeColor.slice();
-
-    // Do the same for custom vertex properties
-    const userVertexProperties = {};
-    for (const propName in immediateGeometry.userVertexProperties){
-      const prop = immediateGeometry.userVertexProperties[propName];
-      const size = prop.getDataSize();
-      userVertexProperties[propName] = [];
-      for (m = 0; m < 4; m++) userVertexProperties[propName].push([]);
-      userVertexProperties[propName][0] = prop.getSrcArray().slice(-size);
-      userVertexProperties[propName][3] = prop.getCurrentData();
-    }
-
-    if (argLength === 6) {
-      this.isBezier = true;
-
-      w_x = [this.immediateMode._bezierVertex[0], args[0], args[2], args[4]];
-      w_y = [this.immediateMode._bezierVertex[1], args[1], args[3], args[5]];
-      // The ratio of the distance between the start point, the two control-
-      // points, and the end point determines the intermediate color.
-      let d0 = Math.hypot(w_x[0]-w_x[1], w_y[0]-w_y[1]);
-      let d1 = Math.hypot(w_x[1]-w_x[2], w_y[1]-w_y[2]);
-      let d2 = Math.hypot(w_x[2]-w_x[3], w_y[2]-w_y[3]);
-      const totalLength = d0 + d1 + d2;
-      d0 /= totalLength;
-      d2 /= totalLength;
-      for (k = 0; k < 4; k++) {
-        fillColors[1].push(
-          fillColors[0][k] * (1-d0) + fillColors[3][k] * d0
-        );
-        fillColors[2].push(
-          fillColors[0][k] * d2 + fillColors[3][k] * (1-d2)
-        );
-        strokeColors[1].push(
-          strokeColors[0][k] * (1-d0) + strokeColors[3][k] * d0
-        );
-        strokeColors[2].push(
-          strokeColors[0][k] * d2 + strokeColors[3][k] * (1-d2)
-        );
-      }
-      for (const propName in immediateGeometry.userVertexProperties){
-        const size = immediateGeometry.userVertexProperties[propName].getDataSize();
-        for (k = 0; k < size; k++){
-          userVertexProperties[propName][1].push(
-            userVertexProperties[propName][0][k] * (1-d0) + userVertexProperties[propName][3][k] * d0
-          );
-          userVertexProperties[propName][2].push(
-            userVertexProperties[propName][0][k] * (1-d2) + userVertexProperties[propName][3][k] * d2
-          );
+    if (argLength === 2) {
+      this.immediateMode._curveVertex.push(args[0]);
+      this.immediateMode._curveVertex.push(args[1]);
+      if (this.immediateMode._curveVertex.length === 8) {
+        this.isCurve = true;
+        w_x = this._bezierToCatmull([
+          this.immediateMode._curveVertex[0],
+          this.immediateMode._curveVertex[2],
+          this.immediateMode._curveVertex[4],
+          this.immediateMode._curveVertex[6]
+        ]);
+        w_y = this._bezierToCatmull([
+          this.immediateMode._curveVertex[1],
+          this.immediateMode._curveVertex[3],
+          this.immediateMode._curveVertex[5],
+          this.immediateMode._curveVertex[7]
+        ]);
+        for (i = 0; i < LUTLength; i++) {
+          _x =
+            w_x[0] * this._lookUpTableBezier[i][0] +
+            w_x[1] * this._lookUpTableBezier[i][1] +
+            w_x[2] * this._lookUpTableBezier[i][2] +
+            w_x[3] * this._lookUpTableBezier[i][3];
+          _y =
+            w_y[0] * this._lookUpTableBezier[i][0] +
+            w_y[1] * this._lookUpTableBezier[i][1] +
+            w_y[2] * this._lookUpTableBezier[i][2] +
+            w_y[3] * this._lookUpTableBezier[i][3];
+          this.vertex(_x, _y);
+        }
+        for (i = 0; i < argLength; i++) {
+          this.immediateMode._curveVertex.shift();
         }
       }
-
-      for (let i = 0; i < LUTLength; i++) {
-        // Interpolate colors using control points
-        this.states.curFillColor = [0, 0, 0, 0];
-        this.states.curStrokeColor = [0, 0, 0, 0];
-        _x = _y = 0;
-        for (let m = 0; m < 4; m++) {
-          for (let k = 0; k < 4; k++) {
-            this.states.curFillColor[k] +=
-              this._lookUpTableBezier[i][m] * fillColors[m][k];
-            this.states.curStrokeColor[k] +=
-              this._lookUpTableBezier[i][m] * strokeColors[m][k];
-          }
-          _x += w_x[m] * this._lookUpTableBezier[i][m];
-          _y += w_y[m] * this._lookUpTableBezier[i][m];
+    } else if (argLength === 3) {
+      this.immediateMode._curveVertex.push(args[0]);
+      this.immediateMode._curveVertex.push(args[1]);
+      this.immediateMode._curveVertex.push(args[2]);
+      if (this.immediateMode._curveVertex.length === 12) {
+        this.isCurve = true;
+        w_x = this._bezierToCatmull([
+          this.immediateMode._curveVertex[0],
+          this.immediateMode._curveVertex[3],
+          this.immediateMode._curveVertex[6],
+          this.immediateMode._curveVertex[9]
+        ]);
+        w_y = this._bezierToCatmull([
+          this.immediateMode._curveVertex[1],
+          this.immediateMode._curveVertex[4],
+          this.immediateMode._curveVertex[7],
+          this.immediateMode._curveVertex[10]
+        ]);
+        w_z = this._bezierToCatmull([
+          this.immediateMode._curveVertex[2],
+          this.immediateMode._curveVertex[5],
+          this.immediateMode._curveVertex[8],
+          this.immediateMode._curveVertex[11]
+        ]);
+        for (i = 0; i < LUTLength; i++) {
+          _x =
+            w_x[0] * this._lookUpTableBezier[i][0] +
+            w_x[1] * this._lookUpTableBezier[i][1] +
+            w_x[2] * this._lookUpTableBezier[i][2] +
+            w_x[3] * this._lookUpTableBezier[i][3];
+          _y =
+            w_y[0] * this._lookUpTableBezier[i][0] +
+            w_y[1] * this._lookUpTableBezier[i][1] +
+            w_y[2] * this._lookUpTableBezier[i][2] +
+            w_y[3] * this._lookUpTableBezier[i][3];
+          _z =
+            w_z[0] * this._lookUpTableBezier[i][0] +
+            w_z[1] * this._lookUpTableBezier[i][1] +
+            w_z[2] * this._lookUpTableBezier[i][2] +
+            w_z[3] * this._lookUpTableBezier[i][3];
+          this.vertex(_x, _y, _z);
         }
-        for (const propName in immediateGeometry.userVertexProperties){
-          const prop = immediateGeometry.userVertexProperties[propName];
-          const size = prop.getDataSize();
-          let newValues = Array(size).fill(0);
-          for (let m = 0; m < 4; m++){
-            for (let k = 0; k < size; k++){
-              newValues[k] += this._lookUpTableBezier[i][m] * userVertexProperties[propName][m][k];
-            }
-          }
-          prop.setCurrentData(newValues);
+        for (i = 0; i < argLength; i++) {
+          this.immediateMode._curveVertex.shift();
         }
-        this.vertex(_x, _y);
-      }
-      // so that we leave currentColor with the last value the user set it to
-      this.states.curFillColor = fillColors[3];
-      this.states.curStrokeColor = strokeColors[3];
-      for (const propName in immediateGeometry.userVertexProperties) {
-        const prop = immediateGeometry.userVertexProperties[propName];
-        prop.setCurrentData(userVertexProperties[propName][2]);
-      }
-      this.immediateMode._bezierVertex[0] = args[4];
-      this.immediateMode._bezierVertex[1] = args[5];
-    } else if (argLength === 9) {
-      this.isBezier = true;
-
-      w_x = [this.immediateMode._bezierVertex[0], args[0], args[3], args[6]];
-      w_y = [this.immediateMode._bezierVertex[1], args[1], args[4], args[7]];
-      w_z = [this.immediateMode._bezierVertex[2], args[2], args[5], args[8]];
-      // The ratio of the distance between the start point, the two control-
-      // points, and the end point determines the intermediate color.
-      let d0 = Math.hypot(w_x[0]-w_x[1], w_y[0]-w_y[1], w_z[0]-w_z[1]);
-      let d1 = Math.hypot(w_x[1]-w_x[2], w_y[1]-w_y[2], w_z[1]-w_z[2]);
-      let d2 = Math.hypot(w_x[2]-w_x[3], w_y[2]-w_y[3], w_z[2]-w_z[3]);
-      const totalLength = d0 + d1 + d2;
-      d0 /= totalLength;
-      d2 /= totalLength;
-      for (let k = 0; k < 4; k++) {
-        fillColors[1].push(
-          fillColors[0][k] * (1-d0) + fillColors[3][k] * d0
-        );
-        fillColors[2].push(
-          fillColors[0][k] * d2 + fillColors[3][k] * (1-d2)
-        );
-        strokeColors[1].push(
-          strokeColors[0][k] * (1-d0) + strokeColors[3][k] * d0
-        );
-        strokeColors[2].push(
-          strokeColors[0][k] * d2 + strokeColors[3][k] * (1-d2)
-        );
-      }
-      for (const propName in immediateGeometry.userVertexProperties){
-        const size = immediateGeometry.userVertexProperties[propName].getDataSize();
-        for (k = 0; k < size; k++){
-          userVertexProperties[propName][1].push(
-            userVertexProperties[propName][0][k] * (1-d0) + userVertexProperties[propName][3][k] * d0
-          );
-          userVertexProperties[propName][2].push(
-            userVertexProperties[propName][0][k] * (1-d2) + userVertexProperties[propName][3][k] * d2
-          );
-        }
-      }
-      for (let i = 0; i < LUTLength; i++) {
-        // Interpolate colors using control points
-        this.states.curFillColor = [0, 0, 0, 0];
-        this.states.curStrokeColor = [0, 0, 0, 0];
-        _x = _y = _z = 0;
-        for (m = 0; m < 4; m++) {
-          for (k = 0; k < 4; k++) {
-            this.states.curFillColor[k] +=
-              this._lookUpTableBezier[i][m] * fillColors[m][k];
-            this.states.curStrokeColor[k] +=
-              this._lookUpTableBezier[i][m] * strokeColors[m][k];
-          }
-          _x += w_x[m] * this._lookUpTableBezier[i][m];
-          _y += w_y[m] * this._lookUpTableBezier[i][m];
-          _z += w_z[m] * this._lookUpTableBezier[i][m];
-        }
-        for (const propName in immediateGeometry.userVertexProperties){
-          const prop = immediateGeometry.userVertexProperties[propName];
-          const size = prop.getDataSize();
-          let newValues = Array(size).fill(0);
-          for (let m = 0; m < 4; m++){
-            for (let k = 0; k < size; k++){
-              newValues[k] += this._lookUpTableBezier[i][m] * userVertexProperties[propName][m][k];
-            }
-          }
-          prop.setCurrentData(newValues);
-        }
-        this.vertex(_x, _y, _z);
-      }
-      // so that we leave currentColor with the last value the user set it to
-      this.states.curFillColor = fillColors[3];
-      this.states.curStrokeColor = strokeColors[3];
-      for (const propName in immediateGeometry.userVertexProperties) {
-        const prop = immediateGeometry.userVertexProperties[propName];
-        prop.setCurrentData(userVertexProperties[propName][2]);
-      }
-      this.immediateMode._bezierVertex[0] = args[6];
-      this.immediateMode._bezierVertex[1] = args[7];
-      this.immediateMode._bezierVertex[2] = args[8];
-    }
-  }
-};
-
-p5.RendererGL.prototype.quadraticVertex = function(...args) {
-  if (this.immediateMode._quadraticVertex.length === 0) {
-    throw Error('vertex() must be used once before calling quadraticVertex()');
-  } else {
-    let w_x = [];
-    let w_y = [];
-    let w_z = [];
-    let t, _x, _y, _z, i, k, m;
-    // variable i for bezierPoints, k for components, and m for anchor points.
-    const argLength = args.length;
-
-    t = 0;
-
-    if (
-      this._lookUpTableQuadratic.length === 0 ||
-      this._lutQuadraticDetail !== this._pInst._curveDetail
-    ) {
-      this._lookUpTableQuadratic = [];
-      this._lutQuadraticDetail = this._pInst._curveDetail;
-      const step = 1 / this._lutQuadraticDetail;
-      let start = 0;
-      let end = 1;
-      let j = 0;
-      while (start < 1) {
-        t = parseFloat(start.toFixed(6));
-        this._lookUpTableQuadratic[j] = this._quadraticCoefficients(t);
-        if (end.toFixed(6) === step.toFixed(6)) {
-          t = parseFloat(end.toFixed(6)) + parseFloat(start.toFixed(6));
-          ++j;
-          this._lookUpTableQuadratic[j] = this._quadraticCoefficients(t);
-          break;
-        }
-        start += step;
-        end -= step;
-        ++j;
       }
     }
+  };
 
-    const LUTLength = this._lookUpTableQuadratic.length;
-    const immediateGeometry = this.immediateMode.geometry;
-
-    // fillColors[0]: start point color
-    // fillColors[1]: control point color
-    // fillColors[2]: end point color
-    const fillColors = [];
-    for (m = 0; m < 3; m++) fillColors.push([]);
-    fillColors[0] = immediateGeometry.vertexColors.slice(-4);
-    fillColors[2] = this.states.curFillColor.slice();
-
-    // Do the same for strokeColor.
-    const strokeColors = [];
-    for (m = 0; m < 3; m++) strokeColors.push([]);
-    strokeColors[0] = immediateGeometry.vertexStrokeColors.slice(-4);
-    strokeColors[2] = this.states.curStrokeColor.slice();
-
-    // Do the same for user defined vertex properties
-    const userVertexProperties = {};
-    for (const propName in immediateGeometry.userVertexProperties){
-      const prop = immediateGeometry.userVertexProperties[propName];
-      const size = prop.getDataSize();
-      userVertexProperties[propName] = [];
-      for (m = 0; m < 3; m++) userVertexProperties[propName].push([]);
-      userVertexProperties[propName][0] = prop.getSrcArray().slice(-size);
-      userVertexProperties[propName][2] = prop.getCurrentData();
-    }
-
-    if (argLength === 4) {
-      this.isQuadratic = true;
-
-      w_x = [this.immediateMode._quadraticVertex[0], args[0], args[2]];
-      w_y = [this.immediateMode._quadraticVertex[1], args[1], args[3]];
-
-      // The ratio of the distance between the start point, the control-
-      // point, and the end point determines the intermediate color.
-      let d0 = Math.hypot(w_x[0]-w_x[1], w_y[0]-w_y[1]);
-      let d1 = Math.hypot(w_x[1]-w_x[2], w_y[1]-w_y[2]);
-      const totalLength = d0 + d1;
-      d0 /= totalLength;
-      for (let k = 0; k < 4; k++) {
-        fillColors[1].push(
-          fillColors[0][k] * (1-d0) + fillColors[2][k] * d0
-        );
-        strokeColors[1].push(
-          strokeColors[0][k] * (1-d0) + strokeColors[2][k] * d0
-        );
-      }
-      for (const propName in immediateGeometry.userVertexProperties){
-        const prop = immediateGeometry.userVertexProperties[propName];
-        const size = prop.getDataSize();
-        for (let k = 0; k < size; k++){
-          userVertexProperties[propName][1].push(
-            userVertexProperties[propName][0][k] * (1-d0) + userVertexProperties[propName][2][k] * d0
-          );
-        }
-      }
-
-      for (let i = 0; i < LUTLength; i++) {
-        // Interpolate colors using control points
-        this.states.curFillColor = [0, 0, 0, 0];
-        this.states.curStrokeColor = [0, 0, 0, 0];
-        _x = _y = 0;
-        for (let m = 0; m < 3; m++) {
-          for (let k = 0; k < 4; k++) {
-            this.states.curFillColor[k] +=
-              this._lookUpTableQuadratic[i][m] * fillColors[m][k];
-            this.states.curStrokeColor[k] +=
-              this._lookUpTableQuadratic[i][m] * strokeColors[m][k];
-          }
-          _x += w_x[m] * this._lookUpTableQuadratic[i][m];
-          _y += w_y[m] * this._lookUpTableQuadratic[i][m];
-        }
-
-        for (const propName in immediateGeometry.userVertexProperties) {
-          const prop = immediateGeometry.userVertexProperties[propName];
-          const size = prop.getDataSize();
-          let newValues = Array(size).fill(0);
-          for (let m = 0; m < 3; m++){
-            for (let k = 0; k < size; k++){
-              newValues[k] += this._lookUpTableQuadratic[i][m] * userVertexProperties[propName][m][k];
-            }
-          }
-          prop.setCurrentData(newValues);
-        }
-        this.vertex(_x, _y);
-      }
-
-      // so that we leave currentColor with the last value the user set it to
-      this.states.curFillColor = fillColors[2];
-      this.states.curStrokeColor = strokeColors[2];
-      for (const propName in immediateGeometry.userVertexProperties) {
-        const prop = immediateGeometry.userVertexProperties[propName];
-        prop.setCurrentData(userVertexProperties[propName][2]);
-      }
-      this.immediateMode._quadraticVertex[0] = args[2];
-      this.immediateMode._quadraticVertex[1] = args[3];
-    } else if (argLength === 6) {
-      this.isQuadratic = true;
-
-      w_x = [this.immediateMode._quadraticVertex[0], args[0], args[3]];
-      w_y = [this.immediateMode._quadraticVertex[1], args[1], args[4]];
-      w_z = [this.immediateMode._quadraticVertex[2], args[2], args[5]];
-
-      // The ratio of the distance between the start point, the control-
-      // point, and the end point determines the intermediate color.
-      let d0 = Math.hypot(w_x[0]-w_x[1], w_y[0]-w_y[1], w_z[0]-w_z[1]);
-      let d1 = Math.hypot(w_x[1]-w_x[2], w_y[1]-w_y[2], w_z[1]-w_z[2]);
-      const totalLength = d0 + d1;
-      d0 /= totalLength;
-      for (k = 0; k < 4; k++) {
-        fillColors[1].push(
-          fillColors[0][k] * (1-d0) + fillColors[2][k] * d0
-        );
-        strokeColors[1].push(
-          strokeColors[0][k] * (1-d0) + strokeColors[2][k] * d0
-        );
-      }
-
-      for (const propName in immediateGeometry.userVertexProperties){
-        const prop = immediateGeometry.userVertexProperties[propName];
-        const size = prop.getDataSize();
-        for (let k = 0; k < size; k++){
-          userVertexProperties[propName][1].push(
-            userVertexProperties[propName][0][k] * (1-d0) + userVertexProperties[propName][2][k] * d0
-          );
-        }
-      }
-
-      for (i = 0; i < LUTLength; i++) {
-        // Interpolate colors using control points
-        this.states.curFillColor = [0, 0, 0, 0];
-        this.states.curStrokeColor = [0, 0, 0, 0];
-        _x = _y = _z = 0;
-        for (m = 0; m < 3; m++) {
-          for (k = 0; k < 4; k++) {
-            this.states.curFillColor[k] +=
-              this._lookUpTableQuadratic[i][m] * fillColors[m][k];
-            this.states.curStrokeColor[k] +=
-              this._lookUpTableQuadratic[i][m] * strokeColors[m][k];
-          }
-          _x += w_x[m] * this._lookUpTableQuadratic[i][m];
-          _y += w_y[m] * this._lookUpTableQuadratic[i][m];
-          _z += w_z[m] * this._lookUpTableQuadratic[i][m];
-        }
-        for (const propName in immediateGeometry.userVertexProperties) {
-          const prop = immediateGeometry.userVertexProperties[propName];
-          const size = prop.getDataSize();
-          let newValues = Array(size).fill(0);
-          for (let m = 0; m < 3; m++){
-            for (let k = 0; k < size; k++){
-              newValues[k] += this._lookUpTableQuadratic[i][m] * userVertexProperties[propName][m][k];
-            }
-          }
-          prop.setCurrentData(newValues);
-        }
-        this.vertex(_x, _y, _z);
-      }
-
-      // so that we leave currentColor with the last value the user set it to
-      this.states.curFillColor = fillColors[2];
-      this.states.curStrokeColor = strokeColors[2];
-      for (const propName in immediateGeometry.userVertexProperties) {
-        const prop = immediateGeometry.userVertexProperties[propName];
-        prop.setCurrentData(userVertexProperties[propName][2]);
-      }
-      this.immediateMode._quadraticVertex[0] = args[3];
-      this.immediateMode._quadraticVertex[1] = args[4];
-      this.immediateMode._quadraticVertex[2] = args[5];
-    }
-  }
-};
-
-p5.RendererGL.prototype.curveVertex = function(...args) {
-  let w_x = [];
-  let w_y = [];
-  let w_z = [];
-  let t, _x, _y, _z, i;
-  t = 0;
-  const argLength = args.length;
-
-  if (
-    this._lookUpTableBezier.length === 0 ||
-    this._lutBezierDetail !== this._pInst._curveDetail
+  p5.RendererGL.prototype.image = function(
+    img,
+    sx,
+    sy,
+    sWidth,
+    sHeight,
+    dx,
+    dy,
+    dWidth,
+    dHeight
   ) {
-    this._lookUpTableBezier = [];
-    this._lutBezierDetail = this._pInst._curveDetail;
-    const step = 1 / this._lutBezierDetail;
-    let start = 0;
-    let end = 1;
-    let j = 0;
-    while (start < 1) {
-      t = parseFloat(start.toFixed(6));
-      this._lookUpTableBezier[j] = this._bezierCoefficients(t);
-      if (end.toFixed(6) === step.toFixed(6)) {
-        t = parseFloat(end.toFixed(6)) + parseFloat(start.toFixed(6));
-        ++j;
-        this._lookUpTableBezier[j] = this._bezierCoefficients(t);
-        break;
-      }
-      start += step;
-      end -= step;
-      ++j;
+    if (this._isErasing) {
+      this.blendMode(this._cachedBlendMode);
     }
-  }
 
-  const LUTLength = this._lookUpTableBezier.length;
+    this._pInst.push();
 
-  if (argLength === 2) {
-    this.immediateMode._curveVertex.push(args[0]);
-    this.immediateMode._curveVertex.push(args[1]);
-    if (this.immediateMode._curveVertex.length === 8) {
-      this.isCurve = true;
-      w_x = this._bezierToCatmull([
-        this.immediateMode._curveVertex[0],
-        this.immediateMode._curveVertex[2],
-        this.immediateMode._curveVertex[4],
-        this.immediateMode._curveVertex[6]
-      ]);
-      w_y = this._bezierToCatmull([
-        this.immediateMode._curveVertex[1],
-        this.immediateMode._curveVertex[3],
-        this.immediateMode._curveVertex[5],
-        this.immediateMode._curveVertex[7]
-      ]);
-      for (i = 0; i < LUTLength; i++) {
-        _x =
-          w_x[0] * this._lookUpTableBezier[i][0] +
-          w_x[1] * this._lookUpTableBezier[i][1] +
-          w_x[2] * this._lookUpTableBezier[i][2] +
-          w_x[3] * this._lookUpTableBezier[i][3];
-        _y =
-          w_y[0] * this._lookUpTableBezier[i][0] +
-          w_y[1] * this._lookUpTableBezier[i][1] +
-          w_y[2] * this._lookUpTableBezier[i][2] +
-          w_y[3] * this._lookUpTableBezier[i][3];
-        this.vertex(_x, _y);
-      }
-      for (i = 0; i < argLength; i++) {
-        this.immediateMode._curveVertex.shift();
-      }
+    this._pInst.noLights();
+    this._pInst.noStroke();
+
+    this._pInst.texture(img);
+    this._pInst.textureMode(constants.NORMAL);
+
+    let u0 = 0;
+    if (sx <= img.width) {
+      u0 = sx / img.width;
     }
-  } else if (argLength === 3) {
-    this.immediateMode._curveVertex.push(args[0]);
-    this.immediateMode._curveVertex.push(args[1]);
-    this.immediateMode._curveVertex.push(args[2]);
-    if (this.immediateMode._curveVertex.length === 12) {
-      this.isCurve = true;
-      w_x = this._bezierToCatmull([
-        this.immediateMode._curveVertex[0],
-        this.immediateMode._curveVertex[3],
-        this.immediateMode._curveVertex[6],
-        this.immediateMode._curveVertex[9]
-      ]);
-      w_y = this._bezierToCatmull([
-        this.immediateMode._curveVertex[1],
-        this.immediateMode._curveVertex[4],
-        this.immediateMode._curveVertex[7],
-        this.immediateMode._curveVertex[10]
-      ]);
-      w_z = this._bezierToCatmull([
-        this.immediateMode._curveVertex[2],
-        this.immediateMode._curveVertex[5],
-        this.immediateMode._curveVertex[8],
-        this.immediateMode._curveVertex[11]
-      ]);
-      for (i = 0; i < LUTLength; i++) {
-        _x =
-          w_x[0] * this._lookUpTableBezier[i][0] +
-          w_x[1] * this._lookUpTableBezier[i][1] +
-          w_x[2] * this._lookUpTableBezier[i][2] +
-          w_x[3] * this._lookUpTableBezier[i][3];
-        _y =
-          w_y[0] * this._lookUpTableBezier[i][0] +
-          w_y[1] * this._lookUpTableBezier[i][1] +
-          w_y[2] * this._lookUpTableBezier[i][2] +
-          w_y[3] * this._lookUpTableBezier[i][3];
-        _z =
-          w_z[0] * this._lookUpTableBezier[i][0] +
-          w_z[1] * this._lookUpTableBezier[i][1] +
-          w_z[2] * this._lookUpTableBezier[i][2] +
-          w_z[3] * this._lookUpTableBezier[i][3];
-        this.vertex(_x, _y, _z);
-      }
-      for (i = 0; i < argLength; i++) {
-        this.immediateMode._curveVertex.shift();
-      }
+
+    let u1 = 1;
+    if (sx + sWidth <= img.width) {
+      u1 = (sx + sWidth) / img.width;
     }
-  }
-};
 
-p5.RendererGL.prototype.image = function(
-  img,
-  sx,
-  sy,
-  sWidth,
-  sHeight,
-  dx,
-  dy,
-  dWidth,
-  dHeight
-) {
-  if (this._isErasing) {
-    this.blendMode(this._cachedBlendMode);
-  }
+    let v0 = 0;
+    if (sy <= img.height) {
+      v0 = sy / img.height;
+    }
 
-  this._pInst.push();
+    let v1 = 1;
+    if (sy + sHeight <= img.height) {
+      v1 = (sy + sHeight) / img.height;
+    }
 
-  this._pInst.noLights();
-  this._pInst.noStroke();
+    this.beginShape();
+    this.vertex(dx, dy, 0, u0, v0);
+    this.vertex(dx + dWidth, dy, 0, u1, v0);
+    this.vertex(dx + dWidth, dy + dHeight, 0, u1, v1);
+    this.vertex(dx, dy + dHeight, 0, u0, v1);
+    this.endShape(constants.CLOSE);
 
-  this._pInst.texture(img);
-  this._pInst.textureMode(constants.NORMAL);
+    this._pInst.pop();
 
-  let u0 = 0;
-  if (sx <= img.width) {
-    u0 = sx / img.width;
-  }
+    if (this._isErasing) {
+      this.blendMode(constants.REMOVE);
+    }
+  };
+}
 
-  let u1 = 1;
-  if (sx + sWidth <= img.width) {
-    u1 = (sx + sWidth) / img.width;
-  }
+export default primitives3D;
 
-  let v0 = 0;
-  if (sy <= img.height) {
-    v0 = sy / img.height;
-  }
-
-  let v1 = 1;
-  if (sy + sHeight <= img.height) {
-    v1 = (sy + sHeight) / img.height;
-  }
-
-  this.beginShape();
-  this.vertex(dx, dy, 0, u0, v0);
-  this.vertex(dx + dWidth, dy, 0, u1, v0);
-  this.vertex(dx + dWidth, dy + dHeight, 0, u1, v1);
-  this.vertex(dx, dy + dHeight, 0, u0, v1);
-  this.endShape(constants.CLOSE);
-
-  this._pInst.pop();
-
-  if (this._isErasing) {
-    this.blendMode(constants.REMOVE);
-  }
-};
-
-export default p5;
+if(typeof p5 !== 'undefined'){
+  primitives3D(p5, p5.prototype);
+}

--- a/src/webgl/index.js
+++ b/src/webgl/index.js
@@ -12,6 +12,7 @@ import framebuffer from './p5.Framebuffer';
 import dataArray from './p5.DataArray';
 import shader from './p5.Shader';
 import camera from './p5.Camera';
+import texture from './p5.Texture';
 
 export default function(p5){
   primitives3D(p5, p5.prototype);
@@ -28,4 +29,5 @@ export default function(p5){
   framebuffer(p5, p5.prototype);
   dataArray(p5, p5.prototype);
   shader(p5, p5.prototype);
+  texture(p5, p5.prototype);
 }

--- a/src/webgl/index.js
+++ b/src/webgl/index.js
@@ -1,0 +1,31 @@
+import primitives3D from './3d_primitives';
+import interaction from './interaction';
+import light from './light';
+import loading from './loading';
+import material from './material';
+import text from './text';
+import renderBuffer from './p5.RenderBuffer';
+import quat from './p5.Quat';
+import matrix from './p5.Matrix';
+import geometry from './p5.Geometry';
+import framebuffer from './p5.Framebuffer';
+import dataArray from './p5.DataArray';
+import shader from './p5.Shader';
+import camera from './p5.Camera';
+
+export default function(p5){
+  primitives3D(p5, p5.prototype);
+  interaction(p5, p5.prototype);
+  light(p5, p5.prototype);
+  loading(p5, p5.prototype);
+  material(p5, p5.prototype);
+  text(p5, p5.prototype);
+  renderBuffer(p5, p5.prototype);
+  quat(p5, p5.prototype);
+  matrix(p5, p5.prototype);
+  geometry(p5, p5.prototype);
+  camera(p5, p5.prototype);
+  framebuffer(p5, p5.prototype);
+  dataArray(p5, p5.prototype);
+  shader(p5, p5.prototype);
+}

--- a/src/webgl/interaction.js
+++ b/src/webgl/interaction.js
@@ -5,884 +5,889 @@
  * @requires core
  */
 
-import p5 from '../core/main';
 import * as constants from '../core/constants';
 
-/**
- * Allows the user to orbit around a 3D sketch using a mouse, trackpad, or
- * touchscreen.
- *
- * 3D sketches are viewed through an imaginary camera. Calling
- * `orbitControl()` within the <a href="#/p5/draw">draw()</a> function allows
- * the user to change the camera’s position:
- *
- * ```js
- * function draw() {
- *   background(200);
- *
- *   // Enable orbiting with the mouse.
- *   orbitControl();
- *
- *   // Rest of sketch.
- * }
- * ```
- *
- * Left-clicking and dragging or swipe motion will rotate the camera position
- * about the center of the sketch. Right-clicking and dragging or multi-swipe
- * will pan the camera position without rotation. Using the mouse wheel
- * (scrolling) or pinch in/out will move the camera further or closer from the
- * center of the sketch.
- *
- * The first three parameters, `sensitivityX`, `sensitivityY`, and
- * `sensitivityZ`, are optional. They’re numbers that set the sketch’s
- * sensitivity to movement along each axis. For example, calling
- * `orbitControl(1, 2, -1)` keeps movement along the x-axis at its default
- * value, makes the sketch twice as sensitive to movement along the y-axis,
- * and reverses motion along the z-axis. By default, all sensitivity values
- * are 1.
- *
- * The fourth parameter, `options`, is also optional. It’s an object that
- * changes the behavior of orbiting. For example, calling
- * `orbitControl(1, 1, 1, options)` keeps the default sensitivity values while
- * changing the behaviors set with `options`. The object can have the
- * following properties:
- *
- * ```js
- * let options = {
- *   // Setting this to false makes mobile interactions smoother by
- *   // preventing accidental interactions with the page while orbiting.
- *   // By default, it's true.
- *   disableTouchActions: true,
- *
- *   // Setting this to true makes the camera always rotate in the
- *   // direction the mouse/touch is moving.
- *   // By default, it's false.
- *   freeRotation: false
- * };
- *
- * orbitControl(1, 1, 1, options);
- * ```
- *
- * @method orbitControl
- * @for p5
- * @param  {Number} [sensitivityX] sensitivity to movement along the x-axis. Defaults to 1.
- * @param  {Number} [sensitivityY] sensitivity to movement along the y-axis. Defaults to 1.
- * @param  {Number} [sensitivityZ] sensitivity to movement along the z-axis. Defaults to 1.
- * @param  {Object} [options] object with two optional properties, `disableTouchActions`
- *                            and `freeRotation`. Both are `Boolean`s. `disableTouchActions`
- *                            defaults to `true` and `freeRotation` defaults to `false`.
- * @chainable
- *
- * @example
- * <div>
- * <code>
- * // Click and drag the mouse to view the scene from different angles.
- *
- * function setup() {
- *   createCanvas(100, 100, WEBGL);
- *
- *   describe('A multicolor box on a gray background. The camera angle changes when the user interacts using a mouse, trackpad, or touchscreen.');
- * }
- *
- * function draw() {
- *   background(200);
- *
- *   // Enable orbiting with the mouse.
- *   orbitControl();
- *
- *   // Style the box.
- *   normalMaterial();
- *
- *   // Draw the box.
- *   box(30, 50);
- * }
- * </code>
- * </div>
- *
- * <div>
- * <code>
- * // Click and drag the mouse to view the scene from different angles.
- *
- * function setup() {
- *   createCanvas(100, 100, WEBGL);
- *
- *   describe('A multicolor box on a gray background. The camera angle changes when the user interacts using a mouse, trackpad, or touchscreen.');
- * }
- *
- * function draw() {
- *   background(200);
- *
- *   // Enable orbiting with the mouse.
- *   // Make the interactions 3X sensitive.
- *   orbitControl(3, 3, 3);
- *
- *   // Style the box.
- *   normalMaterial();
- *
- *   // Draw the box.
- *   box(30, 50);
- * }
- * </code>
- * </div>
- *
- * <div>
- * <code>
- * // Click and drag the mouse to view the scene from different angles.
- *
- * function setup() {
- *   createCanvas(100, 100, WEBGL);
- *
- *   describe('A multicolor box on a gray background. The camera angle changes when the user interacts using a mouse, trackpad, or touchscreen.');
- * }
- *
- * function draw() {
- *   background(200);
- *
- *   // Create an options object.
- *   let options = {
- *     disableTouchActions: false,
- *     freeRotation: true
- *   };
- *
- *   // Enable orbiting with the mouse.
- *   // Prevent accidental touch actions on touchscreen devices
- *   // and enable free rotation.
- *   orbitControl(1, 1, 1, options);
- *
- *   // Style the box.
- *   normalMaterial();
- *
- *   // Draw the box.
- *   box(30, 50);
- * }
- * </code>
- * </div>
- */
+function interaction(p5, fn){
+  /**
+   * Allows the user to orbit around a 3D sketch using a mouse, trackpad, or
+   * touchscreen.
+   *
+   * 3D sketches are viewed through an imaginary camera. Calling
+   * `orbitControl()` within the <a href="#/p5/draw">draw()</a> function allows
+   * the user to change the camera’s position:
+   *
+   * ```js
+   * function draw() {
+   *   background(200);
+   *
+   *   // Enable orbiting with the mouse.
+   *   orbitControl();
+   *
+   *   // Rest of sketch.
+   * }
+   * ```
+   *
+   * Left-clicking and dragging or swipe motion will rotate the camera position
+   * about the center of the sketch. Right-clicking and dragging or multi-swipe
+   * will pan the camera position without rotation. Using the mouse wheel
+   * (scrolling) or pinch in/out will move the camera further or closer from the
+   * center of the sketch.
+   *
+   * The first three parameters, `sensitivityX`, `sensitivityY`, and
+   * `sensitivityZ`, are optional. They’re numbers that set the sketch’s
+   * sensitivity to movement along each axis. For example, calling
+   * `orbitControl(1, 2, -1)` keeps movement along the x-axis at its default
+   * value, makes the sketch twice as sensitive to movement along the y-axis,
+   * and reverses motion along the z-axis. By default, all sensitivity values
+   * are 1.
+   *
+   * The fourth parameter, `options`, is also optional. It’s an object that
+   * changes the behavior of orbiting. For example, calling
+   * `orbitControl(1, 1, 1, options)` keeps the default sensitivity values while
+   * changing the behaviors set with `options`. The object can have the
+   * following properties:
+   *
+   * ```js
+   * let options = {
+   *   // Setting this to false makes mobile interactions smoother by
+   *   // preventing accidental interactions with the page while orbiting.
+   *   // By default, it's true.
+   *   disableTouchActions: true,
+   *
+   *   // Setting this to true makes the camera always rotate in the
+   *   // direction the mouse/touch is moving.
+   *   // By default, it's false.
+   *   freeRotation: false
+   * };
+   *
+   * orbitControl(1, 1, 1, options);
+   * ```
+   *
+   * @method orbitControl
+   * @for p5
+   * @param  {Number} [sensitivityX] sensitivity to movement along the x-axis. Defaults to 1.
+   * @param  {Number} [sensitivityY] sensitivity to movement along the y-axis. Defaults to 1.
+   * @param  {Number} [sensitivityZ] sensitivity to movement along the z-axis. Defaults to 1.
+   * @param  {Object} [options] object with two optional properties, `disableTouchActions`
+   *                            and `freeRotation`. Both are `Boolean`s. `disableTouchActions`
+   *                            defaults to `true` and `freeRotation` defaults to `false`.
+   * @chainable
+   *
+   * @example
+   * <div>
+   * <code>
+   * // Click and drag the mouse to view the scene from different angles.
+   *
+   * function setup() {
+   *   createCanvas(100, 100, WEBGL);
+   *
+   *   describe('A multicolor box on a gray background. The camera angle changes when the user interacts using a mouse, trackpad, or touchscreen.');
+   * }
+   *
+   * function draw() {
+   *   background(200);
+   *
+   *   // Enable orbiting with the mouse.
+   *   orbitControl();
+   *
+   *   // Style the box.
+   *   normalMaterial();
+   *
+   *   // Draw the box.
+   *   box(30, 50);
+   * }
+   * </code>
+   * </div>
+   *
+   * <div>
+   * <code>
+   * // Click and drag the mouse to view the scene from different angles.
+   *
+   * function setup() {
+   *   createCanvas(100, 100, WEBGL);
+   *
+   *   describe('A multicolor box on a gray background. The camera angle changes when the user interacts using a mouse, trackpad, or touchscreen.');
+   * }
+   *
+   * function draw() {
+   *   background(200);
+   *
+   *   // Enable orbiting with the mouse.
+   *   // Make the interactions 3X sensitive.
+   *   orbitControl(3, 3, 3);
+   *
+   *   // Style the box.
+   *   normalMaterial();
+   *
+   *   // Draw the box.
+   *   box(30, 50);
+   * }
+   * </code>
+   * </div>
+   *
+   * <div>
+   * <code>
+   * // Click and drag the mouse to view the scene from different angles.
+   *
+   * function setup() {
+   *   createCanvas(100, 100, WEBGL);
+   *
+   *   describe('A multicolor box on a gray background. The camera angle changes when the user interacts using a mouse, trackpad, or touchscreen.');
+   * }
+   *
+   * function draw() {
+   *   background(200);
+   *
+   *   // Create an options object.
+   *   let options = {
+   *     disableTouchActions: false,
+   *     freeRotation: true
+   *   };
+   *
+   *   // Enable orbiting with the mouse.
+   *   // Prevent accidental touch actions on touchscreen devices
+   *   // and enable free rotation.
+   *   orbitControl(1, 1, 1, options);
+   *
+   *   // Style the box.
+   *   normalMaterial();
+   *
+   *   // Draw the box.
+   *   box(30, 50);
+   * }
+   * </code>
+   * </div>
+   */
 
-// implementation based on three.js 'orbitControls':
-// https://github.com/mrdoob/three.js/blob/6afb8595c0bf8b2e72818e42b64e6fe22707d896/examples/jsm/controls/OrbitControls.js#L22
-p5.prototype.orbitControl = function(
-  sensitivityX,
-  sensitivityY,
-  sensitivityZ,
-  options
-) {
-  this._assert3d('orbitControl');
-  p5._validateParameters('orbitControl', arguments);
+  // implementation based on three.js 'orbitControls':
+  // https://github.com/mrdoob/three.js/blob/6afb8595c0bf8b2e72818e42b64e6fe22707d896/examples/jsm/controls/OrbitControls.js#L22
+  fn.orbitControl = function(
+    sensitivityX,
+    sensitivityY,
+    sensitivityZ,
+    options
+  ) {
+    this._assert3d('orbitControl');
+    p5._validateParameters('orbitControl', arguments);
 
-  const cam = this._renderer.states.curCamera;
+    const cam = this._renderer.states.curCamera;
 
-  if (typeof sensitivityX === 'undefined') {
-    sensitivityX = 1;
-  }
-  if (typeof sensitivityY === 'undefined') {
-    sensitivityY = sensitivityX;
-  }
-  if (typeof sensitivityZ === 'undefined') {
-    sensitivityZ = 1;
-  }
-  if (typeof options !== 'object') {
-    options = {};
-  }
+    if (typeof sensitivityX === 'undefined') {
+      sensitivityX = 1;
+    }
+    if (typeof sensitivityY === 'undefined') {
+      sensitivityY = sensitivityX;
+    }
+    if (typeof sensitivityZ === 'undefined') {
+      sensitivityZ = 1;
+    }
+    if (typeof options !== 'object') {
+      options = {};
+    }
 
-  // default right-mouse and mouse-wheel behaviors (context menu and scrolling,
-  // respectively) are disabled here to allow use of those events for panning and
-  // zooming. However, whether or not to disable touch actions is an option.
+    // default right-mouse and mouse-wheel behaviors (context menu and scrolling,
+    // respectively) are disabled here to allow use of those events for panning and
+    // zooming. However, whether or not to disable touch actions is an option.
 
-  // disable context menu for canvas element and add 'contextMenuDisabled'
-  // flag to p5 instance
-  if (this.contextMenuDisabled !== true) {
-    this.canvas.oncontextmenu = () => false;
-    this.contextMenuDisabled = true;
-  }
+    // disable context menu for canvas element and add 'contextMenuDisabled'
+    // flag to p5 instance
+    if (this.contextMenuDisabled !== true) {
+      this.canvas.oncontextmenu = () => false;
+      this.contextMenuDisabled = true;
+    }
 
-  // disable default scrolling behavior on the canvas element and add
-  // 'wheelDefaultDisabled' flag to p5 instance
-  if (this.wheelDefaultDisabled !== true) {
-    this.canvas.onwheel = () => false;
-    this.wheelDefaultDisabled = true;
-  }
+    // disable default scrolling behavior on the canvas element and add
+    // 'wheelDefaultDisabled' flag to p5 instance
+    if (this.wheelDefaultDisabled !== true) {
+      this.canvas.onwheel = () => false;
+      this.wheelDefaultDisabled = true;
+    }
 
-  // disable default touch behavior on the canvas element and add
-  // 'touchActionsDisabled' flag to p5 instance
-  const { disableTouchActions = true } = options;
-  if (this.touchActionsDisabled !== true && disableTouchActions) {
-    this.canvas.style['touch-action'] = 'none';
-    this.touchActionsDisabled = true;
-  }
+    // disable default touch behavior on the canvas element and add
+    // 'touchActionsDisabled' flag to p5 instance
+    const { disableTouchActions = true } = options;
+    if (this.touchActionsDisabled !== true && disableTouchActions) {
+      this.canvas.style['touch-action'] = 'none';
+      this.touchActionsDisabled = true;
+    }
 
-  // If option.freeRotation is true, the camera always rotates freely in the direction
-  // the pointer moves. default value is false (normal behavior)
-  const { freeRotation = false } = options;
+    // If option.freeRotation is true, the camera always rotates freely in the direction
+    // the pointer moves. default value is false (normal behavior)
+    const { freeRotation = false } = options;
 
-  // get moved touches.
-  const movedTouches = [];
+    // get moved touches.
+    const movedTouches = [];
 
-  this.touches.forEach(curTouch => {
-    this._renderer.prevTouches.forEach(prevTouch => {
-      if (curTouch.id === prevTouch.id) {
-        const movedTouch = {
-          x: curTouch.x,
-          y: curTouch.y,
-          px: prevTouch.x,
-          py: prevTouch.y
-        };
-        movedTouches.push(movedTouch);
-      }
+    this.touches.forEach(curTouch => {
+      this._renderer.prevTouches.forEach(prevTouch => {
+        if (curTouch.id === prevTouch.id) {
+          const movedTouch = {
+            x: curTouch.x,
+            y: curTouch.y,
+            px: prevTouch.x,
+            py: prevTouch.y
+          };
+          movedTouches.push(movedTouch);
+        }
+      });
     });
-  });
 
-  this._renderer.prevTouches = this.touches;
+    this._renderer.prevTouches = this.touches;
 
-  // The idea of using damping is based on the following website. thank you.
-  // https://github.com/freshfork/p5.EasyCam/blob/9782964680f6a5c4c9bee825c475d9f2021d5134/p5.easycam.js#L1124
+    // The idea of using damping is based on the following website. thank you.
+    // https://github.com/freshfork/p5.EasyCam/blob/9782964680f6a5c4c9bee825c475d9f2021d5134/p5.easycam.js#L1124
 
-  // variables for interaction
-  let deltaRadius = 0;
-  let deltaTheta = 0;
-  let deltaPhi = 0;
-  let moveDeltaX = 0;
-  let moveDeltaY = 0;
-  // constants for dampingProcess
-  const damping = 0.85;
-  const rotateAccelerationFactor = 0.6;
-  const moveAccelerationFactor = 0.15;
-  // For touches, the appropriate scale is different
-  // because the distance difference is multiplied.
-  const mouseZoomScaleFactor = 0.01;
-  const touchZoomScaleFactor = 0.0004;
-  const scaleFactor = this.height < this.width ? this.height : this.width;
-  // Flag whether the mouse or touch pointer is inside the canvas
-  let pointersInCanvas = false;
+    // variables for interaction
+    let deltaRadius = 0;
+    let deltaTheta = 0;
+    let deltaPhi = 0;
+    let moveDeltaX = 0;
+    let moveDeltaY = 0;
+    // constants for dampingProcess
+    const damping = 0.85;
+    const rotateAccelerationFactor = 0.6;
+    const moveAccelerationFactor = 0.15;
+    // For touches, the appropriate scale is different
+    // because the distance difference is multiplied.
+    const mouseZoomScaleFactor = 0.01;
+    const touchZoomScaleFactor = 0.0004;
+    const scaleFactor = this.height < this.width ? this.height : this.width;
+    // Flag whether the mouse or touch pointer is inside the canvas
+    let pointersInCanvas = false;
 
-  // calculate and determine flags and variables.
-  if (movedTouches.length > 0) {
-    /* for touch */
-    // if length === 1, rotate
-    // if length > 1, zoom and move
+    // calculate and determine flags and variables.
+    if (movedTouches.length > 0) {
+      /* for touch */
+      // if length === 1, rotate
+      // if length > 1, zoom and move
 
-    // for touch, it is calculated based on one moved touch pointer position.
-    pointersInCanvas =
-      movedTouches[0].x > 0 && movedTouches[0].x < this.width &&
-      movedTouches[0].y > 0 && movedTouches[0].y < this.height;
+      // for touch, it is calculated based on one moved touch pointer position.
+      pointersInCanvas =
+        movedTouches[0].x > 0 && movedTouches[0].x < this.width &&
+        movedTouches[0].y > 0 && movedTouches[0].y < this.height;
 
-    if (movedTouches.length === 1) {
-      const t = movedTouches[0];
-      deltaTheta = -sensitivityX * (t.x - t.px) / scaleFactor;
-      deltaPhi = sensitivityY * (t.y - t.py) / scaleFactor;
-    } else {
-      const t0 = movedTouches[0];
-      const t1 = movedTouches[1];
-      const distWithTouches = Math.hypot(t0.x - t1.x, t0.y - t1.y);
-      const prevDistWithTouches = Math.hypot(t0.px - t1.px, t0.py - t1.py);
-      const changeDist = distWithTouches - prevDistWithTouches;
-      // move the camera farther when the distance between the two touch points
-      // decreases, move the camera closer when it increases.
-      deltaRadius = -changeDist * sensitivityZ * touchZoomScaleFactor;
-      // Move the center of the camera along with the movement of
-      // the center of gravity of the two touch points.
-      moveDeltaX = 0.5 * (t0.x + t1.x) - 0.5 * (t0.px + t1.px);
-      moveDeltaY = 0.5 * (t0.y + t1.y) - 0.5 * (t0.py + t1.py);
-    }
-    if (this.touches.length > 0) {
-      if (pointersInCanvas) {
-        // Initiate an interaction if touched in the canvas
-        this._renderer.executeRotateAndMove = true;
-        this._renderer.executeZoom = true;
+      if (movedTouches.length === 1) {
+        const t = movedTouches[0];
+        deltaTheta = -sensitivityX * (t.x - t.px) / scaleFactor;
+        deltaPhi = sensitivityY * (t.y - t.py) / scaleFactor;
+      } else {
+        const t0 = movedTouches[0];
+        const t1 = movedTouches[1];
+        const distWithTouches = Math.hypot(t0.x - t1.x, t0.y - t1.y);
+        const prevDistWithTouches = Math.hypot(t0.px - t1.px, t0.py - t1.py);
+        const changeDist = distWithTouches - prevDistWithTouches;
+        // move the camera farther when the distance between the two touch points
+        // decreases, move the camera closer when it increases.
+        deltaRadius = -changeDist * sensitivityZ * touchZoomScaleFactor;
+        // Move the center of the camera along with the movement of
+        // the center of gravity of the two touch points.
+        moveDeltaX = 0.5 * (t0.x + t1.x) - 0.5 * (t0.px + t1.px);
+        moveDeltaY = 0.5 * (t0.y + t1.y) - 0.5 * (t0.py + t1.py);
+      }
+      if (this.touches.length > 0) {
+        if (pointersInCanvas) {
+          // Initiate an interaction if touched in the canvas
+          this._renderer.executeRotateAndMove = true;
+          this._renderer.executeZoom = true;
+        }
+      } else {
+        // End an interaction when the touch is released
+        this._renderer.executeRotateAndMove = false;
+        this._renderer.executeZoom = false;
       }
     } else {
-      // End an interaction when the touch is released
-      this._renderer.executeRotateAndMove = false;
-      this._renderer.executeZoom = false;
-    }
-  } else {
-    /* for mouse */
-    // if wheelDeltaY !== 0, zoom
-    // if mouseLeftButton is down, rotate
-    // if mouseRightButton is down, move
+      /* for mouse */
+      // if wheelDeltaY !== 0, zoom
+      // if mouseLeftButton is down, rotate
+      // if mouseRightButton is down, move
 
-    // For mouse, it is calculated based on the mouse position.
-    pointersInCanvas =
-      (this.mouseX > 0 && this.mouseX < this.width) &&
-      (this.mouseY > 0 && this.mouseY < this.height);
+      // For mouse, it is calculated based on the mouse position.
+      pointersInCanvas =
+        (this.mouseX > 0 && this.mouseX < this.width) &&
+        (this.mouseY > 0 && this.mouseY < this.height);
 
-    if (this._mouseWheelDeltaY !== 0) {
-      // zoom the camera depending on the value of _mouseWheelDeltaY.
-      // move away if positive, move closer if negative
-      deltaRadius = Math.sign(this._mouseWheelDeltaY) * sensitivityZ;
-      deltaRadius *= mouseZoomScaleFactor;
-      this._mouseWheelDeltaY = 0;
-      // start zoom when the mouse is wheeled within the canvas.
-      if (pointersInCanvas) this._renderer.executeZoom = true;
-    } else {
-      // quit zoom when you stop wheeling.
-      this._renderer.executeZoom = false;
-    }
-    if (this.mouseIsPressed) {
-      if (this.mouseButton === this.LEFT) {
-        deltaTheta = -sensitivityX * this.movedX / scaleFactor;
-        deltaPhi = sensitivityY * this.movedY / scaleFactor;
-      } else if (this.mouseButton === this.RIGHT) {
-        moveDeltaX = this.movedX;
-        moveDeltaY =  this.movedY * cam.yScale;
+      if (this._mouseWheelDeltaY !== 0) {
+        // zoom the camera depending on the value of _mouseWheelDeltaY.
+        // move away if positive, move closer if negative
+        deltaRadius = Math.sign(this._mouseWheelDeltaY) * sensitivityZ;
+        deltaRadius *= mouseZoomScaleFactor;
+        this._mouseWheelDeltaY = 0;
+        // start zoom when the mouse is wheeled within the canvas.
+        if (pointersInCanvas) this._renderer.executeZoom = true;
+      } else {
+        // quit zoom when you stop wheeling.
+        this._renderer.executeZoom = false;
       }
-      // start rotate and move when mouse is pressed within the canvas.
-      if (pointersInCanvas) this._renderer.executeRotateAndMove = true;
+      if (this.mouseIsPressed) {
+        if (this.mouseButton === this.LEFT) {
+          deltaTheta = -sensitivityX * this.movedX / scaleFactor;
+          deltaPhi = sensitivityY * this.movedY / scaleFactor;
+        } else if (this.mouseButton === this.RIGHT) {
+          moveDeltaX = this.movedX;
+          moveDeltaY =  this.movedY * cam.yScale;
+        }
+        // start rotate and move when mouse is pressed within the canvas.
+        if (pointersInCanvas) this._renderer.executeRotateAndMove = true;
+      } else {
+        // quit rotate and move if mouse is released.
+        this._renderer.executeRotateAndMove = false;
+      }
+    }
+
+    // interactions
+
+    // zoom process
+    if (deltaRadius !== 0 && this._renderer.executeZoom) {
+      // accelerate zoom velocity
+      this._renderer.zoomVelocity += deltaRadius;
+    }
+    if (Math.abs(this._renderer.zoomVelocity) > 0.001) {
+      // if freeRotation is true, we use _orbitFree() instead of _orbit()
+      if (freeRotation) {
+        cam._orbitFree(
+          0, 0, this._renderer.zoomVelocity
+        );
+      } else {
+        cam._orbit(
+          0, 0, this._renderer.zoomVelocity
+        );
+      }
+      // In orthogonal projection, the scale does not change even if
+      // the distance to the gaze point is changed, so the projection matrix
+      // needs to be modified.
+      if (cam.projMatrix.mat4[15] !== 0) {
+        cam.projMatrix.mat4[0] *= Math.pow(
+          10, -this._renderer.zoomVelocity
+        );
+        cam.projMatrix.mat4[5] *= Math.pow(
+          10, -this._renderer.zoomVelocity
+        );
+        // modify uPMatrix
+        this._renderer.states.uPMatrix.mat4[0] = cam.projMatrix.mat4[0];
+        this._renderer.states.uPMatrix.mat4[5] = cam.projMatrix.mat4[5];
+      }
+      // damping
+      this._renderer.zoomVelocity *= damping;
     } else {
-      // quit rotate and move if mouse is released.
-      this._renderer.executeRotateAndMove = false;
+      this._renderer.zoomVelocity = 0;
     }
-  }
 
-  // interactions
-
-  // zoom process
-  if (deltaRadius !== 0 && this._renderer.executeZoom) {
-    // accelerate zoom velocity
-    this._renderer.zoomVelocity += deltaRadius;
-  }
-  if (Math.abs(this._renderer.zoomVelocity) > 0.001) {
-    // if freeRotation is true, we use _orbitFree() instead of _orbit()
-    if (freeRotation) {
-      cam._orbitFree(
-        0, 0, this._renderer.zoomVelocity
+    // rotate process
+    if ((deltaTheta !== 0 || deltaPhi !== 0) &&
+    this._renderer.executeRotateAndMove) {
+      // accelerate rotate velocity
+      this._renderer.rotateVelocity.add(
+        deltaTheta * rotateAccelerationFactor,
+        deltaPhi * rotateAccelerationFactor
       );
+    }
+    if (this._renderer.rotateVelocity.magSq() > 0.000001) {
+      // if freeRotation is true, the camera always rotates freely in the direction the pointer moves
+      if (freeRotation) {
+        cam._orbitFree(
+          -this._renderer.rotateVelocity.x,
+          this._renderer.rotateVelocity.y,
+          0
+        );
+      } else {
+        cam._orbit(
+          this._renderer.rotateVelocity.x,
+          this._renderer.rotateVelocity.y,
+          0
+        );
+      }
+      // damping
+      this._renderer.rotateVelocity.mult(damping);
     } else {
-      cam._orbit(
-        0, 0, this._renderer.zoomVelocity
-      );
+      this._renderer.rotateVelocity.set(0, 0);
     }
-    // In orthogonal projection, the scale does not change even if
-    // the distance to the gaze point is changed, so the projection matrix
-    // needs to be modified.
-    if (cam.projMatrix.mat4[15] !== 0) {
-      cam.projMatrix.mat4[0] *= Math.pow(
-        10, -this._renderer.zoomVelocity
-      );
-      cam.projMatrix.mat4[5] *= Math.pow(
-        10, -this._renderer.zoomVelocity
-      );
-      // modify uPMatrix
-      this._renderer.states.uPMatrix.mat4[0] = cam.projMatrix.mat4[0];
-      this._renderer.states.uPMatrix.mat4[5] = cam.projMatrix.mat4[5];
-    }
-    // damping
-    this._renderer.zoomVelocity *= damping;
-  } else {
-    this._renderer.zoomVelocity = 0;
-  }
 
-  // rotate process
-  if ((deltaTheta !== 0 || deltaPhi !== 0) &&
-  this._renderer.executeRotateAndMove) {
-    // accelerate rotate velocity
-    this._renderer.rotateVelocity.add(
-      deltaTheta * rotateAccelerationFactor,
-      deltaPhi * rotateAccelerationFactor
-    );
-  }
-  if (this._renderer.rotateVelocity.magSq() > 0.000001) {
-    // if freeRotation is true, the camera always rotates freely in the direction the pointer moves
-    if (freeRotation) {
-      cam._orbitFree(
-        -this._renderer.rotateVelocity.x,
-        this._renderer.rotateVelocity.y,
-        0
+    // move process
+    if ((moveDeltaX !== 0 || moveDeltaY !== 0) &&
+    this._renderer.executeRotateAndMove) {
+      // Normalize movement distance
+      const ndcX = moveDeltaX * 2/this.width;
+      const ndcY = -moveDeltaY * 2/this.height;
+      // accelerate move velocity
+      this._renderer.moveVelocity.add(
+        ndcX * moveAccelerationFactor,
+        ndcY * moveAccelerationFactor
       );
+    }
+    if (this._renderer.moveVelocity.magSq() > 0.000001) {
+      // Translate the camera so that the entire object moves
+      // perpendicular to the line of sight when the mouse is moved
+      // or when the centers of gravity of the two touch pointers move.
+      const local = cam._getLocalAxes();
+
+      // Calculate the z coordinate in the view coordinates of
+      // the center, that is, the distance to the view point
+      const diffX = cam.eyeX - cam.centerX;
+      const diffY = cam.eyeY - cam.centerY;
+      const diffZ = cam.eyeZ - cam.centerZ;
+      const viewZ = Math.sqrt(diffX * diffX + diffY * diffY + diffZ * diffZ);
+
+      // position vector of the center.
+      let cv = new p5.Vector(cam.centerX, cam.centerY, cam.centerZ);
+
+      // Calculate the normalized device coordinates of the center.
+      cv = cam.cameraMatrix.multiplyPoint(cv);
+      cv = this._renderer.states.uPMatrix.multiplyAndNormalizePoint(cv);
+
+      // Move the center by this distance
+      // in the normalized device coordinate system.
+      cv.x -= this._renderer.moveVelocity.x;
+      cv.y -= this._renderer.moveVelocity.y;
+
+      // Calculate the translation vector
+      // in the direction perpendicular to the line of sight of center.
+      let dx, dy;
+      const uP = this._renderer.states.uPMatrix.mat4;
+
+      if (uP[15] === 0) {
+        dx = ((uP[8] + cv.x)/uP[0]) * viewZ;
+        dy = ((uP[9] + cv.y)/uP[5]) * viewZ;
+      } else {
+        dx = (cv.x - uP[12])/uP[0];
+        dy = (cv.y - uP[13])/uP[5];
+      }
+
+      // translate the camera.
+      cam.setPosition(
+        cam.eyeX + dx * local.x[0] + dy * local.y[0],
+        cam.eyeY + dx * local.x[1] + dy * local.y[1],
+        cam.eyeZ + dx * local.x[2] + dy * local.y[2]
+      );
+      // damping
+      this._renderer.moveVelocity.mult(damping);
     } else {
-      cam._orbit(
-        this._renderer.rotateVelocity.x,
-        this._renderer.rotateVelocity.y,
-        0
-      );
-    }
-    // damping
-    this._renderer.rotateVelocity.mult(damping);
-  } else {
-    this._renderer.rotateVelocity.set(0, 0);
-  }
-
-  // move process
-  if ((moveDeltaX !== 0 || moveDeltaY !== 0) &&
-  this._renderer.executeRotateAndMove) {
-    // Normalize movement distance
-    const ndcX = moveDeltaX * 2/this.width;
-    const ndcY = -moveDeltaY * 2/this.height;
-    // accelerate move velocity
-    this._renderer.moveVelocity.add(
-      ndcX * moveAccelerationFactor,
-      ndcY * moveAccelerationFactor
-    );
-  }
-  if (this._renderer.moveVelocity.magSq() > 0.000001) {
-    // Translate the camera so that the entire object moves
-    // perpendicular to the line of sight when the mouse is moved
-    // or when the centers of gravity of the two touch pointers move.
-    const local = cam._getLocalAxes();
-
-    // Calculate the z coordinate in the view coordinates of
-    // the center, that is, the distance to the view point
-    const diffX = cam.eyeX - cam.centerX;
-    const diffY = cam.eyeY - cam.centerY;
-    const diffZ = cam.eyeZ - cam.centerZ;
-    const viewZ = Math.sqrt(diffX * diffX + diffY * diffY + diffZ * diffZ);
-
-    // position vector of the center.
-    let cv = new p5.Vector(cam.centerX, cam.centerY, cam.centerZ);
-
-    // Calculate the normalized device coordinates of the center.
-    cv = cam.cameraMatrix.multiplyPoint(cv);
-    cv = this._renderer.states.uPMatrix.multiplyAndNormalizePoint(cv);
-
-    // Move the center by this distance
-    // in the normalized device coordinate system.
-    cv.x -= this._renderer.moveVelocity.x;
-    cv.y -= this._renderer.moveVelocity.y;
-
-    // Calculate the translation vector
-    // in the direction perpendicular to the line of sight of center.
-    let dx, dy;
-    const uP = this._renderer.states.uPMatrix.mat4;
-
-    if (uP[15] === 0) {
-      dx = ((uP[8] + cv.x)/uP[0]) * viewZ;
-      dy = ((uP[9] + cv.y)/uP[5]) * viewZ;
-    } else {
-      dx = (cv.x - uP[12])/uP[0];
-      dy = (cv.y - uP[13])/uP[5];
+      this._renderer.moveVelocity.set(0, 0);
     }
 
-    // translate the camera.
-    cam.setPosition(
-      cam.eyeX + dx * local.x[0] + dy * local.y[0],
-      cam.eyeY + dx * local.x[1] + dy * local.y[1],
-      cam.eyeZ + dx * local.x[2] + dy * local.y[2]
-    );
-    // damping
-    this._renderer.moveVelocity.mult(damping);
-  } else {
-    this._renderer.moveVelocity.set(0, 0);
-  }
-
-  return this;
-};
-
-
-/**
- * Adds a grid and an axes icon to clarify orientation in 3D sketches.
- *
- * `debugMode()` adds a grid that shows where the “ground” is in a sketch. By
- * default, the grid will run through the origin `(0, 0, 0)` of the sketch
- * along the XZ plane. `debugMode()` also adds an axes icon that points along
- * the positive x-, y-, and z-axes. Calling `debugMode()` displays the grid
- * and axes icon with their default size and position.
- *
- * There are four ways to call `debugMode()` with optional parameters to
- * customize the debugging environment.
- *
- * The first way to call `debugMode()` has one parameter, `mode`. If the
- * system constant `GRID` is passed, as in `debugMode(GRID)`, then the grid
- * will be displayed and the axes icon will be hidden. If the constant `AXES`
- * is passed, as in `debugMode(AXES)`, then the axes icon will be displayed
- * and the grid will be hidden.
- *
- * The second way to call `debugMode()` has six parameters. The first
- * parameter, `mode`, selects either `GRID` or `AXES` to be displayed. The
- * next five parameters, `gridSize`, `gridDivisions`, `xOff`, `yOff`, and
- * `zOff` are optional. They’re numbers that set the appearance of the grid
- * (`gridSize` and `gridDivisions`) and the placement of the axes icon
- * (`xOff`, `yOff`, and `zOff`). For example, calling
- * `debugMode(20, 5, 10, 10, 10)` sets the `gridSize` to 20 pixels, the number
- * of `gridDivisions` to 5, and offsets the axes icon by 10 pixels along the
- * x-, y-, and z-axes.
- *
- * The third way to call `debugMode()` has five parameters. The first
- * parameter, `mode`, selects either `GRID` or `AXES` to be displayed. The
- * next four parameters, `axesSize`, `xOff`, `yOff`, and `zOff` are optional.
- * They’re numbers that set the appearance of the size of the axes icon
- * (`axesSize`) and its placement (`xOff`, `yOff`, and `zOff`).
- *
- * The fourth way to call `debugMode()` has nine optional parameters. The
- * first five parameters, `gridSize`, `gridDivisions`, `gridXOff`, `gridYOff`,
- * and `gridZOff` are numbers that set the appearance of the grid. For
- * example, calling `debugMode(100, 5, 0, 0, 0)` sets the `gridSize` to 100,
- * the number of `gridDivisions` to 5, and sets all the offsets to 0 so that
- * the grid is centered at the origin. The next four parameters, `axesSize`,
- * `xOff`, `yOff`, and `zOff` are numbers that set the appearance of the size
- * of the axes icon (`axesSize`) and its placement (`axesXOff`, `axesYOff`,
- * and `axesZOff`). For example, calling
- * `debugMode(100, 5, 0, 0, 0, 50, 10, 10, 10)` sets the `gridSize` to 100,
- * the number of `gridDivisions` to 5, and sets all the offsets to 0 so that
- * the grid is centered at the origin. It then sets the `axesSize` to 50 and
- * offsets the icon 10 pixels along each axis.
- *
- * @method debugMode
- *
- * @example
- * <div>
- * <code>
- * // Click and drag the mouse to view the scene from different angles.
- *
- * function setup() {
- *   createCanvas(100, 100, WEBGL);
- *
- *   // Enable debug mode.
- *   debugMode();
- *
- *   describe('A multicolor box on a gray background. A grid and axes icon are displayed near the box.');
- * }
- *
- * function draw() {
- *   background(200);
- *
- *   // Enable orbiting with the mouse.
- *   orbitControl();
- *
- *   // Style the box.
- *   normalMaterial();
- *
- *   // Draw the box.
- *   box(20, 40);
- * }
- * </code>
- * </div>
- *
- * <div>
- * <code>
- * // Click and drag the mouse to view the scene from different angles.
- *
- * function setup() {
- *   createCanvas(100, 100, WEBGL);
- *
- *   // Enable debug mode.
- *   // Only display the axes icon.
- *   debugMode(AXES);
- *
- *   describe('A multicolor box on a gray background. A grid and axes icon are displayed near the box.');
- * }
- *
- * function draw() {
- *   background(200);
- *
- *   // Enable orbiting with the mouse.
- *   orbitControl();
- *
- *   // Style the box.
- *   normalMaterial();
- *
- *   // Draw the box.
- *   box(20, 40);
- * }
- * </code>
- * </div>
- *
- * <div>
- * <code>
- * // Click and drag the mouse to view the scene from different angles.
- *
- * function setup() {
- *   createCanvas(100, 100, WEBGL);
- *
- *   // Enable debug mode.
- *   // Only display the grid and customize it:
- *   // - size: 50
- *   // - divisions: 10
- *   // - offsets: 0, 20, 0
- *   debugMode(GRID, 50, 10, 0, 20, 0);
- *
- *   describe('A multicolor box on a gray background. A grid is displayed below the box.');
- * }
- *
- * function draw() {
- *   background(200);
- *
- *   // Enable orbiting with the mouse.
- *   orbitControl();
- *
- *   // Style the box.
- *   normalMaterial();
- *
- *   // Draw the box.
- *   box(20, 40);
- * }
- * </code>
- * </div>
- *
- * <div>
- * <code>
- * // Click and drag the mouse to view the scene from different angles.
- *
- * function setup() {
- *   createCanvas(100, 100, WEBGL);
- *
- *   // Enable debug mode.
- *   // Display the grid and axes icon and customize them:
- *   // Grid
- *   // ----
- *   // - size: 50
- *   // - divisions: 10
- *   // - offsets: 0, 20, 0
- *   // Axes
- *   // ----
- *   // - size: 50
- *   // - offsets: 0, 0, 0
- *   debugMode(50, 10, 0, 20, 0, 50, 0, 0, 0);
- *
- *   describe('A multicolor box on a gray background. A grid is displayed below the box. An axes icon is displayed at the center of the box.');
- * }
- *
- * function draw() {
- *   background(200);
- *
- *   // Enable orbiting with the mouse.
- *   orbitControl();
- *
- *   // Style the box.
- *   normalMaterial();
- *
- *   // Draw the box.
- *   box(20, 40);
- * }
- * </code>
- * </div>
- */
-
-/**
- * @method debugMode
- * @param {(GRID|AXES)} mode either GRID or AXES
- */
-
-/**
- * @method debugMode
- * @param {(GRID|AXES)} mode
- * @param {Number} [gridSize] side length of the grid.
- * @param {Number} [gridDivisions] number of divisions in the grid.
- * @param {Number} [xOff] offset from origin along the x-axis.
- * @param {Number} [yOff] offset from origin along the y-axis.
- * @param {Number} [zOff] offset from origin along the z-axis.
- */
-
-/**
- * @method debugMode
- * @param {(GRID|AXES)} mode
- * @param {Number} [axesSize] length of axes icon markers.
- * @param {Number} [xOff]
- * @param {Number} [yOff]
- * @param {Number} [zOff]
- */
-
-/**
- * @method debugMode
- * @param {Number} [gridSize]
- * @param {Number} [gridDivisions]
- * @param {Number} [gridXOff] grid offset from the origin along the x-axis.
- * @param {Number} [gridYOff] grid offset from the origin along the y-axis.
- * @param {Number} [gridZOff] grid offset from the origin along the z-axis.
- * @param {Number} [axesSize]
- * @param {Number} [axesXOff] axes icon offset from the origin along the x-axis.
- * @param {Number} [axesYOff] axes icon offset from the origin along the y-axis.
- * @param {Number} [axesZOff] axes icon offset from the origin along the z-axis.
- */
-
-p5.prototype.debugMode = function(...args) {
-  this._assert3d('debugMode');
-  p5._validateParameters('debugMode', args);
-
-  // start by removing existing 'post' registered debug methods
-  for (let i = this._registeredMethods.post.length - 1; i >= 0; i--) {
-    // test for equality...
-    if (
-      this._registeredMethods.post[i].toString() === this._grid().toString() ||
-      this._registeredMethods.post[i].toString() === this._axesIcon().toString()
-    ) {
-      this._registeredMethods.post.splice(i, 1);
-    }
-  }
-
-  // then add new debugMode functions according to the argument list
-  if (args[0] === constants.GRID) {
-    this.registerMethod(
-      'post',
-      this._grid(args[1], args[2], args[3], args[4], args[5])
-    );
-  } else if (args[0] === constants.AXES) {
-    this.registerMethod(
-      'post',
-      this._axesIcon(args[1], args[2], args[3], args[4])
-    );
-  } else {
-    this.registerMethod(
-      'post',
-      this._grid(args[0], args[1], args[2], args[3], args[4])
-    );
-    this.registerMethod(
-      'post',
-      this._axesIcon(args[5], args[6], args[7], args[8])
-    );
-  }
-};
-
-/**
- * Turns off <a href="#/p5/debugMode">debugMode()</a> in a 3D sketch.
- *
- * @method noDebugMode
- *
- * @example
- * <div>
- * <code>
- * // Click and drag the mouse to view the scene from different angles.
- *
- * function setup() {
- *   createCanvas(100, 100, WEBGL);
- *
- *   // Enable debug mode.
- *   debugMode();
- *
- *   describe('A multicolor box on a gray background. A grid and axes icon are displayed near the box. They disappear when the user double-clicks.');
- * }
- *
- * function draw() {
- *   background(200);
- *
- *   // Enable orbiting with the mouse.
- *   orbitControl();
- *
- *   // Style the box.
- *   normalMaterial();
- *
- *   // Draw the box.  box(20, 40);
- * }
- *
- * // Disable debug mode when the user double-clicks.
- * function doubleClicked() {
- *   noDebugMode();
- * }
- * </code>
- * </div>
- */
-p5.prototype.noDebugMode = function() {
-  this._assert3d('noDebugMode');
-
-  // start by removing existing 'post' registered debug methods
-  for (let i = this._registeredMethods.post.length - 1; i >= 0; i--) {
-    // test for equality...
-    if (
-      this._registeredMethods.post[i].toString() === this._grid().toString() ||
-      this._registeredMethods.post[i].toString() === this._axesIcon().toString()
-    ) {
-      this._registeredMethods.post.splice(i, 1);
-    }
-  }
-};
-
-/**
- * For use with debugMode
- * @private
- * @method _grid
- * @param {Number} [size] size of grid sides
- * @param {Number} [div] number of grid divisions
- * @param {Number} [xOff] offset of grid center from origin in X axis
- * @param {Number} [yOff] offset of grid center from origin in Y axis
- * @param {Number} [zOff] offset of grid center from origin in Z axis
- */
-p5.prototype._grid = function(size, numDivs, xOff, yOff, zOff) {
-  if (typeof size === 'undefined') {
-    size = this.width / 2;
-  }
-  if (typeof numDivs === 'undefined') {
-    // ensure at least 2 divisions
-    numDivs = Math.round(size / 30) < 4 ? 4 : Math.round(size / 30);
-  }
-  if (typeof xOff === 'undefined') {
-    xOff = 0;
-  }
-  if (typeof yOff === 'undefined') {
-    yOff = 0;
-  }
-  if (typeof zOff === 'undefined') {
-    zOff = 0;
-  }
-
-  const spacing = size / numDivs;
-  const halfSize = size / 2;
-
-  return function() {
-    this.push();
-    this.stroke(
-      this._renderer.states.curStrokeColor[0] * 255,
-      this._renderer.states.curStrokeColor[1] * 255,
-      this._renderer.states.curStrokeColor[2] * 255
-    );
-    this._renderer.states.uModelMatrix.reset();
-
-    // Lines along X axis
-    for (let q = 0; q <= numDivs; q++) {
-      this.beginShape(this.LINES);
-      this.vertex(-halfSize + xOff, yOff, q * spacing - halfSize + zOff);
-      this.vertex(+halfSize + xOff, yOff, q * spacing - halfSize + zOff);
-      this.endShape();
-    }
-
-    // Lines along Z axis
-    for (let i = 0; i <= numDivs; i++) {
-      this.beginShape(this.LINES);
-      this.vertex(i * spacing - halfSize + xOff, yOff, -halfSize + zOff);
-      this.vertex(i * spacing - halfSize + xOff, yOff, +halfSize + zOff);
-      this.endShape();
-    }
-
-    this.pop();
+    return this;
   };
-};
 
-/**
- * For use with debugMode
- * @private
- * @method _axesIcon
- * @param {Number} [size] size of axes icon lines
- * @param {Number} [xOff] offset of icon from origin in X axis
- * @param {Number} [yOff] offset of icon from origin in Y axis
- * @param {Number} [zOff] offset of icon from origin in Z axis
- */
-p5.prototype._axesIcon = function(size, xOff, yOff, zOff) {
-  if (typeof size === 'undefined') {
-    size = this.width / 20 > 40 ? this.width / 20 : 40;
-  }
-  if (typeof xOff === 'undefined') {
-    xOff = -this.width / 4;
-  }
-  if (typeof yOff === 'undefined') {
-    yOff = xOff;
-  }
-  if (typeof zOff === 'undefined') {
-    zOff = xOff;
-  }
 
-  return function() {
-    this.push();
-    this._renderer.states.uModelMatrix.reset();
+  /**
+   * Adds a grid and an axes icon to clarify orientation in 3D sketches.
+   *
+   * `debugMode()` adds a grid that shows where the “ground” is in a sketch. By
+   * default, the grid will run through the origin `(0, 0, 0)` of the sketch
+   * along the XZ plane. `debugMode()` also adds an axes icon that points along
+   * the positive x-, y-, and z-axes. Calling `debugMode()` displays the grid
+   * and axes icon with their default size and position.
+   *
+   * There are four ways to call `debugMode()` with optional parameters to
+   * customize the debugging environment.
+   *
+   * The first way to call `debugMode()` has one parameter, `mode`. If the
+   * system constant `GRID` is passed, as in `debugMode(GRID)`, then the grid
+   * will be displayed and the axes icon will be hidden. If the constant `AXES`
+   * is passed, as in `debugMode(AXES)`, then the axes icon will be displayed
+   * and the grid will be hidden.
+   *
+   * The second way to call `debugMode()` has six parameters. The first
+   * parameter, `mode`, selects either `GRID` or `AXES` to be displayed. The
+   * next five parameters, `gridSize`, `gridDivisions`, `xOff`, `yOff`, and
+   * `zOff` are optional. They’re numbers that set the appearance of the grid
+   * (`gridSize` and `gridDivisions`) and the placement of the axes icon
+   * (`xOff`, `yOff`, and `zOff`). For example, calling
+   * `debugMode(20, 5, 10, 10, 10)` sets the `gridSize` to 20 pixels, the number
+   * of `gridDivisions` to 5, and offsets the axes icon by 10 pixels along the
+   * x-, y-, and z-axes.
+   *
+   * The third way to call `debugMode()` has five parameters. The first
+   * parameter, `mode`, selects either `GRID` or `AXES` to be displayed. The
+   * next four parameters, `axesSize`, `xOff`, `yOff`, and `zOff` are optional.
+   * They’re numbers that set the appearance of the size of the axes icon
+   * (`axesSize`) and its placement (`xOff`, `yOff`, and `zOff`).
+   *
+   * The fourth way to call `debugMode()` has nine optional parameters. The
+   * first five parameters, `gridSize`, `gridDivisions`, `gridXOff`, `gridYOff`,
+   * and `gridZOff` are numbers that set the appearance of the grid. For
+   * example, calling `debugMode(100, 5, 0, 0, 0)` sets the `gridSize` to 100,
+   * the number of `gridDivisions` to 5, and sets all the offsets to 0 so that
+   * the grid is centered at the origin. The next four parameters, `axesSize`,
+   * `xOff`, `yOff`, and `zOff` are numbers that set the appearance of the size
+   * of the axes icon (`axesSize`) and its placement (`axesXOff`, `axesYOff`,
+   * and `axesZOff`). For example, calling
+   * `debugMode(100, 5, 0, 0, 0, 50, 10, 10, 10)` sets the `gridSize` to 100,
+   * the number of `gridDivisions` to 5, and sets all the offsets to 0 so that
+   * the grid is centered at the origin. It then sets the `axesSize` to 50 and
+   * offsets the icon 10 pixels along each axis.
+   *
+   * @method debugMode
+   *
+   * @example
+   * <div>
+   * <code>
+   * // Click and drag the mouse to view the scene from different angles.
+   *
+   * function setup() {
+   *   createCanvas(100, 100, WEBGL);
+   *
+   *   // Enable debug mode.
+   *   debugMode();
+   *
+   *   describe('A multicolor box on a gray background. A grid and axes icon are displayed near the box.');
+   * }
+   *
+   * function draw() {
+   *   background(200);
+   *
+   *   // Enable orbiting with the mouse.
+   *   orbitControl();
+   *
+   *   // Style the box.
+   *   normalMaterial();
+   *
+   *   // Draw the box.
+   *   box(20, 40);
+   * }
+   * </code>
+   * </div>
+   *
+   * <div>
+   * <code>
+   * // Click and drag the mouse to view the scene from different angles.
+   *
+   * function setup() {
+   *   createCanvas(100, 100, WEBGL);
+   *
+   *   // Enable debug mode.
+   *   // Only display the axes icon.
+   *   debugMode(AXES);
+   *
+   *   describe('A multicolor box on a gray background. A grid and axes icon are displayed near the box.');
+   * }
+   *
+   * function draw() {
+   *   background(200);
+   *
+   *   // Enable orbiting with the mouse.
+   *   orbitControl();
+   *
+   *   // Style the box.
+   *   normalMaterial();
+   *
+   *   // Draw the box.
+   *   box(20, 40);
+   * }
+   * </code>
+   * </div>
+   *
+   * <div>
+   * <code>
+   * // Click and drag the mouse to view the scene from different angles.
+   *
+   * function setup() {
+   *   createCanvas(100, 100, WEBGL);
+   *
+   *   // Enable debug mode.
+   *   // Only display the grid and customize it:
+   *   // - size: 50
+   *   // - divisions: 10
+   *   // - offsets: 0, 20, 0
+   *   debugMode(GRID, 50, 10, 0, 20, 0);
+   *
+   *   describe('A multicolor box on a gray background. A grid is displayed below the box.');
+   * }
+   *
+   * function draw() {
+   *   background(200);
+   *
+   *   // Enable orbiting with the mouse.
+   *   orbitControl();
+   *
+   *   // Style the box.
+   *   normalMaterial();
+   *
+   *   // Draw the box.
+   *   box(20, 40);
+   * }
+   * </code>
+   * </div>
+   *
+   * <div>
+   * <code>
+   * // Click and drag the mouse to view the scene from different angles.
+   *
+   * function setup() {
+   *   createCanvas(100, 100, WEBGL);
+   *
+   *   // Enable debug mode.
+   *   // Display the grid and axes icon and customize them:
+   *   // Grid
+   *   // ----
+   *   // - size: 50
+   *   // - divisions: 10
+   *   // - offsets: 0, 20, 0
+   *   // Axes
+   *   // ----
+   *   // - size: 50
+   *   // - offsets: 0, 0, 0
+   *   debugMode(50, 10, 0, 20, 0, 50, 0, 0, 0);
+   *
+   *   describe('A multicolor box on a gray background. A grid is displayed below the box. An axes icon is displayed at the center of the box.');
+   * }
+   *
+   * function draw() {
+   *   background(200);
+   *
+   *   // Enable orbiting with the mouse.
+   *   orbitControl();
+   *
+   *   // Style the box.
+   *   normalMaterial();
+   *
+   *   // Draw the box.
+   *   box(20, 40);
+   * }
+   * </code>
+   * </div>
+   */
 
-    // X axis
-    this.strokeWeight(2);
-    this.stroke(255, 0, 0);
-    this.beginShape(this.LINES);
-    this.vertex(xOff, yOff, zOff);
-    this.vertex(xOff + size, yOff, zOff);
-    this.endShape();
-    // Y axis
-    this.stroke(0, 255, 0);
-    this.beginShape(this.LINES);
-    this.vertex(xOff, yOff, zOff);
-    this.vertex(xOff, yOff + size, zOff);
-    this.endShape();
-    // Z axis
-    this.stroke(0, 0, 255);
-    this.beginShape(this.LINES);
-    this.vertex(xOff, yOff, zOff);
-    this.vertex(xOff, yOff, zOff + size);
-    this.endShape();
-    this.pop();
+  /**
+   * @method debugMode
+   * @param {(GRID|AXES)} mode either GRID or AXES
+   */
+
+  /**
+   * @method debugMode
+   * @param {(GRID|AXES)} mode
+   * @param {Number} [gridSize] side length of the grid.
+   * @param {Number} [gridDivisions] number of divisions in the grid.
+   * @param {Number} [xOff] offset from origin along the x-axis.
+   * @param {Number} [yOff] offset from origin along the y-axis.
+   * @param {Number} [zOff] offset from origin along the z-axis.
+   */
+
+  /**
+   * @method debugMode
+   * @param {(GRID|AXES)} mode
+   * @param {Number} [axesSize] length of axes icon markers.
+   * @param {Number} [xOff]
+   * @param {Number} [yOff]
+   * @param {Number} [zOff]
+   */
+
+  /**
+   * @method debugMode
+   * @param {Number} [gridSize]
+   * @param {Number} [gridDivisions]
+   * @param {Number} [gridXOff] grid offset from the origin along the x-axis.
+   * @param {Number} [gridYOff] grid offset from the origin along the y-axis.
+   * @param {Number} [gridZOff] grid offset from the origin along the z-axis.
+   * @param {Number} [axesSize]
+   * @param {Number} [axesXOff] axes icon offset from the origin along the x-axis.
+   * @param {Number} [axesYOff] axes icon offset from the origin along the y-axis.
+   * @param {Number} [axesZOff] axes icon offset from the origin along the z-axis.
+   */
+
+  fn.debugMode = function(...args) {
+    this._assert3d('debugMode');
+    p5._validateParameters('debugMode', args);
+
+    // start by removing existing 'post' registered debug methods
+    for (let i = this._registeredMethods.post.length - 1; i >= 0; i--) {
+      // test for equality...
+      if (
+        this._registeredMethods.post[i].toString() === this._grid().toString() ||
+        this._registeredMethods.post[i].toString() === this._axesIcon().toString()
+      ) {
+        this._registeredMethods.post.splice(i, 1);
+      }
+    }
+
+    // then add new debugMode functions according to the argument list
+    if (args[0] === constants.GRID) {
+      this.registerMethod(
+        'post',
+        this._grid(args[1], args[2], args[3], args[4], args[5])
+      );
+    } else if (args[0] === constants.AXES) {
+      this.registerMethod(
+        'post',
+        this._axesIcon(args[1], args[2], args[3], args[4])
+      );
+    } else {
+      this.registerMethod(
+        'post',
+        this._grid(args[0], args[1], args[2], args[3], args[4])
+      );
+      this.registerMethod(
+        'post',
+        this._axesIcon(args[5], args[6], args[7], args[8])
+      );
+    }
   };
-};
 
-export default p5;
+  /**
+   * Turns off <a href="#/p5/debugMode">debugMode()</a> in a 3D sketch.
+   *
+   * @method noDebugMode
+   *
+   * @example
+   * <div>
+   * <code>
+   * // Click and drag the mouse to view the scene from different angles.
+   *
+   * function setup() {
+   *   createCanvas(100, 100, WEBGL);
+   *
+   *   // Enable debug mode.
+   *   debugMode();
+   *
+   *   describe('A multicolor box on a gray background. A grid and axes icon are displayed near the box. They disappear when the user double-clicks.');
+   * }
+   *
+   * function draw() {
+   *   background(200);
+   *
+   *   // Enable orbiting with the mouse.
+   *   orbitControl();
+   *
+   *   // Style the box.
+   *   normalMaterial();
+   *
+   *   // Draw the box.  box(20, 40);
+   * }
+   *
+   * // Disable debug mode when the user double-clicks.
+   * function doubleClicked() {
+   *   noDebugMode();
+   * }
+   * </code>
+   * </div>
+   */
+  fn.noDebugMode = function() {
+    this._assert3d('noDebugMode');
+
+    // start by removing existing 'post' registered debug methods
+    for (let i = this._registeredMethods.post.length - 1; i >= 0; i--) {
+      // test for equality...
+      if (
+        this._registeredMethods.post[i].toString() === this._grid().toString() ||
+        this._registeredMethods.post[i].toString() === this._axesIcon().toString()
+      ) {
+        this._registeredMethods.post.splice(i, 1);
+      }
+    }
+  };
+
+  /**
+   * For use with debugMode
+   * @private
+   * @method _grid
+   * @param {Number} [size] size of grid sides
+   * @param {Number} [div] number of grid divisions
+   * @param {Number} [xOff] offset of grid center from origin in X axis
+   * @param {Number} [yOff] offset of grid center from origin in Y axis
+   * @param {Number} [zOff] offset of grid center from origin in Z axis
+   */
+  fn._grid = function(size, numDivs, xOff, yOff, zOff) {
+    if (typeof size === 'undefined') {
+      size = this.width / 2;
+    }
+    if (typeof numDivs === 'undefined') {
+      // ensure at least 2 divisions
+      numDivs = Math.round(size / 30) < 4 ? 4 : Math.round(size / 30);
+    }
+    if (typeof xOff === 'undefined') {
+      xOff = 0;
+    }
+    if (typeof yOff === 'undefined') {
+      yOff = 0;
+    }
+    if (typeof zOff === 'undefined') {
+      zOff = 0;
+    }
+
+    const spacing = size / numDivs;
+    const halfSize = size / 2;
+
+    return function() {
+      this.push();
+      this.stroke(
+        this._renderer.states.curStrokeColor[0] * 255,
+        this._renderer.states.curStrokeColor[1] * 255,
+        this._renderer.states.curStrokeColor[2] * 255
+      );
+      this._renderer.states.uModelMatrix.reset();
+
+      // Lines along X axis
+      for (let q = 0; q <= numDivs; q++) {
+        this.beginShape(this.LINES);
+        this.vertex(-halfSize + xOff, yOff, q * spacing - halfSize + zOff);
+        this.vertex(+halfSize + xOff, yOff, q * spacing - halfSize + zOff);
+        this.endShape();
+      }
+
+      // Lines along Z axis
+      for (let i = 0; i <= numDivs; i++) {
+        this.beginShape(this.LINES);
+        this.vertex(i * spacing - halfSize + xOff, yOff, -halfSize + zOff);
+        this.vertex(i * spacing - halfSize + xOff, yOff, +halfSize + zOff);
+        this.endShape();
+      }
+
+      this.pop();
+    };
+  };
+
+  /**
+   * For use with debugMode
+   * @private
+   * @method _axesIcon
+   * @param {Number} [size] size of axes icon lines
+   * @param {Number} [xOff] offset of icon from origin in X axis
+   * @param {Number} [yOff] offset of icon from origin in Y axis
+   * @param {Number} [zOff] offset of icon from origin in Z axis
+   */
+  fn._axesIcon = function(size, xOff, yOff, zOff) {
+    if (typeof size === 'undefined') {
+      size = this.width / 20 > 40 ? this.width / 20 : 40;
+    }
+    if (typeof xOff === 'undefined') {
+      xOff = -this.width / 4;
+    }
+    if (typeof yOff === 'undefined') {
+      yOff = xOff;
+    }
+    if (typeof zOff === 'undefined') {
+      zOff = xOff;
+    }
+
+    return function() {
+      this.push();
+      this._renderer.states.uModelMatrix.reset();
+
+      // X axis
+      this.strokeWeight(2);
+      this.stroke(255, 0, 0);
+      this.beginShape(this.LINES);
+      this.vertex(xOff, yOff, zOff);
+      this.vertex(xOff + size, yOff, zOff);
+      this.endShape();
+      // Y axis
+      this.stroke(0, 255, 0);
+      this.beginShape(this.LINES);
+      this.vertex(xOff, yOff, zOff);
+      this.vertex(xOff, yOff + size, zOff);
+      this.endShape();
+      // Z axis
+      this.stroke(0, 0, 255);
+      this.beginShape(this.LINES);
+      this.vertex(xOff, yOff, zOff);
+      this.vertex(xOff, yOff, zOff + size);
+      this.endShape();
+      this.pop();
+    };
+  };
+}
+
+export default interaction;
+
+if(typeof p5 !== 'undefined'){
+  interaction(p5, p5.prototype);
+}

--- a/src/webgl/light.js
+++ b/src/webgl/light.js
@@ -5,1773 +5,1777 @@
  * @requires core
  */
 
-import p5 from '../core/main';
+function light(p5, fn){
+  /**
+   * Creates a light that shines from all directions.
+   *
+   * Ambient light does not come from one direction. Instead, 3D shapes are
+   * lit evenly from all sides. Ambient lights are almost always used in
+   * combination with other types of lights.
+   *
+   * There are three ways to call `ambientLight()` with optional parameters to
+   * set the light’s color.
+   *
+   * The first way to call `ambientLight()` has two parameters, `gray` and
+   * `alpha`. `alpha` is optional. Grayscale and alpha values between 0 and 255
+   * can be passed to set the ambient light’s color, as in `ambientLight(50)` or
+   * `ambientLight(50, 30)`.
+   *
+   * The second way to call `ambientLight()` has one parameter, color. A
+   * <a href="#/p5.Color">p5.Color</a> object, an array of color values, or a
+   * CSS color string, as in `ambientLight('magenta')`, can be passed to set the
+   * ambient light’s color.
+   *
+   * The third way to call `ambientLight()` has four parameters, `v1`, `v2`,
+   * `v3`, and `alpha`. `alpha` is optional. RGBA, HSBA, or HSLA values can be
+   * passed to set the ambient light’s colors, as in `ambientLight(255, 0, 0)`
+   * or `ambientLight(255, 0, 0, 30)`. Color values will be interpreted using
+   * the current <a href="#/p5/colorMode">colorMode()</a>.
+   *
+   * @method ambientLight
+   * @param  {Number}        v1 red or hue value in the current
+   *                            <a href="#/p5/colorMode">colorMode()</a>.
+   * @param  {Number}        v2 green or saturation value in the current
+   *                            <a href="#/p5/colorMode">colorMode()</a>.
+   * @param  {Number}        v3 blue, brightness, or lightness value in the current
+   *                            <a href="#/p5/colorMode">colorMode()</a>.
+   * @param  {Number}        [alpha] alpha (transparency) value in the current
+   *                                 <a href="#/p5/colorMode">colorMode()</a>.
+   * @chainable
+   *
+   * @example
+   * <div>
+   * <code>
+   * // Click and drag the mouse to view the scene from different angles.
+   * // Double-click the canvas to turn on the light.
+   *
+   * let isLit = false;
+   *
+   * function setup() {
+   *   createCanvas(100, 100, WEBGL);
+   *
+   *   describe('A sphere drawn against a gray background. The sphere appears to change color when the user double-clicks.');
+   * }
+   *
+   * function draw() {
+   *   background(200);
+   *
+   *   // Enable orbiting with the mouse.
+   *   orbitControl();
+   *
+   *   // Control the light.
+   *   if (isLit === true) {
+   *     // Use a grayscale value of 80.
+   *     ambientLight(80);
+   *   }
+   *
+   *   // Draw the sphere.
+   *   sphere(30);
+   * }
+   *
+   * // Turn on the ambient light when the user double-clicks.
+   * function doubleClicked() {
+   *   isLit = true;
+   * }
+   * </code>
+   * </div>
+   *
+   * <div>
+   * <code>
+   * // Click and drag the mouse to view the scene from different angles.
+   *
+   * function setup() {
+   *   createCanvas(100, 100, WEBGL);
+   *
+   *   describe('A faded magenta sphere drawn against a gray background.');
+   * }
+   *
+   * function draw() {
+   *   background(200);
+   *
+   *   // Enable orbiting with the mouse.
+   *   orbitControl();
+   *
+   *   // Turn on the lights.
+   *   // Use a p5.Color object.
+   *   let c = color('orchid');
+   *   ambientLight(c);
+   *
+   *   // Draw the sphere.
+   *   sphere();
+   * }
+   * </code>
+   * </div>
+   *
+   * <div>
+   * <code>
+   * // Click and drag the mouse to view the scene from different angles.
+   *
+   * function setup() {
+   *   createCanvas(100, 100, WEBGL);
+   *
+   *   describe('A faded magenta sphere drawn against a gray background.');
+   * }
+   *
+   * function draw() {
+   *   background(200);
+   *
+   *   // Enable orbiting with the mouse.
+   *   orbitControl();
+   *
+   *   // Turn on the lights.
+   *   // Use a CSS color string.
+   *   ambientLight('#DA70D6');
+   *
+   *   // Draw the sphere.
+   *   sphere(30);
+   * }
+   * </code>
+   * </div>
+   *
+   * <div>
+   * <code>
+   * // Click and drag the mouse to view the scene from different angles.
+   *
+   * function setup() {
+   *   createCanvas(100, 100, WEBGL);
+   *
+   *   describe('A faded magenta sphere drawn against a gray background.');
+   * }
+   *
+   * function draw() {
+   *   background(200);
+   *
+   *   // Enable orbiting with the mouse.
+   *   orbitControl();
+   *
+   *   // Turn on the lights.
+   *   // Use RGB values
+   *   ambientLight(218, 112, 214);
+   *
+   *   // Draw the sphere.
+   *   sphere(30);
+   * }
+   * </code>
+   * </div>
+   */
 
-/**
- * Creates a light that shines from all directions.
- *
- * Ambient light does not come from one direction. Instead, 3D shapes are
- * lit evenly from all sides. Ambient lights are almost always used in
- * combination with other types of lights.
- *
- * There are three ways to call `ambientLight()` with optional parameters to
- * set the light’s color.
- *
- * The first way to call `ambientLight()` has two parameters, `gray` and
- * `alpha`. `alpha` is optional. Grayscale and alpha values between 0 and 255
- * can be passed to set the ambient light’s color, as in `ambientLight(50)` or
- * `ambientLight(50, 30)`.
- *
- * The second way to call `ambientLight()` has one parameter, color. A
- * <a href="#/p5.Color">p5.Color</a> object, an array of color values, or a
- * CSS color string, as in `ambientLight('magenta')`, can be passed to set the
- * ambient light’s color.
- *
- * The third way to call `ambientLight()` has four parameters, `v1`, `v2`,
- * `v3`, and `alpha`. `alpha` is optional. RGBA, HSBA, or HSLA values can be
- * passed to set the ambient light’s colors, as in `ambientLight(255, 0, 0)`
- * or `ambientLight(255, 0, 0, 30)`. Color values will be interpreted using
- * the current <a href="#/p5/colorMode">colorMode()</a>.
- *
- * @method ambientLight
- * @param  {Number}        v1 red or hue value in the current
- *                            <a href="#/p5/colorMode">colorMode()</a>.
- * @param  {Number}        v2 green or saturation value in the current
- *                            <a href="#/p5/colorMode">colorMode()</a>.
- * @param  {Number}        v3 blue, brightness, or lightness value in the current
- *                            <a href="#/p5/colorMode">colorMode()</a>.
- * @param  {Number}        [alpha] alpha (transparency) value in the current
- *                                 <a href="#/p5/colorMode">colorMode()</a>.
- * @chainable
- *
- * @example
- * <div>
- * <code>
- * // Click and drag the mouse to view the scene from different angles.
- * // Double-click the canvas to turn on the light.
- *
- * let isLit = false;
- *
- * function setup() {
- *   createCanvas(100, 100, WEBGL);
- *
- *   describe('A sphere drawn against a gray background. The sphere appears to change color when the user double-clicks.');
- * }
- *
- * function draw() {
- *   background(200);
- *
- *   // Enable orbiting with the mouse.
- *   orbitControl();
- *
- *   // Control the light.
- *   if (isLit === true) {
- *     // Use a grayscale value of 80.
- *     ambientLight(80);
- *   }
- *
- *   // Draw the sphere.
- *   sphere(30);
- * }
- *
- * // Turn on the ambient light when the user double-clicks.
- * function doubleClicked() {
- *   isLit = true;
- * }
- * </code>
- * </div>
- *
- * <div>
- * <code>
- * // Click and drag the mouse to view the scene from different angles.
- *
- * function setup() {
- *   createCanvas(100, 100, WEBGL);
- *
- *   describe('A faded magenta sphere drawn against a gray background.');
- * }
- *
- * function draw() {
- *   background(200);
- *
- *   // Enable orbiting with the mouse.
- *   orbitControl();
- *
- *   // Turn on the lights.
- *   // Use a p5.Color object.
- *   let c = color('orchid');
- *   ambientLight(c);
- *
- *   // Draw the sphere.
- *   sphere();
- * }
- * </code>
- * </div>
- *
- * <div>
- * <code>
- * // Click and drag the mouse to view the scene from different angles.
- *
- * function setup() {
- *   createCanvas(100, 100, WEBGL);
- *
- *   describe('A faded magenta sphere drawn against a gray background.');
- * }
- *
- * function draw() {
- *   background(200);
- *
- *   // Enable orbiting with the mouse.
- *   orbitControl();
- *
- *   // Turn on the lights.
- *   // Use a CSS color string.
- *   ambientLight('#DA70D6');
- *
- *   // Draw the sphere.
- *   sphere(30);
- * }
- * </code>
- * </div>
- *
- * <div>
- * <code>
- * // Click and drag the mouse to view the scene from different angles.
- *
- * function setup() {
- *   createCanvas(100, 100, WEBGL);
- *
- *   describe('A faded magenta sphere drawn against a gray background.');
- * }
- *
- * function draw() {
- *   background(200);
- *
- *   // Enable orbiting with the mouse.
- *   orbitControl();
- *
- *   // Turn on the lights.
- *   // Use RGB values
- *   ambientLight(218, 112, 214);
- *
- *   // Draw the sphere.
- *   sphere(30);
- * }
- * </code>
- * </div>
- */
+  /**
+   * @method ambientLight
+   * @param  {Number}        gray  grayscale value between 0 and 255.
+   * @param  {Number}        [alpha]
+   * @chainable
+   */
 
-/**
- * @method ambientLight
- * @param  {Number}        gray  grayscale value between 0 and 255.
- * @param  {Number}        [alpha]
- * @chainable
- */
+  /**
+   * @method ambientLight
+   * @param  {String}        value color as a CSS string.
+   * @chainable
+   */
 
-/**
- * @method ambientLight
- * @param  {String}        value color as a CSS string.
- * @chainable
- */
+  /**
+   * @method ambientLight
+   * @param  {Number[]}      values color as an array of RGBA, HSBA, or HSLA
+   *                                 values.
+   * @chainable
+   */
 
-/**
- * @method ambientLight
- * @param  {Number[]}      values color as an array of RGBA, HSBA, or HSLA
- *                                 values.
- * @chainable
- */
+  /**
+   * @method ambientLight
+   * @param  {p5.Color}      color color as a <a href="#/p5.Color">p5.Color</a> object.
+   * @chainable
+   */
+  fn.ambientLight = function (v1, v2, v3, a) {
+    this._assert3d('ambientLight');
+    p5._validateParameters('ambientLight', arguments);
+    const color = this.color(...arguments);
 
-/**
- * @method ambientLight
- * @param  {p5.Color}      color color as a <a href="#/p5.Color">p5.Color</a> object.
- * @chainable
- */
-p5.prototype.ambientLight = function (v1, v2, v3, a) {
-  this._assert3d('ambientLight');
-  p5._validateParameters('ambientLight', arguments);
-  const color = this.color(...arguments);
-
-  this._renderer.states.ambientLightColors.push(
-    color._array[0],
-    color._array[1],
-    color._array[2]
-  );
-
-  this._renderer.states._enableLighting = true;
-
-  return this;
-};
-
-/**
- * Sets the specular color for lights.
- *
- * `specularColor()` affects lights that bounce off a surface in a preferred
- * direction. These lights include
- * <a href="#/p5/directionalLight">directionalLight()</a>,
- * <a href="#/p5/pointLight">pointLight()</a>, and
- * <a href="#/p5/spotLight">spotLight()</a>. The function helps to create
- * highlights on <a href="#/p5.Geometry">p5.Geometry</a> objects that are
- * styled with <a href="#/p5/specularMaterial">specularMaterial()</a>. If a
- * geometry does not use
- * <a href="#/p5/specularMaterial">specularMaterial()</a>, then
- * `specularColor()` will have no effect.
- *
- * Note: `specularColor()` doesn’t affect lights that bounce in all
- * directions, including <a href="#/p5/ambientLight">ambientLight()</a> and
- * <a href="#/p5/imageLight">imageLight()</a>.
- *
- * There are three ways to call `specularColor()` with optional parameters to
- * set the specular highlight color.
- *
- * The first way to call `specularColor()` has two optional parameters, `gray`
- * and `alpha`. Grayscale and alpha values between 0 and 255, as in
- * `specularColor(50)` or `specularColor(50, 80)`, can be passed to set the
- * specular highlight color.
- *
- * The second way to call `specularColor()` has one optional parameter,
- * `color`. A <a href="#/p5.Color">p5.Color</a> object, an array of color
- * values, or a CSS color string can be passed to set the specular highlight
- * color.
- *
- * The third way to call `specularColor()` has four optional parameters, `v1`,
- * `v2`, `v3`, and `alpha`. RGBA, HSBA, or HSLA values, as in
- * `specularColor(255, 0, 0, 80)`, can be passed to set the specular highlight
- * color. Color values will be interpreted using the current
- * <a href="#/p5/colorMode">colorMode()</a>.
- *
- * @method specularColor
- * @param  {Number}        v1 red or hue value in the current
- *                            <a href="#/p5/colorMode">colorMode()</a>.
- * @param  {Number}        v2 green or saturation value in the current
- *                            <a href="#/p5/colorMode">colorMode()</a>.
- * @param  {Number}        v3 blue, brightness, or lightness value in the current
- *                            <a href="#/p5/colorMode">colorMode()</a>.
- * @chainable
- *
- * @example
- * <div>
- * <code>
- * // Click and drag the mouse to view the scene from different angles.
- *
- * function setup() {
- *   createCanvas(100, 100, WEBGL);
- *
- *   describe('A white sphere drawn on a gray background.');
- * }
- *
- * function draw() {
- *   background(200);
- *
- *   // Enable orbiting with the mouse.
- *   orbitControl();
- *
- *   // No specular color.
- *   // Draw the sphere.
- *   sphere(30);
- * }
- * </code>
- * </div>
- *
- * <div>
- * <code>
- * // Click and drag the mouse to view the scene from different angles.
- * // Double-click the canvas to add a point light.
- *
- * let isLit = false;
- *
- * function setup() {
- *   createCanvas(100, 100, WEBGL);
- *
- *   describe('A sphere drawn on a gray background. A spotlight starts shining when the user double-clicks.');
- * }
- *
- * function draw() {
- *   background(200);
- *
- *   // Enable orbiting with the mouse.
- *   orbitControl();
- *
- *   // Style the sphere.
- *   noStroke();
- *   specularColor(100);
- *   specularMaterial(255, 255, 255);
- *
- *   // Control the light.
- *   if (isLit === true) {
- *     // Add a white point light from the top-right.
- *     pointLight(255, 255, 255, 30, -20, 40);
- *   }
- *
- *   // Draw the sphere.
- *   sphere(30);
- * }
- *
- * // Turn on the point light when the user double-clicks.
- * function doubleClicked() {
- *   isLit = true;
- * }
- * </code>
- * </div>
- *
- * <div>
- * <code>
- * // Click and drag the mouse to view the scene from different angles.
- *
- * function setup() {
- *   createCanvas(100, 100, WEBGL);
- *
- *   describe('A black sphere drawn on a gray background. An area on the surface of the sphere is highlighted in blue.');
- * }
- *
- * function draw() {
- *   background(200);
- *
- *   // Enable orbiting with the mouse.
- *   orbitControl();
- *
- *   // Add a specular highlight.
- *   // Use a p5.Color object.
- *   let c = color('dodgerblue');
- *   specularColor(c);
- *
- *   // Add a white point light from the top-right.
- *   pointLight(255, 255, 255, 30, -20, 40);
- *
- *   // Style the sphere.
- *   noStroke();
- *
- *   // Add a white specular material.
- *   specularMaterial(255, 255, 255);
- *
- *   // Draw the sphere.
- *   sphere(30);
- * }
- * </code>
- * </div>
- *
- * <div>
- * <code>
- * // Click and drag the mouse to view the scene from different angles.
- *
- * function setup() {
- *   createCanvas(100, 100, WEBGL);
- *
- *   describe('A black sphere drawn on a gray background. An area on the surface of the sphere is highlighted in blue.');
- * }
- *
- * function draw() {
- *   background(200);
- *
- *   // Enable orbiting with the mouse.
- *   orbitControl();
- *
- *   // Add a specular highlight.
- *   // Use a CSS color string.
- *   specularColor('#1E90FF');
- *
- *   // Add a white point light from the top-right.
- *   pointLight(255, 255, 255, 30, -20, 40);
- *
- *   // Style the sphere.
- *   noStroke();
- *
- *   // Add a white specular material.
- *   specularMaterial(255, 255, 255);
- *
- *   // Draw the sphere.
- *   sphere(30);
- * }
- * </code>
- * </div>
- *
- * <div>
- * <code>
- * // Click and drag the mouse to view the scene from different angles.
- *
- * function setup() {
- *   createCanvas(100, 100, WEBGL);
- *
- *   describe('A black sphere drawn on a gray background. An area on the surface of the sphere is highlighted in blue.');
- * }
- *
- * function draw() {
- *   background(200);
- *
- *   // Enable orbiting with the mouse.
- *   orbitControl();
- *
- *   // Add a specular highlight.
- *   // Use RGB values.
- *   specularColor(30, 144, 255);
- *
- *   // Add a white point light from the top-right.
- *   pointLight(255, 255, 255, 30, -20, 40);
- *
- *   // Style the sphere.
- *   noStroke();
- *
- *   // Add a white specular material.
- *   specularMaterial(255, 255, 255);
- *
- *   // Draw the sphere.
- *   sphere(30);
- * }
- * </code>
- * </div>
- */
-
-/**
- * @method specularColor
- * @param  {Number}        gray grayscale value between 0 and 255.
- * @chainable
- */
-
-/**
- * @method specularColor
- * @param  {String}        value color as a CSS string.
- * @chainable
- */
-
-/**
- * @method specularColor
- * @param  {Number[]}      values color as an array of RGBA, HSBA, or HSLA
- *                                 values.
- * @chainable
- */
-
-/**
- * @method specularColor
- * @param  {p5.Color}      color color as a <a href="#/p5.Color">p5.Color</a> object.
- * @chainable
- */
-p5.prototype.specularColor = function (v1, v2, v3) {
-  this._assert3d('specularColor');
-  p5._validateParameters('specularColor', arguments);
-  const color = this.color(...arguments);
-
-  this._renderer.states.specularColors = [
-    color._array[0],
-    color._array[1],
-    color._array[2]
-  ];
-
-  return this;
-};
-
-/**
- * Creates a light that shines in one direction.
- *
- * Directional lights don’t shine from a specific point. They’re like a sun
- * that shines from somewhere offscreen. The light’s direction is set using
- * three `(x, y, z)` values between -1 and 1. For example, setting a light’s
- * direction as `(1, 0, 0)` will light <a href="#/p5.Geometry">p5.Geometry</a>
- * objects from the left since the light faces directly to the right.
- *
- * There are four ways to call `directionalLight()` with parameters to set the
- * light’s color and direction.
- *
- * The first way to call `directionalLight()` has six parameters. The first
- * three parameters, `v1`, `v2`, and `v3`, set the light’s color using the
- * current <a href="#/p5/colorMode">colorMode()</a>. The last three
- * parameters, `x`, `y`, and `z`, set the light’s direction. For example,
- * `directionalLight(255, 0, 0, 1, 0, 0)` creates a red `(255, 0, 0)` light
- * that shines to the right `(1, 0, 0)`.
- *
- * The second way to call `directionalLight()` has four parameters. The first
- * three parameters, `v1`, `v2`, and `v3`, set the light’s color using the
- * current <a href="#/p5/colorMode">colorMode()</a>. The last parameter,
- * `direction` sets the light’s direction using a
- * <a href="#/p5.Geometry">p5.Geometry</a> object. For example,
- * `directionalLight(255, 0, 0, lightDir)` creates a red `(255, 0, 0)` light
- * that shines in the direction the `lightDir` vector points.
- *
- * The third way to call `directionalLight()` has four parameters. The first
- * parameter, `color`, sets the light’s color using a
- * <a href="#/p5.Color">p5.Color</a> object or an array of color values. The
- * last three parameters, `x`, `y`, and `z`, set the light’s direction. For
- * example, `directionalLight(myColor, 1, 0, 0)` creates a light that shines
- * to the right `(1, 0, 0)` with the color value of `myColor`.
- *
- * The fourth way to call `directionalLight()` has two parameters. The first
- * parameter, `color`, sets the light’s color using a
- * <a href="#/p5.Color">p5.Color</a> object or an array of color values. The
- * second parameter, `direction`, sets the light’s direction using a
- * <a href="#/p5.Color">p5.Color</a> object. For example,
- * `directionalLight(myColor, lightDir)` creates a light that shines in the
- * direction the `lightDir` vector points with the color value of `myColor`.
- *
- * @method directionalLight
- * @param  {Number}    v1 red or hue value in the current
- *                        <a href="#/p5/colorMode">colorMode()</a>.
- * @param  {Number}    v2 green or saturation value in the current
- *                        <a href="#/p5/colorMode">colorMode()</a>.
- * @param  {Number}    v3 blue, brightness, or lightness value in the current
- *                        <a href="#/p5/colorMode">colorMode()</a>.
- * @param  {Number}    x  x-component of the light's direction between -1 and 1.
- * @param  {Number}    y  y-component of the light's direction between -1 and 1.
- * @param  {Number}    z  z-component of the light's direction between -1 and 1.
- * @chainable
- *
- * @example
- * <div>
- * <code>
- * // Click and drag the mouse to view the scene from different angles.
- * // Double-click to turn on the directional light.
- *
- * let isLit = false;
- *
- * function setup() {
- *   createCanvas(100, 100, WEBGL);
- *
- *   describe('A sphere drawn on a gray background. A red light starts shining from above when the user double-clicks.');
- * }
- *
- * function draw() {
- *   background(200);
- *
- *   // Enable orbiting with the mouse.
- *   orbitControl();
- *
- *   // Control the light.
- *   if (isLit === true) {
- *     // Add a red directional light from above.
- *     // Use RGB values and XYZ directions.
- *     directionalLight(255, 0, 0, 0, 1, 0);
- *   }
- *
- *   // Style the sphere.
- *   noStroke();
- *
- *   // Draw the sphere.
- *   sphere(30);
- * }
- * </code>
- * </div>
- *
- * <div>
- * <code>
- * // Click and drag the mouse to view the scene from different angles.
- *
- * function setup() {
- *   createCanvas(100, 100, WEBGL);
- *
- *   describe('A sphere drawn on a gray background. The top of the sphere appears bright red. The color gets darker toward the bottom.');
- * }
- *
- * function draw() {
- *   background(200);
- *
- *   // Enable orbiting with the mouse.
- *   orbitControl();
- *
- *   // Add a red directional light from above.
- *   // Use a p5.Color object and XYZ directions.
- *   let c = color(255, 0, 0);
- *   directionalLight(c, 0, 1, 0);
- *
- *   // Style the sphere.
- *   noStroke();
- *
- *   // Draw the sphere.
- *   sphere(30);
- * }
- * </code>
- * </div>
- *
- * <div>
- * <code>
- * // Click and drag the mouse to view the scene from different angles.
- *
- * function setup() {
- *   createCanvas(100, 100, WEBGL);
- *
- *   describe('A sphere drawn on a gray background. The top of the sphere appears bright red. The color gets darker toward the bottom.');
- * }
- *
- * function draw() {
- *   background(200);
- *
- *   // Enable orbiting with the mouse.
- *   orbitControl();
- *
- *   // Add a red directional light from above.
- *   // Use a p5.Color object and a p5.Vector object.
- *   let c = color(255, 0, 0);
- *   let lightDir = createVector(0, 1, 0);
- *   directionalLight(c, lightDir);
- *
- *   // Style the sphere.
- *   noStroke();
- *
- *   // Draw the sphere.
- *   sphere(30);
- * }
- * </code>
- * </div>
- */
-
-/**
- * @method directionalLight
- * @param  {Number}    v1
- * @param  {Number}    v2
- * @param  {Number}    v3
- * @param  {p5.Vector} direction direction of the light as a
- *                               <a href="#/p5.Vector">p5.Vector</a> object.
- * @chainable
- */
-
-/**
- * @method directionalLight
- * @param  {p5.Color|Number[]|String} color color as a <a href="#/p5.Color">p5.Color</a> object,
- *                                           an array of color values, or as a CSS string.
- * @param  {Number}                   x
- * @param  {Number}                   y
- * @param  {Number}                   z
- * @chainable
- */
-
-/**
- * @method directionalLight
- * @param  {p5.Color|Number[]|String} color
- * @param  {p5.Vector}                direction
- * @chainable
- */
-p5.prototype.directionalLight = function (v1, v2, v3, x, y, z) {
-  this._assert3d('directionalLight');
-  p5._validateParameters('directionalLight', arguments);
-
-  //@TODO: check parameters number
-  let color;
-  if (v1 instanceof p5.Color) {
-    color = v1;
-  } else {
-    color = this.color(v1, v2, v3);
-  }
-
-  let _x, _y, _z;
-  const v = arguments[arguments.length - 1];
-  if (typeof v === 'number') {
-    _x = arguments[arguments.length - 3];
-    _y = arguments[arguments.length - 2];
-    _z = arguments[arguments.length - 1];
-  } else {
-    _x = v.x;
-    _y = v.y;
-    _z = v.z;
-  }
-
-  // normalize direction
-  const l = Math.sqrt(_x * _x + _y * _y + _z * _z);
-  this._renderer.states.directionalLightDirections.push(_x / l, _y / l, _z / l);
-
-  this._renderer.states.directionalLightDiffuseColors.push(
-    color._array[0],
-    color._array[1],
-    color._array[2]
-  );
-  Array.prototype.push.apply(
-    this._renderer.states.directionalLightSpecularColors,
-    this._renderer.states.specularColors
-  );
-
-  this._renderer.states._enableLighting = true;
-
-  return this;
-};
-
-/**
- * Creates a light that shines from a point in all directions.
- *
- * Point lights are like light bulbs that shine in all directions. They can be
- * placed at different positions to achieve different lighting effects. A
- * maximum of 5 point lights can be active at once.
- *
- * There are four ways to call `pointLight()` with parameters to set the
- * light’s color and position.
- *
- * The first way to call `pointLight()` has six parameters. The first three
- * parameters, `v1`, `v2`, and `v3`, set the light’s color using the current
- * <a href="#/p5/colorMode">colorMode()</a>. The last three parameters, `x`,
- * `y`, and `z`, set the light’s position. For example,
- * `pointLight(255, 0, 0, 50, 0, 0)` creates a red `(255, 0, 0)` light that
- * shines from the coordinates `(50, 0, 0)`.
- *
- * The second way to call `pointLight()` has four parameters. The first three
- * parameters, `v1`, `v2`, and `v3`, set the light’s color using the current
- * <a href="#/p5/colorMode">colorMode()</a>. The last parameter, position sets
- * the light’s position using a <a href="#/p5.Vector">p5.Vector</a> object.
- * For example, `pointLight(255, 0, 0, lightPos)` creates a red `(255, 0, 0)`
- * light that shines from the position set by the `lightPos` vector.
- *
- * The third way to call `pointLight()` has four parameters. The first
- * parameter, `color`, sets the light’s color using a
- * <a href="#/p5.Color">p5.Color</a> object or an array of color values. The
- * last three parameters, `x`, `y`, and `z`, set the light’s position. For
- * example, `directionalLight(myColor, 50, 0, 0)` creates a light that shines
- * from the coordinates `(50, 0, 0)` with the color value of `myColor`.
- *
- * The fourth way to call `pointLight()` has two parameters. The first
- * parameter, `color`, sets the light’s color using a
- * <a href="#/p5.Color">p5.Color</a> object or an array of color values. The
- * second parameter, `position`, sets the light’s position using a
- * <a href="#/p5.Vector">p5.Vector</a> object. For example,
- * `directionalLight(myColor, lightPos)` creates a light that shines from the
- * position set by the `lightPos` vector with the color value of `myColor`.
- *
- * @method pointLight
- * @param  {Number}    v1 red or hue value in the current
- *                        <a href="#/p5/colorMode">colorMode()</a>.
- * @param  {Number}    v2 green or saturation value in the current
- *                        <a href="#/p5/colorMode">colorMode()</a>.
- * @param  {Number}    v3 blue, brightness, or lightness value in the current
- *                        <a href="#/p5/colorMode">colorMode()</a>.
- * @param  {Number}    x  x-coordinate of the light.
- * @param  {Number}    y  y-coordinate of the light.
- * @param  {Number}    z  z-coordinate of the light.
- * @chainable
- *
- * @example
- *
- * <div>
- * <code>
- * // Click and drag the mouse to view the scene from different angles.
- * // Double-click to turn on the point light.
- *
- * let isLit = false;
- *
- * function setup() {
- *   createCanvas(100, 100, WEBGL);
- *
- *   describe('A sphere drawn on a gray background. A red light starts shining from above when the user double-clicks.');
- * }
- *
- * function draw() {
- *   background(200);
- *
- *   // Enable orbiting with the mouse.
- *   orbitControl();
- *
- *   // Control the light.
- *   if (isLit === true) {
- *     // Add a red point light from above.
- *     // Use RGB values and XYZ coordinates.
- *     pointLight(255, 0, 0, 0, -150, 0);
- *   }
- *
- *   // Style the sphere.
- *   noStroke();
- *
- *   // Draw the sphere.
- *   sphere(30);
- * }
- *
- * // Turn on the point light when the user double-clicks.
- * function doubleClicked() {
- *   isLit = true;
- * }
- * </code>
- * </div>
- *
- * <div>
- * <code>
- * // Click and drag the mouse to view the scene from different angles.
- *
- * function setup() {
- *   createCanvas(100, 100, WEBGL);
- *
- *   describe('A sphere drawn on a gray background. The top of the sphere appears bright red. The color gets darker toward the bottom.');
- * }
- *
- * function draw() {
- *   background(200);
- *
- *   // Enable orbiting with the mouse.
- *   orbitControl();
- *
- *   // Add a red point light from above.
- *   // Use a p5.Color object and XYZ directions.
- *   let c = color(255, 0, 0);
- *   pointLight(c, 0, -150, 0);
- *
- *   // Style the sphere.
- *   noStroke();
- *
- *   // Draw the sphere.
- *   sphere(30);
- * }
- * </code>
- * </div>
- *
- * <div>
- * <code>
- * // Click and drag the mouse to view the scene from different angles.
- *
- * function setup() {
- *   createCanvas(100, 100, WEBGL);
- *
- *   describe('A sphere drawn on a gray background. The top of the sphere appears bright red. The color gets darker toward the bottom.');
- * }
- *
- * function draw() {
- *   background(200);
- *
- *   // Enable orbiting with the mouse.
- *   orbitControl();
- *
- *   // Add a red point light from above.
- *   // Use a p5.Color object and a p5.Vector object.
- *   let c = color(255, 0, 0);
- *   let lightPos = createVector(0, -150, 0);
- *   pointLight(c, lightPos);
- *
- *   // Style the sphere.
- *   noStroke();
- *
- *   // Draw the sphere.
- *   sphere(30);
- * }
- * </code>
- * </div>
- *
- * <div>
- * <code>
- * // Click and drag the mouse to view the scene from different angles.
- *
- * function setup() {
- *   createCanvas(100, 100, WEBGL);
- *
- *   describe('Four spheres arranged in a square and drawn on a gray background. The spheres appear bright red toward the center of the square. The color gets darker toward the corners of the square.');
- * }
- *
- * function draw() {
- *   background(200);
- *
- *   // Enable orbiting with the mouse.
- *   orbitControl();
- *
- *   // Add a red point light that points to the center of the scene.
- *   // Use a p5.Color object and a p5.Vector object.
- *   let c = color(255, 0, 0);
- *   let lightPos = createVector(0, 0, 65);
- *   pointLight(c, lightPos);
- *
- *   // Style the spheres.
- *   noStroke();
- *
- *   // Draw a sphere up and to the left.
- *   push();
- *   translate(-25, -25, 25);
- *   sphere(10);
- *   pop();
- *
- *   // Draw a box up and to the right.
- *   push();
- *   translate(25, -25, 25);
- *   sphere(10);
- *   pop();
- *
- *   // Draw a sphere down and to the left.
- *   push();
- *   translate(-25, 25, 25);
- *   sphere(10);
- *   pop();
- *
- *   // Draw a box down and to the right.
- *   push();
- *   translate(25, 25, 25);
- *   sphere(10);
- *   pop();
- * }
- * </code>
- * </div>
- */
-
-/**
- * @method pointLight
- * @param  {Number}     v1
- * @param  {Number}     v2
- * @param  {Number}     v3
- * @param  {p5.Vector}  position position of the light as a
- *                               <a href="#/p5.Vector">p5.Vector</a> object.
- * @chainable
- */
-
-/**
- * @method pointLight
- * @param  {p5.Color|Number[]|String} color color as a <a href="#/p5.Color">p5.Color</a> object,
- *                                          an array of color values, or a CSS string.
- * @param  {Number}                   x
- * @param  {Number}                   y
- * @param  {Number}                   z
- * @chainable
- */
-
-/**
- * @method pointLight
- * @param  {p5.Color|Number[]|String} color
- * @param  {p5.Vector}                position
- * @chainable
- */
-p5.prototype.pointLight = function (v1, v2, v3, x, y, z) {
-  this._assert3d('pointLight');
-  p5._validateParameters('pointLight', arguments);
-
-  //@TODO: check parameters number
-  let color;
-  if (v1 instanceof p5.Color) {
-    color = v1;
-  } else {
-    color = this.color(v1, v2, v3);
-  }
-
-  let _x, _y, _z;
-  const v = arguments[arguments.length - 1];
-  if (typeof v === 'number') {
-    _x = arguments[arguments.length - 3];
-    _y = arguments[arguments.length - 2];
-    _z = arguments[arguments.length - 1];
-  } else {
-    _x = v.x;
-    _y = v.y;
-    _z = v.z;
-  }
-
-  this._renderer.states.pointLightPositions.push(_x, _y, _z);
-  this._renderer.states.pointLightDiffuseColors.push(
-    color._array[0],
-    color._array[1],
-    color._array[2]
-  );
-  Array.prototype.push.apply(
-    this._renderer.states.pointLightSpecularColors,
-    this._renderer.states.specularColors
-  );
-
-  this._renderer.states._enableLighting = true;
-
-  return this;
-};
-
-/**
- * Creates an ambient light from an image.
- *
- * `imageLight()` simulates a light shining from all directions. The effect is
- * like placing the sketch at the center of a giant sphere that uses the image
- * as its texture. The image's diffuse light will be affected by
- * <a href="#/p5/fill">fill()</a> and the specular reflections will be
- * affected by <a href="#/p5/specularMaterial">specularMaterial()</a> and
- * <a href="#/p5/shininess">shininess()</a>.
- *
- * The parameter, `img`, is the <a href="#/p5.Image">p5.Image</a> object to
- * use as the light source.
- *
- * @method imageLight
- * @param  {p5.image}    img image to use as the light source.
- *
- * @example
- * <div class="notest">
- * <code>
- * // Click and drag the mouse to view the scene from different angles.
- *
- * let img;
- *
- * // Load an image and create a p5.Image object.
- * function preload() {
- *   img = loadImage('assets/outdoor_spheremap.jpg');
- * }
- *
- * function setup() {
- *   createCanvas(100, 100, WEBGL);
- *
- *   describe('A sphere floating above a landscape. The surface of the sphere reflects the landscape.');
- * }
- *
- * function draw() {
- *   // Enable orbiting with the mouse.
- *   orbitControl();
- *
- *   // Draw the image as a panorama (360˚ background).
- *   panorama(img);
- *
- *   // Add a soft ambient light.
- *   ambientLight(50);
- *
- *   // Add light from the image.
- *   imageLight(img);
- *
- *   // Style the sphere.
- *   specularMaterial(20);
- *   shininess(100);
- *   noStroke();
- *
- *   // Draw the sphere.
- *   sphere(30);
- * }
- * </code>
- * </div>
- */
-p5.prototype.imageLight = function (img) {
-  // activeImageLight property is checked by _setFillUniforms
-  // for sending uniforms to the fillshader
-  this._renderer.states.activeImageLight = img;
-  this._renderer.states._enableLighting = true;
-};
-
-/**
- * Creates an immersive 3D background.
- *
- * `panorama()` transforms images containing 360˚ content, such as maps or
- * HDRIs, into immersive 3D backgrounds that surround a sketch. Exploring the
- * space requires changing the camera's perspective with functions such as
- * <a href="#/p5/orbitControl">orbitControl()</a> or
- * <a href="#/p5/camera">camera()</a>.
- *
- * @method panorama
- * @param {p5.Image} img 360˚ image to use as the background.
- *
- * @example
- * <div class="notest">
- * <code>
- * // Click and drag the mouse to view the scene from different angles.
- *
- * let img;
- *
- * // Load an image and create a p5.Image object.
- * function preload() {
- *   img = loadImage('assets/outdoor_spheremap.jpg');
- * }
- *
- * function setup() {
- *   createCanvas(100 ,100 ,WEBGL);
- *
- *   describe('A sphere floating above a landscape. The surface of the sphere reflects the landscape. The full landscape is viewable in 3D as the user drags the mouse.');
- * }
- *
- * function draw() {
- *   // Add the panorama.
- *   panorama(img);
- *
- *   // Enable orbiting with the mouse.
- *   orbitControl();
- *
- *   // Use the image as a light source.
- *   imageLight(img);
- *
- *   // Style the sphere.
- *   noStroke();
- *   specularMaterial(50);
- *   shininess(200);
- *   metalness(100);
- *
- *   // Draw the sphere.
- *   sphere(30);
- * }
- * </code>
- * </div>
- */
-p5.prototype.panorama = function (img) {
-  this.filter(this._renderer._getSphereMapping(img));
-};
-
-/**
- * Places an ambient and directional light in the scene.
- * The lights are set to ambientLight(128, 128, 128) and
- * directionalLight(128, 128, 128, 0, 0, -1).
- *
- * Note: lights need to be called (whether directly or indirectly)
- * within draw() to remain persistent in a looping program.
- * Placing them in setup() will cause them to only have an effect
- * the first time through the loop.
- *
- * @method lights
- * @chainable
- *
- * @example
- * <div>
- * <code>
- * // Click and drag the mouse to view the scene from different angles.
- * // Double-click to turn on the lights.
- *
- * let isLit = false;
- *
- * function setup() {
- *   createCanvas(100, 100, WEBGL);
- *
- *   describe('A white box drawn against a gray background. The quality of the light changes when the user double-clicks.');
- * }
- *
- * function draw() {
- *   background(50);
- *
- *   // Enable orbiting with the mouse.
- *   orbitControl();
- *
- *   // Control the lights.
- *   if (isLit === true) {
- *     lights();
- *   }
- *
- *   // Draw the box.
- *   box();
- * }
- *
- * // Turn on the lights when the user double-clicks.
- * function doubleClicked() {
- *   isLit = true;
- * }
- * </code>
- * </div>
- *
- * <div>
- * <code>
- * // Click and drag the mouse to view the scene from different angles.
- *
- * function setup() {
- *   createCanvas(100, 100, WEBGL);
- *
- *   describe('A white box drawn against a gray background.');
- * }
- *
- * function draw() {
- *   background(50);
- *
- *   // Enable orbiting with the mouse.
- *   orbitControl();
- *
- *   // Turn on the lights.
- *   ambientLight(128, 128, 128);
- *   directionalLight(128, 128, 128, 0, 0, -1);
- *
- *   // Draw the box.
- *   box();
- * }
- * </code>
- * </div>
- */
-p5.prototype.lights = function () {
-  this._assert3d('lights');
-  // Both specify gray by default.
-  const grayColor = this.color('rgb(128,128,128)');
-  this.ambientLight(grayColor);
-  this.directionalLight(grayColor, 0, 0, -1);
-  return this;
-};
-
-/**
- * Sets the falloff rate for <a href="#/p5/pointLight">pointLight()</a>
- * and <a href="#/p5/spotLight">spotLight()</a>.
- *
- * A light’s falloff describes the intensity of its beam at a distance. For
- * example, a lantern has a slow falloff, a flashlight has a medium falloff,
- * and a laser pointer has a sharp falloff.
- *
- * `lightFalloff()` has three parameters, `constant`, `linear`, and
- * `quadratic`. They’re numbers used to calculate falloff at a distance, `d`,
- * as follows:
- *
- * `falloff = 1 / (constant + d * linear + (d * d) * quadratic)`
- *
- * Note: `constant`, `linear`, and `quadratic` should always be set to values
- * greater than 0.
- *
- * @method lightFalloff
- * @param {Number} constant  constant value for calculating falloff.
- * @param {Number} linear    linear value for calculating falloff.
- * @param {Number} quadratic quadratic value for calculating falloff.
- * @chainable
- *
- * @example
- * <div>
- * <code>
- * // Click and drag the mouse to view the scene from different angles.
- * // Double-click to change the falloff rate.
- *
- * let useFalloff = false;
- *
- * function setup() {
- *   createCanvas(100, 100, WEBGL);
- *
- *   describe('A sphere drawn against a gray background. The intensity of the light changes when the user double-clicks.');
- * }
- *
- * function draw() {
- *   background(50);
- *
- *   // Enable orbiting with the mouse.
- *   orbitControl();
- *
- *   // Set the light falloff.
- *   if (useFalloff === true) {
- *     lightFalloff(2, 0, 0);
- *   }
- *
- *   // Add a white point light from the front.
- *   pointLight(255, 255, 255, 0, 0, 100);
- *
- *   // Style the sphere.
- *   noStroke();
- *
- *   // Draw the sphere.
- *   sphere(30);
- * }
- *
- * // Change the falloff value when the user double-clicks.
- * function doubleClicked() {
- *   useFalloff = true;
- * }
- * </code>
- * </div>
- */
-p5.prototype.lightFalloff = function (
-  constantAttenuation,
-  linearAttenuation,
-  quadraticAttenuation
-) {
-  this._assert3d('lightFalloff');
-  p5._validateParameters('lightFalloff', arguments);
-
-  if (constantAttenuation < 0) {
-    constantAttenuation = 0;
-    console.warn(
-      'Value of constant argument in lightFalloff() should be never be negative. Set to 0.'
+    this._renderer.states.ambientLightColors.push(
+      color._array[0],
+      color._array[1],
+      color._array[2]
     );
-  }
 
-  if (linearAttenuation < 0) {
-    linearAttenuation = 0;
-    console.warn(
-      'Value of linear argument in lightFalloff() should be never be negative. Set to 0.'
-    );
-  }
+    this._renderer.states._enableLighting = true;
 
-  if (quadraticAttenuation < 0) {
-    quadraticAttenuation = 0;
-    console.warn(
-      'Value of quadratic argument in lightFalloff() should be never be negative. Set to 0.'
-    );
-  }
+    return this;
+  };
 
-  if (
-    constantAttenuation === 0 &&
-    (linearAttenuation === 0 && quadraticAttenuation === 0)
-  ) {
-    constantAttenuation = 1;
-    console.warn(
-      'Either one of the three arguments in lightFalloff() should be greater than zero. Set constant argument to 1.'
-    );
-  }
+  /**
+   * Sets the specular color for lights.
+   *
+   * `specularColor()` affects lights that bounce off a surface in a preferred
+   * direction. These lights include
+   * <a href="#/p5/directionalLight">directionalLight()</a>,
+   * <a href="#/p5/pointLight">pointLight()</a>, and
+   * <a href="#/p5/spotLight">spotLight()</a>. The function helps to create
+   * highlights on <a href="#/p5.Geometry">p5.Geometry</a> objects that are
+   * styled with <a href="#/p5/specularMaterial">specularMaterial()</a>. If a
+   * geometry does not use
+   * <a href="#/p5/specularMaterial">specularMaterial()</a>, then
+   * `specularColor()` will have no effect.
+   *
+   * Note: `specularColor()` doesn’t affect lights that bounce in all
+   * directions, including <a href="#/p5/ambientLight">ambientLight()</a> and
+   * <a href="#/p5/imageLight">imageLight()</a>.
+   *
+   * There are three ways to call `specularColor()` with optional parameters to
+   * set the specular highlight color.
+   *
+   * The first way to call `specularColor()` has two optional parameters, `gray`
+   * and `alpha`. Grayscale and alpha values between 0 and 255, as in
+   * `specularColor(50)` or `specularColor(50, 80)`, can be passed to set the
+   * specular highlight color.
+   *
+   * The second way to call `specularColor()` has one optional parameter,
+   * `color`. A <a href="#/p5.Color">p5.Color</a> object, an array of color
+   * values, or a CSS color string can be passed to set the specular highlight
+   * color.
+   *
+   * The third way to call `specularColor()` has four optional parameters, `v1`,
+   * `v2`, `v3`, and `alpha`. RGBA, HSBA, or HSLA values, as in
+   * `specularColor(255, 0, 0, 80)`, can be passed to set the specular highlight
+   * color. Color values will be interpreted using the current
+   * <a href="#/p5/colorMode">colorMode()</a>.
+   *
+   * @method specularColor
+   * @param  {Number}        v1 red or hue value in the current
+   *                            <a href="#/p5/colorMode">colorMode()</a>.
+   * @param  {Number}        v2 green or saturation value in the current
+   *                            <a href="#/p5/colorMode">colorMode()</a>.
+   * @param  {Number}        v3 blue, brightness, or lightness value in the current
+   *                            <a href="#/p5/colorMode">colorMode()</a>.
+   * @chainable
+   *
+   * @example
+   * <div>
+   * <code>
+   * // Click and drag the mouse to view the scene from different angles.
+   *
+   * function setup() {
+   *   createCanvas(100, 100, WEBGL);
+   *
+   *   describe('A white sphere drawn on a gray background.');
+   * }
+   *
+   * function draw() {
+   *   background(200);
+   *
+   *   // Enable orbiting with the mouse.
+   *   orbitControl();
+   *
+   *   // No specular color.
+   *   // Draw the sphere.
+   *   sphere(30);
+   * }
+   * </code>
+   * </div>
+   *
+   * <div>
+   * <code>
+   * // Click and drag the mouse to view the scene from different angles.
+   * // Double-click the canvas to add a point light.
+   *
+   * let isLit = false;
+   *
+   * function setup() {
+   *   createCanvas(100, 100, WEBGL);
+   *
+   *   describe('A sphere drawn on a gray background. A spotlight starts shining when the user double-clicks.');
+   * }
+   *
+   * function draw() {
+   *   background(200);
+   *
+   *   // Enable orbiting with the mouse.
+   *   orbitControl();
+   *
+   *   // Style the sphere.
+   *   noStroke();
+   *   specularColor(100);
+   *   specularMaterial(255, 255, 255);
+   *
+   *   // Control the light.
+   *   if (isLit === true) {
+   *     // Add a white point light from the top-right.
+   *     pointLight(255, 255, 255, 30, -20, 40);
+   *   }
+   *
+   *   // Draw the sphere.
+   *   sphere(30);
+   * }
+   *
+   * // Turn on the point light when the user double-clicks.
+   * function doubleClicked() {
+   *   isLit = true;
+   * }
+   * </code>
+   * </div>
+   *
+   * <div>
+   * <code>
+   * // Click and drag the mouse to view the scene from different angles.
+   *
+   * function setup() {
+   *   createCanvas(100, 100, WEBGL);
+   *
+   *   describe('A black sphere drawn on a gray background. An area on the surface of the sphere is highlighted in blue.');
+   * }
+   *
+   * function draw() {
+   *   background(200);
+   *
+   *   // Enable orbiting with the mouse.
+   *   orbitControl();
+   *
+   *   // Add a specular highlight.
+   *   // Use a p5.Color object.
+   *   let c = color('dodgerblue');
+   *   specularColor(c);
+   *
+   *   // Add a white point light from the top-right.
+   *   pointLight(255, 255, 255, 30, -20, 40);
+   *
+   *   // Style the sphere.
+   *   noStroke();
+   *
+   *   // Add a white specular material.
+   *   specularMaterial(255, 255, 255);
+   *
+   *   // Draw the sphere.
+   *   sphere(30);
+   * }
+   * </code>
+   * </div>
+   *
+   * <div>
+   * <code>
+   * // Click and drag the mouse to view the scene from different angles.
+   *
+   * function setup() {
+   *   createCanvas(100, 100, WEBGL);
+   *
+   *   describe('A black sphere drawn on a gray background. An area on the surface of the sphere is highlighted in blue.');
+   * }
+   *
+   * function draw() {
+   *   background(200);
+   *
+   *   // Enable orbiting with the mouse.
+   *   orbitControl();
+   *
+   *   // Add a specular highlight.
+   *   // Use a CSS color string.
+   *   specularColor('#1E90FF');
+   *
+   *   // Add a white point light from the top-right.
+   *   pointLight(255, 255, 255, 30, -20, 40);
+   *
+   *   // Style the sphere.
+   *   noStroke();
+   *
+   *   // Add a white specular material.
+   *   specularMaterial(255, 255, 255);
+   *
+   *   // Draw the sphere.
+   *   sphere(30);
+   * }
+   * </code>
+   * </div>
+   *
+   * <div>
+   * <code>
+   * // Click and drag the mouse to view the scene from different angles.
+   *
+   * function setup() {
+   *   createCanvas(100, 100, WEBGL);
+   *
+   *   describe('A black sphere drawn on a gray background. An area on the surface of the sphere is highlighted in blue.');
+   * }
+   *
+   * function draw() {
+   *   background(200);
+   *
+   *   // Enable orbiting with the mouse.
+   *   orbitControl();
+   *
+   *   // Add a specular highlight.
+   *   // Use RGB values.
+   *   specularColor(30, 144, 255);
+   *
+   *   // Add a white point light from the top-right.
+   *   pointLight(255, 255, 255, 30, -20, 40);
+   *
+   *   // Style the sphere.
+   *   noStroke();
+   *
+   *   // Add a white specular material.
+   *   specularMaterial(255, 255, 255);
+   *
+   *   // Draw the sphere.
+   *   sphere(30);
+   * }
+   * </code>
+   * </div>
+   */
 
-  this._renderer.states.constantAttenuation = constantAttenuation;
-  this._renderer.states.linearAttenuation = linearAttenuation;
-  this._renderer.states.quadraticAttenuation = quadraticAttenuation;
+  /**
+   * @method specularColor
+   * @param  {Number}        gray grayscale value between 0 and 255.
+   * @chainable
+   */
 
-  return this;
-};
+  /**
+   * @method specularColor
+   * @param  {String}        value color as a CSS string.
+   * @chainable
+   */
 
-/**
- * Creates a light that shines from a point in one direction.
- *
- * Spot lights are like flashlights that shine in one direction creating a
- * cone of light. The shape of the cone can be controlled using the angle and
- * concentration parameters. A maximum of 5 spot lights can be active at once.
- *
- * There are eight ways to call `spotLight()` with parameters to set the
- * light’s color, position, direction. For example,
- * `spotLight(255, 0, 0, 0, 0, 0, 1, 0, 0)` creates a red `(255, 0, 0)` light
- * at the origin `(0, 0, 0)` that points to the right `(1, 0, 0)`.
- *
- * The `angle` parameter is optional. It sets the radius of the light cone.
- * For example, `spotLight(255, 0, 0, 0, 0, 0, 1, 0, 0, PI / 16)` creates a
- * red `(255, 0, 0)` light at the origin `(0, 0, 0)` that points to the right
- * `(1, 0, 0)` with an angle of `PI / 16` radians. By default, `angle` is
- * `PI / 3` radians.
- *
- * The `concentration` parameter is also optional. It focuses the light
- * towards the center of the light cone. For example,
- * `spotLight(255, 0, 0, 0, 0, 0, 1, 0, 0, PI / 16, 50)` creates a red
- * `(255, 0, 0)` light at the origin `(0, 0, 0)` that points to the right
- * `(1, 0, 0)` with an angle of `PI / 16` radians at concentration of 50. By
- * default, `concentration` is 100.
- *
- * @method spotLight
- * @param  {Number}    v1               red or hue value in the current
- *                                      <a href="#/p5/colorMode">colorMode()</a>.
- * @param  {Number}    v2               green or saturation value in the current
- *                                      <a href="#/p5/colorMode">colorMode()</a>.
- * @param  {Number}    v3               blue, brightness, or lightness value in the current
- *                                      <a href="#/p5/colorMode">colorMode()</a>.
- * @param  {Number}    x                x-coordinate of the light.
- * @param  {Number}    y                y-coordinate of the light.
- * @param  {Number}    z                z-coordinate of the light.
- * @param  {Number}    rx               x-component of light direction between -1 and 1.
- * @param  {Number}    ry               y-component of light direction between -1 and 1.
- * @param  {Number}    rz               z-component of light direction between -1 and 1.
- * @param  {Number}    [angle]          angle of the light cone. Defaults to `PI / 3`.
- * @param  {Number}    [concentration]  concentration of the light. Defaults to 100.
- * @chainable
- *
- * @example
- * <div>
- * <code>
- * // Click and drag the mouse to view the scene from different angles.
- * // Double-click to adjust the spotlight.
- *
- * let isLit = false;
- *
- * function setup() {
- *   createCanvas(100, 100, WEBGL);
- *
- *   describe('A white sphere drawn on a gray background. A red spotlight starts shining when the user double-clicks.');
- * }
- *
- * function draw() {
- *   background(50);
- *
- *   // Enable orbiting with the mouse.
- *   orbitControl();
- *
- *   // Turn on the lights.
- *   lights();
- *
- *   // Control the spotlight.
- *   if (isLit === true) {
- *     // Add a red spot light that shines into the screen.
- *     // Set its angle to PI / 32 radians.
- *     spotLight(255, 0, 0, 0, 0, 100, 0, 0, -1, PI / 32);
- *   }
- *
- *   // Draw the sphere.
- *   sphere(30);
- * }
- *
- * // Turn on the spotlight when the user double-clicks.
- * function doubleClicked() {
- *   isLit = true;
- * }
- * </code>
- * </div>
- *
- * <div>
- * <code>
- * // Click and drag the mouse to view the scene from different angles.
- * // Double-click to adjust the spotlight.
- *
- * let isLit = false;
- *
- * function setup() {
- *   createCanvas(100, 100, WEBGL);
- *
- *   describe('A white sphere drawn on a gray background. A red spotlight starts shining when the user double-clicks.');
- * }
- *
- * function draw() {
- *   background(50);
- *
- *   // Enable orbiting with the mouse.
- *   orbitControl();
- *
- *   // Turn on the lights.
- *   lights();
- *
- *   // Control the spotlight.
- *   if (isLit === true) {
- *     // Add a red spot light that shines into the screen.
- *     // Set its angle to PI / 3 radians (default).
- *     // Set its concentration to 1000.
- *     let c = color(255, 0, 0);
- *     let position = createVector(0, 0, 100);
- *     let direction = createVector(0, 0, -1);
- *     spotLight(c, position, direction, PI / 3, 1000);
- *   }
- *
- *   // Draw the sphere.
- *   sphere(30);
- * }
- *
- * // Turn on the spotlight when the user double-clicks.
- * function doubleClicked() {
- *   isLit = true;
- * }
- * </code>
- * </div>
- */
-/**
- * @method spotLight
- * @param  {p5.Color|Number[]|String} color     color as a <a href="#/p5.Color">p5.Color</a> object,
- *                                              an array of color values, or a CSS string.
- * @param  {p5.Vector}                position  position of the light as a <a href="#/p5.Vector">p5.Vector</a> object.
- * @param  {p5.Vector}                direction direction of light as a <a href="#/p5.Vector">p5.Vector</a> object.
- * @param  {Number}                   [angle]
- * @param  {Number}                   [concentration]
- */
-/**
- * @method spotLight
- * @param  {Number}     v1
- * @param  {Number}     v2
- * @param  {Number}     v3
- * @param  {p5.Vector}  position
- * @param  {p5.Vector}  direction
- * @param  {Number}     [angle]
- * @param  {Number}     [concentration]
- */
-/**
- * @method spotLight
- * @param  {p5.Color|Number[]|String} color
- * @param  {Number}                   x
- * @param  {Number}                   y
- * @param  {Number}                   z
- * @param  {p5.Vector}                direction
- * @param  {Number}                   [angle]
- * @param  {Number}                   [concentration]
- */
-/**
- * @method spotLight
- * @param  {p5.Color|Number[]|String} color
- * @param  {p5.Vector}                position
- * @param  {Number}                   rx
- * @param  {Number}                   ry
- * @param  {Number}                   rz
- * @param  {Number}                   [angle]
- * @param  {Number}                   [concentration]
- */
-/**
- * @method spotLight
- * @param  {Number}     v1
- * @param  {Number}     v2
- * @param  {Number}     v3
- * @param  {Number}     x
- * @param  {Number}     y
- * @param  {Number}     z
- * @param  {p5.Vector}  direction
- * @param  {Number}     [angle]
- * @param  {Number}     [concentration]
- */
-/**
- * @method spotLight
- * @param  {Number}     v1
- * @param  {Number}     v2
- * @param  {Number}     v3
- * @param  {p5.Vector}  position
- * @param  {Number}     rx
- * @param  {Number}     ry
- * @param  {Number}     rz
- * @param  {Number}     [angle]
- * @param  {Number}     [concentration]
- */
-/**
- * @method spotLight
- * @param  {p5.Color|Number[]|String} color
- * @param  {Number}                   x
- * @param  {Number}                   y
- * @param  {Number}                   z
- * @param  {Number}                   rx
- * @param  {Number}                   ry
- * @param  {Number}                   rz
- * @param  {Number}                   [angle]
- * @param  {Number}                   [concentration]
- */
-p5.prototype.spotLight = function (
-  v1,
-  v2,
-  v3,
-  x,
-  y,
-  z,
-  nx,
-  ny,
-  nz,
-  angle,
-  concentration
-) {
-  this._assert3d('spotLight');
-  p5._validateParameters('spotLight', arguments);
+  /**
+   * @method specularColor
+   * @param  {Number[]}      values color as an array of RGBA, HSBA, or HSLA
+   *                                 values.
+   * @chainable
+   */
 
-  let color, position, direction;
-  const length = arguments.length;
+  /**
+   * @method specularColor
+   * @param  {p5.Color}      color color as a <a href="#/p5.Color">p5.Color</a> object.
+   * @chainable
+   */
+  fn.specularColor = function (v1, v2, v3) {
+    this._assert3d('specularColor');
+    p5._validateParameters('specularColor', arguments);
+    const color = this.color(...arguments);
 
-  switch (length) {
-    case 11:
-    case 10:
+    this._renderer.states.specularColors = [
+      color._array[0],
+      color._array[1],
+      color._array[2]
+    ];
+
+    return this;
+  };
+
+  /**
+   * Creates a light that shines in one direction.
+   *
+   * Directional lights don’t shine from a specific point. They’re like a sun
+   * that shines from somewhere offscreen. The light’s direction is set using
+   * three `(x, y, z)` values between -1 and 1. For example, setting a light’s
+   * direction as `(1, 0, 0)` will light <a href="#/p5.Geometry">p5.Geometry</a>
+   * objects from the left since the light faces directly to the right.
+   *
+   * There are four ways to call `directionalLight()` with parameters to set the
+   * light’s color and direction.
+   *
+   * The first way to call `directionalLight()` has six parameters. The first
+   * three parameters, `v1`, `v2`, and `v3`, set the light’s color using the
+   * current <a href="#/p5/colorMode">colorMode()</a>. The last three
+   * parameters, `x`, `y`, and `z`, set the light’s direction. For example,
+   * `directionalLight(255, 0, 0, 1, 0, 0)` creates a red `(255, 0, 0)` light
+   * that shines to the right `(1, 0, 0)`.
+   *
+   * The second way to call `directionalLight()` has four parameters. The first
+   * three parameters, `v1`, `v2`, and `v3`, set the light’s color using the
+   * current <a href="#/p5/colorMode">colorMode()</a>. The last parameter,
+   * `direction` sets the light’s direction using a
+   * <a href="#/p5.Geometry">p5.Geometry</a> object. For example,
+   * `directionalLight(255, 0, 0, lightDir)` creates a red `(255, 0, 0)` light
+   * that shines in the direction the `lightDir` vector points.
+   *
+   * The third way to call `directionalLight()` has four parameters. The first
+   * parameter, `color`, sets the light’s color using a
+   * <a href="#/p5.Color">p5.Color</a> object or an array of color values. The
+   * last three parameters, `x`, `y`, and `z`, set the light’s direction. For
+   * example, `directionalLight(myColor, 1, 0, 0)` creates a light that shines
+   * to the right `(1, 0, 0)` with the color value of `myColor`.
+   *
+   * The fourth way to call `directionalLight()` has two parameters. The first
+   * parameter, `color`, sets the light’s color using a
+   * <a href="#/p5.Color">p5.Color</a> object or an array of color values. The
+   * second parameter, `direction`, sets the light’s direction using a
+   * <a href="#/p5.Color">p5.Color</a> object. For example,
+   * `directionalLight(myColor, lightDir)` creates a light that shines in the
+   * direction the `lightDir` vector points with the color value of `myColor`.
+   *
+   * @method directionalLight
+   * @param  {Number}    v1 red or hue value in the current
+   *                        <a href="#/p5/colorMode">colorMode()</a>.
+   * @param  {Number}    v2 green or saturation value in the current
+   *                        <a href="#/p5/colorMode">colorMode()</a>.
+   * @param  {Number}    v3 blue, brightness, or lightness value in the current
+   *                        <a href="#/p5/colorMode">colorMode()</a>.
+   * @param  {Number}    x  x-component of the light's direction between -1 and 1.
+   * @param  {Number}    y  y-component of the light's direction between -1 and 1.
+   * @param  {Number}    z  z-component of the light's direction between -1 and 1.
+   * @chainable
+   *
+   * @example
+   * <div>
+   * <code>
+   * // Click and drag the mouse to view the scene from different angles.
+   * // Double-click to turn on the directional light.
+   *
+   * let isLit = false;
+   *
+   * function setup() {
+   *   createCanvas(100, 100, WEBGL);
+   *
+   *   describe('A sphere drawn on a gray background. A red light starts shining from above when the user double-clicks.');
+   * }
+   *
+   * function draw() {
+   *   background(200);
+   *
+   *   // Enable orbiting with the mouse.
+   *   orbitControl();
+   *
+   *   // Control the light.
+   *   if (isLit === true) {
+   *     // Add a red directional light from above.
+   *     // Use RGB values and XYZ directions.
+   *     directionalLight(255, 0, 0, 0, 1, 0);
+   *   }
+   *
+   *   // Style the sphere.
+   *   noStroke();
+   *
+   *   // Draw the sphere.
+   *   sphere(30);
+   * }
+   * </code>
+   * </div>
+   *
+   * <div>
+   * <code>
+   * // Click and drag the mouse to view the scene from different angles.
+   *
+   * function setup() {
+   *   createCanvas(100, 100, WEBGL);
+   *
+   *   describe('A sphere drawn on a gray background. The top of the sphere appears bright red. The color gets darker toward the bottom.');
+   * }
+   *
+   * function draw() {
+   *   background(200);
+   *
+   *   // Enable orbiting with the mouse.
+   *   orbitControl();
+   *
+   *   // Add a red directional light from above.
+   *   // Use a p5.Color object and XYZ directions.
+   *   let c = color(255, 0, 0);
+   *   directionalLight(c, 0, 1, 0);
+   *
+   *   // Style the sphere.
+   *   noStroke();
+   *
+   *   // Draw the sphere.
+   *   sphere(30);
+   * }
+   * </code>
+   * </div>
+   *
+   * <div>
+   * <code>
+   * // Click and drag the mouse to view the scene from different angles.
+   *
+   * function setup() {
+   *   createCanvas(100, 100, WEBGL);
+   *
+   *   describe('A sphere drawn on a gray background. The top of the sphere appears bright red. The color gets darker toward the bottom.');
+   * }
+   *
+   * function draw() {
+   *   background(200);
+   *
+   *   // Enable orbiting with the mouse.
+   *   orbitControl();
+   *
+   *   // Add a red directional light from above.
+   *   // Use a p5.Color object and a p5.Vector object.
+   *   let c = color(255, 0, 0);
+   *   let lightDir = createVector(0, 1, 0);
+   *   directionalLight(c, lightDir);
+   *
+   *   // Style the sphere.
+   *   noStroke();
+   *
+   *   // Draw the sphere.
+   *   sphere(30);
+   * }
+   * </code>
+   * </div>
+   */
+
+  /**
+   * @method directionalLight
+   * @param  {Number}    v1
+   * @param  {Number}    v2
+   * @param  {Number}    v3
+   * @param  {p5.Vector} direction direction of the light as a
+   *                               <a href="#/p5.Vector">p5.Vector</a> object.
+   * @chainable
+   */
+
+  /**
+   * @method directionalLight
+   * @param  {p5.Color|Number[]|String} color color as a <a href="#/p5.Color">p5.Color</a> object,
+   *                                           an array of color values, or as a CSS string.
+   * @param  {Number}                   x
+   * @param  {Number}                   y
+   * @param  {Number}                   z
+   * @chainable
+   */
+
+  /**
+   * @method directionalLight
+   * @param  {p5.Color|Number[]|String} color
+   * @param  {p5.Vector}                direction
+   * @chainable
+   */
+  fn.directionalLight = function (v1, v2, v3, x, y, z) {
+    this._assert3d('directionalLight');
+    p5._validateParameters('directionalLight', arguments);
+
+    //@TODO: check parameters number
+    let color;
+    if (v1 instanceof p5.Color) {
+      color = v1;
+    } else {
       color = this.color(v1, v2, v3);
-      position = new p5.Vector(x, y, z);
-      direction = new p5.Vector(nx, ny, nz);
-      break;
+    }
 
-    case 9:
-      if (v1 instanceof p5.Color) {
-        color = v1;
-        position = new p5.Vector(v2, v3, x);
-        direction = new p5.Vector(y, z, nx);
-        angle = ny;
-        concentration = nz;
-      } else if (x instanceof p5.Vector) {
-        color = this.color(v1, v2, v3);
-        position = x;
-        direction = new p5.Vector(y, z, nx);
-        angle = ny;
-        concentration = nz;
-      } else if (nx instanceof p5.Vector) {
-        color = this.color(v1, v2, v3);
-        position = new p5.Vector(x, y, z);
-        direction = nx;
-        angle = ny;
-        concentration = nz;
-      } else {
+    let _x, _y, _z;
+    const v = arguments[arguments.length - 1];
+    if (typeof v === 'number') {
+      _x = arguments[arguments.length - 3];
+      _y = arguments[arguments.length - 2];
+      _z = arguments[arguments.length - 1];
+    } else {
+      _x = v.x;
+      _y = v.y;
+      _z = v.z;
+    }
+
+    // normalize direction
+    const l = Math.sqrt(_x * _x + _y * _y + _z * _z);
+    this._renderer.states.directionalLightDirections.push(_x / l, _y / l, _z / l);
+
+    this._renderer.states.directionalLightDiffuseColors.push(
+      color._array[0],
+      color._array[1],
+      color._array[2]
+    );
+    Array.prototype.push.apply(
+      this._renderer.states.directionalLightSpecularColors,
+      this._renderer.states.specularColors
+    );
+
+    this._renderer.states._enableLighting = true;
+
+    return this;
+  };
+
+  /**
+   * Creates a light that shines from a point in all directions.
+   *
+   * Point lights are like light bulbs that shine in all directions. They can be
+   * placed at different positions to achieve different lighting effects. A
+   * maximum of 5 point lights can be active at once.
+   *
+   * There are four ways to call `pointLight()` with parameters to set the
+   * light’s color and position.
+   *
+   * The first way to call `pointLight()` has six parameters. The first three
+   * parameters, `v1`, `v2`, and `v3`, set the light’s color using the current
+   * <a href="#/p5/colorMode">colorMode()</a>. The last three parameters, `x`,
+   * `y`, and `z`, set the light’s position. For example,
+   * `pointLight(255, 0, 0, 50, 0, 0)` creates a red `(255, 0, 0)` light that
+   * shines from the coordinates `(50, 0, 0)`.
+   *
+   * The second way to call `pointLight()` has four parameters. The first three
+   * parameters, `v1`, `v2`, and `v3`, set the light’s color using the current
+   * <a href="#/p5/colorMode">colorMode()</a>. The last parameter, position sets
+   * the light’s position using a <a href="#/p5.Vector">p5.Vector</a> object.
+   * For example, `pointLight(255, 0, 0, lightPos)` creates a red `(255, 0, 0)`
+   * light that shines from the position set by the `lightPos` vector.
+   *
+   * The third way to call `pointLight()` has four parameters. The first
+   * parameter, `color`, sets the light’s color using a
+   * <a href="#/p5.Color">p5.Color</a> object or an array of color values. The
+   * last three parameters, `x`, `y`, and `z`, set the light’s position. For
+   * example, `directionalLight(myColor, 50, 0, 0)` creates a light that shines
+   * from the coordinates `(50, 0, 0)` with the color value of `myColor`.
+   *
+   * The fourth way to call `pointLight()` has two parameters. The first
+   * parameter, `color`, sets the light’s color using a
+   * <a href="#/p5.Color">p5.Color</a> object or an array of color values. The
+   * second parameter, `position`, sets the light’s position using a
+   * <a href="#/p5.Vector">p5.Vector</a> object. For example,
+   * `directionalLight(myColor, lightPos)` creates a light that shines from the
+   * position set by the `lightPos` vector with the color value of `myColor`.
+   *
+   * @method pointLight
+   * @param  {Number}    v1 red or hue value in the current
+   *                        <a href="#/p5/colorMode">colorMode()</a>.
+   * @param  {Number}    v2 green or saturation value in the current
+   *                        <a href="#/p5/colorMode">colorMode()</a>.
+   * @param  {Number}    v3 blue, brightness, or lightness value in the current
+   *                        <a href="#/p5/colorMode">colorMode()</a>.
+   * @param  {Number}    x  x-coordinate of the light.
+   * @param  {Number}    y  y-coordinate of the light.
+   * @param  {Number}    z  z-coordinate of the light.
+   * @chainable
+   *
+   * @example
+   *
+   * <div>
+   * <code>
+   * // Click and drag the mouse to view the scene from different angles.
+   * // Double-click to turn on the point light.
+   *
+   * let isLit = false;
+   *
+   * function setup() {
+   *   createCanvas(100, 100, WEBGL);
+   *
+   *   describe('A sphere drawn on a gray background. A red light starts shining from above when the user double-clicks.');
+   * }
+   *
+   * function draw() {
+   *   background(200);
+   *
+   *   // Enable orbiting with the mouse.
+   *   orbitControl();
+   *
+   *   // Control the light.
+   *   if (isLit === true) {
+   *     // Add a red point light from above.
+   *     // Use RGB values and XYZ coordinates.
+   *     pointLight(255, 0, 0, 0, -150, 0);
+   *   }
+   *
+   *   // Style the sphere.
+   *   noStroke();
+   *
+   *   // Draw the sphere.
+   *   sphere(30);
+   * }
+   *
+   * // Turn on the point light when the user double-clicks.
+   * function doubleClicked() {
+   *   isLit = true;
+   * }
+   * </code>
+   * </div>
+   *
+   * <div>
+   * <code>
+   * // Click and drag the mouse to view the scene from different angles.
+   *
+   * function setup() {
+   *   createCanvas(100, 100, WEBGL);
+   *
+   *   describe('A sphere drawn on a gray background. The top of the sphere appears bright red. The color gets darker toward the bottom.');
+   * }
+   *
+   * function draw() {
+   *   background(200);
+   *
+   *   // Enable orbiting with the mouse.
+   *   orbitControl();
+   *
+   *   // Add a red point light from above.
+   *   // Use a p5.Color object and XYZ directions.
+   *   let c = color(255, 0, 0);
+   *   pointLight(c, 0, -150, 0);
+   *
+   *   // Style the sphere.
+   *   noStroke();
+   *
+   *   // Draw the sphere.
+   *   sphere(30);
+   * }
+   * </code>
+   * </div>
+   *
+   * <div>
+   * <code>
+   * // Click and drag the mouse to view the scene from different angles.
+   *
+   * function setup() {
+   *   createCanvas(100, 100, WEBGL);
+   *
+   *   describe('A sphere drawn on a gray background. The top of the sphere appears bright red. The color gets darker toward the bottom.');
+   * }
+   *
+   * function draw() {
+   *   background(200);
+   *
+   *   // Enable orbiting with the mouse.
+   *   orbitControl();
+   *
+   *   // Add a red point light from above.
+   *   // Use a p5.Color object and a p5.Vector object.
+   *   let c = color(255, 0, 0);
+   *   let lightPos = createVector(0, -150, 0);
+   *   pointLight(c, lightPos);
+   *
+   *   // Style the sphere.
+   *   noStroke();
+   *
+   *   // Draw the sphere.
+   *   sphere(30);
+   * }
+   * </code>
+   * </div>
+   *
+   * <div>
+   * <code>
+   * // Click and drag the mouse to view the scene from different angles.
+   *
+   * function setup() {
+   *   createCanvas(100, 100, WEBGL);
+   *
+   *   describe('Four spheres arranged in a square and drawn on a gray background. The spheres appear bright red toward the center of the square. The color gets darker toward the corners of the square.');
+   * }
+   *
+   * function draw() {
+   *   background(200);
+   *
+   *   // Enable orbiting with the mouse.
+   *   orbitControl();
+   *
+   *   // Add a red point light that points to the center of the scene.
+   *   // Use a p5.Color object and a p5.Vector object.
+   *   let c = color(255, 0, 0);
+   *   let lightPos = createVector(0, 0, 65);
+   *   pointLight(c, lightPos);
+   *
+   *   // Style the spheres.
+   *   noStroke();
+   *
+   *   // Draw a sphere up and to the left.
+   *   push();
+   *   translate(-25, -25, 25);
+   *   sphere(10);
+   *   pop();
+   *
+   *   // Draw a box up and to the right.
+   *   push();
+   *   translate(25, -25, 25);
+   *   sphere(10);
+   *   pop();
+   *
+   *   // Draw a sphere down and to the left.
+   *   push();
+   *   translate(-25, 25, 25);
+   *   sphere(10);
+   *   pop();
+   *
+   *   // Draw a box down and to the right.
+   *   push();
+   *   translate(25, 25, 25);
+   *   sphere(10);
+   *   pop();
+   * }
+   * </code>
+   * </div>
+   */
+
+  /**
+   * @method pointLight
+   * @param  {Number}     v1
+   * @param  {Number}     v2
+   * @param  {Number}     v3
+   * @param  {p5.Vector}  position position of the light as a
+   *                               <a href="#/p5.Vector">p5.Vector</a> object.
+   * @chainable
+   */
+
+  /**
+   * @method pointLight
+   * @param  {p5.Color|Number[]|String} color color as a <a href="#/p5.Color">p5.Color</a> object,
+   *                                          an array of color values, or a CSS string.
+   * @param  {Number}                   x
+   * @param  {Number}                   y
+   * @param  {Number}                   z
+   * @chainable
+   */
+
+  /**
+   * @method pointLight
+   * @param  {p5.Color|Number[]|String} color
+   * @param  {p5.Vector}                position
+   * @chainable
+   */
+  fn.pointLight = function (v1, v2, v3, x, y, z) {
+    this._assert3d('pointLight');
+    p5._validateParameters('pointLight', arguments);
+
+    //@TODO: check parameters number
+    let color;
+    if (v1 instanceof p5.Color) {
+      color = v1;
+    } else {
+      color = this.color(v1, v2, v3);
+    }
+
+    let _x, _y, _z;
+    const v = arguments[arguments.length - 1];
+    if (typeof v === 'number') {
+      _x = arguments[arguments.length - 3];
+      _y = arguments[arguments.length - 2];
+      _z = arguments[arguments.length - 1];
+    } else {
+      _x = v.x;
+      _y = v.y;
+      _z = v.z;
+    }
+
+    this._renderer.states.pointLightPositions.push(_x, _y, _z);
+    this._renderer.states.pointLightDiffuseColors.push(
+      color._array[0],
+      color._array[1],
+      color._array[2]
+    );
+    Array.prototype.push.apply(
+      this._renderer.states.pointLightSpecularColors,
+      this._renderer.states.specularColors
+    );
+
+    this._renderer.states._enableLighting = true;
+
+    return this;
+  };
+
+  /**
+   * Creates an ambient light from an image.
+   *
+   * `imageLight()` simulates a light shining from all directions. The effect is
+   * like placing the sketch at the center of a giant sphere that uses the image
+   * as its texture. The image's diffuse light will be affected by
+   * <a href="#/p5/fill">fill()</a> and the specular reflections will be
+   * affected by <a href="#/p5/specularMaterial">specularMaterial()</a> and
+   * <a href="#/p5/shininess">shininess()</a>.
+   *
+   * The parameter, `img`, is the <a href="#/p5.Image">p5.Image</a> object to
+   * use as the light source.
+   *
+   * @method imageLight
+   * @param  {p5.image}    img image to use as the light source.
+   *
+   * @example
+   * <div class="notest">
+   * <code>
+   * // Click and drag the mouse to view the scene from different angles.
+   *
+   * let img;
+   *
+   * // Load an image and create a p5.Image object.
+   * function preload() {
+   *   img = loadImage('assets/outdoor_spheremap.jpg');
+   * }
+   *
+   * function setup() {
+   *   createCanvas(100, 100, WEBGL);
+   *
+   *   describe('A sphere floating above a landscape. The surface of the sphere reflects the landscape.');
+   * }
+   *
+   * function draw() {
+   *   // Enable orbiting with the mouse.
+   *   orbitControl();
+   *
+   *   // Draw the image as a panorama (360˚ background).
+   *   panorama(img);
+   *
+   *   // Add a soft ambient light.
+   *   ambientLight(50);
+   *
+   *   // Add light from the image.
+   *   imageLight(img);
+   *
+   *   // Style the sphere.
+   *   specularMaterial(20);
+   *   shininess(100);
+   *   noStroke();
+   *
+   *   // Draw the sphere.
+   *   sphere(30);
+   * }
+   * </code>
+   * </div>
+   */
+  fn.imageLight = function (img) {
+    // activeImageLight property is checked by _setFillUniforms
+    // for sending uniforms to the fillshader
+    this._renderer.states.activeImageLight = img;
+    this._renderer.states._enableLighting = true;
+  };
+
+  /**
+   * Creates an immersive 3D background.
+   *
+   * `panorama()` transforms images containing 360˚ content, such as maps or
+   * HDRIs, into immersive 3D backgrounds that surround a sketch. Exploring the
+   * space requires changing the camera's perspective with functions such as
+   * <a href="#/p5/orbitControl">orbitControl()</a> or
+   * <a href="#/p5/camera">camera()</a>.
+   *
+   * @method panorama
+   * @param {p5.Image} img 360˚ image to use as the background.
+   *
+   * @example
+   * <div class="notest">
+   * <code>
+   * // Click and drag the mouse to view the scene from different angles.
+   *
+   * let img;
+   *
+   * // Load an image and create a p5.Image object.
+   * function preload() {
+   *   img = loadImage('assets/outdoor_spheremap.jpg');
+   * }
+   *
+   * function setup() {
+   *   createCanvas(100 ,100 ,WEBGL);
+   *
+   *   describe('A sphere floating above a landscape. The surface of the sphere reflects the landscape. The full landscape is viewable in 3D as the user drags the mouse.');
+   * }
+   *
+   * function draw() {
+   *   // Add the panorama.
+   *   panorama(img);
+   *
+   *   // Enable orbiting with the mouse.
+   *   orbitControl();
+   *
+   *   // Use the image as a light source.
+   *   imageLight(img);
+   *
+   *   // Style the sphere.
+   *   noStroke();
+   *   specularMaterial(50);
+   *   shininess(200);
+   *   metalness(100);
+   *
+   *   // Draw the sphere.
+   *   sphere(30);
+   * }
+   * </code>
+   * </div>
+   */
+  fn.panorama = function (img) {
+    this.filter(this._renderer._getSphereMapping(img));
+  };
+
+  /**
+   * Places an ambient and directional light in the scene.
+   * The lights are set to ambientLight(128, 128, 128) and
+   * directionalLight(128, 128, 128, 0, 0, -1).
+   *
+   * Note: lights need to be called (whether directly or indirectly)
+   * within draw() to remain persistent in a looping program.
+   * Placing them in setup() will cause them to only have an effect
+   * the first time through the loop.
+   *
+   * @method lights
+   * @chainable
+   *
+   * @example
+   * <div>
+   * <code>
+   * // Click and drag the mouse to view the scene from different angles.
+   * // Double-click to turn on the lights.
+   *
+   * let isLit = false;
+   *
+   * function setup() {
+   *   createCanvas(100, 100, WEBGL);
+   *
+   *   describe('A white box drawn against a gray background. The quality of the light changes when the user double-clicks.');
+   * }
+   *
+   * function draw() {
+   *   background(50);
+   *
+   *   // Enable orbiting with the mouse.
+   *   orbitControl();
+   *
+   *   // Control the lights.
+   *   if (isLit === true) {
+   *     lights();
+   *   }
+   *
+   *   // Draw the box.
+   *   box();
+   * }
+   *
+   * // Turn on the lights when the user double-clicks.
+   * function doubleClicked() {
+   *   isLit = true;
+   * }
+   * </code>
+   * </div>
+   *
+   * <div>
+   * <code>
+   * // Click and drag the mouse to view the scene from different angles.
+   *
+   * function setup() {
+   *   createCanvas(100, 100, WEBGL);
+   *
+   *   describe('A white box drawn against a gray background.');
+   * }
+   *
+   * function draw() {
+   *   background(50);
+   *
+   *   // Enable orbiting with the mouse.
+   *   orbitControl();
+   *
+   *   // Turn on the lights.
+   *   ambientLight(128, 128, 128);
+   *   directionalLight(128, 128, 128, 0, 0, -1);
+   *
+   *   // Draw the box.
+   *   box();
+   * }
+   * </code>
+   * </div>
+   */
+  fn.lights = function () {
+    this._assert3d('lights');
+    // Both specify gray by default.
+    const grayColor = this.color('rgb(128,128,128)');
+    this.ambientLight(grayColor);
+    this.directionalLight(grayColor, 0, 0, -1);
+    return this;
+  };
+
+  /**
+   * Sets the falloff rate for <a href="#/p5/pointLight">pointLight()</a>
+   * and <a href="#/p5/spotLight">spotLight()</a>.
+   *
+   * A light’s falloff describes the intensity of its beam at a distance. For
+   * example, a lantern has a slow falloff, a flashlight has a medium falloff,
+   * and a laser pointer has a sharp falloff.
+   *
+   * `lightFalloff()` has three parameters, `constant`, `linear`, and
+   * `quadratic`. They’re numbers used to calculate falloff at a distance, `d`,
+   * as follows:
+   *
+   * `falloff = 1 / (constant + d * linear + (d * d) * quadratic)`
+   *
+   * Note: `constant`, `linear`, and `quadratic` should always be set to values
+   * greater than 0.
+   *
+   * @method lightFalloff
+   * @param {Number} constant  constant value for calculating falloff.
+   * @param {Number} linear    linear value for calculating falloff.
+   * @param {Number} quadratic quadratic value for calculating falloff.
+   * @chainable
+   *
+   * @example
+   * <div>
+   * <code>
+   * // Click and drag the mouse to view the scene from different angles.
+   * // Double-click to change the falloff rate.
+   *
+   * let useFalloff = false;
+   *
+   * function setup() {
+   *   createCanvas(100, 100, WEBGL);
+   *
+   *   describe('A sphere drawn against a gray background. The intensity of the light changes when the user double-clicks.');
+   * }
+   *
+   * function draw() {
+   *   background(50);
+   *
+   *   // Enable orbiting with the mouse.
+   *   orbitControl();
+   *
+   *   // Set the light falloff.
+   *   if (useFalloff === true) {
+   *     lightFalloff(2, 0, 0);
+   *   }
+   *
+   *   // Add a white point light from the front.
+   *   pointLight(255, 255, 255, 0, 0, 100);
+   *
+   *   // Style the sphere.
+   *   noStroke();
+   *
+   *   // Draw the sphere.
+   *   sphere(30);
+   * }
+   *
+   * // Change the falloff value when the user double-clicks.
+   * function doubleClicked() {
+   *   useFalloff = true;
+   * }
+   * </code>
+   * </div>
+   */
+  fn.lightFalloff = function (
+    constantAttenuation,
+    linearAttenuation,
+    quadraticAttenuation
+  ) {
+    this._assert3d('lightFalloff');
+    p5._validateParameters('lightFalloff', arguments);
+
+    if (constantAttenuation < 0) {
+      constantAttenuation = 0;
+      console.warn(
+        'Value of constant argument in lightFalloff() should be never be negative. Set to 0.'
+      );
+    }
+
+    if (linearAttenuation < 0) {
+      linearAttenuation = 0;
+      console.warn(
+        'Value of linear argument in lightFalloff() should be never be negative. Set to 0.'
+      );
+    }
+
+    if (quadraticAttenuation < 0) {
+      quadraticAttenuation = 0;
+      console.warn(
+        'Value of quadratic argument in lightFalloff() should be never be negative. Set to 0.'
+      );
+    }
+
+    if (
+      constantAttenuation === 0 &&
+      (linearAttenuation === 0 && quadraticAttenuation === 0)
+    ) {
+      constantAttenuation = 1;
+      console.warn(
+        'Either one of the three arguments in lightFalloff() should be greater than zero. Set constant argument to 1.'
+      );
+    }
+
+    this._renderer.states.constantAttenuation = constantAttenuation;
+    this._renderer.states.linearAttenuation = linearAttenuation;
+    this._renderer.states.quadraticAttenuation = quadraticAttenuation;
+
+    return this;
+  };
+
+  /**
+   * Creates a light that shines from a point in one direction.
+   *
+   * Spot lights are like flashlights that shine in one direction creating a
+   * cone of light. The shape of the cone can be controlled using the angle and
+   * concentration parameters. A maximum of 5 spot lights can be active at once.
+   *
+   * There are eight ways to call `spotLight()` with parameters to set the
+   * light’s color, position, direction. For example,
+   * `spotLight(255, 0, 0, 0, 0, 0, 1, 0, 0)` creates a red `(255, 0, 0)` light
+   * at the origin `(0, 0, 0)` that points to the right `(1, 0, 0)`.
+   *
+   * The `angle` parameter is optional. It sets the radius of the light cone.
+   * For example, `spotLight(255, 0, 0, 0, 0, 0, 1, 0, 0, PI / 16)` creates a
+   * red `(255, 0, 0)` light at the origin `(0, 0, 0)` that points to the right
+   * `(1, 0, 0)` with an angle of `PI / 16` radians. By default, `angle` is
+   * `PI / 3` radians.
+   *
+   * The `concentration` parameter is also optional. It focuses the light
+   * towards the center of the light cone. For example,
+   * `spotLight(255, 0, 0, 0, 0, 0, 1, 0, 0, PI / 16, 50)` creates a red
+   * `(255, 0, 0)` light at the origin `(0, 0, 0)` that points to the right
+   * `(1, 0, 0)` with an angle of `PI / 16` radians at concentration of 50. By
+   * default, `concentration` is 100.
+   *
+   * @method spotLight
+   * @param  {Number}    v1               red or hue value in the current
+   *                                      <a href="#/p5/colorMode">colorMode()</a>.
+   * @param  {Number}    v2               green or saturation value in the current
+   *                                      <a href="#/p5/colorMode">colorMode()</a>.
+   * @param  {Number}    v3               blue, brightness, or lightness value in the current
+   *                                      <a href="#/p5/colorMode">colorMode()</a>.
+   * @param  {Number}    x                x-coordinate of the light.
+   * @param  {Number}    y                y-coordinate of the light.
+   * @param  {Number}    z                z-coordinate of the light.
+   * @param  {Number}    rx               x-component of light direction between -1 and 1.
+   * @param  {Number}    ry               y-component of light direction between -1 and 1.
+   * @param  {Number}    rz               z-component of light direction between -1 and 1.
+   * @param  {Number}    [angle]          angle of the light cone. Defaults to `PI / 3`.
+   * @param  {Number}    [concentration]  concentration of the light. Defaults to 100.
+   * @chainable
+   *
+   * @example
+   * <div>
+   * <code>
+   * // Click and drag the mouse to view the scene from different angles.
+   * // Double-click to adjust the spotlight.
+   *
+   * let isLit = false;
+   *
+   * function setup() {
+   *   createCanvas(100, 100, WEBGL);
+   *
+   *   describe('A white sphere drawn on a gray background. A red spotlight starts shining when the user double-clicks.');
+   * }
+   *
+   * function draw() {
+   *   background(50);
+   *
+   *   // Enable orbiting with the mouse.
+   *   orbitControl();
+   *
+   *   // Turn on the lights.
+   *   lights();
+   *
+   *   // Control the spotlight.
+   *   if (isLit === true) {
+   *     // Add a red spot light that shines into the screen.
+   *     // Set its angle to PI / 32 radians.
+   *     spotLight(255, 0, 0, 0, 0, 100, 0, 0, -1, PI / 32);
+   *   }
+   *
+   *   // Draw the sphere.
+   *   sphere(30);
+   * }
+   *
+   * // Turn on the spotlight when the user double-clicks.
+   * function doubleClicked() {
+   *   isLit = true;
+   * }
+   * </code>
+   * </div>
+   *
+   * <div>
+   * <code>
+   * // Click and drag the mouse to view the scene from different angles.
+   * // Double-click to adjust the spotlight.
+   *
+   * let isLit = false;
+   *
+   * function setup() {
+   *   createCanvas(100, 100, WEBGL);
+   *
+   *   describe('A white sphere drawn on a gray background. A red spotlight starts shining when the user double-clicks.');
+   * }
+   *
+   * function draw() {
+   *   background(50);
+   *
+   *   // Enable orbiting with the mouse.
+   *   orbitControl();
+   *
+   *   // Turn on the lights.
+   *   lights();
+   *
+   *   // Control the spotlight.
+   *   if (isLit === true) {
+   *     // Add a red spot light that shines into the screen.
+   *     // Set its angle to PI / 3 radians (default).
+   *     // Set its concentration to 1000.
+   *     let c = color(255, 0, 0);
+   *     let position = createVector(0, 0, 100);
+   *     let direction = createVector(0, 0, -1);
+   *     spotLight(c, position, direction, PI / 3, 1000);
+   *   }
+   *
+   *   // Draw the sphere.
+   *   sphere(30);
+   * }
+   *
+   * // Turn on the spotlight when the user double-clicks.
+   * function doubleClicked() {
+   *   isLit = true;
+   * }
+   * </code>
+   * </div>
+   */
+  /**
+   * @method spotLight
+   * @param  {p5.Color|Number[]|String} color     color as a <a href="#/p5.Color">p5.Color</a> object,
+   *                                              an array of color values, or a CSS string.
+   * @param  {p5.Vector}                position  position of the light as a <a href="#/p5.Vector">p5.Vector</a> object.
+   * @param  {p5.Vector}                direction direction of light as a <a href="#/p5.Vector">p5.Vector</a> object.
+   * @param  {Number}                   [angle]
+   * @param  {Number}                   [concentration]
+   */
+  /**
+   * @method spotLight
+   * @param  {Number}     v1
+   * @param  {Number}     v2
+   * @param  {Number}     v3
+   * @param  {p5.Vector}  position
+   * @param  {p5.Vector}  direction
+   * @param  {Number}     [angle]
+   * @param  {Number}     [concentration]
+   */
+  /**
+   * @method spotLight
+   * @param  {p5.Color|Number[]|String} color
+   * @param  {Number}                   x
+   * @param  {Number}                   y
+   * @param  {Number}                   z
+   * @param  {p5.Vector}                direction
+   * @param  {Number}                   [angle]
+   * @param  {Number}                   [concentration]
+   */
+  /**
+   * @method spotLight
+   * @param  {p5.Color|Number[]|String} color
+   * @param  {p5.Vector}                position
+   * @param  {Number}                   rx
+   * @param  {Number}                   ry
+   * @param  {Number}                   rz
+   * @param  {Number}                   [angle]
+   * @param  {Number}                   [concentration]
+   */
+  /**
+   * @method spotLight
+   * @param  {Number}     v1
+   * @param  {Number}     v2
+   * @param  {Number}     v3
+   * @param  {Number}     x
+   * @param  {Number}     y
+   * @param  {Number}     z
+   * @param  {p5.Vector}  direction
+   * @param  {Number}     [angle]
+   * @param  {Number}     [concentration]
+   */
+  /**
+   * @method spotLight
+   * @param  {Number}     v1
+   * @param  {Number}     v2
+   * @param  {Number}     v3
+   * @param  {p5.Vector}  position
+   * @param  {Number}     rx
+   * @param  {Number}     ry
+   * @param  {Number}     rz
+   * @param  {Number}     [angle]
+   * @param  {Number}     [concentration]
+   */
+  /**
+   * @method spotLight
+   * @param  {p5.Color|Number[]|String} color
+   * @param  {Number}                   x
+   * @param  {Number}                   y
+   * @param  {Number}                   z
+   * @param  {Number}                   rx
+   * @param  {Number}                   ry
+   * @param  {Number}                   rz
+   * @param  {Number}                   [angle]
+   * @param  {Number}                   [concentration]
+   */
+  fn.spotLight = function (
+    v1,
+    v2,
+    v3,
+    x,
+    y,
+    z,
+    nx,
+    ny,
+    nz,
+    angle,
+    concentration
+  ) {
+    this._assert3d('spotLight');
+    p5._validateParameters('spotLight', arguments);
+
+    let color, position, direction;
+    const length = arguments.length;
+
+    switch (length) {
+      case 11:
+      case 10:
         color = this.color(v1, v2, v3);
         position = new p5.Vector(x, y, z);
         direction = new p5.Vector(nx, ny, nz);
-      }
-      break;
+        break;
 
-    case 8:
-      if (v1 instanceof p5.Color) {
-        color = v1;
-        position = new p5.Vector(v2, v3, x);
-        direction = new p5.Vector(y, z, nx);
-        angle = ny;
-      } else if (x instanceof p5.Vector) {
-        color = this.color(v1, v2, v3);
-        position = x;
-        direction = new p5.Vector(y, z, nx);
-        angle = ny;
-      } else {
-        color = this.color(v1, v2, v3);
-        position = new p5.Vector(x, y, z);
-        direction = nx;
-        angle = ny;
-      }
-      break;
+      case 9:
+        if (v1 instanceof p5.Color) {
+          color = v1;
+          position = new p5.Vector(v2, v3, x);
+          direction = new p5.Vector(y, z, nx);
+          angle = ny;
+          concentration = nz;
+        } else if (x instanceof p5.Vector) {
+          color = this.color(v1, v2, v3);
+          position = x;
+          direction = new p5.Vector(y, z, nx);
+          angle = ny;
+          concentration = nz;
+        } else if (nx instanceof p5.Vector) {
+          color = this.color(v1, v2, v3);
+          position = new p5.Vector(x, y, z);
+          direction = nx;
+          angle = ny;
+          concentration = nz;
+        } else {
+          color = this.color(v1, v2, v3);
+          position = new p5.Vector(x, y, z);
+          direction = new p5.Vector(nx, ny, nz);
+        }
+        break;
 
-    case 7:
-      if (v1 instanceof p5.Color && v2 instanceof p5.Vector) {
-        color = v1;
-        position = v2;
-        direction = new p5.Vector(v3, x, y);
-        angle = z;
-        concentration = nx;
-      } else if (v1 instanceof p5.Color && y instanceof p5.Vector) {
-        color = v1;
-        position = new p5.Vector(v2, v3, x);
-        direction = y;
-        angle = z;
-        concentration = nx;
-      } else if (x instanceof p5.Vector && y instanceof p5.Vector) {
-        color = this.color(v1, v2, v3);
-        position = x;
-        direction = y;
-        angle = z;
-        concentration = nx;
-      } else if (v1 instanceof p5.Color) {
-        color = v1;
-        position = new p5.Vector(v2, v3, x);
-        direction = new p5.Vector(y, z, nx);
-      } else if (x instanceof p5.Vector) {
-        color = this.color(v1, v2, v3);
-        position = x;
-        direction = new p5.Vector(y, z, nx);
-      } else {
-        color = this.color(v1, v2, v3);
-        position = new p5.Vector(x, y, z);
-        direction = nx;
-      }
-      break;
+      case 8:
+        if (v1 instanceof p5.Color) {
+          color = v1;
+          position = new p5.Vector(v2, v3, x);
+          direction = new p5.Vector(y, z, nx);
+          angle = ny;
+        } else if (x instanceof p5.Vector) {
+          color = this.color(v1, v2, v3);
+          position = x;
+          direction = new p5.Vector(y, z, nx);
+          angle = ny;
+        } else {
+          color = this.color(v1, v2, v3);
+          position = new p5.Vector(x, y, z);
+          direction = nx;
+          angle = ny;
+        }
+        break;
 
-    case 6:
-      if (x instanceof p5.Vector && y instanceof p5.Vector) {
-        color = this.color(v1, v2, v3);
-        position = x;
-        direction = y;
-        angle = z;
-      } else if (v1 instanceof p5.Color && y instanceof p5.Vector) {
-        color = v1;
-        position = new p5.Vector(v2, v3, x);
-        direction = y;
-        angle = z;
-      } else if (v1 instanceof p5.Color && v2 instanceof p5.Vector) {
-        color = v1;
-        position = v2;
-        direction = new p5.Vector(v3, x, y);
-        angle = z;
-      }
-      break;
+      case 7:
+        if (v1 instanceof p5.Color && v2 instanceof p5.Vector) {
+          color = v1;
+          position = v2;
+          direction = new p5.Vector(v3, x, y);
+          angle = z;
+          concentration = nx;
+        } else if (v1 instanceof p5.Color && y instanceof p5.Vector) {
+          color = v1;
+          position = new p5.Vector(v2, v3, x);
+          direction = y;
+          angle = z;
+          concentration = nx;
+        } else if (x instanceof p5.Vector && y instanceof p5.Vector) {
+          color = this.color(v1, v2, v3);
+          position = x;
+          direction = y;
+          angle = z;
+          concentration = nx;
+        } else if (v1 instanceof p5.Color) {
+          color = v1;
+          position = new p5.Vector(v2, v3, x);
+          direction = new p5.Vector(y, z, nx);
+        } else if (x instanceof p5.Vector) {
+          color = this.color(v1, v2, v3);
+          position = x;
+          direction = new p5.Vector(y, z, nx);
+        } else {
+          color = this.color(v1, v2, v3);
+          position = new p5.Vector(x, y, z);
+          direction = nx;
+        }
+        break;
 
-    case 5:
-      if (
-        v1 instanceof p5.Color &&
-        v2 instanceof p5.Vector &&
-        v3 instanceof p5.Vector
-      ) {
+      case 6:
+        if (x instanceof p5.Vector && y instanceof p5.Vector) {
+          color = this.color(v1, v2, v3);
+          position = x;
+          direction = y;
+          angle = z;
+        } else if (v1 instanceof p5.Color && y instanceof p5.Vector) {
+          color = v1;
+          position = new p5.Vector(v2, v3, x);
+          direction = y;
+          angle = z;
+        } else if (v1 instanceof p5.Color && v2 instanceof p5.Vector) {
+          color = v1;
+          position = v2;
+          direction = new p5.Vector(v3, x, y);
+          angle = z;
+        }
+        break;
+
+      case 5:
+        if (
+          v1 instanceof p5.Color &&
+          v2 instanceof p5.Vector &&
+          v3 instanceof p5.Vector
+        ) {
+          color = v1;
+          position = v2;
+          direction = v3;
+          angle = x;
+          concentration = y;
+        } else if (x instanceof p5.Vector && y instanceof p5.Vector) {
+          color = this.color(v1, v2, v3);
+          position = x;
+          direction = y;
+        } else if (v1 instanceof p5.Color && y instanceof p5.Vector) {
+          color = v1;
+          position = new p5.Vector(v2, v3, x);
+          direction = y;
+        } else if (v1 instanceof p5.Color && v2 instanceof p5.Vector) {
+          color = v1;
+          position = v2;
+          direction = new p5.Vector(v3, x, y);
+        }
+        break;
+
+      case 4:
         color = v1;
         position = v2;
         direction = v3;
         angle = x;
-        concentration = y;
-      } else if (x instanceof p5.Vector && y instanceof p5.Vector) {
-        color = this.color(v1, v2, v3);
-        position = x;
-        direction = y;
-      } else if (v1 instanceof p5.Color && y instanceof p5.Vector) {
-        color = v1;
-        position = new p5.Vector(v2, v3, x);
-        direction = y;
-      } else if (v1 instanceof p5.Color && v2 instanceof p5.Vector) {
+        break;
+
+      case 3:
         color = v1;
         position = v2;
-        direction = new p5.Vector(v3, x, y);
-      }
-      break;
+        direction = v3;
+        break;
 
-    case 4:
-      color = v1;
-      position = v2;
-      direction = v3;
-      angle = x;
-      break;
+      default:
+        console.warn(
+          `Sorry, input for spotlight() is not in prescribed format. Too ${
+            length < 3 ? 'few' : 'many'
+          } arguments were provided`
+        );
+        return this;
+    }
+    this._renderer.states.spotLightDiffuseColors = [
+      color._array[0],
+      color._array[1],
+      color._array[2]
+    ];
 
-    case 3:
-      color = v1;
-      position = v2;
-      direction = v3;
-      break;
+    this._renderer.states.spotLightSpecularColors = [
+      ...this._renderer.states.specularColors
+    ];
 
-    default:
+    this._renderer.states.spotLightPositions = [position.x, position.y, position.z];
+    direction.normalize();
+    this._renderer.states.spotLightDirections = [
+      direction.x,
+      direction.y,
+      direction.z
+    ];
+
+    if (angle === undefined) {
+      angle = Math.PI / 3;
+    }
+
+    if (concentration !== undefined && concentration < 1) {
+      concentration = 1;
       console.warn(
-        `Sorry, input for spotlight() is not in prescribed format. Too ${
-          length < 3 ? 'few' : 'many'
-        } arguments were provided`
+        'Value of concentration needs to be greater than 1. Setting it to 1'
       );
-      return this;
-  }
-  this._renderer.states.spotLightDiffuseColors = [
-    color._array[0],
-    color._array[1],
-    color._array[2]
-  ];
+    } else if (concentration === undefined) {
+      concentration = 100;
+    }
 
-  this._renderer.states.spotLightSpecularColors = [
-    ...this._renderer.states.specularColors
-  ];
+    angle = this._renderer._pInst._toRadians(angle);
+    this._renderer.states.spotLightAngle = [Math.cos(angle)];
+    this._renderer.states.spotLightConc = [concentration];
 
-  this._renderer.states.spotLightPositions = [position.x, position.y, position.z];
-  direction.normalize();
-  this._renderer.states.spotLightDirections = [
-    direction.x,
-    direction.y,
-    direction.z
-  ];
+    this._renderer.states._enableLighting = true;
 
-  if (angle === undefined) {
-    angle = Math.PI / 3;
-  }
+    return this;
+  };
 
-  if (concentration !== undefined && concentration < 1) {
-    concentration = 1;
-    console.warn(
-      'Value of concentration needs to be greater than 1. Setting it to 1'
-    );
-  } else if (concentration === undefined) {
-    concentration = 100;
-  }
+  /**
+   * Removes all lights from the sketch.
+   *
+   * Calling `noLights()` removes any lights created with
+   * <a href="#/p5/lights">lights()</a>,
+   * <a href="#/p5/ambientLight">ambientLight()</a>,
+   * <a href="#/p5/directionalLight">directionalLight()</a>,
+   * <a href="#/p5/pointLight">pointLight()</a>, or
+   * <a href="#/p5/spotLight">spotLight()</a>. These functions may be called
+   * after `noLights()` to create a new lighting scheme.
+   *
+   * @method noLights
+   * @chainable
+   *
+   * @example
+   * <div>
+   * <code>
+   * // Click and drag the mouse to view the scene from different angles.
+   *
+   * function setup() {
+   *   createCanvas(100, 100, WEBGL);
+   *
+   *   describe('Two spheres drawn against a gray background. The top sphere is white and the bottom sphere is red.');
+   * }
+   *
+   * function draw() {
+   *   background(50);
+   *
+   *   // Enable orbiting with the mouse.
+   *   orbitControl();
+   *
+   *   // Turn on the lights.
+   *   lights();
+   *
+   *   // Style the spheres.
+   *   noStroke();
+   *
+   *   // Draw the top sphere.
+   *   push();
+   *   translate(0, -25, 0);
+   *   sphere(20);
+   *   pop();
+   *
+   *   // Turn off the lights.
+   *   noLights();
+   *
+   *   // Add a red directional light that points into the screen.
+   *   directionalLight(255, 0, 0, 0, 0, -1);
+   *
+   *   // Draw the bottom sphere.
+   *   push();
+   *   translate(0, 25, 0);
+   *   sphere(20);
+   *   pop();
+   * }
+   * </code>
+   * </div>
+   */
+  fn.noLights = function (...args) {
+    this._assert3d('noLights');
+    p5._validateParameters('noLights', args);
 
-  angle = this._renderer._pInst._toRadians(angle);
-  this._renderer.states.spotLightAngle = [Math.cos(angle)];
-  this._renderer.states.spotLightConc = [concentration];
+    this._renderer.states.activeImageLight = null;
+    this._renderer.states._enableLighting = false;
 
-  this._renderer.states._enableLighting = true;
+    this._renderer.states.ambientLightColors.length = 0;
+    this._renderer.states.specularColors = [1, 1, 1];
 
-  return this;
-};
+    this._renderer.states.directionalLightDirections.length = 0;
+    this._renderer.states.directionalLightDiffuseColors.length = 0;
+    this._renderer.states.directionalLightSpecularColors.length = 0;
 
-/**
- * Removes all lights from the sketch.
- *
- * Calling `noLights()` removes any lights created with
- * <a href="#/p5/lights">lights()</a>,
- * <a href="#/p5/ambientLight">ambientLight()</a>,
- * <a href="#/p5/directionalLight">directionalLight()</a>,
- * <a href="#/p5/pointLight">pointLight()</a>, or
- * <a href="#/p5/spotLight">spotLight()</a>. These functions may be called
- * after `noLights()` to create a new lighting scheme.
- *
- * @method noLights
- * @chainable
- *
- * @example
- * <div>
- * <code>
- * // Click and drag the mouse to view the scene from different angles.
- *
- * function setup() {
- *   createCanvas(100, 100, WEBGL);
- *
- *   describe('Two spheres drawn against a gray background. The top sphere is white and the bottom sphere is red.');
- * }
- *
- * function draw() {
- *   background(50);
- *
- *   // Enable orbiting with the mouse.
- *   orbitControl();
- *
- *   // Turn on the lights.
- *   lights();
- *
- *   // Style the spheres.
- *   noStroke();
- *
- *   // Draw the top sphere.
- *   push();
- *   translate(0, -25, 0);
- *   sphere(20);
- *   pop();
- *
- *   // Turn off the lights.
- *   noLights();
- *
- *   // Add a red directional light that points into the screen.
- *   directionalLight(255, 0, 0, 0, 0, -1);
- *
- *   // Draw the bottom sphere.
- *   push();
- *   translate(0, 25, 0);
- *   sphere(20);
- *   pop();
- * }
- * </code>
- * </div>
- */
-p5.prototype.noLights = function (...args) {
-  this._assert3d('noLights');
-  p5._validateParameters('noLights', args);
+    this._renderer.states.pointLightPositions.length = 0;
+    this._renderer.states.pointLightDiffuseColors.length = 0;
+    this._renderer.states.pointLightSpecularColors.length = 0;
 
-  this._renderer.states.activeImageLight = null;
-  this._renderer.states._enableLighting = false;
+    this._renderer.states.spotLightPositions.length = 0;
+    this._renderer.states.spotLightDirections.length = 0;
+    this._renderer.states.spotLightDiffuseColors.length = 0;
+    this._renderer.states.spotLightSpecularColors.length = 0;
+    this._renderer.states.spotLightAngle.length = 0;
+    this._renderer.states.spotLightConc.length = 0;
 
-  this._renderer.states.ambientLightColors.length = 0;
-  this._renderer.states.specularColors = [1, 1, 1];
+    this._renderer.states.constantAttenuation = 1;
+    this._renderer.states.linearAttenuation = 0;
+    this._renderer.states.quadraticAttenuation = 0;
+    this._renderer.states._useShininess = 1;
+    this._renderer.states._useMetalness = 0;
 
-  this._renderer.states.directionalLightDirections.length = 0;
-  this._renderer.states.directionalLightDiffuseColors.length = 0;
-  this._renderer.states.directionalLightSpecularColors.length = 0;
+    return this;
+  };
+}
 
-  this._renderer.states.pointLightPositions.length = 0;
-  this._renderer.states.pointLightDiffuseColors.length = 0;
-  this._renderer.states.pointLightSpecularColors.length = 0;
+export default light;
 
-  this._renderer.states.spotLightPositions.length = 0;
-  this._renderer.states.spotLightDirections.length = 0;
-  this._renderer.states.spotLightDiffuseColors.length = 0;
-  this._renderer.states.spotLightSpecularColors.length = 0;
-  this._renderer.states.spotLightAngle.length = 0;
-  this._renderer.states.spotLightConc.length = 0;
-
-  this._renderer.states.constantAttenuation = 1;
-  this._renderer.states.linearAttenuation = 0;
-  this._renderer.states.quadraticAttenuation = 0;
-  this._renderer.states._useShininess = 1;
-  this._renderer.states._useMetalness = 0;
-
-  return this;
-};
-
-export default p5;
+if(typeof p5 !== 'undefined'){
+  light(p5, p5.prototype);
+}

--- a/src/webgl/loading.js
+++ b/src/webgl/loading.js
@@ -6,470 +6,433 @@
  * @requires p5.Geometry
  */
 
-import p5 from '../core/main';
-import './p5.Geometry';
-
-/**
- * Loads a 3D model to create a
- * <a href="#/p5.Geometry">p5.Geometry</a> object.
- *
- * `loadModel()` can load 3D models from OBJ and STL files. Once the model is
- * loaded, it can be displayed with the
- * <a href="#/p5/model">model()</a> function, as in `model(shape)`.
- *
- * There are three ways to call `loadModel()` with optional parameters to help
- * process the model.
- *
- * The first parameter, `path`, is always a `String` with the path to the
- * file. Paths to local files should be relative, as in
- * `loadModel('assets/model.obj')`. URLs such as
- * `'https://example.com/model.obj'` may be blocked due to browser security.
- *
- * The first way to call `loadModel()` has three optional parameters after the
- * file path. The first optional parameter, `successCallback`, is a function
- * to call once the model loads. For example,
- * `loadModel('assets/model.obj', handleModel)` will call the `handleModel()`
- * function once the model loads. The second optional parameter,
- * `failureCallback`, is a function to call if the model fails to load. For
- * example, `loadModel('assets/model.obj', handleModel, handleFailure)` will
- * call the `handleFailure()` function if an error occurs while loading. The
- * third optional parameter, `fileType`, is the model’s file extension as a
- * string. For example,
- * `loadModel('assets/model', handleModel, handleFailure, '.obj')` will try to
- * load the file model as a `.obj` file.
- *
- * The second way to call `loadModel()` has four optional parameters after the
- * file path. The first optional parameter is a `Boolean` value. If `true` is
- * passed, as in `loadModel('assets/model.obj', true)`, then the model will be
- * resized to ensure it fits the canvas. The next three parameters are
- * `successCallback`, `failureCallback`, and `fileType` as described above.
- *
- * The third way to call `loadModel()` has one optional parameter after the
- * file path. The optional parameter, `options`, is an `Object` with options,
- * as in `loadModel('assets/model.obj', options)`. The `options` object can
- * have the following properties:
- *
- * ```js
- * let options = {
- *   // Enables standardized size scaling during loading if set to true.
- *   normalize: true,
- *
- *   // Function to call once the model loads.
- *   successCallback: handleModel,
- *
- *   // Function to call if an error occurs while loading.
- *   failureCallback: handleError,
- *
- *   // Model's file extension.
- *   fileType: '.stl',
- *
- *   // Flips the U texture coordinates of the model.
- *   flipU: false,
- *
- *   // Flips the V texture coordinates of the model.
- *   flipV: false
- * };
- *
- * // Pass the options object to loadModel().
- * loadModel('assets/model.obj', options);
- * ```
- *
- * Models can take time to load. Calling `loadModel()` in
- * <a href="#/p5/preload">preload()</a> ensures models load before they're
- * used in <a href="#/p5/setup">setup()</a> or <a href="#/p5/draw">draw()</a>.
- *
- * Note: There’s no support for colored STL files. STL files with color will
- * be rendered without color.
- *
- * @method loadModel
- * @param  {String} path              path of the model to be loaded.
- * @param  {Boolean} normalize        if `true`, scale the model to fit the canvas.
- * @param  {function(p5.Geometry)} [successCallback] function to call once the model is loaded. Will be passed
- *                                                   the <a href="#/p5.Geometry">p5.Geometry</a> object.
- * @param  {function(Event)} [failureCallback] function to call if the model fails to load. Will be passed an `Error` event object.
- * @param  {String} [fileType]          model’s file extension. Either `'.obj'` or `'.stl'`.
- * @return {p5.Geometry} the <a href="#/p5.Geometry">p5.Geometry</a> object
- *
- * @example
- * <div>
- * <code>
- * // Click and drag the mouse to view the scene from different angles.
- *
- * let shape;
- *
- * // Load the file and create a p5.Geometry object.
- * function preload() {
- *   shape = loadModel('assets/teapot.obj');
- * }
- *
- * function setup() {
- *   createCanvas(100, 100, WEBGL);
- *
- *   describe('A white teapot drawn against a gray background.');
- * }
- *
- * function draw() {
- *   background(200);
- *
- *   // Enable orbiting with the mouse.
- *   orbitControl();
- *
- *   // Draw the shape.
- *   model(shape);
- * }
- * </code>
- * </div>
- *
- * <div>
- * <code>
- * // Click and drag the mouse to view the scene from different angles.
- *
- * let shape;
- *
- * // Load the file and create a p5.Geometry object.
- * // Normalize the geometry's size to fit the canvas.
- * function preload() {
- *   shape = loadModel('assets/teapot.obj', true);
- * }
- *
- * function setup() {
- *   createCanvas(100, 100, WEBGL);
- *
- *   describe('A white teapot drawn against a gray background.');
- * }
- *
- * function draw() {
- *   background(200);
- *
- *   // Enable orbiting with the mouse.
- *   orbitControl();
- *
- *   // Draw the shape.
- *   model(shape);
- * }
- * </code>
- * </div>
- *
- * <div>
- * <code>
- * // Click and drag the mouse to view the scene from different angles.
- *
- * let shape;
- *
- * // Load the file and create a p5.Geometry object.
- * function preload() {
- *   loadModel('assets/teapot.obj', true, handleModel);
- * }
- *
- * function setup() {
- *   createCanvas(100, 100, WEBGL);
- *
- *   describe('A white teapot drawn against a gray background.');
- * }
- *
- * function draw() {
- *   background(200);
- *
- *   // Enable orbiting with the mouse.
- *   orbitControl();
- *
- *   // Draw the shape.
- *   model(shape);
- * }
- *
- * // Set the shape variable and log the geometry's
- * // ID to the console.
- * function handleModel(data) {
- *   shape = data;
- *   console.log(shape.gid);
- * }
- * </code>
- * </div>
- *
- * <div class='notest'>
- * <code>
- * // Click and drag the mouse to view the scene from different angles.
- *
- * let shape;
- *
- * // Load the file and create a p5.Geometry object.
- * function preload() {
- *   loadModel('assets/wrong.obj', true, handleModel, handleError);
- * }
- *
- * function setup() {
- *   createCanvas(100, 100, WEBGL);
- *
- *   describe('A white teapot drawn against a gray background.');
- * }
- *
- * function draw() {
- *   background(200);
- *
- *   // Enable orbiting with the mouse.
- *   orbitControl();
- *
- *   // Draw the shape.
- *   model(shape);
- * }
- *
- * // Set the shape variable and print the geometry's
- * // ID to the console.
- * function handleModel(data) {
- *   shape = data;
- *   console.log(shape.gid);
- * }
- *
- * // Print an error message if the file doesn't load.
- * function handleError(error) {
- *   console.error('Oops!', error);
- * }
- * </code>
- * </div>
- *
- * <div>
- * <code>
- * // Click and drag the mouse to view the scene from different angles.
- *
- * let shape;
- *
- * // Load the file and create a p5.Geometry object.
- * function preload() {
- *   loadModel('assets/teapot.obj', true, handleModel, handleError, '.obj');
- * }
- *
- * function setup() {
- *   createCanvas(100, 100, WEBGL);
- *
- *   describe('A white teapot drawn against a gray background.');
- * }
- *
- * function draw() {
- *   background(200);
- *
- *   // Enable orbiting with the mouse.
- *   orbitControl();
- *
- *   // Draw the shape.
- *   model(shape);
- * }
- *
- * // Set the shape variable and print the geometry's
- * // ID to the console.
- * function handleModel(data) {
- *   shape = data;
- *   console.log(shape.gid);
- * }
- *
- * // Print an error message if the file doesn't load.
- * function handleError(error) {
- *   console.error('Oops!', error);
- * }
- * </code>
- * </div>
- *
- * <div>
- * <code>
- * // Click and drag the mouse to view the scene from different angles.
- *
- * let shape;
- * let options = {
- *   normalize: true,
- *   successCallback: handleModel,
- *   failureCallback: handleError,
- *   fileType: '.obj'
- * };
- *
- * // Load the file and create a p5.Geometry object.
- * function preload() {
- *   loadModel('assets/teapot.obj', options);
- * }
- *
- * function setup() {
- *   createCanvas(100, 100, WEBGL);
- *
- *   describe('A white teapot drawn against a gray background.');
- * }
- *
- * function draw() {
- *   background(200);
- *
- *   // Enable orbiting with the mouse.
- *   orbitControl();
- *
- *   // Draw the shape.
- *   model(shape);
- * }
- *
- * // Set the shape variable and print the geometry's
- * // ID to the console.
- * function handleModel(data) {
- *   shape = data;
- *   console.log(shape.gid);
- * }
- *
- * // Print an error message if the file doesn't load.
- * function handleError(error) {
- *   console.error('Oops!', error);
- * }
- * </code>
- * </div>
- */
-/**
- * @method loadModel
- * @param  {String} path
- * @param  {function(p5.Geometry)} [successCallback]
- * @param  {function(Event)} [failureCallback]
- * @param  {String} [fileType]
- * @return {p5.Geometry} new <a href="#/p5.Geometry">p5.Geometry</a> object.
- */
-/**
- * @method loadModel
- * @param  {String} path
- * @param  {Object} [options] loading options.
- * @param  {function(p5.Geometry)} [options.successCallback]
- * @param  {function(Event)} [options.failureCallback]
- * @param  {String} [options.fileType]
- * @param  {Boolean} [options.normalize]
- * @param  {Boolean} [options.flipU]
- * @param  {Boolean} [options.flipV]
- * @return {p5.Geometry} new <a href="#/p5.Geometry">p5.Geometry</a> object.
- */
-p5.prototype.loadModel = async function (path, options) {
-  p5._validateParameters('loadModel', arguments);
-  let normalize = false;
-  let successCallback;
-  let failureCallback;
-  let flipU = false;
-  let flipV = false;
-  let fileType = path.slice(-4);
-  if (options && typeof options === 'object') {
-    normalize = options.normalize || false;
-    successCallback = options.successCallback;
-    failureCallback = options.failureCallback;
-    fileType = options.fileType || fileType;
-    flipU = options.flipU || false;
-    flipV = options.flipV || false;
-  } else if (typeof options === 'boolean') {
-    normalize = options;
-    successCallback = arguments[2];
-    failureCallback = arguments[3];
-    if (typeof arguments[4] !== 'undefined') {
-      fileType = arguments[4];
-    }
-  } else {
-    successCallback = typeof arguments[1] === 'function' ? arguments[1] : undefined;
-    failureCallback = arguments[2];
-    if (typeof arguments[3] !== 'undefined') {
-      fileType = arguments[3];
-    }
-  }
-
-  const model = new p5.Geometry();
-  model.gid = `${path}|${normalize}`;
-  const self = this;
-
-  async function getMaterials(lines) {
-    const parsedMaterialPromises = [];
-
-    for (let i = 0; i < lines.length; i++) {
-      const mtllibMatch = lines[i].match(/^mtllib (.+)/);
-      if (mtllibMatch) {
-        let mtlPath = '';
-        const mtlFilename = mtllibMatch[1];
-        const objPathParts = path.split('/');
-        if (objPathParts.length > 1) {
-          objPathParts.pop();
-          const objFolderPath = objPathParts.join('/');
-          mtlPath = objFolderPath + '/' + mtlFilename;
-        } else {
-          mtlPath = mtlFilename;
-        }
-        parsedMaterialPromises.push(
-          fileExists(mtlPath).then(exists => {
-            if (exists) {
-              return parseMtl(self, mtlPath);
-            } else {
-              console.warn(`MTL file not found or error in parsing; proceeding without materials: ${mtlPath}`);
-              return {};
-
-            }
-          }).catch(error => {
-            console.warn(`Error loading MTL file: ${mtlPath}`, error);
-            return {};
-          })
-        );
+function loading(p5, fn){
+  /**
+   * Loads a 3D model to create a
+   * <a href="#/p5.Geometry">p5.Geometry</a> object.
+   *
+   * `loadModel()` can load 3D models from OBJ and STL files. Once the model is
+   * loaded, it can be displayed with the
+   * <a href="#/p5/model">model()</a> function, as in `model(shape)`.
+   *
+   * There are three ways to call `loadModel()` with optional parameters to help
+   * process the model.
+   *
+   * The first parameter, `path`, is always a `String` with the path to the
+   * file. Paths to local files should be relative, as in
+   * `loadModel('assets/model.obj')`. URLs such as
+   * `'https://example.com/model.obj'` may be blocked due to browser security.
+   *
+   * The first way to call `loadModel()` has three optional parameters after the
+   * file path. The first optional parameter, `successCallback`, is a function
+   * to call once the model loads. For example,
+   * `loadModel('assets/model.obj', handleModel)` will call the `handleModel()`
+   * function once the model loads. The second optional parameter,
+   * `failureCallback`, is a function to call if the model fails to load. For
+   * example, `loadModel('assets/model.obj', handleModel, handleFailure)` will
+   * call the `handleFailure()` function if an error occurs while loading. The
+   * third optional parameter, `fileType`, is the model’s file extension as a
+   * string. For example,
+   * `loadModel('assets/model', handleModel, handleFailure, '.obj')` will try to
+   * load the file model as a `.obj` file.
+   *
+   * The second way to call `loadModel()` has four optional parameters after the
+   * file path. The first optional parameter is a `Boolean` value. If `true` is
+   * passed, as in `loadModel('assets/model.obj', true)`, then the model will be
+   * resized to ensure it fits the canvas. The next three parameters are
+   * `successCallback`, `failureCallback`, and `fileType` as described above.
+   *
+   * The third way to call `loadModel()` has one optional parameter after the
+   * file path. The optional parameter, `options`, is an `Object` with options,
+   * as in `loadModel('assets/model.obj', options)`. The `options` object can
+   * have the following properties:
+   *
+   * ```js
+   * let options = {
+   *   // Enables standardized size scaling during loading if set to true.
+   *   normalize: true,
+   *
+   *   // Function to call once the model loads.
+   *   successCallback: handleModel,
+   *
+   *   // Function to call if an error occurs while loading.
+   *   failureCallback: handleError,
+   *
+   *   // Model's file extension.
+   *   fileType: '.stl',
+   *
+   *   // Flips the U texture coordinates of the model.
+   *   flipU: false,
+   *
+   *   // Flips the V texture coordinates of the model.
+   *   flipV: false
+   * };
+   *
+   * // Pass the options object to loadModel().
+   * loadModel('assets/model.obj', options);
+   * ```
+   *
+   * Models can take time to load. Calling `loadModel()` in
+   * <a href="#/p5/preload">preload()</a> ensures models load before they're
+   * used in <a href="#/p5/setup">setup()</a> or <a href="#/p5/draw">draw()</a>.
+   *
+   * Note: There’s no support for colored STL files. STL files with color will
+   * be rendered without color.
+   *
+   * @method loadModel
+   * @param  {String} path              path of the model to be loaded.
+   * @param  {Boolean} normalize        if `true`, scale the model to fit the canvas.
+   * @param  {function(p5.Geometry)} [successCallback] function to call once the model is loaded. Will be passed
+   *                                                   the <a href="#/p5.Geometry">p5.Geometry</a> object.
+   * @param  {function(Event)} [failureCallback] function to call if the model fails to load. Will be passed an `Error` event object.
+   * @param  {String} [fileType]          model’s file extension. Either `'.obj'` or `'.stl'`.
+   * @return {p5.Geometry} the <a href="#/p5.Geometry">p5.Geometry</a> object
+   *
+   * @example
+   * <div>
+   * <code>
+   * // Click and drag the mouse to view the scene from different angles.
+   *
+   * let shape;
+   *
+   * // Load the file and create a p5.Geometry object.
+   * function preload() {
+   *   shape = loadModel('assets/teapot.obj');
+   * }
+   *
+   * function setup() {
+   *   createCanvas(100, 100, WEBGL);
+   *
+   *   describe('A white teapot drawn against a gray background.');
+   * }
+   *
+   * function draw() {
+   *   background(200);
+   *
+   *   // Enable orbiting with the mouse.
+   *   orbitControl();
+   *
+   *   // Draw the shape.
+   *   model(shape);
+   * }
+   * </code>
+   * </div>
+   *
+   * <div>
+   * <code>
+   * // Click and drag the mouse to view the scene from different angles.
+   *
+   * let shape;
+   *
+   * // Load the file and create a p5.Geometry object.
+   * // Normalize the geometry's size to fit the canvas.
+   * function preload() {
+   *   shape = loadModel('assets/teapot.obj', true);
+   * }
+   *
+   * function setup() {
+   *   createCanvas(100, 100, WEBGL);
+   *
+   *   describe('A white teapot drawn against a gray background.');
+   * }
+   *
+   * function draw() {
+   *   background(200);
+   *
+   *   // Enable orbiting with the mouse.
+   *   orbitControl();
+   *
+   *   // Draw the shape.
+   *   model(shape);
+   * }
+   * </code>
+   * </div>
+   *
+   * <div>
+   * <code>
+   * // Click and drag the mouse to view the scene from different angles.
+   *
+   * let shape;
+   *
+   * // Load the file and create a p5.Geometry object.
+   * function preload() {
+   *   loadModel('assets/teapot.obj', true, handleModel);
+   * }
+   *
+   * function setup() {
+   *   createCanvas(100, 100, WEBGL);
+   *
+   *   describe('A white teapot drawn against a gray background.');
+   * }
+   *
+   * function draw() {
+   *   background(200);
+   *
+   *   // Enable orbiting with the mouse.
+   *   orbitControl();
+   *
+   *   // Draw the shape.
+   *   model(shape);
+   * }
+   *
+   * // Set the shape variable and log the geometry's
+   * // ID to the console.
+   * function handleModel(data) {
+   *   shape = data;
+   *   console.log(shape.gid);
+   * }
+   * </code>
+   * </div>
+   *
+   * <div class='notest'>
+   * <code>
+   * // Click and drag the mouse to view the scene from different angles.
+   *
+   * let shape;
+   *
+   * // Load the file and create a p5.Geometry object.
+   * function preload() {
+   *   loadModel('assets/wrong.obj', true, handleModel, handleError);
+   * }
+   *
+   * function setup() {
+   *   createCanvas(100, 100, WEBGL);
+   *
+   *   describe('A white teapot drawn against a gray background.');
+   * }
+   *
+   * function draw() {
+   *   background(200);
+   *
+   *   // Enable orbiting with the mouse.
+   *   orbitControl();
+   *
+   *   // Draw the shape.
+   *   model(shape);
+   * }
+   *
+   * // Set the shape variable and print the geometry's
+   * // ID to the console.
+   * function handleModel(data) {
+   *   shape = data;
+   *   console.log(shape.gid);
+   * }
+   *
+   * // Print an error message if the file doesn't load.
+   * function handleError(error) {
+   *   console.error('Oops!', error);
+   * }
+   * </code>
+   * </div>
+   *
+   * <div>
+   * <code>
+   * // Click and drag the mouse to view the scene from different angles.
+   *
+   * let shape;
+   *
+   * // Load the file and create a p5.Geometry object.
+   * function preload() {
+   *   loadModel('assets/teapot.obj', true, handleModel, handleError, '.obj');
+   * }
+   *
+   * function setup() {
+   *   createCanvas(100, 100, WEBGL);
+   *
+   *   describe('A white teapot drawn against a gray background.');
+   * }
+   *
+   * function draw() {
+   *   background(200);
+   *
+   *   // Enable orbiting with the mouse.
+   *   orbitControl();
+   *
+   *   // Draw the shape.
+   *   model(shape);
+   * }
+   *
+   * // Set the shape variable and print the geometry's
+   * // ID to the console.
+   * function handleModel(data) {
+   *   shape = data;
+   *   console.log(shape.gid);
+   * }
+   *
+   * // Print an error message if the file doesn't load.
+   * function handleError(error) {
+   *   console.error('Oops!', error);
+   * }
+   * </code>
+   * </div>
+   *
+   * <div>
+   * <code>
+   * // Click and drag the mouse to view the scene from different angles.
+   *
+   * let shape;
+   * let options = {
+   *   normalize: true,
+   *   successCallback: handleModel,
+   *   failureCallback: handleError,
+   *   fileType: '.obj'
+   * };
+   *
+   * // Load the file and create a p5.Geometry object.
+   * function preload() {
+   *   loadModel('assets/teapot.obj', options);
+   * }
+   *
+   * function setup() {
+   *   createCanvas(100, 100, WEBGL);
+   *
+   *   describe('A white teapot drawn against a gray background.');
+   * }
+   *
+   * function draw() {
+   *   background(200);
+   *
+   *   // Enable orbiting with the mouse.
+   *   orbitControl();
+   *
+   *   // Draw the shape.
+   *   model(shape);
+   * }
+   *
+   * // Set the shape variable and print the geometry's
+   * // ID to the console.
+   * function handleModel(data) {
+   *   shape = data;
+   *   console.log(shape.gid);
+   * }
+   *
+   * // Print an error message if the file doesn't load.
+   * function handleError(error) {
+   *   console.error('Oops!', error);
+   * }
+   * </code>
+   * </div>
+   */
+  /**
+   * @method loadModel
+   * @param  {String} path
+   * @param  {function(p5.Geometry)} [successCallback]
+   * @param  {function(Event)} [failureCallback]
+   * @param  {String} [fileType]
+   * @return {p5.Geometry} new <a href="#/p5.Geometry">p5.Geometry</a> object.
+   */
+  /**
+   * @method loadModel
+   * @param  {String} path
+   * @param  {Object} [options] loading options.
+   * @param  {function(p5.Geometry)} [options.successCallback]
+   * @param  {function(Event)} [options.failureCallback]
+   * @param  {String} [options.fileType]
+   * @param  {Boolean} [options.normalize]
+   * @param  {Boolean} [options.flipU]
+   * @param  {Boolean} [options.flipV]
+   * @return {p5.Geometry} new <a href="#/p5.Geometry">p5.Geometry</a> object.
+   */
+  fn.loadModel = async function (path, options) {
+    p5._validateParameters('loadModel', arguments);
+    let normalize = false;
+    let successCallback;
+    let failureCallback;
+    let flipU = false;
+    let flipV = false;
+    let fileType = path.slice(-4);
+    if (options && typeof options === 'object') {
+      normalize = options.normalize || false;
+      successCallback = options.successCallback;
+      failureCallback = options.failureCallback;
+      fileType = options.fileType || fileType;
+      flipU = options.flipU || false;
+      flipV = options.flipV || false;
+    } else if (typeof options === 'boolean') {
+      normalize = options;
+      successCallback = arguments[2];
+      failureCallback = arguments[3];
+      if (typeof arguments[4] !== 'undefined') {
+        fileType = arguments[4];
+      }
+    } else {
+      successCallback = typeof arguments[1] === 'function' ? arguments[1] : undefined;
+      failureCallback = arguments[2];
+      if (typeof arguments[3] !== 'undefined') {
+        fileType = arguments[3];
       }
     }
-    try {
-      const parsedMaterials = await Promise.all(parsedMaterialPromises);
-      const materials = Object.assign({}, ...parsedMaterials);
-      return materials;
-    } catch (error) {
-      return {};
-    }
-  }
 
+    const model = new p5.Geometry();
+    model.gid = `${path}|${normalize}`;
+    const self = this;
 
-  async function fileExists(url) {
-    try {
-      const response = await fetch(url, { method: 'HEAD' });
-      return response.ok;
-    } catch (error) {
-      return false;
-    }
-  }
-  if (fileType.match(/\.stl$/i)) {
-    await new Promise(resolve => this.httpDo(
-      path,
-      'GET',
-      'arrayBuffer',
-      arrayBuffer => {
-        parseSTL(model, arrayBuffer);
+    async function getMaterials(lines) {
+      const parsedMaterialPromises = [];
 
-        if (normalize) {
-          model.normalize();
-        }
-
-        if (flipU) {
-          model.flipU();
-        }
-
-        if (flipV) {
-          model.flipV();
-        }
-
-        resolve();
-        if (typeof successCallback === 'function') {
-          successCallback(model);
-        }
-      },
-      failureCallback
-    ));
-  } else if (fileType.match(/\.obj$/i)) {
-    await new Promise(resolve => this.loadStrings(
-      path,
-      async lines => {
-        try {
-          const parsedMaterials = await getMaterials(lines);
-
-          parseObj(model, lines, parsedMaterials);
-
-        } catch (error) {
-          if (failureCallback) {
-            failureCallback(error);
+      for (let i = 0; i < lines.length; i++) {
+        const mtllibMatch = lines[i].match(/^mtllib (.+)/);
+        if (mtllibMatch) {
+          let mtlPath = '';
+          const mtlFilename = mtllibMatch[1];
+          const objPathParts = path.split('/');
+          if (objPathParts.length > 1) {
+            objPathParts.pop();
+            const objFolderPath = objPathParts.join('/');
+            mtlPath = objFolderPath + '/' + mtlFilename;
           } else {
-            p5._friendlyError('Error during parsing: ' + error.message);
+            mtlPath = mtlFilename;
           }
-          return;
+          parsedMaterialPromises.push(
+            fileExists(mtlPath).then(exists => {
+              if (exists) {
+                return parseMtl(self, mtlPath);
+              } else {
+                console.warn(`MTL file not found or error in parsing; proceeding without materials: ${mtlPath}`);
+                return {};
+
+              }
+            }).catch(error => {
+              console.warn(`Error loading MTL file: ${mtlPath}`, error);
+              return {};
+            })
+          );
         }
-        finally {
+      }
+      try {
+        const parsedMaterials = await Promise.all(parsedMaterialPromises);
+        const materials = Object.assign({}, ...parsedMaterials);
+        return materials;
+      } catch (error) {
+        return {};
+      }
+    }
+
+
+    async function fileExists(url) {
+      try {
+        const response = await fetch(url, { method: 'HEAD' });
+        return response.ok;
+      } catch (error) {
+        return false;
+      }
+    }
+    if (fileType.match(/\.stl$/i)) {
+      await new Promise(resolve => this.httpDo(
+        path,
+        'GET',
+        'arrayBuffer',
+        arrayBuffer => {
+          parseSTL(model, arrayBuffer);
+
           if (normalize) {
             model.normalize();
           }
+
           if (flipU) {
             model.flipU();
           }
+
           if (flipV) {
             model.flipV();
           }
@@ -478,655 +441,695 @@ p5.prototype.loadModel = async function (path, options) {
           if (typeof successCallback === 'function') {
             successCallback(model);
           }
-        }
-      },
-      failureCallback
-    ));
-  } else {
-    p5._friendlyFileLoadError(3, path);
-    if (failureCallback) {
-      failureCallback();
-    } else {
-      p5._friendlyError(
-        'Sorry, the file type is invalid. Only OBJ and STL files are supported.'
-      );
-    }
-  }
-  return model;
-};
+        },
+        failureCallback
+      ));
+    } else if (fileType.match(/\.obj$/i)) {
+      await new Promise(resolve => this.loadStrings(
+        path,
+        async lines => {
+          try {
+            const parsedMaterials = await getMaterials(lines);
 
-function parseMtl(p5, mtlPath) {
-  return new Promise((resolve, reject) => {
-    let currentMaterial = null;
-    let materials = {};
-    p5.loadStrings(
-      mtlPath,
-      lines => {
-        for (let line = 0; line < lines.length; ++line) {
-          const tokens = lines[line].trim().split(/\s+/);
-          if (tokens[0] === 'newmtl') {
-            const materialName = tokens[1];
-            currentMaterial = materialName;
-            materials[currentMaterial] = {};
-          } else if (tokens[0] === 'Kd') {
-            //Diffuse color
-            materials[currentMaterial].diffuseColor = [
-              parseFloat(tokens[1]),
-              parseFloat(tokens[2]),
-              parseFloat(tokens[3])
-            ];
-          } else if (tokens[0] === 'Ka') {
-            //Ambient Color
-            materials[currentMaterial].ambientColor = [
-              parseFloat(tokens[1]),
-              parseFloat(tokens[2]),
-              parseFloat(tokens[3])
-            ];
-          } else if (tokens[0] === 'Ks') {
-            //Specular color
-            materials[currentMaterial].specularColor = [
-              parseFloat(tokens[1]),
-              parseFloat(tokens[2]),
-              parseFloat(tokens[3])
-            ];
+            parseObj(model, lines, parsedMaterials);
 
-          } else if (tokens[0] === 'map_Kd') {
-            //Texture path
-            materials[currentMaterial].texturePath = tokens[1];
+          } catch (error) {
+            if (failureCallback) {
+              failureCallback(error);
+            } else {
+              p5._friendlyError('Error during parsing: ' + error.message);
+            }
+            return;
           }
-        }
-        resolve(materials);
-      }, reject
-    );
-  });
-}
+          finally {
+            if (normalize) {
+              model.normalize();
+            }
+            if (flipU) {
+              model.flipU();
+            }
+            if (flipV) {
+              model.flipV();
+            }
 
-/**
- * Parse OBJ lines into model. For reference, this is what a simple model of a
- * square might look like:
- *
- * v -0.5 -0.5 0.5
- * v -0.5 -0.5 -0.5
- * v -0.5 0.5 -0.5
- * v -0.5 0.5 0.5
- *
- * f 4 3 2 1
- */
-function parseObj(model, lines, materials = {}) {
-  // OBJ allows a face to specify an index for a vertex (in the above example),
-  // but it also allows you to specify a custom combination of vertex, UV
-  // coordinate, and vertex normal. So, "3/4/3" would mean, "use vertex 3 with
-  // UV coordinate 4 and vertex normal 3". In WebGL, every vertex with different
-  // parameters must be a different vertex, so loadedVerts is used to
-  // temporarily store the parsed vertices, normals, etc., and indexedVerts is
-  // used to map a specific combination (keyed on, for example, the string
-  // "3/4/3"), to the actual index of the newly created vertex in the final
-  // object.
-  const loadedVerts = {
-    v: [],
-    vt: [],
-    vn: []
+            resolve();
+            if (typeof successCallback === 'function') {
+              successCallback(model);
+            }
+          }
+        },
+        failureCallback
+      ));
+    } else {
+      p5._friendlyFileLoadError(3, path);
+      if (failureCallback) {
+        failureCallback();
+      } else {
+        p5._friendlyError(
+          'Sorry, the file type is invalid. Only OBJ and STL files are supported.'
+        );
+      }
+    }
+    return model;
   };
 
+  function parseMtl(p5, mtlPath) {
+    return new Promise((resolve, reject) => {
+      let currentMaterial = null;
+      let materials = {};
+      p5.loadStrings(
+        mtlPath,
+        lines => {
+          for (let line = 0; line < lines.length; ++line) {
+            const tokens = lines[line].trim().split(/\s+/);
+            if (tokens[0] === 'newmtl') {
+              const materialName = tokens[1];
+              currentMaterial = materialName;
+              materials[currentMaterial] = {};
+            } else if (tokens[0] === 'Kd') {
+              //Diffuse color
+              materials[currentMaterial].diffuseColor = [
+                parseFloat(tokens[1]),
+                parseFloat(tokens[2]),
+                parseFloat(tokens[3])
+              ];
+            } else if (tokens[0] === 'Ka') {
+              //Ambient Color
+              materials[currentMaterial].ambientColor = [
+                parseFloat(tokens[1]),
+                parseFloat(tokens[2]),
+                parseFloat(tokens[3])
+              ];
+            } else if (tokens[0] === 'Ks') {
+              //Specular color
+              materials[currentMaterial].specularColor = [
+                parseFloat(tokens[1]),
+                parseFloat(tokens[2]),
+                parseFloat(tokens[3])
+              ];
 
-  // Map from source index → Map of material → destination index
-  const usedVerts = {}; // Track colored vertices
-  let currentMaterial = null;
-  const coloredVerts = new Set(); //unique vertices with color
-  let hasColoredVertices = false;
-  let hasColorlessVertices = false;
-  for (let line = 0; line < lines.length; ++line) {
-    // Each line is a separate object (vertex, face, vertex normal, etc)
-    // For each line, split it into tokens on whitespace. The first token
-    // describes the type.
-    const tokens = lines[line].trim().split(/\b\s+/);
+            } else if (tokens[0] === 'map_Kd') {
+              //Texture path
+              materials[currentMaterial].texturePath = tokens[1];
+            }
+          }
+          resolve(materials);
+        }, reject
+      );
+    });
+  }
 
-    if (tokens.length > 0) {
-      if (tokens[0] === 'usemtl') {
-        // Switch to a new material
-        currentMaterial = tokens[1];
-      } else if (tokens[0] === 'v' || tokens[0] === 'vn') {
-        // Check if this line describes a vertex or vertex normal.
-        // It will have three numeric parameters.
-        const vertex = new p5.Vector(
-          parseFloat(tokens[1]),
-          parseFloat(tokens[2]),
-          parseFloat(tokens[3])
-        );
-        loadedVerts[tokens[0]].push(vertex);
-      } else if (tokens[0] === 'vt') {
-        // Check if this line describes a texture coordinate.
-        // It will have two numeric parameters U and V (W is omitted).
-        // Because of WebGL texture coordinates rendering behaviour, the V
-        // coordinate is inversed.
-        const texVertex = [parseFloat(tokens[1]), 1 - parseFloat(tokens[2])];
-        loadedVerts[tokens[0]].push(texVertex);
-      } else if (tokens[0] === 'f') {
-        // Check if this line describes a face.
-        // OBJ faces can have more than three points. Triangulate points.
-        for (let tri = 3; tri < tokens.length; ++tri) {
-          const face = [];
-          const vertexTokens = [1, tri - 1, tri];
+  /**
+   * Parse OBJ lines into model. For reference, this is what a simple model of a
+   * square might look like:
+   *
+   * v -0.5 -0.5 0.5
+   * v -0.5 -0.5 -0.5
+   * v -0.5 0.5 -0.5
+   * v -0.5 0.5 0.5
+   *
+   * f 4 3 2 1
+   */
+  function parseObj(model, lines, materials = {}) {
+    // OBJ allows a face to specify an index for a vertex (in the above example),
+    // but it also allows you to specify a custom combination of vertex, UV
+    // coordinate, and vertex normal. So, "3/4/3" would mean, "use vertex 3 with
+    // UV coordinate 4 and vertex normal 3". In WebGL, every vertex with different
+    // parameters must be a different vertex, so loadedVerts is used to
+    // temporarily store the parsed vertices, normals, etc., and indexedVerts is
+    // used to map a specific combination (keyed on, for example, the string
+    // "3/4/3"), to the actual index of the newly created vertex in the final
+    // object.
+    const loadedVerts = {
+      v: [],
+      vt: [],
+      vn: []
+    };
 
-          for (let tokenInd = 0; tokenInd < vertexTokens.length; ++tokenInd) {
-            // Now, convert the given token into an index
-            const vertString = tokens[vertexTokens[tokenInd]];
-            let vertParts = vertString.split('/');
 
-            // TODO: Faces can technically use negative numbers to refer to the
-            // previous nth vertex. I haven't seen this used in practice, but
-            // it might be good to implement this in the future.
+    // Map from source index → Map of material → destination index
+    const usedVerts = {}; // Track colored vertices
+    let currentMaterial = null;
+    const coloredVerts = new Set(); //unique vertices with color
+    let hasColoredVertices = false;
+    let hasColorlessVertices = false;
+    for (let line = 0; line < lines.length; ++line) {
+      // Each line is a separate object (vertex, face, vertex normal, etc)
+      // For each line, split it into tokens on whitespace. The first token
+      // describes the type.
+      const tokens = lines[line].trim().split(/\b\s+/);
 
-            for (let i = 0; i < vertParts.length; i++) {
-              vertParts[i] = parseInt(vertParts[i]) - 1;
+      if (tokens.length > 0) {
+        if (tokens[0] === 'usemtl') {
+          // Switch to a new material
+          currentMaterial = tokens[1];
+        } else if (tokens[0] === 'v' || tokens[0] === 'vn') {
+          // Check if this line describes a vertex or vertex normal.
+          // It will have three numeric parameters.
+          const vertex = new p5.Vector(
+            parseFloat(tokens[1]),
+            parseFloat(tokens[2]),
+            parseFloat(tokens[3])
+          );
+          loadedVerts[tokens[0]].push(vertex);
+        } else if (tokens[0] === 'vt') {
+          // Check if this line describes a texture coordinate.
+          // It will have two numeric parameters U and V (W is omitted).
+          // Because of WebGL texture coordinates rendering behaviour, the V
+          // coordinate is inversed.
+          const texVertex = [parseFloat(tokens[1]), 1 - parseFloat(tokens[2])];
+          loadedVerts[tokens[0]].push(texVertex);
+        } else if (tokens[0] === 'f') {
+          // Check if this line describes a face.
+          // OBJ faces can have more than three points. Triangulate points.
+          for (let tri = 3; tri < tokens.length; ++tri) {
+            const face = [];
+            const vertexTokens = [1, tri - 1, tri];
+
+            for (let tokenInd = 0; tokenInd < vertexTokens.length; ++tokenInd) {
+              // Now, convert the given token into an index
+              const vertString = tokens[vertexTokens[tokenInd]];
+              let vertParts = vertString.split('/');
+
+              // TODO: Faces can technically use negative numbers to refer to the
+              // previous nth vertex. I haven't seen this used in practice, but
+              // it might be good to implement this in the future.
+
+              for (let i = 0; i < vertParts.length; i++) {
+                vertParts[i] = parseInt(vertParts[i]) - 1;
+              }
+
+              if (!usedVerts[vertString]) {
+                usedVerts[vertString] = {};
+              }
+
+              if (usedVerts[vertString][currentMaterial] === undefined) {
+                const vertIndex = model.vertices.length;
+                model.vertices.push(loadedVerts.v[vertParts[0]].copy());
+                model.uvs.push(loadedVerts.vt[vertParts[1]] ?
+                  loadedVerts.vt[vertParts[1]].slice() : [0, 0]);
+                model.vertexNormals.push(loadedVerts.vn[vertParts[2]] ?
+                  loadedVerts.vn[vertParts[2]].copy() : new p5.Vector());
+
+                usedVerts[vertString][currentMaterial] = vertIndex;
+                face.push(vertIndex);
+                if (currentMaterial
+                  && materials[currentMaterial]
+                  && materials[currentMaterial].diffuseColor) {
+                  // Mark this vertex as colored
+                  coloredVerts.add(loadedVerts.v[vertParts[0]]); //since a set would only push unique values
+                }
+              } else {
+                face.push(usedVerts[vertString][currentMaterial]);
+              }
             }
 
-            if (!usedVerts[vertString]) {
-              usedVerts[vertString] = {};
-            }
-
-            if (usedVerts[vertString][currentMaterial] === undefined) {
-              const vertIndex = model.vertices.length;
-              model.vertices.push(loadedVerts.v[vertParts[0]].copy());
-              model.uvs.push(loadedVerts.vt[vertParts[1]] ?
-                loadedVerts.vt[vertParts[1]].slice() : [0, 0]);
-              model.vertexNormals.push(loadedVerts.vn[vertParts[2]] ?
-                loadedVerts.vn[vertParts[2]].copy() : new p5.Vector());
-
-              usedVerts[vertString][currentMaterial] = vertIndex;
-              face.push(vertIndex);
+            if (
+              face[0] !== face[1] &&
+              face[0] !== face[2] &&
+              face[1] !== face[2]
+            ) {
+              model.faces.push(face);
+              //same material for all vertices in a particular face
               if (currentMaterial
                 && materials[currentMaterial]
                 && materials[currentMaterial].diffuseColor) {
-                // Mark this vertex as colored
-                coloredVerts.add(loadedVerts.v[vertParts[0]]); //since a set would only push unique values
+                hasColoredVertices = true;
+                //flag to track color or no color model
+                hasColoredVertices = true;
+                const materialDiffuseColor =
+                  materials[currentMaterial].diffuseColor;
+                for (let i = 0; i < face.length; i++) {
+                  model.vertexColors.push(materialDiffuseColor[0]);
+                  model.vertexColors.push(materialDiffuseColor[1]);
+                  model.vertexColors.push(materialDiffuseColor[2]);
+                  model.vertexColors.push(1);
+                }
+              } else {
+                hasColorlessVertices = true;
               }
-            } else {
-              face.push(usedVerts[vertString][currentMaterial]);
-            }
-          }
-
-          if (
-            face[0] !== face[1] &&
-            face[0] !== face[2] &&
-            face[1] !== face[2]
-          ) {
-            model.faces.push(face);
-            //same material for all vertices in a particular face
-            if (currentMaterial
-              && materials[currentMaterial]
-              && materials[currentMaterial].diffuseColor) {
-              hasColoredVertices = true;
-              //flag to track color or no color model
-              hasColoredVertices = true;
-              const materialDiffuseColor =
-                materials[currentMaterial].diffuseColor;
-              for (let i = 0; i < face.length; i++) {
-                model.vertexColors.push(materialDiffuseColor[0]);
-                model.vertexColors.push(materialDiffuseColor[1]);
-                model.vertexColors.push(materialDiffuseColor[2]);
-                model.vertexColors.push(1);
-              }
-            } else {
-              hasColorlessVertices = true;
             }
           }
         }
       }
     }
+    // If the model doesn't have normals, compute the normals
+    if (model.vertexNormals.length === 0) {
+      model.computeNormals();
+    }
+    if (hasColoredVertices === hasColorlessVertices) {
+      // If both are true or both are false, throw an error because the model is inconsistent
+      throw new Error('Model coloring is inconsistent. Either all vertices should have colors or none should.');
+    }
+    return model;
   }
-  // If the model doesn't have normals, compute the normals
-  if (model.vertexNormals.length === 0) {
-    model.computeNormals();
-  }
-  if (hasColoredVertices === hasColorlessVertices) {
-    // If both are true or both are false, throw an error because the model is inconsistent
-    throw new Error('Model coloring is inconsistent. Either all vertices should have colors or none should.');
-  }
-  return model;
-}
 
-/**
- * STL files can be of two types, ASCII and Binary,
- *
- * We need to convert the arrayBuffer to an array of strings,
- * to parse it as an ASCII file.
- */
-function parseSTL(model, buffer) {
-  if (isBinary(buffer)) {
-    parseBinarySTL(model, buffer);
-  } else {
+  /**
+   * STL files can be of two types, ASCII and Binary,
+   *
+   * We need to convert the arrayBuffer to an array of strings,
+   * to parse it as an ASCII file.
+   */
+  function parseSTL(model, buffer) {
+    if (isBinary(buffer)) {
+      parseBinarySTL(model, buffer);
+    } else {
+      const reader = new DataView(buffer);
+
+      if (!('TextDecoder' in window)) {
+        console.warn(
+          'Sorry, ASCII STL loading only works in browsers that support TextDecoder (https://caniuse.com/#feat=textencoder)'
+        );
+        return model;
+      }
+
+      const decoder = new TextDecoder('utf-8');
+      const lines = decoder.decode(reader);
+      const lineArray = lines.split('\n');
+      parseASCIISTL(model, lineArray);
+    }
+    return model;
+  }
+
+  /**
+   * This function checks if the file is in ASCII format or in Binary format
+   *
+   * It is done by searching keyword `solid` at the start of the file.
+   *
+   * An ASCII STL data must begin with `solid` as the first six bytes.
+   * However, ASCII STLs lacking the SPACE after the `d` are known to be
+   * plentiful. So, check the first 5 bytes for `solid`.
+   *
+   * Several encodings, such as UTF-8, precede the text with up to 5 bytes:
+   * https://en.wikipedia.org/wiki/Byte_order_mark#Byte_order_marks_by_encoding
+   * Search for `solid` to start anywhere after those prefixes.
+   */
+  function isBinary(data) {
+    const reader = new DataView(data);
+
+    // US-ASCII ordinal values for `s`, `o`, `l`, `i`, `d`
+    const solid = [115, 111, 108, 105, 100];
+    for (let off = 0; off < 5; off++) {
+      // If "solid" text is matched to the current offset, declare it to be an ASCII STL.
+      if (matchDataViewAt(solid, reader, off)) return false;
+    }
+
+    // Couldn't find "solid" text at the beginning; it is binary STL.
+    return true;
+  }
+
+  /**
+   * This function matches the `query` at the provided `offset`
+   */
+  function matchDataViewAt(query, reader, offset) {
+    // Check if each byte in query matches the corresponding byte from the current offset
+    for (let i = 0, il = query.length; i < il; i++) {
+      if (query[i] !== reader.getUint8(offset + i, false)) return false;
+    }
+
+    return true;
+  }
+
+  /**
+   * This function parses the Binary STL files.
+   * https://en.wikipedia.org/wiki/STL_%28file_format%29#Binary_STL
+   *
+   * Currently there is no support for the colors provided in STL files.
+   */
+  function parseBinarySTL(model, buffer) {
     const reader = new DataView(buffer);
 
-    if (!('TextDecoder' in window)) {
-      console.warn(
-        'Sorry, ASCII STL loading only works in browsers that support TextDecoder (https://caniuse.com/#feat=textencoder)'
-      );
-      return model;
-    }
+    // Number of faces is present following the header
+    const faces = reader.getUint32(80, true);
+    let r,
+      g,
+      b,
+      hasColors = false,
+      colors;
+    let defaultR, defaultG, defaultB;
 
-    const decoder = new TextDecoder('utf-8');
-    const lines = decoder.decode(reader);
-    const lineArray = lines.split('\n');
-    parseASCIISTL(model, lineArray);
-  }
-  return model;
-}
+    // Binary files contain 80-byte header, which is generally ignored.
+    for (let index = 0; index < 80 - 10; index++) {
+      // Check for `COLOR=`
+      if (
+        reader.getUint32(index, false) === 0x434f4c4f /*COLO*/ &&
+        reader.getUint8(index + 4) === 0x52 /*'R'*/ &&
+        reader.getUint8(index + 5) === 0x3d /*'='*/
+      ) {
+        hasColors = true;
+        colors = [];
 
-/**
- * This function checks if the file is in ASCII format or in Binary format
- *
- * It is done by searching keyword `solid` at the start of the file.
- *
- * An ASCII STL data must begin with `solid` as the first six bytes.
- * However, ASCII STLs lacking the SPACE after the `d` are known to be
- * plentiful. So, check the first 5 bytes for `solid`.
- *
- * Several encodings, such as UTF-8, precede the text with up to 5 bytes:
- * https://en.wikipedia.org/wiki/Byte_order_mark#Byte_order_marks_by_encoding
- * Search for `solid` to start anywhere after those prefixes.
- */
-function isBinary(data) {
-  const reader = new DataView(data);
-
-  // US-ASCII ordinal values for `s`, `o`, `l`, `i`, `d`
-  const solid = [115, 111, 108, 105, 100];
-  for (let off = 0; off < 5; off++) {
-    // If "solid" text is matched to the current offset, declare it to be an ASCII STL.
-    if (matchDataViewAt(solid, reader, off)) return false;
-  }
-
-  // Couldn't find "solid" text at the beginning; it is binary STL.
-  return true;
-}
-
-/**
- * This function matches the `query` at the provided `offset`
- */
-function matchDataViewAt(query, reader, offset) {
-  // Check if each byte in query matches the corresponding byte from the current offset
-  for (let i = 0, il = query.length; i < il; i++) {
-    if (query[i] !== reader.getUint8(offset + i, false)) return false;
-  }
-
-  return true;
-}
-
-/**
- * This function parses the Binary STL files.
- * https://en.wikipedia.org/wiki/STL_%28file_format%29#Binary_STL
- *
- * Currently there is no support for the colors provided in STL files.
- */
-function parseBinarySTL(model, buffer) {
-  const reader = new DataView(buffer);
-
-  // Number of faces is present following the header
-  const faces = reader.getUint32(80, true);
-  let r,
-    g,
-    b,
-    hasColors = false,
-    colors;
-  let defaultR, defaultG, defaultB;
-
-  // Binary files contain 80-byte header, which is generally ignored.
-  for (let index = 0; index < 80 - 10; index++) {
-    // Check for `COLOR=`
-    if (
-      reader.getUint32(index, false) === 0x434f4c4f /*COLO*/ &&
-      reader.getUint8(index + 4) === 0x52 /*'R'*/ &&
-      reader.getUint8(index + 5) === 0x3d /*'='*/
-    ) {
-      hasColors = true;
-      colors = [];
-
-      defaultR = reader.getUint8(index + 6) / 255;
-      defaultG = reader.getUint8(index + 7) / 255;
-      defaultB = reader.getUint8(index + 8) / 255;
-      // To be used when color support is added
-      // alpha = reader.getUint8(index + 9) / 255;
-    }
-  }
-  const dataOffset = 84;
-  const faceLength = 12 * 4 + 2;
-
-  // Iterate the faces
-  for (let face = 0; face < faces; face++) {
-    const start = dataOffset + face * faceLength;
-    const normalX = reader.getFloat32(start, true);
-    const normalY = reader.getFloat32(start + 4, true);
-    const normalZ = reader.getFloat32(start + 8, true);
-
-    if (hasColors) {
-      const packedColor = reader.getUint16(start + 48, true);
-
-      if ((packedColor & 0x8000) === 0) {
-        // facet has its own unique color
-        r = (packedColor & 0x1f) / 31;
-        g = ((packedColor >> 5) & 0x1f) / 31;
-        b = ((packedColor >> 10) & 0x1f) / 31;
-      } else {
-        r = defaultR;
-        g = defaultG;
-        b = defaultB;
+        defaultR = reader.getUint8(index + 6) / 255;
+        defaultG = reader.getUint8(index + 7) / 255;
+        defaultB = reader.getUint8(index + 8) / 255;
+        // To be used when color support is added
+        // alpha = reader.getUint8(index + 9) / 255;
       }
     }
-    const newNormal = new p5.Vector(normalX, normalY, normalZ);
+    const dataOffset = 84;
+    const faceLength = 12 * 4 + 2;
 
-    for (let i = 1; i <= 3; i++) {
-      const vertexstart = start + i * 12;
-
-      const newVertex = new p5.Vector(
-        reader.getFloat32(vertexstart, true),
-        reader.getFloat32(vertexstart + 4, true),
-        reader.getFloat32(vertexstart + 8, true)
-      );
-
-      model.vertices.push(newVertex);
-      model.vertexNormals.push(newNormal);
+    // Iterate the faces
+    for (let face = 0; face < faces; face++) {
+      const start = dataOffset + face * faceLength;
+      const normalX = reader.getFloat32(start, true);
+      const normalY = reader.getFloat32(start + 4, true);
+      const normalZ = reader.getFloat32(start + 8, true);
 
       if (hasColors) {
-        colors.push(r, g, b);
+        const packedColor = reader.getUint16(start + 48, true);
+
+        if ((packedColor & 0x8000) === 0) {
+          // facet has its own unique color
+          r = (packedColor & 0x1f) / 31;
+          g = ((packedColor >> 5) & 0x1f) / 31;
+          b = ((packedColor >> 10) & 0x1f) / 31;
+        } else {
+          r = defaultR;
+          g = defaultG;
+          b = defaultB;
+        }
+      }
+      const newNormal = new p5.Vector(normalX, normalY, normalZ);
+
+      for (let i = 1; i <= 3; i++) {
+        const vertexstart = start + i * 12;
+
+        const newVertex = new p5.Vector(
+          reader.getFloat32(vertexstart, true),
+          reader.getFloat32(vertexstart + 4, true),
+          reader.getFloat32(vertexstart + 8, true)
+        );
+
+        model.vertices.push(newVertex);
+        model.vertexNormals.push(newNormal);
+
+        if (hasColors) {
+          colors.push(r, g, b);
+        }
+      }
+
+      model.faces.push([3 * face, 3 * face + 1, 3 * face + 2]);
+      model.uvs.push([0, 0], [0, 0], [0, 0]);
+    }
+    if (hasColors) {
+      // add support for colors here.
+    }
+    return model;
+  }
+
+  /**
+   * ASCII STL file starts with `solid 'nameOfFile'`
+   * Then contain the normal of the face, starting with `facet normal`
+   * Next contain a keyword indicating the start of face vertex, `outer loop`
+   * Next comes the three vertex, starting with `vertex x y z`
+   * Vertices ends with `endloop`
+   * Face ends with `endfacet`
+   * Next face starts with `facet normal`
+   * The end of the file is indicated by `endsolid`
+   */
+  function parseASCIISTL(model, lines) {
+    let state = '';
+    let curVertexIndex = [];
+    let newNormal, newVertex;
+
+    for (let iterator = 0; iterator < lines.length; ++iterator) {
+      const line = lines[iterator].trim();
+      const parts = line.split(' ');
+
+      for (let partsiterator = 0; partsiterator < parts.length; ++partsiterator) {
+        if (parts[partsiterator] === '') {
+          // Ignoring multiple whitespaces
+          parts.splice(partsiterator, 1);
+        }
+      }
+
+      if (parts.length === 0) {
+        // Remove newline
+        continue;
+      }
+
+      switch (state) {
+        case '': // First run
+          if (parts[0] !== 'solid') {
+            // Invalid state
+            console.error(line);
+            console.error(`Invalid state "${parts[0]}", should be "solid"`);
+            return;
+          } else {
+            state = 'solid';
+          }
+          break;
+
+        case 'solid': // First face
+          if (parts[0] !== 'facet' || parts[1] !== 'normal') {
+            // Invalid state
+            console.error(line);
+            console.error(
+              `Invalid state "${parts[0]}", should be "facet normal"`
+            );
+            return;
+          } else {
+            // Push normal for first face
+            newNormal = new p5.Vector(
+              parseFloat(parts[2]),
+              parseFloat(parts[3]),
+              parseFloat(parts[4])
+            );
+            model.vertexNormals.push(newNormal, newNormal, newNormal);
+            state = 'facet normal';
+          }
+          break;
+
+        case 'facet normal': // After normal is defined
+          if (parts[0] !== 'outer' || parts[1] !== 'loop') {
+            // Invalid State
+            console.error(line);
+            console.error(`Invalid state "${parts[0]}", should be "outer loop"`);
+            return;
+          } else {
+            // Next should be vertices
+            state = 'vertex';
+          }
+          break;
+
+        case 'vertex':
+          if (parts[0] === 'vertex') {
+            //Vertex of triangle
+            newVertex = new p5.Vector(
+              parseFloat(parts[1]),
+              parseFloat(parts[2]),
+              parseFloat(parts[3])
+            );
+            model.vertices.push(newVertex);
+            model.uvs.push([0, 0]);
+            curVertexIndex.push(model.vertices.indexOf(newVertex));
+          } else if (parts[0] === 'endloop') {
+            // End of vertices
+            model.faces.push(curVertexIndex);
+            curVertexIndex = [];
+            state = 'endloop';
+          } else {
+            // Invalid State
+            console.error(line);
+            console.error(
+              `Invalid state "${parts[0]}", should be "vertex" or "endloop"`
+            );
+            return;
+          }
+          break;
+
+        case 'endloop':
+          if (parts[0] !== 'endfacet') {
+            // End of face
+            console.error(line);
+            console.error(`Invalid state "${parts[0]}", should be "endfacet"`);
+            return;
+          } else {
+            state = 'endfacet';
+          }
+          break;
+
+        case 'endfacet':
+          if (parts[0] === 'endsolid') {
+            // End of solid
+          } else if (parts[0] === 'facet' && parts[1] === 'normal') {
+            // Next face
+            newNormal = new p5.Vector(
+              parseFloat(parts[2]),
+              parseFloat(parts[3]),
+              parseFloat(parts[4])
+            );
+            model.vertexNormals.push(newNormal, newNormal, newNormal);
+            state = 'facet normal';
+          } else {
+            // Invalid State
+            console.error(line);
+            console.error(
+              `Invalid state "${parts[0]
+              }", should be "endsolid" or "facet normal"`
+            );
+            return;
+          }
+          break;
+
+        default:
+          console.error(`Invalid state "${state}"`);
+          break;
       }
     }
+    return model;
+  }
 
-    model.faces.push([3 * face, 3 * face + 1, 3 * face + 2]);
-    model.uvs.push([0, 0], [0, 0], [0, 0]);
-  }
-  if (hasColors) {
-    // add support for colors here.
-  }
-  return model;
+  /**
+   * Draws a <a href="#/p5.Geometry">p5.Geometry</a> object to the canvas.
+   *
+   * The parameter, `model`, is the
+   * <a href="#/p5.Geometry">p5.Geometry</a> object to draw.
+   * <a href="#/p5.Geometry">p5.Geometry</a> objects can be built with
+   * <a href="#/p5/buildGeometry">buildGeometry()</a>, or
+   * <a href="#/p5/beginGeometry">beginGeometry()</a> and
+   * <a href="#/p5/endGeometry">endGeometry()</a>. They can also be loaded from
+   * a file with <a href="#/p5/loadGeometry">loadGeometry()</a>.
+   *
+   * Note: `model()` can only be used in WebGL mode.
+   *
+   * @method model
+   * @param  {p5.Geometry} model 3D shape to be drawn.
+   *
+   * @example
+   * <div>
+   * <code>
+   * // Click and drag the mouse to view the scene from different angles.
+   *
+   * let shape;
+   *
+   * function setup() {
+   *   createCanvas(100, 100, WEBGL);
+   *
+   *   // Create the p5.Geometry object.
+   *   shape = buildGeometry(createShape);
+   *
+   *   describe('A white cone drawn on a gray background.');
+   * }
+   *
+   * function draw() {
+   *   background(200);
+   *
+   *   // Enable orbiting with the mouse.
+   *   orbitControl();
+   *
+   *   // Draw the p5.Geometry object.
+   *   model(shape);
+   * }
+   *
+   * // Create p5.Geometry object from a single cone.
+   * function createShape() {
+   *   cone();
+   * }
+   * </code>
+   * </div>
+   *
+   * <div>
+   * <code>
+   * // Click and drag the mouse to view the scene from different angles.
+   *
+   * let shape;
+   *
+   * function setup() {
+   *   createCanvas(100, 100, WEBGL);
+   *
+   *   // Create the p5.Geometry object.
+   *   shape = buildGeometry(createArrow);
+   *
+   *   describe('Two white arrows drawn on a gray background. The arrow on the right rotates slowly.');
+   * }
+   *
+   * function draw() {
+   *   background(50);
+   *
+   *   // Enable orbiting with the mouse.
+   *   orbitControl();
+   *
+   *   // Turn on the lights.
+   *   lights();
+   *
+   *   // Style the arrows.
+   *   noStroke();
+   *
+   *   // Draw the p5.Geometry object.
+   *   model(shape);
+   *
+   *   // Translate and rotate the coordinate system.
+   *   translate(30, 0, 0);
+   *   rotateZ(frameCount * 0.01);
+   *
+   *   // Draw the p5.Geometry object again.
+   *   model(shape);
+   * }
+   *
+   * function createArrow() {
+   *   // Add shapes to the p5.Geometry object.
+   *   push();
+   *   rotateX(PI);
+   *   cone(10);
+   *   translate(0, -10, 0);
+   *   cylinder(3, 20);
+   *   pop();
+   * }
+   * </code>
+   * </div>
+   *
+   * <div>
+   * <code>
+   * // Click and drag the mouse to view the scene from different angles.
+   *
+   * let shape;
+   *
+   * // Load the file and create a p5.Geometry object.
+   * function preload() {
+   *   shape = loadModel('assets/octahedron.obj');
+   * }
+   *
+   * function setup() {
+   *   createCanvas(100, 100, WEBGL);
+   *
+   *   describe('A white octahedron drawn against a gray background.');
+   * }
+   *
+   * function draw() {
+   *   background(200);
+   *
+   *   // Enable orbiting with the mouse.
+   *   orbitControl();
+   *
+   *   // Draw the shape.
+   *   model(shape);
+   * }
+   * </code>
+   * </div>
+   */
+  fn.model = function (model) {
+    this._assert3d('model');
+    p5._validateParameters('model', arguments);
+    if (model.vertices.length > 0) {
+      if (!this._renderer.geometryInHash(model.gid)) {
+
+        if (model.edges.length === 0) {
+          model._makeTriangleEdges();
+        }
+
+        model._edgesToVertices();
+        this._renderer.createBuffers(model.gid, model);
+      }
+
+      this._renderer.drawBuffers(model.gid);
+    }
+  };
 }
 
-/**
- * ASCII STL file starts with `solid 'nameOfFile'`
- * Then contain the normal of the face, starting with `facet normal`
- * Next contain a keyword indicating the start of face vertex, `outer loop`
- * Next comes the three vertex, starting with `vertex x y z`
- * Vertices ends with `endloop`
- * Face ends with `endfacet`
- * Next face starts with `facet normal`
- * The end of the file is indicated by `endsolid`
- */
-function parseASCIISTL(model, lines) {
-  let state = '';
-  let curVertexIndex = [];
-  let newNormal, newVertex;
+export default loading;
 
-  for (let iterator = 0; iterator < lines.length; ++iterator) {
-    const line = lines[iterator].trim();
-    const parts = line.split(' ');
-
-    for (let partsiterator = 0; partsiterator < parts.length; ++partsiterator) {
-      if (parts[partsiterator] === '') {
-        // Ignoring multiple whitespaces
-        parts.splice(partsiterator, 1);
-      }
-    }
-
-    if (parts.length === 0) {
-      // Remove newline
-      continue;
-    }
-
-    switch (state) {
-      case '': // First run
-        if (parts[0] !== 'solid') {
-          // Invalid state
-          console.error(line);
-          console.error(`Invalid state "${parts[0]}", should be "solid"`);
-          return;
-        } else {
-          state = 'solid';
-        }
-        break;
-
-      case 'solid': // First face
-        if (parts[0] !== 'facet' || parts[1] !== 'normal') {
-          // Invalid state
-          console.error(line);
-          console.error(
-            `Invalid state "${parts[0]}", should be "facet normal"`
-          );
-          return;
-        } else {
-          // Push normal for first face
-          newNormal = new p5.Vector(
-            parseFloat(parts[2]),
-            parseFloat(parts[3]),
-            parseFloat(parts[4])
-          );
-          model.vertexNormals.push(newNormal, newNormal, newNormal);
-          state = 'facet normal';
-        }
-        break;
-
-      case 'facet normal': // After normal is defined
-        if (parts[0] !== 'outer' || parts[1] !== 'loop') {
-          // Invalid State
-          console.error(line);
-          console.error(`Invalid state "${parts[0]}", should be "outer loop"`);
-          return;
-        } else {
-          // Next should be vertices
-          state = 'vertex';
-        }
-        break;
-
-      case 'vertex':
-        if (parts[0] === 'vertex') {
-          //Vertex of triangle
-          newVertex = new p5.Vector(
-            parseFloat(parts[1]),
-            parseFloat(parts[2]),
-            parseFloat(parts[3])
-          );
-          model.vertices.push(newVertex);
-          model.uvs.push([0, 0]);
-          curVertexIndex.push(model.vertices.indexOf(newVertex));
-        } else if (parts[0] === 'endloop') {
-          // End of vertices
-          model.faces.push(curVertexIndex);
-          curVertexIndex = [];
-          state = 'endloop';
-        } else {
-          // Invalid State
-          console.error(line);
-          console.error(
-            `Invalid state "${parts[0]}", should be "vertex" or "endloop"`
-          );
-          return;
-        }
-        break;
-
-      case 'endloop':
-        if (parts[0] !== 'endfacet') {
-          // End of face
-          console.error(line);
-          console.error(`Invalid state "${parts[0]}", should be "endfacet"`);
-          return;
-        } else {
-          state = 'endfacet';
-        }
-        break;
-
-      case 'endfacet':
-        if (parts[0] === 'endsolid') {
-          // End of solid
-        } else if (parts[0] === 'facet' && parts[1] === 'normal') {
-          // Next face
-          newNormal = new p5.Vector(
-            parseFloat(parts[2]),
-            parseFloat(parts[3]),
-            parseFloat(parts[4])
-          );
-          model.vertexNormals.push(newNormal, newNormal, newNormal);
-          state = 'facet normal';
-        } else {
-          // Invalid State
-          console.error(line);
-          console.error(
-            `Invalid state "${parts[0]
-            }", should be "endsolid" or "facet normal"`
-          );
-          return;
-        }
-        break;
-
-      default:
-        console.error(`Invalid state "${state}"`);
-        break;
-    }
-  }
-  return model;
+if(typeof p5 !== 'undefined'){
+  loading(p5, p5.prototype);
 }
-
-/**
- * Draws a <a href="#/p5.Geometry">p5.Geometry</a> object to the canvas.
- *
- * The parameter, `model`, is the
- * <a href="#/p5.Geometry">p5.Geometry</a> object to draw.
- * <a href="#/p5.Geometry">p5.Geometry</a> objects can be built with
- * <a href="#/p5/buildGeometry">buildGeometry()</a>, or
- * <a href="#/p5/beginGeometry">beginGeometry()</a> and
- * <a href="#/p5/endGeometry">endGeometry()</a>. They can also be loaded from
- * a file with <a href="#/p5/loadGeometry">loadGeometry()</a>.
- *
- * Note: `model()` can only be used in WebGL mode.
- *
- * @method model
- * @param  {p5.Geometry} model 3D shape to be drawn.
- *
- * @example
- * <div>
- * <code>
- * // Click and drag the mouse to view the scene from different angles.
- *
- * let shape;
- *
- * function setup() {
- *   createCanvas(100, 100, WEBGL);
- *
- *   // Create the p5.Geometry object.
- *   shape = buildGeometry(createShape);
- *
- *   describe('A white cone drawn on a gray background.');
- * }
- *
- * function draw() {
- *   background(200);
- *
- *   // Enable orbiting with the mouse.
- *   orbitControl();
- *
- *   // Draw the p5.Geometry object.
- *   model(shape);
- * }
- *
- * // Create p5.Geometry object from a single cone.
- * function createShape() {
- *   cone();
- * }
- * </code>
- * </div>
- *
- * <div>
- * <code>
- * // Click and drag the mouse to view the scene from different angles.
- *
- * let shape;
- *
- * function setup() {
- *   createCanvas(100, 100, WEBGL);
- *
- *   // Create the p5.Geometry object.
- *   shape = buildGeometry(createArrow);
- *
- *   describe('Two white arrows drawn on a gray background. The arrow on the right rotates slowly.');
- * }
- *
- * function draw() {
- *   background(50);
- *
- *   // Enable orbiting with the mouse.
- *   orbitControl();
- *
- *   // Turn on the lights.
- *   lights();
- *
- *   // Style the arrows.
- *   noStroke();
- *
- *   // Draw the p5.Geometry object.
- *   model(shape);
- *
- *   // Translate and rotate the coordinate system.
- *   translate(30, 0, 0);
- *   rotateZ(frameCount * 0.01);
- *
- *   // Draw the p5.Geometry object again.
- *   model(shape);
- * }
- *
- * function createArrow() {
- *   // Add shapes to the p5.Geometry object.
- *   push();
- *   rotateX(PI);
- *   cone(10);
- *   translate(0, -10, 0);
- *   cylinder(3, 20);
- *   pop();
- * }
- * </code>
- * </div>
- *
- * <div>
- * <code>
- * // Click and drag the mouse to view the scene from different angles.
- *
- * let shape;
- *
- * // Load the file and create a p5.Geometry object.
- * function preload() {
- *   shape = loadModel('assets/octahedron.obj');
- * }
- *
- * function setup() {
- *   createCanvas(100, 100, WEBGL);
- *
- *   describe('A white octahedron drawn against a gray background.');
- * }
- *
- * function draw() {
- *   background(200);
- *
- *   // Enable orbiting with the mouse.
- *   orbitControl();
- *
- *   // Draw the shape.
- *   model(shape);
- * }
- * </code>
- * </div>
- */
-p5.prototype.model = function (model) {
-  this._assert3d('model');
-  p5._validateParameters('model', arguments);
-  if (model.vertices.length > 0) {
-    if (!this._renderer.geometryInHash(model.gid)) {
-
-      if (model.edges.length === 0) {
-        model._makeTriangleEdges();
-      }
-
-      model._edgesToVertices();
-      this._renderer.createBuffers(model.gid, model);
-    }
-
-    this._renderer.drawBuffers(model.gid);
-  }
-};
-
-export default p5;

--- a/src/webgl/material.js
+++ b/src/webgl/material.js
@@ -5,3306 +5,3310 @@
  * @requires core
  */
 
-import p5 from '../core/main';
 import * as constants from '../core/constants';
-import './p5.Texture';
 
-/**
- * Loads vertex and fragment shaders to create a
- * <a href="#/p5.Shader">p5.Shader</a> object.
- *
- * Shaders are programs that run on the graphics processing unit (GPU). They
- * can process many pixels at the same time, making them fast for many
- * graphics tasks. They’re written in a language called
- * <a href="https://developer.mozilla.org/en-US/docs/Games/Techniques/3D_on_the_web/GLSL_Shaders" target="_blank">GLSL</a>
- * and run along with the rest of the code in a sketch.
- *
- * Once the <a href="#/p5.Shader">p5.Shader</a> object is created, it can be
- * used with the <a href="#/p5/shader">shader()</a> function, as in
- * `shader(myShader)`. A shader program consists of two files, a vertex shader
- * and a fragment shader. The vertex shader affects where 3D geometry is drawn
- * on the screen and the fragment shader affects color.
- *
- * `loadShader()` loads the vertex and fragment shaders from their `.vert` and
- * `.frag` files. For example, calling
- * `loadShader('assets/shader.vert', 'assets/shader.frag')` loads both
- * required shaders and returns a <a href="#/p5.Shader">p5.Shader</a> object.
- *
- * The third parameter, `successCallback`, is optional. If a function is
- * passed, it will be called once the shader has loaded. The callback function
- * can use the new <a href="#/p5.Shader">p5.Shader</a> object as its
- * parameter.
- *
- * The fourth parameter, `failureCallback`, is also optional. If a function is
- * passed, it will be called if the shader fails to load. The callback
- * function can use the event error as its parameter.
- *
- * Shaders can take time to load. Calling `loadShader()` in
- * <a href="#/p5/preload">preload()</a> ensures shaders load before they're
- * used in <a href="#/p5/setup">setup()</a> or <a href="#/p5/draw">draw()</a>.
- *
- * Note: Shaders can only be used in WebGL mode.
- *
- * @method loadShader
- * @param {String} vertFilename path of the vertex shader to be loaded.
- * @param {String} fragFilename path of the fragment shader to be loaded.
- * @param {Function} [successCallback] function to call once the shader is loaded. Can be passed the
- *                                     <a href="#/p5.Shader">p5.Shader</a> object.
- * @param {Function} [failureCallback] function to call if the shader fails to load. Can be passed an
- *                                     `Error` event object.
- * @return {p5.Shader} new shader created from the vertex and fragment shader files.
- *
- * @example
- * <div modernizr='webgl'>
- * <code>
- * // Note: A "uniform" is a global variable within a shader program.
- *
- * let mandelbrot;
- *
- * // Load the shader and create a p5.Shader object.
- * function preload() {
- *   mandelbrot = loadShader('assets/shader.vert', 'assets/shader.frag');
- * }
- *
- * function setup() {
- *   createCanvas(100, 100, WEBGL);
- *
- *   // Compile and apply the p5.Shader object.
- *   shader(mandelbrot);
- *
- *   // Set the shader uniform p to an array.
- *   mandelbrot.setUniform('p', [-0.74364388703, 0.13182590421]);
- *
- *   // Set the shader uniform r to the value 1.5.
- *   mandelbrot.setUniform('r', 1.5);
- *
- *   // Add a quad as a display surface for the shader.
- *   quad(-1, -1, 1, -1, 1, 1, -1, 1);
- *
- *   describe('A black fractal image on a magenta background.');
- * }
- * </code>
- * </div>
- *
- * <div>
- * <code>
- * // Note: A "uniform" is a global variable within a shader program.
- *
- * let mandelbrot;
- *
- * // Load the shader and create a p5.Shader object.
- * function preload() {
- *   mandelbrot = loadShader('assets/shader.vert', 'assets/shader.frag');
- * }
- *
- * function setup() {
- *   createCanvas(100, 100, WEBGL);
- *
- *   // Use the p5.Shader object.
- *   shader(mandelbrot);
- *
- *   // Set the shader uniform p to an array.
- *   mandelbrot.setUniform('p', [-0.74364388703, 0.13182590421]);
- *
- *   describe('A fractal image zooms in and out of focus.');
- * }
- *
- * function draw() {
- *   // Set the shader uniform r to a value that oscillates between 0 and 2.
- *   mandelbrot.setUniform('r', sin(frameCount * 0.01) + 1);
- *
- *   // Add a quad as a display surface for the shader.
- *   quad(-1, -1, 1, -1, 1, 1, -1, 1);
- * }
- * </code>
- * </div>
- */
-p5.prototype.loadShader = function (
-  vertFilename,
-  fragFilename,
-  successCallback,
-  failureCallback
-) {
-  p5._validateParameters('loadShader', arguments);
-  if (!failureCallback) {
-    failureCallback = console.error;
-  }
+function material(p5, fn){
+  /**
+   * Loads vertex and fragment shaders to create a
+   * <a href="#/p5.Shader">p5.Shader</a> object.
+   *
+   * Shaders are programs that run on the graphics processing unit (GPU). They
+   * can process many pixels at the same time, making them fast for many
+   * graphics tasks. They’re written in a language called
+   * <a href="https://developer.mozilla.org/en-US/docs/Games/Techniques/3D_on_the_web/GLSL_Shaders" target="_blank">GLSL</a>
+   * and run along with the rest of the code in a sketch.
+   *
+   * Once the <a href="#/p5.Shader">p5.Shader</a> object is created, it can be
+   * used with the <a href="#/p5/shader">shader()</a> function, as in
+   * `shader(myShader)`. A shader program consists of two files, a vertex shader
+   * and a fragment shader. The vertex shader affects where 3D geometry is drawn
+   * on the screen and the fragment shader affects color.
+   *
+   * `loadShader()` loads the vertex and fragment shaders from their `.vert` and
+   * `.frag` files. For example, calling
+   * `loadShader('assets/shader.vert', 'assets/shader.frag')` loads both
+   * required shaders and returns a <a href="#/p5.Shader">p5.Shader</a> object.
+   *
+   * The third parameter, `successCallback`, is optional. If a function is
+   * passed, it will be called once the shader has loaded. The callback function
+   * can use the new <a href="#/p5.Shader">p5.Shader</a> object as its
+   * parameter.
+   *
+   * The fourth parameter, `failureCallback`, is also optional. If a function is
+   * passed, it will be called if the shader fails to load. The callback
+   * function can use the event error as its parameter.
+   *
+   * Shaders can take time to load. Calling `loadShader()` in
+   * <a href="#/p5/preload">preload()</a> ensures shaders load before they're
+   * used in <a href="#/p5/setup">setup()</a> or <a href="#/p5/draw">draw()</a>.
+   *
+   * Note: Shaders can only be used in WebGL mode.
+   *
+   * @method loadShader
+   * @param {String} vertFilename path of the vertex shader to be loaded.
+   * @param {String} fragFilename path of the fragment shader to be loaded.
+   * @param {Function} [successCallback] function to call once the shader is loaded. Can be passed the
+   *                                     <a href="#/p5.Shader">p5.Shader</a> object.
+   * @param {Function} [failureCallback] function to call if the shader fails to load. Can be passed an
+   *                                     `Error` event object.
+   * @return {p5.Shader} new shader created from the vertex and fragment shader files.
+   *
+   * @example
+   * <div modernizr='webgl'>
+   * <code>
+   * // Note: A "uniform" is a global variable within a shader program.
+   *
+   * let mandelbrot;
+   *
+   * // Load the shader and create a p5.Shader object.
+   * function preload() {
+   *   mandelbrot = loadShader('assets/shader.vert', 'assets/shader.frag');
+   * }
+   *
+   * function setup() {
+   *   createCanvas(100, 100, WEBGL);
+   *
+   *   // Compile and apply the p5.Shader object.
+   *   shader(mandelbrot);
+   *
+   *   // Set the shader uniform p to an array.
+   *   mandelbrot.setUniform('p', [-0.74364388703, 0.13182590421]);
+   *
+   *   // Set the shader uniform r to the value 1.5.
+   *   mandelbrot.setUniform('r', 1.5);
+   *
+   *   // Add a quad as a display surface for the shader.
+   *   quad(-1, -1, 1, -1, 1, 1, -1, 1);
+   *
+   *   describe('A black fractal image on a magenta background.');
+   * }
+   * </code>
+   * </div>
+   *
+   * <div>
+   * <code>
+   * // Note: A "uniform" is a global variable within a shader program.
+   *
+   * let mandelbrot;
+   *
+   * // Load the shader and create a p5.Shader object.
+   * function preload() {
+   *   mandelbrot = loadShader('assets/shader.vert', 'assets/shader.frag');
+   * }
+   *
+   * function setup() {
+   *   createCanvas(100, 100, WEBGL);
+   *
+   *   // Use the p5.Shader object.
+   *   shader(mandelbrot);
+   *
+   *   // Set the shader uniform p to an array.
+   *   mandelbrot.setUniform('p', [-0.74364388703, 0.13182590421]);
+   *
+   *   describe('A fractal image zooms in and out of focus.');
+   * }
+   *
+   * function draw() {
+   *   // Set the shader uniform r to a value that oscillates between 0 and 2.
+   *   mandelbrot.setUniform('r', sin(frameCount * 0.01) + 1);
+   *
+   *   // Add a quad as a display surface for the shader.
+   *   quad(-1, -1, 1, -1, 1, 1, -1, 1);
+   * }
+   * </code>
+   * </div>
+   */
+  fn.loadShader = function (
+    vertFilename,
+    fragFilename,
+    successCallback,
+    failureCallback
+  ) {
+    p5._validateParameters('loadShader', arguments);
+    if (!failureCallback) {
+      failureCallback = console.error;
+    }
 
-  const loadedShader = new p5.Shader();
+    const loadedShader = new p5.Shader();
 
-  const self = this;
-  let loadedFrag = false;
-  let loadedVert = false;
+    const self = this;
+    let loadedFrag = false;
+    let loadedVert = false;
 
-  const onLoad = () => {
-    self._decrementPreload();
-    if (successCallback) {
-      successCallback(loadedShader);
+    const onLoad = () => {
+      self._decrementPreload();
+      if (successCallback) {
+        successCallback(loadedShader);
+      }
+    };
+
+    this.loadStrings(
+      vertFilename,
+      result => {
+        loadedShader._vertSrc = result.join('\n');
+        loadedVert = true;
+        if (loadedFrag) {
+          onLoad();
+        }
+      },
+      failureCallback
+    );
+
+    this.loadStrings(
+      fragFilename,
+      result => {
+        loadedShader._fragSrc = result.join('\n');
+        loadedFrag = true;
+        if (loadedVert) {
+          onLoad();
+        }
+      },
+      failureCallback
+    );
+
+    return loadedShader;
+  };
+
+  /**
+   * Creates a new <a href="#/p5.Shader">p5.Shader</a> object.
+   *
+   * Shaders are programs that run on the graphics processing unit (GPU). They
+   * can process many pixels at the same time, making them fast for many
+   * graphics tasks. They’re written in a language called
+   * <a href="https://developer.mozilla.org/en-US/docs/Games/Techniques/3D_on_the_web/GLSL_Shaders" target="_blank">GLSL</a>
+   * and run along with the rest of the code in a sketch.
+   *
+   * Once the <a href="#/p5.Shader">p5.Shader</a> object is created, it can be
+   * used with the <a href="#/p5/shader">shader()</a> function, as in
+   * `shader(myShader)`. A shader program consists of two parts, a vertex shader
+   * and a fragment shader. The vertex shader affects where 3D geometry is drawn
+   * on the screen and the fragment shader affects color.
+   *
+   * The first parameter, `vertSrc`, sets the vertex shader. It’s a string that
+   * contains the vertex shader program written in GLSL.
+   *
+   * The second parameter, `fragSrc`, sets the fragment shader. It’s a string
+   * that contains the fragment shader program written in GLSL.
+   *
+   * A shader can optionally describe *hooks,* which are functions in GLSL that
+   * users may choose to provide to customize the behavior of the shader using the
+   * <a href="#/p5.Shader/modify">`modify()`</a> method of `p5.Shader`. These are added by
+   * describing the hooks in a third parameter, `options`, and referencing the hooks in
+   * your `vertSrc` or `fragSrc`. Hooks for the vertex or fragment shader are described under
+   * the `vertex` and `fragment` keys of `options`. Each one is an object. where each key is
+   * the type and name of a hook function, and each value is a string with the
+   * parameter list and default implementation of the hook. For example, to let users
+   * optionally run code at the start of the vertex shader, the options object could
+   * include:
+   *
+   * ```js
+   * {
+   *   vertex: {
+   *     'void beforeVertex': '() {}'
+   *   }
+   * }
+   * ```
+   *
+   * Then, in your vertex shader source, you can run a hook by calling a function
+   * with the same name prefixed by `HOOK_`. If you want to check if the default
+   * hook has been replaced, maybe to avoid extra overhead, you can check if the
+   * same name prefixed by `AUGMENTED_HOOK_` has been defined:
+   *
+   * ```glsl
+   * void main() {
+   *   // In most cases, just calling the hook is fine:
+   *   HOOK_beforeVertex();
+   *
+   *   // Alternatively, for more efficiency:
+   *   #ifdef AUGMENTED_HOOK_beforeVertex
+   *   HOOK_beforeVertex();
+   *   #endif
+   *
+   *   // Add the rest of your shader code here!
+   * }
+   * ```
+   *
+   * Note: Only filter shaders can be used in 2D mode. All shaders can be used
+   * in WebGL mode.
+   *
+   * @method createShader
+   * @param {String} vertSrc source code for the vertex shader.
+   * @param {String} fragSrc source code for the fragment shader.
+   * @param {Object} [options] An optional object describing how this shader can
+   * be augmented with hooks. It can include:
+   *  - `vertex`: An object describing the available vertex shader hooks.
+   *  - `fragment`: An object describing the available frament shader hooks.
+   * @returns {p5.Shader} new shader object created from the
+   * vertex and fragment shaders.
+   *
+   * @example
+   * <div modernizr='webgl'>
+   * <code>
+   * // Note: A "uniform" is a global variable within a shader program.
+   *
+   * // Create a string with the vertex shader program.
+   * // The vertex shader is called for each vertex.
+   * let vertSrc = `
+   * precision highp float;
+   * uniform mat4 uModelViewMatrix;
+   * uniform mat4 uProjectionMatrix;
+   * attribute vec3 aPosition;
+   * attribute vec2 aTexCoord;
+   * varying vec2 vTexCoord;
+   *
+   * void main() {
+   *   vTexCoord = aTexCoord;
+   *   vec4 positionVec4 = vec4(aPosition, 1.0);
+   *   gl_Position = uProjectionMatrix * uModelViewMatrix * positionVec4;
+   * }
+   * `;
+   *
+   * // Create a string with the fragment shader program.
+   * // The fragment shader is called for each pixel.
+   * let fragSrc = `
+   * precision highp float;
+   *
+   * void main() {
+   *   // Set each pixel's RGBA value to yellow.
+   *   gl_FragColor = vec4(1.0, 1.0, 0.0, 1.0);
+   * }
+   * `;
+   *
+   * function setup() {
+   *   createCanvas(100, 100, WEBGL);
+   *
+   *   // Create a p5.Shader object.
+   *   let shaderProgram = createShader(vertSrc, fragSrc);
+   *
+   *   // Compile and apply the p5.Shader object.
+   *   shader(shaderProgram);
+   *
+   *   // Style the drawing surface.
+   *   noStroke();
+   *
+   *   // Add a plane as a drawing surface.
+   *   plane(100, 100);
+   *
+   *   describe('A yellow square.');
+   * }
+   * </code>
+   * </div>
+   *
+   * <div>
+   * <code>
+   * // Note: A "uniform" is a global variable within a shader program.
+   *
+   * // Create a string with the vertex shader program.
+   * // The vertex shader is called for each vertex.
+   * let vertSrc = `
+   * precision highp float;
+   * uniform mat4 uModelViewMatrix;
+   * uniform mat4 uProjectionMatrix;
+   * attribute vec3 aPosition;
+   * attribute vec2 aTexCoord;
+   * varying vec2 vTexCoord;
+   *
+   * void main() {
+   *   vTexCoord = aTexCoord;
+   *   vec4 positionVec4 = vec4(aPosition, 1.0);
+   *   gl_Position = uProjectionMatrix * uModelViewMatrix * positionVec4;
+   * }
+   * `;
+   *
+   * // Create a string with the fragment shader program.
+   * // The fragment shader is called for each pixel.
+   * let fragSrc = `
+   * precision highp float;
+   * uniform vec2 p;
+   * uniform float r;
+   * const int numIterations = 500;
+   * varying vec2 vTexCoord;
+   *
+   * void main() {
+   *   vec2 c = p + gl_FragCoord.xy * r;
+   *   vec2 z = c;
+   *   float n = 0.0;
+   *
+   *   for (int i = numIterations; i > 0; i--) {
+   *     if (z.x * z.x + z.y * z.y > 4.0) {
+   *       n = float(i) / float(numIterations);
+   *       break;
+   *     }
+   *     z = vec2(z.x * z.x - z.y * z.y, 2.0 * z.x * z.y) + c;
+   *   }
+   *
+   *   gl_FragColor = vec4(
+   *     0.5 - cos(n * 17.0) / 2.0,
+   *     0.5 - cos(n * 13.0) / 2.0,
+   *     0.5 - cos(n * 23.0) / 2.0,
+   *     1.0
+   *   );
+   * }
+   * `;
+   *
+   * function setup() {
+   *   createCanvas(100, 100, WEBGL);
+   *
+   *   // Create a p5.Shader object.
+   *   let mandelbrot = createShader(vertSrc, fragSrc);
+   *
+   *   // Compile and apply the p5.Shader object.
+   *   shader(mandelbrot);
+   *
+   *   // Set the shader uniform p to an array.
+   *   // p is the center point of the Mandelbrot image.
+   *   mandelbrot.setUniform('p', [-0.74364388703, 0.13182590421]);
+   *
+   *   // Set the shader uniform r to 0.005.
+   *   // r is the size of the image in Mandelbrot-space.
+   *   mandelbrot.setUniform('r', 0.005);
+   *
+   *   // Style the drawing surface.
+   *   noStroke();
+   *
+   *   // Add a plane as a drawing surface.
+   *   plane(100, 100);
+   *
+   *   describe('A black fractal image on a magenta background.');
+   * }
+   * </code>
+   * </div>
+   *
+   * <div>
+   * <code>
+   * // Note: A "uniform" is a global variable within a shader program.
+   *
+   * // Create a string with the vertex shader program.
+   * // The vertex shader is called for each vertex.
+   * let vertSrc = `
+   * precision highp float;
+   * uniform mat4 uModelViewMatrix;
+   * uniform mat4 uProjectionMatrix;
+   *
+   * attribute vec3 aPosition;
+   * attribute vec2 aTexCoord;
+   * varying vec2 vTexCoord;
+   *
+   * void main() {
+   *   vTexCoord = aTexCoord;
+   *   vec4 positionVec4 = vec4(aPosition, 1.0);
+   *   gl_Position = uProjectionMatrix * uModelViewMatrix * positionVec4;
+   * }
+   * `;
+   *
+   * // Create a string with the fragment shader program.
+   * // The fragment shader is called for each pixel.
+   * let fragSrc = `
+   * precision highp float;
+   * uniform vec2 p;
+   * uniform float r;
+   * const int numIterations = 500;
+   * varying vec2 vTexCoord;
+   *
+   * void main() {
+   *   vec2 c = p + gl_FragCoord.xy * r;
+   *   vec2 z = c;
+   *   float n = 0.0;
+   *
+   *   for (int i = numIterations; i > 0; i--) {
+   *     if (z.x * z.x + z.y * z.y > 4.0) {
+   *       n = float(i) / float(numIterations);
+   *       break;
+   *     }
+   *
+   *     z = vec2(z.x * z.x - z.y * z.y, 2.0 * z.x * z.y) + c;
+   *   }
+   *
+   *   gl_FragColor = vec4(
+   *     0.5 - cos(n * 17.0) / 2.0,
+   *     0.5 - cos(n * 13.0) / 2.0,
+   *     0.5 - cos(n * 23.0) / 2.0,
+   *     1.0
+   *   );
+   * }
+   * `;
+   *
+   * let mandelbrot;
+   *
+   * function setup() {
+   *   createCanvas(100, 100, WEBGL);
+   *
+   *   // Create a p5.Shader object.
+   *   mandelbrot = createShader(vertSrc, fragSrc);
+   *
+   *   // Apply the p5.Shader object.
+   *   shader(mandelbrot);
+   *
+   *   // Set the shader uniform p to an array.
+   *   // p is the center point of the Mandelbrot image.
+   *   mandelbrot.setUniform('p', [-0.74364388703, 0.13182590421]);
+   *
+   *   describe('A fractal image zooms in and out of focus.');
+   * }
+   *
+   * function draw() {
+   *   // Set the shader uniform r to a value that oscillates
+   *   // between 0 and 0.005.
+   *   // r is the size of the image in Mandelbrot-space.
+   *   let radius = 0.005 * (sin(frameCount * 0.01) + 1);
+   *   mandelbrot.setUniform('r', radius);
+   *
+   *   // Style the drawing surface.
+   *   noStroke();
+   *
+   *   // Add a plane as a drawing surface.
+   *   plane(100, 100);
+   * }
+   * </code>
+   * </div>
+   *
+   * <div>
+   * <code>
+   * // A shader with hooks.
+   * let myShader;
+   *
+   * // A shader with modified hooks.
+   * let modifiedShader;
+   *
+   * // Create a string with the vertex shader program.
+   * // The vertex shader is called for each vertex.
+   * let vertSrc = `
+   * precision highp float;
+   * uniform mat4 uModelViewMatrix;
+   * uniform mat4 uProjectionMatrix;
+   *
+   * attribute vec3 aPosition;
+   * attribute vec2 aTexCoord;
+   *
+   * void main() {
+   *   vec4 positionVec4 = vec4(aPosition, 1.0);
+   *   gl_Position = uProjectionMatrix * uModelViewMatrix * positionVec4;
+   * }
+   * `;
+   *
+   * // Create a fragment shader that uses a hook.
+   * let fragSrc = `
+   * precision highp float;
+   * void main() {
+   *   // Let users override the color
+   *   gl_FragColor = HOOK_getColor(vec4(1., 0., 0., 1.));
+   * }
+   * `;
+   *
+   * function setup() {
+   *   createCanvas(50, 50, WEBGL);
+   *
+   *   // Create a shader with hooks
+   *   myShader = createShader(vertSrc, fragSrc, {
+   *     fragment: {
+   *       'vec4 getColor': '(vec4 color) { return color; }'
+   *     }
+   *   });
+   *
+   *   // Make a version of the shader with a hook overridden
+   *   modifiedShader = myShader.modify({
+   *     'vec4 getColor': `(vec4 color) {
+   *       return vec4(0., 0., 1., 1.);
+   *     }`
+   *   });
+   * }
+   *
+   * function draw() {
+   *   noStroke();
+   *
+   *   push();
+   *   shader(myShader);
+   *   translate(-width/3, 0);
+   *   sphere(10);
+   *   pop();
+   *
+   *   push();
+   *   shader(modifiedShader);
+   *   translate(width/3, 0);
+   *   sphere(10);
+   *   pop();
+   * }
+   * </code>
+   * </div>
+   */
+  fn.createShader = function (vertSrc, fragSrc, options) {
+    p5._validateParameters('createShader', arguments);
+    return new p5.Shader(this._renderer, vertSrc, fragSrc, options);
+  };
+
+  /**
+   * Creates a <a href="#/p5.Shader">p5.Shader</a> object to be used with the
+   * <a href="#/p5/filter">filter()</a> function.
+   *
+   * `createFilterShader()` works like
+   * <a href="#/p5/createShader">createShader()</a> but has a default vertex
+   * shader included. `createFilterShader()` is intended to be used along with
+   * <a href="#/p5/filter">filter()</a> for filtering the contents of a canvas.
+   * A filter shader will be applied to the whole canvas instead of just
+   * <a href="#/p5.Geometry">p5.Geometry</a> objects.
+   *
+   * The parameter, `fragSrc`, sets the fragment shader. It’s a string that
+   * contains the fragment shader program written in
+   * <a href="https://developer.mozilla.org/en-US/docs/Games/Techniques/3D_on_the_web/GLSL_Shaders" target="_blank">GLSL</a>.
+   *
+   * The <a href="#/p5.Shader">p5.Shader</a> object that's created has some
+   * uniforms that can be set:
+   * - `sampler2D tex0`, which contains the canvas contents as a texture.
+   * - `vec2 canvasSize`, which is the width and height of the canvas, not including pixel density.
+   * - `vec2 texelSize`, which is the size of a physical pixel including pixel density. This is calculated as `1.0 / (width * density)` for the pixel width and `1.0 / (height * density)` for the pixel height.
+   *
+   * The <a href="#/p5.Shader">p5.Shader</a> that's created also provides
+   * `varying vec2 vTexCoord`, a coordinate with values between 0 and 1.
+   * `vTexCoord` describes where on the canvas the pixel will be drawn.
+   *
+   * For more info about filters and shaders, see Adam Ferriss' <a href="https://github.com/aferriss/p5jsShaderExamples">repo of shader examples</a>
+   * or the <a href="https://p5js.org/learn/getting-started-in-webgl-shaders.html">Introduction to Shaders</a> tutorial.
+   *
+   * @method createFilterShader
+   * @param {String} fragSrc source code for the fragment shader.
+   * @returns {p5.Shader} new shader object created from the fragment shader.
+   *
+   * @example
+   * <div modernizr='webgl'>
+   * <code>
+   * function setup() {
+   *   let fragSrc = `precision highp float;
+   *   void main() {
+   *     gl_FragColor = vec4(1.0, 1.0, 0.0, 1.0);
+   *   }`;
+   *
+   *   createCanvas(100, 100, WEBGL);
+   *   let s = createFilterShader(fragSrc);
+   *   filter(s);
+   *   describe('a yellow canvas');
+   * }
+   * </code>
+   * </div>
+   *
+   * <div modernizr='webgl'>
+   * <code>
+   * let img, s;
+   * function preload() {
+   *   img = loadImage('assets/bricks.jpg');
+   * }
+   * function setup() {
+   *   let fragSrc = `precision highp float;
+   *
+   *   // x,y coordinates, given from the vertex shader
+   *   varying vec2 vTexCoord;
+   *
+   *   // the canvas contents, given from filter()
+   *   uniform sampler2D tex0;
+   *   // other useful information from the canvas
+   *   uniform vec2 texelSize;
+   *   uniform vec2 canvasSize;
+   *   // a custom variable from this sketch
+   *   uniform float darkness;
+   *
+   *   void main() {
+   *     // get the color at current pixel
+   *     vec4 color = texture2D(tex0, vTexCoord);
+   *     // set the output color
+   *     color.b = 1.0;
+   *     color *= darkness;
+   *     gl_FragColor = vec4(color.rgb, 1.0);
+   *   }`;
+   *
+   *   createCanvas(100, 100, WEBGL);
+   *   s = createFilterShader(fragSrc);
+   * }
+   * function draw() {
+   *   image(img, -50, -50);
+   *   s.setUniform('darkness', 0.5);
+   *   filter(s);
+   *   describe('a image of bricks tinted dark blue');
+   * }
+   * </code>
+   * </div>
+   */
+  fn.createFilterShader = function (fragSrc) {
+    p5._validateParameters('createFilterShader', arguments);
+    let defaultVertV1 = `
+      uniform mat4 uModelViewMatrix;
+      uniform mat4 uProjectionMatrix;
+
+      attribute vec3 aPosition;
+      // texcoords only come from p5 to vertex shader
+      // so pass texcoords on to the fragment shader in a varying variable
+      attribute vec2 aTexCoord;
+      varying vec2 vTexCoord;
+
+      void main() {
+        // transferring texcoords for the frag shader
+        vTexCoord = aTexCoord;
+
+        // copy position with a fourth coordinate for projection (1.0 is normal)
+        vec4 positionVec4 = vec4(aPosition, 1.0);
+
+        // project to 3D space
+        gl_Position = uProjectionMatrix * uModelViewMatrix * positionVec4;
+      }
+    `;
+    let defaultVertV2 = `#version 300 es
+      uniform mat4 uModelViewMatrix;
+      uniform mat4 uProjectionMatrix;
+
+      in vec3 aPosition;
+      in vec2 aTexCoord;
+      out vec2 vTexCoord;
+
+      void main() {
+        // transferring texcoords for the frag shader
+        vTexCoord = aTexCoord;
+
+        // copy position with a fourth coordinate for projection (1.0 is normal)
+        vec4 positionVec4 = vec4(aPosition, 1.0);
+
+        // project to 3D space
+        gl_Position = uProjectionMatrix * uModelViewMatrix * positionVec4;
+      }
+    `;
+    let vertSrc = fragSrc.includes('#version 300 es') ? defaultVertV2 : defaultVertV1;
+    const shader = new p5.Shader(this._renderer, vertSrc, fragSrc);
+    if (this._renderer.GL) {
+      shader.ensureCompiledOnContext(this);
+    } else {
+      shader.ensureCompiledOnContext(this._renderer.getFilterGraphicsLayer());
+    }
+    return shader;
+  };
+
+  /**
+   * Sets the <a href="#/p5.Shader">p5.Shader</a> object to apply while drawing.
+   *
+   * Shaders are programs that run on the graphics processing unit (GPU). They
+   * can process many pixels or vertices at the same time, making them fast for
+   * many graphics tasks. They’re written in a language called
+   * <a href="https://developer.mozilla.org/en-US/docs/Games/Techniques/3D_on_the_web/GLSL_Shaders" target="_blank">GLSL</a>
+   * and run along with the rest of the code in a sketch.
+   * <a href="#/p5.Shader">p5.Shader</a> objects can be created using the
+   * <a href="#/p5/createShader">createShader()</a> and
+   * <a href="#/p5/loadShader">loadShader()</a> functions.
+   *
+   * The parameter, `s`, is the <a href="#/p5.Shader">p5.Shader</a> object to
+   * apply. For example, calling `shader(myShader)` applies `myShader` to
+   * process each pixel on the canvas. The shader will be used for:
+   * - Fills when a texture is enabled if it includes a uniform `sampler2D`.
+   * - Fills when lights are enabled if it includes the attribute `aNormal`, or if it has any of the following uniforms: `uUseLighting`, `uAmbientLightCount`, `uDirectionalLightCount`, `uPointLightCount`, `uAmbientColor`, `uDirectionalDiffuseColors`, `uDirectionalSpecularColors`, `uPointLightLocation`, `uPointLightDiffuseColors`, `uPointLightSpecularColors`, `uLightingDirection`, or `uSpecular`.
+   * - Fills whenever there are no lights or textures.
+   * - Strokes if it includes the uniform `uStrokeWeight`.
+   *
+   * The source code from a <a href="#/p5.Shader">p5.Shader</a> object's
+   * fragment and vertex shaders will be compiled the first time it's passed to
+   * `shader()`. See
+   * <a href="https://developer.mozilla.org/en-US/docs/Web/API/WebGLRenderingContext/compileShader" target="_blank">MDN</a>
+   * for more information about compiling shaders.
+   *
+   * Calling <a href="#/p5/resetShader">resetShader()</a> restores a sketch’s
+   * default shaders.
+   *
+   * Note: Shaders can only be used in WebGL mode.
+   *
+   * @method shader
+   * @chainable
+   * @param {p5.Shader} s <a href="#/p5.Shader">p5.Shader</a> object
+   *                      to apply.
+   *
+   * @example
+   * <div modernizr='webgl'>
+   * <code>
+   * // Note: A "uniform" is a global variable within a shader program.
+   *
+   * // Create a string with the vertex shader program.
+   * // The vertex shader is called for each vertex.
+   * let vertSrc = `
+   * precision highp float;
+   * uniform mat4 uModelViewMatrix;
+   * uniform mat4 uProjectionMatrix;
+   *
+   * attribute vec3 aPosition;
+   * attribute vec2 aTexCoord;
+   * varying vec2 vTexCoord;
+   *
+   * void main() {
+   *   vTexCoord = aTexCoord;
+   *   vec4 positionVec4 = vec4(aPosition, 1.0);
+   *   gl_Position = uProjectionMatrix * uModelViewMatrix * positionVec4;
+   * }
+   * `;
+   *
+   * // Create a string with the fragment shader program.
+   * // The fragment shader is called for each pixel.
+   * let fragSrc = `
+   * precision highp float;
+   *
+   * void main() {
+   *   // Set each pixel's RGBA value to yellow.
+   *   gl_FragColor = vec4(1.0, 1.0, 0.0, 1.0);
+   * }
+   * `;
+   *
+   * function setup() {
+   *   createCanvas(100, 100, WEBGL);
+   *
+   *   // Create a p5.Shader object.
+   *   let shaderProgram = createShader(vertSrc, fragSrc);
+   *
+   *   // Apply the p5.Shader object.
+   *   shader(shaderProgram);
+   *
+   *   // Style the drawing surface.
+   *   noStroke();
+   *
+   *   // Add a plane as a drawing surface.
+   *   plane(100, 100);
+   *
+   *   describe('A yellow square.');
+   * }
+   * </code>
+   * </div>
+   *
+   * <div>
+   * <code>
+   * // Note: A "uniform" is a global variable within a shader program.
+   *
+   * let mandelbrot;
+   *
+   * // Load the shader and create a p5.Shader object.
+   * function preload() {
+   *   mandelbrot = loadShader('assets/shader.vert', 'assets/shader.frag');
+   * }
+   *
+   * function setup() {
+   *   createCanvas(100, 100, WEBGL);
+   *
+   *   // Use the p5.Shader object.
+   *   shader(mandelbrot);
+   *
+   *   // Set the shader uniform p to an array.
+   *   mandelbrot.setUniform('p', [-0.74364388703, 0.13182590421]);
+   *
+   *   describe('A fractal image zooms in and out of focus.');
+   * }
+   *
+   * function draw() {
+   *   // Set the shader uniform r to a value that oscillates between 0 and 2.
+   *   mandelbrot.setUniform('r', sin(frameCount * 0.01) + 1);
+   *
+   *   // Add a quad as a display surface for the shader.
+   *   quad(-1, -1, 1, -1, 1, 1, -1, 1);
+   * }
+   * </code>
+   * </div>
+   *
+   * <div>
+   * <code>
+   * // Note: A "uniform" is a global variable within a shader program.
+   *
+   * let redGreen;
+   * let orangeBlue;
+   * let showRedGreen = false;
+   *
+   * // Load the shader and create two separate p5.Shader objects.
+   * function preload() {
+   *   redGreen = loadShader('assets/shader.vert', 'assets/shader-gradient.frag');
+   *   orangeBlue = loadShader('assets/shader.vert', 'assets/shader-gradient.frag');
+   * }
+   *
+   * function setup() {
+   *   createCanvas(100, 100, WEBGL);
+   *
+   *   // Initialize the redGreen shader.
+   *   shader(redGreen);
+   *
+   *   // Set the redGreen shader's center and background color.
+   *   redGreen.setUniform('colorCenter', [1.0, 0.0, 0.0]);
+   *   redGreen.setUniform('colorBackground', [0.0, 1.0, 0.0]);
+   *
+   *   // Initialize the orangeBlue shader.
+   *   shader(orangeBlue);
+   *
+   *   // Set the orangeBlue shader's center and background color.
+   *   orangeBlue.setUniform('colorCenter', [1.0, 0.5, 0.0]);
+   *   orangeBlue.setUniform('colorBackground', [0.226, 0.0, 0.615]);
+   *
+   *   describe(
+   *     'The scene toggles between two circular gradients when the user double-clicks. An orange and blue gradient vertically, and red and green gradient moves horizontally.'
+   *   );
+   * }
+   *
+   * function draw() {
+   *   // Update the offset values for each shader.
+   *   // Move orangeBlue vertically.
+   *   // Move redGreen horizontally.
+   *   orangeBlue.setUniform('offset', [0, sin(frameCount * 0.01) + 1]);
+   *   redGreen.setUniform('offset', [sin(frameCount * 0.01), 1]);
+   *
+   *   if (showRedGreen === true) {
+   *     shader(redGreen);
+   *   } else {
+   *     shader(orangeBlue);
+   *   }
+   *
+   *   // Style the drawing surface.
+   *   noStroke();
+   *
+   *   // Add a quad as a drawing surface.
+   *   quad(-1, -1, 1, -1, 1, 1, -1, 1);
+   * }
+   *
+   * // Toggle between shaders when the user double-clicks.
+   * function doubleClicked() {
+   *   showRedGreen = !showRedGreen;
+   * }
+   * </code>
+   * </div>
+   */
+  fn.shader = function (s) {
+    this._assert3d('shader');
+    p5._validateParameters('shader', arguments);
+
+    s.ensureCompiledOnContext(this);
+
+    if (s.isStrokeShader()) {
+      this._renderer.states.userStrokeShader = s;
+    } else {
+      this._renderer.states.userFillShader = s;
+      this._renderer.states._useNormalMaterial = false;
+    }
+
+    s.setDefaultUniforms();
+
+    return this;
+  };
+
+  /**
+   * Get the default shader used with lights, materials,
+   * and textures.
+   *
+   * You can call <a href="#/p5.Shader/modify">`baseMaterialShader().modify()`</a>
+   * and change any of the following hooks:
+   *
+   * <table>
+   * <tr><th>Hook</th><th>Description</th></tr>
+   * <tr><td>
+   *
+   * `void beforeVertex`
+   *
+   * </td><td>
+   *
+   * Called at the start of the vertex shader.
+   *
+   * </td></tr>
+   * <tr><td>
+   *
+   * `vec3 getLocalPosition`
+   *
+   * </td><td>
+   *
+   * Update the position of vertices before transforms are applied. It takes in `vec3 position` and must return a modified version.
+   *
+   * </td></tr>
+   * <tr><td>
+   *
+   * `vec3 getWorldPosition`
+   *
+   * </td><td>
+   *
+   * Update the position of vertices after transforms are applied. It takes in `vec3 position` and pust return a modified version.
+   *
+   * </td></tr>
+   * <tr><td>
+   *
+   * `vec3 getLocalNormal`
+   *
+   * </td><td>
+   *
+   * Update the normal before transforms are applied. It takes in `vec3 normal` and must return a modified version.
+   *
+   * </td></tr>
+   * <tr><td>
+   *
+   * `vec3 getWorldNormal`
+   *
+   * </td><td>
+   *
+   * Update the normal after transforms are applied. It takes in `vec3 normal` and must return a modified version.
+   *
+   * </td></tr>
+   * <tr><td>
+   *
+   * `vec2 getUV`
+   *
+   * </td><td>
+   *
+   * Update the texture coordinates. It takes in `vec2 uv` and must return a modified version.
+   *
+   * </td></tr>
+   * <tr><td>
+   *
+   * `vec4 getVertexColor`
+   *
+   * </td><td>
+   *
+   * Update the color of each vertex. It takes in a `vec4 color` and must return a modified version.
+   *
+   * </td></tr>
+   * <tr><td>
+   *
+   * `void afterVertex`
+   *
+   * </td><td>
+   *
+   * Called at the end of the vertex shader.
+   *
+   * </td></tr>
+   * <tr><td>
+   *
+   * `void beforeFragment`
+   *
+   * </td><td>
+   *
+   * Called at the start of the fragment shader.
+   *
+   * </td></tr>
+   * <tr><td>
+   *
+   * `Inputs getPixelInputs`
+   *
+   * </td><td>
+   *
+   * Update the per-pixel inputs of the material. It takes in an `Inputs` struct, which includes:
+   * - `vec3 normal`, the direction pointing out of the surface
+   * - `vec2 texCoord`, a vector where `x` and `y` are between 0 and 1 describing the spot on a texture the pixel is mapped to, as a fraction of the texture size
+   * - `vec3 ambientLight`, the ambient light color on the vertex
+   * - `vec4 color`, the base material color of the pixel
+   * - `vec3 ambientMaterial`, the color of the pixel when affected by ambient light
+   * - `vec3 specularMaterial`, the color of the pixel when reflecting specular highlights
+   * - `vec3 emissiveMaterial`, the light color emitted by the pixel
+   * - `float shininess`, a number representing how sharp specular reflections should be, from 1 to infinity
+   * - `float metalness`, a number representing how mirrorlike the material should be, between 0 and 1
+   * The struct can be modified and returned.
+   * </td></tr>
+   * <tr><td>
+   *
+   * `vec4 combineColors`
+   *
+   * </td><td>
+   *
+   * Take in a `ColorComponents` struct containing all the different components of light, and combining them into
+   * a single final color. The struct contains:
+   * - `vec3 baseColor`, the base color of the pixel
+   * - `float opacity`, the opacity between 0 and 1 that it should be drawn at
+   * - `vec3 ambientColor`, the color of the pixel when affected by ambient light
+   * - `vec3 specularColor`, the color of the pixel when affected by specular reflections
+   * - `vec3 diffuse`, the amount of diffused light hitting the pixel
+   * - `vec3 ambient`, the amount of ambient light hitting the pixel
+   * - `vec3 specular`, the amount of specular reflection hitting the pixel
+   * - `vec3 emissive`, the amount of light emitted by the pixel
+   *
+   * </td></tr>
+   * <tr><td>
+   *
+   * `vec4 getFinalColor`
+   *
+   * </td><td>
+   *
+   * Update the final color after mixing. It takes in a `vec4 color` and must return a modified version.
+   *
+   * </td></tr>
+   * <tr><td>
+   *
+   * `void afterFragment`
+   *
+   * </td><td>
+   *
+   * Called at the end of the fragment shader.
+   *
+   * </td></tr>
+   * </table>
+   *
+   * Most of the time, you will need to write your hooks in GLSL ES version 300. If you
+   * are using WebGL 1 instead of 2, write your hooks in GLSL ES 100 instead.
+   *
+   * Call `baseMaterialShader().inspectHooks()` to see all the possible hooks and
+   * their default implementations.
+   *
+   * @method baseMaterialShader
+   * @beta
+   * @returns {p5.Shader} The material shader
+   *
+   * @example
+   * <div modernizr='webgl'>
+   * <code>
+   * let myShader;
+   *
+   * function setup() {
+   *   createCanvas(200, 200, WEBGL);
+   *   myShader = baseMaterialShader().modify({
+   *     uniforms: {
+   *       'float time': () => millis()
+   *     },
+   *     'vec3 getWorldPosition': `(vec3 pos) {
+   *       pos.y += 20.0 * sin(time * 0.001 + pos.x * 0.05);
+   *       return pos;
+   *     }`
+   *   });
+   * }
+   *
+   * function draw() {
+   *   background(255);
+   *   shader(myShader);
+   *   lights();
+   *   noStroke();
+   *   fill('red');
+   *   sphere(50);
+   * }
+   * </code>
+   * </div>
+   *
+   * @example
+   * <div modernizr='webgl'>
+   * <code>
+   * let myShader;
+   *
+   * function setup() {
+   *   createCanvas(200, 200, WEBGL);
+   *   myShader = baseMaterialShader().modify({
+   *     declarations: 'vec3 myNormal;',
+   *     'Inputs getPixelInputs': `(Inputs inputs) {
+   *       myNormal = inputs.normal;
+   *       return inputs;
+   *     }`,
+   *     'vec4 getFinalColor': `(vec4 color) {
+   *       return mix(
+   *         vec4(1.0, 1.0, 1.0, 1.0),
+   *         color,
+   *         abs(dot(myNormal, vec3(0.0, 0.0, 1.0)))
+   *       );
+   *     }`
+   *   });
+   * }
+   *
+   * function draw() {
+   *   background(255);
+   *   rotateY(millis() * 0.001);
+   *   shader(myShader);
+   *   lights();
+   *   noStroke();
+   *   fill('red');
+   *   torus(30);
+   * }
+   * </code>
+   * </div>
+   *
+   * @example
+   * <div modernizr='webgl'>
+   * <code>
+   * let myShader;
+   * let environment;
+   *
+   * function preload() {
+   *   environment = loadImage('assets/outdoor_spheremap.jpg');
+   * }
+   *
+   * function setup() {
+   *   createCanvas(200, 200, WEBGL);
+   *   myShader = baseMaterialShader().modify({
+   *     'Inputs getPixelInputs': `(Inputs inputs) {
+   *       float factor =
+   *         sin(
+   *           inputs.texCoord.x * ${TWO_PI} +
+   *           inputs.texCoord.y * ${TWO_PI}
+   *         ) * 0.4 + 0.5;
+   *       inputs.shininess = mix(1., 100., factor);
+   *       inputs.metalness = factor;
+   *       return inputs;
+   *     }`
+   *   });
+   * }
+   *
+   * function draw() {
+   *   panorama(environment);
+   *   ambientLight(100);
+   *   imageLight(environment);
+   *   rotateY(millis() * 0.001);
+   *   shader(myShader);
+   *   noStroke();
+   *   fill(255);
+   *   specularMaterial(150);
+   *   sphere(50);
+   * }
+   * </code>
+   * </div>
+   *
+   * @example
+   * <div modernizr='webgl'>
+   * <code>
+   * let myShader;
+   *
+   * function setup() {
+   *   createCanvas(200, 200, WEBGL);
+   *   myShader = baseMaterialShader().modify({
+   *     'Inputs getPixelInputs': `(Inputs inputs) {
+   *       vec3 newNormal = inputs.normal;
+   *       // Simple bump mapping: adjust the normal based on position
+   *       newNormal.x += 0.2 * sin(
+   *           sin(
+   *             inputs.texCoord.y * ${TWO_PI} * 10.0 +
+   *             inputs.texCoord.x * ${TWO_PI} * 25.0
+   *           )
+   *         );
+   *       newNormal.y += 0.2 * sin(
+   *         sin(
+   *             inputs.texCoord.x * ${TWO_PI} * 10.0 +
+   *             inputs.texCoord.y * ${TWO_PI} * 25.0
+   *           )
+   *       );
+   *       inputs.normal = normalize(newNormal);
+   *       return inputs;
+   *     }`
+   *   });
+   * }
+   *
+   * function draw() {
+   *   background(255);
+   *   shader(myShader);
+   *   ambientLight(150);
+   *   pointLight(
+   *     255, 255, 255,
+   *     100*cos(frameCount*0.04), -50, 100*sin(frameCount*0.04)
+   *   );
+   *   noStroke();
+   *   fill('red');
+   *   shininess(200);
+   *   specularMaterial(255);
+   *   sphere(50);
+   * }
+   * </code>
+   * </div>
+   */
+  fn.baseMaterialShader = function() {
+    this._assert3d('baseMaterialShader');
+    return this._renderer.baseMaterialShader();
+  };
+
+  /**
+   * Get the shader used by <a href="#/p5/normalMaterial">`normalMaterial()`</a>.
+   *
+   * You can call <a href="#/p5.Shader/modify">`baseNormalShader().modify()`</a>
+   * and change any of the following hooks:
+   *
+   * Hook | Description
+   * -----|------------
+   * `void beforeVertex` | Called at the start of the vertex shader.
+   * `vec3 getLocalPosition` | Update the position of vertices before transforms are applied. It takes in `vec3 position` and must return a modified version.
+   * `vec3 getWorldPosition` | Update the position of vertices after transforms are applied. It takes in `vec3 position` and pust return a modified version.
+   * `vec3 getLocalNormal` | Update the normal before transforms are applied. It takes in `vec3 normal` and must return a modified version.
+   * `vec3 getWorldNormal` | Update the normal after transforms are applied. It takes in `vec3 normal` and must return a modified version.
+   * `vec2 getUV` | Update the texture coordinates. It takes in `vec2 uv` and must return a modified version.
+   * `vec4 getVertexColor` | Update the color of each vertex. It takes in a `vec4 color` and must return a modified version.
+   * `void afterVertex` | Called at the end of the vertex shader.
+   * `void beforeFragment` | Called at the start of the fragment shader.
+   * `vec4 getFinalColor` | Update the final color after mixing. It takes in a `vec4 color` and must return a modified version.
+   * `void afterFragment` | Called at the end of the fragment shader.
+   *
+   * Most of the time, you will need to write your hooks in GLSL ES version 300. If you
+   * are using WebGL 1 instead of 2, write your hooks in GLSL ES 100 instead.
+   *
+   * Call `baseNormalShader().inspectHooks()` to see all the possible hooks and
+   * their default implementations.
+   *
+   * @method baseNormalShader
+   * @beta
+   * @returns {p5.Shader} The `normalMaterial` shader
+   *
+   * @example
+   * <div modernizr='webgl'>
+   * <code>
+   * let myShader;
+   *
+   * function setup() {
+   *   createCanvas(200, 200, WEBGL);
+   *   myShader = baseNormalShader().modify({
+   *     uniforms: {
+   *       'float time': () => millis()
+   *     },
+   *     'vec3 getWorldPosition': `(vec3 pos) {
+   *       pos.y += 20. * sin(time * 0.001 + pos.x * 0.05);
+   *       return pos;
+   *     }`
+   *   });
+   * }
+   *
+   * function draw() {
+   *   background(255);
+   *   shader(myShader);
+   *   noStroke();
+   *   sphere(50);
+   * }
+   * </code>
+   * </div>
+   *
+   * @example
+   * <div modernizr='webgl'>
+   * <code>
+   * let myShader;
+   *
+   * function setup() {
+   *   createCanvas(200, 200, WEBGL);
+   *   myShader = baseNormalShader().modify({
+   *     'vec3 getWorldNormal': '(vec3 normal) { return abs(normal); }',
+   *     'vec4 getFinalColor': `(vec4 color) {
+   *       // Map the r, g, and b values of the old normal to new colors
+   *       // instead of just red, green, and blue:
+   *       vec3 newColor =
+   *         color.r * vec3(89.0, 240.0, 232.0) / 255.0 +
+   *         color.g * vec3(240.0, 237.0, 89.0) / 255.0 +
+   *         color.b * vec3(205.0, 55.0, 222.0) / 255.0;
+   *       newColor = newColor / (color.r + color.g + color.b);
+   *       return vec4(newColor, 1.0) * color.a;
+   *     }`
+   *   });
+   * }
+   *
+   * function draw() {
+   *   background(255);
+   *   shader(myShader);
+   *   noStroke();
+   *   rotateX(frameCount * 0.01);
+   *   rotateY(frameCount * 0.015);
+   *   box(100);
+   * }
+   * </code>
+   * </div>
+   */
+  fn.baseNormalShader = function() {
+    this._assert3d('baseNormalShader');
+    return this._renderer.baseNormalShader();
+  };
+
+  /**
+   * Get the shader used when no lights or materials are applied.
+   *
+   * You can call <a href="#/p5.Shader/modify">`baseColorShader().modify()`</a>
+   * and change any of the following hooks:
+   *
+   * Hook | Description
+   * -------|-------------
+   * `void beforeVertex` | Called at the start of the vertex shader.
+   * `vec3 getLocalPosition` | Update the position of vertices before transforms are applied. It takes in `vec3 position` and must return a modified version.
+   * `vec3 getWorldPosition` | Update the position of vertices after transforms are applied. It takes in `vec3 position` and pust return a modified version.
+   * `vec3 getLocalNormal` | Update the normal before transforms are applied. It takes in `vec3 normal` and must return a modified version.
+   * `vec3 getWorldNormal` | Update the normal after transforms are applied. It takes in `vec3 normal` and must return a modified version.
+   * `vec2 getUV` | Update the texture coordinates. It takes in `vec2 uv` and must return a modified version.
+   * `vec4 getVertexColor` | Update the color of each vertex. It takes in a `vec4 color` and must return a modified version.
+   * `void afterVertex` | Called at the end of the vertex shader.
+   * `void beforeFragment` | Called at the start of the fragment shader.
+   * `vec4 getFinalColor` | Update the final color after mixing. It takes in a `vec4 color` and must return a modified version.
+   * `void afterFragment` | Called at the end of the fragment shader.
+   *
+   * Most of the time, you will need to write your hooks in GLSL ES version 300. If you
+   * are using WebGL 1 instead of 2, write your hooks in GLSL ES 100 instead.
+   *
+   * Call `baseColorShader().inspectHooks()` to see all the possible hooks and
+   * their default implementations.
+   *
+   * @method baseColorShader
+   * @beta
+   * @returns {p5.Shader} The color shader
+   *
+   * @example
+   * <div modernizr='webgl'>
+   * <code>
+   * let myShader;
+   *
+   * function setup() {
+   *   createCanvas(200, 200, WEBGL);
+   *   myShader = baseColorShader().modify({
+   *     uniforms: {
+   *       'float time': () => millis()
+   *     },
+   *     'vec3 getWorldPosition': `(vec3 pos) {
+   *       pos.y += 20. * sin(time * 0.001 + pos.x * 0.05);
+   *       return pos;
+   *     }`
+   *   });
+   * }
+   *
+   * function draw() {
+   *   background(255);
+   *   shader(myShader);
+   *   noStroke();
+   *   fill('red');
+   *   circle(0, 0, 50);
+   * }
+   * </code>
+   * </div>
+   */
+  fn.baseColorShader = function() {
+    this._assert3d('baseColorShader');
+    return this._renderer.baseColorShader();
+  };
+
+  /**
+   * Get the shader used when drawing the strokes of shapes.
+   *
+   * You can call <a href="#/p5.Shader/modify">`baseStrokeShader().modify()`</a>
+   * and change any of the following hooks:
+   *
+   * <table>
+   * <tr><th>Hook</th><th>Description</th></tr>
+   * <tr><td>
+   *
+   * `void beforeVertex`
+   *
+   * </td><td>
+   *
+   * Called at the start of the vertex shader.
+   *
+   * </td></tr>
+   * <tr><td>
+   *
+   * `vec3 getLocalPosition`
+   *
+   * </td><td>
+   *
+   * Update the position of vertices before transforms are applied. It takes in `vec3 position` and must return a modified version.
+   *
+   * </td></tr>
+   * <tr><td>
+   *
+   * `vec3 getWorldPosition`
+   *
+   * </td><td>
+   *
+   * Update the position of vertices after transforms are applied. It takes in `vec3 position` and pust return a modified version.
+   *
+   * </td></tr>
+   * <tr><td>
+   *
+   * `float getStrokeWeight`
+   *
+   * </td><td>
+   *
+   * Update the stroke weight. It takes in `float weight` and pust return a modified version.
+   *
+   * </td></tr>
+   * <tr><td>
+   *
+   * `vec2 getLineCenter`
+   *
+   * </td><td>
+   *
+   * Update the center of the line. It takes in `vec2 center` and must return a modified version.
+   *
+   * </td></tr>
+   * <tr><td>
+   *
+   * `vec2 getLinePosition`
+   *
+   * </td><td>
+   *
+   * Update the position of each vertex on the edge of the line. It takes in `vec2 position` and must return a modified version.
+   *
+   * </td></tr>
+   * <tr><td>
+   *
+   * `vec4 getVertexColor`
+   *
+   * </td><td>
+   *
+   * Update the color of each vertex. It takes in a `vec4 color` and must return a modified version.
+   *
+   * </td></tr>
+   * <tr><td>
+   *
+   * `void afterVertex`
+   *
+   * </td><td>
+   *
+   * Called at the end of the vertex shader.
+   *
+   * </td></tr>
+   * <tr><td>
+   *
+   * `void beforeFragment`
+   *
+   * </td><td>
+   *
+   * Called at the start of the fragment shader.
+   *
+   * </td></tr>
+   * <tr><td>
+   *
+   * `Inputs getPixelInputs`
+   *
+   * </td><td>
+   *
+   * Update the inputs to the shader. It takes in a struct `Inputs inputs`, which includes:
+   * - `vec4 color`, the color of the stroke
+   * - `vec2 tangent`, the direction of the stroke in screen space
+   * - `vec2 center`, the coordinate of the center of the stroke in screen space p5.js pixels
+   * - `vec2 position`, the coordinate of the current pixel in screen space p5.js pixels
+   * - `float strokeWeight`, the thickness of the stroke in p5.js pixels
+   *
+   * </td></tr>
+   * <tr><td>
+   *
+   * `bool shouldDiscard`
+   *
+   * </td><td>
+   *
+   * Caps and joins are made by discarded pixels in the fragment shader to carve away unwanted areas. Use this to change this logic. It takes in a `bool willDiscard` and must return a modified version.
+   *
+   * </td></tr>
+   * <tr><td>
+   *
+   * `vec4 getFinalColor`
+   *
+   * </td><td>
+   *
+   * Update the final color after mixing. It takes in a `vec4 color` and must return a modified version.
+   *
+   * </td></tr>
+   * <tr><td>
+   *
+   * `void afterFragment`
+   *
+   * </td><td>
+   *
+   * Called at the end of the fragment shader.
+   *
+   * </td></tr>
+   * </table>
+   *
+   * Most of the time, you will need to write your hooks in GLSL ES version 300. If you
+   * are using WebGL 1 instead of 2, write your hooks in GLSL ES 100 instead.
+   *
+   * Call `baseStrokeShader().inspectHooks()` to see all the possible hooks and
+   * their default implementations.
+   *
+   * @method baseStrokeShader
+   * @beta
+   * @returns {p5.Shader} The stroke shader
+   *
+   * @example
+   * <div modernizr='webgl'>
+   * <code>
+   * let myShader;
+   *
+   * function setup() {
+   *   createCanvas(200, 200, WEBGL);
+   *   myShader = baseStrokeShader().modify({
+   *     'Inputs getPixelInputs': `(Inputs inputs) {
+   *       float opacity = 1.0 - smoothstep(
+   *         0.0,
+   *         15.0,
+   *         length(inputs.position - inputs.center)
+   *       );
+   *       inputs.color *= opacity;
+   *       return inputs;
+   *     }`
+   *   });
+   * }
+   *
+   * function draw() {
+   *   background(255);
+   *   shader(myShader);
+   *   strokeWeight(30);
+   *   line(
+   *     -width/3,
+   *     sin(millis()*0.001) * height/4,
+   *     width/3,
+   *     sin(millis()*0.001 + 1) * height/4
+   *   );
+   * }
+   * </code>
+   * </div>
+   *
+   * @example
+   * <div modernizr='webgl'>
+   * <code>
+   * let myShader;
+   *
+   * function setup() {
+   *   createCanvas(200, 200, WEBGL);
+   *   myShader = baseStrokeShader().modify({
+   *     uniforms: {
+   *       'float time': () => millis()
+   *     },
+   *     declarations: 'vec3 myPosition;',
+   *     'vec3 getWorldPosition': `(vec3 pos) {
+   *       myPosition = pos;
+   *       return pos;
+   *     }`,
+   *     'float getStrokeWeight': `(float w) {
+   *       // Add a somewhat random offset to the weight
+   *       // that varies based on position and time
+   *       float scale = 0.8 + 0.2*sin(10.0 * sin(
+   *         floor(time/250.) +
+   *         myPosition.x*0.01 +
+   *         myPosition.y*0.01
+   *       ));
+   *       return w * scale;
+   *     }`
+   *   });
+   * }
+   *
+   * function draw() {
+   *   background(255);
+   *   shader(myShader);
+   *   myShader.setUniform('time', millis());
+   *   strokeWeight(10);
+   *   beginShape();
+   *   for (let i = 0; i <= 50; i++) {
+   *     let r = map(i, 0, 50, 0, width/3);
+   *     let x = r*cos(i*0.2);
+   *     let y = r*sin(i*0.2);
+   *     vertex(x, y);
+   *   }
+   *   endShape();
+   * }
+   * </code>
+   * </div>
+   *
+   * @example
+   * <div modernizr='webgl'>
+   * <code>
+   * let myShader;
+   *
+   * function setup() {
+   *   createCanvas(200, 200, WEBGL);
+   *   myShader = baseStrokeShader().modify({
+   *     'float random': `(vec2 p) {
+   *       vec3 p3  = fract(vec3(p.xyx) * .1031);
+   *       p3 += dot(p3, p3.yzx + 33.33);
+   *       return fract((p3.x + p3.y) * p3.z);
+   *     }`,
+   *     'Inputs getPixelInputs': `(Inputs inputs) {
+   *       // Replace alpha in the color with dithering by
+   *       // randomly setting pixel colors to 0 based on opacity
+   *       float a = inputs.color.a;
+   *       inputs.color.a = 1.0;
+   *       inputs.color *= random(inputs.position.xy) > a ? 0.0 : 1.0;
+   *       return inputs;
+   *     }`
+   *   });
+   * }
+   *
+   * function draw() {
+   *   background(255);
+   *   shader(myShader);
+   *   strokeWeight(10);
+   *   beginShape();
+   *   for (let i = 0; i <= 50; i++) {
+   *     stroke(
+   *       0,
+   *       255
+   *         * map(i, 0, 20, 0, 1, true)
+   *         * map(i, 30, 50, 1, 0, true)
+   *     );
+   *     vertex(
+   *       map(i, 0, 50, -1, 1) * width/3,
+   *       50 * sin(i/10 + frameCount/100)
+   *     );
+   *   }
+   *   endShape();
+   * }
+   * </code>
+   * </div>
+   */
+  fn.baseStrokeShader = function() {
+    this._assert3d('baseStrokeShader');
+    return this._renderer.baseStrokeShader();
+  };
+
+  /**
+   * Restores the default shaders.
+   *
+   * `resetShader()` deactivates any shaders previously applied by
+   * <a href="#/p5/shader">shader()</a>.
+   *
+   * Note: Shaders can only be used in WebGL mode.
+   *
+   * @method resetShader
+   * @chainable
+   *
+   * @example
+   * <div>
+   * <code>
+   * // Create a string with the vertex shader program.
+   * // The vertex shader is called for each vertex.
+   * let vertSrc = `
+   * attribute vec3 aPosition;
+   * attribute vec2 aTexCoord;
+   * uniform mat4 uProjectionMatrix;
+   * uniform mat4 uModelViewMatrix;
+   * varying vec2 vTexCoord;
+   *
+   * void main() {
+   *   vTexCoord = aTexCoord;
+   *   vec4 position = vec4(aPosition, 1.0);
+   *   gl_Position = uProjectionMatrix * uModelViewMatrix * position;
+   * }
+   * `;
+   *
+   * // Create a string with the fragment shader program.
+   * // The fragment shader is called for each pixel.
+   * let fragSrc = `
+   * precision mediump float;
+   * varying vec2 vTexCoord;
+   *
+   * void main() {
+   *   vec2 uv = vTexCoord;
+   *   vec3 color = vec3(uv.x, uv.y, min(uv.x + uv.y, 1.0));
+   *   gl_FragColor = vec4(color, 1.0);
+   * }
+   * `;
+   *
+   * let myShader;
+   *
+   * function setup() {
+   *   createCanvas(100, 100, WEBGL);
+   *
+   *   // Create a p5.Shader object.
+   *   myShader = createShader(vertSrc, fragSrc);
+   *
+   *   describe(
+   *     'Two rotating cubes on a gray background. The left one has a blue-purple gradient on each face. The right one is red.'
+   *   );
+   * }
+   *
+   * function draw() {
+   *   background(200);
+   *
+   *   // Draw a box using the p5.Shader.
+   *   // shader() sets the active shader to myShader.
+   *   shader(myShader);
+   *   push();
+   *   translate(-25, 0, 0);
+   *   rotateX(frameCount * 0.01);
+   *   rotateY(frameCount * 0.01);
+   *   box(width / 4);
+   *   pop();
+   *
+   *   // Draw a box using the default fill shader.
+   *   // resetShader() restores the default fill shader.
+   *   resetShader();
+   *   fill(255, 0, 0);
+   *   push();
+   *   translate(25, 0, 0);
+   *   rotateX(frameCount * 0.01);
+   *   rotateY(frameCount * 0.01);
+   *   box(width / 4);
+   *   pop();
+   * }
+   * </code>
+   * </div>
+   */
+  fn.resetShader = function () {
+    this._renderer.states.userFillShader = this._renderer.states.userStrokeShader = null;
+    return this;
+  };
+
+  /**
+   * Sets the texture that will be used on shapes.
+   *
+   * A texture is like a skin that wraps around a shape. `texture()` works with
+   * built-in shapes, such as <a href="#/p5/square">square()</a> and
+   * <a href="#/p5/sphere">sphere()</a>, and custom shapes created with
+   * functions such as <a href="#/p5/buildGeometry">buildGeometry()</a>. To
+   * texture a geometry created with <a href="#/p5/beginShape">beginShape()</a>,
+   * uv coordinates must be passed to each
+   * <a href="#/p5/vertex">vertex()</a> call.
+   *
+   * The parameter, `tex`, is the texture to apply. `texture()` can use a range
+   * of sources including images, videos, and offscreen renderers such as
+   * <a href="#/p5.Graphics">p5.Graphics</a> and
+   * <a href="#/p5.Framebuffer">p5.Framebuffer</a> objects.
+   *
+   * To texture a geometry created with <a href="#/p5/beginShape">beginShape()</a>,
+   * you will need to specify uv coordinates in <a href="#/p5/vertex">vertex()</a>.
+   *
+   * Note: `texture()` can only be used in WebGL mode.
+   *
+   * @method texture
+   * @param {p5.Image|p5.MediaElement|p5.Graphics|p5.Texture|p5.Framebuffer|p5.FramebufferTexture} tex media to use as the texture.
+   * @chainable
+   *
+   * @example
+   * <div>
+   * <code>
+   * let img;
+   *
+   * // Load an image and create a p5.Image object.
+   * function preload() {
+   *   img = loadImage('assets/laDefense.jpg');
+   * }
+   *
+   * function setup() {
+   *   createCanvas(100, 100, WEBGL);
+   *
+   *   describe('A spinning cube with an image of a ceiling on each face.');
+   * }
+   *
+   * function draw() {
+   *   background(0);
+   *
+   *   // Rotate around the x-, y-, and z-axes.
+   *   rotateZ(frameCount * 0.01);
+   *   rotateX(frameCount * 0.01);
+   *   rotateY(frameCount * 0.01);
+   *
+   *   // Apply the image as a texture.
+   *   texture(img);
+   *
+   *   // Draw the box.
+   *   box(50);
+   * }
+   * </code>
+   * </div>
+   *
+   * <div>
+   * <code>
+   * let pg;
+   *
+   * function setup() {
+   *   createCanvas(100, 100, WEBGL);
+   *
+   *   // Create a p5.Graphics object.
+   *   pg = createGraphics(100, 100);
+   *
+   *   // Draw a circle to the p5.Graphics object.
+   *   pg.background(200);
+   *   pg.circle(50, 50, 30);
+   *
+   *   describe('A spinning cube with circle at the center of each face.');
+   * }
+   *
+   * function draw() {
+   *   background(0);
+   *
+   *   // Rotate around the x-, y-, and z-axes.
+   *   rotateZ(frameCount * 0.01);
+   *   rotateX(frameCount * 0.01);
+   *   rotateY(frameCount * 0.01);
+   *
+   *   // Apply the p5.Graphics object as a texture.
+   *   texture(pg);
+   *
+   *   // Draw the box.
+   *   box(50);
+   * }
+   * </code>
+   * </div>
+   *
+   * <div>
+   * <code>
+   * let vid;
+   *
+   * // Load a video and create a p5.MediaElement object.
+   * function preload() {
+   *   vid = createVideo('assets/fingers.mov');
+   * }
+   *
+   * function setup() {
+   *   createCanvas(100, 100, WEBGL);
+   *
+   *   // Hide the video.
+   *   vid.hide();
+   *
+   *   // Set the video to loop.
+   *   vid.loop();
+   *
+   *   describe('A rectangle with video as texture');
+   * }
+   *
+   * function draw() {
+   *   background(0);
+   *
+   *   // Rotate around the y-axis.
+   *   rotateY(frameCount * 0.01);
+   *
+   *   // Apply the video as a texture.
+   *   texture(vid);
+   *
+   *   // Draw the rectangle.
+   *   rect(-40, -40, 80, 80);
+   * }
+   * </code>
+   * </div>
+   *
+   * <div>
+   * <code>
+   * let vid;
+   *
+   * // Load a video and create a p5.MediaElement object.
+   * function preload() {
+   *   vid = createVideo('assets/fingers.mov');
+   * }
+   *
+   * function setup() {
+   *   createCanvas(100, 100, WEBGL);
+   *
+   *   // Hide the video.
+   *   vid.hide();
+   *
+   *   // Set the video to loop.
+   *   vid.loop();
+   *
+   *   describe('A rectangle with video as texture');
+   * }
+   *
+   * function draw() {
+   *   background(0);
+   *
+   *   // Rotate around the y-axis.
+   *   rotateY(frameCount * 0.01);
+   *
+   *   // Set the texture mode.
+   *   textureMode(NORMAL);
+   *
+   *   // Apply the video as a texture.
+   *   texture(vid);
+   *
+   *   // Draw a custom shape using uv coordinates.
+   *   beginShape();
+   *   vertex(-40, -40, 0, 0);
+   *   vertex(40, -40, 1, 0);
+   *   vertex(40, 40, 1, 1);
+   *   vertex(-40, 40, 0, 1);
+   *   endShape();
+   * }
+   * </code>
+   * </div>
+   */
+  fn.texture = function (tex) {
+    this._assert3d('texture');
+    p5._validateParameters('texture', arguments);
+    if (tex.gifProperties) {
+      tex._animateGif(this);
+    }
+
+    this._renderer.states.drawMode = constants.TEXTURE;
+    this._renderer.states._useNormalMaterial = false;
+    this._renderer.states._tex = tex;
+    this._renderer.states.doFill = true;
+
+    return this;
+  };
+
+  /**
+   * Changes the coordinate system used for textures when they’re applied to
+   * custom shapes.
+   *
+   * In order for <a href="#/p5/texture">texture()</a> to work, a shape needs a
+   * way to map the points on its surface to the pixels in an image. Built-in
+   * shapes such as <a href="#/p5/rect">rect()</a> and
+   * <a href="#/p5/box">box()</a> already have these texture mappings based on
+   * their vertices. Custom shapes created with
+   * <a href="#/p5/vertex">vertex()</a> require texture mappings to be passed as
+   * uv coordinates.
+   *
+   * Each call to <a href="#/p5/vertex">vertex()</a> must include 5 arguments,
+   * as in `vertex(x, y, z, u, v)`, to map the vertex at coordinates `(x, y, z)`
+   * to the pixel at coordinates `(u, v)` within an image. For example, the
+   * corners of a rectangular image are mapped to the corners of a rectangle by default:
+   *
+   * <code>
+   * // Apply the image as a texture.
+   * texture(img);
+   *
+   * // Draw the rectangle.
+   * rect(0, 0, 30, 50);
+   * </code>
+   *
+   * If the image in the code snippet above has dimensions of 300 x 500 pixels,
+   * the same result could be achieved as follows:
+   *
+   * <code>
+   * // Apply the image as a texture.
+   * texture(img);
+   *
+   * // Draw the rectangle.
+   * beginShape();
+   *
+   * // Top-left.
+   * // u: 0, v: 0
+   * vertex(0, 0, 0, 0, 0);
+   *
+   * // Top-right.
+   * // u: 300, v: 0
+   * vertex(30, 0, 0, 300, 0);
+   *
+   * // Bottom-right.
+   * // u: 300, v: 500
+   * vertex(30, 50, 0, 300, 500);
+   *
+   * // Bottom-left.
+   * // u: 0, v: 500
+   * vertex(0, 50, 0, 0, 500);
+   *
+   * endShape();
+   * </code>
+   *
+   * `textureMode()` changes the coordinate system for uv coordinates.
+   *
+   * The parameter, `mode`, accepts two possible constants. If `NORMAL` is
+   * passed, as in `textureMode(NORMAL)`, then the texture’s uv coordinates can
+   * be provided in the range 0 to 1 instead of the image’s dimensions. This can
+   * be helpful for using the same code for multiple images of different sizes.
+   * For example, the code snippet above could be rewritten as follows:
+   *
+   * <code>
+   * // Set the texture mode to use normalized coordinates.
+   * textureMode(NORMAL);
+   *
+   * // Apply the image as a texture.
+   * texture(img);
+   *
+   * // Draw the rectangle.
+   * beginShape();
+   *
+   * // Top-left.
+   * // u: 0, v: 0
+   * vertex(0, 0, 0, 0, 0);
+   *
+   * // Top-right.
+   * // u: 1, v: 0
+   * vertex(30, 0, 0, 1, 0);
+   *
+   * // Bottom-right.
+   * // u: 1, v: 1
+   * vertex(30, 50, 0, 1, 1);
+   *
+   * // Bottom-left.
+   * // u: 0, v: 1
+   * vertex(0, 50, 0, 0, 1);
+   *
+   * endShape();
+   * </code>
+   *
+   * By default, `mode` is `IMAGE`, which scales uv coordinates to the
+   * dimensions of the image. Calling `textureMode(IMAGE)` applies the default.
+   *
+   * Note: `textureMode()` can only be used in WebGL mode.
+   *
+   * @method  textureMode
+   * @param {(IMAGE|NORMAL)} mode either IMAGE or NORMAL.
+   *
+   * @example
+   * <div>
+   * <code>
+   * let img;
+   *
+   * // Load an image and create a p5.Image object.
+   * function preload() {
+   *   img = loadImage('assets/laDefense.jpg');
+   * }
+   *
+   * function setup() {
+   *   createCanvas(100, 100, WEBGL);
+   *
+   *   describe('An image of a ceiling against a black background.');
+   * }
+   *
+   * function draw() {
+   *   background(0);
+   *
+   *   // Apply the image as a texture.
+   *   texture(img);
+   *
+   *   // Draw the custom shape.
+   *   // Use the image's width and height as uv coordinates.
+   *   beginShape();
+   *   vertex(-30, -30, 0, 0);
+   *   vertex(30, -30, img.width, 0);
+   *   vertex(30, 30, img.width, img.height);
+   *   vertex(-30, 30, 0, img.height);
+   *   endShape();
+   * }
+   * </code>
+   * </div>
+   *
+   * <div>
+   * <code>
+   * let img;
+   *
+   * // Load an image and create a p5.Image object.
+   * function preload() {
+   *   img = loadImage('assets/laDefense.jpg');
+   * }
+   *
+   * function setup() {
+   *   createCanvas(100, 100, WEBGL);
+   *
+   *   describe('An image of a ceiling against a black background.');
+   * }
+   *
+   * function draw() {
+   *   background(0);
+   *
+   *   // Set the texture mode.
+   *   textureMode(NORMAL);
+   *
+   *   // Apply the image as a texture.
+   *   texture(img);
+   *
+   *   // Draw the custom shape.
+   *   // Use normalized uv coordinates.
+   *   beginShape();
+   *   vertex(-30, -30, 0, 0);
+   *   vertex(30, -30, 1, 0);
+   *   vertex(30, 30, 1, 1);
+   *   vertex(-30, 30, 0, 1);
+   *   endShape();
+   * }
+   * </code>
+   * </div>
+   */
+  fn.textureMode = function (mode) {
+    if (mode !== constants.IMAGE && mode !== constants.NORMAL) {
+      console.warn(
+        `You tried to set ${mode} textureMode only supports IMAGE & NORMAL `
+      );
+    } else {
+      this._renderer.textureMode = mode;
     }
   };
 
-  this.loadStrings(
-    vertFilename,
-    result => {
-      loadedShader._vertSrc = result.join('\n');
-      loadedVert = true;
-      if (loadedFrag) {
-        onLoad();
-      }
-    },
-    failureCallback
-  );
+  /**
+   * Changes the way textures behave when a shape’s uv coordinates go beyond the
+   * texture.
+   *
+   * In order for <a href="#/p5/texture">texture()</a> to work, a shape needs a
+   * way to map the points on its surface to the pixels in an image. Built-in
+   * shapes such as <a href="#/p5/rect">rect()</a> and
+   * <a href="#/p5/box">box()</a> already have these texture mappings based on
+   * their vertices. Custom shapes created with
+   * <a href="#/p5/vertex">vertex()</a> require texture mappings to be passed as
+   * uv coordinates.
+   *
+   * Each call to <a href="#/p5/vertex">vertex()</a> must include 5 arguments,
+   * as in `vertex(x, y, z, u, v)`, to map the vertex at coordinates `(x, y, z)`
+   * to the pixel at coordinates `(u, v)` within an image. For example, the
+   * corners of a rectangular image are mapped to the corners of a rectangle by default:
+   *
+   * ```js
+   * // Apply the image as a texture.
+   * texture(img);
+   *
+   * // Draw the rectangle.
+   * rect(0, 0, 30, 50);
+   * ```
+   *
+   * If the image in the code snippet above has dimensions of 300 x 500 pixels,
+   * the same result could be achieved as follows:
+   *
+   * ```js
+   * // Apply the image as a texture.
+   * texture(img);
+   *
+   * // Draw the rectangle.
+   * beginShape();
+   *
+   * // Top-left.
+   * // u: 0, v: 0
+   * vertex(0, 0, 0, 0, 0);
+   *
+   * // Top-right.
+   * // u: 300, v: 0
+   * vertex(30, 0, 0, 300, 0);
+   *
+   * // Bottom-right.
+   * // u: 300, v: 500
+   * vertex(30, 50, 0, 300, 500);
+   *
+   * // Bottom-left.
+   * // u: 0, v: 500
+   * vertex(0, 50, 0, 0, 500);
+   *
+   * endShape();
+   * ```
+   *
+   * `textureWrap()` controls how textures behave when their uv's go beyond the
+   * texture. Doing so can produce interesting visual effects such as tiling.
+   * For example, the custom shape above could have u-coordinates are greater
+   * than the image’s width:
+   *
+   * ```js
+   * // Apply the image as a texture.
+   * texture(img);
+   *
+   * // Draw the rectangle.
+   * beginShape();
+   * vertex(0, 0, 0, 0, 0);
+   *
+   * // Top-right.
+   * // u: 600
+   * vertex(30, 0, 0, 600, 0);
+   *
+   * // Bottom-right.
+   * // u: 600
+   * vertex(30, 50, 0, 600, 500);
+   *
+   * vertex(0, 50, 0, 0, 500);
+   * endShape();
+   * ```
+   *
+   * The u-coordinates of 600 are greater than the texture image’s width of 300.
+   * This creates interesting possibilities.
+   *
+   * The first parameter, `wrapX`, accepts three possible constants. If `CLAMP`
+   * is passed, as in `textureWrap(CLAMP)`, the pixels at the edge of the
+   * texture will extend to the shape’s edges. If `REPEAT` is passed, as in
+   * `textureWrap(REPEAT)`, the texture will tile repeatedly until reaching the
+   * shape’s edges. If `MIRROR` is passed, as in `textureWrap(MIRROR)`, the
+   * texture will tile repeatedly until reaching the shape’s edges, flipping
+   * its orientation between tiles. By default, textures `CLAMP`.
+   *
+   * The second parameter, `wrapY`, is optional. It accepts the same three
+   * constants, `CLAMP`, `REPEAT`, and `MIRROR`. If one of these constants is
+   * passed, as in `textureWRAP(MIRROR, REPEAT)`, then the texture will `MIRROR`
+   * horizontally and `REPEAT` vertically. By default, `wrapY` will be set to
+   * the same value as `wrapX`.
+   *
+   * Note: `textureWrap()` can only be used in WebGL mode.
+   *
+   * @method textureWrap
+   * @param {(CLAMP|REPEAT|MIRROR)} wrapX either CLAMP, REPEAT, or MIRROR
+   * @param {(CLAMP|REPEAT|MIRROR)} [wrapY=wrapX] either CLAMP, REPEAT, or MIRROR
+   *
+   * @example
+   * <div>
+   * <code>
+   * let img;
+   *
+   * function preload() {
+   *   img = loadImage('assets/rockies128.jpg');
+   * }
+   *
+   * function setup() {
+   *   createCanvas(100, 100, WEBGL);
+   *
+   *   describe(
+   *     'An image of a landscape occupies the top-left corner of a square. Its edge colors smear to cover the other thre quarters of the square.'
+   *   );
+   * }
+   *
+   * function draw() {
+   *   background(0);
+   *
+   *   // Set the texture mode.
+   *   textureMode(NORMAL);
+   *
+   *   // Set the texture wrapping.
+   *   // Note: CLAMP is the default mode.
+   *   textureWrap(CLAMP);
+   *
+   *   // Apply the image as a texture.
+   *   texture(img);
+   *
+   *   // Style the shape.
+   *   noStroke();
+   *
+   *   // Draw the shape.
+   *   // Use uv coordinates > 1.
+   *   beginShape();
+   *   vertex(-30, -30, 0, 0, 0);
+   *   vertex(30, -30, 0, 2, 0);
+   *   vertex(30, 30, 0, 2, 2);
+   *   vertex(-30, 30, 0, 0, 2);
+   *   endShape();
+   * }
+   * </code>
+   * </div>
+   *
+   * <div>
+   * <code>
+   * let img;
+   *
+   * function preload() {
+   *   img = loadImage('assets/rockies128.jpg');
+   * }
+   *
+   * function setup() {
+   *   createCanvas(100, 100, WEBGL);
+   *
+   *   describe('Four identical images of a landscape arranged in a grid.');
+   * }
+   *
+   * function draw() {
+   *   background(0);
+   *
+   *   // Set the texture mode.
+   *   textureMode(NORMAL);
+   *
+   *   // Set the texture wrapping.
+   *   textureWrap(REPEAT);
+   *
+   *   // Apply the image as a texture.
+   *   texture(img);
+   *
+   *   // Style the shape.
+   *   noStroke();
+   *
+   *   // Draw the shape.
+   *   // Use uv coordinates > 1.
+   *   beginShape();
+   *   vertex(-30, -30, 0, 0, 0);
+   *   vertex(30, -30, 0, 2, 0);
+   *   vertex(30, 30, 0, 2, 2);
+   *   vertex(-30, 30, 0, 0, 2);
+   *   endShape();
+   * }
+   * </code>
+   * </div>
+   *
+   * <div>
+   * <code>
+   * let img;
+   *
+   * function preload() {
+   *   img = loadImage('assets/rockies128.jpg');
+   * }
+   *
+   * function setup() {
+   *   createCanvas(100, 100, WEBGL);
+   *
+   *   describe(
+   *     'Four identical images of a landscape arranged in a grid. The images are reflected horizontally and vertically, creating a kaleidoscope effect.'
+   *   );
+   * }
+   *
+   * function draw() {
+   *   background(0);
+   *
+   *   // Set the texture mode.
+   *   textureMode(NORMAL);
+   *
+   *   // Set the texture wrapping.
+   *   textureWrap(MIRROR);
+   *
+   *   // Apply the image as a texture.
+   *   texture(img);
+   *
+   *   // Style the shape.
+   *   noStroke();
+   *
+   *   // Draw the shape.
+   *   // Use uv coordinates > 1.
+   *   beginShape();
+   *   vertex(-30, -30, 0, 0, 0);
+   *   vertex(30, -30, 0, 2, 0);
+   *   vertex(30, 30, 0, 2, 2);
+   *   vertex(-30, 30, 0, 0, 2);
+   *   endShape();
+   * }
+   * </code>
+   * </div>
+   *
+   * <div>
+   * <code>
+   * let img;
+   *
+   * function preload() {
+   *   img = loadImage('assets/rockies128.jpg');
+   * }
+   *
+   * function setup() {
+   *   createCanvas(100, 100, WEBGL);
+   *
+   *   describe(
+   *     'Four identical images of a landscape arranged in a grid. The top row and bottom row are reflections of each other.'
+   *   );
+   * }
+   *
+   * function draw() {
+   *   background(0);
+   *
+   *   // Set the texture mode.
+   *   textureMode(NORMAL);
+   *
+   *   // Set the texture wrapping.
+   *   textureWrap(REPEAT, MIRROR);
+   *
+   *   // Apply the image as a texture.
+   *   texture(img);
+   *
+   *   // Style the shape.
+   *   noStroke();
+   *
+   *   // Draw the shape.
+   *   // Use uv coordinates > 1.
+   *   beginShape();
+   *   vertex(-30, -30, 0, 0, 0);
+   *   vertex(30, -30, 0, 2, 0);
+   *   vertex(30, 30, 0, 2, 2);
+   *   vertex(-30, 30, 0, 0, 2);
+   *   endShape();
+   * }
+   * </code>
+   * </div>
+   */
+  fn.textureWrap = function (wrapX, wrapY = wrapX) {
+    this._renderer.textureWrapX = wrapX;
+    this._renderer.textureWrapY = wrapY;
 
-  this.loadStrings(
-    fragFilename,
-    result => {
-      loadedShader._fragSrc = result.join('\n');
-      loadedFrag = true;
-      if (loadedVert) {
-        onLoad();
-      }
-    },
-    failureCallback
-  );
-
-  return loadedShader;
-};
-
-/**
- * Creates a new <a href="#/p5.Shader">p5.Shader</a> object.
- *
- * Shaders are programs that run on the graphics processing unit (GPU). They
- * can process many pixels at the same time, making them fast for many
- * graphics tasks. They’re written in a language called
- * <a href="https://developer.mozilla.org/en-US/docs/Games/Techniques/3D_on_the_web/GLSL_Shaders" target="_blank">GLSL</a>
- * and run along with the rest of the code in a sketch.
- *
- * Once the <a href="#/p5.Shader">p5.Shader</a> object is created, it can be
- * used with the <a href="#/p5/shader">shader()</a> function, as in
- * `shader(myShader)`. A shader program consists of two parts, a vertex shader
- * and a fragment shader. The vertex shader affects where 3D geometry is drawn
- * on the screen and the fragment shader affects color.
- *
- * The first parameter, `vertSrc`, sets the vertex shader. It’s a string that
- * contains the vertex shader program written in GLSL.
- *
- * The second parameter, `fragSrc`, sets the fragment shader. It’s a string
- * that contains the fragment shader program written in GLSL.
- *
- * A shader can optionally describe *hooks,* which are functions in GLSL that
- * users may choose to provide to customize the behavior of the shader using the
- * <a href="#/p5.Shader/modify">`modify()`</a> method of `p5.Shader`. These are added by
- * describing the hooks in a third parameter, `options`, and referencing the hooks in
- * your `vertSrc` or `fragSrc`. Hooks for the vertex or fragment shader are described under
- * the `vertex` and `fragment` keys of `options`. Each one is an object. where each key is
- * the type and name of a hook function, and each value is a string with the
- * parameter list and default implementation of the hook. For example, to let users
- * optionally run code at the start of the vertex shader, the options object could
- * include:
- *
- * ```js
- * {
- *   vertex: {
- *     'void beforeVertex': '() {}'
- *   }
- * }
- * ```
- *
- * Then, in your vertex shader source, you can run a hook by calling a function
- * with the same name prefixed by `HOOK_`. If you want to check if the default
- * hook has been replaced, maybe to avoid extra overhead, you can check if the
- * same name prefixed by `AUGMENTED_HOOK_` has been defined:
- *
- * ```glsl
- * void main() {
- *   // In most cases, just calling the hook is fine:
- *   HOOK_beforeVertex();
- *
- *   // Alternatively, for more efficiency:
- *   #ifdef AUGMENTED_HOOK_beforeVertex
- *   HOOK_beforeVertex();
- *   #endif
- *
- *   // Add the rest of your shader code here!
- * }
- * ```
- *
- * Note: Only filter shaders can be used in 2D mode. All shaders can be used
- * in WebGL mode.
- *
- * @method createShader
- * @param {String} vertSrc source code for the vertex shader.
- * @param {String} fragSrc source code for the fragment shader.
- * @param {Object} [options] An optional object describing how this shader can
- * be augmented with hooks. It can include:
- *  - `vertex`: An object describing the available vertex shader hooks.
- *  - `fragment`: An object describing the available frament shader hooks.
- * @returns {p5.Shader} new shader object created from the
- * vertex and fragment shaders.
- *
- * @example
- * <div modernizr='webgl'>
- * <code>
- * // Note: A "uniform" is a global variable within a shader program.
- *
- * // Create a string with the vertex shader program.
- * // The vertex shader is called for each vertex.
- * let vertSrc = `
- * precision highp float;
- * uniform mat4 uModelViewMatrix;
- * uniform mat4 uProjectionMatrix;
- * attribute vec3 aPosition;
- * attribute vec2 aTexCoord;
- * varying vec2 vTexCoord;
- *
- * void main() {
- *   vTexCoord = aTexCoord;
- *   vec4 positionVec4 = vec4(aPosition, 1.0);
- *   gl_Position = uProjectionMatrix * uModelViewMatrix * positionVec4;
- * }
- * `;
- *
- * // Create a string with the fragment shader program.
- * // The fragment shader is called for each pixel.
- * let fragSrc = `
- * precision highp float;
- *
- * void main() {
- *   // Set each pixel's RGBA value to yellow.
- *   gl_FragColor = vec4(1.0, 1.0, 0.0, 1.0);
- * }
- * `;
- *
- * function setup() {
- *   createCanvas(100, 100, WEBGL);
- *
- *   // Create a p5.Shader object.
- *   let shaderProgram = createShader(vertSrc, fragSrc);
- *
- *   // Compile and apply the p5.Shader object.
- *   shader(shaderProgram);
- *
- *   // Style the drawing surface.
- *   noStroke();
- *
- *   // Add a plane as a drawing surface.
- *   plane(100, 100);
- *
- *   describe('A yellow square.');
- * }
- * </code>
- * </div>
- *
- * <div>
- * <code>
- * // Note: A "uniform" is a global variable within a shader program.
- *
- * // Create a string with the vertex shader program.
- * // The vertex shader is called for each vertex.
- * let vertSrc = `
- * precision highp float;
- * uniform mat4 uModelViewMatrix;
- * uniform mat4 uProjectionMatrix;
- * attribute vec3 aPosition;
- * attribute vec2 aTexCoord;
- * varying vec2 vTexCoord;
- *
- * void main() {
- *   vTexCoord = aTexCoord;
- *   vec4 positionVec4 = vec4(aPosition, 1.0);
- *   gl_Position = uProjectionMatrix * uModelViewMatrix * positionVec4;
- * }
- * `;
- *
- * // Create a string with the fragment shader program.
- * // The fragment shader is called for each pixel.
- * let fragSrc = `
- * precision highp float;
- * uniform vec2 p;
- * uniform float r;
- * const int numIterations = 500;
- * varying vec2 vTexCoord;
- *
- * void main() {
- *   vec2 c = p + gl_FragCoord.xy * r;
- *   vec2 z = c;
- *   float n = 0.0;
- *
- *   for (int i = numIterations; i > 0; i--) {
- *     if (z.x * z.x + z.y * z.y > 4.0) {
- *       n = float(i) / float(numIterations);
- *       break;
- *     }
- *     z = vec2(z.x * z.x - z.y * z.y, 2.0 * z.x * z.y) + c;
- *   }
- *
- *   gl_FragColor = vec4(
- *     0.5 - cos(n * 17.0) / 2.0,
- *     0.5 - cos(n * 13.0) / 2.0,
- *     0.5 - cos(n * 23.0) / 2.0,
- *     1.0
- *   );
- * }
- * `;
- *
- * function setup() {
- *   createCanvas(100, 100, WEBGL);
- *
- *   // Create a p5.Shader object.
- *   let mandelbrot = createShader(vertSrc, fragSrc);
- *
- *   // Compile and apply the p5.Shader object.
- *   shader(mandelbrot);
- *
- *   // Set the shader uniform p to an array.
- *   // p is the center point of the Mandelbrot image.
- *   mandelbrot.setUniform('p', [-0.74364388703, 0.13182590421]);
- *
- *   // Set the shader uniform r to 0.005.
- *   // r is the size of the image in Mandelbrot-space.
- *   mandelbrot.setUniform('r', 0.005);
- *
- *   // Style the drawing surface.
- *   noStroke();
- *
- *   // Add a plane as a drawing surface.
- *   plane(100, 100);
- *
- *   describe('A black fractal image on a magenta background.');
- * }
- * </code>
- * </div>
- *
- * <div>
- * <code>
- * // Note: A "uniform" is a global variable within a shader program.
- *
- * // Create a string with the vertex shader program.
- * // The vertex shader is called for each vertex.
- * let vertSrc = `
- * precision highp float;
- * uniform mat4 uModelViewMatrix;
- * uniform mat4 uProjectionMatrix;
- *
- * attribute vec3 aPosition;
- * attribute vec2 aTexCoord;
- * varying vec2 vTexCoord;
- *
- * void main() {
- *   vTexCoord = aTexCoord;
- *   vec4 positionVec4 = vec4(aPosition, 1.0);
- *   gl_Position = uProjectionMatrix * uModelViewMatrix * positionVec4;
- * }
- * `;
- *
- * // Create a string with the fragment shader program.
- * // The fragment shader is called for each pixel.
- * let fragSrc = `
- * precision highp float;
- * uniform vec2 p;
- * uniform float r;
- * const int numIterations = 500;
- * varying vec2 vTexCoord;
- *
- * void main() {
- *   vec2 c = p + gl_FragCoord.xy * r;
- *   vec2 z = c;
- *   float n = 0.0;
- *
- *   for (int i = numIterations; i > 0; i--) {
- *     if (z.x * z.x + z.y * z.y > 4.0) {
- *       n = float(i) / float(numIterations);
- *       break;
- *     }
- *
- *     z = vec2(z.x * z.x - z.y * z.y, 2.0 * z.x * z.y) + c;
- *   }
- *
- *   gl_FragColor = vec4(
- *     0.5 - cos(n * 17.0) / 2.0,
- *     0.5 - cos(n * 13.0) / 2.0,
- *     0.5 - cos(n * 23.0) / 2.0,
- *     1.0
- *   );
- * }
- * `;
- *
- * let mandelbrot;
- *
- * function setup() {
- *   createCanvas(100, 100, WEBGL);
- *
- *   // Create a p5.Shader object.
- *   mandelbrot = createShader(vertSrc, fragSrc);
- *
- *   // Apply the p5.Shader object.
- *   shader(mandelbrot);
- *
- *   // Set the shader uniform p to an array.
- *   // p is the center point of the Mandelbrot image.
- *   mandelbrot.setUniform('p', [-0.74364388703, 0.13182590421]);
- *
- *   describe('A fractal image zooms in and out of focus.');
- * }
- *
- * function draw() {
- *   // Set the shader uniform r to a value that oscillates
- *   // between 0 and 0.005.
- *   // r is the size of the image in Mandelbrot-space.
- *   let radius = 0.005 * (sin(frameCount * 0.01) + 1);
- *   mandelbrot.setUniform('r', radius);
- *
- *   // Style the drawing surface.
- *   noStroke();
- *
- *   // Add a plane as a drawing surface.
- *   plane(100, 100);
- * }
- * </code>
- * </div>
- *
- * <div>
- * <code>
- * // A shader with hooks.
- * let myShader;
- *
- * // A shader with modified hooks.
- * let modifiedShader;
- *
- * // Create a string with the vertex shader program.
- * // The vertex shader is called for each vertex.
- * let vertSrc = `
- * precision highp float;
- * uniform mat4 uModelViewMatrix;
- * uniform mat4 uProjectionMatrix;
- *
- * attribute vec3 aPosition;
- * attribute vec2 aTexCoord;
- *
- * void main() {
- *   vec4 positionVec4 = vec4(aPosition, 1.0);
- *   gl_Position = uProjectionMatrix * uModelViewMatrix * positionVec4;
- * }
- * `;
- *
- * // Create a fragment shader that uses a hook.
- * let fragSrc = `
- * precision highp float;
- * void main() {
- *   // Let users override the color
- *   gl_FragColor = HOOK_getColor(vec4(1., 0., 0., 1.));
- * }
- * `;
- *
- * function setup() {
- *   createCanvas(50, 50, WEBGL);
- *
- *   // Create a shader with hooks
- *   myShader = createShader(vertSrc, fragSrc, {
- *     fragment: {
- *       'vec4 getColor': '(vec4 color) { return color; }'
- *     }
- *   });
- *
- *   // Make a version of the shader with a hook overridden
- *   modifiedShader = myShader.modify({
- *     'vec4 getColor': `(vec4 color) {
- *       return vec4(0., 0., 1., 1.);
- *     }`
- *   });
- * }
- *
- * function draw() {
- *   noStroke();
- *
- *   push();
- *   shader(myShader);
- *   translate(-width/3, 0);
- *   sphere(10);
- *   pop();
- *
- *   push();
- *   shader(modifiedShader);
- *   translate(width/3, 0);
- *   sphere(10);
- *   pop();
- * }
- * </code>
- * </div>
- */
-p5.prototype.createShader = function (vertSrc, fragSrc, options) {
-  p5._validateParameters('createShader', arguments);
-  return new p5.Shader(this._renderer, vertSrc, fragSrc, options);
-};
-
-/**
- * Creates a <a href="#/p5.Shader">p5.Shader</a> object to be used with the
- * <a href="#/p5/filter">filter()</a> function.
- *
- * `createFilterShader()` works like
- * <a href="#/p5/createShader">createShader()</a> but has a default vertex
- * shader included. `createFilterShader()` is intended to be used along with
- * <a href="#/p5/filter">filter()</a> for filtering the contents of a canvas.
- * A filter shader will be applied to the whole canvas instead of just
- * <a href="#/p5.Geometry">p5.Geometry</a> objects.
- *
- * The parameter, `fragSrc`, sets the fragment shader. It’s a string that
- * contains the fragment shader program written in
- * <a href="https://developer.mozilla.org/en-US/docs/Games/Techniques/3D_on_the_web/GLSL_Shaders" target="_blank">GLSL</a>.
- *
- * The <a href="#/p5.Shader">p5.Shader</a> object that's created has some
- * uniforms that can be set:
- * - `sampler2D tex0`, which contains the canvas contents as a texture.
- * - `vec2 canvasSize`, which is the width and height of the canvas, not including pixel density.
- * - `vec2 texelSize`, which is the size of a physical pixel including pixel density. This is calculated as `1.0 / (width * density)` for the pixel width and `1.0 / (height * density)` for the pixel height.
- *
- * The <a href="#/p5.Shader">p5.Shader</a> that's created also provides
- * `varying vec2 vTexCoord`, a coordinate with values between 0 and 1.
- * `vTexCoord` describes where on the canvas the pixel will be drawn.
- *
- * For more info about filters and shaders, see Adam Ferriss' <a href="https://github.com/aferriss/p5jsShaderExamples">repo of shader examples</a>
- * or the <a href="https://p5js.org/learn/getting-started-in-webgl-shaders.html">Introduction to Shaders</a> tutorial.
- *
- * @method createFilterShader
- * @param {String} fragSrc source code for the fragment shader.
- * @returns {p5.Shader} new shader object created from the fragment shader.
- *
- * @example
- * <div modernizr='webgl'>
- * <code>
- * function setup() {
- *   let fragSrc = `precision highp float;
- *   void main() {
- *     gl_FragColor = vec4(1.0, 1.0, 0.0, 1.0);
- *   }`;
- *
- *   createCanvas(100, 100, WEBGL);
- *   let s = createFilterShader(fragSrc);
- *   filter(s);
- *   describe('a yellow canvas');
- * }
- * </code>
- * </div>
- *
- * <div modernizr='webgl'>
- * <code>
- * let img, s;
- * function preload() {
- *   img = loadImage('assets/bricks.jpg');
- * }
- * function setup() {
- *   let fragSrc = `precision highp float;
- *
- *   // x,y coordinates, given from the vertex shader
- *   varying vec2 vTexCoord;
- *
- *   // the canvas contents, given from filter()
- *   uniform sampler2D tex0;
- *   // other useful information from the canvas
- *   uniform vec2 texelSize;
- *   uniform vec2 canvasSize;
- *   // a custom variable from this sketch
- *   uniform float darkness;
- *
- *   void main() {
- *     // get the color at current pixel
- *     vec4 color = texture2D(tex0, vTexCoord);
- *     // set the output color
- *     color.b = 1.0;
- *     color *= darkness;
- *     gl_FragColor = vec4(color.rgb, 1.0);
- *   }`;
- *
- *   createCanvas(100, 100, WEBGL);
- *   s = createFilterShader(fragSrc);
- * }
- * function draw() {
- *   image(img, -50, -50);
- *   s.setUniform('darkness', 0.5);
- *   filter(s);
- *   describe('a image of bricks tinted dark blue');
- * }
- * </code>
- * </div>
- */
-p5.prototype.createFilterShader = function (fragSrc) {
-  p5._validateParameters('createFilterShader', arguments);
-  let defaultVertV1 = `
-    uniform mat4 uModelViewMatrix;
-    uniform mat4 uProjectionMatrix;
-
-    attribute vec3 aPosition;
-    // texcoords only come from p5 to vertex shader
-    // so pass texcoords on to the fragment shader in a varying variable
-    attribute vec2 aTexCoord;
-    varying vec2 vTexCoord;
-
-    void main() {
-      // transferring texcoords for the frag shader
-      vTexCoord = aTexCoord;
-
-      // copy position with a fourth coordinate for projection (1.0 is normal)
-      vec4 positionVec4 = vec4(aPosition, 1.0);
-
-      // project to 3D space
-      gl_Position = uProjectionMatrix * uModelViewMatrix * positionVec4;
+    for (const texture of this._renderer.textures.values()) {
+      texture.setWrapMode(wrapX, wrapY);
     }
-  `;
-  let defaultVertV2 = `#version 300 es
-    uniform mat4 uModelViewMatrix;
-    uniform mat4 uProjectionMatrix;
+  };
 
-    in vec3 aPosition;
-    in vec2 aTexCoord;
-    out vec2 vTexCoord;
+  /**
+   * Sets the current material as a normal material.
+   *
+   * A normal material sets surfaces facing the x-axis to red, those facing the
+   * y-axis to green, and those facing the z-axis to blue. Normal material isn't
+   * affected by light. It’s often used as a placeholder material when debugging.
+   *
+   * Note: `normalMaterial()` can only be used in WebGL mode.
+   *
+   * @method normalMaterial
+   * @chainable
+   *
+   * @example
+   * <div>
+   * <code>
+   * // Click and drag the mouse to view the scene from different angles.
+   *
+   * function setup() {
+   *   createCanvas(100, 100, WEBGL);
+   *
+   *   describe('A multicolor torus drawn on a gray background.');
+   * }
+   *
+   * function draw() {
+   *   background(200);
+   *
+   *   // Enable orbiting with the mouse.
+   *   orbitControl();
+   *
+   *   // Style the torus.
+   *   normalMaterial();
+   *
+   *   // Draw the torus.
+   *   torus(30);
+   * }
+   * </code>
+   * </div>
+   */
+  fn.normalMaterial = function (...args) {
+    this._assert3d('normalMaterial');
+    p5._validateParameters('normalMaterial', args);
+    this._renderer.states.drawMode = constants.FILL;
+    this._renderer.states._useSpecularMaterial = false;
+    this._renderer.states._useEmissiveMaterial = false;
+    this._renderer.states._useNormalMaterial = true;
+    this._renderer.states.curFillColor = [1, 1, 1, 1];
+    this._renderer.states.doFill = true;
+    this.noStroke();
+    return this;
+  };
 
-    void main() {
-      // transferring texcoords for the frag shader
-      vTexCoord = aTexCoord;
+  /**
+   * Sets the ambient color of shapes’ surface material.
+   *
+   * The `ambientMaterial()` color sets the components of the
+   * <a href="#/p5/ambientLight">ambientLight()</a> color that shapes will
+   * reflect. For example, calling `ambientMaterial(255, 255, 0)` would cause a
+   * shape to reflect red and green light, but not blue light.
+   *
+   * `ambientMaterial()` can be called three ways with different parameters to
+   * set the material’s color.
+   *
+   * The first way to call `ambientMaterial()` has one parameter, `gray`.
+   * Grayscale values between 0 and 255, as in `ambientMaterial(50)`, can be
+   * passed to set the material’s color. Higher grayscale values make shapes
+   * appear brighter.
+   *
+   * The second way to call `ambientMaterial()` has one parameter, `color`. A
+   * <a href="#/p5.Color">p5.Color</a> object, an array of color values, or a
+   * CSS color string, as in `ambientMaterial('magenta')`, can be passed to set
+   * the material’s color.
+   *
+   * The third way to call `ambientMaterial()` has three parameters, `v1`, `v2`,
+   * and `v3`. RGB, HSB, or HSL values, as in `ambientMaterial(255, 0, 0)`, can
+   * be passed to set the material’s colors. Color values will be interpreted
+   * using the current <a href="#/p5/colorMode">colorMode()</a>.
+   *
+   * Note: `ambientMaterial()` can only be used in WebGL mode.
+   *
+   * @method ambientMaterial
+   * @param  {Number} v1  red or hue value in the current
+   *                       <a href="#/p5/colorMode">colorMode()</a>.
+   * @param  {Number} v2  green or saturation value in the
+   *                      current <a href="#/p5/colorMode">colorMode()</a>.
+   * @param  {Number} v3  blue, brightness, or lightness value in the
+   *                      current <a href="#/p5/colorMode">colorMode()</a>.
+   * @chainable
+   *
+   * @example
+   * <div>
+   * <code>
+   * // Click and drag the mouse to view the scene from different angles.
+   *
+   * function setup() {
+   *   createCanvas(100, 100, WEBGL);
+   *
+   *   describe('A magenta cube drawn on a gray background.');
+   * }
+   *
+   * function draw() {
+   *   background(200);
+   *
+   *   // Enable orbiting with the mouse.
+   *   orbitControl();
+   *
+   *   // Turn on a magenta ambient light.
+   *   ambientLight(255, 0, 255);
+   *
+   *   // Draw the box.
+   *   box();
+   * }
+   * </code>
+   * </div>
+   *
+   * <div>
+   * <code>
+   * // Click and drag the mouse to view the scene from different angles.
+   *
+   * function setup() {
+   *   createCanvas(100, 100, WEBGL);
+   *
+   *   describe('A purple cube drawn on a gray background.');
+   * }
+   *
+   * function draw() {
+   *   background(200);
+   *
+   *   // Enable orbiting with the mouse.
+   *   orbitControl();
+   *
+   *   // Turn on a magenta ambient light.
+   *   ambientLight(255, 0, 255);
+   *
+   *   // Add a dark gray ambient material.
+   *   ambientMaterial(150);
+   *
+   *   // Draw the box.
+   *   box();
+   * }
+   * </code>
+   * </div>
+   *
+   * <div>
+   * <code>
+   * // Click and drag the mouse to view the scene from different angles.
+   *
+   * function setup() {
+   *   createCanvas(100, 100, WEBGL);
+   *
+   *   describe('A red cube drawn on a gray background.');
+   * }
+   *
+   * function draw() {
+   *   background(200);
+   *
+   *   // Enable orbiting with the mouse.
+   *   orbitControl();
+   *
+   *   // Turn on a magenta ambient light.
+   *   ambientLight(255, 0, 255);
+   *
+   *   // Add a yellow ambient material using RGB values.
+   *   ambientMaterial(255, 255, 0);
+   *
+   *   // Draw the box.
+   *   box();
+   * }
+   * </code>
+   * </div>
+   *
+   * <div>
+   * <code>
+   * // Click and drag the mouse to view the scene from different angles.
+   *
+   * function setup() {
+   *   createCanvas(100, 100, WEBGL);
+   *
+   *   describe('A red cube drawn on a gray background.');
+   * }
+   *
+   * function draw() {
+   *   background(200);
+   *
+   *   // Enable orbiting with the mouse.
+   *   orbitControl();
+   *
+   *   // Turn on a magenta ambient light.
+   *   ambientLight(255, 0, 255);
+   *
+   *   // Add a yellow ambient material using a p5.Color object.
+   *   let c = color(255, 255, 0);
+   *   ambientMaterial(c);
+   *
+   *   // Draw the box.
+   *   box();
+   * }
+   * </code>
+   * </div>
+   *
+   * <div>
+   * <code>
+   * // Click and drag the mouse to view the scene from different angles.
+   *
+   * function setup() {
+   *   createCanvas(100, 100, WEBGL);
+   *
+   *   describe('A red cube drawn on a gray background.');
+   * }
+   *
+   * function draw() {
+   *   background(200);
+   *
+   *   // Enable orbiting with the mouse.
+   *   orbitControl();
+   *
+   *   // Turn on a magenta ambient light.
+   *   ambientLight(255, 0, 255);
+   *
+   *   // Add a yellow ambient material using a color string.
+   *   ambientMaterial('yellow');
+   *
+   *   // Draw the box.
+   *   box();
+   * }
+   * </code>
+   * </div>
+   *
+   * <div>
+   * <code>
+   * // Click and drag the mouse to view the scene from different angles.
+   *
+   * function setup() {
+   *   createCanvas(100, 100, WEBGL);
+   *
+   *   describe('A yellow cube drawn on a gray background.');
+   * }
+   *
+   * function draw() {
+   *   background(200);
+   *
+   *   // Enable orbiting with the mouse.
+   *   orbitControl();
+   *
+   *   // Turn on a white ambient light.
+   *   ambientLight(255, 255, 255);
+   *
+   *   // Add a yellow ambient material using a color string.
+   *   ambientMaterial('yellow');
+   *
+   *   // Draw the box.
+   *   box();
+   * }
+   * </code>
+   * </div>
+   */
 
-      // copy position with a fourth coordinate for projection (1.0 is normal)
-      vec4 positionVec4 = vec4(aPosition, 1.0);
+  /**
+   * @method ambientMaterial
+   * @param  {Number} gray grayscale value between 0 (black) and 255 (white).
+   * @chainable
+   */
 
-      // project to 3D space
-      gl_Position = uProjectionMatrix * uModelViewMatrix * positionVec4;
-    }
-  `;
-  let vertSrc = fragSrc.includes('#version 300 es') ? defaultVertV2 : defaultVertV1;
-  const shader = new p5.Shader(this._renderer, vertSrc, fragSrc);
-  if (this._renderer.GL) {
-    shader.ensureCompiledOnContext(this);
-  } else {
-    shader.ensureCompiledOnContext(this._renderer.getFilterGraphicsLayer());
-  }
-  return shader;
-};
+  /**
+   * @method ambientMaterial
+   * @param  {p5.Color|Number[]|String} color
+   *           color as a <a href="#/p5.Color">p5.Color</a> object,
+   *            an array of color values, or a CSS string.
+   * @chainable
+   */
+  fn.ambientMaterial = function (v1, v2, v3) {
+    this._assert3d('ambientMaterial');
+    p5._validateParameters('ambientMaterial', arguments);
 
-/**
- * Sets the <a href="#/p5.Shader">p5.Shader</a> object to apply while drawing.
- *
- * Shaders are programs that run on the graphics processing unit (GPU). They
- * can process many pixels or vertices at the same time, making them fast for
- * many graphics tasks. They’re written in a language called
- * <a href="https://developer.mozilla.org/en-US/docs/Games/Techniques/3D_on_the_web/GLSL_Shaders" target="_blank">GLSL</a>
- * and run along with the rest of the code in a sketch.
- * <a href="#/p5.Shader">p5.Shader</a> objects can be created using the
- * <a href="#/p5/createShader">createShader()</a> and
- * <a href="#/p5/loadShader">loadShader()</a> functions.
- *
- * The parameter, `s`, is the <a href="#/p5.Shader">p5.Shader</a> object to
- * apply. For example, calling `shader(myShader)` applies `myShader` to
- * process each pixel on the canvas. The shader will be used for:
- * - Fills when a texture is enabled if it includes a uniform `sampler2D`.
- * - Fills when lights are enabled if it includes the attribute `aNormal`, or if it has any of the following uniforms: `uUseLighting`, `uAmbientLightCount`, `uDirectionalLightCount`, `uPointLightCount`, `uAmbientColor`, `uDirectionalDiffuseColors`, `uDirectionalSpecularColors`, `uPointLightLocation`, `uPointLightDiffuseColors`, `uPointLightSpecularColors`, `uLightingDirection`, or `uSpecular`.
- * - Fills whenever there are no lights or textures.
- * - Strokes if it includes the uniform `uStrokeWeight`.
- *
- * The source code from a <a href="#/p5.Shader">p5.Shader</a> object's
- * fragment and vertex shaders will be compiled the first time it's passed to
- * `shader()`. See
- * <a href="https://developer.mozilla.org/en-US/docs/Web/API/WebGLRenderingContext/compileShader" target="_blank">MDN</a>
- * for more information about compiling shaders.
- *
- * Calling <a href="#/p5/resetShader">resetShader()</a> restores a sketch’s
- * default shaders.
- *
- * Note: Shaders can only be used in WebGL mode.
- *
- * @method shader
- * @chainable
- * @param {p5.Shader} s <a href="#/p5.Shader">p5.Shader</a> object
- *                      to apply.
- *
- * @example
- * <div modernizr='webgl'>
- * <code>
- * // Note: A "uniform" is a global variable within a shader program.
- *
- * // Create a string with the vertex shader program.
- * // The vertex shader is called for each vertex.
- * let vertSrc = `
- * precision highp float;
- * uniform mat4 uModelViewMatrix;
- * uniform mat4 uProjectionMatrix;
- *
- * attribute vec3 aPosition;
- * attribute vec2 aTexCoord;
- * varying vec2 vTexCoord;
- *
- * void main() {
- *   vTexCoord = aTexCoord;
- *   vec4 positionVec4 = vec4(aPosition, 1.0);
- *   gl_Position = uProjectionMatrix * uModelViewMatrix * positionVec4;
- * }
- * `;
- *
- * // Create a string with the fragment shader program.
- * // The fragment shader is called for each pixel.
- * let fragSrc = `
- * precision highp float;
- *
- * void main() {
- *   // Set each pixel's RGBA value to yellow.
- *   gl_FragColor = vec4(1.0, 1.0, 0.0, 1.0);
- * }
- * `;
- *
- * function setup() {
- *   createCanvas(100, 100, WEBGL);
- *
- *   // Create a p5.Shader object.
- *   let shaderProgram = createShader(vertSrc, fragSrc);
- *
- *   // Apply the p5.Shader object.
- *   shader(shaderProgram);
- *
- *   // Style the drawing surface.
- *   noStroke();
- *
- *   // Add a plane as a drawing surface.
- *   plane(100, 100);
- *
- *   describe('A yellow square.');
- * }
- * </code>
- * </div>
- *
- * <div>
- * <code>
- * // Note: A "uniform" is a global variable within a shader program.
- *
- * let mandelbrot;
- *
- * // Load the shader and create a p5.Shader object.
- * function preload() {
- *   mandelbrot = loadShader('assets/shader.vert', 'assets/shader.frag');
- * }
- *
- * function setup() {
- *   createCanvas(100, 100, WEBGL);
- *
- *   // Use the p5.Shader object.
- *   shader(mandelbrot);
- *
- *   // Set the shader uniform p to an array.
- *   mandelbrot.setUniform('p', [-0.74364388703, 0.13182590421]);
- *
- *   describe('A fractal image zooms in and out of focus.');
- * }
- *
- * function draw() {
- *   // Set the shader uniform r to a value that oscillates between 0 and 2.
- *   mandelbrot.setUniform('r', sin(frameCount * 0.01) + 1);
- *
- *   // Add a quad as a display surface for the shader.
- *   quad(-1, -1, 1, -1, 1, 1, -1, 1);
- * }
- * </code>
- * </div>
- *
- * <div>
- * <code>
- * // Note: A "uniform" is a global variable within a shader program.
- *
- * let redGreen;
- * let orangeBlue;
- * let showRedGreen = false;
- *
- * // Load the shader and create two separate p5.Shader objects.
- * function preload() {
- *   redGreen = loadShader('assets/shader.vert', 'assets/shader-gradient.frag');
- *   orangeBlue = loadShader('assets/shader.vert', 'assets/shader-gradient.frag');
- * }
- *
- * function setup() {
- *   createCanvas(100, 100, WEBGL);
- *
- *   // Initialize the redGreen shader.
- *   shader(redGreen);
- *
- *   // Set the redGreen shader's center and background color.
- *   redGreen.setUniform('colorCenter', [1.0, 0.0, 0.0]);
- *   redGreen.setUniform('colorBackground', [0.0, 1.0, 0.0]);
- *
- *   // Initialize the orangeBlue shader.
- *   shader(orangeBlue);
- *
- *   // Set the orangeBlue shader's center and background color.
- *   orangeBlue.setUniform('colorCenter', [1.0, 0.5, 0.0]);
- *   orangeBlue.setUniform('colorBackground', [0.226, 0.0, 0.615]);
- *
- *   describe(
- *     'The scene toggles between two circular gradients when the user double-clicks. An orange and blue gradient vertically, and red and green gradient moves horizontally.'
- *   );
- * }
- *
- * function draw() {
- *   // Update the offset values for each shader.
- *   // Move orangeBlue vertically.
- *   // Move redGreen horizontally.
- *   orangeBlue.setUniform('offset', [0, sin(frameCount * 0.01) + 1]);
- *   redGreen.setUniform('offset', [sin(frameCount * 0.01), 1]);
- *
- *   if (showRedGreen === true) {
- *     shader(redGreen);
- *   } else {
- *     shader(orangeBlue);
- *   }
- *
- *   // Style the drawing surface.
- *   noStroke();
- *
- *   // Add a quad as a drawing surface.
- *   quad(-1, -1, 1, -1, 1, 1, -1, 1);
- * }
- *
- * // Toggle between shaders when the user double-clicks.
- * function doubleClicked() {
- *   showRedGreen = !showRedGreen;
- * }
- * </code>
- * </div>
- */
-p5.prototype.shader = function (s) {
-  this._assert3d('shader');
-  p5._validateParameters('shader', arguments);
-
-  s.ensureCompiledOnContext(this);
-
-  if (s.isStrokeShader()) {
-    this._renderer.states.userStrokeShader = s;
-  } else {
-    this._renderer.states.userFillShader = s;
+    const color = fn.color.apply(this, arguments);
+    this._renderer.states._hasSetAmbient = true;
+    this._renderer.states.curAmbientColor = color._array;
     this._renderer.states._useNormalMaterial = false;
-  }
+    this._renderer.states._enableLighting = true;
+    this._renderer.states.doFill = true;
+    return this;
+  };
 
-  s.setDefaultUniforms();
+  /**
+   * Sets the emissive color of shapes’ surface material.
+   *
+   * The `emissiveMaterial()` color sets a color shapes display at full
+   * strength, regardless of lighting. This can give the appearance that a shape
+   * is glowing. However, emissive materials don’t actually emit light that
+   * can affect surrounding objects.
+   *
+   * `emissiveMaterial()` can be called three ways with different parameters to
+   * set the material’s color.
+   *
+   * The first way to call `emissiveMaterial()` has one parameter, `gray`.
+   * Grayscale values between 0 and 255, as in `emissiveMaterial(50)`, can be
+   * passed to set the material’s color. Higher grayscale values make shapes
+   * appear brighter.
+   *
+   * The second way to call `emissiveMaterial()` has one parameter, `color`. A
+   * <a href="#/p5.Color">p5.Color</a> object, an array of color values, or a
+   * CSS color string, as in `emissiveMaterial('magenta')`, can be passed to set
+   * the material’s color.
+   *
+   * The third way to call `emissiveMaterial()` has four parameters, `v1`, `v2`,
+   * `v3`, and `alpha`. `alpha` is optional. RGBA, HSBA, or HSLA values can be
+   * passed to set the material’s colors, as in `emissiveMaterial(255, 0, 0)` or
+   * `emissiveMaterial(255, 0, 0, 30)`. Color values will be interpreted using
+   * the current <a href="#/p5/colorMode">colorMode()</a>.
+   *
+   * Note: `emissiveMaterial()` can only be used in WebGL mode.
+   *
+   * @method emissiveMaterial
+   * @param  {Number} v1       red or hue value in the current
+   *                           <a href="#/p5/colorMode">colorMode()</a>.
+   * @param  {Number} v2       green or saturation value in the
+   *                           current <a href="#/p5/colorMode">colorMode()</a>.
+   * @param  {Number} v3       blue, brightness, or lightness value in the
+   *                           current <a href="#/p5/colorMode">colorMode()</a>.
+   * @param  {Number} [alpha]  alpha value in the current
+   *                           <a href="#/p5/colorMode">colorMode()</a>.
+   * @chainable
+   *
+   * @example
+   * <div>
+   * <code>
+   * // Click and drag the mouse to view the scene from different angles.
+   *
+   * function setup() {
+   *   createCanvas(100, 100, WEBGL);
+   *
+   *   describe('A red cube drawn on a gray background.');
+   * }
+   *
+   * function draw() {
+   *   background(200);
+   *
+   *   // Enable orbiting with the mouse.
+   *   orbitControl();
+   *
+   *   // Turn on a white ambient light.
+   *   ambientLight(255, 255, 255);
+   *
+   *   // Add a red emissive material using RGB values.
+   *   emissiveMaterial(255, 0, 0);
+   *
+   *   // Draw the box.
+   *   box();
+   * }
+   * </code>
+   * </div>
+   */
 
-  return this;
-};
+  /**
+   * @method emissiveMaterial
+   * @param  {Number} gray grayscale value between 0 (black) and 255 (white).
+   * @chainable
+   */
 
-/**
- * Get the default shader used with lights, materials,
- * and textures.
- *
- * You can call <a href="#/p5.Shader/modify">`baseMaterialShader().modify()`</a>
- * and change any of the following hooks:
- *
- * <table>
- * <tr><th>Hook</th><th>Description</th></tr>
- * <tr><td>
- *
- * `void beforeVertex`
- *
- * </td><td>
- *
- * Called at the start of the vertex shader.
- *
- * </td></tr>
- * <tr><td>
- *
- * `vec3 getLocalPosition`
- *
- * </td><td>
- *
- * Update the position of vertices before transforms are applied. It takes in `vec3 position` and must return a modified version.
- *
- * </td></tr>
- * <tr><td>
- *
- * `vec3 getWorldPosition`
- *
- * </td><td>
- *
- * Update the position of vertices after transforms are applied. It takes in `vec3 position` and pust return a modified version.
- *
- * </td></tr>
- * <tr><td>
- *
- * `vec3 getLocalNormal`
- *
- * </td><td>
- *
- * Update the normal before transforms are applied. It takes in `vec3 normal` and must return a modified version.
- *
- * </td></tr>
- * <tr><td>
- *
- * `vec3 getWorldNormal`
- *
- * </td><td>
- *
- * Update the normal after transforms are applied. It takes in `vec3 normal` and must return a modified version.
- *
- * </td></tr>
- * <tr><td>
- *
- * `vec2 getUV`
- *
- * </td><td>
- *
- * Update the texture coordinates. It takes in `vec2 uv` and must return a modified version.
- *
- * </td></tr>
- * <tr><td>
- *
- * `vec4 getVertexColor`
- *
- * </td><td>
- *
- * Update the color of each vertex. It takes in a `vec4 color` and must return a modified version.
- *
- * </td></tr>
- * <tr><td>
- *
- * `void afterVertex`
- *
- * </td><td>
- *
- * Called at the end of the vertex shader.
- *
- * </td></tr>
- * <tr><td>
- *
- * `void beforeFragment`
- *
- * </td><td>
- *
- * Called at the start of the fragment shader.
- *
- * </td></tr>
- * <tr><td>
- *
- * `Inputs getPixelInputs`
- *
- * </td><td>
- *
- * Update the per-pixel inputs of the material. It takes in an `Inputs` struct, which includes:
- * - `vec3 normal`, the direction pointing out of the surface
- * - `vec2 texCoord`, a vector where `x` and `y` are between 0 and 1 describing the spot on a texture the pixel is mapped to, as a fraction of the texture size
- * - `vec3 ambientLight`, the ambient light color on the vertex
- * - `vec4 color`, the base material color of the pixel
- * - `vec3 ambientMaterial`, the color of the pixel when affected by ambient light
- * - `vec3 specularMaterial`, the color of the pixel when reflecting specular highlights
- * - `vec3 emissiveMaterial`, the light color emitted by the pixel
- * - `float shininess`, a number representing how sharp specular reflections should be, from 1 to infinity
- * - `float metalness`, a number representing how mirrorlike the material should be, between 0 and 1
- * The struct can be modified and returned.
- * </td></tr>
- * <tr><td>
- *
- * `vec4 combineColors`
- *
- * </td><td>
- *
- * Take in a `ColorComponents` struct containing all the different components of light, and combining them into
- * a single final color. The struct contains:
- * - `vec3 baseColor`, the base color of the pixel
- * - `float opacity`, the opacity between 0 and 1 that it should be drawn at
- * - `vec3 ambientColor`, the color of the pixel when affected by ambient light
- * - `vec3 specularColor`, the color of the pixel when affected by specular reflections
- * - `vec3 diffuse`, the amount of diffused light hitting the pixel
- * - `vec3 ambient`, the amount of ambient light hitting the pixel
- * - `vec3 specular`, the amount of specular reflection hitting the pixel
- * - `vec3 emissive`, the amount of light emitted by the pixel
- *
- * </td></tr>
- * <tr><td>
- *
- * `vec4 getFinalColor`
- *
- * </td><td>
- *
- * Update the final color after mixing. It takes in a `vec4 color` and must return a modified version.
- *
- * </td></tr>
- * <tr><td>
- *
- * `void afterFragment`
- *
- * </td><td>
- *
- * Called at the end of the fragment shader.
- *
- * </td></tr>
- * </table>
- *
- * Most of the time, you will need to write your hooks in GLSL ES version 300. If you
- * are using WebGL 1 instead of 2, write your hooks in GLSL ES 100 instead.
- *
- * Call `baseMaterialShader().inspectHooks()` to see all the possible hooks and
- * their default implementations.
- *
- * @method baseMaterialShader
- * @beta
- * @returns {p5.Shader} The material shader
- *
- * @example
- * <div modernizr='webgl'>
- * <code>
- * let myShader;
- *
- * function setup() {
- *   createCanvas(200, 200, WEBGL);
- *   myShader = baseMaterialShader().modify({
- *     uniforms: {
- *       'float time': () => millis()
- *     },
- *     'vec3 getWorldPosition': `(vec3 pos) {
- *       pos.y += 20.0 * sin(time * 0.001 + pos.x * 0.05);
- *       return pos;
- *     }`
- *   });
- * }
- *
- * function draw() {
- *   background(255);
- *   shader(myShader);
- *   lights();
- *   noStroke();
- *   fill('red');
- *   sphere(50);
- * }
- * </code>
- * </div>
- *
- * @example
- * <div modernizr='webgl'>
- * <code>
- * let myShader;
- *
- * function setup() {
- *   createCanvas(200, 200, WEBGL);
- *   myShader = baseMaterialShader().modify({
- *     declarations: 'vec3 myNormal;',
- *     'Inputs getPixelInputs': `(Inputs inputs) {
- *       myNormal = inputs.normal;
- *       return inputs;
- *     }`,
- *     'vec4 getFinalColor': `(vec4 color) {
- *       return mix(
- *         vec4(1.0, 1.0, 1.0, 1.0),
- *         color,
- *         abs(dot(myNormal, vec3(0.0, 0.0, 1.0)))
- *       );
- *     }`
- *   });
- * }
- *
- * function draw() {
- *   background(255);
- *   rotateY(millis() * 0.001);
- *   shader(myShader);
- *   lights();
- *   noStroke();
- *   fill('red');
- *   torus(30);
- * }
- * </code>
- * </div>
- *
- * @example
- * <div modernizr='webgl'>
- * <code>
- * let myShader;
- * let environment;
- *
- * function preload() {
- *   environment = loadImage('assets/outdoor_spheremap.jpg');
- * }
- *
- * function setup() {
- *   createCanvas(200, 200, WEBGL);
- *   myShader = baseMaterialShader().modify({
- *     'Inputs getPixelInputs': `(Inputs inputs) {
- *       float factor =
- *         sin(
- *           inputs.texCoord.x * ${TWO_PI} +
- *           inputs.texCoord.y * ${TWO_PI}
- *         ) * 0.4 + 0.5;
- *       inputs.shininess = mix(1., 100., factor);
- *       inputs.metalness = factor;
- *       return inputs;
- *     }`
- *   });
- * }
- *
- * function draw() {
- *   panorama(environment);
- *   ambientLight(100);
- *   imageLight(environment);
- *   rotateY(millis() * 0.001);
- *   shader(myShader);
- *   noStroke();
- *   fill(255);
- *   specularMaterial(150);
- *   sphere(50);
- * }
- * </code>
- * </div>
- *
- * @example
- * <div modernizr='webgl'>
- * <code>
- * let myShader;
- *
- * function setup() {
- *   createCanvas(200, 200, WEBGL);
- *   myShader = baseMaterialShader().modify({
- *     'Inputs getPixelInputs': `(Inputs inputs) {
- *       vec3 newNormal = inputs.normal;
- *       // Simple bump mapping: adjust the normal based on position
- *       newNormal.x += 0.2 * sin(
- *           sin(
- *             inputs.texCoord.y * ${TWO_PI} * 10.0 +
- *             inputs.texCoord.x * ${TWO_PI} * 25.0
- *           )
- *         );
- *       newNormal.y += 0.2 * sin(
- *         sin(
- *             inputs.texCoord.x * ${TWO_PI} * 10.0 +
- *             inputs.texCoord.y * ${TWO_PI} * 25.0
- *           )
- *       );
- *       inputs.normal = normalize(newNormal);
- *       return inputs;
- *     }`
- *   });
- * }
- *
- * function draw() {
- *   background(255);
- *   shader(myShader);
- *   ambientLight(150);
- *   pointLight(
- *     255, 255, 255,
- *     100*cos(frameCount*0.04), -50, 100*sin(frameCount*0.04)
- *   );
- *   noStroke();
- *   fill('red');
- *   shininess(200);
- *   specularMaterial(255);
- *   sphere(50);
- * }
- * </code>
- * </div>
- */
-p5.prototype.baseMaterialShader = function() {
-  this._assert3d('baseMaterialShader');
-  return this._renderer.baseMaterialShader();
-};
+  /**
+   * @method emissiveMaterial
+   * @param  {p5.Color|Number[]|String} color
+   *           color as a <a href="#/p5.Color">p5.Color</a> object,
+   *            an array of color values, or a CSS string.
+   * @chainable
+   */
+  fn.emissiveMaterial = function (v1, v2, v3, a) {
+    this._assert3d('emissiveMaterial');
+    p5._validateParameters('emissiveMaterial', arguments);
 
-/**
- * Get the shader used by <a href="#/p5/normalMaterial">`normalMaterial()`</a>.
- *
- * You can call <a href="#/p5.Shader/modify">`baseNormalShader().modify()`</a>
- * and change any of the following hooks:
- *
- * Hook | Description
- * -----|------------
- * `void beforeVertex` | Called at the start of the vertex shader.
- * `vec3 getLocalPosition` | Update the position of vertices before transforms are applied. It takes in `vec3 position` and must return a modified version.
- * `vec3 getWorldPosition` | Update the position of vertices after transforms are applied. It takes in `vec3 position` and pust return a modified version.
- * `vec3 getLocalNormal` | Update the normal before transforms are applied. It takes in `vec3 normal` and must return a modified version.
- * `vec3 getWorldNormal` | Update the normal after transforms are applied. It takes in `vec3 normal` and must return a modified version.
- * `vec2 getUV` | Update the texture coordinates. It takes in `vec2 uv` and must return a modified version.
- * `vec4 getVertexColor` | Update the color of each vertex. It takes in a `vec4 color` and must return a modified version.
- * `void afterVertex` | Called at the end of the vertex shader.
- * `void beforeFragment` | Called at the start of the fragment shader.
- * `vec4 getFinalColor` | Update the final color after mixing. It takes in a `vec4 color` and must return a modified version.
- * `void afterFragment` | Called at the end of the fragment shader.
- *
- * Most of the time, you will need to write your hooks in GLSL ES version 300. If you
- * are using WebGL 1 instead of 2, write your hooks in GLSL ES 100 instead.
- *
- * Call `baseNormalShader().inspectHooks()` to see all the possible hooks and
- * their default implementations.
- *
- * @method baseNormalShader
- * @beta
- * @returns {p5.Shader} The `normalMaterial` shader
- *
- * @example
- * <div modernizr='webgl'>
- * <code>
- * let myShader;
- *
- * function setup() {
- *   createCanvas(200, 200, WEBGL);
- *   myShader = baseNormalShader().modify({
- *     uniforms: {
- *       'float time': () => millis()
- *     },
- *     'vec3 getWorldPosition': `(vec3 pos) {
- *       pos.y += 20. * sin(time * 0.001 + pos.x * 0.05);
- *       return pos;
- *     }`
- *   });
- * }
- *
- * function draw() {
- *   background(255);
- *   shader(myShader);
- *   noStroke();
- *   sphere(50);
- * }
- * </code>
- * </div>
- *
- * @example
- * <div modernizr='webgl'>
- * <code>
- * let myShader;
- *
- * function setup() {
- *   createCanvas(200, 200, WEBGL);
- *   myShader = baseNormalShader().modify({
- *     'vec3 getWorldNormal': '(vec3 normal) { return abs(normal); }',
- *     'vec4 getFinalColor': `(vec4 color) {
- *       // Map the r, g, and b values of the old normal to new colors
- *       // instead of just red, green, and blue:
- *       vec3 newColor =
- *         color.r * vec3(89.0, 240.0, 232.0) / 255.0 +
- *         color.g * vec3(240.0, 237.0, 89.0) / 255.0 +
- *         color.b * vec3(205.0, 55.0, 222.0) / 255.0;
- *       newColor = newColor / (color.r + color.g + color.b);
- *       return vec4(newColor, 1.0) * color.a;
- *     }`
- *   });
- * }
- *
- * function draw() {
- *   background(255);
- *   shader(myShader);
- *   noStroke();
- *   rotateX(frameCount * 0.01);
- *   rotateY(frameCount * 0.015);
- *   box(100);
- * }
- * </code>
- * </div>
- */
-p5.prototype.baseNormalShader = function() {
-  this._assert3d('baseNormalShader');
-  return this._renderer.baseNormalShader();
-};
+    const color = fn.color.apply(this, arguments);
+    this._renderer.states.curEmissiveColor = color._array;
+    this._renderer.states._useEmissiveMaterial = true;
+    this._renderer.states._useNormalMaterial = false;
+    this._renderer.states._enableLighting = true;
 
-/**
- * Get the shader used when no lights or materials are applied.
- *
- * You can call <a href="#/p5.Shader/modify">`baseColorShader().modify()`</a>
- * and change any of the following hooks:
- *
- * Hook | Description
- * -------|-------------
- * `void beforeVertex` | Called at the start of the vertex shader.
- * `vec3 getLocalPosition` | Update the position of vertices before transforms are applied. It takes in `vec3 position` and must return a modified version.
- * `vec3 getWorldPosition` | Update the position of vertices after transforms are applied. It takes in `vec3 position` and pust return a modified version.
- * `vec3 getLocalNormal` | Update the normal before transforms are applied. It takes in `vec3 normal` and must return a modified version.
- * `vec3 getWorldNormal` | Update the normal after transforms are applied. It takes in `vec3 normal` and must return a modified version.
- * `vec2 getUV` | Update the texture coordinates. It takes in `vec2 uv` and must return a modified version.
- * `vec4 getVertexColor` | Update the color of each vertex. It takes in a `vec4 color` and must return a modified version.
- * `void afterVertex` | Called at the end of the vertex shader.
- * `void beforeFragment` | Called at the start of the fragment shader.
- * `vec4 getFinalColor` | Update the final color after mixing. It takes in a `vec4 color` and must return a modified version.
- * `void afterFragment` | Called at the end of the fragment shader.
- *
- * Most of the time, you will need to write your hooks in GLSL ES version 300. If you
- * are using WebGL 1 instead of 2, write your hooks in GLSL ES 100 instead.
- *
- * Call `baseColorShader().inspectHooks()` to see all the possible hooks and
- * their default implementations.
- *
- * @method baseColorShader
- * @beta
- * @returns {p5.Shader} The color shader
- *
- * @example
- * <div modernizr='webgl'>
- * <code>
- * let myShader;
- *
- * function setup() {
- *   createCanvas(200, 200, WEBGL);
- *   myShader = baseColorShader().modify({
- *     uniforms: {
- *       'float time': () => millis()
- *     },
- *     'vec3 getWorldPosition': `(vec3 pos) {
- *       pos.y += 20. * sin(time * 0.001 + pos.x * 0.05);
- *       return pos;
- *     }`
- *   });
- * }
- *
- * function draw() {
- *   background(255);
- *   shader(myShader);
- *   noStroke();
- *   fill('red');
- *   circle(0, 0, 50);
- * }
- * </code>
- * </div>
- */
-p5.prototype.baseColorShader = function() {
-  this._assert3d('baseColorShader');
-  return this._renderer.baseColorShader();
-};
+    return this;
+  };
 
-/**
- * Get the shader used when drawing the strokes of shapes.
- *
- * You can call <a href="#/p5.Shader/modify">`baseStrokeShader().modify()`</a>
- * and change any of the following hooks:
- *
- * <table>
- * <tr><th>Hook</th><th>Description</th></tr>
- * <tr><td>
- *
- * `void beforeVertex`
- *
- * </td><td>
- *
- * Called at the start of the vertex shader.
- *
- * </td></tr>
- * <tr><td>
- *
- * `vec3 getLocalPosition`
- *
- * </td><td>
- *
- * Update the position of vertices before transforms are applied. It takes in `vec3 position` and must return a modified version.
- *
- * </td></tr>
- * <tr><td>
- *
- * `vec3 getWorldPosition`
- *
- * </td><td>
- *
- * Update the position of vertices after transforms are applied. It takes in `vec3 position` and pust return a modified version.
- *
- * </td></tr>
- * <tr><td>
- *
- * `float getStrokeWeight`
- *
- * </td><td>
- *
- * Update the stroke weight. It takes in `float weight` and pust return a modified version.
- *
- * </td></tr>
- * <tr><td>
- *
- * `vec2 getLineCenter`
- *
- * </td><td>
- *
- * Update the center of the line. It takes in `vec2 center` and must return a modified version.
- *
- * </td></tr>
- * <tr><td>
- *
- * `vec2 getLinePosition`
- *
- * </td><td>
- *
- * Update the position of each vertex on the edge of the line. It takes in `vec2 position` and must return a modified version.
- *
- * </td></tr>
- * <tr><td>
- *
- * `vec4 getVertexColor`
- *
- * </td><td>
- *
- * Update the color of each vertex. It takes in a `vec4 color` and must return a modified version.
- *
- * </td></tr>
- * <tr><td>
- *
- * `void afterVertex`
- *
- * </td><td>
- *
- * Called at the end of the vertex shader.
- *
- * </td></tr>
- * <tr><td>
- *
- * `void beforeFragment`
- *
- * </td><td>
- *
- * Called at the start of the fragment shader.
- *
- * </td></tr>
- * <tr><td>
- *
- * `Inputs getPixelInputs`
- *
- * </td><td>
- *
- * Update the inputs to the shader. It takes in a struct `Inputs inputs`, which includes:
- * - `vec4 color`, the color of the stroke
- * - `vec2 tangent`, the direction of the stroke in screen space
- * - `vec2 center`, the coordinate of the center of the stroke in screen space p5.js pixels
- * - `vec2 position`, the coordinate of the current pixel in screen space p5.js pixels
- * - `float strokeWeight`, the thickness of the stroke in p5.js pixels
- *
- * </td></tr>
- * <tr><td>
- *
- * `bool shouldDiscard`
- *
- * </td><td>
- *
- * Caps and joins are made by discarded pixels in the fragment shader to carve away unwanted areas. Use this to change this logic. It takes in a `bool willDiscard` and must return a modified version.
- *
- * </td></tr>
- * <tr><td>
- *
- * `vec4 getFinalColor`
- *
- * </td><td>
- *
- * Update the final color after mixing. It takes in a `vec4 color` and must return a modified version.
- *
- * </td></tr>
- * <tr><td>
- *
- * `void afterFragment`
- *
- * </td><td>
- *
- * Called at the end of the fragment shader.
- *
- * </td></tr>
- * </table>
- *
- * Most of the time, you will need to write your hooks in GLSL ES version 300. If you
- * are using WebGL 1 instead of 2, write your hooks in GLSL ES 100 instead.
- *
- * Call `baseStrokeShader().inspectHooks()` to see all the possible hooks and
- * their default implementations.
- *
- * @method baseStrokeShader
- * @beta
- * @returns {p5.Shader} The stroke shader
- *
- * @example
- * <div modernizr='webgl'>
- * <code>
- * let myShader;
- *
- * function setup() {
- *   createCanvas(200, 200, WEBGL);
- *   myShader = baseStrokeShader().modify({
- *     'Inputs getPixelInputs': `(Inputs inputs) {
- *       float opacity = 1.0 - smoothstep(
- *         0.0,
- *         15.0,
- *         length(inputs.position - inputs.center)
- *       );
- *       inputs.color *= opacity;
- *       return inputs;
- *     }`
- *   });
- * }
- *
- * function draw() {
- *   background(255);
- *   shader(myShader);
- *   strokeWeight(30);
- *   line(
- *     -width/3,
- *     sin(millis()*0.001) * height/4,
- *     width/3,
- *     sin(millis()*0.001 + 1) * height/4
- *   );
- * }
- * </code>
- * </div>
- *
- * @example
- * <div modernizr='webgl'>
- * <code>
- * let myShader;
- *
- * function setup() {
- *   createCanvas(200, 200, WEBGL);
- *   myShader = baseStrokeShader().modify({
- *     uniforms: {
- *       'float time': () => millis()
- *     },
- *     declarations: 'vec3 myPosition;',
- *     'vec3 getWorldPosition': `(vec3 pos) {
- *       myPosition = pos;
- *       return pos;
- *     }`,
- *     'float getStrokeWeight': `(float w) {
- *       // Add a somewhat random offset to the weight
- *       // that varies based on position and time
- *       float scale = 0.8 + 0.2*sin(10.0 * sin(
- *         floor(time/250.) +
- *         myPosition.x*0.01 +
- *         myPosition.y*0.01
- *       ));
- *       return w * scale;
- *     }`
- *   });
- * }
- *
- * function draw() {
- *   background(255);
- *   shader(myShader);
- *   myShader.setUniform('time', millis());
- *   strokeWeight(10);
- *   beginShape();
- *   for (let i = 0; i <= 50; i++) {
- *     let r = map(i, 0, 50, 0, width/3);
- *     let x = r*cos(i*0.2);
- *     let y = r*sin(i*0.2);
- *     vertex(x, y);
- *   }
- *   endShape();
- * }
- * </code>
- * </div>
- *
- * @example
- * <div modernizr='webgl'>
- * <code>
- * let myShader;
- *
- * function setup() {
- *   createCanvas(200, 200, WEBGL);
- *   myShader = baseStrokeShader().modify({
- *     'float random': `(vec2 p) {
- *       vec3 p3  = fract(vec3(p.xyx) * .1031);
- *       p3 += dot(p3, p3.yzx + 33.33);
- *       return fract((p3.x + p3.y) * p3.z);
- *     }`,
- *     'Inputs getPixelInputs': `(Inputs inputs) {
- *       // Replace alpha in the color with dithering by
- *       // randomly setting pixel colors to 0 based on opacity
- *       float a = inputs.color.a;
- *       inputs.color.a = 1.0;
- *       inputs.color *= random(inputs.position.xy) > a ? 0.0 : 1.0;
- *       return inputs;
- *     }`
- *   });
- * }
- *
- * function draw() {
- *   background(255);
- *   shader(myShader);
- *   strokeWeight(10);
- *   beginShape();
- *   for (let i = 0; i <= 50; i++) {
- *     stroke(
- *       0,
- *       255
- *         * map(i, 0, 20, 0, 1, true)
- *         * map(i, 30, 50, 1, 0, true)
- *     );
- *     vertex(
- *       map(i, 0, 50, -1, 1) * width/3,
- *       50 * sin(i/10 + frameCount/100)
- *     );
- *   }
- *   endShape();
- * }
- * </code>
- * </div>
- */
-p5.prototype.baseStrokeShader = function() {
-  this._assert3d('baseStrokeShader');
-  return this._renderer.baseStrokeShader();
-};
+  /**
+   * Sets the specular color of shapes’ surface material.
+   *
+   * The `specularMaterial()` color sets the components of light color that
+   * glossy coats on shapes will reflect. For example, calling
+   * `specularMaterial(255, 255, 0)` would cause a shape to reflect red and
+   * green light, but not blue light.
+   *
+   * Unlike <a href="#/p5/ambientMaterial">ambientMaterial()</a>,
+   * `specularMaterial()` will reflect the full color of light sources including
+   * <a href="#/p5/directionalLight">directionalLight()</a>,
+   * <a href="#/p5/pointLight">pointLight()</a>,
+   * and <a href="#/p5/spotLight">spotLight()</a>. This is what gives it shapes
+   * their "shiny" appearance. The material’s shininess can be controlled by the
+   * <a href="#/p5/shininess">shininess()</a> function.
+   *
+   * `specularMaterial()` can be called three ways with different parameters to
+   * set the material’s color.
+   *
+   * The first way to call `specularMaterial()` has one parameter, `gray`.
+   * Grayscale values between 0 and 255, as in `specularMaterial(50)`, can be
+   * passed to set the material’s color. Higher grayscale values make shapes
+   * appear brighter.
+   *
+   * The second way to call `specularMaterial()` has one parameter, `color`. A
+   * <a href="#/p5.Color">p5.Color> object, an array of color values, or a CSS
+   * color string, as in `specularMaterial('magenta')`, can be passed to set the
+   * material’s color.
+   *
+   * The third way to call `specularMaterial()` has four parameters, `v1`, `v2`,
+   * `v3`, and `alpha`. `alpha` is optional. RGBA, HSBA, or HSLA values can be
+   * passed to set the material’s colors, as in `specularMaterial(255, 0, 0)` or
+   * `specularMaterial(255, 0, 0, 30)`. Color values will be interpreted using
+   * the current <a href="#/p5/colorMode">colorMode()</a>.
+   *
+   * @method specularMaterial
+   * @param  {Number} gray grayscale value between 0 (black) and 255 (white).
+   * @param  {Number} [alpha] alpha value in the current current
+   *                          <a href="#/p5/colorMode">colorMode()</a>.
+   * @chainable
+   *
+   * @example
+   * <div>
+   * <code>
+   * // Click and drag the mouse to view the scene from different angles.
+   * // Double-click the canvas to apply a specular material.
+   *
+   * let isGlossy = false;
+   *
+   * function setup() {
+   *   createCanvas(100, 100, WEBGL);
+   *
+   *   describe('A red torus drawn on a gray background. It becomes glossy when the user double-clicks.');
+   * }
+   *
+   * function draw() {
+   *   background(200);
+   *
+   *   // Enable orbiting with the mouse.
+   *   orbitControl();
+   *
+   *   // Turn on a white point light at the top-right.
+   *   pointLight(255, 255, 255, 30, -40, 30);
+   *
+   *   // Add a glossy coat if the user has double-clicked.
+   *   if (isGlossy === true) {
+   *     specularMaterial(255);
+   *     shininess(50);
+   *   }
+   *
+   *   // Style the torus.
+   *   noStroke();
+   *   fill(255, 0, 0);
+   *
+   *   // Draw the torus.
+   *   torus(30);
+   * }
+   *
+   * // Make the torus glossy when the user double-clicks.
+   * function doubleClicked() {
+   *   isGlossy = true;
+   * }
+   * </code>
+   * </div>
+   *
+   * <div>
+   * <code>
+   * // Click and drag the mouse to view the scene from different angles.
+   * // Double-click the canvas to apply a specular material.
+   *
+   * let isGlossy = false;
+   *
+   * function setup() {
+   *   createCanvas(100, 100, WEBGL);
+   *
+   *   describe(
+   *     'A red torus drawn on a gray background. It becomes glossy and reflects green light when the user double-clicks.'
+   *   );
+   * }
+   *
+   * function draw() {
+   *   background(200);
+   *
+   *   // Enable orbiting with the mouse.
+   *   orbitControl();
+   *
+   *   // Turn on a white point light at the top-right.
+   *   pointLight(255, 255, 255, 30, -40, 30);
+   *
+   *   // Add a glossy green coat if the user has double-clicked.
+   *   if (isGlossy === true) {
+   *     specularMaterial(0, 255, 0);
+   *     shininess(50);
+   *   }
+   *
+   *   // Style the torus.
+   *   noStroke();
+   *   fill(255, 0, 0);
+   *
+   *   // Draw the torus.
+   *   torus(30);
+   * }
+   *
+   * // Make the torus glossy when the user double-clicks.
+   * function doubleClicked() {
+   *   isGlossy = true;
+   * }
+   * </code>
+   * </div>
+   *
+   * <div>
+   * <code>
+   * // Click and drag the mouse to view the scene from different angles.
+   * // Double-click the canvas to apply a specular material.
+   *
+   * let isGlossy = false;
+   *
+   * function setup() {
+   *   createCanvas(100, 100, WEBGL);
+   *
+   *   describe(
+   *     'A red torus drawn on a gray background. It becomes glossy and reflects green light when the user double-clicks.'
+   *   );
+   * }
+   *
+   * function draw() {
+   *   background(200);
+   *
+   *   // Enable orbiting with the mouse.
+   *   orbitControl();
+   *
+   *   // Turn on a white point light at the top-right.
+   *   pointLight(255, 255, 255, 30, -40, 30);
+   *
+   *   // Add a glossy green coat if the user has double-clicked.
+   *   if (isGlossy === true) {
+   *     // Create a p5.Color object.
+   *     let c = color('green');
+   *     specularMaterial(c);
+   *     shininess(50);
+   *   }
+   *
+   *   // Style the torus.
+   *   noStroke();
+   *   fill(255, 0, 0);
+   *
+   *   // Draw the torus.
+   *   torus(30);
+   * }
+   *
+   * // Make the torus glossy when the user double-clicks.
+   * function doubleClicked() {
+   *   isGlossy = true;
+   * }
+   * </code>
+   * </div>
+   *
+   * <div>
+   * <code>
+   * // Click and drag the mouse to view the scene from different angles.
+   * // Double-click the canvas to apply a specular material.
+   *
+   * let isGlossy = false;
+   *
+   * function setup() {
+   *   createCanvas(100, 100, WEBGL);
+   *
+   *   describe(
+   *     'A red torus drawn on a gray background. It becomes glossy and reflects green light when the user double-clicks.'
+   *   );
+   * }
+   *
+   * function draw() {
+   *   background(200);
+   *
+   *   // Enable orbiting with the mouse.
+   *   orbitControl();
+   *
+   *   // Turn on a white point light at the top-right.
+   *   pointLight(255, 255, 255, 30, -40, 30);
+   *
+   *   // Add a glossy green coat if the user has double-clicked.
+   *   if (isGlossy === true) {
+   *     specularMaterial('#00FF00');
+   *     shininess(50);
+   *   }
+   *
+   *   // Style the torus.
+   *   noStroke();
+   *   fill(255, 0, 0);
+   *
+   *   // Draw the torus.
+   *   torus(30);
+   * }
+   *
+   * // Make the torus glossy when the user double-clicks.
+   * function doubleClicked() {
+   *   isGlossy = true;
+   * }
+   * </code>
+   * </div>
+   */
 
-/**
- * Restores the default shaders.
- *
- * `resetShader()` deactivates any shaders previously applied by
- * <a href="#/p5/shader">shader()</a>.
- *
- * Note: Shaders can only be used in WebGL mode.
- *
- * @method resetShader
- * @chainable
- *
- * @example
- * <div>
- * <code>
- * // Create a string with the vertex shader program.
- * // The vertex shader is called for each vertex.
- * let vertSrc = `
- * attribute vec3 aPosition;
- * attribute vec2 aTexCoord;
- * uniform mat4 uProjectionMatrix;
- * uniform mat4 uModelViewMatrix;
- * varying vec2 vTexCoord;
- *
- * void main() {
- *   vTexCoord = aTexCoord;
- *   vec4 position = vec4(aPosition, 1.0);
- *   gl_Position = uProjectionMatrix * uModelViewMatrix * position;
- * }
- * `;
- *
- * // Create a string with the fragment shader program.
- * // The fragment shader is called for each pixel.
- * let fragSrc = `
- * precision mediump float;
- * varying vec2 vTexCoord;
- *
- * void main() {
- *   vec2 uv = vTexCoord;
- *   vec3 color = vec3(uv.x, uv.y, min(uv.x + uv.y, 1.0));
- *   gl_FragColor = vec4(color, 1.0);
- * }
- * `;
- *
- * let myShader;
- *
- * function setup() {
- *   createCanvas(100, 100, WEBGL);
- *
- *   // Create a p5.Shader object.
- *   myShader = createShader(vertSrc, fragSrc);
- *
- *   describe(
- *     'Two rotating cubes on a gray background. The left one has a blue-purple gradient on each face. The right one is red.'
- *   );
- * }
- *
- * function draw() {
- *   background(200);
- *
- *   // Draw a box using the p5.Shader.
- *   // shader() sets the active shader to myShader.
- *   shader(myShader);
- *   push();
- *   translate(-25, 0, 0);
- *   rotateX(frameCount * 0.01);
- *   rotateY(frameCount * 0.01);
- *   box(width / 4);
- *   pop();
- *
- *   // Draw a box using the default fill shader.
- *   // resetShader() restores the default fill shader.
- *   resetShader();
- *   fill(255, 0, 0);
- *   push();
- *   translate(25, 0, 0);
- *   rotateX(frameCount * 0.01);
- *   rotateY(frameCount * 0.01);
- *   box(width / 4);
- *   pop();
- * }
- * </code>
- * </div>
- */
-p5.prototype.resetShader = function () {
-  this._renderer.states.userFillShader = this._renderer.states.userStrokeShader = null;
-  return this;
-};
+  /**
+   * @method specularMaterial
+   * @param  {Number}        v1      red or hue value in
+   *                                 the current <a href="#/p5/colorMode">colorMode()</a>.
+   * @param  {Number}        v2      green or saturation value
+   *                                 in the current <a href="#/p5/colorMode">colorMode()</a>.
+   * @param  {Number}        v3      blue, brightness, or lightness value
+   *                                 in the current <a href="#/p5/colorMode">colorMode()</a>.
+   * @param  {Number}        [alpha]
+   * @chainable
+   */
 
-/**
- * Sets the texture that will be used on shapes.
- *
- * A texture is like a skin that wraps around a shape. `texture()` works with
- * built-in shapes, such as <a href="#/p5/square">square()</a> and
- * <a href="#/p5/sphere">sphere()</a>, and custom shapes created with
- * functions such as <a href="#/p5/buildGeometry">buildGeometry()</a>. To
- * texture a geometry created with <a href="#/p5/beginShape">beginShape()</a>,
- * uv coordinates must be passed to each
- * <a href="#/p5/vertex">vertex()</a> call.
- *
- * The parameter, `tex`, is the texture to apply. `texture()` can use a range
- * of sources including images, videos, and offscreen renderers such as
- * <a href="#/p5.Graphics">p5.Graphics</a> and
- * <a href="#/p5.Framebuffer">p5.Framebuffer</a> objects.
- *
- * To texture a geometry created with <a href="#/p5/beginShape">beginShape()</a>,
- * you will need to specify uv coordinates in <a href="#/p5/vertex">vertex()</a>.
- *
- * Note: `texture()` can only be used in WebGL mode.
- *
- * @method texture
- * @param {p5.Image|p5.MediaElement|p5.Graphics|p5.Texture|p5.Framebuffer|p5.FramebufferTexture} tex media to use as the texture.
- * @chainable
- *
- * @example
- * <div>
- * <code>
- * let img;
- *
- * // Load an image and create a p5.Image object.
- * function preload() {
- *   img = loadImage('assets/laDefense.jpg');
- * }
- *
- * function setup() {
- *   createCanvas(100, 100, WEBGL);
- *
- *   describe('A spinning cube with an image of a ceiling on each face.');
- * }
- *
- * function draw() {
- *   background(0);
- *
- *   // Rotate around the x-, y-, and z-axes.
- *   rotateZ(frameCount * 0.01);
- *   rotateX(frameCount * 0.01);
- *   rotateY(frameCount * 0.01);
- *
- *   // Apply the image as a texture.
- *   texture(img);
- *
- *   // Draw the box.
- *   box(50);
- * }
- * </code>
- * </div>
- *
- * <div>
- * <code>
- * let pg;
- *
- * function setup() {
- *   createCanvas(100, 100, WEBGL);
- *
- *   // Create a p5.Graphics object.
- *   pg = createGraphics(100, 100);
- *
- *   // Draw a circle to the p5.Graphics object.
- *   pg.background(200);
- *   pg.circle(50, 50, 30);
- *
- *   describe('A spinning cube with circle at the center of each face.');
- * }
- *
- * function draw() {
- *   background(0);
- *
- *   // Rotate around the x-, y-, and z-axes.
- *   rotateZ(frameCount * 0.01);
- *   rotateX(frameCount * 0.01);
- *   rotateY(frameCount * 0.01);
- *
- *   // Apply the p5.Graphics object as a texture.
- *   texture(pg);
- *
- *   // Draw the box.
- *   box(50);
- * }
- * </code>
- * </div>
- *
- * <div>
- * <code>
- * let vid;
- *
- * // Load a video and create a p5.MediaElement object.
- * function preload() {
- *   vid = createVideo('assets/fingers.mov');
- * }
- *
- * function setup() {
- *   createCanvas(100, 100, WEBGL);
- *
- *   // Hide the video.
- *   vid.hide();
- *
- *   // Set the video to loop.
- *   vid.loop();
- *
- *   describe('A rectangle with video as texture');
- * }
- *
- * function draw() {
- *   background(0);
- *
- *   // Rotate around the y-axis.
- *   rotateY(frameCount * 0.01);
- *
- *   // Apply the video as a texture.
- *   texture(vid);
- *
- *   // Draw the rectangle.
- *   rect(-40, -40, 80, 80);
- * }
- * </code>
- * </div>
- *
- * <div>
- * <code>
- * let vid;
- *
- * // Load a video and create a p5.MediaElement object.
- * function preload() {
- *   vid = createVideo('assets/fingers.mov');
- * }
- *
- * function setup() {
- *   createCanvas(100, 100, WEBGL);
- *
- *   // Hide the video.
- *   vid.hide();
- *
- *   // Set the video to loop.
- *   vid.loop();
- *
- *   describe('A rectangle with video as texture');
- * }
- *
- * function draw() {
- *   background(0);
- *
- *   // Rotate around the y-axis.
- *   rotateY(frameCount * 0.01);
- *
- *   // Set the texture mode.
- *   textureMode(NORMAL);
- *
- *   // Apply the video as a texture.
- *   texture(vid);
- *
- *   // Draw a custom shape using uv coordinates.
- *   beginShape();
- *   vertex(-40, -40, 0, 0);
- *   vertex(40, -40, 1, 0);
- *   vertex(40, 40, 1, 1);
- *   vertex(-40, 40, 0, 1);
- *   endShape();
- * }
- * </code>
- * </div>
- */
-p5.prototype.texture = function (tex) {
-  this._assert3d('texture');
-  p5._validateParameters('texture', arguments);
-  if (tex.gifProperties) {
-    tex._animateGif(this);
-  }
+  /**
+   * @method specularMaterial
+   * @param  {p5.Color|Number[]|String} color
+   *           color as a <a href="#/p5.Color">p5.Color</a> object,
+   *            an array of color values, or a CSS string.
+   * @chainable
+   */
+  fn.specularMaterial = function (v1, v2, v3, alpha) {
+    this._assert3d('specularMaterial');
+    p5._validateParameters('specularMaterial', arguments);
 
-  this._renderer.states.drawMode = constants.TEXTURE;
-  this._renderer.states._useNormalMaterial = false;
-  this._renderer.states._tex = tex;
-  this._renderer.states.doFill = true;
+    const color = fn.color.apply(this, arguments);
+    this._renderer.states.curSpecularColor = color._array;
+    this._renderer.states._useSpecularMaterial = true;
+    this._renderer.states._useNormalMaterial = false;
+    this._renderer.states._enableLighting = true;
 
-  return this;
-};
+    return this;
+  };
 
-/**
- * Changes the coordinate system used for textures when they’re applied to
- * custom shapes.
- *
- * In order for <a href="#/p5/texture">texture()</a> to work, a shape needs a
- * way to map the points on its surface to the pixels in an image. Built-in
- * shapes such as <a href="#/p5/rect">rect()</a> and
- * <a href="#/p5/box">box()</a> already have these texture mappings based on
- * their vertices. Custom shapes created with
- * <a href="#/p5/vertex">vertex()</a> require texture mappings to be passed as
- * uv coordinates.
- *
- * Each call to <a href="#/p5/vertex">vertex()</a> must include 5 arguments,
- * as in `vertex(x, y, z, u, v)`, to map the vertex at coordinates `(x, y, z)`
- * to the pixel at coordinates `(u, v)` within an image. For example, the
- * corners of a rectangular image are mapped to the corners of a rectangle by default:
- *
- * <code>
- * // Apply the image as a texture.
- * texture(img);
- *
- * // Draw the rectangle.
- * rect(0, 0, 30, 50);
- * </code>
- *
- * If the image in the code snippet above has dimensions of 300 x 500 pixels,
- * the same result could be achieved as follows:
- *
- * <code>
- * // Apply the image as a texture.
- * texture(img);
- *
- * // Draw the rectangle.
- * beginShape();
- *
- * // Top-left.
- * // u: 0, v: 0
- * vertex(0, 0, 0, 0, 0);
- *
- * // Top-right.
- * // u: 300, v: 0
- * vertex(30, 0, 0, 300, 0);
- *
- * // Bottom-right.
- * // u: 300, v: 500
- * vertex(30, 50, 0, 300, 500);
- *
- * // Bottom-left.
- * // u: 0, v: 500
- * vertex(0, 50, 0, 0, 500);
- *
- * endShape();
- * </code>
- *
- * `textureMode()` changes the coordinate system for uv coordinates.
- *
- * The parameter, `mode`, accepts two possible constants. If `NORMAL` is
- * passed, as in `textureMode(NORMAL)`, then the texture’s uv coordinates can
- * be provided in the range 0 to 1 instead of the image’s dimensions. This can
- * be helpful for using the same code for multiple images of different sizes.
- * For example, the code snippet above could be rewritten as follows:
- *
- * <code>
- * // Set the texture mode to use normalized coordinates.
- * textureMode(NORMAL);
- *
- * // Apply the image as a texture.
- * texture(img);
- *
- * // Draw the rectangle.
- * beginShape();
- *
- * // Top-left.
- * // u: 0, v: 0
- * vertex(0, 0, 0, 0, 0);
- *
- * // Top-right.
- * // u: 1, v: 0
- * vertex(30, 0, 0, 1, 0);
- *
- * // Bottom-right.
- * // u: 1, v: 1
- * vertex(30, 50, 0, 1, 1);
- *
- * // Bottom-left.
- * // u: 0, v: 1
- * vertex(0, 50, 0, 0, 1);
- *
- * endShape();
- * </code>
- *
- * By default, `mode` is `IMAGE`, which scales uv coordinates to the
- * dimensions of the image. Calling `textureMode(IMAGE)` applies the default.
- *
- * Note: `textureMode()` can only be used in WebGL mode.
- *
- * @method  textureMode
- * @param {(IMAGE|NORMAL)} mode either IMAGE or NORMAL.
- *
- * @example
- * <div>
- * <code>
- * let img;
- *
- * // Load an image and create a p5.Image object.
- * function preload() {
- *   img = loadImage('assets/laDefense.jpg');
- * }
- *
- * function setup() {
- *   createCanvas(100, 100, WEBGL);
- *
- *   describe('An image of a ceiling against a black background.');
- * }
- *
- * function draw() {
- *   background(0);
- *
- *   // Apply the image as a texture.
- *   texture(img);
- *
- *   // Draw the custom shape.
- *   // Use the image's width and height as uv coordinates.
- *   beginShape();
- *   vertex(-30, -30, 0, 0);
- *   vertex(30, -30, img.width, 0);
- *   vertex(30, 30, img.width, img.height);
- *   vertex(-30, 30, 0, img.height);
- *   endShape();
- * }
- * </code>
- * </div>
- *
- * <div>
- * <code>
- * let img;
- *
- * // Load an image and create a p5.Image object.
- * function preload() {
- *   img = loadImage('assets/laDefense.jpg');
- * }
- *
- * function setup() {
- *   createCanvas(100, 100, WEBGL);
- *
- *   describe('An image of a ceiling against a black background.');
- * }
- *
- * function draw() {
- *   background(0);
- *
- *   // Set the texture mode.
- *   textureMode(NORMAL);
- *
- *   // Apply the image as a texture.
- *   texture(img);
- *
- *   // Draw the custom shape.
- *   // Use normalized uv coordinates.
- *   beginShape();
- *   vertex(-30, -30, 0, 0);
- *   vertex(30, -30, 1, 0);
- *   vertex(30, 30, 1, 1);
- *   vertex(-30, 30, 0, 1);
- *   endShape();
- * }
- * </code>
- * </div>
- */
-p5.prototype.textureMode = function (mode) {
-  if (mode !== constants.IMAGE && mode !== constants.NORMAL) {
-    console.warn(
-      `You tried to set ${mode} textureMode only supports IMAGE & NORMAL `
-    );
-  } else {
-    this._renderer.textureMode = mode;
-  }
-};
+  /**
+   * Sets the amount of gloss ("shininess") of a
+   * <a href="#/p5/specularMaterial">specularMaterial()</a>.
+   *
+   * Shiny materials focus reflected light more than dull materials.
+   * `shininess()` affects the way materials reflect light sources including
+   * <a href="#/p5/directionalLight">directionalLight()</a>,
+   * <a href="#/p5/pointLight">pointLight()</a>,
+   * and <a href="#/p5/spotLight">spotLight()</a>.
+   *
+   * The parameter, `shine`, is a number that sets the amount of shininess.
+   * `shine` must be greater than 1, which is its default value.
+   *
+   * @method shininess
+   * @param {Number} shine amount of shine.
+   * @chainable
+   *
+   * @example
+   * <div>
+   * <code>
+   * function setup() {
+   *   createCanvas(100, 100, WEBGL);
+   *
+   *   describe(
+   *     'Two red spheres drawn on a gray background. White light reflects from their surfaces as the mouse moves. The right sphere is shinier than the left sphere.'
+   *   );
+   * }
+   *
+   * function draw() {
+   *   background(200);
+   *
+   *   // Turn on a red ambient light.
+   *   ambientLight(255, 0, 0);
+   *
+   *   // Get the mouse's coordinates.
+   *   let mx = mouseX - 50;
+   *   let my = mouseY - 50;
+   *
+   *   // Turn on a white point light that follows the mouse.
+   *   pointLight(255, 255, 255, mx, my, 50);
+   *
+   *   // Style the sphere.
+   *   noStroke();
+   *
+   *   // Add a specular material with a grayscale value.
+   *   specularMaterial(255);
+   *
+   *   // Draw the left sphere with low shininess.
+   *   translate(-25, 0, 0);
+   *   shininess(10);
+   *   sphere(20);
+   *
+   *   // Draw the right sphere with high shininess.
+   *   translate(50, 0, 0);
+   *   shininess(100);
+   *   sphere(20);
+   * }
+   * </code>
+   * </div>
+   */
+  fn.shininess = function (shine) {
+    this._assert3d('shininess');
+    p5._validateParameters('shininess', arguments);
 
-/**
- * Changes the way textures behave when a shape’s uv coordinates go beyond the
- * texture.
- *
- * In order for <a href="#/p5/texture">texture()</a> to work, a shape needs a
- * way to map the points on its surface to the pixels in an image. Built-in
- * shapes such as <a href="#/p5/rect">rect()</a> and
- * <a href="#/p5/box">box()</a> already have these texture mappings based on
- * their vertices. Custom shapes created with
- * <a href="#/p5/vertex">vertex()</a> require texture mappings to be passed as
- * uv coordinates.
- *
- * Each call to <a href="#/p5/vertex">vertex()</a> must include 5 arguments,
- * as in `vertex(x, y, z, u, v)`, to map the vertex at coordinates `(x, y, z)`
- * to the pixel at coordinates `(u, v)` within an image. For example, the
- * corners of a rectangular image are mapped to the corners of a rectangle by default:
- *
- * ```js
- * // Apply the image as a texture.
- * texture(img);
- *
- * // Draw the rectangle.
- * rect(0, 0, 30, 50);
- * ```
- *
- * If the image in the code snippet above has dimensions of 300 x 500 pixels,
- * the same result could be achieved as follows:
- *
- * ```js
- * // Apply the image as a texture.
- * texture(img);
- *
- * // Draw the rectangle.
- * beginShape();
- *
- * // Top-left.
- * // u: 0, v: 0
- * vertex(0, 0, 0, 0, 0);
- *
- * // Top-right.
- * // u: 300, v: 0
- * vertex(30, 0, 0, 300, 0);
- *
- * // Bottom-right.
- * // u: 300, v: 500
- * vertex(30, 50, 0, 300, 500);
- *
- * // Bottom-left.
- * // u: 0, v: 500
- * vertex(0, 50, 0, 0, 500);
- *
- * endShape();
- * ```
- *
- * `textureWrap()` controls how textures behave when their uv's go beyond the
- * texture. Doing so can produce interesting visual effects such as tiling.
- * For example, the custom shape above could have u-coordinates are greater
- * than the image’s width:
- *
- * ```js
- * // Apply the image as a texture.
- * texture(img);
- *
- * // Draw the rectangle.
- * beginShape();
- * vertex(0, 0, 0, 0, 0);
- *
- * // Top-right.
- * // u: 600
- * vertex(30, 0, 0, 600, 0);
- *
- * // Bottom-right.
- * // u: 600
- * vertex(30, 50, 0, 600, 500);
- *
- * vertex(0, 50, 0, 0, 500);
- * endShape();
- * ```
- *
- * The u-coordinates of 600 are greater than the texture image’s width of 300.
- * This creates interesting possibilities.
- *
- * The first parameter, `wrapX`, accepts three possible constants. If `CLAMP`
- * is passed, as in `textureWrap(CLAMP)`, the pixels at the edge of the
- * texture will extend to the shape’s edges. If `REPEAT` is passed, as in
- * `textureWrap(REPEAT)`, the texture will tile repeatedly until reaching the
- * shape’s edges. If `MIRROR` is passed, as in `textureWrap(MIRROR)`, the
- * texture will tile repeatedly until reaching the shape’s edges, flipping
- * its orientation between tiles. By default, textures `CLAMP`.
- *
- * The second parameter, `wrapY`, is optional. It accepts the same three
- * constants, `CLAMP`, `REPEAT`, and `MIRROR`. If one of these constants is
- * passed, as in `textureWRAP(MIRROR, REPEAT)`, then the texture will `MIRROR`
- * horizontally and `REPEAT` vertically. By default, `wrapY` will be set to
- * the same value as `wrapX`.
- *
- * Note: `textureWrap()` can only be used in WebGL mode.
- *
- * @method textureWrap
- * @param {(CLAMP|REPEAT|MIRROR)} wrapX either CLAMP, REPEAT, or MIRROR
- * @param {(CLAMP|REPEAT|MIRROR)} [wrapY=wrapX] either CLAMP, REPEAT, or MIRROR
- *
- * @example
- * <div>
- * <code>
- * let img;
- *
- * function preload() {
- *   img = loadImage('assets/rockies128.jpg');
- * }
- *
- * function setup() {
- *   createCanvas(100, 100, WEBGL);
- *
- *   describe(
- *     'An image of a landscape occupies the top-left corner of a square. Its edge colors smear to cover the other thre quarters of the square.'
- *   );
- * }
- *
- * function draw() {
- *   background(0);
- *
- *   // Set the texture mode.
- *   textureMode(NORMAL);
- *
- *   // Set the texture wrapping.
- *   // Note: CLAMP is the default mode.
- *   textureWrap(CLAMP);
- *
- *   // Apply the image as a texture.
- *   texture(img);
- *
- *   // Style the shape.
- *   noStroke();
- *
- *   // Draw the shape.
- *   // Use uv coordinates > 1.
- *   beginShape();
- *   vertex(-30, -30, 0, 0, 0);
- *   vertex(30, -30, 0, 2, 0);
- *   vertex(30, 30, 0, 2, 2);
- *   vertex(-30, 30, 0, 0, 2);
- *   endShape();
- * }
- * </code>
- * </div>
- *
- * <div>
- * <code>
- * let img;
- *
- * function preload() {
- *   img = loadImage('assets/rockies128.jpg');
- * }
- *
- * function setup() {
- *   createCanvas(100, 100, WEBGL);
- *
- *   describe('Four identical images of a landscape arranged in a grid.');
- * }
- *
- * function draw() {
- *   background(0);
- *
- *   // Set the texture mode.
- *   textureMode(NORMAL);
- *
- *   // Set the texture wrapping.
- *   textureWrap(REPEAT);
- *
- *   // Apply the image as a texture.
- *   texture(img);
- *
- *   // Style the shape.
- *   noStroke();
- *
- *   // Draw the shape.
- *   // Use uv coordinates > 1.
- *   beginShape();
- *   vertex(-30, -30, 0, 0, 0);
- *   vertex(30, -30, 0, 2, 0);
- *   vertex(30, 30, 0, 2, 2);
- *   vertex(-30, 30, 0, 0, 2);
- *   endShape();
- * }
- * </code>
- * </div>
- *
- * <div>
- * <code>
- * let img;
- *
- * function preload() {
- *   img = loadImage('assets/rockies128.jpg');
- * }
- *
- * function setup() {
- *   createCanvas(100, 100, WEBGL);
- *
- *   describe(
- *     'Four identical images of a landscape arranged in a grid. The images are reflected horizontally and vertically, creating a kaleidoscope effect.'
- *   );
- * }
- *
- * function draw() {
- *   background(0);
- *
- *   // Set the texture mode.
- *   textureMode(NORMAL);
- *
- *   // Set the texture wrapping.
- *   textureWrap(MIRROR);
- *
- *   // Apply the image as a texture.
- *   texture(img);
- *
- *   // Style the shape.
- *   noStroke();
- *
- *   // Draw the shape.
- *   // Use uv coordinates > 1.
- *   beginShape();
- *   vertex(-30, -30, 0, 0, 0);
- *   vertex(30, -30, 0, 2, 0);
- *   vertex(30, 30, 0, 2, 2);
- *   vertex(-30, 30, 0, 0, 2);
- *   endShape();
- * }
- * </code>
- * </div>
- *
- * <div>
- * <code>
- * let img;
- *
- * function preload() {
- *   img = loadImage('assets/rockies128.jpg');
- * }
- *
- * function setup() {
- *   createCanvas(100, 100, WEBGL);
- *
- *   describe(
- *     'Four identical images of a landscape arranged in a grid. The top row and bottom row are reflections of each other.'
- *   );
- * }
- *
- * function draw() {
- *   background(0);
- *
- *   // Set the texture mode.
- *   textureMode(NORMAL);
- *
- *   // Set the texture wrapping.
- *   textureWrap(REPEAT, MIRROR);
- *
- *   // Apply the image as a texture.
- *   texture(img);
- *
- *   // Style the shape.
- *   noStroke();
- *
- *   // Draw the shape.
- *   // Use uv coordinates > 1.
- *   beginShape();
- *   vertex(-30, -30, 0, 0, 0);
- *   vertex(30, -30, 0, 2, 0);
- *   vertex(30, 30, 0, 2, 2);
- *   vertex(-30, 30, 0, 0, 2);
- *   endShape();
- * }
- * </code>
- * </div>
- */
-p5.prototype.textureWrap = function (wrapX, wrapY = wrapX) {
-  this._renderer.textureWrapX = wrapX;
-  this._renderer.textureWrapY = wrapY;
-
-  for (const texture of this._renderer.textures.values()) {
-    texture.setWrapMode(wrapX, wrapY);
-  }
-};
-
-/**
- * Sets the current material as a normal material.
- *
- * A normal material sets surfaces facing the x-axis to red, those facing the
- * y-axis to green, and those facing the z-axis to blue. Normal material isn't
- * affected by light. It’s often used as a placeholder material when debugging.
- *
- * Note: `normalMaterial()` can only be used in WebGL mode.
- *
- * @method normalMaterial
- * @chainable
- *
- * @example
- * <div>
- * <code>
- * // Click and drag the mouse to view the scene from different angles.
- *
- * function setup() {
- *   createCanvas(100, 100, WEBGL);
- *
- *   describe('A multicolor torus drawn on a gray background.');
- * }
- *
- * function draw() {
- *   background(200);
- *
- *   // Enable orbiting with the mouse.
- *   orbitControl();
- *
- *   // Style the torus.
- *   normalMaterial();
- *
- *   // Draw the torus.
- *   torus(30);
- * }
- * </code>
- * </div>
- */
-p5.prototype.normalMaterial = function (...args) {
-  this._assert3d('normalMaterial');
-  p5._validateParameters('normalMaterial', args);
-  this._renderer.states.drawMode = constants.FILL;
-  this._renderer.states._useSpecularMaterial = false;
-  this._renderer.states._useEmissiveMaterial = false;
-  this._renderer.states._useNormalMaterial = true;
-  this._renderer.states.curFillColor = [1, 1, 1, 1];
-  this._renderer.states.doFill = true;
-  this.noStroke();
-  return this;
-};
-
-/**
- * Sets the ambient color of shapes’ surface material.
- *
- * The `ambientMaterial()` color sets the components of the
- * <a href="#/p5/ambientLight">ambientLight()</a> color that shapes will
- * reflect. For example, calling `ambientMaterial(255, 255, 0)` would cause a
- * shape to reflect red and green light, but not blue light.
- *
- * `ambientMaterial()` can be called three ways with different parameters to
- * set the material’s color.
- *
- * The first way to call `ambientMaterial()` has one parameter, `gray`.
- * Grayscale values between 0 and 255, as in `ambientMaterial(50)`, can be
- * passed to set the material’s color. Higher grayscale values make shapes
- * appear brighter.
- *
- * The second way to call `ambientMaterial()` has one parameter, `color`. A
- * <a href="#/p5.Color">p5.Color</a> object, an array of color values, or a
- * CSS color string, as in `ambientMaterial('magenta')`, can be passed to set
- * the material’s color.
- *
- * The third way to call `ambientMaterial()` has three parameters, `v1`, `v2`,
- * and `v3`. RGB, HSB, or HSL values, as in `ambientMaterial(255, 0, 0)`, can
- * be passed to set the material’s colors. Color values will be interpreted
- * using the current <a href="#/p5/colorMode">colorMode()</a>.
- *
- * Note: `ambientMaterial()` can only be used in WebGL mode.
- *
- * @method ambientMaterial
- * @param  {Number} v1  red or hue value in the current
- *                       <a href="#/p5/colorMode">colorMode()</a>.
- * @param  {Number} v2  green or saturation value in the
- *                      current <a href="#/p5/colorMode">colorMode()</a>.
- * @param  {Number} v3  blue, brightness, or lightness value in the
- *                      current <a href="#/p5/colorMode">colorMode()</a>.
- * @chainable
- *
- * @example
- * <div>
- * <code>
- * // Click and drag the mouse to view the scene from different angles.
- *
- * function setup() {
- *   createCanvas(100, 100, WEBGL);
- *
- *   describe('A magenta cube drawn on a gray background.');
- * }
- *
- * function draw() {
- *   background(200);
- *
- *   // Enable orbiting with the mouse.
- *   orbitControl();
- *
- *   // Turn on a magenta ambient light.
- *   ambientLight(255, 0, 255);
- *
- *   // Draw the box.
- *   box();
- * }
- * </code>
- * </div>
- *
- * <div>
- * <code>
- * // Click and drag the mouse to view the scene from different angles.
- *
- * function setup() {
- *   createCanvas(100, 100, WEBGL);
- *
- *   describe('A purple cube drawn on a gray background.');
- * }
- *
- * function draw() {
- *   background(200);
- *
- *   // Enable orbiting with the mouse.
- *   orbitControl();
- *
- *   // Turn on a magenta ambient light.
- *   ambientLight(255, 0, 255);
- *
- *   // Add a dark gray ambient material.
- *   ambientMaterial(150);
- *
- *   // Draw the box.
- *   box();
- * }
- * </code>
- * </div>
- *
- * <div>
- * <code>
- * // Click and drag the mouse to view the scene from different angles.
- *
- * function setup() {
- *   createCanvas(100, 100, WEBGL);
- *
- *   describe('A red cube drawn on a gray background.');
- * }
- *
- * function draw() {
- *   background(200);
- *
- *   // Enable orbiting with the mouse.
- *   orbitControl();
- *
- *   // Turn on a magenta ambient light.
- *   ambientLight(255, 0, 255);
- *
- *   // Add a yellow ambient material using RGB values.
- *   ambientMaterial(255, 255, 0);
- *
- *   // Draw the box.
- *   box();
- * }
- * </code>
- * </div>
- *
- * <div>
- * <code>
- * // Click and drag the mouse to view the scene from different angles.
- *
- * function setup() {
- *   createCanvas(100, 100, WEBGL);
- *
- *   describe('A red cube drawn on a gray background.');
- * }
- *
- * function draw() {
- *   background(200);
- *
- *   // Enable orbiting with the mouse.
- *   orbitControl();
- *
- *   // Turn on a magenta ambient light.
- *   ambientLight(255, 0, 255);
- *
- *   // Add a yellow ambient material using a p5.Color object.
- *   let c = color(255, 255, 0);
- *   ambientMaterial(c);
- *
- *   // Draw the box.
- *   box();
- * }
- * </code>
- * </div>
- *
- * <div>
- * <code>
- * // Click and drag the mouse to view the scene from different angles.
- *
- * function setup() {
- *   createCanvas(100, 100, WEBGL);
- *
- *   describe('A red cube drawn on a gray background.');
- * }
- *
- * function draw() {
- *   background(200);
- *
- *   // Enable orbiting with the mouse.
- *   orbitControl();
- *
- *   // Turn on a magenta ambient light.
- *   ambientLight(255, 0, 255);
- *
- *   // Add a yellow ambient material using a color string.
- *   ambientMaterial('yellow');
- *
- *   // Draw the box.
- *   box();
- * }
- * </code>
- * </div>
- *
- * <div>
- * <code>
- * // Click and drag the mouse to view the scene from different angles.
- *
- * function setup() {
- *   createCanvas(100, 100, WEBGL);
- *
- *   describe('A yellow cube drawn on a gray background.');
- * }
- *
- * function draw() {
- *   background(200);
- *
- *   // Enable orbiting with the mouse.
- *   orbitControl();
- *
- *   // Turn on a white ambient light.
- *   ambientLight(255, 255, 255);
- *
- *   // Add a yellow ambient material using a color string.
- *   ambientMaterial('yellow');
- *
- *   // Draw the box.
- *   box();
- * }
- * </code>
- * </div>
- */
-
-/**
- * @method ambientMaterial
- * @param  {Number} gray grayscale value between 0 (black) and 255 (white).
- * @chainable
- */
-
-/**
- * @method ambientMaterial
- * @param  {p5.Color|Number[]|String} color
- *           color as a <a href="#/p5.Color">p5.Color</a> object,
- *            an array of color values, or a CSS string.
- * @chainable
- */
-p5.prototype.ambientMaterial = function (v1, v2, v3) {
-  this._assert3d('ambientMaterial');
-  p5._validateParameters('ambientMaterial', arguments);
-
-  const color = p5.prototype.color.apply(this, arguments);
-  this._renderer.states._hasSetAmbient = true;
-  this._renderer.states.curAmbientColor = color._array;
-  this._renderer.states._useNormalMaterial = false;
-  this._renderer.states._enableLighting = true;
-  this._renderer.states.doFill = true;
-  return this;
-};
-
-/**
- * Sets the emissive color of shapes’ surface material.
- *
- * The `emissiveMaterial()` color sets a color shapes display at full
- * strength, regardless of lighting. This can give the appearance that a shape
- * is glowing. However, emissive materials don’t actually emit light that
- * can affect surrounding objects.
- *
- * `emissiveMaterial()` can be called three ways with different parameters to
- * set the material’s color.
- *
- * The first way to call `emissiveMaterial()` has one parameter, `gray`.
- * Grayscale values between 0 and 255, as in `emissiveMaterial(50)`, can be
- * passed to set the material’s color. Higher grayscale values make shapes
- * appear brighter.
- *
- * The second way to call `emissiveMaterial()` has one parameter, `color`. A
- * <a href="#/p5.Color">p5.Color</a> object, an array of color values, or a
- * CSS color string, as in `emissiveMaterial('magenta')`, can be passed to set
- * the material’s color.
- *
- * The third way to call `emissiveMaterial()` has four parameters, `v1`, `v2`,
- * `v3`, and `alpha`. `alpha` is optional. RGBA, HSBA, or HSLA values can be
- * passed to set the material’s colors, as in `emissiveMaterial(255, 0, 0)` or
- * `emissiveMaterial(255, 0, 0, 30)`. Color values will be interpreted using
- * the current <a href="#/p5/colorMode">colorMode()</a>.
- *
- * Note: `emissiveMaterial()` can only be used in WebGL mode.
- *
- * @method emissiveMaterial
- * @param  {Number} v1       red or hue value in the current
- *                           <a href="#/p5/colorMode">colorMode()</a>.
- * @param  {Number} v2       green or saturation value in the
- *                           current <a href="#/p5/colorMode">colorMode()</a>.
- * @param  {Number} v3       blue, brightness, or lightness value in the
- *                           current <a href="#/p5/colorMode">colorMode()</a>.
- * @param  {Number} [alpha]  alpha value in the current
- *                           <a href="#/p5/colorMode">colorMode()</a>.
- * @chainable
- *
- * @example
- * <div>
- * <code>
- * // Click and drag the mouse to view the scene from different angles.
- *
- * function setup() {
- *   createCanvas(100, 100, WEBGL);
- *
- *   describe('A red cube drawn on a gray background.');
- * }
- *
- * function draw() {
- *   background(200);
- *
- *   // Enable orbiting with the mouse.
- *   orbitControl();
- *
- *   // Turn on a white ambient light.
- *   ambientLight(255, 255, 255);
- *
- *   // Add a red emissive material using RGB values.
- *   emissiveMaterial(255, 0, 0);
- *
- *   // Draw the box.
- *   box();
- * }
- * </code>
- * </div>
- */
-
-/**
- * @method emissiveMaterial
- * @param  {Number} gray grayscale value between 0 (black) and 255 (white).
- * @chainable
- */
-
-/**
- * @method emissiveMaterial
- * @param  {p5.Color|Number[]|String} color
- *           color as a <a href="#/p5.Color">p5.Color</a> object,
- *            an array of color values, or a CSS string.
- * @chainable
- */
-p5.prototype.emissiveMaterial = function (v1, v2, v3, a) {
-  this._assert3d('emissiveMaterial');
-  p5._validateParameters('emissiveMaterial', arguments);
-
-  const color = p5.prototype.color.apply(this, arguments);
-  this._renderer.states.curEmissiveColor = color._array;
-  this._renderer.states._useEmissiveMaterial = true;
-  this._renderer.states._useNormalMaterial = false;
-  this._renderer.states._enableLighting = true;
-
-  return this;
-};
-
-/**
- * Sets the specular color of shapes’ surface material.
- *
- * The `specularMaterial()` color sets the components of light color that
- * glossy coats on shapes will reflect. For example, calling
- * `specularMaterial(255, 255, 0)` would cause a shape to reflect red and
- * green light, but not blue light.
- *
- * Unlike <a href="#/p5/ambientMaterial">ambientMaterial()</a>,
- * `specularMaterial()` will reflect the full color of light sources including
- * <a href="#/p5/directionalLight">directionalLight()</a>,
- * <a href="#/p5/pointLight">pointLight()</a>,
- * and <a href="#/p5/spotLight">spotLight()</a>. This is what gives it shapes
- * their "shiny" appearance. The material’s shininess can be controlled by the
- * <a href="#/p5/shininess">shininess()</a> function.
- *
- * `specularMaterial()` can be called three ways with different parameters to
- * set the material’s color.
- *
- * The first way to call `specularMaterial()` has one parameter, `gray`.
- * Grayscale values between 0 and 255, as in `specularMaterial(50)`, can be
- * passed to set the material’s color. Higher grayscale values make shapes
- * appear brighter.
- *
- * The second way to call `specularMaterial()` has one parameter, `color`. A
- * <a href="#/p5.Color">p5.Color> object, an array of color values, or a CSS
- * color string, as in `specularMaterial('magenta')`, can be passed to set the
- * material’s color.
- *
- * The third way to call `specularMaterial()` has four parameters, `v1`, `v2`,
- * `v3`, and `alpha`. `alpha` is optional. RGBA, HSBA, or HSLA values can be
- * passed to set the material’s colors, as in `specularMaterial(255, 0, 0)` or
- * `specularMaterial(255, 0, 0, 30)`. Color values will be interpreted using
- * the current <a href="#/p5/colorMode">colorMode()</a>.
- *
- * @method specularMaterial
- * @param  {Number} gray grayscale value between 0 (black) and 255 (white).
- * @param  {Number} [alpha] alpha value in the current current
- *                          <a href="#/p5/colorMode">colorMode()</a>.
- * @chainable
- *
- * @example
- * <div>
- * <code>
- * // Click and drag the mouse to view the scene from different angles.
- * // Double-click the canvas to apply a specular material.
- *
- * let isGlossy = false;
- *
- * function setup() {
- *   createCanvas(100, 100, WEBGL);
- *
- *   describe('A red torus drawn on a gray background. It becomes glossy when the user double-clicks.');
- * }
- *
- * function draw() {
- *   background(200);
- *
- *   // Enable orbiting with the mouse.
- *   orbitControl();
- *
- *   // Turn on a white point light at the top-right.
- *   pointLight(255, 255, 255, 30, -40, 30);
- *
- *   // Add a glossy coat if the user has double-clicked.
- *   if (isGlossy === true) {
- *     specularMaterial(255);
- *     shininess(50);
- *   }
- *
- *   // Style the torus.
- *   noStroke();
- *   fill(255, 0, 0);
- *
- *   // Draw the torus.
- *   torus(30);
- * }
- *
- * // Make the torus glossy when the user double-clicks.
- * function doubleClicked() {
- *   isGlossy = true;
- * }
- * </code>
- * </div>
- *
- * <div>
- * <code>
- * // Click and drag the mouse to view the scene from different angles.
- * // Double-click the canvas to apply a specular material.
- *
- * let isGlossy = false;
- *
- * function setup() {
- *   createCanvas(100, 100, WEBGL);
- *
- *   describe(
- *     'A red torus drawn on a gray background. It becomes glossy and reflects green light when the user double-clicks.'
- *   );
- * }
- *
- * function draw() {
- *   background(200);
- *
- *   // Enable orbiting with the mouse.
- *   orbitControl();
- *
- *   // Turn on a white point light at the top-right.
- *   pointLight(255, 255, 255, 30, -40, 30);
- *
- *   // Add a glossy green coat if the user has double-clicked.
- *   if (isGlossy === true) {
- *     specularMaterial(0, 255, 0);
- *     shininess(50);
- *   }
- *
- *   // Style the torus.
- *   noStroke();
- *   fill(255, 0, 0);
- *
- *   // Draw the torus.
- *   torus(30);
- * }
- *
- * // Make the torus glossy when the user double-clicks.
- * function doubleClicked() {
- *   isGlossy = true;
- * }
- * </code>
- * </div>
- *
- * <div>
- * <code>
- * // Click and drag the mouse to view the scene from different angles.
- * // Double-click the canvas to apply a specular material.
- *
- * let isGlossy = false;
- *
- * function setup() {
- *   createCanvas(100, 100, WEBGL);
- *
- *   describe(
- *     'A red torus drawn on a gray background. It becomes glossy and reflects green light when the user double-clicks.'
- *   );
- * }
- *
- * function draw() {
- *   background(200);
- *
- *   // Enable orbiting with the mouse.
- *   orbitControl();
- *
- *   // Turn on a white point light at the top-right.
- *   pointLight(255, 255, 255, 30, -40, 30);
- *
- *   // Add a glossy green coat if the user has double-clicked.
- *   if (isGlossy === true) {
- *     // Create a p5.Color object.
- *     let c = color('green');
- *     specularMaterial(c);
- *     shininess(50);
- *   }
- *
- *   // Style the torus.
- *   noStroke();
- *   fill(255, 0, 0);
- *
- *   // Draw the torus.
- *   torus(30);
- * }
- *
- * // Make the torus glossy when the user double-clicks.
- * function doubleClicked() {
- *   isGlossy = true;
- * }
- * </code>
- * </div>
- *
- * <div>
- * <code>
- * // Click and drag the mouse to view the scene from different angles.
- * // Double-click the canvas to apply a specular material.
- *
- * let isGlossy = false;
- *
- * function setup() {
- *   createCanvas(100, 100, WEBGL);
- *
- *   describe(
- *     'A red torus drawn on a gray background. It becomes glossy and reflects green light when the user double-clicks.'
- *   );
- * }
- *
- * function draw() {
- *   background(200);
- *
- *   // Enable orbiting with the mouse.
- *   orbitControl();
- *
- *   // Turn on a white point light at the top-right.
- *   pointLight(255, 255, 255, 30, -40, 30);
- *
- *   // Add a glossy green coat if the user has double-clicked.
- *   if (isGlossy === true) {
- *     specularMaterial('#00FF00');
- *     shininess(50);
- *   }
- *
- *   // Style the torus.
- *   noStroke();
- *   fill(255, 0, 0);
- *
- *   // Draw the torus.
- *   torus(30);
- * }
- *
- * // Make the torus glossy when the user double-clicks.
- * function doubleClicked() {
- *   isGlossy = true;
- * }
- * </code>
- * </div>
- */
-
-/**
- * @method specularMaterial
- * @param  {Number}        v1      red or hue value in
- *                                 the current <a href="#/p5/colorMode">colorMode()</a>.
- * @param  {Number}        v2      green or saturation value
- *                                 in the current <a href="#/p5/colorMode">colorMode()</a>.
- * @param  {Number}        v3      blue, brightness, or lightness value
- *                                 in the current <a href="#/p5/colorMode">colorMode()</a>.
- * @param  {Number}        [alpha]
- * @chainable
- */
-
-/**
- * @method specularMaterial
- * @param  {p5.Color|Number[]|String} color
- *           color as a <a href="#/p5.Color">p5.Color</a> object,
- *            an array of color values, or a CSS string.
- * @chainable
- */
-p5.prototype.specularMaterial = function (v1, v2, v3, alpha) {
-  this._assert3d('specularMaterial');
-  p5._validateParameters('specularMaterial', arguments);
-
-  const color = p5.prototype.color.apply(this, arguments);
-  this._renderer.states.curSpecularColor = color._array;
-  this._renderer.states._useSpecularMaterial = true;
-  this._renderer.states._useNormalMaterial = false;
-  this._renderer.states._enableLighting = true;
-
-  return this;
-};
-
-/**
- * Sets the amount of gloss ("shininess") of a
- * <a href="#/p5/specularMaterial">specularMaterial()</a>.
- *
- * Shiny materials focus reflected light more than dull materials.
- * `shininess()` affects the way materials reflect light sources including
- * <a href="#/p5/directionalLight">directionalLight()</a>,
- * <a href="#/p5/pointLight">pointLight()</a>,
- * and <a href="#/p5/spotLight">spotLight()</a>.
- *
- * The parameter, `shine`, is a number that sets the amount of shininess.
- * `shine` must be greater than 1, which is its default value.
- *
- * @method shininess
- * @param {Number} shine amount of shine.
- * @chainable
- *
- * @example
- * <div>
- * <code>
- * function setup() {
- *   createCanvas(100, 100, WEBGL);
- *
- *   describe(
- *     'Two red spheres drawn on a gray background. White light reflects from their surfaces as the mouse moves. The right sphere is shinier than the left sphere.'
- *   );
- * }
- *
- * function draw() {
- *   background(200);
- *
- *   // Turn on a red ambient light.
- *   ambientLight(255, 0, 0);
- *
- *   // Get the mouse's coordinates.
- *   let mx = mouseX - 50;
- *   let my = mouseY - 50;
- *
- *   // Turn on a white point light that follows the mouse.
- *   pointLight(255, 255, 255, mx, my, 50);
- *
- *   // Style the sphere.
- *   noStroke();
- *
- *   // Add a specular material with a grayscale value.
- *   specularMaterial(255);
- *
- *   // Draw the left sphere with low shininess.
- *   translate(-25, 0, 0);
- *   shininess(10);
- *   sphere(20);
- *
- *   // Draw the right sphere with high shininess.
- *   translate(50, 0, 0);
- *   shininess(100);
- *   sphere(20);
- * }
- * </code>
- * </div>
- */
-p5.prototype.shininess = function (shine) {
-  this._assert3d('shininess');
-  p5._validateParameters('shininess', arguments);
-
-  if (shine < 1) {
-    shine = 1;
-  }
-  this._renderer.states._useShininess = shine;
-  return this;
-};
-
-/**
- * Sets the amount of "metalness" of a
- * <a href="#/p5/specularMaterial">specularMaterial()</a>.
- *
- * `metalness()` can make materials appear more metallic. It affects the way
- * materials reflect light sources including
- * affects the way materials reflect light sources including
- * <a href="#/p5/directionalLight">directionalLight()</a>,
- * <a href="#/p5/pointLight">pointLight()</a>,
- * <a href="#/p5/spotLight">spotLight()</a>, and
- * <a href="#/p5/imageLight">imageLight()</a>.
- *
- * The parameter, `metallic`, is a number that sets the amount of metalness.
- * `metallic` must be greater than 1, which is its default value. Higher
- * values, such as `metalness(100)`, make specular materials appear more
- * metallic.
- *
- * @method metalness
- * @param {Number} metallic amount of metalness.
- *
- * @example
- * <div>
- * <code>
- * function setup() {
- *   createCanvas(100, 100, WEBGL);
- *
- *   describe(
- *     'Two blue spheres drawn on a gray background. White light reflects from their surfaces as the mouse moves. The right sphere is more metallic than the left sphere.'
- *   );
- * }
- *
- * function draw() {
- *   background(200);
- *
- *   // Turn on an ambient light.
- *   ambientLight(200);
- *
- *   // Get the mouse's coordinates.
- *   let mx = mouseX - 50;
- *   let my = mouseY - 50;
- *
- *   // Turn on a white point light that follows the mouse.
- *   pointLight(255, 255, 255, mx, my, 50);
- *
- *   // Style the spheres.
- *   noStroke();
- *   fill(30, 30, 255);
- *   specularMaterial(255);
- *   shininess(20);
- *
- *   // Draw the left sphere with low metalness.
- *   translate(-25, 0, 0);
- *   metalness(1);
- *   sphere(20);
- *
- *   // Draw the right sphere with high metalness.
- *   translate(50, 0, 0);
- *   metalness(50);
- *   sphere(20);
- * }
- * </code>
- * </div>
- *
- * <div>
- * <code>
- * // Click and drag the mouse to view the scene from different angles.
- *
- * let img;
- *
- * function preload() {
- *   img = loadImage('assets/outdoor_spheremap.jpg');
- * }
- *
- * function setup() {
- *   createCanvas(100 ,100 ,WEBGL);
- *
- *   describe(
- *     'Two spheres floating above a landscape. The surface of the spheres reflect the landscape. The right sphere is more reflective than the left sphere.'
- *   );
- * }
- *
- * function draw() {
- *   // Add the panorama.
- *   panorama(img);
- *
- *   // Enable orbiting with the mouse.
- *   orbitControl();
- *
- *   // Use the image as a light source.
- *   imageLight(img);
- *
- *   // Style the spheres.
- *   noStroke();
- *   specularMaterial(50);
- *   shininess(200);
- *
- *   // Draw the left sphere with low metalness.
- *   translate(-25, 0, 0);
- *   metalness(1);
- *   sphere(20);
- *
- *   // Draw the right sphere with high metalness.
- *   translate(50, 0, 0);
- *   metalness(50);
- *   sphere(20);
- * }
- * </code>
- * </div>
- */
-p5.prototype.metalness = function (metallic) {
-  this._assert3d('metalness');
-  const metalMix = 1 - Math.exp(-metallic / 100);
-  this._renderer.states._useMetalness = metalMix;
-  return this;
-};
-
-/**
- * @private blends colors according to color components.
- * If alpha value is less than 1, or non-standard blendMode
- * we need to enable blending on our gl context.
- * @param  {Number[]} color The currently set color, with values in 0-1 range
- * @param  {Boolean} [hasTransparency] Whether the shape being drawn has other
- * transparency internally, e.g. via vertex colors
- * @return {Number[]}  Normalized numbers array
- */
-p5.RendererGL.prototype._applyColorBlend = function (colors, hasTransparency) {
-  const gl = this.GL;
-
-  const isTexture = this.states.drawMode === constants.TEXTURE;
-  const doBlend =
-    hasTransparency ||
-    this.states.userFillShader ||
-    this.states.userStrokeShader ||
-    this.states.userPointShader ||
-    isTexture ||
-    this.states.curBlendMode !== constants.BLEND ||
-    colors[colors.length - 1] < 1.0 ||
-    this._isErasing;
-
-  if (doBlend !== this._isBlending) {
-    if (
-      doBlend ||
-      (this.states.curBlendMode !== constants.BLEND &&
-        this.states.curBlendMode !== constants.ADD)
-    ) {
-      gl.enable(gl.BLEND);
-    } else {
-      gl.disable(gl.BLEND);
+    if (shine < 1) {
+      shine = 1;
     }
-    gl.depthMask(true);
-    this._isBlending = doBlend;
-  }
-  this._applyBlendMode();
-  return colors;
-};
+    this._renderer.states._useShininess = shine;
+    return this;
+  };
 
-/**
- * @private sets blending in gl context to curBlendMode
- * @param  {Number[]} color [description]
- * @return {Number[]}  Normalized numbers array
- */
-p5.RendererGL.prototype._applyBlendMode = function () {
-  if (this._cachedBlendMode === this.states.curBlendMode) {
-    return;
-  }
-  const gl = this.GL;
-  switch (this.states.curBlendMode) {
-    case constants.BLEND:
-      gl.blendEquation(gl.FUNC_ADD);
-      gl.blendFunc(gl.ONE, gl.ONE_MINUS_SRC_ALPHA);
-      break;
-    case constants.ADD:
-      gl.blendEquation(gl.FUNC_ADD);
-      gl.blendFunc(gl.ONE, gl.ONE);
-      break;
-    case constants.REMOVE:
-      gl.blendEquation(gl.FUNC_ADD);
-      gl.blendFunc(gl.ZERO, gl.ONE_MINUS_SRC_ALPHA);
-      break;
-    case constants.MULTIPLY:
-      gl.blendEquation(gl.FUNC_ADD);
-      gl.blendFunc(gl.DST_COLOR, gl.ONE_MINUS_SRC_ALPHA);
-      break;
-    case constants.SCREEN:
-      gl.blendEquation(gl.FUNC_ADD);
-      gl.blendFunc(gl.ONE, gl.ONE_MINUS_SRC_COLOR);
-      break;
-    case constants.EXCLUSION:
-      gl.blendEquationSeparate(gl.FUNC_ADD, gl.FUNC_ADD);
-      gl.blendFuncSeparate(
-        gl.ONE_MINUS_DST_COLOR,
-        gl.ONE_MINUS_SRC_COLOR,
-        gl.ONE,
-        gl.ONE
-      );
-      break;
-    case constants.REPLACE:
-      gl.blendEquation(gl.FUNC_ADD);
-      gl.blendFunc(gl.ONE, gl.ZERO);
-      break;
-    case constants.SUBTRACT:
-      gl.blendEquationSeparate(gl.FUNC_REVERSE_SUBTRACT, gl.FUNC_ADD);
-      gl.blendFuncSeparate(gl.ONE, gl.ONE, gl.ONE, gl.ONE_MINUS_SRC_ALPHA);
-      break;
-    case constants.DARKEST:
-      if (this.blendExt) {
-        gl.blendEquationSeparate(
-          this.blendExt.MIN || this.blendExt.MIN_EXT,
-          gl.FUNC_ADD
-        );
-        gl.blendFuncSeparate(gl.ONE, gl.ONE, gl.ONE, gl.ONE);
-      } else {
-        console.warn(
-          'blendMode(DARKEST) does not work in your browser in WEBGL mode.'
-        );
-      }
-      break;
-    case constants.LIGHTEST:
-      if (this.blendExt) {
-        gl.blendEquationSeparate(
-          this.blendExt.MAX || this.blendExt.MAX_EXT,
-          gl.FUNC_ADD
-        );
-        gl.blendFuncSeparate(gl.ONE, gl.ONE, gl.ONE, gl.ONE);
-      } else {
-        console.warn(
-          'blendMode(LIGHTEST) does not work in your browser in WEBGL mode.'
-        );
-      }
-      break;
-    default:
-      console.error(
-        'Oops! Somehow RendererGL set curBlendMode to an unsupported mode.'
-      );
-      break;
-  }
-  if (!this._isErasing) {
-    this._cachedBlendMode = this.states.curBlendMode;
-  }
-};
+  /**
+   * Sets the amount of "metalness" of a
+   * <a href="#/p5/specularMaterial">specularMaterial()</a>.
+   *
+   * `metalness()` can make materials appear more metallic. It affects the way
+   * materials reflect light sources including
+   * affects the way materials reflect light sources including
+   * <a href="#/p5/directionalLight">directionalLight()</a>,
+   * <a href="#/p5/pointLight">pointLight()</a>,
+   * <a href="#/p5/spotLight">spotLight()</a>, and
+   * <a href="#/p5/imageLight">imageLight()</a>.
+   *
+   * The parameter, `metallic`, is a number that sets the amount of metalness.
+   * `metallic` must be greater than 1, which is its default value. Higher
+   * values, such as `metalness(100)`, make specular materials appear more
+   * metallic.
+   *
+   * @method metalness
+   * @param {Number} metallic amount of metalness.
+   *
+   * @example
+   * <div>
+   * <code>
+   * function setup() {
+   *   createCanvas(100, 100, WEBGL);
+   *
+   *   describe(
+   *     'Two blue spheres drawn on a gray background. White light reflects from their surfaces as the mouse moves. The right sphere is more metallic than the left sphere.'
+   *   );
+   * }
+   *
+   * function draw() {
+   *   background(200);
+   *
+   *   // Turn on an ambient light.
+   *   ambientLight(200);
+   *
+   *   // Get the mouse's coordinates.
+   *   let mx = mouseX - 50;
+   *   let my = mouseY - 50;
+   *
+   *   // Turn on a white point light that follows the mouse.
+   *   pointLight(255, 255, 255, mx, my, 50);
+   *
+   *   // Style the spheres.
+   *   noStroke();
+   *   fill(30, 30, 255);
+   *   specularMaterial(255);
+   *   shininess(20);
+   *
+   *   // Draw the left sphere with low metalness.
+   *   translate(-25, 0, 0);
+   *   metalness(1);
+   *   sphere(20);
+   *
+   *   // Draw the right sphere with high metalness.
+   *   translate(50, 0, 0);
+   *   metalness(50);
+   *   sphere(20);
+   * }
+   * </code>
+   * </div>
+   *
+   * <div>
+   * <code>
+   * // Click and drag the mouse to view the scene from different angles.
+   *
+   * let img;
+   *
+   * function preload() {
+   *   img = loadImage('assets/outdoor_spheremap.jpg');
+   * }
+   *
+   * function setup() {
+   *   createCanvas(100 ,100 ,WEBGL);
+   *
+   *   describe(
+   *     'Two spheres floating above a landscape. The surface of the spheres reflect the landscape. The right sphere is more reflective than the left sphere.'
+   *   );
+   * }
+   *
+   * function draw() {
+   *   // Add the panorama.
+   *   panorama(img);
+   *
+   *   // Enable orbiting with the mouse.
+   *   orbitControl();
+   *
+   *   // Use the image as a light source.
+   *   imageLight(img);
+   *
+   *   // Style the spheres.
+   *   noStroke();
+   *   specularMaterial(50);
+   *   shininess(200);
+   *
+   *   // Draw the left sphere with low metalness.
+   *   translate(-25, 0, 0);
+   *   metalness(1);
+   *   sphere(20);
+   *
+   *   // Draw the right sphere with high metalness.
+   *   translate(50, 0, 0);
+   *   metalness(50);
+   *   sphere(20);
+   * }
+   * </code>
+   * </div>
+   */
+  fn.metalness = function (metallic) {
+    this._assert3d('metalness');
+    const metalMix = 1 - Math.exp(-metallic / 100);
+    this._renderer.states._useMetalness = metalMix;
+    return this;
+  };
 
-export default p5;
+  /**
+   * @private blends colors according to color components.
+   * If alpha value is less than 1, or non-standard blendMode
+   * we need to enable blending on our gl context.
+   * @param  {Number[]} color The currently set color, with values in 0-1 range
+   * @param  {Boolean} [hasTransparency] Whether the shape being drawn has other
+   * transparency internally, e.g. via vertex colors
+   * @return {Number[]}  Normalized numbers array
+   */
+  p5.RendererGL.prototype._applyColorBlend = function (colors, hasTransparency) {
+    const gl = this.GL;
+
+    const isTexture = this.states.drawMode === constants.TEXTURE;
+    const doBlend =
+      hasTransparency ||
+      this.states.userFillShader ||
+      this.states.userStrokeShader ||
+      this.states.userPointShader ||
+      isTexture ||
+      this.states.curBlendMode !== constants.BLEND ||
+      colors[colors.length - 1] < 1.0 ||
+      this._isErasing;
+
+    if (doBlend !== this._isBlending) {
+      if (
+        doBlend ||
+        (this.states.curBlendMode !== constants.BLEND &&
+          this.states.curBlendMode !== constants.ADD)
+      ) {
+        gl.enable(gl.BLEND);
+      } else {
+        gl.disable(gl.BLEND);
+      }
+      gl.depthMask(true);
+      this._isBlending = doBlend;
+    }
+    this._applyBlendMode();
+    return colors;
+  };
+
+  /**
+   * @private sets blending in gl context to curBlendMode
+   * @param  {Number[]} color [description]
+   * @return {Number[]}  Normalized numbers array
+   */
+  p5.RendererGL.prototype._applyBlendMode = function () {
+    if (this._cachedBlendMode === this.states.curBlendMode) {
+      return;
+    }
+    const gl = this.GL;
+    switch (this.states.curBlendMode) {
+      case constants.BLEND:
+        gl.blendEquation(gl.FUNC_ADD);
+        gl.blendFunc(gl.ONE, gl.ONE_MINUS_SRC_ALPHA);
+        break;
+      case constants.ADD:
+        gl.blendEquation(gl.FUNC_ADD);
+        gl.blendFunc(gl.ONE, gl.ONE);
+        break;
+      case constants.REMOVE:
+        gl.blendEquation(gl.FUNC_ADD);
+        gl.blendFunc(gl.ZERO, gl.ONE_MINUS_SRC_ALPHA);
+        break;
+      case constants.MULTIPLY:
+        gl.blendEquation(gl.FUNC_ADD);
+        gl.blendFunc(gl.DST_COLOR, gl.ONE_MINUS_SRC_ALPHA);
+        break;
+      case constants.SCREEN:
+        gl.blendEquation(gl.FUNC_ADD);
+        gl.blendFunc(gl.ONE, gl.ONE_MINUS_SRC_COLOR);
+        break;
+      case constants.EXCLUSION:
+        gl.blendEquationSeparate(gl.FUNC_ADD, gl.FUNC_ADD);
+        gl.blendFuncSeparate(
+          gl.ONE_MINUS_DST_COLOR,
+          gl.ONE_MINUS_SRC_COLOR,
+          gl.ONE,
+          gl.ONE
+        );
+        break;
+      case constants.REPLACE:
+        gl.blendEquation(gl.FUNC_ADD);
+        gl.blendFunc(gl.ONE, gl.ZERO);
+        break;
+      case constants.SUBTRACT:
+        gl.blendEquationSeparate(gl.FUNC_REVERSE_SUBTRACT, gl.FUNC_ADD);
+        gl.blendFuncSeparate(gl.ONE, gl.ONE, gl.ONE, gl.ONE_MINUS_SRC_ALPHA);
+        break;
+      case constants.DARKEST:
+        if (this.blendExt) {
+          gl.blendEquationSeparate(
+            this.blendExt.MIN || this.blendExt.MIN_EXT,
+            gl.FUNC_ADD
+          );
+          gl.blendFuncSeparate(gl.ONE, gl.ONE, gl.ONE, gl.ONE);
+        } else {
+          console.warn(
+            'blendMode(DARKEST) does not work in your browser in WEBGL mode.'
+          );
+        }
+        break;
+      case constants.LIGHTEST:
+        if (this.blendExt) {
+          gl.blendEquationSeparate(
+            this.blendExt.MAX || this.blendExt.MAX_EXT,
+            gl.FUNC_ADD
+          );
+          gl.blendFuncSeparate(gl.ONE, gl.ONE, gl.ONE, gl.ONE);
+        } else {
+          console.warn(
+            'blendMode(LIGHTEST) does not work in your browser in WEBGL mode.'
+          );
+        }
+        break;
+      default:
+        console.error(
+          'Oops! Somehow RendererGL set curBlendMode to an unsupported mode.'
+        );
+        break;
+    }
+    if (!this._isErasing) {
+      this._cachedBlendMode = this.states.curBlendMode;
+    }
+  };
+}
+
+export default material;
+
+if(typeof p5 !== 'undefined'){
+  loading(p5, p5.prototype);
+}

--- a/src/webgl/p5.Camera.js
+++ b/src/webgl/p5.Camera.js
@@ -4,3936 +4,3940 @@
  * @requires core
  */
 
-import p5 from '../core/main';
-
-////////////////////////////////////////////////////////////////////////////////
-// p5.Prototype Methods
-////////////////////////////////////////////////////////////////////////////////
-
-/**
- * Sets the position and orientation of the current camera in a 3D sketch.
- *
- * `camera()` allows objects to be viewed from different angles. It has nine
- * parameters that are all optional.
- *
- * The first three parameters, `x`, `y`, and `z`, are the coordinates of the
- * camera’s position. For example, calling `camera(0, 0, 0)` places the camera
- * at the origin `(0, 0, 0)`. By default, the camera is placed at
- * `(0, 0, 800)`.
- *
- * The next three parameters, `centerX`, `centerY`, and `centerZ` are the
- * coordinates of the point where the camera faces. For example, calling
- * `camera(0, 0, 0, 10, 20, 30)` places the camera at the origin `(0, 0, 0)`
- * and points it at `(10, 20, 30)`. By default, the camera points at the
- * origin `(0, 0, 0)`.
- *
- * The last three parameters, `upX`, `upY`, and `upZ` are the components of
- * the "up" vector. The "up" vector orients the camera’s y-axis. For example,
- * calling `camera(0, 0, 0, 10, 20, 30, 0, -1, 0)` places the camera at the
- * origin `(0, 0, 0)`, points it at `(10, 20, 30)`, and sets the "up" vector
- * to `(0, -1, 0)` which is like holding it upside-down. By default, the "up"
- * vector is `(0, 1, 0)`.
- *
- * Note: `camera()` can only be used in WebGL mode.
- *
- * @method camera
- * @for p5
- * @param  {Number} [x]        x-coordinate of the camera. Defaults to 0.
- * @param  {Number} [y]        y-coordinate of the camera. Defaults to 0.
- * @param  {Number} [z]        z-coordinate of the camera. Defaults to 800.
- * @param  {Number} [centerX]  x-coordinate of the point the camera faces. Defaults to 0.
- * @param  {Number} [centerY]  y-coordinate of the point the camera faces. Defaults to 0.
- * @param  {Number} [centerZ]  z-coordinate of the point the camera faces. Defaults to 0.
- * @param  {Number} [upX]      x-component of the camera’s "up" vector. Defaults to 0.
- * @param  {Number} [upY]      y-component of the camera’s "up" vector. Defaults to 1.
- * @param  {Number} [upZ]      z-component of the camera’s "up" vector. Defaults to 0.
- * @chainable
- *
- * @example
- * <div>
- * <code>
- * function setup() {
- *   createCanvas(100, 100, WEBGL);
- *
- *   describe('A white cube on a gray background.');
- * }
- *
- * function draw() {
- *   background(200);
- *
- *   // Move the camera to the top-right.
- *   camera(200, -400, 800);
- *
- *   // Draw the box.
- *   box();
- * }
- * </code>
- * </div>
- *
- * <div>
- * <code>
- * function setup() {
- *   createCanvas(100, 100, WEBGL);
- *
- *   describe('A white cube apperas to sway left and right on a gray background.');
- * }
- *
- * function draw() {
- *   background(200);
- *
- *   // Calculate the camera's x-coordinate.
- *   let x = 400 * cos(frameCount * 0.01);
- *
- *   // Orbit the camera around the box.
- *   camera(x, -400, 800);
- *
- *   // Draw the box.
- *   box();
- * }
- * </code>
- * </div>
- *
- * <div>
- * <code>
- * // Adjust the range sliders to change the camera's position.
- *
- * let xSlider;
- * let ySlider;
- * let zSlider;
- *
- * function setup() {
- *   createCanvas(100, 100, WEBGL);
- *
- *   // Create slider objects to set the camera's coordinates.
- *   xSlider = createSlider(-400, 400, 400);
- *   xSlider.position(0, 100);
- *   xSlider.size(100);
- *   ySlider = createSlider(-400, 400, -200);
- *   ySlider.position(0, 120);
- *   ySlider.size(100);
- *   zSlider = createSlider(0, 1600, 800);
- *   zSlider.position(0, 140);
- *   zSlider.size(100);
- *
- *   describe(
- *     'A white cube drawn against a gray background. Three range sliders appear beneath the image. The camera position changes when the user moves the sliders.'
- *   );
- * }
- *
- * function draw() {
- *   background(200);
- *
- *   // Get the camera's coordinates from the sliders.
- *   let x = xSlider.value();
- *   let y = ySlider.value();
- *   let z = zSlider.value();
- *
- *   // Move the camera.
- *   camera(x, y, z);
- *
- *   // Draw the box.
- *   box();
- * }
- * </code>
- * </div>
- */
-p5.prototype.camera = function (...args) {
-  this._assert3d('camera');
-  p5._validateParameters('camera', args);
-  this._renderer.states.curCamera.camera(...args);
-  return this;
-};
-
-/**
- * Sets a perspective projection for the current camera in a 3D sketch.
- *
- * In a perspective projection, shapes that are further from the camera appear
- * smaller than shapes that are near the camera. This technique, called
- * foreshortening, creates realistic 3D scenes. It’s applied by default in
- * WebGL mode.
- *
- * `perspective()` changes the camera’s perspective by changing its viewing
- * frustum. The frustum is the volume of space that’s visible to the camera.
- * Its shape is a pyramid with its top cut off. The camera is placed where
- * the top of the pyramid should be and views everything between the frustum’s
- * top (near) plane and its bottom (far) plane.
- *
- * The first parameter, `fovy`, is the camera’s vertical field of view. It’s
- * an angle that describes how tall or narrow a view the camera has. For
- * example, calling `perspective(0.5)` sets the camera’s vertical field of
- * view to 0.5 radians. By default, `fovy` is calculated based on the sketch’s
- * height and the camera’s default z-coordinate, which is 800. The formula for
- * the default `fovy` is `2 * atan(height / 2 / 800)`.
- *
- * The second parameter, `aspect`, is the camera’s aspect ratio. It’s a number
- * that describes the ratio of the top plane’s width to its height. For
- * example, calling `perspective(0.5, 1.5)` sets the camera’s field of view to
- * 0.5 radians and aspect ratio to 1.5, which would make shapes appear thinner
- * on a square canvas. By default, aspect is set to `width / height`.
- *
- * The third parameter, `near`, is the distance from the camera to the near
- * plane. For example, calling `perspective(0.5, 1.5, 100)` sets the camera’s
- * field of view to 0.5 radians, its aspect ratio to 1.5, and places the near
- * plane 100 pixels from the camera. Any shapes drawn less than 100 pixels
- * from the camera won’t be visible. By default, near is set to `0.1 * 800`,
- * which is 1/10th the default distance between the camera and the origin.
- *
- * The fourth parameter, `far`, is the distance from the camera to the far
- * plane. For example, calling `perspective(0.5, 1.5, 100, 10000)` sets the
- * camera’s field of view to 0.5 radians, its aspect ratio to 1.5, places the
- * near plane 100 pixels from the camera, and places the far plane 10,000
- * pixels from the camera. Any shapes drawn more than 10,000 pixels from the
- * camera won’t be visible. By default, far is set to `10 * 800`, which is 10
- * times the default distance between the camera and the origin.
- *
- * Note: `perspective()` can only be used in WebGL mode.
- *
- * @method  perspective
- * @for p5
- * @param  {Number} [fovy]   camera frustum vertical field of view. Defaults to
- *                           `2 * atan(height / 2 / 800)`.
- * @param  {Number} [aspect] camera frustum aspect ratio. Defaults to
- *                           `width / height`.
- * @param  {Number} [near]   distance from the camera to the near clipping plane.
- *                           Defaults to `0.1 * 800`.
- * @param  {Number} [far]    distance from the camera to the far clipping plane.
- *                           Defaults to `10 * 800`.
- * @chainable
- *
- * @example
- * <div>
- * <code>
- * // Double-click to squeeze the box.
- *
- * let isSqueezed = false;
- *
- * function setup() {
- *   createCanvas(100, 100, WEBGL);
- *
- *   describe('A white rectangular prism on a gray background. The box appears to become thinner when the user double-clicks.');
- * }
- *
- * function draw() {
- *   background(200);
- *
- *   // Place the camera at the top-right.
- *   camera(400, -400, 800);
- *
- *   if (isSqueezed === true) {
- *     // Set fovy to 0.2.
- *     // Set aspect to 1.5.
- *     perspective(0.2, 1.5);
- *   }
- *
- *   // Draw the box.
- *   box();
- * }
- *
- * // Change the camera's perspective when the user double-clicks.
- * function doubleClicked() {
- *   isSqueezed = true;
- * }
- * </code>
- * </div>
- *
- * <div>
- * <code>
- * function setup() {
- *   createCanvas(100, 100, WEBGL);
- *
- *   describe('A white rectangular prism on a gray background. The prism moves away from the camera until it disappears.');
- * }
- *
- * function draw() {
- *   background(200);
- *
- *   // Place the camera at the top-right.
- *   camera(400, -400, 800);
- *
- *   // Set fovy to 0.2.
- *   // Set aspect to 1.5.
- *   // Set near to 600.
- *   // Set far to 1200.
- *   perspective(0.2, 1.5, 600, 1200);
- *
- *   // Move the origin away from the camera.
- *   let x = -frameCount;
- *   let y = frameCount;
- *   let z = -2 * frameCount;
- *   translate(x, y, z);
- *
- *   // Draw the box.
- *   box();
- * }
- * </code>
- * </div>
- */
-p5.prototype.perspective = function (...args) {
-  this._assert3d('perspective');
-  p5._validateParameters('perspective', args);
-  this._renderer.states.curCamera.perspective(...args);
-  return this;
-};
-
-
-/**
- * Enables or disables perspective for lines in 3D sketches.
- *
- * In WebGL mode, lines can be drawn with a thinner stroke when they’re
- * further from the camera. Doing so gives them a more realistic appearance.
- *
- * By default, lines are drawn differently based on the type of perspective
- * being used:
- * - `perspective()` and `frustum()` simulate a realistic perspective. In
- * these modes, stroke weight is affected by the line’s distance from the
- * camera. Doing so results in a more natural appearance. `perspective()` is
- * the default mode for 3D sketches.
- * - `ortho()` doesn’t simulate a realistic perspective. In this mode, stroke
- * weights are consistent regardless of the line’s distance from the camera.
- * Doing so results in a more predictable and consistent appearance.
- *
- * `linePerspective()` can override the default line drawing mode.
- *
- * The parameter, `enable`, is optional. It’s a `Boolean` value that sets the
- * way lines are drawn. If `true` is passed, as in `linePerspective(true)`,
- * then lines will appear thinner when they are further from the camera. If
- * `false` is passed, as in `linePerspective(false)`, then lines will have
- * consistent stroke weights regardless of their distance from the camera. By
- * default, `linePerspective()` is enabled.
- *
- * Calling `linePerspective()` without passing an argument returns `true` if
- * it's enabled and `false` if not.
- *
- * Note: `linePerspective()` can only be used in WebGL mode.
- *
- * @method linePerspective
- * @for p5
- * @param {Boolean} enable whether to enable line perspective.
- *
- * @example
- * <div>
- * <code>
- * // Double-click the canvas to toggle the line perspective.
- *
- * function setup() {
- *   createCanvas(100, 100, WEBGL);
- *
- *   describe(
- *     'A white cube with black edges on a gray background. Its edges toggle between thick and thin when the user double-clicks.'
- *   );
- * }
- *
- * function draw() {
- *   background(200);
- *
- *   // Translate the origin toward the camera.
- *   translate(-10, 10, 600);
- *
- *   // Rotate the coordinate system.
- *   rotateY(-0.1);
- *   rotateX(-0.1);
- *
- *   // Draw the row of boxes.
- *   for (let i = 0; i < 6; i += 1) {
- *     translate(0, 0, -40);
- *     box(10);
- *   }
- * }
- *
- * // Toggle the line perspective when the user double-clicks.
- * function doubleClicked() {
- *   let isEnabled = linePerspective();
- *   linePerspective(!isEnabled);
- * }
- * </code>
- * </div>
- *
- * <div>
- * <code>
- * // Double-click the canvas to toggle the line perspective.
- *
- * function setup() {
- *   createCanvas(100, 100, WEBGL);
- *
- *   describe(
- *     'A row of cubes with black edges on a gray background. Their edges toggle between thick and thin when the user double-clicks.'
- *   );
- * }
- *
- * function draw() {
- *   background(200);
- *
- *   // Use an orthographic projection.
- *   ortho();
- *
- *   // Translate the origin toward the camera.
- *   translate(-10, 10, 600);
- *
- *   // Rotate the coordinate system.
- *   rotateY(-0.1);
- *   rotateX(-0.1);
- *
- *   // Draw the row of boxes.
- *   for (let i = 0; i < 6; i += 1) {
- *     translate(0, 0, -40);
- *     box(10);
- *   }
- * }
- *
- * // Toggle the line perspective when the user double-clicks.
- * function doubleClicked() {
- *   let isEnabled = linePerspective();
- *   linePerspective(!isEnabled);
- * }
- * </code>
- * </div>
- */
-/**
- * @method linePerspective
- * @return {Boolean} whether line perspective is enabled.
- */
-
-p5.prototype.linePerspective = function (enable) {
-  p5._validateParameters('linePerspective', arguments);
-  if (!(this._renderer instanceof p5.RendererGL)) {
-    throw new Error('linePerspective() must be called in WebGL mode.');
-  }
-  if (enable !== undefined) {
-    // Set the line perspective if enable is provided
-    this._renderer.states.curCamera.useLinePerspective = enable;
-  } else {
-    // If no argument is provided, return the current value
-    return this._renderer.states.curCamera.useLinePerspective;
-  }
-};
-
-
-/**
- * Sets an orthographic projection for the current camera in a 3D sketch.
- *
- * In an orthographic projection, shapes with the same size always appear the
- * same size, regardless of whether they are near or far from the camera.
- *
- * `ortho()` changes the camera’s perspective by changing its viewing frustum
- * from a truncated pyramid to a rectangular prism. The camera is placed in
- * front of the frustum and views everything between the frustum’s near plane
- * and its far plane. `ortho()` has six optional parameters to define the
- * frustum.
- *
- * The first four parameters, `left`, `right`, `bottom`, and `top`, set the
- * coordinates of the frustum’s sides, bottom, and top. For example, calling
- * `ortho(-100, 100, 200, -200)` creates a frustum that’s 200 pixels wide and
- * 400 pixels tall. By default, these coordinates are set based on the
- * sketch’s width and height, as in
- * `ortho(-width / 2, width / 2, -height / 2, height / 2)`.
- *
- * The last two parameters, `near` and `far`, set the distance of the
- * frustum’s near and far plane from the camera. For example, calling
- * `ortho(-100, 100, 200, 200, 50, 1000)` creates a frustum that’s 200 pixels
- * wide, 400 pixels tall, starts 50 pixels from the camera, and ends 1,000
- * pixels from the camera. By default, `near` and `far` are set to 0 and
- * `max(width, height) + 800`, respectively.
- *
- * Note: `ortho()` can only be used in WebGL mode.
- *
- * @method  ortho
- * @for p5
- * @param  {Number} [left]   x-coordinate of the frustum’s left plane. Defaults to `-width / 2`.
- * @param  {Number} [right]  x-coordinate of the frustum’s right plane. Defaults to `width / 2`.
- * @param  {Number} [bottom] y-coordinate of the frustum’s bottom plane. Defaults to `height / 2`.
- * @param  {Number} [top]    y-coordinate of the frustum’s top plane. Defaults to `-height / 2`.
- * @param  {Number} [near]   z-coordinate of the frustum’s near plane. Defaults to 0.
- * @param  {Number} [far]    z-coordinate of the frustum’s far plane. Defaults to `max(width, height) + 800`.
- * @chainable
- *
- * @example
- * <div>
- * <code>
- * function setup() {
- *   createCanvas(100, 100, WEBGL);
- *
- *   describe('A row of tiny, white cubes on a gray background. All the cubes appear the same size.');
- * }
- *
- * function draw() {
- *   background(200);
- *
- *   // Apply an orthographic projection.
- *   ortho();
- *
- *   // Translate the origin toward the camera.
- *   translate(-10, 10, 600);
- *
- *   // Rotate the coordinate system.
- *   rotateY(-0.1);
- *   rotateX(-0.1);
- *
- *   // Draw the row of boxes.
- *   for (let i = 0; i < 6; i += 1) {
- *     translate(0, 0, -40);
- *     box(10);
- *   }
- * }
- * </code>
- * </div>
- *
- * <div>
- * <code>
- * function setup() {
- *   createCanvas(100, 100, WEBGL);
- *
- *   describe('A white cube on a gray background.');
- * }
- *
- * function draw() {
- *   background(200);
- *
- *   // Apply an orthographic projection.
- *   // Center the frustum.
- *   // Set its width and height to 20.
- *   // Place its near plane 300 pixels from the camera.
- *   // Place its far plane 350 pixels from the camera.
- *   ortho(-10, 10, -10, 10, 300, 350);
- *
- *   // Translate the origin toward the camera.
- *   translate(-10, 10, 600);
- *
- *   // Rotate the coordinate system.
- *   rotateY(-0.1);
- *   rotateX(-0.1);
- *
- *   // Draw the row of boxes.
- *   for (let i = 0; i < 6; i += 1) {
- *     translate(0, 0, -40);
- *     box(10);
- *   }
- * }
- * </code>
- * </div>
- */
-p5.prototype.ortho = function (...args) {
-  this._assert3d('ortho');
-  p5._validateParameters('ortho', args);
-  this._renderer.states.curCamera.ortho(...args);
-  return this;
-};
-
-/**
- * Sets the frustum of the current camera in a 3D sketch.
- *
- * In a frustum projection, shapes that are further from the camera appear
- * smaller than shapes that are near the camera. This technique, called
- * foreshortening, creates realistic 3D scenes.
- *
- * `frustum()` changes the default camera’s perspective by changing its
- * viewing frustum. The frustum is the volume of space that’s visible to the
- * camera. The frustum’s shape is a pyramid with its top cut off. The camera
- * is placed where the top of the pyramid should be and points towards the
- * base of the pyramid. It views everything within the frustum.
- *
- * The first four parameters, `left`, `right`, `bottom`, and `top`, set the
- * coordinates of the frustum’s sides, bottom, and top. For example, calling
- * `frustum(-100, 100, 200, -200)` creates a frustum that’s 200 pixels wide
- * and 400 pixels tall. By default, these coordinates are set based on the
- * sketch’s width and height, as in
- * `ortho(-width / 20, width / 20, height / 20, -height / 20)`.
- *
- * The last two parameters, `near` and `far`, set the distance of the
- * frustum’s near and far plane from the camera. For example, calling
- * `ortho(-100, 100, 200, -200, 50, 1000)` creates a frustum that’s 200 pixels
- * wide, 400 pixels tall, starts 50 pixels from the camera, and ends 1,000
- * pixels from the camera. By default, near is set to `0.1 * 800`, which is
- * 1/10th the default distance between the camera and the origin. `far` is set
- * to `10 * 800`, which is 10 times the default distance between the camera
- * and the origin.
- *
- * Note: `frustum()` can only be used in WebGL mode.
- *
- * @method frustum
- * @for p5
- * @param  {Number} [left]   x-coordinate of the frustum’s left plane. Defaults to `-width / 20`.
- * @param  {Number} [right]  x-coordinate of the frustum’s right plane. Defaults to `width / 20`.
- * @param  {Number} [bottom] y-coordinate of the frustum’s bottom plane. Defaults to `height / 20`.
- * @param  {Number} [top]    y-coordinate of the frustum’s top plane. Defaults to `-height / 20`.
- * @param  {Number} [near]   z-coordinate of the frustum’s near plane. Defaults to `0.1 * 800`.
- * @param  {Number} [far]    z-coordinate of the frustum’s far plane. Defaults to `10 * 800`.
- * @chainable
- *
- * @example
- * <div>
- * <code>
- * function setup() {
- *   createCanvas(100, 100, WEBGL);
- *
- *   describe('A row of white cubes on a gray background.');
- * }
- *
- * function draw() {
- *   background(200);
- *
- *   // Apply the default frustum projection.
- *   frustum();
- *
- *   // Translate the origin toward the camera.
- *   translate(-10, 10, 600);
- *
- *   // Rotate the coordinate system.
- *   rotateY(-0.1);
- *   rotateX(-0.1);
- *
- *   // Draw the row of boxes.
- *   for (let i = 0; i < 6; i += 1) {
- *     translate(0, 0, -40);
- *     box(10);
- *   }
- * }
- * </code>
- * </div>
- *
- * <div>
- * <code>
- * function setup() {
- *   createCanvas(100, 100, WEBGL);
- *   describe('A white cube on a gray background.');
- * }
- *
- * function draw() {
- *   background(200);
- *
- *   // Adjust the frustum.
- *   // Center it.
- *   // Set its width and height to 20 pixels.
- *   // Place its near plane 300 pixels from the camera.
- *   // Place its far plane 350 pixels from the camera.
- *   frustum(-10, 10, -10, 10, 300, 350);
- *
- *   // Translate the origin toward the camera.
- *   translate(-10, 10, 600);
- *
- *   // Rotate the coordinate system.
- *   rotateY(-0.1);
- *   rotateX(-0.1);
- *
- *   // Draw the row of boxes.
- *   for (let i = 0; i < 6; i += 1) {
- *     translate(0, 0, -40);
- *     box(10);
- *   }
- * }
- * </code>
- * </div>
- */
-p5.prototype.frustum = function (...args) {
-  this._assert3d('frustum');
-  p5._validateParameters('frustum', args);
-  this._renderer.states.curCamera.frustum(...args);
-  return this;
-};
-
-////////////////////////////////////////////////////////////////////////////////
-// p5.Camera
-////////////////////////////////////////////////////////////////////////////////
-
-/**
- * Creates a new <a href="#/p5.Camera">p5.Camera</a> object and sets it
- * as the current (active) camera.
- *
- * The new camera is initialized with a default position `(0, 0, 800)` and a
- * default perspective projection. Its properties can be controlled with
- * <a href="#/p5.Camera">p5.Camera</a> methods such as
- * `myCamera.lookAt(0, 0, 0)`.
- *
- * Note: Every 3D sketch starts with a default camera initialized.
- * This camera can be controlled with the functions
- * <a href="#/p5/camera">camera()</a>,
- * <a href="#/p5/perspective">perspective()</a>,
- * <a href="#/p5/ortho">ortho()</a>, and
- * <a href="#/p5/frustum">frustum()</a> if it's the only camera in the scene.
- *
- * Note: `createCamera()` can only be used in WebGL mode.
- *
- * @method createCamera
- * @return {p5.Camera} the new camera.
- * @for p5
- *
- * @example
- * <div>
- * <code>
- * // Double-click to toggle between cameras.
- *
- * let cam1;
- * let cam2;
- * let usingCam1 = true;
- *
- * function setup() {
- *   createCanvas(100, 100, WEBGL);
- *
- *   // Create the first camera.
- *   // Keep its default settings.
- *   cam1 = createCamera();
- *
- *   // Create the second camera.
- *   // Place it at the top-left.
- *   // Point it at the origin.
- *   cam2 = createCamera();
- *   cam2.setPosition(400, -400, 800);
- *   cam2.lookAt(0, 0, 0);
- *
- *   // Set the current camera to cam1.
- *   setCamera(cam1);
- *
- *   describe('A white cube on a gray background. The camera toggles between frontal and aerial views when the user double-clicks.');
- * }
- *
- * function draw() {
- *   background(200);
- *
- *   // Draw the box.
- *   box();
- * }
- *
- * // Toggle the current camera when the user double-clicks.
- * function doubleClicked() {
- *   if (usingCam1 === true) {
- *     setCamera(cam2);
- *     usingCam1 = false;
- *   } else {
- *     setCamera(cam1);
- *     usingCam1 = true;
- *   }
- * }
- * </code>
- * </div>
- */
-p5.prototype.createCamera = function () {
-  this._assert3d('createCamera');
-
-  // compute default camera settings, then set a default camera
-  const _cam = new p5.Camera(this._renderer);
-  _cam._computeCameraDefaultSettings();
-  _cam._setDefaultCamera();
-
-  return _cam;
-};
-
-/**
- * A class to describe a camera for viewing a 3D sketch.
- *
- * Each `p5.Camera` object represents a camera that views a section of 3D
- * space. It stores information about the camera’s position, orientation, and
- * projection.
- *
- * In WebGL mode, the default camera is a `p5.Camera` object that can be
- * controlled with the <a href="#/p5/camera">camera()</a>,
- * <a href="#/p5/perspective">perspective()</a>,
- * <a href="#/p5/ortho">ortho()</a>, and
- * <a href="#/p5/frustum">frustum()</a> functions. Additional cameras can be
- * created with <a href="#/p5/createCamera">createCamera()</a> and activated
- * with <a href="#/p5/setCamera">setCamera()</a>.
- *
- * Note: `p5.Camera`’s methods operate in two coordinate systems:
- * - The “world” coordinate system describes positions in terms of their
- * relationship to the origin along the x-, y-, and z-axes. For example,
- * calling `myCamera.setPosition()` places the camera in 3D space using
- * "world" coordinates.
- * - The "local" coordinate system describes positions from the camera's point
- * of view: left-right, up-down, and forward-backward. For example, calling
- * `myCamera.move()` moves the camera along its own axes.
- *
- * @class p5.Camera
- * @param {rendererGL} rendererGL instance of WebGL renderer
- *
- * @example
- * <div>
- * <code>
- * let cam;
- * let delta = 0.001;
- *
- * function setup() {
- *   createCanvas(100, 100, WEBGL);
- *
- *   // Create a p5.Camera object.
- *   cam = createCamera();
- *
- *   // Place the camera at the top-center.
- *   cam.setPosition(0, -400, 800);
- *
- *   // Point the camera at the origin.
- *   cam.lookAt(0, 0, 0);
- *
- *   describe(
- *     'A white cube on a gray background. The cube goes in and out of view as the camera pans left and right.'
- *   );
- * }
- *
- * function draw() {
- *   background(200);
- *
- *   // Turn the camera left and right, called "panning".
- *   cam.pan(delta);
- *
- *   // Switch directions every 120 frames.
- *   if (frameCount % 120 === 0) {
- *     delta *= -1;
- *   }
- *
- *   // Draw the box.
- *   box();
- * }
- * </code>
- * </div>
- *
- * <div>
- * <code>
- * // Double-click to toggle between cameras.
- *
- * let cam1;
- * let cam2;
- * let isDefaultCamera = true;
- *
- * function setup() {
- *   createCanvas(100, 100, WEBGL);
- *
- *   // Create the first camera.
- *   // Keep its default settings.
- *   cam1 = createCamera();
- *
- *   // Create the second camera.
- *   // Place it at the top-left.
- *   // Point it at the origin.
- *   cam2 = createCamera();
- *   cam2.setPosition(400, -400, 800);
- *   cam2.lookAt(0, 0, 0);
- *
- *   // Set the current camera to cam1.
- *   setCamera(cam1);
- *
- *   describe(
- *     'A white cube on a gray background. The camera toggles between frontal and aerial views when the user double-clicks.'
- *   );
- * }
- *
- * function draw() {
- *   background(200);
- *
- *   // Draw the box.
- *   box();
- * }
- *
- * // Toggle the current camera when the user double-clicks.
- * function doubleClicked() {
- *   if (isDefaultCamera === true) {
- *     setCamera(cam2);
- *     isDefaultCamera = false;
- *   } else {
- *     setCamera(cam1);
- *     isDefaultCamera = true;
- *   }
- * }
- * </code>
- * </div>
- */
-p5.Camera = class Camera {
-  constructor(renderer) {
-    this._renderer = renderer;
-
-    this.cameraType = 'default';
-    this.useLinePerspective = true;
-    this.cameraMatrix = new p5.Matrix();
-    this.projMatrix = new p5.Matrix();
-    this.yScale = 1;
-  }
-  /**
- * The camera’s y-coordinate.
- *
- * By default, the camera’s y-coordinate is set to 0 in "world" space.
- *
- * @property {Number} eyeX
- * @readonly
- *
- * @example
- * <div>
- * <code>
- * let cam;
- * let font;
- *
- * // Load a font and create a p5.Font object.
- * function preload() {
- *   font = loadFont('assets/inconsolata.otf');
- * }
- *
- * function setup() {
- *   createCanvas(100, 100, WEBGL);
- *
- *   // Create a p5.Camera object.
- *   cam = createCamera();
- *
- *   // Place the camera at the top-center.
- *   cam.setPosition(0, -400, 800);
- *
- *   // Point the camera at the origin.
- *   cam.lookAt(0, 0, 0);
- *
- *   describe(
- *     'A white cube on a gray background. The text "eyeX: 0" is written in black beneath it.'
- *   );
- * }
- *
- * function draw() {
- *   background(200);
- *
- *   // Style the box.
- *   fill(255);
- *
- *   // Draw the box.
- *   box();
- *
- *   // Style the text.
- *   textAlign(CENTER);
- *   textSize(16);
- *   textFont(font);
- *   fill(0);
- *
- *   // Display the value of eyeX, rounded to the nearest integer.
- *   text(`eyeX: ${round(cam.eyeX)}`, 0, 55);
- * }
- * </code>
- * </div>
- *
- * <div>
- * <code>
- * let cam;
- * let font;
- *
- * // Load a font and create a p5.Font object.
- * function preload() {
- *   font = loadFont('assets/inconsolata.otf');
- * }
- *
- * function setup() {
- *   createCanvas(100, 100, WEBGL);
- *
- *   // Create a p5.Camera object.
- *   cam = createCamera();
- *
- *   // Place the camera at the top-center.
- *   cam.setPosition(0, -400, 800);
- *
- *   // Point the camera at the origin.
- *   cam.lookAt(0, 0, 0);
- *
- *   describe(
- *     'A white cube on a gray background. The cube appears to move left and right as the camera moves. The text "eyeX: X" is written in black beneath the cube. X oscillates between -25 and 25.'
- *   );
- * }
- *
- * function draw() {
- *   background(200);
- *
- *   // Style the box.
- *   fill(255);
- *
- *   // Draw the box.
- *   box();
- *
- *   // Style the text.
- *   textAlign(CENTER);
- *   textSize(16);
- *   textFont(font);
- *   fill(0);
- *
- *   // Calculate the new x-coordinate.
- *   let x = 25 * sin(frameCount * 0.01);
- *
- *   // Set the camera's position.
- *   cam.setPosition(x, -400, 800);
- *
- *   // Display the value of eyeX, rounded to the nearest integer.
- *   text(`eyeX: ${round(cam.eyeX)}`, 0, 55);
- * }
- * </code>
- * </div>
- */
-
-  /**
- * The camera’s y-coordinate.
- *
- * By default, the camera’s y-coordinate is set to 0 in "world" space.
- *
- * @property {Number} eyeY
- * @readonly
- *
- * @example
- * <div>
- * <code>
- * let cam;
- * let font;
- *
- * // Load a font and create a p5.Font object.
- * function preload() {
- *   font = loadFont('assets/inconsolata.otf');
- * }
- *
- * function setup() {
- *   createCanvas(100, 100, WEBGL);
- *
- *   // Create a p5.Camera object.
- *   cam = createCamera();
- *
- *   // Place the camera at the top-center.
- *   cam.setPosition(0, -400, 800);
- *
- *   // Point the camera at the origin.
- *   cam.lookAt(0, 0, 0);
- *
- *   describe(
- *     'A white cube on a gray background. The text "eyeY: -400" is written in black beneath it.'
- *   );
- * }
- *
- * function draw() {
- *   background(200);
- *
- *   // Style the box.
- *   fill(255);
- *
- *   // Draw the box.
- *   box();
- *
- *   // Style the text.
- *   textAlign(CENTER);
- *   textSize(16);
- *   textFont(font);
- *   fill(0);
- *
- *   // Display the value of eyeY, rounded to the nearest integer.
- *   text(`eyeX: ${round(cam.eyeY)}`, 0, 55);
- * }
- * </code>
- * </div>
- *
- * <div>
- * <code>
- * let cam;
- * let font;
- *
- * // Load a font and create a p5.Font object.
- * function preload() {
- *   font = loadFont('assets/inconsolata.otf');
- * }
- *
- * function setup() {
- *   createCanvas(100, 100, WEBGL);
- *
- *   // Create a p5.Camera object.
- *   cam = createCamera();
- *
- *   // Place the camera at the top-center.
- *   cam.setPosition(0, -400, 800);
- *
- *   // Point the camera at the origin.
- *   cam.lookAt(0, 0, 0);
- *
- *   describe(
- *     'A white cube on a gray background. The cube appears to move up and down as the camera moves. The text "eyeY: Y" is written in black beneath the cube. Y oscillates between -374 and -425.'
- *   );
- * }
- *
- * function draw() {
- *   background(200);
- *
- *   // Style the box.
- *   fill(255);
- *
- *   // Draw the box.
- *   box();
- *
- *   // Style the text.
- *   textAlign(CENTER);
- *   textSize(16);
- *   textFont(font);
- *   fill(0);
- *
- *   // Calculate the new y-coordinate.
- *   let y = 25 * sin(frameCount * 0.01) - 400;
- *
- *   // Set the camera's position.
- *   cam.setPosition(0, y, 800);
- *
- *   // Display the value of eyeY, rounded to the nearest integer.
- *   text(`eyeY: ${round(cam.eyeY)}`, 0, 55);
- * }
- * </code>
- * </div>
- */
-
-  /**
- * The camera’s z-coordinate.
- *
- * By default, the camera’s z-coordinate is set to 800 in "world" space.
- *
- * @property {Number} eyeZ
- * @readonly
- *
- * @example
- * <div>
- * <code>
- * let cam;
- * let font;
- *
- * // Load a font and create a p5.Font object.
- * function preload() {
- *   font = loadFont('assets/inconsolata.otf');
- * }
- *
- * function setup() {
- *   createCanvas(100, 100, WEBGL);
- *
- *   // Create a p5.Camera object.
- *   cam = createCamera();
- *
- *   // Place the camera at the top-center.
- *   cam.setPosition(0, -400, 800);
- *
- *   // Point the camera at the origin.
- *   cam.lookAt(0, 0, 0);
- *
- *   describe(
- *     'A white cube on a gray background. The text "eyeZ: 800" is written in black beneath it.'
- *   );
- * }
- *
- * function draw() {
- *   background(200);
- *
- *   // Style the box.
- *   fill(255);
- *
- *   // Draw the box.
- *   box();
- *
- *   // Style the text.
- *   textAlign(CENTER);
- *   textSize(16);
- *   textFont(font);
- *   fill(0);
- *
- *   // Display the value of eyeZ, rounded to the nearest integer.
- *   text(`eyeZ: ${round(cam.eyeZ)}`, 0, 55);
- * }
- * </code>
- * </div>
- *
- * <div>
- * <code>
- * let cam;
- * let font;
- *
- * // Load a font and create a p5.Font object.
- * function preload() {
- *   font = loadFont('assets/inconsolata.otf');
- * }
- *
- * function setup() {
- *   createCanvas(100, 100, WEBGL);
- *
- *   // Create a p5.Camera object.
- *   cam = createCamera();
- *
- *   // Place the camera at the top-center.
- *   cam.setPosition(0, -400, 800);
- *
- *   // Point the camera at the origin.
- *   cam.lookAt(0, 0, 0);
- *
- *   describe(
- *     'A white cube on a gray background. The cube appears to move forward and back as the camera moves. The text "eyeZ: Z" is written in black beneath the cube. Z oscillates between 700 and 900.'
- *   );
- * }
- *
- * function draw() {
- *   background(200);
- *
- *   // Style the box.
- *   fill(255);
- *
- *   // Draw the box.
- *   box();
- *
- *   // Style the text.
- *   textAlign(CENTER);
- *   textSize(16);
- *   textFont(font);
- *   fill(0);
- *
- *   // Calculate the new z-coordinate.
- *   let z = 100 * sin(frameCount * 0.01) + 800;
- *
- *   // Set the camera's position.
- *   cam.setPosition(0, -400, z);
- *
- *   // Display the value of eyeZ, rounded to the nearest integer.
- *   text(`eyeZ: ${round(cam.eyeZ)}`, 0, 55);
- * }
- * </code>
- * </div>
- */
-
-  /**
- * The x-coordinate of the place where the camera looks.
- *
- * By default, the camera looks at the origin `(0, 0, 0)` in "world" space, so
- * `myCamera.centerX` is 0.
- *
- * @property {Number} centerX
- * @readonly
- *
- * @example
- * <div>
- * <code>
- * let cam;
- * let font;
- *
- * // Load a font and create a p5.Font object.
- * function preload() {
- *   font = loadFont('assets/inconsolata.otf');
- * }
- *
- * function setup() {
- *   createCanvas(100, 100, WEBGL);
- *
- *   // Create a p5.Camera object.
- *   cam = createCamera();
- *
- *   // Place the camera at the top-center.
- *   cam.setPosition(0, -400, 800);
- *
- *   // Point the camera at (10, 20, -30).
- *   cam.lookAt(10, 20, -30);
- *
- *   describe(
- *     'A white cube on a gray background. The text "centerX: 10" is written in black beneath it.'
- *   );
- * }
- *
- * function draw() {
- *   background(200);
- *
- *   // Style the box.
- *   fill(255);
- *
- *   // Draw the box.
- *   box();
- *
- *   // Style the text.
- *   textAlign(CENTER);
- *   textSize(16);
- *   textFont(font);
- *   fill(0);
- *
- *   // Display the value of centerX, rounded to the nearest integer.
- *   text(`centerX: ${round(cam.centerX)}`, 0, 55);
- * }
- * </code>
- * </div>
- *
- * <div>
- * <code>
- * let cam;
- * let font;
- *
- * // Load a font and create a p5.Font object.
- * function preload() {
- *   font = loadFont('assets/inconsolata.otf');
- * }
- *
- * function setup() {
- *   createCanvas(100, 100, WEBGL);
- *
- *   // Create a p5.Camera object.
- *   cam = createCamera();
- *
- *   // Place the camera at the top-right.
- *   cam.setPosition(100, -400, 800);
- *
- *   // Point the camera at (10, 20, -30).
- *   cam.lookAt(10, 20, -30);
- *
- *   describe(
- *     'A white cube on a gray background. The cube appears to move left and right as the camera shifts its focus. The text "centerX: X" is written in black beneath the cube. X oscillates between -15 and 35.'
- *   );
- * }
- *
- * function draw() {
- *   background(200);
- *
- *   // Style the box.
- *   fill(255);
- *
- *   // Draw the box.
- *   box();
- *
- *   // Style the text.
- *   textAlign(CENTER);
- *   textSize(16);
- *   textFont(font);
- *   fill(0);
- *
- *   // Calculate the new x-coordinate.
- *   let x = 25 * sin(frameCount * 0.01) + 10;
- *
- *   // Point the camera.
- *   cam.lookAt(x, 20, -30);
- *
- *   // Display the value of centerX, rounded to the nearest integer.
- *   text(`centerX: ${round(cam.centerX)}`, 0, 55);
- * }
- * </code>
- * </div>
- */
-
-  /**
- * The y-coordinate of the place where the camera looks.
- *
- * By default, the camera looks at the origin `(0, 0, 0)` in "world" space, so
- * `myCamera.centerY` is 0.
- *
- * @property {Number} centerY
- * @readonly
- *
- * @example
- * <div>
- * <code>
- * let cam;
- * let font;
- *
- * // Load a font and create a p5.Font object.
- * function preload() {
- *   font = loadFont('assets/inconsolata.otf');
- * }
- *
- * function setup() {
- *   createCanvas(100, 100, WEBGL);
- *
- *   // Create a p5.Camera object.
- *   cam = createCamera();
- *
- *   // Place the camera at the top-center.
- *   cam.setPosition(0, -400, 800);
- *
- *   // Point the camera at (10, 20, -30).
- *   cam.lookAt(10, 20, -30);
- *
- *   describe(
- *     'A white cube on a gray background. The text "centerY: 20" is written in black beneath it.'
- *   );
- * }
- *
- * function draw() {
- *   background(200);
- *
- *   // Style the box.
- *   fill(255);
- *
- *   // Draw the box.
- *   box();
- *
- *   // Style the text.
- *   textAlign(CENTER);
- *   textSize(16);
- *   textFont(font);
- *   fill(0);
- *
- *   // Display the value of centerY, rounded to the nearest integer.
- *   text(`centerY: ${round(cam.centerY)}`, 0, 55);
- * }
- * </code>
- * </div>
- *
- * <div>
- * <code>
- * let cam;
- * let font;
- *
- * // Load a font and create a p5.Font object.
- * function preload() {
- *   font = loadFont('assets/inconsolata.otf');
- * }
- *
- * function setup() {
- *   createCanvas(100, 100, WEBGL);
- *
- *   // Create a p5.Camera object.
- *   cam = createCamera();
- *
- *   // Place the camera at the top-right.
- *   cam.setPosition(100, -400, 800);
- *
- *   // Point the camera at (10, 20, -30).
- *   cam.lookAt(10, 20, -30);
- *
- *   describe(
- *     'A white cube on a gray background. The cube appears to move up and down as the camera shifts its focus. The text "centerY: Y" is written in black beneath the cube. Y oscillates between -5 and 45.'
- *   );
- * }
- *
- * function draw() {
- *   background(200);
- *
- *   // Style the box.
- *   fill(255);
- *
- *   // Draw the box.
- *   box();
- *
- *   // Style the text.
- *   textAlign(CENTER);
- *   textSize(16);
- *   textFont(font);
- *   fill(0);
- *
- *   // Calculate the new y-coordinate.
- *   let y = 25 * sin(frameCount * 0.01) + 20;
- *
- *   // Point the camera.
- *   cam.lookAt(10, y, -30);
- *
- *   // Display the value of centerY, rounded to the nearest integer.
- *   text(`centerY: ${round(cam.centerY)}`, 0, 55);
- * }
- * </code>
- * </div>
- */
-
-  /**
- * The y-coordinate of the place where the camera looks.
- *
- * By default, the camera looks at the origin `(0, 0, 0)` in "world" space, so
- * `myCamera.centerZ` is 0.
- *
- * @property {Number} centerZ
- * @readonly
- *
- * @example
- * <div>
- * <code>
- * let cam;
- * let font;
- *
- * // Load a font and create a p5.Font object.
- * function preload() {
- *   font = loadFont('assets/inconsolata.otf');
- * }
- *
- * function setup() {
- *   createCanvas(100, 100, WEBGL);
- *
- *   // Create a p5.Camera object.
- *   cam = createCamera();
- *
- *   // Place the camera at the top-center.
- *   cam.setPosition(0, -400, 800);
- *
- *   // Point the camera at (10, 20, -30).
- *   cam.lookAt(10, 20, -30);
- *
- *   describe(
- *     'A white cube on a gray background. The text "centerZ: -30" is written in black beneath it.'
- *   );
- * }
- *
- * function draw() {
- *   background(200);
- *
- *   // Style the box.
- *   fill(255);
- *
- *   // Draw the box.
- *   box();
- *
- *   // Style the text.
- *   textAlign(CENTER);
- *   textSize(16);
- *   textFont(font);
- *   fill(0);
- *
- *   // Display the value of centerZ, rounded to the nearest integer.
- *   text(`centerZ: ${round(cam.centerZ)}`, 0, 55);
- * }
- * </code>
- * </div>
- *
- * <div>
- * <code>
- * let cam;
- * let font;
- *
- * // Load a font and create a p5.Font object.
- * function preload() {
- *   font = loadFont('assets/inconsolata.otf');
- * }
- *
- * function setup() {
- *   createCanvas(100, 100, WEBGL);
- *
- *   // Create a p5.Camera object.
- *   cam = createCamera();
- *
- *   // Place the camera at the top-right.
- *   cam.setPosition(100, -400, 800);
- *
- *   // Point the camera at (10, 20, -30).
- *   cam.lookAt(10, 20, -30);
- *
- *   describe(
- *     'A white cube on a gray background. The cube appears to move forward and back as the camera shifts its focus. The text "centerZ: Z" is written in black beneath the cube. Z oscillates between -55 and -25.'
- *   );
- * }
- *
- * function draw() {
- *   background(200);
- *
- *   // Style the box.
- *   fill(255);
- *
- *   // Draw the box.
- *   box();
- *
- *   // Style the text.
- *   textAlign(CENTER);
- *   textSize(16);
- *   textFont(font);
- *   fill(0);
- *
- *   // Calculate the new z-coordinate.
- *   let z = 25 * sin(frameCount * 0.01) - 30;
- *
- *   // Point the camera.
- *   cam.lookAt(10, 20, z);
- *
- *   // Display the value of centerZ, rounded to the nearest integer.
- *   text(`centerZ: ${round(cam.centerZ)}`, 0, 55);
- * }
- * </code>
- * </div>
- */
-
-  /**
- * The x-component of the camera's "up" vector.
- *
- * The camera's "up" vector orients its y-axis. By default, the "up" vector is
- * `(0, 1, 0)`, so its x-component is 0 in "local" space.
- *
- * @property {Number} upX
- * @readonly
- *
- * @example
- * <div>
- * <code>
- * let cam;
- * let font;
- *
- * // Load a font and create a p5.Font object.
- * function preload() {
- *   font = loadFont('assets/inconsolata.otf');
- * }
- *
- * function setup() {
- *   createCanvas(100, 100, WEBGL);
- *
- *   // Create a p5.Camera object.
- *   cam = createCamera();
- *
- *   // Place the camera at the top-right: (100, -400, 800)
- *   // Point it at the origin: (0, 0, 0)
- *   // Set its "up" vector: (0, 1, 0).
- *   cam.camera(100, -400, 800, 0, 0, 0, 0, 1, 0);
- *
- *   describe(
- *     'A white cube on a gray background. The text "upX: 0" is written in black beneath it.'
- *   );
- * }
- *
- * function draw() {
- *   background(200);
- *
- *   // Style the box.
- *   fill(255);
- *
- *   // Draw the box.
- *   box();
- *
- *   // Style the text.
- *   textAlign(CENTER);
- *   textSize(16);
- *   textFont(font);
- *   fill(0);
- *
- *   // Display the value of upX, rounded to the nearest tenth.
- *   text(`upX: ${round(cam.upX, 1)}`, 0, 55);
- * }
- * </code>
- * </div>
- *
- * <div>
- * <code>
- * let cam;
- * let font;
- *
- * // Load a font and create a p5.Font object.
- * function preload() {
- *   font = loadFont('assets/inconsolata.otf');
- * }
- *
- * function setup() {
- *   createCanvas(100, 100, WEBGL);
- *
- *   // Create a p5.Camera object.
- *   cam = createCamera();
- *
- *   // Place the camera at the top-right: (100, -400, 800)
- *   // Point it at the origin: (0, 0, 0)
- *   // Set its "up" vector: (0, 1, 0).
- *   cam.camera(100, -400, 800, 0, 0, 0, 0, 1, 0);
- *
- *   describe(
- *     'A white cube on a gray background. The cube appears to rock back and forth. The text "upX: X" is written in black beneath it. X oscillates between -1 and 1.'
- *   );
- * }
- *
- * function draw() {
- *   background(200);
- *
- *   // Style the box.
- *   fill(255);
- *
- *   // Draw the box.
- *   box();
- *
- *   // Style the text.
- *   textAlign(CENTER);
- *   textSize(16);
- *   textFont(font);
- *   fill(0);
- *
- *   // Calculate the x-component.
- *   let x = sin(frameCount * 0.01);
- *
- *   // Update the camera's "up" vector.
- *   cam.camera(100, -400, 800, 0, 0, 0, x, 1, 0);
- *
- *   // Display the value of upX, rounded to the nearest tenth.
- *   text(`upX: ${round(cam.upX, 1)}`, 0, 55);
- * }
- * </code>
- * </div>
- */
-
-  /**
- * The y-component of the camera's "up" vector.
- *
- * The camera's "up" vector orients its y-axis. By default, the "up" vector is
- * `(0, 1, 0)`, so its y-component is 1 in "local" space.
- *
- * @property {Number} upY
- * @readonly
- *
- * @example
- * <div>
- * <code>
- * let cam;
- * let font;
- *
- * // Load a font and create a p5.Font object.
- * function preload() {
- *   font = loadFont('assets/inconsolata.otf');
- * }
- *
- * function setup() {
- *   createCanvas(100, 100, WEBGL);
- *
- *   // Create a p5.Camera object.
- *   cam = createCamera();
- *
- *   // Place the camera at the top-right: (100, -400, 800)
- *   // Point it at the origin: (0, 0, 0)
- *   // Set its "up" vector: (0, 1, 0).
- *   cam.camera(100, -400, 800, 0, 0, 0, 0, 1, 0);
- *
- *   describe(
- *     'A white cube on a gray background. The text "upY: 1" is written in black beneath it.'
- *   );
- * }
- *
- * function draw() {
- *   background(200);
- *
- *   // Style the box.
- *   fill(255);
- *
- *   // Draw the box.
- *   box();
- *
- *   // Style the text.
- *   textAlign(CENTER);
- *   textSize(16);
- *   textFont(font);
- *   fill(0);
- *
- *   // Display the value of upY, rounded to the nearest tenth.
- *   text(`upY: ${round(cam.upY, 1)}`, 0, 55);
- * }
- * </code>
- * </div>
- *
- * <div>
- * <code>
- * let cam;
- * let font;
- *
- * // Load a font and create a p5.Font object.
- * function preload() {
- *   font = loadFont('assets/inconsolata.otf');
- * }
- *
- * function setup() {
- *   createCanvas(100, 100, WEBGL);
- *
- *   // Create a p5.Camera object.
- *   cam = createCamera();
- *
- *   // Place the camera at the top-right: (100, -400, 800)
- *   // Point it at the origin: (0, 0, 0)
- *   // Set its "up" vector: (0, 1, 0).
- *   cam.camera(100, -400, 800, 0, 0, 0, 0, 1, 0);
- *
- *   describe(
- *     'A white cube on a gray background. The cube flips upside-down periodically. The text "upY: Y" is written in black beneath it. Y oscillates between -1 and 1.'
- *   );
- * }
- *
- * function draw() {
- *   background(200);
- *
- *   // Style the box.
- *   fill(255);
- *
- *   // Draw the box.
- *   box();
- *
- *   // Style the text.
- *   textAlign(CENTER);
- *   textSize(16);
- *   textFont(font);
- *   fill(0);
- *
- *   // Calculate the y-component.
- *   let y = sin(frameCount * 0.01);
- *
- *   // Update the camera's "up" vector.
- *   cam.camera(100, -400, 800, 0, 0, 0, 0, y, 0);
- *
- *   // Display the value of upY, rounded to the nearest tenth.
- *   text(`upY: ${round(cam.upY, 1)}`, 0, 55);
- * }
- * </code>
- * </div>
- */
-
-  /**
- * The z-component of the camera's "up" vector.
- *
- * The camera's "up" vector orients its y-axis. By default, the "up" vector is
- * `(0, 1, 0)`, so its z-component is 0 in "local" space.
- *
- * @property {Number} upZ
- * @readonly
- *
- * @example
- * <div>
- * <code>
- * let cam;
- * let font;
- *
- * // Load a font and create a p5.Font object.
- * function preload() {
- *   font = loadFont('assets/inconsolata.otf');
- * }
- *
- * function setup() {
- *   createCanvas(100, 100, WEBGL);
- *
- *   // Create a p5.Camera object.
- *   cam = createCamera();
- *
- *   // Place the camera at the top-right: (100, -400, 800)
- *   // Point it at the origin: (0, 0, 0)
- *   // Set its "up" vector: (0, 1, 0).
- *   cam.camera(100, -400, 800, 0, 0, 0, 0, 1, 0);
- *
- *   describe(
- *     'A white cube on a gray background. The text "upZ: 0" is written in black beneath it.'
- *   );
- * }
- *
- * function draw() {
- *   background(200);
- *
- *   // Style the box.
- *   fill(255);
- *
- *   // Draw the box.
- *   box();
- *
- *   // Style the text.
- *   textAlign(CENTER);
- *   textSize(16);
- *   textFont(font);
- *   fill(0);
- *
- *   // Display the value of upZ, rounded to the nearest tenth.
- *   text(`upZ: ${round(cam.upZ, 1)}`, 0, 55);
- * }
- * </code>
- * </div>
- *
- * <div>
- * <code>
- * let cam;
- * let font;
- *
- * // Load a font and create a p5.Font object.
- * function preload() {
- *   font = loadFont('assets/inconsolata.otf');
- * }
- *
- * function setup() {
- *   createCanvas(100, 100, WEBGL);
- *
- *   // Create a p5.Camera object.
- *   cam = createCamera();
- *
- *   // Place the camera at the top-right: (100, -400, 800)
- *   // Point it at the origin: (0, 0, 0)
- *   // Set its "up" vector: (0, 1, 0).
- *   cam.camera(100, -400, 800, 0, 0, 0, 0, 1, 0);
- *
- *   describe(
- *     'A white cube on a gray background. The cube appears to rock back and forth. The text "upZ: Z" is written in black beneath it. Z oscillates between -1 and 1.'
- *   );
- * }
- *
- * function draw() {
- *   background(200);
- *
- *   // Style the box.
- *   fill(255);
- *
- *   // Draw the box.
- *   box();
- *
- *   // Style the text.
- *   textAlign(CENTER);
- *   textSize(16);
- *   textFont(font);
- *   fill(0);
- *
- *   // Calculate the z-component.
- *   let z = sin(frameCount * 0.01);
- *
- *   // Update the camera's "up" vector.
- *   cam.camera(100, -400, 800, 0, 0, 0, 0, 1, z);
- *
- *   // Display the value of upZ, rounded to the nearest tenth.
- *   text(`upZ: ${round(cam.upZ, 1)}`, 0, 55);
- * }
- * </code>
- * </div>
- */
-
+function camera(p5, fn){
   ////////////////////////////////////////////////////////////////////////////////
-  // Camera Projection Methods
+  // p5.Prototype Methods
   ////////////////////////////////////////////////////////////////////////////////
 
   /**
- * Sets a perspective projection for the camera.
- *
- * In a perspective projection, shapes that are further from the camera appear
- * smaller than shapes that are near the camera. This technique, called
- * foreshortening, creates realistic 3D scenes. It’s applied by default in new
- * `p5.Camera` objects.
- *
- * `myCamera.perspective()` changes the camera’s perspective by changing its
- * viewing frustum. The frustum is the volume of space that’s visible to the
- * camera. The frustum’s shape is a pyramid with its top cut off. The camera
- * is placed where the top of the pyramid should be and points towards the
- * base of the pyramid. It views everything within the frustum.
- *
- * The first parameter, `fovy`, is the camera’s vertical field of view. It’s
- * an angle that describes how tall or narrow a view the camera has. For
- * example, calling `myCamera.perspective(0.5)` sets the camera’s vertical
- * field of view to 0.5 radians. By default, `fovy` is calculated based on the
- * sketch’s height and the camera’s default z-coordinate, which is 800. The
- * formula for the default `fovy` is `2 * atan(height / 2 / 800)`.
- *
- * The second parameter, `aspect`, is the camera’s aspect ratio. It’s a number
- * that describes the ratio of the top plane’s width to its height. For
- * example, calling `myCamera.perspective(0.5, 1.5)` sets the camera’s field
- * of view to 0.5 radians and aspect ratio to 1.5, which would make shapes
- * appear thinner on a square canvas. By default, `aspect` is set to
- * `width / height`.
- *
- * The third parameter, `near`, is the distance from the camera to the near
- * plane. For example, calling `myCamera.perspective(0.5, 1.5, 100)` sets the
- * camera’s field of view to 0.5 radians, its aspect ratio to 1.5, and places
- * the near plane 100 pixels from the camera. Any shapes drawn less than 100
- * pixels from the camera won’t be visible. By default, `near` is set to
- * `0.1 * 800`, which is 1/10th the default distance between the camera and
- * the origin.
- *
- * The fourth parameter, `far`, is the distance from the camera to the far
- * plane. For example, calling `myCamera.perspective(0.5, 1.5, 100, 10000)`
- * sets the camera’s field of view to 0.5 radians, its aspect ratio to 1.5,
- * places the near plane 100 pixels from the camera, and places the far plane
- * 10,000 pixels from the camera. Any shapes drawn more than 10,000 pixels
- * from the camera won’t be visible. By default, `far` is set to `10 * 800`,
- * which is 10 times the default distance between the camera and the origin.
- *
- * @for p5.Camera
- * @param  {Number} [fovy]   camera frustum vertical field of view. Defaults to
- *                           `2 * atan(height / 2 / 800)`.
- * @param  {Number} [aspect] camera frustum aspect ratio. Defaults to
- *                           `width / height`.
- * @param  {Number} [near]   distance from the camera to the near clipping plane.
- *                           Defaults to `0.1 * 800`.
- * @param  {Number} [far]    distance from the camera to the far clipping plane.
- *                           Defaults to `10 * 800`.
- *
- * @example
- * <div>
- * <code>
- * // Double-click to toggle between cameras.
- *
- * let cam1;
- * let cam2;
- * let isDefaultCamera = true;
- *
- * function setup() {
- *   createCanvas(100, 100, WEBGL);
- *
- *   // Create the first camera.
- *   // Keep its default settings.
- *   cam1 = createCamera();
- *
- *   // Create the second camera.
- *   cam2 = createCamera();
- *
- *   // Place it at the top-right.
- *   cam2.camera(400, -400, 800);
- *
- *   // Set its fovy to 0.2.
- *   // Set its aspect to 1.5.
- *   // Set its near to 600.
- *   // Set its far to 1200.
- *   cam2.perspective(0.2, 1.5, 600, 1200);
- *
- *   // Set the current camera to cam1.
- *   setCamera(cam1);
- *
- *   describe('A white cube on a gray background. The camera toggles between a frontal view and a skewed aerial view when the user double-clicks.');
- * }
- *
- * function draw() {
- *   background(200);
- *
- *   // Draw the box.
- *   box();
- * }
- *
- * // Toggle the current camera when the user double-clicks.
- * function doubleClicked() {
- *   if (isDefaultCamera === true) {
- *     setCamera(cam2);
- *     isDefaultCamera = false;
- *   } else {
- *     setCamera(cam1);
- *     isDefaultCamera = true;
- *   }
- * }
- * </code>
- * </div>
- *
- * <div>
- * <code>
- * // Double-click to toggle between cameras.
- *
- * let cam1;
- * let cam2;
- * let isDefaultCamera = true;
- *
- * function setup() {
- *   createCanvas(100, 100, WEBGL);
- *
- *   // Create the first camera.
- *   // Keep its default settings.
- *   cam1 = createCamera();
- *
- *   // Create the second camera.
- *   cam2 = createCamera();
- *
- *   // Place it at the top-right.
- *   cam2.camera(400, -400, 800);
- *
- *   // Set its fovy to 0.2.
- *   // Set its aspect to 1.5.
- *   // Set its near to 600.
- *   // Set its far to 1200.
- *   cam2.perspective(0.2, 1.5, 600, 1200);
- *
- *   // Set the current camera to cam1.
- *   setCamera(cam1);
- *
- *   describe('A white cube moves left and right on a gray background. The camera toggles between a frontal and a skewed aerial view when the user double-clicks.');
- * }
- *
- * function draw() {
- *   background(200);
- *
- *   // Translate the origin left and right.
- *   let x = 100 * sin(frameCount * 0.01);
- *   translate(x, 0, 0);
- *
- *   // Draw the box.
- *   box();
- * }
- *
- * // Toggle the current camera when the user double-clicks.
- * function doubleClicked() {
- *   if (isDefaultCamera === true) {
- *     setCamera(cam2);
- *     isDefaultCamera = false;
- *   } else {
- *     setCamera(cam1);
- *     isDefaultCamera = true;
- *   }
- * }
- * </code>
- * </div>
- */
-  perspective(fovy, aspect, near, far) {
-    this.cameraType = arguments.length > 0 ? 'custom' : 'default';
-    if (typeof fovy === 'undefined') {
-      fovy = this.defaultCameraFOV;
-      // this avoids issue where setting angleMode(DEGREES) before calling
-      // perspective leads to a smaller than expected FOV (because
-      // _computeCameraDefaultSettings computes in radians)
-      this.cameraFOV = fovy;
-    } else {
-      this.cameraFOV = this._renderer._pInst._toRadians(fovy);
-    }
-    if (typeof aspect === 'undefined') {
-      aspect = this.defaultAspectRatio;
-    }
-    if (typeof near === 'undefined') {
-      near = this.defaultCameraNear;
-    }
-    if (typeof far === 'undefined') {
-      far = this.defaultCameraFar;
-    }
-
-    if (near <= 0.0001) {
-      near = 0.01;
-      console.log(
-        'Avoid perspective near plane values close to or below 0. ' +
-        'Setting value to 0.01.'
-      );
-    }
-
-    if (far < near) {
-      console.log(
-        'Perspective far plane value is less than near plane value. ' +
-        'Nothing will be shown.'
-      );
-    }
-
-    this.aspectRatio = aspect;
-    this.cameraNear = near;
-    this.cameraFar = far;
-
-    this.projMatrix = p5.Matrix.identity();
-
-    const f = 1.0 / Math.tan(this.cameraFOV / 2);
-    const nf = 1.0 / (this.cameraNear - this.cameraFar);
-
-    /* eslint-disable indent */
-    this.projMatrix.set(f / aspect, 0, 0, 0,
-      0, -f * this.yScale, 0, 0,
-      0, 0, (far + near) * nf, -1,
-      0, 0, (2 * far * near) * nf, 0);
-    /* eslint-enable indent */
-
-    if (this._isActive()) {
-      this._renderer.states.uPMatrix.set(this.projMatrix);
-    }
-  }
-
-  /**
- * Sets an orthographic projection for the camera.
- *
- * In an orthographic projection, shapes with the same size always appear the
- * same size, regardless of whether they are near or far from the camera.
- *
- * `myCamera.ortho()` changes the camera’s perspective by changing its viewing
- * frustum from a truncated pyramid to a rectangular prism. The frustum is the
- * volume of space that’s visible to the camera. The camera is placed in front
- * of the frustum and views everything within the frustum. `myCamera.ortho()`
- * has six optional parameters to define the viewing frustum.
- *
- * The first four parameters, `left`, `right`, `bottom`, and `top`, set the
- * coordinates of the frustum’s sides, bottom, and top. For example, calling
- * `myCamera.ortho(-100, 100, 200, -200)` creates a frustum that’s 200 pixels
- * wide and 400 pixels tall. By default, these dimensions are set based on
- * the sketch’s width and height, as in
- * `myCamera.ortho(-width / 2, width / 2, -height / 2, height / 2)`.
- *
- * The last two parameters, `near` and `far`, set the distance of the
- * frustum’s near and far plane from the camera. For example, calling
- * `myCamera.ortho(-100, 100, 200, -200, 50, 1000)` creates a frustum that’s
- * 200 pixels wide, 400 pixels tall, starts 50 pixels from the camera, and
- * ends 1,000 pixels from the camera. By default, `near` and `far` are set to
- * 0 and `max(width, height) + 800`, respectively.
- *
- * @for p5.Camera
- * @param  {Number} [left]   x-coordinate of the frustum’s left plane. Defaults to `-width / 2`.
- * @param  {Number} [right]  x-coordinate of the frustum’s right plane. Defaults to `width / 2`.
- * @param  {Number} [bottom] y-coordinate of the frustum’s bottom plane. Defaults to `height / 2`.
- * @param  {Number} [top]    y-coordinate of the frustum’s top plane. Defaults to `-height / 2`.
- * @param  {Number} [near]   z-coordinate of the frustum’s near plane. Defaults to 0.
- * @param  {Number} [far]    z-coordinate of the frustum’s far plane. Defaults to `max(width, height) + 800`.
- *
- * @example
- * <div>
- * <code>
- * // Double-click to toggle between cameras.
- *
- * let cam1;
- * let cam2;
- * let isDefaultCamera = true;
- *
- * function setup() {
- *   createCanvas(100, 100, WEBGL);
- *
- *   // Create the first camera.
- *   // Keep its default settings.
- *   cam1 = createCamera();
- *
- *   // Create the second camera.
- *   cam2 = createCamera();
- *
- *   // Apply an orthographic projection.
- *   cam2.ortho();
- *
- *   // Set the current camera to cam1.
- *   setCamera(cam1);
- *
- *   describe('A row of white cubes against a gray background. The camera toggles between a perspective and an orthographic projection when the user double-clicks.');
- * }
- *
- * function draw() {
- *   background(200);
- *
- *   // Translate the origin toward the camera.
- *   translate(-10, 10, 500);
- *
- *   // Rotate the coordinate system.
- *   rotateY(-0.1);
- *   rotateX(-0.1);
- *
- *   // Draw the row of boxes.
- *   for (let i = 0; i < 6; i += 1) {
- *     translate(0, 0, -40);
- *     box(10);
- *   }
- * }
- *
- * // Toggle the current camera when the user double-clicks.
- * function doubleClicked() {
- *   if (isDefaultCamera === true) {
- *     setCamera(cam2);
- *     isDefaultCamera = false;
- *   } else {
- *     setCamera(cam1);
- *     isDefaultCamera = true;
- *   }
- * }
- * </code>
- * </div>
- *
- * <div>
- * <code>
- * // Double-click to toggle between cameras.
- *
- * let cam1;
- * let cam2;
- * let isDefaultCamera = true;
- *
- * function setup() {
- *   createCanvas(100, 100, WEBGL);
- *
- *   // Create the first camera.
- *   // Keep its default settings.
- *   cam1 = createCamera();
- *
- *   // Create the second camera.
- *   cam2 = createCamera();
- *
- *   // Apply an orthographic projection.
- *   cam2.ortho();
- *
- *   // Set the current camera to cam1.
- *   setCamera(cam1);
- *
- *   describe('A row of white cubes slither like a snake against a gray background. The camera toggles between a perspective and an orthographic projection when the user double-clicks.');
- * }
- *
- * function draw() {
- *   background(200);
- *
- *   // Translate the origin toward the camera.
- *   translate(-10, 10, 500);
- *
- *   // Rotate the coordinate system.
- *   rotateY(-0.1);
- *   rotateX(-0.1);
- *
- *   // Draw the row of boxes.
- *   for (let i = 0; i < 6; i += 1) {
- *     push();
- *     // Calculate the box's coordinates.
- *     let x = 10 * sin(frameCount * 0.02 + i * 0.6);
- *     let z = -40 * i;
- *     // Translate the origin.
- *     translate(x, 0, z);
- *     // Draw the box.
- *     box(10);
- *     pop();
- *   }
- * }
- *
- * // Toggle the current camera when the user double-clicks.
- * function doubleClicked() {
- *   if (isDefaultCamera === true) {
- *     setCamera(cam2);
- *     isDefaultCamera = false;
- *   } else {
- *     setCamera(cam1);
- *     isDefaultCamera = true;
- *   }
- * }
- * </code>
- * </div>
- */
-  ortho(left, right, bottom, top, near, far) {
-    const source = this.fbo || this._renderer;
-    if (left === undefined) left = -source.width / 2;
-    if (right === undefined) right = +source.width / 2;
-    if (bottom === undefined) bottom = -source.height / 2;
-    if (top === undefined) top = +source.height / 2;
-    if (near === undefined) near = 0;
-    if (far === undefined) far = Math.max(source.width, source.height) + 800;
-    this.cameraNear = near;
-    this.cameraFar = far;
-    const w = right - left;
-    const h = top - bottom;
-    const d = far - near;
-    const x = +2.0 / w;
-    const y = +2.0 / h * this.yScale;
-    const z = -2.0 / d;
-    const tx = -(right + left) / w;
-    const ty = -(top + bottom) / h;
-    const tz = -(far + near) / d;
-    this.projMatrix = p5.Matrix.identity();
-    /* eslint-disable indent */
-    this.projMatrix.set(x, 0, 0, 0,
-      0, -y, 0, 0,
-      0, 0, z, 0,
-      tx, ty, tz, 1);
-    /* eslint-enable indent */
-    if (this._isActive()) {
-      this._renderer.states.uPMatrix.set(this.projMatrix);
-    }
-    this.cameraType = 'custom';
-  }
-  /**
- * Sets the camera's frustum.
- *
- * In a frustum projection, shapes that are further from the camera appear
- * smaller than shapes that are near the camera. This technique, called
- * foreshortening, creates realistic 3D scenes.
- *
- * `myCamera.frustum()` changes the camera’s perspective by changing its
- * viewing frustum. The frustum is the volume of space that’s visible to the
- * camera. The frustum’s shape is a pyramid with its top cut off. The camera
- * is placed where the top of the pyramid should be and points towards the
- * base of the pyramid. It views everything within the frustum.
- *
- * The first four parameters, `left`, `right`, `bottom`, and `top`, set the
- * coordinates of the frustum’s sides, bottom, and top. For example, calling
- * `myCamera.frustum(-100, 100, 200, -200)` creates a frustum that’s 200
- * pixels wide and 400 pixels tall. By default, these coordinates are set
- * based on the sketch’s width and height, as in
- * `myCamera.frustum(-width / 20, width / 20, height / 20, -height / 20)`.
- *
- * The last two parameters, `near` and `far`, set the distance of the
- * frustum’s near and far plane from the camera. For example, calling
- * `myCamera.frustum(-100, 100, 200, -200, 50, 1000)` creates a frustum that’s
- * 200 pixels wide, 400 pixels tall, starts 50 pixels from the camera, and ends
- * 1,000 pixels from the camera. By default, near is set to `0.1 * 800`, which
- * is 1/10th the default distance between the camera and the origin. `far` is
- * set to `10 * 800`, which is 10 times the default distance between the
- * camera and the origin.
- *
- * @for p5.Camera
- * @param  {Number} [left]   x-coordinate of the frustum’s left plane. Defaults to `-width / 20`.
- * @param  {Number} [right]  x-coordinate of the frustum’s right plane. Defaults to `width / 20`.
- * @param  {Number} [bottom] y-coordinate of the frustum’s bottom plane. Defaults to `height / 20`.
- * @param  {Number} [top]    y-coordinate of the frustum’s top plane. Defaults to `-height / 20`.
- * @param  {Number} [near]   z-coordinate of the frustum’s near plane. Defaults to `0.1 * 800`.
- * @param  {Number} [far]    z-coordinate of the frustum’s far plane. Defaults to `10 * 800`.
- *
- * @example
- * <div>
- * <code>
- * // Double-click to toggle between cameras.
- *
- * let cam1;
- * let cam2;
- * let isDefaultCamera = true;
- *
- * function setup() {
- *   createCanvas(100, 100, WEBGL);
- *
- *   // Create the first camera.
- *   // Keep its default settings.
- *   cam1 = createCamera();
- *
- *   // Create the second camera.
- *   cam2 = createCamera();
- *
- *   // Adjust the frustum.
- *   // Center it.
- *   // Set its width and height to 20 pixels.
- *   // Place its near plane 300 pixels from the camera.
- *   // Place its far plane 350 pixels from the camera.
- *   cam2.frustum(-10, 10, -10, 10, 300, 350);
- *
- *   // Set the current camera to cam1.
- *   setCamera(cam1);
- *
- *   describe(
- *     'A row of white cubes against a gray background. The camera zooms in on one cube when the user double-clicks.'
- *   );
- * }
- *
- * function draw() {
- *   background(200);
- *
- *   // Translate the origin toward the camera.
- *   translate(-10, 10, 600);
- *
- *   // Rotate the coordinate system.
- *   rotateY(-0.1);
- *   rotateX(-0.1);
- *
- *   // Draw the row of boxes.
- *   for (let i = 0; i < 6; i += 1) {
- *     translate(0, 0, -40);
- *     box(10);
- *   }
- * }
- *
- * // Toggle the current camera when the user double-clicks.
- * function doubleClicked() {
- *   if (isDefaultCamera === true) {
- *     setCamera(cam2);
- *     isDefaultCamera = false;
- *   } else {
- *     setCamera(cam1);
- *     isDefaultCamera = true;
- *   }
- * }
- * </code>
- * </div>
- */
-  frustum(left, right, bottom, top, near, far) {
-    if (left === undefined) left = -this._renderer.width * 0.05;
-    if (right === undefined) right = +this._renderer.width * 0.05;
-    if (bottom === undefined) bottom = +this._renderer.height * 0.05;
-    if (top === undefined) top = -this._renderer.height * 0.05;
-    if (near === undefined) near = this.defaultCameraNear;
-    if (far === undefined) far = this.defaultCameraFar;
-
-    this.cameraNear = near;
-    this.cameraFar = far;
-
-    const w = right - left;
-    const h = top - bottom;
-    const d = far - near;
-
-    const x = +(2.0 * near) / w;
-    const y = +(2.0 * near) / h * this.yScale;
-    const z = -(2.0 * far * near) / d;
-
-    const tx = (right + left) / w;
-    const ty = (top + bottom) / h;
-    const tz = -(far + near) / d;
-
-    this.projMatrix = p5.Matrix.identity();
-
-    /* eslint-disable indent */
-    this.projMatrix.set(x, 0, 0, 0,
-      0, -y, 0, 0,
-      tx, ty, tz, -1,
-      0, 0, z, 0);
-    /* eslint-enable indent */
-
-    if (this._isActive()) {
-      this._renderer.states.uPMatrix.set(this.projMatrix);
-    }
-
-    this.cameraType = 'custom';
-  }
-
-  ////////////////////////////////////////////////////////////////////////////////
-  // Camera Orientation Methods
-  ////////////////////////////////////////////////////////////////////////////////
-
-  /**
- * Rotate camera view about arbitrary axis defined by x,y,z
- * based on http://learnwebgl.brown37.net/07_cameras/camera_rotating_motion.html
- * @private
- */
-  _rotateView(a, x, y, z) {
-    let centerX = this.centerX;
-    let centerY = this.centerY;
-    let centerZ = this.centerZ;
-
-    // move center by eye position such that rotation happens around eye position
-    centerX -= this.eyeX;
-    centerY -= this.eyeY;
-    centerZ -= this.eyeZ;
-
-    const rotation = p5.Matrix.identity(this._renderer._pInst);
-    rotation.rotate(this._renderer._pInst._toRadians(a), x, y, z);
-
-    /* eslint-disable max-len */
-    const rotatedCenter = [
-      centerX * rotation.mat4[0] + centerY * rotation.mat4[4] + centerZ * rotation.mat4[8],
-      centerX * rotation.mat4[1] + centerY * rotation.mat4[5] + centerZ * rotation.mat4[9],
-      centerX * rotation.mat4[2] + centerY * rotation.mat4[6] + centerZ * rotation.mat4[10]
-    ];
-    /* eslint-enable max-len */
-
-    // add eye position back into center
-    rotatedCenter[0] += this.eyeX;
-    rotatedCenter[1] += this.eyeY;
-    rotatedCenter[2] += this.eyeZ;
-
-    this.camera(
-      this.eyeX,
-      this.eyeY,
-      this.eyeZ,
-      rotatedCenter[0],
-      rotatedCenter[1],
-      rotatedCenter[2],
-      this.upX,
-      this.upY,
-      this.upZ
-    );
-  }
-
-  /**
- * Rotates the camera in a clockwise/counter-clockwise direction.
- *
- * Rolling rotates the camera without changing its orientation. The rotation
- * happens in the camera’s "local" space.
- *
- * The parameter, `angle`, is the angle the camera should rotate. Passing a
- * positive angle, as in `myCamera.roll(0.001)`, rotates the camera in counter-clockwise direction.
- * Passing a negative angle, as in `myCamera.roll(-0.001)`, rotates the
- * camera in clockwise direction.
- *
- * Note: Angles are interpreted based on the current
- * <a href="#/p5/angleMode">angleMode()</a>.
- *
- * @method roll
- * @param {Number} angle amount to rotate camera in current
- * <a href="#/p5/angleMode">angleMode</a> units.
- * @example
- * <div>
- * <code>
- * let cam;
- * let delta = 0.01;
- *
- * function setup() {
- *   createCanvas(100, 100, WEBGL);
- *   normalMaterial();
- *   // Create a p5.Camera object.
- *   cam = createCamera();
- * }
- *
- * function draw() {
- *   background(200);
- *
- *   // Roll camera according to angle 'delta'
- *   cam.roll(delta);
- *
- *   translate(0, 0, 0);
- *   box(20);
- *   translate(0, 25, 0);
- *   box(20);
- *   translate(0, 26, 0);
- *   box(20);
- *   translate(0, 27, 0);
- *   box(20);
- *   translate(0, 28, 0);
- *   box(20);
- *   translate(0,29, 0);
- *   box(20);
- *   translate(0, 30, 0);
- *   box(20);
- * }
- * </code>
- * </div>
- *
- * @alt
- * camera view rotates in counter clockwise direction with vertically stacked boxes in front of it.
- */
-  roll(amount) {
-    const local = this._getLocalAxes();
-    const axisQuaternion = p5.Quat.fromAxisAngle(
-      this._renderer._pInst._toRadians(amount),
-      local.z[0], local.z[1], local.z[2]);
-    // const upQuat = new p5.Quat(0, this.upX, this.upY, this.upZ);
-    const newUpVector = axisQuaternion.rotateVector(
-      new p5.Vector(this.upX, this.upY, this.upZ));
-    this.camera(
-      this.eyeX,
-      this.eyeY,
-      this.eyeZ,
-      this.centerX,
-      this.centerY,
-      this.centerZ,
-      newUpVector.x,
-      newUpVector.y,
-      newUpVector.z
-    );
-  }
-
-  /**
- * Rotates the camera left and right.
- *
- * Panning rotates the camera without changing its position. The rotation
- * happens in the camera’s "local" space.
- *
- * The parameter, `angle`, is the angle the camera should rotate. Passing a
- * positive angle, as in `myCamera.pan(0.001)`, rotates the camera to the
- * right. Passing a negative angle, as in `myCamera.pan(-0.001)`, rotates the
- * camera to the left.
- *
- * Note: Angles are interpreted based on the current
- * <a href="#/p5/angleMode">angleMode()</a>.
- *
- * @param {Number} angle amount to rotate in the current
- *                       <a href="#/p5/angleMode">angleMode()</a>.
- *
- * @example
- * <div>
- * <code>
- * let cam;
- * let delta = 0.001;
- *
- * function setup() {
- *   createCanvas(100, 100, WEBGL);
- *
- *   // Create a p5.Camera object.
- *   cam = createCamera();
- *
- *   // Place the camera at the top-center.
- *   cam.setPosition(0, -400, 800);
- *
- *   // Point the camera at the origin.
- *   cam.lookAt(0, 0, 0);
- *
- *   describe(
- *     'A white cube on a gray background. The cube goes in and out of view as the camera pans left and right.'
- *   );
- * }
- *
- * function draw() {
- *   background(200);
- *
- *   // Pan with the camera.
- *   cam.pan(delta);
- *
- *   // Switch directions every 120 frames.
- *   if (frameCount % 120 === 0) {
- *     delta *= -1;
- *   }
- *
- *   // Draw the box.
- *   box();
- * }
- * </code>
- * </div>
- */
-  pan(amount) {
-    const local = this._getLocalAxes();
-    this._rotateView(amount, local.y[0], local.y[1], local.y[2]);
-  }
-
-  /**
- * Rotates the camera up and down.
- *
- * Tilting rotates the camera without changing its position. The rotation
- * happens in the camera’s "local" space.
- *
- * The parameter, `angle`, is the angle the camera should rotate. Passing a
- * positive angle, as in `myCamera.tilt(0.001)`, rotates the camera down.
- * Passing a negative angle, as in `myCamera.tilt(-0.001)`, rotates the camera
- * up.
- *
- * Note: Angles are interpreted based on the current
- * <a href="#/p5/angleMode">angleMode()</a>.
- *
- * @param {Number} angle amount to rotate in the current
- *                       <a href="#/p5/angleMode">angleMode()</a>.
- *
- * @example
- * <div>
- * <code>
- * let cam;
- * let delta = 0.001;
- *
- * function setup() {
- *   createCanvas(100, 100, WEBGL);
- *
- *   // Create a p5.Camera object.
- *   cam = createCamera();
- *
- *   // Place the camera at the top-center.
- *   cam.setPosition(0, -400, 800);
- *
- *   // Point the camera at the origin.
- *   cam.lookAt(0, 0, 0);
- *
- *   describe(
- *     'A white cube on a gray background. The cube goes in and out of view as the camera tilts up and down.'
- *   );
- * }
- *
- * function draw() {
- *   background(200);
- *
- *   // Pan with the camera.
- *   cam.tilt(delta);
- *
- *   // Switch directions every 120 frames.
- *   if (frameCount % 120 === 0) {
- *     delta *= -1;
- *   }
- *
- *   // Draw the box.
- *   box();
- * }
- * </code>
- * </div>
- */
-  tilt(amount) {
-    const local = this._getLocalAxes();
-    this._rotateView(amount, local.x[0], local.x[1], local.x[2]);
-  }
-
-  /**
- * Points the camera at a location.
- *
- * `myCamera.lookAt()` changes the camera’s orientation without changing its
- * position.
- *
- * The parameters, `x`, `y`, and `z`, are the coordinates in "world" space
- * where the camera should point. For example, calling
- * `myCamera.lookAt(10, 20, 30)` points the camera at the coordinates
- * `(10, 20, 30)`.
- *
- * @for p5.Camera
- * @param {Number} x x-coordinate of the position where the camera should look in "world" space.
- * @param {Number} y y-coordinate of the position where the camera should look in "world" space.
- * @param {Number} z z-coordinate of the position where the camera should look in "world" space.
- *
- * @example
- * <div>
- * <code>
- * // Double-click to look at a different cube.
- *
- * let cam;
- * let isLookingLeft = true;
- *
- * function setup() {
- *   createCanvas(100, 100, WEBGL);
- *
- *   // Create a p5.Camera object.
- *   cam = createCamera();
- *
- *   // Place the camera at the top-center.
- *   cam.setPosition(0, -400, 800);
- *
- *   // Point the camera at the origin.
- *   cam.lookAt(-30, 0, 0);
- *
- *   describe(
- *     'A red cube and a blue cube on a gray background. The camera switches focus between the cubes when the user double-clicks.'
- *   );
- * }
- *
- * function draw() {
- *   background(200);
- *
- *   // Draw the box on the left.
- *   push();
- *   // Translate the origin to the left.
- *   translate(-30, 0, 0);
- *   // Style the box.
- *   fill(255, 0, 0);
- *   // Draw the box.
- *   box(20);
- *   pop();
- *
- *   // Draw the box on the right.
- *   push();
- *   // Translate the origin to the right.
- *   translate(30, 0, 0);
- *   // Style the box.
- *   fill(0, 0, 255);
- *   // Draw the box.
- *   box(20);
- *   pop();
- * }
- *
- * // Change the camera's focus when the user double-clicks.
- * function doubleClicked() {
- *   if (isLookingLeft === true) {
- *     cam.lookAt(30, 0, 0);
- *     isLookingLeft = false;
- *   } else {
- *     cam.lookAt(-30, 0, 0);
- *     isLookingLeft = true;
- *   }
- * }
- * </code>
- * </div>
- */
-  lookAt(x, y, z) {
-    this.camera(
-      this.eyeX,
-      this.eyeY,
-      this.eyeZ,
-      x,
-      y,
-      z,
-      this.upX,
-      this.upY,
-      this.upZ
-    );
-  }
-
-  ////////////////////////////////////////////////////////////////////////////////
-  // Camera Position Methods
-  ////////////////////////////////////////////////////////////////////////////////
-
-  /**
- * Sets the position and orientation of the camera.
- *
- * `myCamera.camera()` allows objects to be viewed from different angles. It
- * has nine parameters that are all optional.
- *
- * The first three parameters, `x`, `y`, and `z`, are the coordinates of the
- * camera’s position in "world" space. For example, calling
- * `myCamera.camera(0, 0, 0)` places the camera at the origin `(0, 0, 0)`. By
- * default, the camera is placed at `(0, 0, 800)`.
- *
- * The next three parameters, `centerX`, `centerY`, and `centerZ` are the
- * coordinates of the point where the camera faces in "world" space. For
- * example, calling `myCamera.camera(0, 0, 0, 10, 20, 30)` places the camera
- * at the origin `(0, 0, 0)` and points it at `(10, 20, 30)`. By default, the
- * camera points at the origin `(0, 0, 0)`.
- *
- * The last three parameters, `upX`, `upY`, and `upZ` are the components of
- * the "up" vector in "local" space. The "up" vector orients the camera’s
- * y-axis. For example, calling
- * `myCamera.camera(0, 0, 0, 10, 20, 30, 0, -1, 0)` places the camera at the
- * origin `(0, 0, 0)`, points it at `(10, 20, 30)`, and sets the "up" vector
- * to `(0, -1, 0)` which is like holding it upside-down. By default, the "up"
- * vector is `(0, 1, 0)`.
- *
- * @for p5.Camera
- * @param  {Number} [x]        x-coordinate of the camera. Defaults to 0.
- * @param  {Number} [y]        y-coordinate of the camera. Defaults to 0.
- * @param  {Number} [z]        z-coordinate of the camera. Defaults to 800.
- * @param  {Number} [centerX]  x-coordinate of the point the camera faces. Defaults to 0.
- * @param  {Number} [centerY]  y-coordinate of the point the camera faces. Defaults to 0.
- * @param  {Number} [centerZ]  z-coordinate of the point the camera faces. Defaults to 0.
- * @param  {Number} [upX]      x-component of the camera’s "up" vector. Defaults to 0.
- * @param  {Number} [upY]      x-component of the camera’s "up" vector. Defaults to 1.
- * @param  {Number} [upZ]      z-component of the camera’s "up" vector. Defaults to 0.
- *
- * @example
- * <div>
- * <code>
- * // Double-click to toggle between cameras.
- *
- * let cam1;
- * let cam2;
- * let isDefaultCamera = true;
- *
- * function setup() {
- *   createCanvas(100, 100, WEBGL);
- *
- *   // Create the first camera.
- *   // Keep its default settings.
- *   cam1 = createCamera();
- *
- *   // Create the second camera.
- *   cam2 = createCamera();
- *
- *   // Place it at the top-right: (1200, -600, 100)
- *   // Point it at the row of boxes: (-10, -10, 400)
- *   // Set its "up" vector to the default: (0, 1, 0)
- *   cam2.camera(1200, -600, 100, -10, -10, 400, 0, 1, 0);
- *
- *   // Set the current camera to cam1.
- *   setCamera(cam1);
- *
- *   describe(
- *     'A row of white cubes against a gray background. The camera toggles between a frontal and an aerial view when the user double-clicks.'
- *   );
- * }
- *
- * function draw() {
- *   background(200);
- *
- *   // Translate the origin toward the camera.
- *   translate(-10, 10, 500);
- *
- *   // Rotate the coordinate system.
- *   rotateY(-0.1);
- *   rotateX(-0.1);
- *
- *   // Draw the row of boxes.
- *   for (let i = 0; i < 6; i += 1) {
- *     translate(0, 0, -30);
- *     box(10);
- *   }
- * }
- *
- * // Toggle the current camera when the user double-clicks.
- * function doubleClicked() {
- *   if (isDefaultCamera === true) {
- *     setCamera(cam2);
- *     isDefaultCamera = false;
- *   } else {
- *     setCamera(cam1);
- *     isDefaultCamera = true;
- *   }
- * }
- * </code>
- * </div>
- *
- * <div>
- * <code>
- * // Double-click to toggle between cameras.
- *
- * let cam1;
- * let cam2;
- * let isDefaultCamera = true;
- *
- * function setup() {
- *   createCanvas(100, 100, WEBGL);
- *
- *   // Create the first camera.
- *   // Keep its default settings.
- *   cam1 = createCamera();
- *
- *   // Create the second camera.
- *   cam2 = createCamera();
- *
- *   // Place it at the right: (1200, 0, 100)
- *   // Point it at the row of boxes: (-10, -10, 400)
- *   // Set its "up" vector to the default: (0, 1, 0)
- *   cam2.camera(1200, 0, 100, -10, -10, 400, 0, 1, 0);
- *
- *   // Set the current camera to cam1.
- *   setCamera(cam1);
- *
- *   describe(
- *     'A row of white cubes against a gray background. The camera toggles between a static frontal view and an orbiting view when the user double-clicks.'
- *   );
- * }
- *
- * function draw() {
- *   background(200);
- *
- *   // Update cam2's position.
- *   let x = 1200 * cos(frameCount * 0.01);
- *   let y = -600 * sin(frameCount * 0.01);
- *   cam2.camera(x, y, 100, -10, -10, 400, 0, 1, 0);
- *
- *   // Translate the origin toward the camera.
- *   translate(-10, 10, 500);
- *
- *   // Rotate the coordinate system.
- *   rotateY(-0.1);
- *   rotateX(-0.1);
- *
- *   // Draw the row of boxes.
- *   for (let i = 0; i < 6; i += 1) {
- *     translate(0, 0, -30);
- *     box(10);
- *   }
- * }
- *
- * // Toggle the current camera when the user double-clicks.
- * function doubleClicked() {
- *   if (isDefaultCamera === true) {
- *     setCamera(cam2);
- *     isDefaultCamera = false;
- *   } else {
- *     setCamera(cam1);
- *     isDefaultCamera = true;
- *   }
- * }
- * </code>
- * </div>
- */
-  camera(
-    eyeX,
-    eyeY,
-    eyeZ,
-    centerX,
-    centerY,
-    centerZ,
-    upX,
-    upY,
-    upZ
-  ) {
-    if (typeof eyeX === 'undefined') {
-      eyeX = this.defaultEyeX;
-      eyeY = this.defaultEyeY;
-      eyeZ = this.defaultEyeZ;
-      centerX = eyeX;
-      centerY = eyeY;
-      centerZ = 0;
-      upX = 0;
-      upY = 1;
-      upZ = 0;
-    }
-
-    this.eyeX = eyeX;
-    this.eyeY = eyeY;
-    this.eyeZ = eyeZ;
-
-    if (typeof centerX !== 'undefined') {
-      this.centerX = centerX;
-      this.centerY = centerY;
-      this.centerZ = centerZ;
-    }
-
-    if (typeof upX !== 'undefined') {
-      this.upX = upX;
-      this.upY = upY;
-      this.upZ = upZ;
-    }
-
-    const local = this._getLocalAxes();
-
-    // the camera affects the model view matrix, insofar as it
-    // inverse translates the world to the eye position of the camera
-    // and rotates it.
-    /* eslint-disable indent */
-    this.cameraMatrix.set(local.x[0], local.y[0], local.z[0], 0,
-      local.x[1], local.y[1], local.z[1], 0,
-      local.x[2], local.y[2], local.z[2], 0,
-      0, 0, 0, 1);
-    /* eslint-enable indent */
-
-    const tx = -eyeX;
-    const ty = -eyeY;
-    const tz = -eyeZ;
-
-    this.cameraMatrix.translate([tx, ty, tz]);
-
-    if (this._isActive()) {
-      this._renderer.states.uViewMatrix.set(this.cameraMatrix);
-    }
+   * Sets the position and orientation of the current camera in a 3D sketch.
+   *
+   * `camera()` allows objects to be viewed from different angles. It has nine
+   * parameters that are all optional.
+   *
+   * The first three parameters, `x`, `y`, and `z`, are the coordinates of the
+   * camera’s position. For example, calling `camera(0, 0, 0)` places the camera
+   * at the origin `(0, 0, 0)`. By default, the camera is placed at
+   * `(0, 0, 800)`.
+   *
+   * The next three parameters, `centerX`, `centerY`, and `centerZ` are the
+   * coordinates of the point where the camera faces. For example, calling
+   * `camera(0, 0, 0, 10, 20, 30)` places the camera at the origin `(0, 0, 0)`
+   * and points it at `(10, 20, 30)`. By default, the camera points at the
+   * origin `(0, 0, 0)`.
+   *
+   * The last three parameters, `upX`, `upY`, and `upZ` are the components of
+   * the "up" vector. The "up" vector orients the camera’s y-axis. For example,
+   * calling `camera(0, 0, 0, 10, 20, 30, 0, -1, 0)` places the camera at the
+   * origin `(0, 0, 0)`, points it at `(10, 20, 30)`, and sets the "up" vector
+   * to `(0, -1, 0)` which is like holding it upside-down. By default, the "up"
+   * vector is `(0, 1, 0)`.
+   *
+   * Note: `camera()` can only be used in WebGL mode.
+   *
+   * @method camera
+   * @for p5
+   * @param  {Number} [x]        x-coordinate of the camera. Defaults to 0.
+   * @param  {Number} [y]        y-coordinate of the camera. Defaults to 0.
+   * @param  {Number} [z]        z-coordinate of the camera. Defaults to 800.
+   * @param  {Number} [centerX]  x-coordinate of the point the camera faces. Defaults to 0.
+   * @param  {Number} [centerY]  y-coordinate of the point the camera faces. Defaults to 0.
+   * @param  {Number} [centerZ]  z-coordinate of the point the camera faces. Defaults to 0.
+   * @param  {Number} [upX]      x-component of the camera’s "up" vector. Defaults to 0.
+   * @param  {Number} [upY]      y-component of the camera’s "up" vector. Defaults to 1.
+   * @param  {Number} [upZ]      z-component of the camera’s "up" vector. Defaults to 0.
+   * @chainable
+   *
+   * @example
+   * <div>
+   * <code>
+   * function setup() {
+   *   createCanvas(100, 100, WEBGL);
+   *
+   *   describe('A white cube on a gray background.');
+   * }
+   *
+   * function draw() {
+   *   background(200);
+   *
+   *   // Move the camera to the top-right.
+   *   camera(200, -400, 800);
+   *
+   *   // Draw the box.
+   *   box();
+   * }
+   * </code>
+   * </div>
+   *
+   * <div>
+   * <code>
+   * function setup() {
+   *   createCanvas(100, 100, WEBGL);
+   *
+   *   describe('A white cube apperas to sway left and right on a gray background.');
+   * }
+   *
+   * function draw() {
+   *   background(200);
+   *
+   *   // Calculate the camera's x-coordinate.
+   *   let x = 400 * cos(frameCount * 0.01);
+   *
+   *   // Orbit the camera around the box.
+   *   camera(x, -400, 800);
+   *
+   *   // Draw the box.
+   *   box();
+   * }
+   * </code>
+   * </div>
+   *
+   * <div>
+   * <code>
+   * // Adjust the range sliders to change the camera's position.
+   *
+   * let xSlider;
+   * let ySlider;
+   * let zSlider;
+   *
+   * function setup() {
+   *   createCanvas(100, 100, WEBGL);
+   *
+   *   // Create slider objects to set the camera's coordinates.
+   *   xSlider = createSlider(-400, 400, 400);
+   *   xSlider.position(0, 100);
+   *   xSlider.size(100);
+   *   ySlider = createSlider(-400, 400, -200);
+   *   ySlider.position(0, 120);
+   *   ySlider.size(100);
+   *   zSlider = createSlider(0, 1600, 800);
+   *   zSlider.position(0, 140);
+   *   zSlider.size(100);
+   *
+   *   describe(
+   *     'A white cube drawn against a gray background. Three range sliders appear beneath the image. The camera position changes when the user moves the sliders.'
+   *   );
+   * }
+   *
+   * function draw() {
+   *   background(200);
+   *
+   *   // Get the camera's coordinates from the sliders.
+   *   let x = xSlider.value();
+   *   let y = ySlider.value();
+   *   let z = zSlider.value();
+   *
+   *   // Move the camera.
+   *   camera(x, y, z);
+   *
+   *   // Draw the box.
+   *   box();
+   * }
+   * </code>
+   * </div>
+   */
+  fn.camera = function (...args) {
+    this._assert3d('camera');
+    p5._validateParameters('camera', args);
+    this._renderer.states.curCamera.camera(...args);
     return this;
-  }
+  };
 
   /**
- * Moves the camera along its "local" axes without changing its orientation.
- *
- * The parameters, `x`, `y`, and `z`, are the distances the camera should
- * move. For example, calling `myCamera.move(10, 20, 30)` moves the camera 10
- * pixels to the right, 20 pixels down, and 30 pixels backward in its "local"
- * space.
- *
- * @param {Number} x distance to move along the camera’s "local" x-axis.
- * @param {Number} y distance to move along the camera’s "local" y-axis.
- * @param {Number} z distance to move along the camera’s "local" z-axis.
- * @example
- * <div>
- * <code>
- * // Click the canvas to begin detecting key presses.
- *
- * let cam;
- *
- * function setup() {
- *   createCanvas(100, 100, WEBGL);
- *
- *   // Create the first camera.
- *   // Keep its default settings.
- *   cam = createCamera();
- *
- *   // Place the camera at the top-right.
- *   cam.setPosition(400, -400, 800);
- *
- *   // Point it at the origin.
- *   cam.lookAt(0, 0, 0);
- *
- *   describe(
- *     'A white cube drawn against a gray background. The cube appears to move when the user presses certain keys.'
- *   );
- * }
- *
- * function draw() {
- *   background(200);
- *
- *   // Move the camera along its "local" axes
- *   // when the user presses certain keys.
- *   if (keyIsPressed === true) {
- *
- *     // Move horizontally.
- *     if (keyCode === LEFT_ARROW) {
- *       cam.move(-1, 0, 0);
- *     }
- *     if (keyCode === RIGHT_ARROW) {
- *       cam.move(1, 0, 0);
- *     }
- *
- *     // Move vertically.
- *     if (keyCode === UP_ARROW) {
- *       cam.move(0, -1, 0);
- *     }
- *     if (keyCode === DOWN_ARROW) {
- *       cam.move(0, 1, 0);
- *     }
- *
- *     // Move in/out of the screen.
- *     if (key === 'i') {
- *       cam.move(0, 0, -1);
- *     }
- *     if (key === 'o') {
- *       cam.move(0, 0, 1);
- *     }
- *   }
- *
- *   // Draw the box.
- *   box();
- * }
- * </code>
- * </div>
- */
-  move(x, y, z) {
-    const local = this._getLocalAxes();
+   * Sets a perspective projection for the current camera in a 3D sketch.
+   *
+   * In a perspective projection, shapes that are further from the camera appear
+   * smaller than shapes that are near the camera. This technique, called
+   * foreshortening, creates realistic 3D scenes. It’s applied by default in
+   * WebGL mode.
+   *
+   * `perspective()` changes the camera’s perspective by changing its viewing
+   * frustum. The frustum is the volume of space that’s visible to the camera.
+   * Its shape is a pyramid with its top cut off. The camera is placed where
+   * the top of the pyramid should be and views everything between the frustum’s
+   * top (near) plane and its bottom (far) plane.
+   *
+   * The first parameter, `fovy`, is the camera’s vertical field of view. It’s
+   * an angle that describes how tall or narrow a view the camera has. For
+   * example, calling `perspective(0.5)` sets the camera’s vertical field of
+   * view to 0.5 radians. By default, `fovy` is calculated based on the sketch’s
+   * height and the camera’s default z-coordinate, which is 800. The formula for
+   * the default `fovy` is `2 * atan(height / 2 / 800)`.
+   *
+   * The second parameter, `aspect`, is the camera’s aspect ratio. It’s a number
+   * that describes the ratio of the top plane’s width to its height. For
+   * example, calling `perspective(0.5, 1.5)` sets the camera’s field of view to
+   * 0.5 radians and aspect ratio to 1.5, which would make shapes appear thinner
+   * on a square canvas. By default, aspect is set to `width / height`.
+   *
+   * The third parameter, `near`, is the distance from the camera to the near
+   * plane. For example, calling `perspective(0.5, 1.5, 100)` sets the camera’s
+   * field of view to 0.5 radians, its aspect ratio to 1.5, and places the near
+   * plane 100 pixels from the camera. Any shapes drawn less than 100 pixels
+   * from the camera won’t be visible. By default, near is set to `0.1 * 800`,
+   * which is 1/10th the default distance between the camera and the origin.
+   *
+   * The fourth parameter, `far`, is the distance from the camera to the far
+   * plane. For example, calling `perspective(0.5, 1.5, 100, 10000)` sets the
+   * camera’s field of view to 0.5 radians, its aspect ratio to 1.5, places the
+   * near plane 100 pixels from the camera, and places the far plane 10,000
+   * pixels from the camera. Any shapes drawn more than 10,000 pixels from the
+   * camera won’t be visible. By default, far is set to `10 * 800`, which is 10
+   * times the default distance between the camera and the origin.
+   *
+   * Note: `perspective()` can only be used in WebGL mode.
+   *
+   * @method  perspective
+   * @for p5
+   * @param  {Number} [fovy]   camera frustum vertical field of view. Defaults to
+   *                           `2 * atan(height / 2 / 800)`.
+   * @param  {Number} [aspect] camera frustum aspect ratio. Defaults to
+   *                           `width / height`.
+   * @param  {Number} [near]   distance from the camera to the near clipping plane.
+   *                           Defaults to `0.1 * 800`.
+   * @param  {Number} [far]    distance from the camera to the far clipping plane.
+   *                           Defaults to `10 * 800`.
+   * @chainable
+   *
+   * @example
+   * <div>
+   * <code>
+   * // Double-click to squeeze the box.
+   *
+   * let isSqueezed = false;
+   *
+   * function setup() {
+   *   createCanvas(100, 100, WEBGL);
+   *
+   *   describe('A white rectangular prism on a gray background. The box appears to become thinner when the user double-clicks.');
+   * }
+   *
+   * function draw() {
+   *   background(200);
+   *
+   *   // Place the camera at the top-right.
+   *   camera(400, -400, 800);
+   *
+   *   if (isSqueezed === true) {
+   *     // Set fovy to 0.2.
+   *     // Set aspect to 1.5.
+   *     perspective(0.2, 1.5);
+   *   }
+   *
+   *   // Draw the box.
+   *   box();
+   * }
+   *
+   * // Change the camera's perspective when the user double-clicks.
+   * function doubleClicked() {
+   *   isSqueezed = true;
+   * }
+   * </code>
+   * </div>
+   *
+   * <div>
+   * <code>
+   * function setup() {
+   *   createCanvas(100, 100, WEBGL);
+   *
+   *   describe('A white rectangular prism on a gray background. The prism moves away from the camera until it disappears.');
+   * }
+   *
+   * function draw() {
+   *   background(200);
+   *
+   *   // Place the camera at the top-right.
+   *   camera(400, -400, 800);
+   *
+   *   // Set fovy to 0.2.
+   *   // Set aspect to 1.5.
+   *   // Set near to 600.
+   *   // Set far to 1200.
+   *   perspective(0.2, 1.5, 600, 1200);
+   *
+   *   // Move the origin away from the camera.
+   *   let x = -frameCount;
+   *   let y = frameCount;
+   *   let z = -2 * frameCount;
+   *   translate(x, y, z);
+   *
+   *   // Draw the box.
+   *   box();
+   * }
+   * </code>
+   * </div>
+   */
+  fn.perspective = function (...args) {
+    this._assert3d('perspective');
+    p5._validateParameters('perspective', args);
+    this._renderer.states.curCamera.perspective(...args);
+    return this;
+  };
 
-    // scale local axes by movement amounts
-    // based on http://learnwebgl.brown37.net/07_cameras/camera_linear_motion.html
-    const dx = [local.x[0] * x, local.x[1] * x, local.x[2] * x];
-    const dy = [local.y[0] * y, local.y[1] * y, local.y[2] * y];
-    const dz = [local.z[0] * z, local.z[1] * z, local.z[2] * z];
-
-    this.camera(
-      this.eyeX + dx[0] + dy[0] + dz[0],
-      this.eyeY + dx[1] + dy[1] + dz[1],
-      this.eyeZ + dx[2] + dy[2] + dz[2],
-      this.centerX + dx[0] + dy[0] + dz[0],
-      this.centerY + dx[1] + dy[1] + dz[1],
-      this.centerZ + dx[2] + dy[2] + dz[2],
-      this.upX,
-      this.upY,
-      this.upZ
-    );
-  }
-
-  /**
- * Sets the camera’s position in "world" space without changing its
- * orientation.
- *
- * The parameters, `x`, `y`, and `z`, are the coordinates where the camera
- * should be placed. For example, calling `myCamera.setPosition(10, 20, 30)`
- * places the camera at coordinates `(10, 20, 30)` in "world" space.
- *
- * @param {Number} x x-coordinate in "world" space.
- * @param {Number} y y-coordinate in "world" space.
- * @param {Number} z z-coordinate in "world" space.
- *
- * @example
- * <div>
- * <code>
- * // Double-click to toggle between cameras.
- *
- * let cam1;
- * let cam2;
- * let isDefaultCamera = true;
- *
- * function setup() {
- *   createCanvas(100, 100, WEBGL);
- *
- *   // Create the first camera.
- *   // Keep its default settings.
- *   cam1 = createCamera();
- *
- *   // Create the second camera.
- *   cam2 = createCamera();
- *
- *   // Place it closer to the origin.
- *   cam2.setPosition(0, 0, 600);
- *
- *   // Set the current camera to cam1.
- *   setCamera(cam1);
- *
- *   describe(
- *     'A row of white cubes against a gray background. The camera toggles the amount of zoom when the user double-clicks.'
- *   );
- * }
- *
- * function draw() {
- *   background(200);
- *
- *   // Translate the origin toward the camera.
- *   translate(-10, 10, 500);
- *
- *   // Rotate the coordinate system.
- *   rotateY(-0.1);
- *   rotateX(-0.1);
- *
- *   // Draw the row of boxes.
- *   for (let i = 0; i < 6; i += 1) {
- *     translate(0, 0, -30);
- *     box(10);
- *   }
- * }
- *
- * // Toggle the current camera when the user double-clicks.
- * function doubleClicked() {
- *   if (isDefaultCamera === true) {
- *     setCamera(cam2);
- *     isDefaultCamera = false;
- *   } else {
- *     setCamera(cam1);
- *     isDefaultCamera = true;
- *   }
- * }
- * </code>
- * </div>
- *
- * <div>
- * <code>
- * // Double-click to toggle between cameras.
- *
- * let cam1;
- * let cam2;
- * let isDefaultCamera = true;
- *
- * function setup() {
- *   createCanvas(100, 100, WEBGL);
- *
- *   // Create the first camera.
- *   // Keep its default settings.
- *   cam1 = createCamera();
- *
- *   // Create the second camera.
- *   cam2 = createCamera();
- *
- *   // Place it closer to the origin.
- *   cam2.setPosition(0, 0, 600);
- *
- *   // Set the current camera to cam1.
- *   setCamera(cam1);
- *
- *   describe(
- *     'A row of white cubes against a gray background. The camera toggles between a static view and a view that zooms in and out when the user double-clicks.'
- *   );
- * }
- *
- * function draw() {
- *   background(200);
- *
- *   // Update cam2's z-coordinate.
- *   let z = 100 * sin(frameCount * 0.01) + 700;
- *   cam2.setPosition(0, 0, z);
- *
- *   // Translate the origin toward the camera.
- *   translate(-10, 10, 500);
- *
- *   // Rotate the coordinate system.
- *   rotateY(-0.1);
- *   rotateX(-0.1);
- *
- *   // Draw the row of boxes.
- *   for (let i = 0; i < 6; i += 1) {
- *     translate(0, 0, -30);
- *     box(10);
- *   }
- * }
- *
- * // Toggle the current camera when the user double-clicks.
- * function doubleClicked() {
- *   if (isDefaultCamera === true) {
- *     setCamera(cam2);
- *     isDefaultCamera = false;
- *   } else {
- *     setCamera(cam1);
- *     isDefaultCamera = true;
- *   }
- * }
- * </code>
- * </div>
- */
-  setPosition(x, y, z) {
-    const diffX = x - this.eyeX;
-    const diffY = y - this.eyeY;
-    const diffZ = z - this.eyeZ;
-
-    this.camera(
-      x,
-      y,
-      z,
-      this.centerX + diffX,
-      this.centerY + diffY,
-      this.centerZ + diffZ,
-      this.upX,
-      this.upY,
-      this.upZ
-    );
-  }
 
   /**
- * Sets the camera’s position, orientation, and projection by copying another
- * camera.
- *
- * The parameter, `cam`, is the `p5.Camera` object to copy. For example, calling
- * `cam2.set(cam1)` will set `cam2` using `cam1`’s configuration.
- *
- * @param {p5.Camera} cam camera to copy.
- *
- * @example
- * <div>
- * <code>
- * // Double-click to "reset" the camera zoom.
- *
- * let cam1;
- * let cam2;
- *
- * function setup() {
- *   createCanvas(100, 100, WEBGL);
- *
- *   // Create the first camera.
- *   cam1 = createCamera();
- *
- *   // Place the camera at the top-right.
- *   cam1.setPosition(400, -400, 800);
- *
- *   // Point it at the origin.
- *   cam1.lookAt(0, 0, 0);
- *
- *   // Create the second camera.
- *   cam2 = createCamera();
- *
- *   // Copy cam1's configuration.
- *   cam2.set(cam1);
- *
- *   describe(
- *     'A white cube drawn against a gray background. The camera slowly moves forward. The camera resets when the user double-clicks.'
- *   );
- * }
- *
- * function draw() {
- *   background(200);
- *
- *   // Update cam2's position.
- *   cam2.move(0, 0, -1);
- *
- *   // Draw the box.
- *   box();
- * }
- *
- * // "Reset" the camera when the user double-clicks.
- * function doubleClicked() {
- *   cam2.set(cam1);
- * }
- */
-  set(cam) {
-    const keyNamesOfThePropToCopy = [
-      'eyeX', 'eyeY', 'eyeZ',
-      'centerX', 'centerY', 'centerZ',
-      'upX', 'upY', 'upZ',
-      'cameraFOV', 'aspectRatio', 'cameraNear', 'cameraFar', 'cameraType',
-      'yScale'
-    ];
-    for (const keyName of keyNamesOfThePropToCopy) {
-      this[keyName] = cam[keyName];
+   * Enables or disables perspective for lines in 3D sketches.
+   *
+   * In WebGL mode, lines can be drawn with a thinner stroke when they’re
+   * further from the camera. Doing so gives them a more realistic appearance.
+   *
+   * By default, lines are drawn differently based on the type of perspective
+   * being used:
+   * - `perspective()` and `frustum()` simulate a realistic perspective. In
+   * these modes, stroke weight is affected by the line’s distance from the
+   * camera. Doing so results in a more natural appearance. `perspective()` is
+   * the default mode for 3D sketches.
+   * - `ortho()` doesn’t simulate a realistic perspective. In this mode, stroke
+   * weights are consistent regardless of the line’s distance from the camera.
+   * Doing so results in a more predictable and consistent appearance.
+   *
+   * `linePerspective()` can override the default line drawing mode.
+   *
+   * The parameter, `enable`, is optional. It’s a `Boolean` value that sets the
+   * way lines are drawn. If `true` is passed, as in `linePerspective(true)`,
+   * then lines will appear thinner when they are further from the camera. If
+   * `false` is passed, as in `linePerspective(false)`, then lines will have
+   * consistent stroke weights regardless of their distance from the camera. By
+   * default, `linePerspective()` is enabled.
+   *
+   * Calling `linePerspective()` without passing an argument returns `true` if
+   * it's enabled and `false` if not.
+   *
+   * Note: `linePerspective()` can only be used in WebGL mode.
+   *
+   * @method linePerspective
+   * @for p5
+   * @param {Boolean} enable whether to enable line perspective.
+   *
+   * @example
+   * <div>
+   * <code>
+   * // Double-click the canvas to toggle the line perspective.
+   *
+   * function setup() {
+   *   createCanvas(100, 100, WEBGL);
+   *
+   *   describe(
+   *     'A white cube with black edges on a gray background. Its edges toggle between thick and thin when the user double-clicks.'
+   *   );
+   * }
+   *
+   * function draw() {
+   *   background(200);
+   *
+   *   // Translate the origin toward the camera.
+   *   translate(-10, 10, 600);
+   *
+   *   // Rotate the coordinate system.
+   *   rotateY(-0.1);
+   *   rotateX(-0.1);
+   *
+   *   // Draw the row of boxes.
+   *   for (let i = 0; i < 6; i += 1) {
+   *     translate(0, 0, -40);
+   *     box(10);
+   *   }
+   * }
+   *
+   * // Toggle the line perspective when the user double-clicks.
+   * function doubleClicked() {
+   *   let isEnabled = linePerspective();
+   *   linePerspective(!isEnabled);
+   * }
+   * </code>
+   * </div>
+   *
+   * <div>
+   * <code>
+   * // Double-click the canvas to toggle the line perspective.
+   *
+   * function setup() {
+   *   createCanvas(100, 100, WEBGL);
+   *
+   *   describe(
+   *     'A row of cubes with black edges on a gray background. Their edges toggle between thick and thin when the user double-clicks.'
+   *   );
+   * }
+   *
+   * function draw() {
+   *   background(200);
+   *
+   *   // Use an orthographic projection.
+   *   ortho();
+   *
+   *   // Translate the origin toward the camera.
+   *   translate(-10, 10, 600);
+   *
+   *   // Rotate the coordinate system.
+   *   rotateY(-0.1);
+   *   rotateX(-0.1);
+   *
+   *   // Draw the row of boxes.
+   *   for (let i = 0; i < 6; i += 1) {
+   *     translate(0, 0, -40);
+   *     box(10);
+   *   }
+   * }
+   *
+   * // Toggle the line perspective when the user double-clicks.
+   * function doubleClicked() {
+   *   let isEnabled = linePerspective();
+   *   linePerspective(!isEnabled);
+   * }
+   * </code>
+   * </div>
+   */
+  /**
+   * @method linePerspective
+   * @return {Boolean} whether line perspective is enabled.
+   */
+
+  fn.linePerspective = function (enable) {
+    p5._validateParameters('linePerspective', arguments);
+    if (!(this._renderer instanceof p5.RendererGL)) {
+      throw new Error('linePerspective() must be called in WebGL mode.');
     }
-
-    this.cameraMatrix = cam.cameraMatrix.copy();
-    this.projMatrix = cam.projMatrix.copy();
-
-    if (this._isActive()) {
-      this._renderer.states.uModelMatrix.reset();
-      this._renderer.states.uViewMatrix.set(this.cameraMatrix);
-      this._renderer.states.uPMatrix.set(this.projMatrix);
+    if (enable !== undefined) {
+      // Set the line perspective if enable is provided
+      this._renderer.states.curCamera.useLinePerspective = enable;
+    } else {
+      // If no argument is provided, return the current value
+      return this._renderer.states.curCamera.useLinePerspective;
     }
-  }
+  };
+
+
   /**
- * Sets the camera’s position and orientation to values that are in-between
- * those of two other cameras.
- *
- * `myCamera.slerp()` uses spherical linear interpolation to calculate a
- * position and orientation that’s in-between two other cameras. Doing so is
- * helpful for transitioning smoothly between two perspectives.
- *
- * The first two parameters, `cam0` and `cam1`, are the `p5.Camera` objects
- * that should be used to set the current camera.
- *
- * The third parameter, `amt`, is the amount to interpolate between `cam0` and
- * `cam1`. 0.0 keeps the camera’s position and orientation equal to `cam0`’s,
- * 0.5 sets them halfway between `cam0`’s and `cam1`’s , and 1.0 sets the
- * position and orientation equal to `cam1`’s.
- *
- * For example, calling `myCamera.slerp(cam0, cam1, 0.1)` sets cam’s position
- * and orientation very close to `cam0`’s. Calling
- * `myCamera.slerp(cam0, cam1, 0.9)` sets cam’s position and orientation very
- * close to `cam1`’s.
- *
- * Note: All of the cameras must use the same projection.
- *
- * @param {p5.Camera} cam0 first camera.
- * @param {p5.Camera} cam1 second camera.
- * @param {Number} amt amount of interpolation between 0.0 (`cam0`) and 1.0 (`cam1`).
- *
- * @example
- * <div>
- * <code>
- * let cam;
- * let cam0;
- * let cam1;
- *
- * function setup() {
- *   createCanvas(100, 100, WEBGL);
- *
- *   // Create the main camera.
- *   // Keep its default settings.
- *   cam = createCamera();
- *
- *   // Create the first camera.
- *   // Keep its default settings.
- *   cam0 = createCamera();
- *
- *   // Create the second camera.
- *   cam1 = createCamera();
- *
- *   // Place it at the top-right.
- *   cam1.setPosition(400, -400, 800);
- *
- *   // Point it at the origin.
- *   cam1.lookAt(0, 0, 0);
- *
- *   // Set the current camera to cam.
- *   setCamera(cam);
- *
- *   describe('A white cube drawn against a gray background. The camera slowly oscillates between a frontal view and an aerial view.');
- * }
- *
- * function draw() {
- *   background(200);
- *
- *   // Calculate the amount to interpolate between cam0 and cam1.
- *   let amt = 0.5 * sin(frameCount * 0.01) + 0.5;
- *
- *   // Update the main camera's position and orientation.
- *   cam.slerp(cam0, cam1, amt);
- *
- *   box();
- * }
- * </code>
- * </div>
- */
-  slerp(cam0, cam1, amt) {
-    // If t is 0 or 1, do not interpolate and set the argument camera.
-    if (amt === 0) {
-      this.set(cam0);
-      return;
-    } else if (amt === 1) {
-      this.set(cam1);
-      return;
-    }
+   * Sets an orthographic projection for the current camera in a 3D sketch.
+   *
+   * In an orthographic projection, shapes with the same size always appear the
+   * same size, regardless of whether they are near or far from the camera.
+   *
+   * `ortho()` changes the camera’s perspective by changing its viewing frustum
+   * from a truncated pyramid to a rectangular prism. The camera is placed in
+   * front of the frustum and views everything between the frustum’s near plane
+   * and its far plane. `ortho()` has six optional parameters to define the
+   * frustum.
+   *
+   * The first four parameters, `left`, `right`, `bottom`, and `top`, set the
+   * coordinates of the frustum’s sides, bottom, and top. For example, calling
+   * `ortho(-100, 100, 200, -200)` creates a frustum that’s 200 pixels wide and
+   * 400 pixels tall. By default, these coordinates are set based on the
+   * sketch’s width and height, as in
+   * `ortho(-width / 2, width / 2, -height / 2, height / 2)`.
+   *
+   * The last two parameters, `near` and `far`, set the distance of the
+   * frustum’s near and far plane from the camera. For example, calling
+   * `ortho(-100, 100, 200, 200, 50, 1000)` creates a frustum that’s 200 pixels
+   * wide, 400 pixels tall, starts 50 pixels from the camera, and ends 1,000
+   * pixels from the camera. By default, `near` and `far` are set to 0 and
+   * `max(width, height) + 800`, respectively.
+   *
+   * Note: `ortho()` can only be used in WebGL mode.
+   *
+   * @method  ortho
+   * @for p5
+   * @param  {Number} [left]   x-coordinate of the frustum’s left plane. Defaults to `-width / 2`.
+   * @param  {Number} [right]  x-coordinate of the frustum’s right plane. Defaults to `width / 2`.
+   * @param  {Number} [bottom] y-coordinate of the frustum’s bottom plane. Defaults to `height / 2`.
+   * @param  {Number} [top]    y-coordinate of the frustum’s top plane. Defaults to `-height / 2`.
+   * @param  {Number} [near]   z-coordinate of the frustum’s near plane. Defaults to 0.
+   * @param  {Number} [far]    z-coordinate of the frustum’s far plane. Defaults to `max(width, height) + 800`.
+   * @chainable
+   *
+   * @example
+   * <div>
+   * <code>
+   * function setup() {
+   *   createCanvas(100, 100, WEBGL);
+   *
+   *   describe('A row of tiny, white cubes on a gray background. All the cubes appear the same size.');
+   * }
+   *
+   * function draw() {
+   *   background(200);
+   *
+   *   // Apply an orthographic projection.
+   *   ortho();
+   *
+   *   // Translate the origin toward the camera.
+   *   translate(-10, 10, 600);
+   *
+   *   // Rotate the coordinate system.
+   *   rotateY(-0.1);
+   *   rotateX(-0.1);
+   *
+   *   // Draw the row of boxes.
+   *   for (let i = 0; i < 6; i += 1) {
+   *     translate(0, 0, -40);
+   *     box(10);
+   *   }
+   * }
+   * </code>
+   * </div>
+   *
+   * <div>
+   * <code>
+   * function setup() {
+   *   createCanvas(100, 100, WEBGL);
+   *
+   *   describe('A white cube on a gray background.');
+   * }
+   *
+   * function draw() {
+   *   background(200);
+   *
+   *   // Apply an orthographic projection.
+   *   // Center the frustum.
+   *   // Set its width and height to 20.
+   *   // Place its near plane 300 pixels from the camera.
+   *   // Place its far plane 350 pixels from the camera.
+   *   ortho(-10, 10, -10, 10, 300, 350);
+   *
+   *   // Translate the origin toward the camera.
+   *   translate(-10, 10, 600);
+   *
+   *   // Rotate the coordinate system.
+   *   rotateY(-0.1);
+   *   rotateX(-0.1);
+   *
+   *   // Draw the row of boxes.
+   *   for (let i = 0; i < 6; i += 1) {
+   *     translate(0, 0, -40);
+   *     box(10);
+   *   }
+   * }
+   * </code>
+   * </div>
+   */
+  fn.ortho = function (...args) {
+    this._assert3d('ortho');
+    p5._validateParameters('ortho', args);
+    this._renderer.states.curCamera.ortho(...args);
+    return this;
+  };
 
-    // For this cameras is ortho, assume that cam0 and cam1 are also ortho
-    // and interpolate the elements of the projection matrix.
-    // Use logarithmic interpolation for interpolation.
-    if (this.projMatrix.mat4[15] !== 0) {
-      this.projMatrix.mat4[0] =
-        cam0.projMatrix.mat4[0] *
-        Math.pow(cam1.projMatrix.mat4[0] / cam0.projMatrix.mat4[0], amt);
-      this.projMatrix.mat4[5] =
-        cam0.projMatrix.mat4[5] *
-        Math.pow(cam1.projMatrix.mat4[5] / cam0.projMatrix.mat4[5], amt);
-      // If the camera is active, make uPMatrix reflect changes in projMatrix.
+  /**
+   * Sets the frustum of the current camera in a 3D sketch.
+   *
+   * In a frustum projection, shapes that are further from the camera appear
+   * smaller than shapes that are near the camera. This technique, called
+   * foreshortening, creates realistic 3D scenes.
+   *
+   * `frustum()` changes the default camera’s perspective by changing its
+   * viewing frustum. The frustum is the volume of space that’s visible to the
+   * camera. The frustum’s shape is a pyramid with its top cut off. The camera
+   * is placed where the top of the pyramid should be and points towards the
+   * base of the pyramid. It views everything within the frustum.
+   *
+   * The first four parameters, `left`, `right`, `bottom`, and `top`, set the
+   * coordinates of the frustum’s sides, bottom, and top. For example, calling
+   * `frustum(-100, 100, 200, -200)` creates a frustum that’s 200 pixels wide
+   * and 400 pixels tall. By default, these coordinates are set based on the
+   * sketch’s width and height, as in
+   * `ortho(-width / 20, width / 20, height / 20, -height / 20)`.
+   *
+   * The last two parameters, `near` and `far`, set the distance of the
+   * frustum’s near and far plane from the camera. For example, calling
+   * `ortho(-100, 100, 200, -200, 50, 1000)` creates a frustum that’s 200 pixels
+   * wide, 400 pixels tall, starts 50 pixels from the camera, and ends 1,000
+   * pixels from the camera. By default, near is set to `0.1 * 800`, which is
+   * 1/10th the default distance between the camera and the origin. `far` is set
+   * to `10 * 800`, which is 10 times the default distance between the camera
+   * and the origin.
+   *
+   * Note: `frustum()` can only be used in WebGL mode.
+   *
+   * @method frustum
+   * @for p5
+   * @param  {Number} [left]   x-coordinate of the frustum’s left plane. Defaults to `-width / 20`.
+   * @param  {Number} [right]  x-coordinate of the frustum’s right plane. Defaults to `width / 20`.
+   * @param  {Number} [bottom] y-coordinate of the frustum’s bottom plane. Defaults to `height / 20`.
+   * @param  {Number} [top]    y-coordinate of the frustum’s top plane. Defaults to `-height / 20`.
+   * @param  {Number} [near]   z-coordinate of the frustum’s near plane. Defaults to `0.1 * 800`.
+   * @param  {Number} [far]    z-coordinate of the frustum’s far plane. Defaults to `10 * 800`.
+   * @chainable
+   *
+   * @example
+   * <div>
+   * <code>
+   * function setup() {
+   *   createCanvas(100, 100, WEBGL);
+   *
+   *   describe('A row of white cubes on a gray background.');
+   * }
+   *
+   * function draw() {
+   *   background(200);
+   *
+   *   // Apply the default frustum projection.
+   *   frustum();
+   *
+   *   // Translate the origin toward the camera.
+   *   translate(-10, 10, 600);
+   *
+   *   // Rotate the coordinate system.
+   *   rotateY(-0.1);
+   *   rotateX(-0.1);
+   *
+   *   // Draw the row of boxes.
+   *   for (let i = 0; i < 6; i += 1) {
+   *     translate(0, 0, -40);
+   *     box(10);
+   *   }
+   * }
+   * </code>
+   * </div>
+   *
+   * <div>
+   * <code>
+   * function setup() {
+   *   createCanvas(100, 100, WEBGL);
+   *   describe('A white cube on a gray background.');
+   * }
+   *
+   * function draw() {
+   *   background(200);
+   *
+   *   // Adjust the frustum.
+   *   // Center it.
+   *   // Set its width and height to 20 pixels.
+   *   // Place its near plane 300 pixels from the camera.
+   *   // Place its far plane 350 pixels from the camera.
+   *   frustum(-10, 10, -10, 10, 300, 350);
+   *
+   *   // Translate the origin toward the camera.
+   *   translate(-10, 10, 600);
+   *
+   *   // Rotate the coordinate system.
+   *   rotateY(-0.1);
+   *   rotateX(-0.1);
+   *
+   *   // Draw the row of boxes.
+   *   for (let i = 0; i < 6; i += 1) {
+   *     translate(0, 0, -40);
+   *     box(10);
+   *   }
+   * }
+   * </code>
+   * </div>
+   */
+  fn.frustum = function (...args) {
+    this._assert3d('frustum');
+    p5._validateParameters('frustum', args);
+    this._renderer.states.curCamera.frustum(...args);
+    return this;
+  };
+
+  ////////////////////////////////////////////////////////////////////////////////
+  // p5.Camera
+  ////////////////////////////////////////////////////////////////////////////////
+
+  /**
+   * Creates a new <a href="#/p5.Camera">p5.Camera</a> object and sets it
+   * as the current (active) camera.
+   *
+   * The new camera is initialized with a default position `(0, 0, 800)` and a
+   * default perspective projection. Its properties can be controlled with
+   * <a href="#/p5.Camera">p5.Camera</a> methods such as
+   * `myCamera.lookAt(0, 0, 0)`.
+   *
+   * Note: Every 3D sketch starts with a default camera initialized.
+   * This camera can be controlled with the functions
+   * <a href="#/p5/camera">camera()</a>,
+   * <a href="#/p5/perspective">perspective()</a>,
+   * <a href="#/p5/ortho">ortho()</a>, and
+   * <a href="#/p5/frustum">frustum()</a> if it's the only camera in the scene.
+   *
+   * Note: `createCamera()` can only be used in WebGL mode.
+   *
+   * @method createCamera
+   * @return {p5.Camera} the new camera.
+   * @for p5
+   *
+   * @example
+   * <div>
+   * <code>
+   * // Double-click to toggle between cameras.
+   *
+   * let cam1;
+   * let cam2;
+   * let usingCam1 = true;
+   *
+   * function setup() {
+   *   createCanvas(100, 100, WEBGL);
+   *
+   *   // Create the first camera.
+   *   // Keep its default settings.
+   *   cam1 = createCamera();
+   *
+   *   // Create the second camera.
+   *   // Place it at the top-left.
+   *   // Point it at the origin.
+   *   cam2 = createCamera();
+   *   cam2.setPosition(400, -400, 800);
+   *   cam2.lookAt(0, 0, 0);
+   *
+   *   // Set the current camera to cam1.
+   *   setCamera(cam1);
+   *
+   *   describe('A white cube on a gray background. The camera toggles between frontal and aerial views when the user double-clicks.');
+   * }
+   *
+   * function draw() {
+   *   background(200);
+   *
+   *   // Draw the box.
+   *   box();
+   * }
+   *
+   * // Toggle the current camera when the user double-clicks.
+   * function doubleClicked() {
+   *   if (usingCam1 === true) {
+   *     setCamera(cam2);
+   *     usingCam1 = false;
+   *   } else {
+   *     setCamera(cam1);
+   *     usingCam1 = true;
+   *   }
+   * }
+   * </code>
+   * </div>
+   */
+  fn.createCamera = function () {
+    this._assert3d('createCamera');
+
+    // compute default camera settings, then set a default camera
+    const _cam = new p5.Camera(this._renderer);
+    _cam._computeCameraDefaultSettings();
+    _cam._setDefaultCamera();
+
+    return _cam;
+  };
+
+  /**
+   * A class to describe a camera for viewing a 3D sketch.
+   *
+   * Each `p5.Camera` object represents a camera that views a section of 3D
+   * space. It stores information about the camera’s position, orientation, and
+   * projection.
+   *
+   * In WebGL mode, the default camera is a `p5.Camera` object that can be
+   * controlled with the <a href="#/p5/camera">camera()</a>,
+   * <a href="#/p5/perspective">perspective()</a>,
+   * <a href="#/p5/ortho">ortho()</a>, and
+   * <a href="#/p5/frustum">frustum()</a> functions. Additional cameras can be
+   * created with <a href="#/p5/createCamera">createCamera()</a> and activated
+   * with <a href="#/p5/setCamera">setCamera()</a>.
+   *
+   * Note: `p5.Camera`’s methods operate in two coordinate systems:
+   * - The “world” coordinate system describes positions in terms of their
+   * relationship to the origin along the x-, y-, and z-axes. For example,
+   * calling `myCamera.setPosition()` places the camera in 3D space using
+   * "world" coordinates.
+   * - The "local" coordinate system describes positions from the camera's point
+   * of view: left-right, up-down, and forward-backward. For example, calling
+   * `myCamera.move()` moves the camera along its own axes.
+   *
+   * @class p5.Camera
+   * @param {rendererGL} rendererGL instance of WebGL renderer
+   *
+   * @example
+   * <div>
+   * <code>
+   * let cam;
+   * let delta = 0.001;
+   *
+   * function setup() {
+   *   createCanvas(100, 100, WEBGL);
+   *
+   *   // Create a p5.Camera object.
+   *   cam = createCamera();
+   *
+   *   // Place the camera at the top-center.
+   *   cam.setPosition(0, -400, 800);
+   *
+   *   // Point the camera at the origin.
+   *   cam.lookAt(0, 0, 0);
+   *
+   *   describe(
+   *     'A white cube on a gray background. The cube goes in and out of view as the camera pans left and right.'
+   *   );
+   * }
+   *
+   * function draw() {
+   *   background(200);
+   *
+   *   // Turn the camera left and right, called "panning".
+   *   cam.pan(delta);
+   *
+   *   // Switch directions every 120 frames.
+   *   if (frameCount % 120 === 0) {
+   *     delta *= -1;
+   *   }
+   *
+   *   // Draw the box.
+   *   box();
+   * }
+   * </code>
+   * </div>
+   *
+   * <div>
+   * <code>
+   * // Double-click to toggle between cameras.
+   *
+   * let cam1;
+   * let cam2;
+   * let isDefaultCamera = true;
+   *
+   * function setup() {
+   *   createCanvas(100, 100, WEBGL);
+   *
+   *   // Create the first camera.
+   *   // Keep its default settings.
+   *   cam1 = createCamera();
+   *
+   *   // Create the second camera.
+   *   // Place it at the top-left.
+   *   // Point it at the origin.
+   *   cam2 = createCamera();
+   *   cam2.setPosition(400, -400, 800);
+   *   cam2.lookAt(0, 0, 0);
+   *
+   *   // Set the current camera to cam1.
+   *   setCamera(cam1);
+   *
+   *   describe(
+   *     'A white cube on a gray background. The camera toggles between frontal and aerial views when the user double-clicks.'
+   *   );
+   * }
+   *
+   * function draw() {
+   *   background(200);
+   *
+   *   // Draw the box.
+   *   box();
+   * }
+   *
+   * // Toggle the current camera when the user double-clicks.
+   * function doubleClicked() {
+   *   if (isDefaultCamera === true) {
+   *     setCamera(cam2);
+   *     isDefaultCamera = false;
+   *   } else {
+   *     setCamera(cam1);
+   *     isDefaultCamera = true;
+   *   }
+   * }
+   * </code>
+   * </div>
+   */
+  p5.Camera = class Camera {
+    constructor(renderer) {
+      this._renderer = renderer;
+
+      this.cameraType = 'default';
+      this.useLinePerspective = true;
+      this.cameraMatrix = new p5.Matrix();
+      this.projMatrix = new p5.Matrix();
+      this.yScale = 1;
+    }
+    /**
+   * The camera’s y-coordinate.
+   *
+   * By default, the camera’s y-coordinate is set to 0 in "world" space.
+   *
+   * @property {Number} eyeX
+   * @readonly
+   *
+   * @example
+   * <div>
+   * <code>
+   * let cam;
+   * let font;
+   *
+   * // Load a font and create a p5.Font object.
+   * function preload() {
+   *   font = loadFont('assets/inconsolata.otf');
+   * }
+   *
+   * function setup() {
+   *   createCanvas(100, 100, WEBGL);
+   *
+   *   // Create a p5.Camera object.
+   *   cam = createCamera();
+   *
+   *   // Place the camera at the top-center.
+   *   cam.setPosition(0, -400, 800);
+   *
+   *   // Point the camera at the origin.
+   *   cam.lookAt(0, 0, 0);
+   *
+   *   describe(
+   *     'A white cube on a gray background. The text "eyeX: 0" is written in black beneath it.'
+   *   );
+   * }
+   *
+   * function draw() {
+   *   background(200);
+   *
+   *   // Style the box.
+   *   fill(255);
+   *
+   *   // Draw the box.
+   *   box();
+   *
+   *   // Style the text.
+   *   textAlign(CENTER);
+   *   textSize(16);
+   *   textFont(font);
+   *   fill(0);
+   *
+   *   // Display the value of eyeX, rounded to the nearest integer.
+   *   text(`eyeX: ${round(cam.eyeX)}`, 0, 55);
+   * }
+   * </code>
+   * </div>
+   *
+   * <div>
+   * <code>
+   * let cam;
+   * let font;
+   *
+   * // Load a font and create a p5.Font object.
+   * function preload() {
+   *   font = loadFont('assets/inconsolata.otf');
+   * }
+   *
+   * function setup() {
+   *   createCanvas(100, 100, WEBGL);
+   *
+   *   // Create a p5.Camera object.
+   *   cam = createCamera();
+   *
+   *   // Place the camera at the top-center.
+   *   cam.setPosition(0, -400, 800);
+   *
+   *   // Point the camera at the origin.
+   *   cam.lookAt(0, 0, 0);
+   *
+   *   describe(
+   *     'A white cube on a gray background. The cube appears to move left and right as the camera moves. The text "eyeX: X" is written in black beneath the cube. X oscillates between -25 and 25.'
+   *   );
+   * }
+   *
+   * function draw() {
+   *   background(200);
+   *
+   *   // Style the box.
+   *   fill(255);
+   *
+   *   // Draw the box.
+   *   box();
+   *
+   *   // Style the text.
+   *   textAlign(CENTER);
+   *   textSize(16);
+   *   textFont(font);
+   *   fill(0);
+   *
+   *   // Calculate the new x-coordinate.
+   *   let x = 25 * sin(frameCount * 0.01);
+   *
+   *   // Set the camera's position.
+   *   cam.setPosition(x, -400, 800);
+   *
+   *   // Display the value of eyeX, rounded to the nearest integer.
+   *   text(`eyeX: ${round(cam.eyeX)}`, 0, 55);
+   * }
+   * </code>
+   * </div>
+   */
+
+    /**
+   * The camera’s y-coordinate.
+   *
+   * By default, the camera’s y-coordinate is set to 0 in "world" space.
+   *
+   * @property {Number} eyeY
+   * @readonly
+   *
+   * @example
+   * <div>
+   * <code>
+   * let cam;
+   * let font;
+   *
+   * // Load a font and create a p5.Font object.
+   * function preload() {
+   *   font = loadFont('assets/inconsolata.otf');
+   * }
+   *
+   * function setup() {
+   *   createCanvas(100, 100, WEBGL);
+   *
+   *   // Create a p5.Camera object.
+   *   cam = createCamera();
+   *
+   *   // Place the camera at the top-center.
+   *   cam.setPosition(0, -400, 800);
+   *
+   *   // Point the camera at the origin.
+   *   cam.lookAt(0, 0, 0);
+   *
+   *   describe(
+   *     'A white cube on a gray background. The text "eyeY: -400" is written in black beneath it.'
+   *   );
+   * }
+   *
+   * function draw() {
+   *   background(200);
+   *
+   *   // Style the box.
+   *   fill(255);
+   *
+   *   // Draw the box.
+   *   box();
+   *
+   *   // Style the text.
+   *   textAlign(CENTER);
+   *   textSize(16);
+   *   textFont(font);
+   *   fill(0);
+   *
+   *   // Display the value of eyeY, rounded to the nearest integer.
+   *   text(`eyeX: ${round(cam.eyeY)}`, 0, 55);
+   * }
+   * </code>
+   * </div>
+   *
+   * <div>
+   * <code>
+   * let cam;
+   * let font;
+   *
+   * // Load a font and create a p5.Font object.
+   * function preload() {
+   *   font = loadFont('assets/inconsolata.otf');
+   * }
+   *
+   * function setup() {
+   *   createCanvas(100, 100, WEBGL);
+   *
+   *   // Create a p5.Camera object.
+   *   cam = createCamera();
+   *
+   *   // Place the camera at the top-center.
+   *   cam.setPosition(0, -400, 800);
+   *
+   *   // Point the camera at the origin.
+   *   cam.lookAt(0, 0, 0);
+   *
+   *   describe(
+   *     'A white cube on a gray background. The cube appears to move up and down as the camera moves. The text "eyeY: Y" is written in black beneath the cube. Y oscillates between -374 and -425.'
+   *   );
+   * }
+   *
+   * function draw() {
+   *   background(200);
+   *
+   *   // Style the box.
+   *   fill(255);
+   *
+   *   // Draw the box.
+   *   box();
+   *
+   *   // Style the text.
+   *   textAlign(CENTER);
+   *   textSize(16);
+   *   textFont(font);
+   *   fill(0);
+   *
+   *   // Calculate the new y-coordinate.
+   *   let y = 25 * sin(frameCount * 0.01) - 400;
+   *
+   *   // Set the camera's position.
+   *   cam.setPosition(0, y, 800);
+   *
+   *   // Display the value of eyeY, rounded to the nearest integer.
+   *   text(`eyeY: ${round(cam.eyeY)}`, 0, 55);
+   * }
+   * </code>
+   * </div>
+   */
+
+    /**
+   * The camera’s z-coordinate.
+   *
+   * By default, the camera’s z-coordinate is set to 800 in "world" space.
+   *
+   * @property {Number} eyeZ
+   * @readonly
+   *
+   * @example
+   * <div>
+   * <code>
+   * let cam;
+   * let font;
+   *
+   * // Load a font and create a p5.Font object.
+   * function preload() {
+   *   font = loadFont('assets/inconsolata.otf');
+   * }
+   *
+   * function setup() {
+   *   createCanvas(100, 100, WEBGL);
+   *
+   *   // Create a p5.Camera object.
+   *   cam = createCamera();
+   *
+   *   // Place the camera at the top-center.
+   *   cam.setPosition(0, -400, 800);
+   *
+   *   // Point the camera at the origin.
+   *   cam.lookAt(0, 0, 0);
+   *
+   *   describe(
+   *     'A white cube on a gray background. The text "eyeZ: 800" is written in black beneath it.'
+   *   );
+   * }
+   *
+   * function draw() {
+   *   background(200);
+   *
+   *   // Style the box.
+   *   fill(255);
+   *
+   *   // Draw the box.
+   *   box();
+   *
+   *   // Style the text.
+   *   textAlign(CENTER);
+   *   textSize(16);
+   *   textFont(font);
+   *   fill(0);
+   *
+   *   // Display the value of eyeZ, rounded to the nearest integer.
+   *   text(`eyeZ: ${round(cam.eyeZ)}`, 0, 55);
+   * }
+   * </code>
+   * </div>
+   *
+   * <div>
+   * <code>
+   * let cam;
+   * let font;
+   *
+   * // Load a font and create a p5.Font object.
+   * function preload() {
+   *   font = loadFont('assets/inconsolata.otf');
+   * }
+   *
+   * function setup() {
+   *   createCanvas(100, 100, WEBGL);
+   *
+   *   // Create a p5.Camera object.
+   *   cam = createCamera();
+   *
+   *   // Place the camera at the top-center.
+   *   cam.setPosition(0, -400, 800);
+   *
+   *   // Point the camera at the origin.
+   *   cam.lookAt(0, 0, 0);
+   *
+   *   describe(
+   *     'A white cube on a gray background. The cube appears to move forward and back as the camera moves. The text "eyeZ: Z" is written in black beneath the cube. Z oscillates between 700 and 900.'
+   *   );
+   * }
+   *
+   * function draw() {
+   *   background(200);
+   *
+   *   // Style the box.
+   *   fill(255);
+   *
+   *   // Draw the box.
+   *   box();
+   *
+   *   // Style the text.
+   *   textAlign(CENTER);
+   *   textSize(16);
+   *   textFont(font);
+   *   fill(0);
+   *
+   *   // Calculate the new z-coordinate.
+   *   let z = 100 * sin(frameCount * 0.01) + 800;
+   *
+   *   // Set the camera's position.
+   *   cam.setPosition(0, -400, z);
+   *
+   *   // Display the value of eyeZ, rounded to the nearest integer.
+   *   text(`eyeZ: ${round(cam.eyeZ)}`, 0, 55);
+   * }
+   * </code>
+   * </div>
+   */
+
+    /**
+   * The x-coordinate of the place where the camera looks.
+   *
+   * By default, the camera looks at the origin `(0, 0, 0)` in "world" space, so
+   * `myCamera.centerX` is 0.
+   *
+   * @property {Number} centerX
+   * @readonly
+   *
+   * @example
+   * <div>
+   * <code>
+   * let cam;
+   * let font;
+   *
+   * // Load a font and create a p5.Font object.
+   * function preload() {
+   *   font = loadFont('assets/inconsolata.otf');
+   * }
+   *
+   * function setup() {
+   *   createCanvas(100, 100, WEBGL);
+   *
+   *   // Create a p5.Camera object.
+   *   cam = createCamera();
+   *
+   *   // Place the camera at the top-center.
+   *   cam.setPosition(0, -400, 800);
+   *
+   *   // Point the camera at (10, 20, -30).
+   *   cam.lookAt(10, 20, -30);
+   *
+   *   describe(
+   *     'A white cube on a gray background. The text "centerX: 10" is written in black beneath it.'
+   *   );
+   * }
+   *
+   * function draw() {
+   *   background(200);
+   *
+   *   // Style the box.
+   *   fill(255);
+   *
+   *   // Draw the box.
+   *   box();
+   *
+   *   // Style the text.
+   *   textAlign(CENTER);
+   *   textSize(16);
+   *   textFont(font);
+   *   fill(0);
+   *
+   *   // Display the value of centerX, rounded to the nearest integer.
+   *   text(`centerX: ${round(cam.centerX)}`, 0, 55);
+   * }
+   * </code>
+   * </div>
+   *
+   * <div>
+   * <code>
+   * let cam;
+   * let font;
+   *
+   * // Load a font and create a p5.Font object.
+   * function preload() {
+   *   font = loadFont('assets/inconsolata.otf');
+   * }
+   *
+   * function setup() {
+   *   createCanvas(100, 100, WEBGL);
+   *
+   *   // Create a p5.Camera object.
+   *   cam = createCamera();
+   *
+   *   // Place the camera at the top-right.
+   *   cam.setPosition(100, -400, 800);
+   *
+   *   // Point the camera at (10, 20, -30).
+   *   cam.lookAt(10, 20, -30);
+   *
+   *   describe(
+   *     'A white cube on a gray background. The cube appears to move left and right as the camera shifts its focus. The text "centerX: X" is written in black beneath the cube. X oscillates between -15 and 35.'
+   *   );
+   * }
+   *
+   * function draw() {
+   *   background(200);
+   *
+   *   // Style the box.
+   *   fill(255);
+   *
+   *   // Draw the box.
+   *   box();
+   *
+   *   // Style the text.
+   *   textAlign(CENTER);
+   *   textSize(16);
+   *   textFont(font);
+   *   fill(0);
+   *
+   *   // Calculate the new x-coordinate.
+   *   let x = 25 * sin(frameCount * 0.01) + 10;
+   *
+   *   // Point the camera.
+   *   cam.lookAt(x, 20, -30);
+   *
+   *   // Display the value of centerX, rounded to the nearest integer.
+   *   text(`centerX: ${round(cam.centerX)}`, 0, 55);
+   * }
+   * </code>
+   * </div>
+   */
+
+    /**
+   * The y-coordinate of the place where the camera looks.
+   *
+   * By default, the camera looks at the origin `(0, 0, 0)` in "world" space, so
+   * `myCamera.centerY` is 0.
+   *
+   * @property {Number} centerY
+   * @readonly
+   *
+   * @example
+   * <div>
+   * <code>
+   * let cam;
+   * let font;
+   *
+   * // Load a font and create a p5.Font object.
+   * function preload() {
+   *   font = loadFont('assets/inconsolata.otf');
+   * }
+   *
+   * function setup() {
+   *   createCanvas(100, 100, WEBGL);
+   *
+   *   // Create a p5.Camera object.
+   *   cam = createCamera();
+   *
+   *   // Place the camera at the top-center.
+   *   cam.setPosition(0, -400, 800);
+   *
+   *   // Point the camera at (10, 20, -30).
+   *   cam.lookAt(10, 20, -30);
+   *
+   *   describe(
+   *     'A white cube on a gray background. The text "centerY: 20" is written in black beneath it.'
+   *   );
+   * }
+   *
+   * function draw() {
+   *   background(200);
+   *
+   *   // Style the box.
+   *   fill(255);
+   *
+   *   // Draw the box.
+   *   box();
+   *
+   *   // Style the text.
+   *   textAlign(CENTER);
+   *   textSize(16);
+   *   textFont(font);
+   *   fill(0);
+   *
+   *   // Display the value of centerY, rounded to the nearest integer.
+   *   text(`centerY: ${round(cam.centerY)}`, 0, 55);
+   * }
+   * </code>
+   * </div>
+   *
+   * <div>
+   * <code>
+   * let cam;
+   * let font;
+   *
+   * // Load a font and create a p5.Font object.
+   * function preload() {
+   *   font = loadFont('assets/inconsolata.otf');
+   * }
+   *
+   * function setup() {
+   *   createCanvas(100, 100, WEBGL);
+   *
+   *   // Create a p5.Camera object.
+   *   cam = createCamera();
+   *
+   *   // Place the camera at the top-right.
+   *   cam.setPosition(100, -400, 800);
+   *
+   *   // Point the camera at (10, 20, -30).
+   *   cam.lookAt(10, 20, -30);
+   *
+   *   describe(
+   *     'A white cube on a gray background. The cube appears to move up and down as the camera shifts its focus. The text "centerY: Y" is written in black beneath the cube. Y oscillates between -5 and 45.'
+   *   );
+   * }
+   *
+   * function draw() {
+   *   background(200);
+   *
+   *   // Style the box.
+   *   fill(255);
+   *
+   *   // Draw the box.
+   *   box();
+   *
+   *   // Style the text.
+   *   textAlign(CENTER);
+   *   textSize(16);
+   *   textFont(font);
+   *   fill(0);
+   *
+   *   // Calculate the new y-coordinate.
+   *   let y = 25 * sin(frameCount * 0.01) + 20;
+   *
+   *   // Point the camera.
+   *   cam.lookAt(10, y, -30);
+   *
+   *   // Display the value of centerY, rounded to the nearest integer.
+   *   text(`centerY: ${round(cam.centerY)}`, 0, 55);
+   * }
+   * </code>
+   * </div>
+   */
+
+    /**
+   * The y-coordinate of the place where the camera looks.
+   *
+   * By default, the camera looks at the origin `(0, 0, 0)` in "world" space, so
+   * `myCamera.centerZ` is 0.
+   *
+   * @property {Number} centerZ
+   * @readonly
+   *
+   * @example
+   * <div>
+   * <code>
+   * let cam;
+   * let font;
+   *
+   * // Load a font and create a p5.Font object.
+   * function preload() {
+   *   font = loadFont('assets/inconsolata.otf');
+   * }
+   *
+   * function setup() {
+   *   createCanvas(100, 100, WEBGL);
+   *
+   *   // Create a p5.Camera object.
+   *   cam = createCamera();
+   *
+   *   // Place the camera at the top-center.
+   *   cam.setPosition(0, -400, 800);
+   *
+   *   // Point the camera at (10, 20, -30).
+   *   cam.lookAt(10, 20, -30);
+   *
+   *   describe(
+   *     'A white cube on a gray background. The text "centerZ: -30" is written in black beneath it.'
+   *   );
+   * }
+   *
+   * function draw() {
+   *   background(200);
+   *
+   *   // Style the box.
+   *   fill(255);
+   *
+   *   // Draw the box.
+   *   box();
+   *
+   *   // Style the text.
+   *   textAlign(CENTER);
+   *   textSize(16);
+   *   textFont(font);
+   *   fill(0);
+   *
+   *   // Display the value of centerZ, rounded to the nearest integer.
+   *   text(`centerZ: ${round(cam.centerZ)}`, 0, 55);
+   * }
+   * </code>
+   * </div>
+   *
+   * <div>
+   * <code>
+   * let cam;
+   * let font;
+   *
+   * // Load a font and create a p5.Font object.
+   * function preload() {
+   *   font = loadFont('assets/inconsolata.otf');
+   * }
+   *
+   * function setup() {
+   *   createCanvas(100, 100, WEBGL);
+   *
+   *   // Create a p5.Camera object.
+   *   cam = createCamera();
+   *
+   *   // Place the camera at the top-right.
+   *   cam.setPosition(100, -400, 800);
+   *
+   *   // Point the camera at (10, 20, -30).
+   *   cam.lookAt(10, 20, -30);
+   *
+   *   describe(
+   *     'A white cube on a gray background. The cube appears to move forward and back as the camera shifts its focus. The text "centerZ: Z" is written in black beneath the cube. Z oscillates between -55 and -25.'
+   *   );
+   * }
+   *
+   * function draw() {
+   *   background(200);
+   *
+   *   // Style the box.
+   *   fill(255);
+   *
+   *   // Draw the box.
+   *   box();
+   *
+   *   // Style the text.
+   *   textAlign(CENTER);
+   *   textSize(16);
+   *   textFont(font);
+   *   fill(0);
+   *
+   *   // Calculate the new z-coordinate.
+   *   let z = 25 * sin(frameCount * 0.01) - 30;
+   *
+   *   // Point the camera.
+   *   cam.lookAt(10, 20, z);
+   *
+   *   // Display the value of centerZ, rounded to the nearest integer.
+   *   text(`centerZ: ${round(cam.centerZ)}`, 0, 55);
+   * }
+   * </code>
+   * </div>
+   */
+
+    /**
+   * The x-component of the camera's "up" vector.
+   *
+   * The camera's "up" vector orients its y-axis. By default, the "up" vector is
+   * `(0, 1, 0)`, so its x-component is 0 in "local" space.
+   *
+   * @property {Number} upX
+   * @readonly
+   *
+   * @example
+   * <div>
+   * <code>
+   * let cam;
+   * let font;
+   *
+   * // Load a font and create a p5.Font object.
+   * function preload() {
+   *   font = loadFont('assets/inconsolata.otf');
+   * }
+   *
+   * function setup() {
+   *   createCanvas(100, 100, WEBGL);
+   *
+   *   // Create a p5.Camera object.
+   *   cam = createCamera();
+   *
+   *   // Place the camera at the top-right: (100, -400, 800)
+   *   // Point it at the origin: (0, 0, 0)
+   *   // Set its "up" vector: (0, 1, 0).
+   *   cam.camera(100, -400, 800, 0, 0, 0, 0, 1, 0);
+   *
+   *   describe(
+   *     'A white cube on a gray background. The text "upX: 0" is written in black beneath it.'
+   *   );
+   * }
+   *
+   * function draw() {
+   *   background(200);
+   *
+   *   // Style the box.
+   *   fill(255);
+   *
+   *   // Draw the box.
+   *   box();
+   *
+   *   // Style the text.
+   *   textAlign(CENTER);
+   *   textSize(16);
+   *   textFont(font);
+   *   fill(0);
+   *
+   *   // Display the value of upX, rounded to the nearest tenth.
+   *   text(`upX: ${round(cam.upX, 1)}`, 0, 55);
+   * }
+   * </code>
+   * </div>
+   *
+   * <div>
+   * <code>
+   * let cam;
+   * let font;
+   *
+   * // Load a font and create a p5.Font object.
+   * function preload() {
+   *   font = loadFont('assets/inconsolata.otf');
+   * }
+   *
+   * function setup() {
+   *   createCanvas(100, 100, WEBGL);
+   *
+   *   // Create a p5.Camera object.
+   *   cam = createCamera();
+   *
+   *   // Place the camera at the top-right: (100, -400, 800)
+   *   // Point it at the origin: (0, 0, 0)
+   *   // Set its "up" vector: (0, 1, 0).
+   *   cam.camera(100, -400, 800, 0, 0, 0, 0, 1, 0);
+   *
+   *   describe(
+   *     'A white cube on a gray background. The cube appears to rock back and forth. The text "upX: X" is written in black beneath it. X oscillates between -1 and 1.'
+   *   );
+   * }
+   *
+   * function draw() {
+   *   background(200);
+   *
+   *   // Style the box.
+   *   fill(255);
+   *
+   *   // Draw the box.
+   *   box();
+   *
+   *   // Style the text.
+   *   textAlign(CENTER);
+   *   textSize(16);
+   *   textFont(font);
+   *   fill(0);
+   *
+   *   // Calculate the x-component.
+   *   let x = sin(frameCount * 0.01);
+   *
+   *   // Update the camera's "up" vector.
+   *   cam.camera(100, -400, 800, 0, 0, 0, x, 1, 0);
+   *
+   *   // Display the value of upX, rounded to the nearest tenth.
+   *   text(`upX: ${round(cam.upX, 1)}`, 0, 55);
+   * }
+   * </code>
+   * </div>
+   */
+
+    /**
+   * The y-component of the camera's "up" vector.
+   *
+   * The camera's "up" vector orients its y-axis. By default, the "up" vector is
+   * `(0, 1, 0)`, so its y-component is 1 in "local" space.
+   *
+   * @property {Number} upY
+   * @readonly
+   *
+   * @example
+   * <div>
+   * <code>
+   * let cam;
+   * let font;
+   *
+   * // Load a font and create a p5.Font object.
+   * function preload() {
+   *   font = loadFont('assets/inconsolata.otf');
+   * }
+   *
+   * function setup() {
+   *   createCanvas(100, 100, WEBGL);
+   *
+   *   // Create a p5.Camera object.
+   *   cam = createCamera();
+   *
+   *   // Place the camera at the top-right: (100, -400, 800)
+   *   // Point it at the origin: (0, 0, 0)
+   *   // Set its "up" vector: (0, 1, 0).
+   *   cam.camera(100, -400, 800, 0, 0, 0, 0, 1, 0);
+   *
+   *   describe(
+   *     'A white cube on a gray background. The text "upY: 1" is written in black beneath it.'
+   *   );
+   * }
+   *
+   * function draw() {
+   *   background(200);
+   *
+   *   // Style the box.
+   *   fill(255);
+   *
+   *   // Draw the box.
+   *   box();
+   *
+   *   // Style the text.
+   *   textAlign(CENTER);
+   *   textSize(16);
+   *   textFont(font);
+   *   fill(0);
+   *
+   *   // Display the value of upY, rounded to the nearest tenth.
+   *   text(`upY: ${round(cam.upY, 1)}`, 0, 55);
+   * }
+   * </code>
+   * </div>
+   *
+   * <div>
+   * <code>
+   * let cam;
+   * let font;
+   *
+   * // Load a font and create a p5.Font object.
+   * function preload() {
+   *   font = loadFont('assets/inconsolata.otf');
+   * }
+   *
+   * function setup() {
+   *   createCanvas(100, 100, WEBGL);
+   *
+   *   // Create a p5.Camera object.
+   *   cam = createCamera();
+   *
+   *   // Place the camera at the top-right: (100, -400, 800)
+   *   // Point it at the origin: (0, 0, 0)
+   *   // Set its "up" vector: (0, 1, 0).
+   *   cam.camera(100, -400, 800, 0, 0, 0, 0, 1, 0);
+   *
+   *   describe(
+   *     'A white cube on a gray background. The cube flips upside-down periodically. The text "upY: Y" is written in black beneath it. Y oscillates between -1 and 1.'
+   *   );
+   * }
+   *
+   * function draw() {
+   *   background(200);
+   *
+   *   // Style the box.
+   *   fill(255);
+   *
+   *   // Draw the box.
+   *   box();
+   *
+   *   // Style the text.
+   *   textAlign(CENTER);
+   *   textSize(16);
+   *   textFont(font);
+   *   fill(0);
+   *
+   *   // Calculate the y-component.
+   *   let y = sin(frameCount * 0.01);
+   *
+   *   // Update the camera's "up" vector.
+   *   cam.camera(100, -400, 800, 0, 0, 0, 0, y, 0);
+   *
+   *   // Display the value of upY, rounded to the nearest tenth.
+   *   text(`upY: ${round(cam.upY, 1)}`, 0, 55);
+   * }
+   * </code>
+   * </div>
+   */
+
+    /**
+   * The z-component of the camera's "up" vector.
+   *
+   * The camera's "up" vector orients its y-axis. By default, the "up" vector is
+   * `(0, 1, 0)`, so its z-component is 0 in "local" space.
+   *
+   * @property {Number} upZ
+   * @readonly
+   *
+   * @example
+   * <div>
+   * <code>
+   * let cam;
+   * let font;
+   *
+   * // Load a font and create a p5.Font object.
+   * function preload() {
+   *   font = loadFont('assets/inconsolata.otf');
+   * }
+   *
+   * function setup() {
+   *   createCanvas(100, 100, WEBGL);
+   *
+   *   // Create a p5.Camera object.
+   *   cam = createCamera();
+   *
+   *   // Place the camera at the top-right: (100, -400, 800)
+   *   // Point it at the origin: (0, 0, 0)
+   *   // Set its "up" vector: (0, 1, 0).
+   *   cam.camera(100, -400, 800, 0, 0, 0, 0, 1, 0);
+   *
+   *   describe(
+   *     'A white cube on a gray background. The text "upZ: 0" is written in black beneath it.'
+   *   );
+   * }
+   *
+   * function draw() {
+   *   background(200);
+   *
+   *   // Style the box.
+   *   fill(255);
+   *
+   *   // Draw the box.
+   *   box();
+   *
+   *   // Style the text.
+   *   textAlign(CENTER);
+   *   textSize(16);
+   *   textFont(font);
+   *   fill(0);
+   *
+   *   // Display the value of upZ, rounded to the nearest tenth.
+   *   text(`upZ: ${round(cam.upZ, 1)}`, 0, 55);
+   * }
+   * </code>
+   * </div>
+   *
+   * <div>
+   * <code>
+   * let cam;
+   * let font;
+   *
+   * // Load a font and create a p5.Font object.
+   * function preload() {
+   *   font = loadFont('assets/inconsolata.otf');
+   * }
+   *
+   * function setup() {
+   *   createCanvas(100, 100, WEBGL);
+   *
+   *   // Create a p5.Camera object.
+   *   cam = createCamera();
+   *
+   *   // Place the camera at the top-right: (100, -400, 800)
+   *   // Point it at the origin: (0, 0, 0)
+   *   // Set its "up" vector: (0, 1, 0).
+   *   cam.camera(100, -400, 800, 0, 0, 0, 0, 1, 0);
+   *
+   *   describe(
+   *     'A white cube on a gray background. The cube appears to rock back and forth. The text "upZ: Z" is written in black beneath it. Z oscillates between -1 and 1.'
+   *   );
+   * }
+   *
+   * function draw() {
+   *   background(200);
+   *
+   *   // Style the box.
+   *   fill(255);
+   *
+   *   // Draw the box.
+   *   box();
+   *
+   *   // Style the text.
+   *   textAlign(CENTER);
+   *   textSize(16);
+   *   textFont(font);
+   *   fill(0);
+   *
+   *   // Calculate the z-component.
+   *   let z = sin(frameCount * 0.01);
+   *
+   *   // Update the camera's "up" vector.
+   *   cam.camera(100, -400, 800, 0, 0, 0, 0, 1, z);
+   *
+   *   // Display the value of upZ, rounded to the nearest tenth.
+   *   text(`upZ: ${round(cam.upZ, 1)}`, 0, 55);
+   * }
+   * </code>
+   * </div>
+   */
+
+    ////////////////////////////////////////////////////////////////////////////////
+    // Camera Projection Methods
+    ////////////////////////////////////////////////////////////////////////////////
+
+    /**
+   * Sets a perspective projection for the camera.
+   *
+   * In a perspective projection, shapes that are further from the camera appear
+   * smaller than shapes that are near the camera. This technique, called
+   * foreshortening, creates realistic 3D scenes. It’s applied by default in new
+   * `p5.Camera` objects.
+   *
+   * `myCamera.perspective()` changes the camera’s perspective by changing its
+   * viewing frustum. The frustum is the volume of space that’s visible to the
+   * camera. The frustum’s shape is a pyramid with its top cut off. The camera
+   * is placed where the top of the pyramid should be and points towards the
+   * base of the pyramid. It views everything within the frustum.
+   *
+   * The first parameter, `fovy`, is the camera’s vertical field of view. It’s
+   * an angle that describes how tall or narrow a view the camera has. For
+   * example, calling `myCamera.perspective(0.5)` sets the camera’s vertical
+   * field of view to 0.5 radians. By default, `fovy` is calculated based on the
+   * sketch’s height and the camera’s default z-coordinate, which is 800. The
+   * formula for the default `fovy` is `2 * atan(height / 2 / 800)`.
+   *
+   * The second parameter, `aspect`, is the camera’s aspect ratio. It’s a number
+   * that describes the ratio of the top plane’s width to its height. For
+   * example, calling `myCamera.perspective(0.5, 1.5)` sets the camera’s field
+   * of view to 0.5 radians and aspect ratio to 1.5, which would make shapes
+   * appear thinner on a square canvas. By default, `aspect` is set to
+   * `width / height`.
+   *
+   * The third parameter, `near`, is the distance from the camera to the near
+   * plane. For example, calling `myCamera.perspective(0.5, 1.5, 100)` sets the
+   * camera’s field of view to 0.5 radians, its aspect ratio to 1.5, and places
+   * the near plane 100 pixels from the camera. Any shapes drawn less than 100
+   * pixels from the camera won’t be visible. By default, `near` is set to
+   * `0.1 * 800`, which is 1/10th the default distance between the camera and
+   * the origin.
+   *
+   * The fourth parameter, `far`, is the distance from the camera to the far
+   * plane. For example, calling `myCamera.perspective(0.5, 1.5, 100, 10000)`
+   * sets the camera’s field of view to 0.5 radians, its aspect ratio to 1.5,
+   * places the near plane 100 pixels from the camera, and places the far plane
+   * 10,000 pixels from the camera. Any shapes drawn more than 10,000 pixels
+   * from the camera won’t be visible. By default, `far` is set to `10 * 800`,
+   * which is 10 times the default distance between the camera and the origin.
+   *
+   * @for p5.Camera
+   * @param  {Number} [fovy]   camera frustum vertical field of view. Defaults to
+   *                           `2 * atan(height / 2 / 800)`.
+   * @param  {Number} [aspect] camera frustum aspect ratio. Defaults to
+   *                           `width / height`.
+   * @param  {Number} [near]   distance from the camera to the near clipping plane.
+   *                           Defaults to `0.1 * 800`.
+   * @param  {Number} [far]    distance from the camera to the far clipping plane.
+   *                           Defaults to `10 * 800`.
+   *
+   * @example
+   * <div>
+   * <code>
+   * // Double-click to toggle between cameras.
+   *
+   * let cam1;
+   * let cam2;
+   * let isDefaultCamera = true;
+   *
+   * function setup() {
+   *   createCanvas(100, 100, WEBGL);
+   *
+   *   // Create the first camera.
+   *   // Keep its default settings.
+   *   cam1 = createCamera();
+   *
+   *   // Create the second camera.
+   *   cam2 = createCamera();
+   *
+   *   // Place it at the top-right.
+   *   cam2.camera(400, -400, 800);
+   *
+   *   // Set its fovy to 0.2.
+   *   // Set its aspect to 1.5.
+   *   // Set its near to 600.
+   *   // Set its far to 1200.
+   *   cam2.perspective(0.2, 1.5, 600, 1200);
+   *
+   *   // Set the current camera to cam1.
+   *   setCamera(cam1);
+   *
+   *   describe('A white cube on a gray background. The camera toggles between a frontal view and a skewed aerial view when the user double-clicks.');
+   * }
+   *
+   * function draw() {
+   *   background(200);
+   *
+   *   // Draw the box.
+   *   box();
+   * }
+   *
+   * // Toggle the current camera when the user double-clicks.
+   * function doubleClicked() {
+   *   if (isDefaultCamera === true) {
+   *     setCamera(cam2);
+   *     isDefaultCamera = false;
+   *   } else {
+   *     setCamera(cam1);
+   *     isDefaultCamera = true;
+   *   }
+   * }
+   * </code>
+   * </div>
+   *
+   * <div>
+   * <code>
+   * // Double-click to toggle between cameras.
+   *
+   * let cam1;
+   * let cam2;
+   * let isDefaultCamera = true;
+   *
+   * function setup() {
+   *   createCanvas(100, 100, WEBGL);
+   *
+   *   // Create the first camera.
+   *   // Keep its default settings.
+   *   cam1 = createCamera();
+   *
+   *   // Create the second camera.
+   *   cam2 = createCamera();
+   *
+   *   // Place it at the top-right.
+   *   cam2.camera(400, -400, 800);
+   *
+   *   // Set its fovy to 0.2.
+   *   // Set its aspect to 1.5.
+   *   // Set its near to 600.
+   *   // Set its far to 1200.
+   *   cam2.perspective(0.2, 1.5, 600, 1200);
+   *
+   *   // Set the current camera to cam1.
+   *   setCamera(cam1);
+   *
+   *   describe('A white cube moves left and right on a gray background. The camera toggles between a frontal and a skewed aerial view when the user double-clicks.');
+   * }
+   *
+   * function draw() {
+   *   background(200);
+   *
+   *   // Translate the origin left and right.
+   *   let x = 100 * sin(frameCount * 0.01);
+   *   translate(x, 0, 0);
+   *
+   *   // Draw the box.
+   *   box();
+   * }
+   *
+   * // Toggle the current camera when the user double-clicks.
+   * function doubleClicked() {
+   *   if (isDefaultCamera === true) {
+   *     setCamera(cam2);
+   *     isDefaultCamera = false;
+   *   } else {
+   *     setCamera(cam1);
+   *     isDefaultCamera = true;
+   *   }
+   * }
+   * </code>
+   * </div>
+   */
+    perspective(fovy, aspect, near, far) {
+      this.cameraType = arguments.length > 0 ? 'custom' : 'default';
+      if (typeof fovy === 'undefined') {
+        fovy = this.defaultCameraFOV;
+        // this avoids issue where setting angleMode(DEGREES) before calling
+        // perspective leads to a smaller than expected FOV (because
+        // _computeCameraDefaultSettings computes in radians)
+        this.cameraFOV = fovy;
+      } else {
+        this.cameraFOV = this._renderer._pInst._toRadians(fovy);
+      }
+      if (typeof aspect === 'undefined') {
+        aspect = this.defaultAspectRatio;
+      }
+      if (typeof near === 'undefined') {
+        near = this.defaultCameraNear;
+      }
+      if (typeof far === 'undefined') {
+        far = this.defaultCameraFar;
+      }
+
+      if (near <= 0.0001) {
+        near = 0.01;
+        console.log(
+          'Avoid perspective near plane values close to or below 0. ' +
+          'Setting value to 0.01.'
+        );
+      }
+
+      if (far < near) {
+        console.log(
+          'Perspective far plane value is less than near plane value. ' +
+          'Nothing will be shown.'
+        );
+      }
+
+      this.aspectRatio = aspect;
+      this.cameraNear = near;
+      this.cameraFar = far;
+
+      this.projMatrix = p5.Matrix.identity();
+
+      const f = 1.0 / Math.tan(this.cameraFOV / 2);
+      const nf = 1.0 / (this.cameraNear - this.cameraFar);
+
+      /* eslint-disable indent */
+      this.projMatrix.set(f / aspect, 0, 0, 0,
+        0, -f * this.yScale, 0, 0,
+        0, 0, (far + near) * nf, -1,
+        0, 0, (2 * far * near) * nf, 0);
+      /* eslint-enable indent */
+
       if (this._isActive()) {
-        this._renderer.states.uPMatrix.mat4 = this.projMatrix.mat4.slice();
+        this._renderer.states.uPMatrix.set(this.projMatrix);
       }
     }
 
-    // prepare eye vector and center vector of argument cameras.
-    const eye0 = new p5.Vector(cam0.eyeX, cam0.eyeY, cam0.eyeZ);
-    const eye1 = new p5.Vector(cam1.eyeX, cam1.eyeY, cam1.eyeZ);
-    const center0 = new p5.Vector(cam0.centerX, cam0.centerY, cam0.centerZ);
-    const center1 = new p5.Vector(cam1.centerX, cam1.centerY, cam1.centerZ);
+    /**
+   * Sets an orthographic projection for the camera.
+   *
+   * In an orthographic projection, shapes with the same size always appear the
+   * same size, regardless of whether they are near or far from the camera.
+   *
+   * `myCamera.ortho()` changes the camera’s perspective by changing its viewing
+   * frustum from a truncated pyramid to a rectangular prism. The frustum is the
+   * volume of space that’s visible to the camera. The camera is placed in front
+   * of the frustum and views everything within the frustum. `myCamera.ortho()`
+   * has six optional parameters to define the viewing frustum.
+   *
+   * The first four parameters, `left`, `right`, `bottom`, and `top`, set the
+   * coordinates of the frustum’s sides, bottom, and top. For example, calling
+   * `myCamera.ortho(-100, 100, 200, -200)` creates a frustum that’s 200 pixels
+   * wide and 400 pixels tall. By default, these dimensions are set based on
+   * the sketch’s width and height, as in
+   * `myCamera.ortho(-width / 2, width / 2, -height / 2, height / 2)`.
+   *
+   * The last two parameters, `near` and `far`, set the distance of the
+   * frustum’s near and far plane from the camera. For example, calling
+   * `myCamera.ortho(-100, 100, 200, -200, 50, 1000)` creates a frustum that’s
+   * 200 pixels wide, 400 pixels tall, starts 50 pixels from the camera, and
+   * ends 1,000 pixels from the camera. By default, `near` and `far` are set to
+   * 0 and `max(width, height) + 800`, respectively.
+   *
+   * @for p5.Camera
+   * @param  {Number} [left]   x-coordinate of the frustum’s left plane. Defaults to `-width / 2`.
+   * @param  {Number} [right]  x-coordinate of the frustum’s right plane. Defaults to `width / 2`.
+   * @param  {Number} [bottom] y-coordinate of the frustum’s bottom plane. Defaults to `height / 2`.
+   * @param  {Number} [top]    y-coordinate of the frustum’s top plane. Defaults to `-height / 2`.
+   * @param  {Number} [near]   z-coordinate of the frustum’s near plane. Defaults to 0.
+   * @param  {Number} [far]    z-coordinate of the frustum’s far plane. Defaults to `max(width, height) + 800`.
+   *
+   * @example
+   * <div>
+   * <code>
+   * // Double-click to toggle between cameras.
+   *
+   * let cam1;
+   * let cam2;
+   * let isDefaultCamera = true;
+   *
+   * function setup() {
+   *   createCanvas(100, 100, WEBGL);
+   *
+   *   // Create the first camera.
+   *   // Keep its default settings.
+   *   cam1 = createCamera();
+   *
+   *   // Create the second camera.
+   *   cam2 = createCamera();
+   *
+   *   // Apply an orthographic projection.
+   *   cam2.ortho();
+   *
+   *   // Set the current camera to cam1.
+   *   setCamera(cam1);
+   *
+   *   describe('A row of white cubes against a gray background. The camera toggles between a perspective and an orthographic projection when the user double-clicks.');
+   * }
+   *
+   * function draw() {
+   *   background(200);
+   *
+   *   // Translate the origin toward the camera.
+   *   translate(-10, 10, 500);
+   *
+   *   // Rotate the coordinate system.
+   *   rotateY(-0.1);
+   *   rotateX(-0.1);
+   *
+   *   // Draw the row of boxes.
+   *   for (let i = 0; i < 6; i += 1) {
+   *     translate(0, 0, -40);
+   *     box(10);
+   *   }
+   * }
+   *
+   * // Toggle the current camera when the user double-clicks.
+   * function doubleClicked() {
+   *   if (isDefaultCamera === true) {
+   *     setCamera(cam2);
+   *     isDefaultCamera = false;
+   *   } else {
+   *     setCamera(cam1);
+   *     isDefaultCamera = true;
+   *   }
+   * }
+   * </code>
+   * </div>
+   *
+   * <div>
+   * <code>
+   * // Double-click to toggle between cameras.
+   *
+   * let cam1;
+   * let cam2;
+   * let isDefaultCamera = true;
+   *
+   * function setup() {
+   *   createCanvas(100, 100, WEBGL);
+   *
+   *   // Create the first camera.
+   *   // Keep its default settings.
+   *   cam1 = createCamera();
+   *
+   *   // Create the second camera.
+   *   cam2 = createCamera();
+   *
+   *   // Apply an orthographic projection.
+   *   cam2.ortho();
+   *
+   *   // Set the current camera to cam1.
+   *   setCamera(cam1);
+   *
+   *   describe('A row of white cubes slither like a snake against a gray background. The camera toggles between a perspective and an orthographic projection when the user double-clicks.');
+   * }
+   *
+   * function draw() {
+   *   background(200);
+   *
+   *   // Translate the origin toward the camera.
+   *   translate(-10, 10, 500);
+   *
+   *   // Rotate the coordinate system.
+   *   rotateY(-0.1);
+   *   rotateX(-0.1);
+   *
+   *   // Draw the row of boxes.
+   *   for (let i = 0; i < 6; i += 1) {
+   *     push();
+   *     // Calculate the box's coordinates.
+   *     let x = 10 * sin(frameCount * 0.02 + i * 0.6);
+   *     let z = -40 * i;
+   *     // Translate the origin.
+   *     translate(x, 0, z);
+   *     // Draw the box.
+   *     box(10);
+   *     pop();
+   *   }
+   * }
+   *
+   * // Toggle the current camera when the user double-clicks.
+   * function doubleClicked() {
+   *   if (isDefaultCamera === true) {
+   *     setCamera(cam2);
+   *     isDefaultCamera = false;
+   *   } else {
+   *     setCamera(cam1);
+   *     isDefaultCamera = true;
+   *   }
+   * }
+   * </code>
+   * </div>
+   */
+    ortho(left, right, bottom, top, near, far) {
+      const source = this.fbo || this._renderer;
+      if (left === undefined) left = -source.width / 2;
+      if (right === undefined) right = +source.width / 2;
+      if (bottom === undefined) bottom = -source.height / 2;
+      if (top === undefined) top = +source.height / 2;
+      if (near === undefined) near = 0;
+      if (far === undefined) far = Math.max(source.width, source.height) + 800;
+      this.cameraNear = near;
+      this.cameraFar = far;
+      const w = right - left;
+      const h = top - bottom;
+      const d = far - near;
+      const x = +2.0 / w;
+      const y = +2.0 / h * this.yScale;
+      const z = -2.0 / d;
+      const tx = -(right + left) / w;
+      const ty = -(top + bottom) / h;
+      const tz = -(far + near) / d;
+      this.projMatrix = p5.Matrix.identity();
+      /* eslint-disable indent */
+      this.projMatrix.set(x, 0, 0, 0,
+        0, -y, 0, 0,
+        0, 0, z, 0,
+        tx, ty, tz, 1);
+      /* eslint-enable indent */
+      if (this._isActive()) {
+        this._renderer.states.uPMatrix.set(this.projMatrix);
+      }
+      this.cameraType = 'custom';
+    }
+    /**
+   * Sets the camera's frustum.
+   *
+   * In a frustum projection, shapes that are further from the camera appear
+   * smaller than shapes that are near the camera. This technique, called
+   * foreshortening, creates realistic 3D scenes.
+   *
+   * `myCamera.frustum()` changes the camera’s perspective by changing its
+   * viewing frustum. The frustum is the volume of space that’s visible to the
+   * camera. The frustum’s shape is a pyramid with its top cut off. The camera
+   * is placed where the top of the pyramid should be and points towards the
+   * base of the pyramid. It views everything within the frustum.
+   *
+   * The first four parameters, `left`, `right`, `bottom`, and `top`, set the
+   * coordinates of the frustum’s sides, bottom, and top. For example, calling
+   * `myCamera.frustum(-100, 100, 200, -200)` creates a frustum that’s 200
+   * pixels wide and 400 pixels tall. By default, these coordinates are set
+   * based on the sketch’s width and height, as in
+   * `myCamera.frustum(-width / 20, width / 20, height / 20, -height / 20)`.
+   *
+   * The last two parameters, `near` and `far`, set the distance of the
+   * frustum’s near and far plane from the camera. For example, calling
+   * `myCamera.frustum(-100, 100, 200, -200, 50, 1000)` creates a frustum that’s
+   * 200 pixels wide, 400 pixels tall, starts 50 pixels from the camera, and ends
+   * 1,000 pixels from the camera. By default, near is set to `0.1 * 800`, which
+   * is 1/10th the default distance between the camera and the origin. `far` is
+   * set to `10 * 800`, which is 10 times the default distance between the
+   * camera and the origin.
+   *
+   * @for p5.Camera
+   * @param  {Number} [left]   x-coordinate of the frustum’s left plane. Defaults to `-width / 20`.
+   * @param  {Number} [right]  x-coordinate of the frustum’s right plane. Defaults to `width / 20`.
+   * @param  {Number} [bottom] y-coordinate of the frustum’s bottom plane. Defaults to `height / 20`.
+   * @param  {Number} [top]    y-coordinate of the frustum’s top plane. Defaults to `-height / 20`.
+   * @param  {Number} [near]   z-coordinate of the frustum’s near plane. Defaults to `0.1 * 800`.
+   * @param  {Number} [far]    z-coordinate of the frustum’s far plane. Defaults to `10 * 800`.
+   *
+   * @example
+   * <div>
+   * <code>
+   * // Double-click to toggle between cameras.
+   *
+   * let cam1;
+   * let cam2;
+   * let isDefaultCamera = true;
+   *
+   * function setup() {
+   *   createCanvas(100, 100, WEBGL);
+   *
+   *   // Create the first camera.
+   *   // Keep its default settings.
+   *   cam1 = createCamera();
+   *
+   *   // Create the second camera.
+   *   cam2 = createCamera();
+   *
+   *   // Adjust the frustum.
+   *   // Center it.
+   *   // Set its width and height to 20 pixels.
+   *   // Place its near plane 300 pixels from the camera.
+   *   // Place its far plane 350 pixels from the camera.
+   *   cam2.frustum(-10, 10, -10, 10, 300, 350);
+   *
+   *   // Set the current camera to cam1.
+   *   setCamera(cam1);
+   *
+   *   describe(
+   *     'A row of white cubes against a gray background. The camera zooms in on one cube when the user double-clicks.'
+   *   );
+   * }
+   *
+   * function draw() {
+   *   background(200);
+   *
+   *   // Translate the origin toward the camera.
+   *   translate(-10, 10, 600);
+   *
+   *   // Rotate the coordinate system.
+   *   rotateY(-0.1);
+   *   rotateX(-0.1);
+   *
+   *   // Draw the row of boxes.
+   *   for (let i = 0; i < 6; i += 1) {
+   *     translate(0, 0, -40);
+   *     box(10);
+   *   }
+   * }
+   *
+   * // Toggle the current camera when the user double-clicks.
+   * function doubleClicked() {
+   *   if (isDefaultCamera === true) {
+   *     setCamera(cam2);
+   *     isDefaultCamera = false;
+   *   } else {
+   *     setCamera(cam1);
+   *     isDefaultCamera = true;
+   *   }
+   * }
+   * </code>
+   * </div>
+   */
+    frustum(left, right, bottom, top, near, far) {
+      if (left === undefined) left = -this._renderer.width * 0.05;
+      if (right === undefined) right = +this._renderer.width * 0.05;
+      if (bottom === undefined) bottom = +this._renderer.height * 0.05;
+      if (top === undefined) top = -this._renderer.height * 0.05;
+      if (near === undefined) near = this.defaultCameraNear;
+      if (far === undefined) far = this.defaultCameraFar;
 
-    // Calculate the distance between eye and center for each camera.
-    // Logarithmically interpolate these with amt.
-    const dist0 = p5.Vector.dist(eye0, center0);
-    const dist1 = p5.Vector.dist(eye1, center1);
-    const lerpedDist = dist0 * Math.pow(dist1 / dist0, amt);
+      this.cameraNear = near;
+      this.cameraFar = far;
 
-    // Next, calculate the ratio to interpolate the eye and center by a constant
-    // ratio for each camera. This ratio is the same for both. Also, with this ratio
-    // of points, the distance is the minimum distance of the two points of
-    // the same ratio.
-    // With this method, if the viewpoint is fixed, linear interpolation is performed
-    // at the viewpoint, and if the center is fixed, linear interpolation is performed
-    // at the center, resulting in reasonable interpolation. If both move, the point
-    // halfway between them is taken.
-    const eyeDiff = p5.Vector.sub(eye0, eye1);
-    const diffDiff = eye0.copy().sub(eye1).sub(center0).add(center1);
-    // Suppose there are two line segments. Consider the distance between the points
-    // above them as if they were taken in the same ratio. This calculation figures out
-    // a ratio that minimizes this.
-    // Each line segment is, a line segment connecting the viewpoint and the center
-    // for each camera.
-    const divider = diffDiff.magSq();
-    let ratio = 1; // default.
-    if (divider > 0.000001) {
-      ratio = p5.Vector.dot(eyeDiff, diffDiff) / divider;
-      ratio = Math.max(0, Math.min(ratio, 1));
+      const w = right - left;
+      const h = top - bottom;
+      const d = far - near;
+
+      const x = +(2.0 * near) / w;
+      const y = +(2.0 * near) / h * this.yScale;
+      const z = -(2.0 * far * near) / d;
+
+      const tx = (right + left) / w;
+      const ty = (top + bottom) / h;
+      const tz = -(far + near) / d;
+
+      this.projMatrix = p5.Matrix.identity();
+
+      /* eslint-disable indent */
+      this.projMatrix.set(x, 0, 0, 0,
+        0, -y, 0, 0,
+        tx, ty, tz, -1,
+        0, 0, z, 0);
+      /* eslint-enable indent */
+
+      if (this._isActive()) {
+        this._renderer.states.uPMatrix.set(this.projMatrix);
+      }
+
+      this.cameraType = 'custom';
     }
 
-    // Take the appropriate proportions and work out the points
-    // that are between the new viewpoint and the new center position.
-    const lerpedMedium = p5.Vector.lerp(
-      p5.Vector.lerp(eye0, center0, ratio),
-      p5.Vector.lerp(eye1, center1, ratio),
-      amt
-    );
+    ////////////////////////////////////////////////////////////////////////////////
+    // Camera Orientation Methods
+    ////////////////////////////////////////////////////////////////////////////////
 
-    // Prepare each of rotation matrix from their camera matrix
-    const rotMat0 = cam0.cameraMatrix.createSubMatrix3x3();
-    const rotMat1 = cam1.cameraMatrix.createSubMatrix3x3();
+    /**
+   * Rotate camera view about arbitrary axis defined by x,y,z
+   * based on http://learnwebgl.brown37.net/07_cameras/camera_rotating_motion.html
+   * @private
+   */
+    _rotateView(a, x, y, z) {
+      let centerX = this.centerX;
+      let centerY = this.centerY;
+      let centerZ = this.centerZ;
 
-    // get front and up vector from local-coordinate-system.
-    const front0 = rotMat0.row(2);
-    const front1 = rotMat1.row(2);
-    const up0 = rotMat0.row(1);
-    const up1 = rotMat1.row(1);
+      // move center by eye position such that rotation happens around eye position
+      centerX -= this.eyeX;
+      centerY -= this.eyeY;
+      centerZ -= this.eyeZ;
 
-    // prepare new vectors.
-    const newFront = new p5.Vector();
-    const newUp = new p5.Vector();
-    const newEye = new p5.Vector();
-    const newCenter = new p5.Vector();
+      const rotation = p5.Matrix.identity(this._renderer._pInst);
+      rotation.rotate(this._renderer._pInst._toRadians(a), x, y, z);
 
-    // Create the inverse matrix of mat0 by transposing mat0,
-    // and multiply it to mat1 from the right.
-    // This matrix represents the difference between the two.
-    // 'deltaRot' means 'difference of rotation matrices'.
-    const deltaRot = rotMat1.mult3x3(rotMat0.copy().transpose3x3());
+      /* eslint-disable max-len */
+      const rotatedCenter = [
+        centerX * rotation.mat4[0] + centerY * rotation.mat4[4] + centerZ * rotation.mat4[8],
+        centerX * rotation.mat4[1] + centerY * rotation.mat4[5] + centerZ * rotation.mat4[9],
+        centerX * rotation.mat4[2] + centerY * rotation.mat4[6] + centerZ * rotation.mat4[10]
+      ];
+      /* eslint-enable max-len */
 
-    // Calculate the trace and from it the cos value of the angle.
-    // An orthogonal matrix is just an orthonormal basis. If this is not the identity
-    // matrix, it is a centered orthonormal basis plus some angle of rotation about
-    // some axis. That's the angle. Letting this be theta, trace becomes 1+2cos(theta).
-    // reference: https://en.wikipedia.org/wiki/Rotation_matrix#Determining_the_angle
-    const diag = deltaRot.diagonal();
-    let cosTheta = 0.5 * (diag[0] + diag[1] + diag[2] - 1);
+      // add eye position back into center
+      rotatedCenter[0] += this.eyeX;
+      rotatedCenter[1] += this.eyeY;
+      rotatedCenter[2] += this.eyeZ;
 
-    // If the angle is close to 0, the two matrices are very close,
-    // so in that case we execute linearly interpolate.
-    if (1 - cosTheta < 0.0000001) {
-      // Obtain the front vector and up vector by linear interpolation
-      // and normalize them.
+      this.camera(
+        this.eyeX,
+        this.eyeY,
+        this.eyeZ,
+        rotatedCenter[0],
+        rotatedCenter[1],
+        rotatedCenter[2],
+        this.upX,
+        this.upY,
+        this.upZ
+      );
+    }
+
+    /**
+   * Rotates the camera in a clockwise/counter-clockwise direction.
+   *
+   * Rolling rotates the camera without changing its orientation. The rotation
+   * happens in the camera’s "local" space.
+   *
+   * The parameter, `angle`, is the angle the camera should rotate. Passing a
+   * positive angle, as in `myCamera.roll(0.001)`, rotates the camera in counter-clockwise direction.
+   * Passing a negative angle, as in `myCamera.roll(-0.001)`, rotates the
+   * camera in clockwise direction.
+   *
+   * Note: Angles are interpreted based on the current
+   * <a href="#/p5/angleMode">angleMode()</a>.
+   *
+   * @method roll
+   * @param {Number} angle amount to rotate camera in current
+   * <a href="#/p5/angleMode">angleMode</a> units.
+   * @example
+   * <div>
+   * <code>
+   * let cam;
+   * let delta = 0.01;
+   *
+   * function setup() {
+   *   createCanvas(100, 100, WEBGL);
+   *   normalMaterial();
+   *   // Create a p5.Camera object.
+   *   cam = createCamera();
+   * }
+   *
+   * function draw() {
+   *   background(200);
+   *
+   *   // Roll camera according to angle 'delta'
+   *   cam.roll(delta);
+   *
+   *   translate(0, 0, 0);
+   *   box(20);
+   *   translate(0, 25, 0);
+   *   box(20);
+   *   translate(0, 26, 0);
+   *   box(20);
+   *   translate(0, 27, 0);
+   *   box(20);
+   *   translate(0, 28, 0);
+   *   box(20);
+   *   translate(0,29, 0);
+   *   box(20);
+   *   translate(0, 30, 0);
+   *   box(20);
+   * }
+   * </code>
+   * </div>
+   *
+   * @alt
+   * camera view rotates in counter clockwise direction with vertically stacked boxes in front of it.
+   */
+    roll(amount) {
+      const local = this._getLocalAxes();
+      const axisQuaternion = p5.Quat.fromAxisAngle(
+        this._renderer._pInst._toRadians(amount),
+        local.z[0], local.z[1], local.z[2]);
+      // const upQuat = new p5.Quat(0, this.upX, this.upY, this.upZ);
+      const newUpVector = axisQuaternion.rotateVector(
+        new p5.Vector(this.upX, this.upY, this.upZ));
+      this.camera(
+        this.eyeX,
+        this.eyeY,
+        this.eyeZ,
+        this.centerX,
+        this.centerY,
+        this.centerZ,
+        newUpVector.x,
+        newUpVector.y,
+        newUpVector.z
+      );
+    }
+
+    /**
+   * Rotates the camera left and right.
+   *
+   * Panning rotates the camera without changing its position. The rotation
+   * happens in the camera’s "local" space.
+   *
+   * The parameter, `angle`, is the angle the camera should rotate. Passing a
+   * positive angle, as in `myCamera.pan(0.001)`, rotates the camera to the
+   * right. Passing a negative angle, as in `myCamera.pan(-0.001)`, rotates the
+   * camera to the left.
+   *
+   * Note: Angles are interpreted based on the current
+   * <a href="#/p5/angleMode">angleMode()</a>.
+   *
+   * @param {Number} angle amount to rotate in the current
+   *                       <a href="#/p5/angleMode">angleMode()</a>.
+   *
+   * @example
+   * <div>
+   * <code>
+   * let cam;
+   * let delta = 0.001;
+   *
+   * function setup() {
+   *   createCanvas(100, 100, WEBGL);
+   *
+   *   // Create a p5.Camera object.
+   *   cam = createCamera();
+   *
+   *   // Place the camera at the top-center.
+   *   cam.setPosition(0, -400, 800);
+   *
+   *   // Point the camera at the origin.
+   *   cam.lookAt(0, 0, 0);
+   *
+   *   describe(
+   *     'A white cube on a gray background. The cube goes in and out of view as the camera pans left and right.'
+   *   );
+   * }
+   *
+   * function draw() {
+   *   background(200);
+   *
+   *   // Pan with the camera.
+   *   cam.pan(delta);
+   *
+   *   // Switch directions every 120 frames.
+   *   if (frameCount % 120 === 0) {
+   *     delta *= -1;
+   *   }
+   *
+   *   // Draw the box.
+   *   box();
+   * }
+   * </code>
+   * </div>
+   */
+    pan(amount) {
+      const local = this._getLocalAxes();
+      this._rotateView(amount, local.y[0], local.y[1], local.y[2]);
+    }
+
+    /**
+   * Rotates the camera up and down.
+   *
+   * Tilting rotates the camera without changing its position. The rotation
+   * happens in the camera’s "local" space.
+   *
+   * The parameter, `angle`, is the angle the camera should rotate. Passing a
+   * positive angle, as in `myCamera.tilt(0.001)`, rotates the camera down.
+   * Passing a negative angle, as in `myCamera.tilt(-0.001)`, rotates the camera
+   * up.
+   *
+   * Note: Angles are interpreted based on the current
+   * <a href="#/p5/angleMode">angleMode()</a>.
+   *
+   * @param {Number} angle amount to rotate in the current
+   *                       <a href="#/p5/angleMode">angleMode()</a>.
+   *
+   * @example
+   * <div>
+   * <code>
+   * let cam;
+   * let delta = 0.001;
+   *
+   * function setup() {
+   *   createCanvas(100, 100, WEBGL);
+   *
+   *   // Create a p5.Camera object.
+   *   cam = createCamera();
+   *
+   *   // Place the camera at the top-center.
+   *   cam.setPosition(0, -400, 800);
+   *
+   *   // Point the camera at the origin.
+   *   cam.lookAt(0, 0, 0);
+   *
+   *   describe(
+   *     'A white cube on a gray background. The cube goes in and out of view as the camera tilts up and down.'
+   *   );
+   * }
+   *
+   * function draw() {
+   *   background(200);
+   *
+   *   // Pan with the camera.
+   *   cam.tilt(delta);
+   *
+   *   // Switch directions every 120 frames.
+   *   if (frameCount % 120 === 0) {
+   *     delta *= -1;
+   *   }
+   *
+   *   // Draw the box.
+   *   box();
+   * }
+   * </code>
+   * </div>
+   */
+    tilt(amount) {
+      const local = this._getLocalAxes();
+      this._rotateView(amount, local.x[0], local.x[1], local.x[2]);
+    }
+
+    /**
+   * Points the camera at a location.
+   *
+   * `myCamera.lookAt()` changes the camera’s orientation without changing its
+   * position.
+   *
+   * The parameters, `x`, `y`, and `z`, are the coordinates in "world" space
+   * where the camera should point. For example, calling
+   * `myCamera.lookAt(10, 20, 30)` points the camera at the coordinates
+   * `(10, 20, 30)`.
+   *
+   * @for p5.Camera
+   * @param {Number} x x-coordinate of the position where the camera should look in "world" space.
+   * @param {Number} y y-coordinate of the position where the camera should look in "world" space.
+   * @param {Number} z z-coordinate of the position where the camera should look in "world" space.
+   *
+   * @example
+   * <div>
+   * <code>
+   * // Double-click to look at a different cube.
+   *
+   * let cam;
+   * let isLookingLeft = true;
+   *
+   * function setup() {
+   *   createCanvas(100, 100, WEBGL);
+   *
+   *   // Create a p5.Camera object.
+   *   cam = createCamera();
+   *
+   *   // Place the camera at the top-center.
+   *   cam.setPosition(0, -400, 800);
+   *
+   *   // Point the camera at the origin.
+   *   cam.lookAt(-30, 0, 0);
+   *
+   *   describe(
+   *     'A red cube and a blue cube on a gray background. The camera switches focus between the cubes when the user double-clicks.'
+   *   );
+   * }
+   *
+   * function draw() {
+   *   background(200);
+   *
+   *   // Draw the box on the left.
+   *   push();
+   *   // Translate the origin to the left.
+   *   translate(-30, 0, 0);
+   *   // Style the box.
+   *   fill(255, 0, 0);
+   *   // Draw the box.
+   *   box(20);
+   *   pop();
+   *
+   *   // Draw the box on the right.
+   *   push();
+   *   // Translate the origin to the right.
+   *   translate(30, 0, 0);
+   *   // Style the box.
+   *   fill(0, 0, 255);
+   *   // Draw the box.
+   *   box(20);
+   *   pop();
+   * }
+   *
+   * // Change the camera's focus when the user double-clicks.
+   * function doubleClicked() {
+   *   if (isLookingLeft === true) {
+   *     cam.lookAt(30, 0, 0);
+   *     isLookingLeft = false;
+   *   } else {
+   *     cam.lookAt(-30, 0, 0);
+   *     isLookingLeft = true;
+   *   }
+   * }
+   * </code>
+   * </div>
+   */
+    lookAt(x, y, z) {
+      this.camera(
+        this.eyeX,
+        this.eyeY,
+        this.eyeZ,
+        x,
+        y,
+        z,
+        this.upX,
+        this.upY,
+        this.upZ
+      );
+    }
+
+    ////////////////////////////////////////////////////////////////////////////////
+    // Camera Position Methods
+    ////////////////////////////////////////////////////////////////////////////////
+
+    /**
+   * Sets the position and orientation of the camera.
+   *
+   * `myCamera.camera()` allows objects to be viewed from different angles. It
+   * has nine parameters that are all optional.
+   *
+   * The first three parameters, `x`, `y`, and `z`, are the coordinates of the
+   * camera’s position in "world" space. For example, calling
+   * `myCamera.camera(0, 0, 0)` places the camera at the origin `(0, 0, 0)`. By
+   * default, the camera is placed at `(0, 0, 800)`.
+   *
+   * The next three parameters, `centerX`, `centerY`, and `centerZ` are the
+   * coordinates of the point where the camera faces in "world" space. For
+   * example, calling `myCamera.camera(0, 0, 0, 10, 20, 30)` places the camera
+   * at the origin `(0, 0, 0)` and points it at `(10, 20, 30)`. By default, the
+   * camera points at the origin `(0, 0, 0)`.
+   *
+   * The last three parameters, `upX`, `upY`, and `upZ` are the components of
+   * the "up" vector in "local" space. The "up" vector orients the camera’s
+   * y-axis. For example, calling
+   * `myCamera.camera(0, 0, 0, 10, 20, 30, 0, -1, 0)` places the camera at the
+   * origin `(0, 0, 0)`, points it at `(10, 20, 30)`, and sets the "up" vector
+   * to `(0, -1, 0)` which is like holding it upside-down. By default, the "up"
+   * vector is `(0, 1, 0)`.
+   *
+   * @for p5.Camera
+   * @param  {Number} [x]        x-coordinate of the camera. Defaults to 0.
+   * @param  {Number} [y]        y-coordinate of the camera. Defaults to 0.
+   * @param  {Number} [z]        z-coordinate of the camera. Defaults to 800.
+   * @param  {Number} [centerX]  x-coordinate of the point the camera faces. Defaults to 0.
+   * @param  {Number} [centerY]  y-coordinate of the point the camera faces. Defaults to 0.
+   * @param  {Number} [centerZ]  z-coordinate of the point the camera faces. Defaults to 0.
+   * @param  {Number} [upX]      x-component of the camera’s "up" vector. Defaults to 0.
+   * @param  {Number} [upY]      x-component of the camera’s "up" vector. Defaults to 1.
+   * @param  {Number} [upZ]      z-component of the camera’s "up" vector. Defaults to 0.
+   *
+   * @example
+   * <div>
+   * <code>
+   * // Double-click to toggle between cameras.
+   *
+   * let cam1;
+   * let cam2;
+   * let isDefaultCamera = true;
+   *
+   * function setup() {
+   *   createCanvas(100, 100, WEBGL);
+   *
+   *   // Create the first camera.
+   *   // Keep its default settings.
+   *   cam1 = createCamera();
+   *
+   *   // Create the second camera.
+   *   cam2 = createCamera();
+   *
+   *   // Place it at the top-right: (1200, -600, 100)
+   *   // Point it at the row of boxes: (-10, -10, 400)
+   *   // Set its "up" vector to the default: (0, 1, 0)
+   *   cam2.camera(1200, -600, 100, -10, -10, 400, 0, 1, 0);
+   *
+   *   // Set the current camera to cam1.
+   *   setCamera(cam1);
+   *
+   *   describe(
+   *     'A row of white cubes against a gray background. The camera toggles between a frontal and an aerial view when the user double-clicks.'
+   *   );
+   * }
+   *
+   * function draw() {
+   *   background(200);
+   *
+   *   // Translate the origin toward the camera.
+   *   translate(-10, 10, 500);
+   *
+   *   // Rotate the coordinate system.
+   *   rotateY(-0.1);
+   *   rotateX(-0.1);
+   *
+   *   // Draw the row of boxes.
+   *   for (let i = 0; i < 6; i += 1) {
+   *     translate(0, 0, -30);
+   *     box(10);
+   *   }
+   * }
+   *
+   * // Toggle the current camera when the user double-clicks.
+   * function doubleClicked() {
+   *   if (isDefaultCamera === true) {
+   *     setCamera(cam2);
+   *     isDefaultCamera = false;
+   *   } else {
+   *     setCamera(cam1);
+   *     isDefaultCamera = true;
+   *   }
+   * }
+   * </code>
+   * </div>
+   *
+   * <div>
+   * <code>
+   * // Double-click to toggle between cameras.
+   *
+   * let cam1;
+   * let cam2;
+   * let isDefaultCamera = true;
+   *
+   * function setup() {
+   *   createCanvas(100, 100, WEBGL);
+   *
+   *   // Create the first camera.
+   *   // Keep its default settings.
+   *   cam1 = createCamera();
+   *
+   *   // Create the second camera.
+   *   cam2 = createCamera();
+   *
+   *   // Place it at the right: (1200, 0, 100)
+   *   // Point it at the row of boxes: (-10, -10, 400)
+   *   // Set its "up" vector to the default: (0, 1, 0)
+   *   cam2.camera(1200, 0, 100, -10, -10, 400, 0, 1, 0);
+   *
+   *   // Set the current camera to cam1.
+   *   setCamera(cam1);
+   *
+   *   describe(
+   *     'A row of white cubes against a gray background. The camera toggles between a static frontal view and an orbiting view when the user double-clicks.'
+   *   );
+   * }
+   *
+   * function draw() {
+   *   background(200);
+   *
+   *   // Update cam2's position.
+   *   let x = 1200 * cos(frameCount * 0.01);
+   *   let y = -600 * sin(frameCount * 0.01);
+   *   cam2.camera(x, y, 100, -10, -10, 400, 0, 1, 0);
+   *
+   *   // Translate the origin toward the camera.
+   *   translate(-10, 10, 500);
+   *
+   *   // Rotate the coordinate system.
+   *   rotateY(-0.1);
+   *   rotateX(-0.1);
+   *
+   *   // Draw the row of boxes.
+   *   for (let i = 0; i < 6; i += 1) {
+   *     translate(0, 0, -30);
+   *     box(10);
+   *   }
+   * }
+   *
+   * // Toggle the current camera when the user double-clicks.
+   * function doubleClicked() {
+   *   if (isDefaultCamera === true) {
+   *     setCamera(cam2);
+   *     isDefaultCamera = false;
+   *   } else {
+   *     setCamera(cam1);
+   *     isDefaultCamera = true;
+   *   }
+   * }
+   * </code>
+   * </div>
+   */
+    camera(
+      eyeX,
+      eyeY,
+      eyeZ,
+      centerX,
+      centerY,
+      centerZ,
+      upX,
+      upY,
+      upZ
+    ) {
+      if (typeof eyeX === 'undefined') {
+        eyeX = this.defaultEyeX;
+        eyeY = this.defaultEyeY;
+        eyeZ = this.defaultEyeZ;
+        centerX = eyeX;
+        centerY = eyeY;
+        centerZ = 0;
+        upX = 0;
+        upY = 1;
+        upZ = 0;
+      }
+
+      this.eyeX = eyeX;
+      this.eyeY = eyeY;
+      this.eyeZ = eyeZ;
+
+      if (typeof centerX !== 'undefined') {
+        this.centerX = centerX;
+        this.centerY = centerY;
+        this.centerZ = centerZ;
+      }
+
+      if (typeof upX !== 'undefined') {
+        this.upX = upX;
+        this.upY = upY;
+        this.upZ = upZ;
+      }
+
+      const local = this._getLocalAxes();
+
+      // the camera affects the model view matrix, insofar as it
+      // inverse translates the world to the eye position of the camera
+      // and rotates it.
+      /* eslint-disable indent */
+      this.cameraMatrix.set(local.x[0], local.y[0], local.z[0], 0,
+        local.x[1], local.y[1], local.z[1], 0,
+        local.x[2], local.y[2], local.z[2], 0,
+        0, 0, 0, 1);
+      /* eslint-enable indent */
+
+      const tx = -eyeX;
+      const ty = -eyeY;
+      const tz = -eyeZ;
+
+      this.cameraMatrix.translate([tx, ty, tz]);
+
+      if (this._isActive()) {
+        this._renderer.states.uViewMatrix.set(this.cameraMatrix);
+      }
+      return this;
+    }
+
+    /**
+   * Moves the camera along its "local" axes without changing its orientation.
+   *
+   * The parameters, `x`, `y`, and `z`, are the distances the camera should
+   * move. For example, calling `myCamera.move(10, 20, 30)` moves the camera 10
+   * pixels to the right, 20 pixels down, and 30 pixels backward in its "local"
+   * space.
+   *
+   * @param {Number} x distance to move along the camera’s "local" x-axis.
+   * @param {Number} y distance to move along the camera’s "local" y-axis.
+   * @param {Number} z distance to move along the camera’s "local" z-axis.
+   * @example
+   * <div>
+   * <code>
+   * // Click the canvas to begin detecting key presses.
+   *
+   * let cam;
+   *
+   * function setup() {
+   *   createCanvas(100, 100, WEBGL);
+   *
+   *   // Create the first camera.
+   *   // Keep its default settings.
+   *   cam = createCamera();
+   *
+   *   // Place the camera at the top-right.
+   *   cam.setPosition(400, -400, 800);
+   *
+   *   // Point it at the origin.
+   *   cam.lookAt(0, 0, 0);
+   *
+   *   describe(
+   *     'A white cube drawn against a gray background. The cube appears to move when the user presses certain keys.'
+   *   );
+   * }
+   *
+   * function draw() {
+   *   background(200);
+   *
+   *   // Move the camera along its "local" axes
+   *   // when the user presses certain keys.
+   *   if (keyIsPressed === true) {
+   *
+   *     // Move horizontally.
+   *     if (keyCode === LEFT_ARROW) {
+   *       cam.move(-1, 0, 0);
+   *     }
+   *     if (keyCode === RIGHT_ARROW) {
+   *       cam.move(1, 0, 0);
+   *     }
+   *
+   *     // Move vertically.
+   *     if (keyCode === UP_ARROW) {
+   *       cam.move(0, -1, 0);
+   *     }
+   *     if (keyCode === DOWN_ARROW) {
+   *       cam.move(0, 1, 0);
+   *     }
+   *
+   *     // Move in/out of the screen.
+   *     if (key === 'i') {
+   *       cam.move(0, 0, -1);
+   *     }
+   *     if (key === 'o') {
+   *       cam.move(0, 0, 1);
+   *     }
+   *   }
+   *
+   *   // Draw the box.
+   *   box();
+   * }
+   * </code>
+   * </div>
+   */
+    move(x, y, z) {
+      const local = this._getLocalAxes();
+
+      // scale local axes by movement amounts
+      // based on http://learnwebgl.brown37.net/07_cameras/camera_linear_motion.html
+      const dx = [local.x[0] * x, local.x[1] * x, local.x[2] * x];
+      const dy = [local.y[0] * y, local.y[1] * y, local.y[2] * y];
+      const dz = [local.z[0] * z, local.z[1] * z, local.z[2] * z];
+
+      this.camera(
+        this.eyeX + dx[0] + dy[0] + dz[0],
+        this.eyeY + dx[1] + dy[1] + dz[1],
+        this.eyeZ + dx[2] + dy[2] + dz[2],
+        this.centerX + dx[0] + dy[0] + dz[0],
+        this.centerY + dx[1] + dy[1] + dz[1],
+        this.centerZ + dx[2] + dy[2] + dz[2],
+        this.upX,
+        this.upY,
+        this.upZ
+      );
+    }
+
+    /**
+   * Sets the camera’s position in "world" space without changing its
+   * orientation.
+   *
+   * The parameters, `x`, `y`, and `z`, are the coordinates where the camera
+   * should be placed. For example, calling `myCamera.setPosition(10, 20, 30)`
+   * places the camera at coordinates `(10, 20, 30)` in "world" space.
+   *
+   * @param {Number} x x-coordinate in "world" space.
+   * @param {Number} y y-coordinate in "world" space.
+   * @param {Number} z z-coordinate in "world" space.
+   *
+   * @example
+   * <div>
+   * <code>
+   * // Double-click to toggle between cameras.
+   *
+   * let cam1;
+   * let cam2;
+   * let isDefaultCamera = true;
+   *
+   * function setup() {
+   *   createCanvas(100, 100, WEBGL);
+   *
+   *   // Create the first camera.
+   *   // Keep its default settings.
+   *   cam1 = createCamera();
+   *
+   *   // Create the second camera.
+   *   cam2 = createCamera();
+   *
+   *   // Place it closer to the origin.
+   *   cam2.setPosition(0, 0, 600);
+   *
+   *   // Set the current camera to cam1.
+   *   setCamera(cam1);
+   *
+   *   describe(
+   *     'A row of white cubes against a gray background. The camera toggles the amount of zoom when the user double-clicks.'
+   *   );
+   * }
+   *
+   * function draw() {
+   *   background(200);
+   *
+   *   // Translate the origin toward the camera.
+   *   translate(-10, 10, 500);
+   *
+   *   // Rotate the coordinate system.
+   *   rotateY(-0.1);
+   *   rotateX(-0.1);
+   *
+   *   // Draw the row of boxes.
+   *   for (let i = 0; i < 6; i += 1) {
+   *     translate(0, 0, -30);
+   *     box(10);
+   *   }
+   * }
+   *
+   * // Toggle the current camera when the user double-clicks.
+   * function doubleClicked() {
+   *   if (isDefaultCamera === true) {
+   *     setCamera(cam2);
+   *     isDefaultCamera = false;
+   *   } else {
+   *     setCamera(cam1);
+   *     isDefaultCamera = true;
+   *   }
+   * }
+   * </code>
+   * </div>
+   *
+   * <div>
+   * <code>
+   * // Double-click to toggle between cameras.
+   *
+   * let cam1;
+   * let cam2;
+   * let isDefaultCamera = true;
+   *
+   * function setup() {
+   *   createCanvas(100, 100, WEBGL);
+   *
+   *   // Create the first camera.
+   *   // Keep its default settings.
+   *   cam1 = createCamera();
+   *
+   *   // Create the second camera.
+   *   cam2 = createCamera();
+   *
+   *   // Place it closer to the origin.
+   *   cam2.setPosition(0, 0, 600);
+   *
+   *   // Set the current camera to cam1.
+   *   setCamera(cam1);
+   *
+   *   describe(
+   *     'A row of white cubes against a gray background. The camera toggles between a static view and a view that zooms in and out when the user double-clicks.'
+   *   );
+   * }
+   *
+   * function draw() {
+   *   background(200);
+   *
+   *   // Update cam2's z-coordinate.
+   *   let z = 100 * sin(frameCount * 0.01) + 700;
+   *   cam2.setPosition(0, 0, z);
+   *
+   *   // Translate the origin toward the camera.
+   *   translate(-10, 10, 500);
+   *
+   *   // Rotate the coordinate system.
+   *   rotateY(-0.1);
+   *   rotateX(-0.1);
+   *
+   *   // Draw the row of boxes.
+   *   for (let i = 0; i < 6; i += 1) {
+   *     translate(0, 0, -30);
+   *     box(10);
+   *   }
+   * }
+   *
+   * // Toggle the current camera when the user double-clicks.
+   * function doubleClicked() {
+   *   if (isDefaultCamera === true) {
+   *     setCamera(cam2);
+   *     isDefaultCamera = false;
+   *   } else {
+   *     setCamera(cam1);
+   *     isDefaultCamera = true;
+   *   }
+   * }
+   * </code>
+   * </div>
+   */
+    setPosition(x, y, z) {
+      const diffX = x - this.eyeX;
+      const diffY = y - this.eyeY;
+      const diffZ = z - this.eyeZ;
+
+      this.camera(
+        x,
+        y,
+        z,
+        this.centerX + diffX,
+        this.centerY + diffY,
+        this.centerZ + diffZ,
+        this.upX,
+        this.upY,
+        this.upZ
+      );
+    }
+
+    /**
+   * Sets the camera’s position, orientation, and projection by copying another
+   * camera.
+   *
+   * The parameter, `cam`, is the `p5.Camera` object to copy. For example, calling
+   * `cam2.set(cam1)` will set `cam2` using `cam1`’s configuration.
+   *
+   * @param {p5.Camera} cam camera to copy.
+   *
+   * @example
+   * <div>
+   * <code>
+   * // Double-click to "reset" the camera zoom.
+   *
+   * let cam1;
+   * let cam2;
+   *
+   * function setup() {
+   *   createCanvas(100, 100, WEBGL);
+   *
+   *   // Create the first camera.
+   *   cam1 = createCamera();
+   *
+   *   // Place the camera at the top-right.
+   *   cam1.setPosition(400, -400, 800);
+   *
+   *   // Point it at the origin.
+   *   cam1.lookAt(0, 0, 0);
+   *
+   *   // Create the second camera.
+   *   cam2 = createCamera();
+   *
+   *   // Copy cam1's configuration.
+   *   cam2.set(cam1);
+   *
+   *   describe(
+   *     'A white cube drawn against a gray background. The camera slowly moves forward. The camera resets when the user double-clicks.'
+   *   );
+   * }
+   *
+   * function draw() {
+   *   background(200);
+   *
+   *   // Update cam2's position.
+   *   cam2.move(0, 0, -1);
+   *
+   *   // Draw the box.
+   *   box();
+   * }
+   *
+   * // "Reset" the camera when the user double-clicks.
+   * function doubleClicked() {
+   *   cam2.set(cam1);
+   * }
+   */
+    set(cam) {
+      const keyNamesOfThePropToCopy = [
+        'eyeX', 'eyeY', 'eyeZ',
+        'centerX', 'centerY', 'centerZ',
+        'upX', 'upY', 'upZ',
+        'cameraFOV', 'aspectRatio', 'cameraNear', 'cameraFar', 'cameraType',
+        'yScale'
+      ];
+      for (const keyName of keyNamesOfThePropToCopy) {
+        this[keyName] = cam[keyName];
+      }
+
+      this.cameraMatrix = cam.cameraMatrix.copy();
+      this.projMatrix = cam.projMatrix.copy();
+
+      if (this._isActive()) {
+        this._renderer.states.uModelMatrix.reset();
+        this._renderer.states.uViewMatrix.set(this.cameraMatrix);
+        this._renderer.states.uPMatrix.set(this.projMatrix);
+      }
+    }
+    /**
+   * Sets the camera’s position and orientation to values that are in-between
+   * those of two other cameras.
+   *
+   * `myCamera.slerp()` uses spherical linear interpolation to calculate a
+   * position and orientation that’s in-between two other cameras. Doing so is
+   * helpful for transitioning smoothly between two perspectives.
+   *
+   * The first two parameters, `cam0` and `cam1`, are the `p5.Camera` objects
+   * that should be used to set the current camera.
+   *
+   * The third parameter, `amt`, is the amount to interpolate between `cam0` and
+   * `cam1`. 0.0 keeps the camera’s position and orientation equal to `cam0`’s,
+   * 0.5 sets them halfway between `cam0`’s and `cam1`’s , and 1.0 sets the
+   * position and orientation equal to `cam1`’s.
+   *
+   * For example, calling `myCamera.slerp(cam0, cam1, 0.1)` sets cam’s position
+   * and orientation very close to `cam0`’s. Calling
+   * `myCamera.slerp(cam0, cam1, 0.9)` sets cam’s position and orientation very
+   * close to `cam1`’s.
+   *
+   * Note: All of the cameras must use the same projection.
+   *
+   * @param {p5.Camera} cam0 first camera.
+   * @param {p5.Camera} cam1 second camera.
+   * @param {Number} amt amount of interpolation between 0.0 (`cam0`) and 1.0 (`cam1`).
+   *
+   * @example
+   * <div>
+   * <code>
+   * let cam;
+   * let cam0;
+   * let cam1;
+   *
+   * function setup() {
+   *   createCanvas(100, 100, WEBGL);
+   *
+   *   // Create the main camera.
+   *   // Keep its default settings.
+   *   cam = createCamera();
+   *
+   *   // Create the first camera.
+   *   // Keep its default settings.
+   *   cam0 = createCamera();
+   *
+   *   // Create the second camera.
+   *   cam1 = createCamera();
+   *
+   *   // Place it at the top-right.
+   *   cam1.setPosition(400, -400, 800);
+   *
+   *   // Point it at the origin.
+   *   cam1.lookAt(0, 0, 0);
+   *
+   *   // Set the current camera to cam.
+   *   setCamera(cam);
+   *
+   *   describe('A white cube drawn against a gray background. The camera slowly oscillates between a frontal view and an aerial view.');
+   * }
+   *
+   * function draw() {
+   *   background(200);
+   *
+   *   // Calculate the amount to interpolate between cam0 and cam1.
+   *   let amt = 0.5 * sin(frameCount * 0.01) + 0.5;
+   *
+   *   // Update the main camera's position and orientation.
+   *   cam.slerp(cam0, cam1, amt);
+   *
+   *   box();
+   * }
+   * </code>
+   * </div>
+   */
+    slerp(cam0, cam1, amt) {
+      // If t is 0 or 1, do not interpolate and set the argument camera.
+      if (amt === 0) {
+        this.set(cam0);
+        return;
+      } else if (amt === 1) {
+        this.set(cam1);
+        return;
+      }
+
+      // For this cameras is ortho, assume that cam0 and cam1 are also ortho
+      // and interpolate the elements of the projection matrix.
+      // Use logarithmic interpolation for interpolation.
+      if (this.projMatrix.mat4[15] !== 0) {
+        this.projMatrix.mat4[0] =
+          cam0.projMatrix.mat4[0] *
+          Math.pow(cam1.projMatrix.mat4[0] / cam0.projMatrix.mat4[0], amt);
+        this.projMatrix.mat4[5] =
+          cam0.projMatrix.mat4[5] *
+          Math.pow(cam1.projMatrix.mat4[5] / cam0.projMatrix.mat4[5], amt);
+        // If the camera is active, make uPMatrix reflect changes in projMatrix.
+        if (this._isActive()) {
+          this._renderer.states.uPMatrix.mat4 = this.projMatrix.mat4.slice();
+        }
+      }
+
+      // prepare eye vector and center vector of argument cameras.
+      const eye0 = new p5.Vector(cam0.eyeX, cam0.eyeY, cam0.eyeZ);
+      const eye1 = new p5.Vector(cam1.eyeX, cam1.eyeY, cam1.eyeZ);
+      const center0 = new p5.Vector(cam0.centerX, cam0.centerY, cam0.centerZ);
+      const center1 = new p5.Vector(cam1.centerX, cam1.centerY, cam1.centerZ);
+
+      // Calculate the distance between eye and center for each camera.
+      // Logarithmically interpolate these with amt.
+      const dist0 = p5.Vector.dist(eye0, center0);
+      const dist1 = p5.Vector.dist(eye1, center1);
+      const lerpedDist = dist0 * Math.pow(dist1 / dist0, amt);
+
+      // Next, calculate the ratio to interpolate the eye and center by a constant
+      // ratio for each camera. This ratio is the same for both. Also, with this ratio
+      // of points, the distance is the minimum distance of the two points of
+      // the same ratio.
+      // With this method, if the viewpoint is fixed, linear interpolation is performed
+      // at the viewpoint, and if the center is fixed, linear interpolation is performed
+      // at the center, resulting in reasonable interpolation. If both move, the point
+      // halfway between them is taken.
+      const eyeDiff = p5.Vector.sub(eye0, eye1);
+      const diffDiff = eye0.copy().sub(eye1).sub(center0).add(center1);
+      // Suppose there are two line segments. Consider the distance between the points
+      // above them as if they were taken in the same ratio. This calculation figures out
+      // a ratio that minimizes this.
+      // Each line segment is, a line segment connecting the viewpoint and the center
+      // for each camera.
+      const divider = diffDiff.magSq();
+      let ratio = 1; // default.
+      if (divider > 0.000001) {
+        ratio = p5.Vector.dot(eyeDiff, diffDiff) / divider;
+        ratio = Math.max(0, Math.min(ratio, 1));
+      }
+
+      // Take the appropriate proportions and work out the points
+      // that are between the new viewpoint and the new center position.
+      const lerpedMedium = p5.Vector.lerp(
+        p5.Vector.lerp(eye0, center0, ratio),
+        p5.Vector.lerp(eye1, center1, ratio),
+        amt
+      );
+
+      // Prepare each of rotation matrix from their camera matrix
+      const rotMat0 = cam0.cameraMatrix.createSubMatrix3x3();
+      const rotMat1 = cam1.cameraMatrix.createSubMatrix3x3();
+
+      // get front and up vector from local-coordinate-system.
+      const front0 = rotMat0.row(2);
+      const front1 = rotMat1.row(2);
+      const up0 = rotMat0.row(1);
+      const up1 = rotMat1.row(1);
+
+      // prepare new vectors.
+      const newFront = new p5.Vector();
+      const newUp = new p5.Vector();
+      const newEye = new p5.Vector();
+      const newCenter = new p5.Vector();
+
+      // Create the inverse matrix of mat0 by transposing mat0,
+      // and multiply it to mat1 from the right.
+      // This matrix represents the difference between the two.
+      // 'deltaRot' means 'difference of rotation matrices'.
+      const deltaRot = rotMat1.mult3x3(rotMat0.copy().transpose3x3());
+
+      // Calculate the trace and from it the cos value of the angle.
+      // An orthogonal matrix is just an orthonormal basis. If this is not the identity
+      // matrix, it is a centered orthonormal basis plus some angle of rotation about
+      // some axis. That's the angle. Letting this be theta, trace becomes 1+2cos(theta).
+      // reference: https://en.wikipedia.org/wiki/Rotation_matrix#Determining_the_angle
+      const diag = deltaRot.diagonal();
+      let cosTheta = 0.5 * (diag[0] + diag[1] + diag[2] - 1);
+
+      // If the angle is close to 0, the two matrices are very close,
+      // so in that case we execute linearly interpolate.
+      if (1 - cosTheta < 0.0000001) {
+        // Obtain the front vector and up vector by linear interpolation
+        // and normalize them.
+        // calculate newEye, newCenter with newFront vector.
+        newFront.set(p5.Vector.lerp(front0, front1, amt)).normalize();
+
+        newEye.set(newFront).mult(ratio * lerpedDist).add(lerpedMedium);
+        newCenter.set(newFront).mult((ratio - 1) * lerpedDist).add(lerpedMedium);
+
+        newUp.set(p5.Vector.lerp(up0, up1, amt)).normalize();
+
+        // set the camera
+        this.camera(
+          newEye.x, newEye.y, newEye.z,
+          newCenter.x, newCenter.y, newCenter.z,
+          newUp.x, newUp.y, newUp.z
+        );
+        return;
+      }
+
+      // Calculates the axis vector and the angle of the difference orthogonal matrix.
+      // The axis vector is what I explained earlier in the comments.
+      // similar calculation is here:
+      // https://github.com/mrdoob/three.js/blob/883249620049d1632e8791732808fefd1a98c871/src/math/Quaternion.js#L294
+      let a, b, c, sinTheta;
+      let invOneMinusCosTheta = 1 / (1 - cosTheta);
+      const maxDiag = Math.max(diag[0], diag[1], diag[2]);
+      const offDiagSum13 = deltaRot.mat3[1] + deltaRot.mat3[3];
+      const offDiagSum26 = deltaRot.mat3[2] + deltaRot.mat3[6];
+      const offDiagSum57 = deltaRot.mat3[5] + deltaRot.mat3[7];
+
+      if (maxDiag === diag[0]) {
+        a = Math.sqrt((diag[0] - cosTheta) * invOneMinusCosTheta); // not zero.
+        invOneMinusCosTheta /= a;
+        b = 0.5 * offDiagSum13 * invOneMinusCosTheta;
+        c = 0.5 * offDiagSum26 * invOneMinusCosTheta;
+        sinTheta = 0.5 * (deltaRot.mat3[7] - deltaRot.mat3[5]) / a;
+
+      } else if (maxDiag === diag[1]) {
+        b = Math.sqrt((diag[1] - cosTheta) * invOneMinusCosTheta); // not zero.
+        invOneMinusCosTheta /= b;
+        c = 0.5 * offDiagSum57 * invOneMinusCosTheta;
+        a = 0.5 * offDiagSum13 * invOneMinusCosTheta;
+        sinTheta = 0.5 * (deltaRot.mat3[2] - deltaRot.mat3[6]) / b;
+
+      } else {
+        c = Math.sqrt((diag[2] - cosTheta) * invOneMinusCosTheta); // not zero.
+        invOneMinusCosTheta /= c;
+        a = 0.5 * offDiagSum26 * invOneMinusCosTheta;
+        b = 0.5 * offDiagSum57 * invOneMinusCosTheta;
+        sinTheta = 0.5 * (deltaRot.mat3[3] - deltaRot.mat3[1]) / c;
+      }
+
+      // Constructs a new matrix after interpolating the angles.
+      // Multiplying mat0 by the first matrix yields mat1, but by creating a state
+      // in the middle of that matrix, you can obtain a matrix that is
+      // an intermediate state between mat0 and mat1.
+      const angle = amt * Math.atan2(sinTheta, cosTheta);
+      const cosAngle = Math.cos(angle);
+      const sinAngle = Math.sin(angle);
+      const oneMinusCosAngle = 1 - cosAngle;
+      const ab = a * b;
+      const bc = b * c;
+      const ca = c * a;
+      const lerpedRotMat = new p5.Matrix('mat3', [
+        cosAngle + oneMinusCosAngle * a * a,
+        oneMinusCosAngle * ab + sinAngle * c,
+        oneMinusCosAngle * ca - sinAngle * b,
+        oneMinusCosAngle * ab - sinAngle * c,
+        cosAngle + oneMinusCosAngle * b * b,
+        oneMinusCosAngle * bc + sinAngle * a,
+        oneMinusCosAngle * ca + sinAngle * b,
+        oneMinusCosAngle * bc - sinAngle * a,
+        cosAngle + oneMinusCosAngle * c * c
+      ]);
+
+      // Multiply this to mat0 from left to get the interpolated front vector.
       // calculate newEye, newCenter with newFront vector.
-      newFront.set(p5.Vector.lerp(front0, front1, amt)).normalize();
+      lerpedRotMat.multiplyVec3(front0, newFront);
 
       newEye.set(newFront).mult(ratio * lerpedDist).add(lerpedMedium);
       newCenter.set(newFront).mult((ratio - 1) * lerpedDist).add(lerpedMedium);
 
-      newUp.set(p5.Vector.lerp(up0, up1, amt)).normalize();
+      lerpedRotMat.multiplyVec3(up0, newUp);
 
-      // set the camera
+      // We also get the up vector in the same way and set the camera.
+      // The eye position and center position are calculated based on the front vector.
       this.camera(
         newEye.x, newEye.y, newEye.z,
         newCenter.x, newCenter.y, newCenter.z,
         newUp.x, newUp.y, newUp.z
       );
-      return;
     }
 
-    // Calculates the axis vector and the angle of the difference orthogonal matrix.
-    // The axis vector is what I explained earlier in the comments.
-    // similar calculation is here:
-    // https://github.com/mrdoob/three.js/blob/883249620049d1632e8791732808fefd1a98c871/src/math/Quaternion.js#L294
-    let a, b, c, sinTheta;
-    let invOneMinusCosTheta = 1 / (1 - cosTheta);
-    const maxDiag = Math.max(diag[0], diag[1], diag[2]);
-    const offDiagSum13 = deltaRot.mat3[1] + deltaRot.mat3[3];
-    const offDiagSum26 = deltaRot.mat3[2] + deltaRot.mat3[6];
-    const offDiagSum57 = deltaRot.mat3[5] + deltaRot.mat3[7];
+    ////////////////////////////////////////////////////////////////////////////////
+    // Camera Helper Methods
+    ////////////////////////////////////////////////////////////////////////////////
 
-    if (maxDiag === diag[0]) {
-      a = Math.sqrt((diag[0] - cosTheta) * invOneMinusCosTheta); // not zero.
-      invOneMinusCosTheta /= a;
-      b = 0.5 * offDiagSum13 * invOneMinusCosTheta;
-      c = 0.5 * offDiagSum26 * invOneMinusCosTheta;
-      sinTheta = 0.5 * (deltaRot.mat3[7] - deltaRot.mat3[5]) / a;
-
-    } else if (maxDiag === diag[1]) {
-      b = Math.sqrt((diag[1] - cosTheta) * invOneMinusCosTheta); // not zero.
-      invOneMinusCosTheta /= b;
-      c = 0.5 * offDiagSum57 * invOneMinusCosTheta;
-      a = 0.5 * offDiagSum13 * invOneMinusCosTheta;
-      sinTheta = 0.5 * (deltaRot.mat3[2] - deltaRot.mat3[6]) / b;
-
-    } else {
-      c = Math.sqrt((diag[2] - cosTheta) * invOneMinusCosTheta); // not zero.
-      invOneMinusCosTheta /= c;
-      a = 0.5 * offDiagSum26 * invOneMinusCosTheta;
-      b = 0.5 * offDiagSum57 * invOneMinusCosTheta;
-      sinTheta = 0.5 * (deltaRot.mat3[3] - deltaRot.mat3[1]) / c;
+    // @TODO: combine this function with _setDefaultCamera to compute these values
+    // as-needed
+    _computeCameraDefaultSettings() {
+      this.defaultAspectRatio = this._renderer.width / this._renderer.height;
+      this.defaultEyeX = 0;
+      this.defaultEyeY = 0;
+      this.defaultEyeZ = 800;
+      this.defaultCameraFOV =
+        2 * Math.atan(this._renderer.height / 2 / this.defaultEyeZ);
+      this.defaultCenterX = 0;
+      this.defaultCenterY = 0;
+      this.defaultCenterZ = 0;
+      this.defaultCameraNear = this.defaultEyeZ * 0.1;
+      this.defaultCameraFar = this.defaultEyeZ * 10;
     }
 
-    // Constructs a new matrix after interpolating the angles.
-    // Multiplying mat0 by the first matrix yields mat1, but by creating a state
-    // in the middle of that matrix, you can obtain a matrix that is
-    // an intermediate state between mat0 and mat1.
-    const angle = amt * Math.atan2(sinTheta, cosTheta);
-    const cosAngle = Math.cos(angle);
-    const sinAngle = Math.sin(angle);
-    const oneMinusCosAngle = 1 - cosAngle;
-    const ab = a * b;
-    const bc = b * c;
-    const ca = c * a;
-    const lerpedRotMat = new p5.Matrix('mat3', [
-      cosAngle + oneMinusCosAngle * a * a,
-      oneMinusCosAngle * ab + sinAngle * c,
-      oneMinusCosAngle * ca - sinAngle * b,
-      oneMinusCosAngle * ab - sinAngle * c,
-      cosAngle + oneMinusCosAngle * b * b,
-      oneMinusCosAngle * bc + sinAngle * a,
-      oneMinusCosAngle * ca + sinAngle * b,
-      oneMinusCosAngle * bc - sinAngle * a,
-      cosAngle + oneMinusCosAngle * c * c
-    ]);
-
-    // Multiply this to mat0 from left to get the interpolated front vector.
-    // calculate newEye, newCenter with newFront vector.
-    lerpedRotMat.multiplyVec3(front0, newFront);
-
-    newEye.set(newFront).mult(ratio * lerpedDist).add(lerpedMedium);
-    newCenter.set(newFront).mult((ratio - 1) * lerpedDist).add(lerpedMedium);
-
-    lerpedRotMat.multiplyVec3(up0, newUp);
-
-    // We also get the up vector in the same way and set the camera.
-    // The eye position and center position are calculated based on the front vector.
-    this.camera(
-      newEye.x, newEye.y, newEye.z,
-      newCenter.x, newCenter.y, newCenter.z,
-      newUp.x, newUp.y, newUp.z
-    );
-  }
-
-  ////////////////////////////////////////////////////////////////////////////////
-  // Camera Helper Methods
-  ////////////////////////////////////////////////////////////////////////////////
-
-  // @TODO: combine this function with _setDefaultCamera to compute these values
-  // as-needed
-  _computeCameraDefaultSettings() {
-    this.defaultAspectRatio = this._renderer.width / this._renderer.height;
-    this.defaultEyeX = 0;
-    this.defaultEyeY = 0;
-    this.defaultEyeZ = 800;
-    this.defaultCameraFOV =
-      2 * Math.atan(this._renderer.height / 2 / this.defaultEyeZ);
-    this.defaultCenterX = 0;
-    this.defaultCenterY = 0;
-    this.defaultCenterZ = 0;
-    this.defaultCameraNear = this.defaultEyeZ * 0.1;
-    this.defaultCameraFar = this.defaultEyeZ * 10;
-  }
-
-  //detect if user didn't set the camera
-  //then call this function below
-  _setDefaultCamera() {
-    this.cameraFOV = this.defaultCameraFOV;
-    this.aspectRatio = this.defaultAspectRatio;
-    this.eyeX = this.defaultEyeX;
-    this.eyeY = this.defaultEyeY;
-    this.eyeZ = this.defaultEyeZ;
-    this.centerX = this.defaultCenterX;
-    this.centerY = this.defaultCenterY;
-    this.centerZ = this.defaultCenterZ;
-    this.upX = 0;
-    this.upY = 1;
-    this.upZ = 0;
-    this.cameraNear = this.defaultCameraNear;
-    this.cameraFar = this.defaultCameraFar;
-
-    this.perspective();
-    this.camera();
-
-    this.cameraType = 'default';
-  }
-
-  _resize() {
-    // If we're using the default camera, update the aspect ratio
-    if (this.cameraType === 'default') {
-      this._computeCameraDefaultSettings();
+    //detect if user didn't set the camera
+    //then call this function below
+    _setDefaultCamera() {
       this.cameraFOV = this.defaultCameraFOV;
       this.aspectRatio = this.defaultAspectRatio;
+      this.eyeX = this.defaultEyeX;
+      this.eyeY = this.defaultEyeY;
+      this.eyeZ = this.defaultEyeZ;
+      this.centerX = this.defaultCenterX;
+      this.centerY = this.defaultCenterY;
+      this.centerZ = this.defaultCenterZ;
+      this.upX = 0;
+      this.upY = 1;
+      this.upZ = 0;
+      this.cameraNear = this.defaultCameraNear;
+      this.cameraFar = this.defaultCameraFar;
+
       this.perspective();
+      this.camera();
+
+      this.cameraType = 'default';
     }
-  }
+
+    _resize() {
+      // If we're using the default camera, update the aspect ratio
+      if (this.cameraType === 'default') {
+        this._computeCameraDefaultSettings();
+        this.cameraFOV = this.defaultCameraFOV;
+        this.aspectRatio = this.defaultAspectRatio;
+        this.perspective();
+      }
+    }
+
+    /**
+   * Returns a copy of a camera.
+   * @private
+   */
+    copy() {
+      const _cam = new p5.Camera(this._renderer);
+      _cam.cameraFOV = this.cameraFOV;
+      _cam.aspectRatio = this.aspectRatio;
+      _cam.eyeX = this.eyeX;
+      _cam.eyeY = this.eyeY;
+      _cam.eyeZ = this.eyeZ;
+      _cam.centerX = this.centerX;
+      _cam.centerY = this.centerY;
+      _cam.centerZ = this.centerZ;
+      _cam.upX = this.upX;
+      _cam.upY = this.upY;
+      _cam.upZ = this.upZ;
+      _cam.cameraNear = this.cameraNear;
+      _cam.cameraFar = this.cameraFar;
+
+      _cam.cameraType = this.cameraType;
+
+      _cam.cameraMatrix = this.cameraMatrix.copy();
+      _cam.projMatrix = this.projMatrix.copy();
+      _cam.yScale = this.yScale;
+
+      return _cam;
+    }
+
+    clone() {
+      return this.copy();
+    }
+
+    /**
+   * Returns a camera's local axes: left-right, up-down, and forward-backward,
+   * as defined by vectors in world-space.
+   * @private
+   */
+    _getLocalAxes() {
+      // calculate camera local Z vector
+      let z0 = this.eyeX - this.centerX;
+      let z1 = this.eyeY - this.centerY;
+      let z2 = this.eyeZ - this.centerZ;
+
+      // normalize camera local Z vector
+      const eyeDist = Math.sqrt(z0 * z0 + z1 * z1 + z2 * z2);
+      if (eyeDist !== 0) {
+        z0 /= eyeDist;
+        z1 /= eyeDist;
+        z2 /= eyeDist;
+      }
+
+      // calculate camera Y vector
+      let y0 = this.upX;
+      let y1 = this.upY;
+      let y2 = this.upZ;
+
+      // compute camera local X vector as up vector (local Y) cross local Z
+      let x0 = y1 * z2 - y2 * z1;
+      let x1 = -y0 * z2 + y2 * z0;
+      let x2 = y0 * z1 - y1 * z0;
+
+      // recompute y = z cross x
+      y0 = z1 * x2 - z2 * x1;
+      y1 = -z0 * x2 + z2 * x0;
+      y2 = z0 * x1 - z1 * x0;
+
+      // cross product gives area of parallelogram, which is < 1.0 for
+      // non-perpendicular unit-length vectors; so normalize x, y here:
+      const xmag = Math.sqrt(x0 * x0 + x1 * x1 + x2 * x2);
+      if (xmag !== 0) {
+        x0 /= xmag;
+        x1 /= xmag;
+        x2 /= xmag;
+      }
+
+      const ymag = Math.sqrt(y0 * y0 + y1 * y1 + y2 * y2);
+      if (ymag !== 0) {
+        y0 /= ymag;
+        y1 /= ymag;
+        y2 /= ymag;
+      }
+
+      return {
+        x: [x0, x1, x2],
+        y: [y0, y1, y2],
+        z: [z0, z1, z2]
+      };
+    }
+
+    /**
+   * Orbits the camera about center point. For use with orbitControl().
+   * @private
+   * @param {Number} dTheta change in spherical coordinate theta
+   * @param {Number} dPhi change in spherical coordinate phi
+   * @param {Number} dRadius change in radius
+   */
+    _orbit(dTheta, dPhi, dRadius) {
+      // Calculate the vector and its magnitude from the center to the viewpoint
+      const diffX = this.eyeX - this.centerX;
+      const diffY = this.eyeY - this.centerY;
+      const diffZ = this.eyeZ - this.centerZ;
+      let camRadius = Math.hypot(diffX, diffY, diffZ);
+      // front vector. unit vector from center to eye.
+      const front = new p5.Vector(diffX, diffY, diffZ).normalize();
+      // up vector. normalized camera's up vector.
+      const up = new p5.Vector(this.upX, this.upY, this.upZ).normalize(); // y-axis
+      // side vector. Right when viewed from the front
+      const side = p5.Vector.cross(up, front).normalize(); // x-axis
+      // vertical vector. normalized vector of projection of front vector.
+      const vertical = p5.Vector.cross(side, up); // z-axis
+
+      // update camRadius
+      camRadius *= Math.pow(10, dRadius);
+      // prevent zooming through the center:
+      if (camRadius < this.cameraNear) {
+        camRadius = this.cameraNear;
+      }
+      if (camRadius > this.cameraFar) {
+        camRadius = this.cameraFar;
+      }
+
+      // calculate updated camera angle
+      // Find the angle between the "up" and the "front", add dPhi to that.
+      // angleBetween() may return negative value. Since this specification is subject to change
+      // due to version updates, it cannot be adopted, so here we calculate using a method
+      // that directly obtains the absolute value.
+      const camPhi =
+        Math.acos(Math.max(-1, Math.min(1, p5.Vector.dot(front, up)))) + dPhi;
+      // Rotate by dTheta in the shortest direction from "vertical" to "side"
+      const camTheta = dTheta;
+
+      // Invert camera's upX, upY, upZ if dPhi is below 0 or above PI
+      if (camPhi <= 0 || camPhi >= Math.PI) {
+        this.upX *= -1;
+        this.upY *= -1;
+        this.upZ *= -1;
+      }
+
+      // update eye vector by calculate new front vector
+      up.mult(Math.cos(camPhi));
+      vertical.mult(Math.cos(camTheta) * Math.sin(camPhi));
+      side.mult(Math.sin(camTheta) * Math.sin(camPhi));
+
+      front.set(up).add(vertical).add(side);
+
+      this.eyeX = camRadius * front.x + this.centerX;
+      this.eyeY = camRadius * front.y + this.centerY;
+      this.eyeZ = camRadius * front.z + this.centerZ;
+
+      // update camera
+      this.camera(
+        this.eyeX, this.eyeY, this.eyeZ,
+        this.centerX, this.centerY, this.centerZ,
+        this.upX, this.upY, this.upZ
+      );
+    }
+
+    /**
+   * Orbits the camera about center point. For use with orbitControl().
+   * Unlike _orbit(), the direction of rotation always matches the direction of pointer movement.
+   * @private
+   * @param {Number} dx the x component of the rotation vector.
+   * @param {Number} dy the y component of the rotation vector.
+   * @param {Number} dRadius change in radius
+   */
+    _orbitFree(dx, dy, dRadius) {
+      // Calculate the vector and its magnitude from the center to the viewpoint
+      const diffX = this.eyeX - this.centerX;
+      const diffY = this.eyeY - this.centerY;
+      const diffZ = this.eyeZ - this.centerZ;
+      let camRadius = Math.hypot(diffX, diffY, diffZ);
+      // front vector. unit vector from center to eye.
+      const front = new p5.Vector(diffX, diffY, diffZ).normalize();
+      // up vector. camera's up vector.
+      const up = new p5.Vector(this.upX, this.upY, this.upZ);
+      // side vector. Right when viewed from the front. (like x-axis)
+      const side = p5.Vector.cross(up, front).normalize();
+      // down vector. Bottom when viewed from the front. (like y-axis)
+      const down = p5.Vector.cross(front, side);
+
+      // side vector and down vector are no longer used as-is.
+      // Create a vector representing the direction of rotation
+      // in the form cos(direction)*side + sin(direction)*down.
+      // Make the current side vector into this.
+      const directionAngle = Math.atan2(dy, dx);
+      down.mult(Math.sin(directionAngle));
+      side.mult(Math.cos(directionAngle)).add(down);
+      // The amount of rotation is the size of the vector (dx, dy).
+      const rotAngle = Math.sqrt(dx * dx + dy * dy);
+      // The vector that is orthogonal to both the front vector and
+      // the rotation direction vector is the rotation axis vector.
+      const axis = p5.Vector.cross(front, side);
+
+      // update camRadius
+      camRadius *= Math.pow(10, dRadius);
+      // prevent zooming through the center:
+      if (camRadius < this.cameraNear) {
+        camRadius = this.cameraNear;
+      }
+      if (camRadius > this.cameraFar) {
+        camRadius = this.cameraFar;
+      }
+
+      // If the axis vector is likened to the z-axis, the front vector is
+      // the x-axis and the side vector is the y-axis. Rotate the up and front
+      // vectors respectively by thinking of them as rotations around the z-axis.
+
+      // Calculate the components by taking the dot product and
+      // calculate a rotation based on that.
+      const c = Math.cos(rotAngle);
+      const s = Math.sin(rotAngle);
+      const dotFront = up.dot(front);
+      const dotSide = up.dot(side);
+      const ux = dotFront * c + dotSide * s;
+      const uy = -dotFront * s + dotSide * c;
+      const uz = up.dot(axis);
+      up.x = ux * front.x + uy * side.x + uz * axis.x;
+      up.y = ux * front.y + uy * side.y + uz * axis.y;
+      up.z = ux * front.z + uy * side.z + uz * axis.z;
+      // We won't be using the side vector and the front vector anymore,
+      // so let's make the front vector into the vector from the center to the new eye.
+      side.mult(-s);
+      front.mult(c).add(side).mult(camRadius);
+
+      // it's complete. let's update camera.
+      this.camera(
+        front.x + this.centerX,
+        front.y + this.centerY,
+        front.z + this.centerZ,
+        this.centerX, this.centerY, this.centerZ,
+        up.x, up.y, up.z
+      );
+    }
+
+    /**
+   * Returns true if camera is currently attached to renderer.
+   * @private
+   */
+    _isActive() {
+      return this === this._renderer.states.curCamera;
+    }
+  };
 
   /**
- * Returns a copy of a camera.
- * @private
- */
-  copy() {
-    const _cam = new p5.Camera(this._renderer);
-    _cam.cameraFOV = this.cameraFOV;
-    _cam.aspectRatio = this.aspectRatio;
-    _cam.eyeX = this.eyeX;
-    _cam.eyeY = this.eyeY;
-    _cam.eyeZ = this.eyeZ;
-    _cam.centerX = this.centerX;
-    _cam.centerY = this.centerY;
-    _cam.centerZ = this.centerZ;
-    _cam.upX = this.upX;
-    _cam.upY = this.upY;
-    _cam.upZ = this.upZ;
-    _cam.cameraNear = this.cameraNear;
-    _cam.cameraFar = this.cameraFar;
+   * Sets the current (active) camera of a 3D sketch.
+   *
+   * `setCamera()` allows for switching between multiple cameras created with
+   * <a href="#/p5/createCamera">createCamera()</a>.
+   *
+   * Note: `setCamera()` can only be used in WebGL mode.
+   *
+   * @method setCamera
+   * @param  {p5.Camera} cam camera that should be made active.
+   * @for p5
+   *
+   * @example
+   * <div>
+   * <code>
+   * // Double-click to toggle between cameras.
+   *
+   * let cam1;
+   * let cam2;
+   * let usingCam1 = true;
+   *
+   * function setup() {
+   *   createCanvas(100, 100, WEBGL);
+   *
+   *   // Create the first camera.
+   *   // Keep its default settings.
+   *   cam1 = createCamera();
+   *
+   *   // Create the second camera.
+   *   // Place it at the top-left.
+   *   // Point it at the origin.
+   *   cam2 = createCamera();
+   *   cam2.setPosition(400, -400, 800);
+   *   cam2.lookAt(0, 0, 0);
+   *
+   *   // Set the current camera to cam1.
+   *   setCamera(cam1);
+   *
+   *   describe('A white cube on a gray background. The camera toggles between frontal and aerial views when the user double-clicks.');
+   * }
+   *
+   * function draw() {
+   *   background(200);
+   *
+   *   // Draw the box.
+   *   box();
+   * }
+   *
+   * // Toggle the current camera when the user double-clicks.
+   * function doubleClicked() {
+   *   if (usingCam1 === true) {
+   *     setCamera(cam2);
+   *     usingCam1 = false;
+   *   } else {
+   *     setCamera(cam1);
+   *     usingCam1 = true;
+   *   }
+   * }
+   * </code>
+   * </div>
+   */
+  fn.setCamera = function (cam) {
+    this._renderer.states.curCamera = cam;
 
-    _cam.cameraType = this.cameraType;
+    // set the projection matrix (which is not normally updated each frame)
+    this._renderer.states.uPMatrix.set(cam.projMatrix);
+    this._renderer.states.uViewMatrix.set(cam.cameraMatrix);
+  };
+}
 
-    _cam.cameraMatrix = this.cameraMatrix.copy();
-    _cam.projMatrix = this.projMatrix.copy();
-    _cam.yScale = this.yScale;
+export default camera;
 
-    return _cam;
-  }
-
-  clone() {
-    return this.copy();
-  }
-
-  /**
- * Returns a camera's local axes: left-right, up-down, and forward-backward,
- * as defined by vectors in world-space.
- * @private
- */
-  _getLocalAxes() {
-    // calculate camera local Z vector
-    let z0 = this.eyeX - this.centerX;
-    let z1 = this.eyeY - this.centerY;
-    let z2 = this.eyeZ - this.centerZ;
-
-    // normalize camera local Z vector
-    const eyeDist = Math.sqrt(z0 * z0 + z1 * z1 + z2 * z2);
-    if (eyeDist !== 0) {
-      z0 /= eyeDist;
-      z1 /= eyeDist;
-      z2 /= eyeDist;
-    }
-
-    // calculate camera Y vector
-    let y0 = this.upX;
-    let y1 = this.upY;
-    let y2 = this.upZ;
-
-    // compute camera local X vector as up vector (local Y) cross local Z
-    let x0 = y1 * z2 - y2 * z1;
-    let x1 = -y0 * z2 + y2 * z0;
-    let x2 = y0 * z1 - y1 * z0;
-
-    // recompute y = z cross x
-    y0 = z1 * x2 - z2 * x1;
-    y1 = -z0 * x2 + z2 * x0;
-    y2 = z0 * x1 - z1 * x0;
-
-    // cross product gives area of parallelogram, which is < 1.0 for
-    // non-perpendicular unit-length vectors; so normalize x, y here:
-    const xmag = Math.sqrt(x0 * x0 + x1 * x1 + x2 * x2);
-    if (xmag !== 0) {
-      x0 /= xmag;
-      x1 /= xmag;
-      x2 /= xmag;
-    }
-
-    const ymag = Math.sqrt(y0 * y0 + y1 * y1 + y2 * y2);
-    if (ymag !== 0) {
-      y0 /= ymag;
-      y1 /= ymag;
-      y2 /= ymag;
-    }
-
-    return {
-      x: [x0, x1, x2],
-      y: [y0, y1, y2],
-      z: [z0, z1, z2]
-    };
-  }
-
-  /**
- * Orbits the camera about center point. For use with orbitControl().
- * @private
- * @param {Number} dTheta change in spherical coordinate theta
- * @param {Number} dPhi change in spherical coordinate phi
- * @param {Number} dRadius change in radius
- */
-  _orbit(dTheta, dPhi, dRadius) {
-    // Calculate the vector and its magnitude from the center to the viewpoint
-    const diffX = this.eyeX - this.centerX;
-    const diffY = this.eyeY - this.centerY;
-    const diffZ = this.eyeZ - this.centerZ;
-    let camRadius = Math.hypot(diffX, diffY, diffZ);
-    // front vector. unit vector from center to eye.
-    const front = new p5.Vector(diffX, diffY, diffZ).normalize();
-    // up vector. normalized camera's up vector.
-    const up = new p5.Vector(this.upX, this.upY, this.upZ).normalize(); // y-axis
-    // side vector. Right when viewed from the front
-    const side = p5.Vector.cross(up, front).normalize(); // x-axis
-    // vertical vector. normalized vector of projection of front vector.
-    const vertical = p5.Vector.cross(side, up); // z-axis
-
-    // update camRadius
-    camRadius *= Math.pow(10, dRadius);
-    // prevent zooming through the center:
-    if (camRadius < this.cameraNear) {
-      camRadius = this.cameraNear;
-    }
-    if (camRadius > this.cameraFar) {
-      camRadius = this.cameraFar;
-    }
-
-    // calculate updated camera angle
-    // Find the angle between the "up" and the "front", add dPhi to that.
-    // angleBetween() may return negative value. Since this specification is subject to change
-    // due to version updates, it cannot be adopted, so here we calculate using a method
-    // that directly obtains the absolute value.
-    const camPhi =
-      Math.acos(Math.max(-1, Math.min(1, p5.Vector.dot(front, up)))) + dPhi;
-    // Rotate by dTheta in the shortest direction from "vertical" to "side"
-    const camTheta = dTheta;
-
-    // Invert camera's upX, upY, upZ if dPhi is below 0 or above PI
-    if (camPhi <= 0 || camPhi >= Math.PI) {
-      this.upX *= -1;
-      this.upY *= -1;
-      this.upZ *= -1;
-    }
-
-    // update eye vector by calculate new front vector
-    up.mult(Math.cos(camPhi));
-    vertical.mult(Math.cos(camTheta) * Math.sin(camPhi));
-    side.mult(Math.sin(camTheta) * Math.sin(camPhi));
-
-    front.set(up).add(vertical).add(side);
-
-    this.eyeX = camRadius * front.x + this.centerX;
-    this.eyeY = camRadius * front.y + this.centerY;
-    this.eyeZ = camRadius * front.z + this.centerZ;
-
-    // update camera
-    this.camera(
-      this.eyeX, this.eyeY, this.eyeZ,
-      this.centerX, this.centerY, this.centerZ,
-      this.upX, this.upY, this.upZ
-    );
-  }
-
-  /**
- * Orbits the camera about center point. For use with orbitControl().
- * Unlike _orbit(), the direction of rotation always matches the direction of pointer movement.
- * @private
- * @param {Number} dx the x component of the rotation vector.
- * @param {Number} dy the y component of the rotation vector.
- * @param {Number} dRadius change in radius
- */
-  _orbitFree(dx, dy, dRadius) {
-    // Calculate the vector and its magnitude from the center to the viewpoint
-    const diffX = this.eyeX - this.centerX;
-    const diffY = this.eyeY - this.centerY;
-    const diffZ = this.eyeZ - this.centerZ;
-    let camRadius = Math.hypot(diffX, diffY, diffZ);
-    // front vector. unit vector from center to eye.
-    const front = new p5.Vector(diffX, diffY, diffZ).normalize();
-    // up vector. camera's up vector.
-    const up = new p5.Vector(this.upX, this.upY, this.upZ);
-    // side vector. Right when viewed from the front. (like x-axis)
-    const side = p5.Vector.cross(up, front).normalize();
-    // down vector. Bottom when viewed from the front. (like y-axis)
-    const down = p5.Vector.cross(front, side);
-
-    // side vector and down vector are no longer used as-is.
-    // Create a vector representing the direction of rotation
-    // in the form cos(direction)*side + sin(direction)*down.
-    // Make the current side vector into this.
-    const directionAngle = Math.atan2(dy, dx);
-    down.mult(Math.sin(directionAngle));
-    side.mult(Math.cos(directionAngle)).add(down);
-    // The amount of rotation is the size of the vector (dx, dy).
-    const rotAngle = Math.sqrt(dx * dx + dy * dy);
-    // The vector that is orthogonal to both the front vector and
-    // the rotation direction vector is the rotation axis vector.
-    const axis = p5.Vector.cross(front, side);
-
-    // update camRadius
-    camRadius *= Math.pow(10, dRadius);
-    // prevent zooming through the center:
-    if (camRadius < this.cameraNear) {
-      camRadius = this.cameraNear;
-    }
-    if (camRadius > this.cameraFar) {
-      camRadius = this.cameraFar;
-    }
-
-    // If the axis vector is likened to the z-axis, the front vector is
-    // the x-axis and the side vector is the y-axis. Rotate the up and front
-    // vectors respectively by thinking of them as rotations around the z-axis.
-
-    // Calculate the components by taking the dot product and
-    // calculate a rotation based on that.
-    const c = Math.cos(rotAngle);
-    const s = Math.sin(rotAngle);
-    const dotFront = up.dot(front);
-    const dotSide = up.dot(side);
-    const ux = dotFront * c + dotSide * s;
-    const uy = -dotFront * s + dotSide * c;
-    const uz = up.dot(axis);
-    up.x = ux * front.x + uy * side.x + uz * axis.x;
-    up.y = ux * front.y + uy * side.y + uz * axis.y;
-    up.z = ux * front.z + uy * side.z + uz * axis.z;
-    // We won't be using the side vector and the front vector anymore,
-    // so let's make the front vector into the vector from the center to the new eye.
-    side.mult(-s);
-    front.mult(c).add(side).mult(camRadius);
-
-    // it's complete. let's update camera.
-    this.camera(
-      front.x + this.centerX,
-      front.y + this.centerY,
-      front.z + this.centerZ,
-      this.centerX, this.centerY, this.centerZ,
-      up.x, up.y, up.z
-    );
-  }
-
-  /**
- * Returns true if camera is currently attached to renderer.
- * @private
- */
-  _isActive() {
-    return this === this._renderer.states.curCamera;
-  }
-};
-
-/**
- * Sets the current (active) camera of a 3D sketch.
- *
- * `setCamera()` allows for switching between multiple cameras created with
- * <a href="#/p5/createCamera">createCamera()</a>.
- *
- * Note: `setCamera()` can only be used in WebGL mode.
- *
- * @method setCamera
- * @param  {p5.Camera} cam camera that should be made active.
- * @for p5
- *
- * @example
- * <div>
- * <code>
- * // Double-click to toggle between cameras.
- *
- * let cam1;
- * let cam2;
- * let usingCam1 = true;
- *
- * function setup() {
- *   createCanvas(100, 100, WEBGL);
- *
- *   // Create the first camera.
- *   // Keep its default settings.
- *   cam1 = createCamera();
- *
- *   // Create the second camera.
- *   // Place it at the top-left.
- *   // Point it at the origin.
- *   cam2 = createCamera();
- *   cam2.setPosition(400, -400, 800);
- *   cam2.lookAt(0, 0, 0);
- *
- *   // Set the current camera to cam1.
- *   setCamera(cam1);
- *
- *   describe('A white cube on a gray background. The camera toggles between frontal and aerial views when the user double-clicks.');
- * }
- *
- * function draw() {
- *   background(200);
- *
- *   // Draw the box.
- *   box();
- * }
- *
- * // Toggle the current camera when the user double-clicks.
- * function doubleClicked() {
- *   if (usingCam1 === true) {
- *     setCamera(cam2);
- *     usingCam1 = false;
- *   } else {
- *     setCamera(cam1);
- *     usingCam1 = true;
- *   }
- * }
- * </code>
- * </div>
- */
-p5.prototype.setCamera = function (cam) {
-  this._renderer.states.curCamera = cam;
-
-  // set the projection matrix (which is not normally updated each frame)
-  this._renderer.states.uPMatrix.set(cam.projMatrix);
-  this._renderer.states.uViewMatrix.set(cam.cameraMatrix);
-};
-
-export default p5.Camera;
+if(typeof p5 !== 'undefined'){
+  camera(p5, p5.prototype);
+}

--- a/src/webgl/p5.DataArray.js
+++ b/src/webgl/p5.DataArray.js
@@ -1,110 +1,114 @@
-import p5 from '../core/main';
-
-/**
- * An internal class to store data that will be sent to a p5.RenderBuffer.
- * Those need to eventually go into a Float32Array, so this class provides a
- * variable-length array container backed by a Float32Array so that it can be
- * sent to the GPU without allocating a new array each frame.
- *
- * Like a C++ vector, its fixed-length Float32Array backing its contents will
- * double in size when it goes over its capacity.
- *
- * @example
- * <div>
- * <code>
- * // Initialize storage with a capacity of 4
- * const storage = new DataArray(4);
- * console.log(storage.data.length); // 4
- * console.log(storage.length); // 0
- * console.log(storage.dataArray()); // Empty Float32Array
- *
- * storage.push(1, 2, 3, 4, 5, 6);
- * console.log(storage.data.length); // 8
- * console.log(storage.length); // 6
- * console.log(storage.dataArray()); // Float32Array{1, 2, 3, 4, 5, 6}
- * </code>
- * </div>
- */
-p5.DataArray = class DataArray {
-  constructor(initialLength = 128) {
-    this.length = 0;
-    this.data = new Float32Array(initialLength);
-    this.initialLength = initialLength;
-  }
-
+function dataArray(p5, fn){
   /**
-   * Returns a Float32Array window sized to the exact length of the data
+   * An internal class to store data that will be sent to a p5.RenderBuffer.
+   * Those need to eventually go into a Float32Array, so this class provides a
+   * variable-length array container backed by a Float32Array so that it can be
+   * sent to the GPU without allocating a new array each frame.
+   *
+   * Like a C++ vector, its fixed-length Float32Array backing its contents will
+   * double in size when it goes over its capacity.
+   *
+   * @example
+   * <div>
+   * <code>
+   * // Initialize storage with a capacity of 4
+   * const storage = new DataArray(4);
+   * console.log(storage.data.length); // 4
+   * console.log(storage.length); // 0
+   * console.log(storage.dataArray()); // Empty Float32Array
+   *
+   * storage.push(1, 2, 3, 4, 5, 6);
+   * console.log(storage.data.length); // 8
+   * console.log(storage.length); // 6
+   * console.log(storage.dataArray()); // Float32Array{1, 2, 3, 4, 5, 6}
+   * </code>
+   * </div>
    */
-  dataArray() {
-    return this.subArray(0, this.length);
-  }
-
-  /**
-   * A "soft" clear, which keeps the underlying storage size the same, but
-   * empties the contents of its dataArray()
-   */
-  clear() {
-    this.length = 0;
-  }
-
-  /**
-   * Can be used to scale a DataArray back down to fit its contents.
-   */
-  rescale() {
-    if (this.length < this.data.length / 2) {
-      // Find the power of 2 size that fits the data
-      const targetLength = 1 << Math.ceil(Math.log2(this.length));
-      const newData = new Float32Array(targetLength);
-      newData.set(this.data.subarray(0, this.length), 0);
-      this.data = newData;
+  p5.DataArray = class DataArray {
+    constructor(initialLength = 128) {
+      this.length = 0;
+      this.data = new Float32Array(initialLength);
+      this.initialLength = initialLength;
     }
-  }
 
-  /**
-   * A full reset, which allocates a new underlying Float32Array at its initial
-   * length
-   */
-  reset() {
-    this.clear();
-    this.data = new Float32Array(this.initialLength);
-  }
-
-  /**
-   * Adds values to the DataArray, expanding its internal storage to
-   * accommodate the new items.
-   */
-  push(...values) {
-    this.ensureLength(this.length + values.length);
-    this.data.set(values, this.length);
-    this.length += values.length;
-  }
-
-  /**
-   * Returns a copy of the data from the index `from`, inclusive, to the index
-   * `to`, exclusive
-   */
-  slice(from, to) {
-    return this.data.slice(from, Math.min(to, this.length));
-  }
-
-  /**
-   * Returns a mutable Float32Array window from the index `from`, inclusive, to
-   * the index `to`, exclusive
-   */
-  subArray(from, to) {
-    return this.data.subarray(from, Math.min(to, this.length));
-  }
-
-  /**
-   * Expand capacity of the internal storage until it can fit a target size
-   */
-  ensureLength(target) {
-    while (this.data.length < target) {
-      const newData = new Float32Array(this.data.length * 2);
-      newData.set(this.data, 0);
-      this.data = newData;
+    /**
+     * Returns a Float32Array window sized to the exact length of the data
+     */
+    dataArray() {
+      return this.subArray(0, this.length);
     }
-  }
-};
 
-export default p5.DataArray;
+    /**
+     * A "soft" clear, which keeps the underlying storage size the same, but
+     * empties the contents of its dataArray()
+     */
+    clear() {
+      this.length = 0;
+    }
+
+    /**
+     * Can be used to scale a DataArray back down to fit its contents.
+     */
+    rescale() {
+      if (this.length < this.data.length / 2) {
+        // Find the power of 2 size that fits the data
+        const targetLength = 1 << Math.ceil(Math.log2(this.length));
+        const newData = new Float32Array(targetLength);
+        newData.set(this.data.subarray(0, this.length), 0);
+        this.data = newData;
+      }
+    }
+
+    /**
+     * A full reset, which allocates a new underlying Float32Array at its initial
+     * length
+     */
+    reset() {
+      this.clear();
+      this.data = new Float32Array(this.initialLength);
+    }
+
+    /**
+     * Adds values to the DataArray, expanding its internal storage to
+     * accommodate the new items.
+     */
+    push(...values) {
+      this.ensureLength(this.length + values.length);
+      this.data.set(values, this.length);
+      this.length += values.length;
+    }
+
+    /**
+     * Returns a copy of the data from the index `from`, inclusive, to the index
+     * `to`, exclusive
+     */
+    slice(from, to) {
+      return this.data.slice(from, Math.min(to, this.length));
+    }
+
+    /**
+     * Returns a mutable Float32Array window from the index `from`, inclusive, to
+     * the index `to`, exclusive
+     */
+    subArray(from, to) {
+      return this.data.subarray(from, Math.min(to, this.length));
+    }
+
+    /**
+     * Expand capacity of the internal storage until it can fit a target size
+     */
+    ensureLength(target) {
+      while (this.data.length < target) {
+        const newData = new Float32Array(this.data.length * 2);
+        newData.set(this.data, 0);
+        this.data = newData;
+      }
+    }
+  };
+}
+
+export default dataArray;
+
+if(typeof p5 !== 'undefined'){
+  dataArray(p5, p5.prototype);
+}

--- a/src/webgl/p5.Framebuffer.js
+++ b/src/webgl/p5.Framebuffer.js
@@ -3,1831 +3,1836 @@
  * @requires constants
  */
 
-import p5 from '../core/main';
 import * as constants from '../core/constants';
 import { checkWebGLCapabilities } from './p5.Texture';
 import { readPixelsWebGL, readPixelWebGL } from './p5.RendererGL';
 
-/**
- * A <a href="#/p5.Camera">p5.Camera</a> attached to a
- * <a href="#/p5.Framebuffer">p5.Framebuffer</a>.
- *
- * @class p5.FramebufferCamera
- * @param {p5.Framebuffer} framebuffer The framebuffer this camera is
- * attached to
- * @private
- */
-p5.FramebufferCamera = class FramebufferCamera extends p5.Camera {
-  constructor(framebuffer) {
-    super(framebuffer.target._renderer);
-    this.fbo = framebuffer;
+function framebuffer(p5, fn){
+  /**
+   * A <a href="#/p5.Camera">p5.Camera</a> attached to a
+   * <a href="#/p5.Framebuffer">p5.Framebuffer</a>.
+   *
+   * @class p5.FramebufferCamera
+   * @param {p5.Framebuffer} framebuffer The framebuffer this camera is
+   * attached to
+   * @private
+   */
+  p5.FramebufferCamera = class FramebufferCamera extends p5.Camera {
+    constructor(framebuffer) {
+      super(framebuffer.target._renderer);
+      this.fbo = framebuffer;
 
-    // WebGL textures are upside-down compared to textures that come from
-    // images and graphics. Framebuffer cameras need to invert their y
-    // axes when being rendered to so that the texture comes out rightway up
-    // when read in shaders or image().
-    this.yScale = -1;
-  }
-
-  _computeCameraDefaultSettings() {
-    super._computeCameraDefaultSettings();
-    this.defaultAspectRatio = this.fbo.width / this.fbo.height;
-    this.defaultCameraFOV =
-      2 * Math.atan(this.fbo.height / 2 / this.defaultEyeZ);
-  }
-};
-
-/**
- * A <a href="#/p5.Texture">p5.Texture</a> corresponding to a property of a
- * <a href="#/p5.Framebuffer">p5.Framebuffer</a>.
- *
- * @class p5.FramebufferTexture
- * @param {p5.Framebuffer} framebuffer The framebuffer represented by this
- * texture
- * @param {String} property The property of the framebuffer represented by
- * this texture, either `color` or `depth`
- * @private
- */
-p5.FramebufferTexture = class FramebufferTexture {
-  constructor(framebuffer, property) {
-    this.framebuffer = framebuffer;
-    this.property = property;
-  }
-
-  get width() {
-    return this.framebuffer.width * this.framebuffer.density;
-  }
-
-  get height() {
-    return this.framebuffer.height * this.framebuffer.density;
-  }
-
-  rawTexture() {
-    return this.framebuffer[this.property];
-  }
-};
-
-/**
- * A class to describe a high-performance drawing surface for textures.
- *
- * Each `p5.Framebuffer` object provides a dedicated drawing surface called
- * a *framebuffer*. They're similar to
- * <a href="#/p5.Graphics">p5.Graphics</a> objects but can run much faster.
- * Performance is improved because the framebuffer shares the same WebGL
- * context as the canvas used to create it.
- *
- * `p5.Framebuffer` objects have all the drawing features of the main
- * canvas. Drawing instructions meant for the framebuffer must be placed
- * between calls to
- * <a href="#/p5.Framebuffer/begin">myBuffer.begin()</a> and
- * <a href="#/p5.Framebuffer/end">myBuffer.end()</a>. The resulting image
- * can be applied as a texture by passing the `p5.Framebuffer` object to the
- * <a href="#/p5/texture">texture()</a> function, as in `texture(myBuffer)`.
- * It can also be displayed on the main canvas by passing it to the
- * <a href="#/p5/image">image()</a> function, as in `image(myBuffer, 0, 0)`.
- *
- * Note: <a href="#/p5/createFramebuffer">createFramebuffer()</a> is the
- * recommended way to create an instance of this class.
- *
- * @class p5.Framebuffer
- * @param {p5.Graphics|p5} target sketch instance or
- *                                <a href="#/p5.Graphics">p5.Graphics</a>
- *                                object.
- * @param {Object} [settings] configuration options.
- */
-p5.Framebuffer = class Framebuffer {
-  constructor(target, settings = {}) {
-    this.target = target;
-    this.target._renderer.framebuffers.add(this);
-
-    this._isClipApplied = false;
-
-    this.pixels = [];
-
-    this.format = settings.format || constants.UNSIGNED_BYTE;
-    this.channels = settings.channels || (
-      target._renderer._pInst._glAttributes.alpha
-        ? constants.RGBA
-        : constants.RGB
-    );
-    this.useDepth = settings.depth === undefined ? true : settings.depth;
-    this.depthFormat = settings.depthFormat || constants.FLOAT;
-    this.textureFiltering = settings.textureFiltering || constants.LINEAR;
-    if (settings.antialias === undefined) {
-      this.antialiasSamples = target._renderer._pInst._glAttributes.antialias
-        ? 2
-        : 0;
-    } else if (typeof settings.antialias === 'number') {
-      this.antialiasSamples = settings.antialias;
-    } else {
-      this.antialiasSamples = settings.antialias ? 2 : 0;
+      // WebGL textures are upside-down compared to textures that come from
+      // images and graphics. Framebuffer cameras need to invert their y
+      // axes when being rendered to so that the texture comes out rightway up
+      // when read in shaders or image().
+      this.yScale = -1;
     }
-    this.antialias = this.antialiasSamples > 0;
-    if (this.antialias && target.webglVersion !== constants.WEBGL2) {
-      console.warn('Antialiasing is unsupported in a WebGL 1 context');
-      this.antialias = false;
+
+    _computeCameraDefaultSettings() {
+      super._computeCameraDefaultSettings();
+      this.defaultAspectRatio = this.fbo.width / this.fbo.height;
+      this.defaultCameraFOV =
+        2 * Math.atan(this.fbo.height / 2 / this.defaultEyeZ);
     }
-    this.density = settings.density || target.pixelDensity();
-    const gl = target._renderer.GL;
-    this.gl = gl;
-    if (settings.width && settings.height) {
+  };
+
+  /**
+   * A <a href="#/p5.Texture">p5.Texture</a> corresponding to a property of a
+   * <a href="#/p5.Framebuffer">p5.Framebuffer</a>.
+   *
+   * @class p5.FramebufferTexture
+   * @param {p5.Framebuffer} framebuffer The framebuffer represented by this
+   * texture
+   * @param {String} property The property of the framebuffer represented by
+   * this texture, either `color` or `depth`
+   * @private
+   */
+  p5.FramebufferTexture = class FramebufferTexture {
+    constructor(framebuffer, property) {
+      this.framebuffer = framebuffer;
+      this.property = property;
+    }
+
+    get width() {
+      return this.framebuffer.width * this.framebuffer.density;
+    }
+
+    get height() {
+      return this.framebuffer.height * this.framebuffer.density;
+    }
+
+    rawTexture() {
+      return this.framebuffer[this.property];
+    }
+  };
+
+  /**
+   * A class to describe a high-performance drawing surface for textures.
+   *
+   * Each `p5.Framebuffer` object provides a dedicated drawing surface called
+   * a *framebuffer*. They're similar to
+   * <a href="#/p5.Graphics">p5.Graphics</a> objects but can run much faster.
+   * Performance is improved because the framebuffer shares the same WebGL
+   * context as the canvas used to create it.
+   *
+   * `p5.Framebuffer` objects have all the drawing features of the main
+   * canvas. Drawing instructions meant for the framebuffer must be placed
+   * between calls to
+   * <a href="#/p5.Framebuffer/begin">myBuffer.begin()</a> and
+   * <a href="#/p5.Framebuffer/end">myBuffer.end()</a>. The resulting image
+   * can be applied as a texture by passing the `p5.Framebuffer` object to the
+   * <a href="#/p5/texture">texture()</a> function, as in `texture(myBuffer)`.
+   * It can also be displayed on the main canvas by passing it to the
+   * <a href="#/p5/image">image()</a> function, as in `image(myBuffer, 0, 0)`.
+   *
+   * Note: <a href="#/p5/createFramebuffer">createFramebuffer()</a> is the
+   * recommended way to create an instance of this class.
+   *
+   * @class p5.Framebuffer
+   * @param {p5.Graphics|p5} target sketch instance or
+   *                                <a href="#/p5.Graphics">p5.Graphics</a>
+   *                                object.
+   * @param {Object} [settings] configuration options.
+   */
+  p5.Framebuffer = class Framebuffer {
+    constructor(target, settings = {}) {
+      this.target = target;
+      this.target._renderer.framebuffers.add(this);
+
+      this._isClipApplied = false;
+
+      this.pixels = [];
+
+      this.format = settings.format || constants.UNSIGNED_BYTE;
+      this.channels = settings.channels || (
+        target._renderer._pInst._glAttributes.alpha
+          ? constants.RGBA
+          : constants.RGB
+      );
+      this.useDepth = settings.depth === undefined ? true : settings.depth;
+      this.depthFormat = settings.depthFormat || constants.FLOAT;
+      this.textureFiltering = settings.textureFiltering || constants.LINEAR;
+      if (settings.antialias === undefined) {
+        this.antialiasSamples = target._renderer._pInst._glAttributes.antialias
+          ? 2
+          : 0;
+      } else if (typeof settings.antialias === 'number') {
+        this.antialiasSamples = settings.antialias;
+      } else {
+        this.antialiasSamples = settings.antialias ? 2 : 0;
+      }
+      this.antialias = this.antialiasSamples > 0;
+      if (this.antialias && target.webglVersion !== constants.WEBGL2) {
+        console.warn('Antialiasing is unsupported in a WebGL 1 context');
+        this.antialias = false;
+      }
+      this.density = settings.density || target.pixelDensity();
+      const gl = target._renderer.GL;
+      this.gl = gl;
+      if (settings.width && settings.height) {
+        const dimensions =
+          target._renderer._adjustDimensions(settings.width, settings.height);
+        this.width = dimensions.adjustedWidth;
+        this.height = dimensions.adjustedHeight;
+        this._autoSized = false;
+      } else {
+        if ((settings.width === undefined) !== (settings.height === undefined)) {
+          console.warn(
+            'Please supply both width and height for a framebuffer to give it a ' +
+              'size. Only one was given, so the framebuffer will match the size ' +
+              'of its canvas.'
+          );
+        }
+        this.width = target.width;
+        this.height = target.height;
+        this._autoSized = true;
+      }
+      this._checkIfFormatsAvailable();
+
+      if (settings.stencil && !this.useDepth) {
+        console.warn('A stencil buffer can only be used if also using depth. Since the framebuffer has no depth buffer, the stencil buffer will be ignored.');
+      }
+      this.useStencil = this.useDepth &&
+        (settings.stencil === undefined ? true : settings.stencil);
+
+      this.framebuffer = gl.createFramebuffer();
+      if (!this.framebuffer) {
+        throw new Error('Unable to create a framebuffer');
+      }
+      if (this.antialias) {
+        this.aaFramebuffer = gl.createFramebuffer();
+        if (!this.aaFramebuffer) {
+          throw new Error('Unable to create a framebuffer for antialiasing');
+        }
+      }
+
+      this._recreateTextures();
+
+      const prevCam = this.target._renderer.states.curCamera;
+      this.defaultCamera = this.createCamera();
+      this.filterCamera = this.createCamera();
+      this.target._renderer.states.curCamera = prevCam;
+
+      this.draw(() => this.target.clear());
+    }
+
+    /**
+     * Resizes the framebuffer to a given width and height.
+     *
+     * The parameters, `width` and `height`, set the dimensions of the
+     * framebuffer. For example, calling `myBuffer.resize(300, 500)` resizes
+     * the framebuffer to 300×500 pixels, then sets `myBuffer.width` to 300
+     * and `myBuffer.height` 500.
+     *
+     * @param {Number} width width of the framebuffer.
+     * @param {Number} height height of the framebuffer.
+     *
+     * @example
+     * <div>
+     * <code>
+     * let myBuffer;
+     *
+     * function setup() {
+     *   createCanvas(100, 100, WEBGL);
+     *
+     *   // Create a p5.Framebuffer object.
+     *   myBuffer = createFramebuffer();
+     *
+     *   describe('A multicolor sphere on a white surface. The image grows larger or smaller when the user moves the mouse, revealing a gray background.');
+     * }
+     *
+     * function draw() {
+     *   background(200);
+     *
+     *   // Draw to the p5.Framebuffer object.
+     *   myBuffer.begin();
+     *   background(255);
+     *   normalMaterial();
+     *   sphere(20);
+     *   myBuffer.end();
+     *
+     *   // Display the p5.Framebuffer object.
+     *   image(myBuffer, -50, -50);
+     * }
+     *
+     * // Resize the p5.Framebuffer object when the
+     * // user moves the mouse.
+     * function mouseMoved() {
+     *   myBuffer.resize(mouseX, mouseY);
+     * }
+     * </code>
+     * </div>
+     */
+    resize(width, height) {
+      this._autoSized = false;
       const dimensions =
-        target._renderer._adjustDimensions(settings.width, settings.height);
-      this.width = dimensions.adjustedWidth;
-      this.height = dimensions.adjustedHeight;
-      this._autoSized = false;
-    } else {
-      if ((settings.width === undefined) !== (settings.height === undefined)) {
+        this.target._renderer._adjustDimensions(width, height);
+      width = dimensions.adjustedWidth;
+      height = dimensions.adjustedHeight;
+      this.width = width;
+      this.height = height;
+      this._handleResize();
+    }
+
+    /**
+     * Sets the framebuffer's pixel density or returns its current density.
+     *
+     * Computer displays are grids of little lights called pixels. A display's
+     * pixel density describes how many pixels it packs into an area. Displays
+     * with smaller pixels have a higher pixel density and create sharper
+     * images.
+     *
+     * The parameter, `density`, is optional. If a number is passed, as in
+     * `myBuffer.pixelDensity(1)`, it sets the framebuffer's pixel density. By
+     * default, the framebuffer's pixel density will match that of the canvas
+     * where it was created. All canvases default to match the display's pixel
+     * density.
+     *
+     * Calling `myBuffer.pixelDensity()` without an argument returns its current
+     * pixel density.
+     *
+     * @param {Number} [density] pixel density to set.
+     * @returns {Number} current pixel density.
+     *
+     * @example
+     * <div>
+     * <code>
+     * let myBuffer;
+     *
+     * function setup() {
+     *   createCanvas(100, 100, WEBGL);
+     *
+     *   // Create a p5.Framebuffer object.
+     *   myBuffer = createFramebuffer();
+     *
+     *   describe("A white circle on a gray canvas. The circle's edge become fuzzy while the user presses and holds the mouse.");
+     * }
+     *
+     * function draw() {
+     *   // Draw to the p5.Framebuffer object.
+     *   myBuffer.begin();
+     *   background(200);
+     *   circle(0, 0, 40);
+     *   myBuffer.end();
+     *
+     *   // Display the p5.Framebuffer object.
+     *   image(myBuffer, -50, -50);
+     * }
+     *
+     * // Decrease the pixel density when the user
+     * // presses the mouse.
+     * function mousePressed() {
+     *   myBuffer.pixelDensity(1);
+     * }
+     *
+     * // Increase the pixel density when the user
+     * // releases the mouse.
+     * function mouseReleased() {
+     *   myBuffer.pixelDensity(2);
+     * }
+     * </code>
+     * </div>
+     *
+     * <div>
+     * <code>
+     * let myBuffer;
+     * let myFont;
+     *
+     * // Load a font and create a p5.Font object.
+     * function preload() {
+     *   myFont = loadFont('assets/inconsolata.otf');
+     * }
+     *
+     * function setup() {
+     *   createCanvas(100, 100, WEBGL);
+     *
+     *   background(200);
+     *
+     *   // Create a p5.Framebuffer object.
+     *   myBuffer = createFramebuffer();
+     *
+     *   // Get the p5.Framebuffer object's pixel density.
+     *   let d = myBuffer.pixelDensity();
+     *
+     *   // Style the text.
+     *   textAlign(CENTER, CENTER);
+     *   textFont(myFont);
+     *   textSize(16);
+     *   fill(0);
+     *
+     *   // Display the pixel density.
+     *   text(`Density: ${d}`, 0, 0);
+     *
+     *   describe(`The text "Density: ${d}" written in black on a gray background.`);
+     * }
+     * </code>
+     * </div>
+     */
+    pixelDensity(density) {
+      if (density) {
+        this._autoSized = false;
+        this.density = density;
+        this._handleResize();
+      } else {
+        return this.density;
+      }
+    }
+
+    /**
+     * Toggles the framebuffer's autosizing mode or returns the current mode.
+     *
+     * By default, the framebuffer automatically resizes to match the canvas
+     * that created it. Calling `myBuffer.autoSized(false)` disables this
+     * behavior and calling `myBuffer.autoSized(true)` re-enables it.
+     *
+     * Calling `myBuffer.autoSized()` without an argument returns `true` if
+     * the framebuffer automatically resizes and `false` if not.
+     *
+     * @param {Boolean} [autoSized] whether to automatically resize the framebuffer to match the canvas.
+     * @returns {Boolean} current autosize setting.
+     *
+     * @example
+     * <div>
+     * <code>
+     * // Double-click to toggle the autosizing mode.
+     *
+     * let myBuffer;
+     *
+     * function setup() {
+     *   createCanvas(100, 100, WEBGL);
+     *
+     *   // Create a p5.Framebuffer object.
+     *   myBuffer = createFramebuffer();
+     *
+     *   describe('A multicolor sphere on a gray background. The image resizes when the user moves the mouse.');
+     * }
+     *
+     * function draw() {
+     *   background(50);
+     *
+     *   // Draw to the p5.Framebuffer object.
+     *   myBuffer.begin();
+     *   background(200);
+     *   normalMaterial();
+     *   sphere(width / 4);
+     *   myBuffer.end();
+     *
+     *   // Display the p5.Framebuffer object.
+     *   image(myBuffer, -width / 2, -height / 2);
+     * }
+     *
+     * // Resize the canvas when the user moves the mouse.
+     * function mouseMoved() {
+     *   let w = constrain(mouseX, 0, 100);
+     *   let h = constrain(mouseY, 0, 100);
+     *   resizeCanvas(w, h);
+     * }
+     *
+     * // Toggle autoSizing when the user double-clicks.
+     * // Note: opened an issue to fix(?) this.
+     * function doubleClicked() {
+     *   let isAuto = myBuffer.autoSized();
+     *   myBuffer.autoSized(!isAuto);
+     * }
+     * </code>
+     * </div>
+     */
+    autoSized(autoSized) {
+      if (autoSized === undefined) {
+        return this._autoSized;
+      } else {
+        this._autoSized = autoSized;
+        this._handleResize();
+      }
+    }
+
+    /**
+     * Checks the capabilities of the current WebGL environment to see if the
+     * settings supplied by the user are capable of being fulfilled. If they
+     * are not, warnings will be logged and the settings will be changed to
+     * something close that can be fulfilled.
+     *
+     * @private
+     */
+    _checkIfFormatsAvailable() {
+      const gl = this.gl;
+
+      if (
+        this.useDepth &&
+        this.target.webglVersion === constants.WEBGL &&
+        !gl.getExtension('WEBGL_depth_texture')
+      ) {
         console.warn(
-          'Please supply both width and height for a framebuffer to give it a ' +
-            'size. Only one was given, so the framebuffer will match the size ' +
-            'of its canvas.'
+          'Unable to create depth textures in this environment. Falling back ' +
+            'to a framebuffer without depth.'
         );
+        this.useDepth = false;
       }
-      this.width = target.width;
-      this.height = target.height;
-      this._autoSized = true;
-    }
-    this._checkIfFormatsAvailable();
 
-    if (settings.stencil && !this.useDepth) {
-      console.warn('A stencil buffer can only be used if also using depth. Since the framebuffer has no depth buffer, the stencil buffer will be ignored.');
-    }
-    this.useStencil = this.useDepth &&
-      (settings.stencil === undefined ? true : settings.stencil);
+      if (
+        this.useDepth &&
+        this.target.webglVersion === constants.WEBGL &&
+        this.depthFormat === constants.FLOAT
+      ) {
+        console.warn(
+          'FLOAT depth format is unavailable in WebGL 1. ' +
+            'Defaulting to UNSIGNED_INT.'
+        );
+        this.depthFormat = constants.UNSIGNED_INT;
+      }
 
-    this.framebuffer = gl.createFramebuffer();
-    if (!this.framebuffer) {
-      throw new Error('Unable to create a framebuffer');
-    }
-    if (this.antialias) {
-      this.aaFramebuffer = gl.createFramebuffer();
-      if (!this.aaFramebuffer) {
-        throw new Error('Unable to create a framebuffer for antialiasing');
+      if (![
+        constants.UNSIGNED_BYTE,
+        constants.FLOAT,
+        constants.HALF_FLOAT
+      ].includes(this.format)) {
+        console.warn(
+          'Unknown Framebuffer format. ' +
+            'Please use UNSIGNED_BYTE, FLOAT, or HALF_FLOAT. ' +
+            'Defaulting to UNSIGNED_BYTE.'
+        );
+        this.format = constants.UNSIGNED_BYTE;
+      }
+      if (this.useDepth && ![
+        constants.UNSIGNED_INT,
+        constants.FLOAT
+      ].includes(this.depthFormat)) {
+        console.warn(
+          'Unknown Framebuffer depth format. ' +
+            'Please use UNSIGNED_INT or FLOAT. Defaulting to FLOAT.'
+        );
+        this.depthFormat = constants.FLOAT;
+      }
+
+      const support = checkWebGLCapabilities(this.target._renderer);
+      if (!support.float && this.format === constants.FLOAT) {
+        console.warn(
+          'This environment does not support FLOAT textures. ' +
+            'Falling back to UNSIGNED_BYTE.'
+        );
+        this.format = constants.UNSIGNED_BYTE;
+      }
+      if (
+        this.useDepth &&
+        !support.float &&
+        this.depthFormat === constants.FLOAT
+      ) {
+        console.warn(
+          'This environment does not support FLOAT depth textures. ' +
+            'Falling back to UNSIGNED_INT.'
+        );
+        this.depthFormat = constants.UNSIGNED_INT;
+      }
+      if (!support.halfFloat && this.format === constants.HALF_FLOAT) {
+        console.warn(
+          'This environment does not support HALF_FLOAT textures. ' +
+            'Falling back to UNSIGNED_BYTE.'
+        );
+        this.format = constants.UNSIGNED_BYTE;
+      }
+
+      if (
+        this.channels === constants.RGB &&
+        [constants.FLOAT, constants.HALF_FLOAT].includes(this.format)
+      ) {
+        console.warn(
+          'FLOAT and HALF_FLOAT formats do not work cross-platform with only ' +
+            'RGB channels. Falling back to RGBA.'
+        );
+        this.channels = constants.RGBA;
       }
     }
 
-    this._recreateTextures();
+    /**
+     * Creates new textures and renderbuffers given the current size of the
+     * framebuffer.
+     *
+     * @private
+     */
+    _recreateTextures() {
+      const gl = this.gl;
 
-    const prevCam = this.target._renderer.states.curCamera;
-    this.defaultCamera = this.createCamera();
-    this.filterCamera = this.createCamera();
-    this.target._renderer.states.curCamera = prevCam;
+      this._updateSize();
 
-    this.draw(() => this.target.clear());
-  }
+      const prevBoundTexture = gl.getParameter(gl.TEXTURE_BINDING_2D);
+      const prevBoundFramebuffer = gl.getParameter(gl.FRAMEBUFFER_BINDING);
 
-  /**
-   * Resizes the framebuffer to a given width and height.
-   *
-   * The parameters, `width` and `height`, set the dimensions of the
-   * framebuffer. For example, calling `myBuffer.resize(300, 500)` resizes
-   * the framebuffer to 300×500 pixels, then sets `myBuffer.width` to 300
-   * and `myBuffer.height` 500.
-   *
-   * @param {Number} width width of the framebuffer.
-   * @param {Number} height height of the framebuffer.
-   *
-   * @example
-   * <div>
-   * <code>
-   * let myBuffer;
-   *
-   * function setup() {
-   *   createCanvas(100, 100, WEBGL);
-   *
-   *   // Create a p5.Framebuffer object.
-   *   myBuffer = createFramebuffer();
-   *
-   *   describe('A multicolor sphere on a white surface. The image grows larger or smaller when the user moves the mouse, revealing a gray background.');
-   * }
-   *
-   * function draw() {
-   *   background(200);
-   *
-   *   // Draw to the p5.Framebuffer object.
-   *   myBuffer.begin();
-   *   background(255);
-   *   normalMaterial();
-   *   sphere(20);
-   *   myBuffer.end();
-   *
-   *   // Display the p5.Framebuffer object.
-   *   image(myBuffer, -50, -50);
-   * }
-   *
-   * // Resize the p5.Framebuffer object when the
-   * // user moves the mouse.
-   * function mouseMoved() {
-   *   myBuffer.resize(mouseX, mouseY);
-   * }
-   * </code>
-   * </div>
-   */
-  resize(width, height) {
-    this._autoSized = false;
-    const dimensions =
-      this.target._renderer._adjustDimensions(width, height);
-    width = dimensions.adjustedWidth;
-    height = dimensions.adjustedHeight;
-    this.width = width;
-    this.height = height;
-    this._handleResize();
-  }
-
-  /**
-   * Sets the framebuffer's pixel density or returns its current density.
-   *
-   * Computer displays are grids of little lights called pixels. A display's
-   * pixel density describes how many pixels it packs into an area. Displays
-   * with smaller pixels have a higher pixel density and create sharper
-   * images.
-   *
-   * The parameter, `density`, is optional. If a number is passed, as in
-   * `myBuffer.pixelDensity(1)`, it sets the framebuffer's pixel density. By
-   * default, the framebuffer's pixel density will match that of the canvas
-   * where it was created. All canvases default to match the display's pixel
-   * density.
-   *
-   * Calling `myBuffer.pixelDensity()` without an argument returns its current
-   * pixel density.
-   *
-   * @param {Number} [density] pixel density to set.
-   * @returns {Number} current pixel density.
-   *
-   * @example
-   * <div>
-   * <code>
-   * let myBuffer;
-   *
-   * function setup() {
-   *   createCanvas(100, 100, WEBGL);
-   *
-   *   // Create a p5.Framebuffer object.
-   *   myBuffer = createFramebuffer();
-   *
-   *   describe("A white circle on a gray canvas. The circle's edge become fuzzy while the user presses and holds the mouse.");
-   * }
-   *
-   * function draw() {
-   *   // Draw to the p5.Framebuffer object.
-   *   myBuffer.begin();
-   *   background(200);
-   *   circle(0, 0, 40);
-   *   myBuffer.end();
-   *
-   *   // Display the p5.Framebuffer object.
-   *   image(myBuffer, -50, -50);
-   * }
-   *
-   * // Decrease the pixel density when the user
-   * // presses the mouse.
-   * function mousePressed() {
-   *   myBuffer.pixelDensity(1);
-   * }
-   *
-   * // Increase the pixel density when the user
-   * // releases the mouse.
-   * function mouseReleased() {
-   *   myBuffer.pixelDensity(2);
-   * }
-   * </code>
-   * </div>
-   *
-   * <div>
-   * <code>
-   * let myBuffer;
-   * let myFont;
-   *
-   * // Load a font and create a p5.Font object.
-   * function preload() {
-   *   myFont = loadFont('assets/inconsolata.otf');
-   * }
-   *
-   * function setup() {
-   *   createCanvas(100, 100, WEBGL);
-   *
-   *   background(200);
-   *
-   *   // Create a p5.Framebuffer object.
-   *   myBuffer = createFramebuffer();
-   *
-   *   // Get the p5.Framebuffer object's pixel density.
-   *   let d = myBuffer.pixelDensity();
-   *
-   *   // Style the text.
-   *   textAlign(CENTER, CENTER);
-   *   textFont(myFont);
-   *   textSize(16);
-   *   fill(0);
-   *
-   *   // Display the pixel density.
-   *   text(`Density: ${d}`, 0, 0);
-   *
-   *   describe(`The text "Density: ${d}" written in black on a gray background.`);
-   * }
-   * </code>
-   * </div>
-   */
-  pixelDensity(density) {
-    if (density) {
-      this._autoSized = false;
-      this.density = density;
-      this._handleResize();
-    } else {
-      return this.density;
-    }
-  }
-
-  /**
-   * Toggles the framebuffer's autosizing mode or returns the current mode.
-   *
-   * By default, the framebuffer automatically resizes to match the canvas
-   * that created it. Calling `myBuffer.autoSized(false)` disables this
-   * behavior and calling `myBuffer.autoSized(true)` re-enables it.
-   *
-   * Calling `myBuffer.autoSized()` without an argument returns `true` if
-   * the framebuffer automatically resizes and `false` if not.
-   *
-   * @param {Boolean} [autoSized] whether to automatically resize the framebuffer to match the canvas.
-   * @returns {Boolean} current autosize setting.
-   *
-   * @example
-   * <div>
-   * <code>
-   * // Double-click to toggle the autosizing mode.
-   *
-   * let myBuffer;
-   *
-   * function setup() {
-   *   createCanvas(100, 100, WEBGL);
-   *
-   *   // Create a p5.Framebuffer object.
-   *   myBuffer = createFramebuffer();
-   *
-   *   describe('A multicolor sphere on a gray background. The image resizes when the user moves the mouse.');
-   * }
-   *
-   * function draw() {
-   *   background(50);
-   *
-   *   // Draw to the p5.Framebuffer object.
-   *   myBuffer.begin();
-   *   background(200);
-   *   normalMaterial();
-   *   sphere(width / 4);
-   *   myBuffer.end();
-   *
-   *   // Display the p5.Framebuffer object.
-   *   image(myBuffer, -width / 2, -height / 2);
-   * }
-   *
-   * // Resize the canvas when the user moves the mouse.
-   * function mouseMoved() {
-   *   let w = constrain(mouseX, 0, 100);
-   *   let h = constrain(mouseY, 0, 100);
-   *   resizeCanvas(w, h);
-   * }
-   *
-   * // Toggle autoSizing when the user double-clicks.
-   * // Note: opened an issue to fix(?) this.
-   * function doubleClicked() {
-   *   let isAuto = myBuffer.autoSized();
-   *   myBuffer.autoSized(!isAuto);
-   * }
-   * </code>
-   * </div>
-   */
-  autoSized(autoSized) {
-    if (autoSized === undefined) {
-      return this._autoSized;
-    } else {
-      this._autoSized = autoSized;
-      this._handleResize();
-    }
-  }
-
-  /**
-   * Checks the capabilities of the current WebGL environment to see if the
-   * settings supplied by the user are capable of being fulfilled. If they
-   * are not, warnings will be logged and the settings will be changed to
-   * something close that can be fulfilled.
-   *
-   * @private
-   */
-  _checkIfFormatsAvailable() {
-    const gl = this.gl;
-
-    if (
-      this.useDepth &&
-      this.target.webglVersion === constants.WEBGL &&
-      !gl.getExtension('WEBGL_depth_texture')
-    ) {
-      console.warn(
-        'Unable to create depth textures in this environment. Falling back ' +
-          'to a framebuffer without depth.'
-      );
-      this.useDepth = false;
-    }
-
-    if (
-      this.useDepth &&
-      this.target.webglVersion === constants.WEBGL &&
-      this.depthFormat === constants.FLOAT
-    ) {
-      console.warn(
-        'FLOAT depth format is unavailable in WebGL 1. ' +
-          'Defaulting to UNSIGNED_INT.'
-      );
-      this.depthFormat = constants.UNSIGNED_INT;
-    }
-
-    if (![
-      constants.UNSIGNED_BYTE,
-      constants.FLOAT,
-      constants.HALF_FLOAT
-    ].includes(this.format)) {
-      console.warn(
-        'Unknown Framebuffer format. ' +
-          'Please use UNSIGNED_BYTE, FLOAT, or HALF_FLOAT. ' +
-          'Defaulting to UNSIGNED_BYTE.'
-      );
-      this.format = constants.UNSIGNED_BYTE;
-    }
-    if (this.useDepth && ![
-      constants.UNSIGNED_INT,
-      constants.FLOAT
-    ].includes(this.depthFormat)) {
-      console.warn(
-        'Unknown Framebuffer depth format. ' +
-          'Please use UNSIGNED_INT or FLOAT. Defaulting to FLOAT.'
-      );
-      this.depthFormat = constants.FLOAT;
-    }
-
-    const support = checkWebGLCapabilities(this.target._renderer);
-    if (!support.float && this.format === constants.FLOAT) {
-      console.warn(
-        'This environment does not support FLOAT textures. ' +
-          'Falling back to UNSIGNED_BYTE.'
-      );
-      this.format = constants.UNSIGNED_BYTE;
-    }
-    if (
-      this.useDepth &&
-      !support.float &&
-      this.depthFormat === constants.FLOAT
-    ) {
-      console.warn(
-        'This environment does not support FLOAT depth textures. ' +
-          'Falling back to UNSIGNED_INT.'
-      );
-      this.depthFormat = constants.UNSIGNED_INT;
-    }
-    if (!support.halfFloat && this.format === constants.HALF_FLOAT) {
-      console.warn(
-        'This environment does not support HALF_FLOAT textures. ' +
-          'Falling back to UNSIGNED_BYTE.'
-      );
-      this.format = constants.UNSIGNED_BYTE;
-    }
-
-    if (
-      this.channels === constants.RGB &&
-      [constants.FLOAT, constants.HALF_FLOAT].includes(this.format)
-    ) {
-      console.warn(
-        'FLOAT and HALF_FLOAT formats do not work cross-platform with only ' +
-          'RGB channels. Falling back to RGBA.'
-      );
-      this.channels = constants.RGBA;
-    }
-  }
-
-  /**
-   * Creates new textures and renderbuffers given the current size of the
-   * framebuffer.
-   *
-   * @private
-   */
-  _recreateTextures() {
-    const gl = this.gl;
-
-    this._updateSize();
-
-    const prevBoundTexture = gl.getParameter(gl.TEXTURE_BINDING_2D);
-    const prevBoundFramebuffer = gl.getParameter(gl.FRAMEBUFFER_BINDING);
-
-    const colorTexture = gl.createTexture();
-    if (!colorTexture) {
-      throw new Error('Unable to create color texture');
-    }
-    gl.bindTexture(gl.TEXTURE_2D, colorTexture);
-    const colorFormat = this._glColorFormat();
-    gl.texImage2D(
-      gl.TEXTURE_2D,
-      0,
-      colorFormat.internalFormat,
-      this.width * this.density,
-      this.height * this.density,
-      0,
-      colorFormat.format,
-      colorFormat.type,
-      null
-    );
-    this.colorTexture = colorTexture;
-    gl.bindFramebuffer(gl.FRAMEBUFFER, this.framebuffer);
-    gl.framebufferTexture2D(
-      gl.FRAMEBUFFER,
-      gl.COLOR_ATTACHMENT0,
-      gl.TEXTURE_2D,
-      colorTexture,
-      0
-    );
-
-    if (this.useDepth) {
-      // Create the depth texture
-      const depthTexture = gl.createTexture();
-      if (!depthTexture) {
-        throw new Error('Unable to create depth texture');
+      const colorTexture = gl.createTexture();
+      if (!colorTexture) {
+        throw new Error('Unable to create color texture');
       }
-      const depthFormat = this._glDepthFormat();
-      gl.bindTexture(gl.TEXTURE_2D, depthTexture);
+      gl.bindTexture(gl.TEXTURE_2D, colorTexture);
+      const colorFormat = this._glColorFormat();
       gl.texImage2D(
         gl.TEXTURE_2D,
         0,
-        depthFormat.internalFormat,
+        colorFormat.internalFormat,
         this.width * this.density,
         this.height * this.density,
         0,
-        depthFormat.format,
-        depthFormat.type,
+        colorFormat.format,
+        colorFormat.type,
         null
       );
-
+      this.colorTexture = colorTexture;
+      gl.bindFramebuffer(gl.FRAMEBUFFER, this.framebuffer);
       gl.framebufferTexture2D(
         gl.FRAMEBUFFER,
-        this.useStencil ? gl.DEPTH_STENCIL_ATTACHMENT : gl.DEPTH_ATTACHMENT,
+        gl.COLOR_ATTACHMENT0,
         gl.TEXTURE_2D,
-        depthTexture,
+        colorTexture,
         0
-      );
-      this.depthTexture = depthTexture;
-    }
-
-    // Create separate framebuffer for antialiasing
-    if (this.antialias) {
-      this.colorRenderbuffer = gl.createRenderbuffer();
-      gl.bindRenderbuffer(gl.RENDERBUFFER, this.colorRenderbuffer);
-      gl.renderbufferStorageMultisample(
-        gl.RENDERBUFFER,
-        Math.max(
-          0,
-          Math.min(this.antialiasSamples, gl.getParameter(gl.MAX_SAMPLES))
-        ),
-        colorFormat.internalFormat,
-        this.width * this.density,
-        this.height * this.density
       );
 
       if (this.useDepth) {
+        // Create the depth texture
+        const depthTexture = gl.createTexture();
+        if (!depthTexture) {
+          throw new Error('Unable to create depth texture');
+        }
         const depthFormat = this._glDepthFormat();
-        this.depthRenderbuffer = gl.createRenderbuffer();
-        gl.bindRenderbuffer(gl.RENDERBUFFER, this.depthRenderbuffer);
+        gl.bindTexture(gl.TEXTURE_2D, depthTexture);
+        gl.texImage2D(
+          gl.TEXTURE_2D,
+          0,
+          depthFormat.internalFormat,
+          this.width * this.density,
+          this.height * this.density,
+          0,
+          depthFormat.format,
+          depthFormat.type,
+          null
+        );
+
+        gl.framebufferTexture2D(
+          gl.FRAMEBUFFER,
+          this.useStencil ? gl.DEPTH_STENCIL_ATTACHMENT : gl.DEPTH_ATTACHMENT,
+          gl.TEXTURE_2D,
+          depthTexture,
+          0
+        );
+        this.depthTexture = depthTexture;
+      }
+
+      // Create separate framebuffer for antialiasing
+      if (this.antialias) {
+        this.colorRenderbuffer = gl.createRenderbuffer();
+        gl.bindRenderbuffer(gl.RENDERBUFFER, this.colorRenderbuffer);
         gl.renderbufferStorageMultisample(
           gl.RENDERBUFFER,
           Math.max(
             0,
             Math.min(this.antialiasSamples, gl.getParameter(gl.MAX_SAMPLES))
           ),
-          depthFormat.internalFormat,
+          colorFormat.internalFormat,
           this.width * this.density,
           this.height * this.density
         );
-      }
 
-      gl.bindFramebuffer(gl.FRAMEBUFFER, this.aaFramebuffer);
-      gl.framebufferRenderbuffer(
-        gl.FRAMEBUFFER,
-        gl.COLOR_ATTACHMENT0,
-        gl.RENDERBUFFER,
-        this.colorRenderbuffer
-      );
-      if (this.useDepth) {
+        if (this.useDepth) {
+          const depthFormat = this._glDepthFormat();
+          this.depthRenderbuffer = gl.createRenderbuffer();
+          gl.bindRenderbuffer(gl.RENDERBUFFER, this.depthRenderbuffer);
+          gl.renderbufferStorageMultisample(
+            gl.RENDERBUFFER,
+            Math.max(
+              0,
+              Math.min(this.antialiasSamples, gl.getParameter(gl.MAX_SAMPLES))
+            ),
+            depthFormat.internalFormat,
+            this.width * this.density,
+            this.height * this.density
+          );
+        }
+
+        gl.bindFramebuffer(gl.FRAMEBUFFER, this.aaFramebuffer);
         gl.framebufferRenderbuffer(
           gl.FRAMEBUFFER,
-          this.useStencil ? gl.DEPTH_STENCIL_ATTACHMENT : gl.DEPTH_ATTACHMENT,
+          gl.COLOR_ATTACHMENT0,
           gl.RENDERBUFFER,
-          this.depthRenderbuffer
+          this.colorRenderbuffer
         );
-      }
-    }
-
-    if (this.useDepth) {
-      this.depth = new p5.FramebufferTexture(this, 'depthTexture');
-      const depthFilter = gl.NEAREST;
-      this.depthP5Texture = new p5.Texture(
-        this.target._renderer,
-        this.depth,
-        {
-          minFilter: depthFilter,
-          magFilter: depthFilter
+        if (this.useDepth) {
+          gl.framebufferRenderbuffer(
+            gl.FRAMEBUFFER,
+            this.useStencil ? gl.DEPTH_STENCIL_ATTACHMENT : gl.DEPTH_ATTACHMENT,
+            gl.RENDERBUFFER,
+            this.depthRenderbuffer
+          );
         }
-      );
-      this.target._renderer.textures.set(this.depth, this.depthP5Texture);
-    }
-
-    this.color = new p5.FramebufferTexture(this, 'colorTexture');
-    const filter = this.textureFiltering === constants.LINEAR
-      ? gl.LINEAR
-      : gl.NEAREST;
-    this.colorP5Texture = new p5.Texture(
-      this.target._renderer,
-      this.color,
-      {
-        minFilter: filter,
-        magFilter: filter
       }
-    );
-    this.target._renderer.textures.set(this.color, this.colorP5Texture);
 
-    gl.bindTexture(gl.TEXTURE_2D, prevBoundTexture);
-    gl.bindFramebuffer(gl.FRAMEBUFFER, prevBoundFramebuffer);
-  }
-
-  /**
-   * To create a WebGL texture, one needs to supply three pieces of information:
-   * the type (the data type each channel will be stored as, e.g. int or float),
-   * the format (the color channels that will each be stored in the previously
-   * specified type, e.g. rgb or rgba), and the internal format (the specifics
-   * of how data for each channel, in the aforementioned type, will be packed
-   * together, such as how many bits to use, e.g. RGBA32F or RGB565.)
-   *
-   * The format and channels asked for by the user hint at what these values
-   * need to be, and the WebGL version affects what options are avaiable.
-   * This method returns the values for these three properties, given the
-   * framebuffer's settings.
-   *
-   * @private
-   */
-  _glColorFormat() {
-    let type, format, internalFormat;
-    const gl = this.gl;
-
-    if (this.format === constants.FLOAT) {
-      type = gl.FLOAT;
-    } else if (this.format === constants.HALF_FLOAT) {
-      type = this.target.webglVersion === constants.WEBGL2
-        ? gl.HALF_FLOAT
-        : gl.getExtension('OES_texture_half_float').HALF_FLOAT_OES;
-    } else {
-      type = gl.UNSIGNED_BYTE;
-    }
-
-    if (this.channels === constants.RGBA) {
-      format = gl.RGBA;
-    } else {
-      format = gl.RGB;
-    }
-
-    if (this.target.webglVersion === constants.WEBGL2) {
-      // https://webgl2fundamentals.org/webgl/lessons/webgl-data-textures.html
-      const table = {
-        [gl.FLOAT]: {
-          [gl.RGBA]: gl.RGBA32F
-          // gl.RGB32F is not available in Firefox without an alpha channel
-        },
-        [gl.HALF_FLOAT]: {
-          [gl.RGBA]: gl.RGBA16F
-          // gl.RGB16F is not available in Firefox without an alpha channel
-        },
-        [gl.UNSIGNED_BYTE]: {
-          [gl.RGBA]: gl.RGBA8, // gl.RGBA4
-          [gl.RGB]: gl.RGB8 // gl.RGB565
-        }
-      };
-      internalFormat = table[type][format];
-    } else if (this.format === constants.HALF_FLOAT) {
-      internalFormat = gl.RGBA;
-    } else {
-      internalFormat = format;
-    }
-
-    return { internalFormat, format, type };
-  }
-
-  /**
-   * To create a WebGL texture, one needs to supply three pieces of information:
-   * the type (the data type each channel will be stored as, e.g. int or float),
-   * the format (the color channels that will each be stored in the previously
-   * specified type, e.g. rgb or rgba), and the internal format (the specifics
-   * of how data for each channel, in the aforementioned type, will be packed
-   * together, such as how many bits to use, e.g. RGBA32F or RGB565.)
-   *
-   * This method takes into account the settings asked for by the user and
-   * returns values for these three properties that can be used for the
-   * texture storing depth information.
-   *
-   * @private
-   */
-  _glDepthFormat() {
-    let type, format, internalFormat;
-    const gl = this.gl;
-
-    if (this.useStencil) {
-      if (this.depthFormat === constants.FLOAT) {
-        type = gl.FLOAT_32_UNSIGNED_INT_24_8_REV;
-      } else if (this.target.webglVersion === constants.WEBGL2) {
-        type = gl.UNSIGNED_INT_24_8;
-      } else {
-        type = gl.getExtension('WEBGL_depth_texture').UNSIGNED_INT_24_8_WEBGL;
-      }
-    } else {
-      if (this.depthFormat === constants.FLOAT) {
-        type = gl.FLOAT;
-      } else {
-        type = gl.UNSIGNED_INT;
-      }
-    }
-
-    if (this.useStencil) {
-      format = gl.DEPTH_STENCIL;
-    } else {
-      format = gl.DEPTH_COMPONENT;
-    }
-
-    if (this.useStencil) {
-      if (this.depthFormat === constants.FLOAT) {
-        internalFormat = gl.DEPTH32F_STENCIL8;
-      } else if (this.target.webglVersion === constants.WEBGL2) {
-        internalFormat = gl.DEPTH24_STENCIL8;
-      } else {
-        internalFormat = gl.DEPTH_STENCIL;
-      }
-    } else if (this.target.webglVersion === constants.WEBGL2) {
-      if (this.depthFormat === constants.FLOAT) {
-        internalFormat = gl.DEPTH_COMPONENT32F;
-      } else {
-        internalFormat = gl.DEPTH_COMPONENT24;
-      }
-    } else {
-      internalFormat = gl.DEPTH_COMPONENT;
-    }
-
-    return { internalFormat, format, type };
-  }
-
-  /**
-   * A method that will be called when recreating textures. If the framebuffer
-   * is auto-sized, it will update its width, height, and density properties.
-   *
-   * @private
-   */
-  _updateSize() {
-    if (this._autoSized) {
-      this.width = this.target.width;
-      this.height = this.target.height;
-      this.density = this.target.pixelDensity();
-    }
-  }
-
-  /**
-   * Called when the canvas that the framebuffer is attached to resizes. If the
-   * framebuffer is auto-sized, it will update its textures to match the new
-   * size.
-   *
-   * @private
-   */
-  _canvasSizeChanged() {
-    if (this._autoSized) {
-      this._handleResize();
-    }
-  }
-
-  /**
-   * Called when the size of the framebuffer has changed (either by being
-   * manually updated or from auto-size updates when its canvas changes size.)
-   * Old textures and renderbuffers will be deleted, and then recreated with the
-   * new size.
-   *
-   * @private
-   */
-  _handleResize() {
-    const oldColor = this.color;
-    const oldDepth = this.depth;
-    const oldColorRenderbuffer = this.colorRenderbuffer;
-    const oldDepthRenderbuffer = this.depthRenderbuffer;
-
-    this._deleteTexture(oldColor);
-    if (oldDepth) this._deleteTexture(oldDepth);
-    const gl = this.gl;
-    if (oldColorRenderbuffer) gl.deleteRenderbuffer(oldColorRenderbuffer);
-    if (oldDepthRenderbuffer) gl.deleteRenderbuffer(oldDepthRenderbuffer);
-
-    this._recreateTextures();
-    this.defaultCamera._resize();
-  }
-
-  /**
-   * Creates a new
-   * <a href="#/p5.Camera">p5.Camera</a> object to use with the framebuffer.
-   *
-   * The new camera is initialized with a default position `(0, 0, 800)` and a
-   * default perspective projection. Its properties can be controlled with
-   * <a href="#/p5.Camera">p5.Camera</a> methods such as `myCamera.lookAt(0, 0, 0)`.
-   *
-   * Framebuffer cameras should be created between calls to
-   * <a href="#/p5.Framebuffer/begin">myBuffer.begin()</a> and
-   * <a href="#/p5.Framebuffer/end">myBuffer.end()</a> like so:
-   *
-   * ```js
-   * let myCamera;
-   *
-   * myBuffer.begin();
-   *
-   * // Create the camera for the framebuffer.
-   * myCamera = myBuffer.createCamera();
-   *
-   * myBuffer.end();
-   * ```
-   *
-   * Calling <a href="#/p5/setCamera">setCamera()</a> updates the
-   * framebuffer's projection using the camera.
-   * <a href="#/p5/resetMatrix">resetMatrix()</a> must also be called for the
-   * view to change properly:
-   *
-   * ```js
-   * myBuffer.begin();
-   *
-   * // Set the camera for the framebuffer.
-   * setCamera(myCamera);
-   *
-   * // Reset all transformations.
-   * resetMatrix();
-   *
-   * // Draw stuff...
-   *
-   * myBuffer.end();
-   * ```
-   *
-   * @returns {p5.Camera} new camera.
-   *
-   * @example
-   * <div>
-   * <code>
-   * // Double-click to toggle between cameras.
-   *
-   * let myBuffer;
-   * let cam1;
-   * let cam2;
-   * let usingCam1 = true;
-   *
-   * function setup() {
-   *   createCanvas(100, 100, WEBGL);
-   *
-   *   // Create a p5.Framebuffer object.
-   *   myBuffer = createFramebuffer();
-   *
-   *   // Create the cameras between begin() and end().
-   *   myBuffer.begin();
-   *
-   *   // Create the first camera.
-   *   // Keep its default settings.
-   *   cam1 = myBuffer.createCamera();
-   *
-   *   // Create the second camera.
-   *   // Place it at the top-left.
-   *   // Point it at the origin.
-   *   cam2 = myBuffer.createCamera();
-   *   cam2.setPosition(400, -400, 800);
-   *   cam2.lookAt(0, 0, 0);
-   *
-   *   myBuffer.end();
-   *
-   *   describe(
-   *     'A white cube on a gray background. The camera toggles between frontal and aerial views when the user double-clicks.'
-   *   );
-   * }
-   *
-   * function draw() {
-   *   // Draw to the p5.Framebuffer object.
-   *   myBuffer.begin();
-   *   background(200);
-   *
-   *   // Set the camera.
-   *   if (usingCam1 === true) {
-   *     setCamera(cam1);
-   *   } else {
-   *     setCamera(cam2);
-   *   }
-   *
-   *   // Reset all transformations.
-   *   resetMatrix();
-   *
-   *   // Draw the box.
-   *   box();
-   *
-   *   myBuffer.end();
-   *
-   *   // Display the p5.Framebuffer object.
-   *   image(myBuffer, -50, -50);
-   * }
-   *
-   * // Toggle the current camera when the user double-clicks.
-   * function doubleClicked() {
-   *   if (usingCam1 === true) {
-   *     usingCam1 = false;
-   *   } else {
-   *     usingCam1 = true;
-   *   }
-   * }
-   * </code>
-   * </div>
-   */
-  createCamera() {
-    const cam = new p5.FramebufferCamera(this);
-    cam._computeCameraDefaultSettings();
-    cam._setDefaultCamera();
-    this.target._renderer.states.curCamera = cam;
-    return cam;
-  }
-
-  /**
-   * Given a raw texture wrapper, delete its stored texture from WebGL memory,
-   * and remove it from p5's list of active textures.
-   *
-   * @param {p5.FramebufferTexture} texture
-   * @private
-   */
-  _deleteTexture(texture) {
-    const gl = this.gl;
-    gl.deleteTexture(texture.rawTexture());
-
-    this.target._renderer.textures.delete(texture);
-  }
-
-  /**
-   * Deletes the framebuffer from GPU memory.
-   *
-   * Calling `myBuffer.remove()` frees the GPU memory used by the framebuffer.
-   * The framebuffer also uses a bit of memory on the CPU which can be freed
-   * like so:
-   *
-   * ```js
-   * // Delete the framebuffer from GPU memory.
-   * myBuffer.remove();
-   *
-   * // Delete the framebuffer from CPU memory.
-   * myBuffer = undefined;
-   * ```
-   *
-   * Note: All variables that reference the framebuffer must be assigned
-   * the value `undefined` to delete the framebuffer from CPU memory. If any
-   * variable still refers to the framebuffer, then it won't be garbage
-   * collected.
-   *
-   * @example
-   * <div>
-   * <code>
-   * // Double-click to remove the p5.Framebuffer object.
-   *
-   * let myBuffer;
-   *
-   * function setup() {
-   *   createCanvas(100, 100, WEBGL);
-   *
-   *   // Create an options object.
-   *   let options = { width: 60, height: 60 };
-   *
-   *   // Create a p5.Framebuffer object and
-   *   // configure it using options.
-   *   myBuffer = createFramebuffer(options);
-   *
-   *   describe('A white circle at the center of a dark gray square disappears when the user double-clicks.');
-   * }
-   *
-   * function draw() {
-   *   background(200);
-   *
-   *   // Display the p5.Framebuffer object if
-   *   // it's available.
-   *   if (myBuffer) {
-   *     // Draw to the p5.Framebuffer object.
-   *     myBuffer.begin();
-   *     background(100);
-   *     circle(0, 0, 20);
-   *     myBuffer.end();
-   *
-   *     image(myBuffer, -30, -30);
-   *   }
-   * }
-   *
-   * // Remove the p5.Framebuffer object when the
-   * // the user double-clicks.
-   * function doubleClicked() {
-   *   // Delete the framebuffer from GPU memory.
-   *   myBuffer.remove();
-   *
-   *   // Delete the framebuffer from CPU memory.
-   *   myBuffer = undefined;
-   * }
-   * </code>
-   * </div>
-   */
-  remove() {
-    const gl = this.gl;
-    this._deleteTexture(this.color);
-    if (this.depth) this._deleteTexture(this.depth);
-    gl.deleteFramebuffer(this.framebuffer);
-    if (this.aaFramebuffer) {
-      gl.deleteFramebuffer(this.aaFramebuffer);
-    }
-    if (this.depthRenderbuffer) {
-      gl.deleteRenderbuffer(this.depthRenderbuffer);
-    }
-    if (this.colorRenderbuffer) {
-      gl.deleteRenderbuffer(this.colorRenderbuffer);
-    }
-    this.target._renderer.framebuffers.delete(this);
-  }
-
-  /**
-   * Begins drawing shapes to the framebuffer.
-   *
-   * `myBuffer.begin()` and <a href="#/p5.Framebuffer/end">myBuffer.end()</a>
-   * allow shapes to be drawn to the framebuffer. `myBuffer.begin()` begins
-   * drawing to the framebuffer and
-   * <a href="#/p5.Framebuffer/end">myBuffer.end()</a> stops drawing to the
-   * framebuffer. Changes won't be visible until the framebuffer is displayed
-   * as an image or texture.
-   *
-   * @example
-   * <div>
-   * <code>
-   * let myBuffer;
-   *
-   * function setup() {
-   *   createCanvas(100, 100, WEBGL);
-   *
-   *   // Create a p5.Framebuffer object.
-   *   myBuffer = createFramebuffer();
-   *
-   *   describe('An empty gray canvas. The canvas gets darker and a rotating, multicolor torus appears while the user presses and holds the mouse.');
-   * }
-   *
-   * function draw() {
-   *   background(200);
-   *
-   *   // Start drawing to the p5.Framebuffer object.
-   *   myBuffer.begin();
-   *
-   *   background(50);
-   *   rotateY(frameCount * 0.01);
-   *   normalMaterial();
-   *   torus(30);
-   *
-   *   // Stop drawing to the p5.Framebuffer object.
-   *   myBuffer.end();
-   *
-   *   // Display the p5.Framebuffer object while
-   *   // the user presses the mouse.
-   *   if (mouseIsPressed === true) {
-   *     image(myBuffer, -50, -50);
-   *   }
-   * }
-   * </code>
-   * </div>
-   */
-  begin() {
-    this.prevFramebuffer = this.target._renderer.activeFramebuffer();
-    if (this.prevFramebuffer) {
-      this.prevFramebuffer._beforeEnd();
-    }
-    this.target._renderer.activeFramebuffers.push(this);
-    this._beforeBegin();
-    this.target.push();
-    // Apply the framebuffer's camera. This does almost what
-    // RendererGL.reset() does, but this does not try to clear any buffers;
-    // it only sets the camera.
-    this.target.setCamera(this.defaultCamera);
-    this.target.resetMatrix();
-    this.target._renderer.states.uViewMatrix
-      .set(this.target._renderer.states.curCamera.cameraMatrix);
-    this.target._renderer.states.uModelMatrix.reset();
-    this.target._renderer._applyStencilTestIfClipping();
-  }
-
-  /**
-   * When making a p5.Framebuffer active so that it may be drawn to, this method
-   * returns the underlying WebGL framebuffer that needs to be active to
-   * support this. Antialiased framebuffers first write to a multisampled
-   * renderbuffer, while other framebuffers can write directly to their main
-   * framebuffers.
-   *
-   * @private
-   */
-  _framebufferToBind() {
-    if (this.antialias) {
-      // If antialiasing, draw to an antialiased renderbuffer rather
-      // than directly to the texture. In end() we will copy from the
-      // renderbuffer to the texture.
-      return this.aaFramebuffer;
-    } else {
-      return this.framebuffer;
-    }
-  }
-
-  /**
-   * Ensures that the framebuffer is ready to be drawn to
-   *
-   * @private
-   */
-  _beforeBegin() {
-    const gl = this.gl;
-    gl.bindFramebuffer(gl.FRAMEBUFFER, this._framebufferToBind());
-    this.target._renderer.viewport(
-      this.width * this.density,
-      this.height * this.density
-    );
-  }
-
-  /**
-   * Ensures that the framebuffer is ready to be read by other framebuffers.
-   *
-   * @private
-   */
-  _beforeEnd() {
-    if (this.antialias) {
-      const gl = this.gl;
-      gl.bindFramebuffer(gl.READ_FRAMEBUFFER, this.aaFramebuffer);
-      gl.bindFramebuffer(gl.DRAW_FRAMEBUFFER, this.framebuffer);
-      const partsToCopy = [
-        [gl.COLOR_BUFFER_BIT, this.colorP5Texture.glMagFilter]
-      ];
       if (this.useDepth) {
-        partsToCopy.push(
-          [gl.DEPTH_BUFFER_BIT, this.depthP5Texture.glMagFilter]
+        this.depth = new p5.FramebufferTexture(this, 'depthTexture');
+        const depthFilter = gl.NEAREST;
+        this.depthP5Texture = new p5.Texture(
+          this.target._renderer,
+          this.depth,
+          {
+            minFilter: depthFilter,
+            magFilter: depthFilter
+          }
         );
+        this.target._renderer.textures.set(this.depth, this.depthP5Texture);
       }
-      for (const [flag, filter] of partsToCopy) {
-        gl.blitFramebuffer(
-          0, 0,
-          this.width * this.density, this.height * this.density,
-          0, 0,
-          this.width * this.density, this.height * this.density,
-          flag,
-          filter
-        );
-      }
-    }
-  }
 
-  /**
-   * Stops drawing shapes to the framebuffer.
-   *
-   * <a href="#/p5.Framebuffer/begin">myBuffer.begin()</a> and `myBuffer.end()`
-   * allow shapes to be drawn to the framebuffer.
-   * <a href="#/p5.Framebuffer/begin">myBuffer.begin()</a> begins drawing to
-   * the framebuffer and `myBuffer.end()` stops drawing to the framebuffer.
-   * Changes won't be visible until the framebuffer is displayed as an image
-   * or texture.
-   *
-   * @example
-   * <div>
-   * <code>
-   * let myBuffer;
-   *
-   * function setup() {
-   *   createCanvas(100, 100, WEBGL);
-   *
-   *   // Create a p5.Framebuffer object.
-   *   myBuffer = createFramebuffer();
-   *
-   *   describe('An empty gray canvas. The canvas gets darker and a rotating, multicolor torus appears while the user presses and holds the mouse.');
-   * }
-   *
-   * function draw() {
-   *   background(200);
-   *
-   *   // Start drawing to the p5.Framebuffer object.
-   *   myBuffer.begin();
-   *
-   *   background(50);
-   *   rotateY(frameCount * 0.01);
-   *   normalMaterial();
-   *   torus(30);
-   *
-   *   // Stop drawing to the p5.Framebuffer object.
-   *   myBuffer.end();
-   *
-   *   // Display the p5.Framebuffer object while
-   *   // the user presses the mouse.
-   *   if (mouseIsPressed === true) {
-   *     image(myBuffer, -50, -50);
-   *   }
-   * }
-   * </code>
-   * </div>
-   */
-  end() {
-    const gl = this.gl;
-    this.target.pop();
-    const fbo = this.target._renderer.activeFramebuffers.pop();
-    if (fbo !== this) {
-      throw new Error("It looks like you've called end() while another Framebuffer is active.");
+      this.color = new p5.FramebufferTexture(this, 'colorTexture');
+      const filter = this.textureFiltering === constants.LINEAR
+        ? gl.LINEAR
+        : gl.NEAREST;
+      this.colorP5Texture = new p5.Texture(
+        this.target._renderer,
+        this.color,
+        {
+          minFilter: filter,
+          magFilter: filter
+        }
+      );
+      this.target._renderer.textures.set(this.color, this.colorP5Texture);
+
+      gl.bindTexture(gl.TEXTURE_2D, prevBoundTexture);
+      gl.bindFramebuffer(gl.FRAMEBUFFER, prevBoundFramebuffer);
     }
-    this._beforeEnd();
-    if (this.prevFramebuffer) {
-      this.prevFramebuffer._beforeBegin();
-    } else {
-      gl.bindFramebuffer(gl.FRAMEBUFFER, null);
+
+    /**
+     * To create a WebGL texture, one needs to supply three pieces of information:
+     * the type (the data type each channel will be stored as, e.g. int or float),
+     * the format (the color channels that will each be stored in the previously
+     * specified type, e.g. rgb or rgba), and the internal format (the specifics
+     * of how data for each channel, in the aforementioned type, will be packed
+     * together, such as how many bits to use, e.g. RGBA32F or RGB565.)
+     *
+     * The format and channels asked for by the user hint at what these values
+     * need to be, and the WebGL version affects what options are avaiable.
+     * This method returns the values for these three properties, given the
+     * framebuffer's settings.
+     *
+     * @private
+     */
+    _glColorFormat() {
+      let type, format, internalFormat;
+      const gl = this.gl;
+
+      if (this.format === constants.FLOAT) {
+        type = gl.FLOAT;
+      } else if (this.format === constants.HALF_FLOAT) {
+        type = this.target.webglVersion === constants.WEBGL2
+          ? gl.HALF_FLOAT
+          : gl.getExtension('OES_texture_half_float').HALF_FLOAT_OES;
+      } else {
+        type = gl.UNSIGNED_BYTE;
+      }
+
+      if (this.channels === constants.RGBA) {
+        format = gl.RGBA;
+      } else {
+        format = gl.RGB;
+      }
+
+      if (this.target.webglVersion === constants.WEBGL2) {
+        // https://webgl2fundamentals.org/webgl/lessons/webgl-data-textures.html
+        const table = {
+          [gl.FLOAT]: {
+            [gl.RGBA]: gl.RGBA32F
+            // gl.RGB32F is not available in Firefox without an alpha channel
+          },
+          [gl.HALF_FLOAT]: {
+            [gl.RGBA]: gl.RGBA16F
+            // gl.RGB16F is not available in Firefox without an alpha channel
+          },
+          [gl.UNSIGNED_BYTE]: {
+            [gl.RGBA]: gl.RGBA8, // gl.RGBA4
+            [gl.RGB]: gl.RGB8 // gl.RGB565
+          }
+        };
+        internalFormat = table[type][format];
+      } else if (this.format === constants.HALF_FLOAT) {
+        internalFormat = gl.RGBA;
+      } else {
+        internalFormat = format;
+      }
+
+      return { internalFormat, format, type };
+    }
+
+    /**
+     * To create a WebGL texture, one needs to supply three pieces of information:
+     * the type (the data type each channel will be stored as, e.g. int or float),
+     * the format (the color channels that will each be stored in the previously
+     * specified type, e.g. rgb or rgba), and the internal format (the specifics
+     * of how data for each channel, in the aforementioned type, will be packed
+     * together, such as how many bits to use, e.g. RGBA32F or RGB565.)
+     *
+     * This method takes into account the settings asked for by the user and
+     * returns values for these three properties that can be used for the
+     * texture storing depth information.
+     *
+     * @private
+     */
+    _glDepthFormat() {
+      let type, format, internalFormat;
+      const gl = this.gl;
+
+      if (this.useStencil) {
+        if (this.depthFormat === constants.FLOAT) {
+          type = gl.FLOAT_32_UNSIGNED_INT_24_8_REV;
+        } else if (this.target.webglVersion === constants.WEBGL2) {
+          type = gl.UNSIGNED_INT_24_8;
+        } else {
+          type = gl.getExtension('WEBGL_depth_texture').UNSIGNED_INT_24_8_WEBGL;
+        }
+      } else {
+        if (this.depthFormat === constants.FLOAT) {
+          type = gl.FLOAT;
+        } else {
+          type = gl.UNSIGNED_INT;
+        }
+      }
+
+      if (this.useStencil) {
+        format = gl.DEPTH_STENCIL;
+      } else {
+        format = gl.DEPTH_COMPONENT;
+      }
+
+      if (this.useStencil) {
+        if (this.depthFormat === constants.FLOAT) {
+          internalFormat = gl.DEPTH32F_STENCIL8;
+        } else if (this.target.webglVersion === constants.WEBGL2) {
+          internalFormat = gl.DEPTH24_STENCIL8;
+        } else {
+          internalFormat = gl.DEPTH_STENCIL;
+        }
+      } else if (this.target.webglVersion === constants.WEBGL2) {
+        if (this.depthFormat === constants.FLOAT) {
+          internalFormat = gl.DEPTH_COMPONENT32F;
+        } else {
+          internalFormat = gl.DEPTH_COMPONENT24;
+        }
+      } else {
+        internalFormat = gl.DEPTH_COMPONENT;
+      }
+
+      return { internalFormat, format, type };
+    }
+
+    /**
+     * A method that will be called when recreating textures. If the framebuffer
+     * is auto-sized, it will update its width, height, and density properties.
+     *
+     * @private
+     */
+    _updateSize() {
+      if (this._autoSized) {
+        this.width = this.target.width;
+        this.height = this.target.height;
+        this.density = this.target.pixelDensity();
+      }
+    }
+
+    /**
+     * Called when the canvas that the framebuffer is attached to resizes. If the
+     * framebuffer is auto-sized, it will update its textures to match the new
+     * size.
+     *
+     * @private
+     */
+    _canvasSizeChanged() {
+      if (this._autoSized) {
+        this._handleResize();
+      }
+    }
+
+    /**
+     * Called when the size of the framebuffer has changed (either by being
+     * manually updated or from auto-size updates when its canvas changes size.)
+     * Old textures and renderbuffers will be deleted, and then recreated with the
+     * new size.
+     *
+     * @private
+     */
+    _handleResize() {
+      const oldColor = this.color;
+      const oldDepth = this.depth;
+      const oldColorRenderbuffer = this.colorRenderbuffer;
+      const oldDepthRenderbuffer = this.depthRenderbuffer;
+
+      this._deleteTexture(oldColor);
+      if (oldDepth) this._deleteTexture(oldDepth);
+      const gl = this.gl;
+      if (oldColorRenderbuffer) gl.deleteRenderbuffer(oldColorRenderbuffer);
+      if (oldDepthRenderbuffer) gl.deleteRenderbuffer(oldDepthRenderbuffer);
+
+      this._recreateTextures();
+      this.defaultCamera._resize();
+    }
+
+    /**
+     * Creates a new
+     * <a href="#/p5.Camera">p5.Camera</a> object to use with the framebuffer.
+     *
+     * The new camera is initialized with a default position `(0, 0, 800)` and a
+     * default perspective projection. Its properties can be controlled with
+     * <a href="#/p5.Camera">p5.Camera</a> methods such as `myCamera.lookAt(0, 0, 0)`.
+     *
+     * Framebuffer cameras should be created between calls to
+     * <a href="#/p5.Framebuffer/begin">myBuffer.begin()</a> and
+     * <a href="#/p5.Framebuffer/end">myBuffer.end()</a> like so:
+     *
+     * ```js
+     * let myCamera;
+     *
+     * myBuffer.begin();
+     *
+     * // Create the camera for the framebuffer.
+     * myCamera = myBuffer.createCamera();
+     *
+     * myBuffer.end();
+     * ```
+     *
+     * Calling <a href="#/p5/setCamera">setCamera()</a> updates the
+     * framebuffer's projection using the camera.
+     * <a href="#/p5/resetMatrix">resetMatrix()</a> must also be called for the
+     * view to change properly:
+     *
+     * ```js
+     * myBuffer.begin();
+     *
+     * // Set the camera for the framebuffer.
+     * setCamera(myCamera);
+     *
+     * // Reset all transformations.
+     * resetMatrix();
+     *
+     * // Draw stuff...
+     *
+     * myBuffer.end();
+     * ```
+     *
+     * @returns {p5.Camera} new camera.
+     *
+     * @example
+     * <div>
+     * <code>
+     * // Double-click to toggle between cameras.
+     *
+     * let myBuffer;
+     * let cam1;
+     * let cam2;
+     * let usingCam1 = true;
+     *
+     * function setup() {
+     *   createCanvas(100, 100, WEBGL);
+     *
+     *   // Create a p5.Framebuffer object.
+     *   myBuffer = createFramebuffer();
+     *
+     *   // Create the cameras between begin() and end().
+     *   myBuffer.begin();
+     *
+     *   // Create the first camera.
+     *   // Keep its default settings.
+     *   cam1 = myBuffer.createCamera();
+     *
+     *   // Create the second camera.
+     *   // Place it at the top-left.
+     *   // Point it at the origin.
+     *   cam2 = myBuffer.createCamera();
+     *   cam2.setPosition(400, -400, 800);
+     *   cam2.lookAt(0, 0, 0);
+     *
+     *   myBuffer.end();
+     *
+     *   describe(
+     *     'A white cube on a gray background. The camera toggles between frontal and aerial views when the user double-clicks.'
+     *   );
+     * }
+     *
+     * function draw() {
+     *   // Draw to the p5.Framebuffer object.
+     *   myBuffer.begin();
+     *   background(200);
+     *
+     *   // Set the camera.
+     *   if (usingCam1 === true) {
+     *     setCamera(cam1);
+     *   } else {
+     *     setCamera(cam2);
+     *   }
+     *
+     *   // Reset all transformations.
+     *   resetMatrix();
+     *
+     *   // Draw the box.
+     *   box();
+     *
+     *   myBuffer.end();
+     *
+     *   // Display the p5.Framebuffer object.
+     *   image(myBuffer, -50, -50);
+     * }
+     *
+     * // Toggle the current camera when the user double-clicks.
+     * function doubleClicked() {
+     *   if (usingCam1 === true) {
+     *     usingCam1 = false;
+     *   } else {
+     *     usingCam1 = true;
+     *   }
+     * }
+     * </code>
+     * </div>
+     */
+    createCamera() {
+      const cam = new p5.FramebufferCamera(this);
+      cam._computeCameraDefaultSettings();
+      cam._setDefaultCamera();
+      this.target._renderer.states.curCamera = cam;
+      return cam;
+    }
+
+    /**
+     * Given a raw texture wrapper, delete its stored texture from WebGL memory,
+     * and remove it from p5's list of active textures.
+     *
+     * @param {p5.FramebufferTexture} texture
+     * @private
+     */
+    _deleteTexture(texture) {
+      const gl = this.gl;
+      gl.deleteTexture(texture.rawTexture());
+
+      this.target._renderer.textures.delete(texture);
+    }
+
+    /**
+     * Deletes the framebuffer from GPU memory.
+     *
+     * Calling `myBuffer.remove()` frees the GPU memory used by the framebuffer.
+     * The framebuffer also uses a bit of memory on the CPU which can be freed
+     * like so:
+     *
+     * ```js
+     * // Delete the framebuffer from GPU memory.
+     * myBuffer.remove();
+     *
+     * // Delete the framebuffer from CPU memory.
+     * myBuffer = undefined;
+     * ```
+     *
+     * Note: All variables that reference the framebuffer must be assigned
+     * the value `undefined` to delete the framebuffer from CPU memory. If any
+     * variable still refers to the framebuffer, then it won't be garbage
+     * collected.
+     *
+     * @example
+     * <div>
+     * <code>
+     * // Double-click to remove the p5.Framebuffer object.
+     *
+     * let myBuffer;
+     *
+     * function setup() {
+     *   createCanvas(100, 100, WEBGL);
+     *
+     *   // Create an options object.
+     *   let options = { width: 60, height: 60 };
+     *
+     *   // Create a p5.Framebuffer object and
+     *   // configure it using options.
+     *   myBuffer = createFramebuffer(options);
+     *
+     *   describe('A white circle at the center of a dark gray square disappears when the user double-clicks.');
+     * }
+     *
+     * function draw() {
+     *   background(200);
+     *
+     *   // Display the p5.Framebuffer object if
+     *   // it's available.
+     *   if (myBuffer) {
+     *     // Draw to the p5.Framebuffer object.
+     *     myBuffer.begin();
+     *     background(100);
+     *     circle(0, 0, 20);
+     *     myBuffer.end();
+     *
+     *     image(myBuffer, -30, -30);
+     *   }
+     * }
+     *
+     * // Remove the p5.Framebuffer object when the
+     * // the user double-clicks.
+     * function doubleClicked() {
+     *   // Delete the framebuffer from GPU memory.
+     *   myBuffer.remove();
+     *
+     *   // Delete the framebuffer from CPU memory.
+     *   myBuffer = undefined;
+     * }
+     * </code>
+     * </div>
+     */
+    remove() {
+      const gl = this.gl;
+      this._deleteTexture(this.color);
+      if (this.depth) this._deleteTexture(this.depth);
+      gl.deleteFramebuffer(this.framebuffer);
+      if (this.aaFramebuffer) {
+        gl.deleteFramebuffer(this.aaFramebuffer);
+      }
+      if (this.depthRenderbuffer) {
+        gl.deleteRenderbuffer(this.depthRenderbuffer);
+      }
+      if (this.colorRenderbuffer) {
+        gl.deleteRenderbuffer(this.colorRenderbuffer);
+      }
+      this.target._renderer.framebuffers.delete(this);
+    }
+
+    /**
+     * Begins drawing shapes to the framebuffer.
+     *
+     * `myBuffer.begin()` and <a href="#/p5.Framebuffer/end">myBuffer.end()</a>
+     * allow shapes to be drawn to the framebuffer. `myBuffer.begin()` begins
+     * drawing to the framebuffer and
+     * <a href="#/p5.Framebuffer/end">myBuffer.end()</a> stops drawing to the
+     * framebuffer. Changes won't be visible until the framebuffer is displayed
+     * as an image or texture.
+     *
+     * @example
+     * <div>
+     * <code>
+     * let myBuffer;
+     *
+     * function setup() {
+     *   createCanvas(100, 100, WEBGL);
+     *
+     *   // Create a p5.Framebuffer object.
+     *   myBuffer = createFramebuffer();
+     *
+     *   describe('An empty gray canvas. The canvas gets darker and a rotating, multicolor torus appears while the user presses and holds the mouse.');
+     * }
+     *
+     * function draw() {
+     *   background(200);
+     *
+     *   // Start drawing to the p5.Framebuffer object.
+     *   myBuffer.begin();
+     *
+     *   background(50);
+     *   rotateY(frameCount * 0.01);
+     *   normalMaterial();
+     *   torus(30);
+     *
+     *   // Stop drawing to the p5.Framebuffer object.
+     *   myBuffer.end();
+     *
+     *   // Display the p5.Framebuffer object while
+     *   // the user presses the mouse.
+     *   if (mouseIsPressed === true) {
+     *     image(myBuffer, -50, -50);
+     *   }
+     * }
+     * </code>
+     * </div>
+     */
+    begin() {
+      this.prevFramebuffer = this.target._renderer.activeFramebuffer();
+      if (this.prevFramebuffer) {
+        this.prevFramebuffer._beforeEnd();
+      }
+      this.target._renderer.activeFramebuffers.push(this);
+      this._beforeBegin();
+      this.target.push();
+      // Apply the framebuffer's camera. This does almost what
+      // RendererGL.reset() does, but this does not try to clear any buffers;
+      // it only sets the camera.
+      this.target.setCamera(this.defaultCamera);
+      this.target.resetMatrix();
+      this.target._renderer.states.uViewMatrix
+        .set(this.target._renderer.states.curCamera.cameraMatrix);
+      this.target._renderer.states.uModelMatrix.reset();
+      this.target._renderer._applyStencilTestIfClipping();
+    }
+
+    /**
+     * When making a p5.Framebuffer active so that it may be drawn to, this method
+     * returns the underlying WebGL framebuffer that needs to be active to
+     * support this. Antialiased framebuffers first write to a multisampled
+     * renderbuffer, while other framebuffers can write directly to their main
+     * framebuffers.
+     *
+     * @private
+     */
+    _framebufferToBind() {
+      if (this.antialias) {
+        // If antialiasing, draw to an antialiased renderbuffer rather
+        // than directly to the texture. In end() we will copy from the
+        // renderbuffer to the texture.
+        return this.aaFramebuffer;
+      } else {
+        return this.framebuffer;
+      }
+    }
+
+    /**
+     * Ensures that the framebuffer is ready to be drawn to
+     *
+     * @private
+     */
+    _beforeBegin() {
+      const gl = this.gl;
+      gl.bindFramebuffer(gl.FRAMEBUFFER, this._framebufferToBind());
       this.target._renderer.viewport(
-        this.target._renderer._origViewport.width,
-        this.target._renderer._origViewport.height
+        this.width * this.density,
+        this.height * this.density
       );
     }
-    this.target._renderer._applyStencilTestIfClipping();
-  }
 
-  /**
-   * Draws to the framebuffer by calling a function that contains drawing
-   * instructions.
-   *
-   * The parameter, `callback`, is a function with the drawing instructions
-   * for the framebuffer. For example, calling `myBuffer.draw(myFunction)`
-   * will call a function named `myFunction()` to draw to the framebuffer.
-   * Doing so has the same effect as the following:
-   *
-   * ```js
-   * myBuffer.begin();
-   * myFunction();
-   * myBuffer.end();
-   * ```
-   *
-   * @param {Function} callback function that draws to the framebuffer.
-   *
-   * @example
-   * <div>
-   * <code>
-   * // Click the canvas to display the framebuffer.
-   *
-   * let myBuffer;
-   *
-   * function setup() {
-   *   createCanvas(100, 100, WEBGL);
-   *
-   *   // Create a p5.Framebuffer object.
-   *   myBuffer = createFramebuffer();
-   *
-   *   describe('An empty gray canvas. The canvas gets darker and a rotating, multicolor torus appears while the user presses and holds the mouse.');
-   * }
-   *
-   * function draw() {
-   *   background(200);
-   *
-   *   // Draw to the p5.Framebuffer object.
-   *   myBuffer.draw(bagel);
-   *
-   *   // Display the p5.Framebuffer object while
-   *   // the user presses the mouse.
-   *   if (mouseIsPressed === true) {
-   *     image(myBuffer, -50, -50);
-   *   }
-   * }
-   *
-   * // Draw a rotating, multicolor torus.
-   * function bagel() {
-   *   background(50);
-   *   rotateY(frameCount * 0.01);
-   *   normalMaterial();
-   *   torus(30);
-   * }
-   * </code>
-   * </div>
-   */
-  draw(callback) {
-    this.begin();
-    callback();
-    this.end();
-  }
-
-  /**
-   * Loads the current value of each pixel in the framebuffer into its
-   * <a href="#/p5.Framebuffer/pixels">pixels</a> array.
-   *
-   * `myBuffer.loadPixels()` must be called before reading from or writing to
-   * <a href="#/p5.Framebuffer/pixels">myBuffer.pixels</a>.
-   *
-   * @method loadPixels
-   *
-   * @example
-   * <div>
-   * <code>
-   * function setup() {
-   *   createCanvas(100, 100, WEBGL);
-   *
-   *   background(200);
-   *
-   *   // Create a p5.Framebuffer object.
-   *   let myBuffer = createFramebuffer();
-   *
-   *   // Load the pixels array.
-   *   myBuffer.loadPixels();
-   *
-   *   // Get the number of pixels in the
-   *   // top half of the framebuffer.
-   *   let numPixels = myBuffer.pixels.length / 2;
-   *
-   *   // Set the framebuffer's top half to pink.
-   *   for (let i = 0; i < numPixels; i += 4) {
-   *     myBuffer.pixels[i] = 255;
-   *     myBuffer.pixels[i + 1] = 102;
-   *     myBuffer.pixels[i + 2] = 204;
-   *     myBuffer.pixels[i + 3] = 255;
-   *   }
-   *
-   *   // Update the pixels array.
-   *   myBuffer.updatePixels();
-   *
-   *   // Draw the p5.Framebuffer object to the canvas.
-   *   image(myBuffer, -50, -50);
-   *
-   *   describe('A pink rectangle above a gray rectangle.');
-   * }
-   * </code>
-   * </div>
-   */
-  loadPixels() {
-    const gl = this.gl;
-    const prevFramebuffer = this.target._renderer.activeFramebuffer();
-    gl.bindFramebuffer(gl.FRAMEBUFFER, this.framebuffer);
-    const colorFormat = this._glColorFormat();
-    this.pixels = readPixelsWebGL(
-      this.pixels,
-      gl,
-      this.framebuffer,
-      0,
-      0,
-      this.width * this.density,
-      this.height * this.density,
-      colorFormat.format,
-      colorFormat.type
-    );
-    if (prevFramebuffer) {
-      gl.bindFramebuffer(gl.FRAMEBUFFER, prevFramebuffer._framebufferToBind());
-    } else {
-      gl.bindFramebuffer(gl.FRAMEBUFFER, null);
-    }
-  }
-
-  /**
-   * Gets a pixel or a region of pixels from the framebuffer.
-   *
-   * `myBuffer.get()` is easy to use but it's not as fast as
-   * <a href="#/p5.Framebuffer/pixels">myBuffer.pixels</a>. Use
-   * <a href="#/p5.Framebuffer/pixels">myBuffer.pixels</a> to read many pixel
-   * values.
-   *
-   * The version of `myBuffer.get()` with no parameters returns the entire
-   * framebuffer as a a <a href="#/p5.Image">p5.Image</a> object.
-   *
-   * The version of `myBuffer.get()` with two parameters interprets them as
-   * coordinates. It returns an array with the `[R, G, B, A]` values of the
-   * pixel at the given point.
-   *
-   * The version of `myBuffer.get()` with four parameters interprets them as
-   * coordinates and dimensions. It returns a subsection of the framebuffer as
-   * a <a href="#/p5.Image">p5.Image</a> object. The first two parameters are
-   * the coordinates for the upper-left corner of the subsection. The last two
-   * parameters are the width and height of the subsection.
-   *
-   * @param  {Number} x x-coordinate of the pixel. Defaults to 0.
-   * @param  {Number} y y-coordinate of the pixel. Defaults to 0.
-   * @param  {Number} w width of the subsection to be returned.
-   * @param  {Number} h height of the subsection to be returned.
-   * @return {p5.Image} subsection as a <a href="#/p5.Image">p5.Image</a> object.
-   */
-  /**
-   * @return {p5.Image} entire framebuffer as a <a href="#/p5.Image">p5.Image</a> object.
-   */
-  /**
-   * @param  {Number} x
-   * @param  {Number} y
-   * @return {Number[]}  color of the pixel at `(x, y)` as an array of color values `[R, G, B, A]`.
-   */
-  get(x, y, w, h) {
-    p5._validateParameters('p5.Framebuffer.get', arguments);
-    const colorFormat = this._glColorFormat();
-    if (x === undefined && y === undefined) {
-      x = 0;
-      y = 0;
-      w = this.width;
-      h = this.height;
-    } else if (w === undefined && h === undefined) {
-      if (x < 0 || y < 0 || x >= this.width || y >= this.height) {
-        console.warn(
-          'The x and y values passed to p5.Framebuffer.get are outside of its range and will be clamped.'
-        );
-        x = this.target.constrain(x, 0, this.width - 1);
-        y = this.target.constrain(y, 0, this.height - 1);
+    /**
+     * Ensures that the framebuffer is ready to be read by other framebuffers.
+     *
+     * @private
+     */
+    _beforeEnd() {
+      if (this.antialias) {
+        const gl = this.gl;
+        gl.bindFramebuffer(gl.READ_FRAMEBUFFER, this.aaFramebuffer);
+        gl.bindFramebuffer(gl.DRAW_FRAMEBUFFER, this.framebuffer);
+        const partsToCopy = [
+          [gl.COLOR_BUFFER_BIT, this.colorP5Texture.glMagFilter]
+        ];
+        if (this.useDepth) {
+          partsToCopy.push(
+            [gl.DEPTH_BUFFER_BIT, this.depthP5Texture.glMagFilter]
+          );
+        }
+        for (const [flag, filter] of partsToCopy) {
+          gl.blitFramebuffer(
+            0, 0,
+            this.width * this.density, this.height * this.density,
+            0, 0,
+            this.width * this.density, this.height * this.density,
+            flag,
+            filter
+          );
+        }
       }
+    }
 
-      return readPixelWebGL(
-        this.gl,
+    /**
+     * Stops drawing shapes to the framebuffer.
+     *
+     * <a href="#/p5.Framebuffer/begin">myBuffer.begin()</a> and `myBuffer.end()`
+     * allow shapes to be drawn to the framebuffer.
+     * <a href="#/p5.Framebuffer/begin">myBuffer.begin()</a> begins drawing to
+     * the framebuffer and `myBuffer.end()` stops drawing to the framebuffer.
+     * Changes won't be visible until the framebuffer is displayed as an image
+     * or texture.
+     *
+     * @example
+     * <div>
+     * <code>
+     * let myBuffer;
+     *
+     * function setup() {
+     *   createCanvas(100, 100, WEBGL);
+     *
+     *   // Create a p5.Framebuffer object.
+     *   myBuffer = createFramebuffer();
+     *
+     *   describe('An empty gray canvas. The canvas gets darker and a rotating, multicolor torus appears while the user presses and holds the mouse.');
+     * }
+     *
+     * function draw() {
+     *   background(200);
+     *
+     *   // Start drawing to the p5.Framebuffer object.
+     *   myBuffer.begin();
+     *
+     *   background(50);
+     *   rotateY(frameCount * 0.01);
+     *   normalMaterial();
+     *   torus(30);
+     *
+     *   // Stop drawing to the p5.Framebuffer object.
+     *   myBuffer.end();
+     *
+     *   // Display the p5.Framebuffer object while
+     *   // the user presses the mouse.
+     *   if (mouseIsPressed === true) {
+     *     image(myBuffer, -50, -50);
+     *   }
+     * }
+     * </code>
+     * </div>
+     */
+    end() {
+      const gl = this.gl;
+      this.target.pop();
+      const fbo = this.target._renderer.activeFramebuffers.pop();
+      if (fbo !== this) {
+        throw new Error("It looks like you've called end() while another Framebuffer is active.");
+      }
+      this._beforeEnd();
+      if (this.prevFramebuffer) {
+        this.prevFramebuffer._beforeBegin();
+      } else {
+        gl.bindFramebuffer(gl.FRAMEBUFFER, null);
+        this.target._renderer.viewport(
+          this.target._renderer._origViewport.width,
+          this.target._renderer._origViewport.height
+        );
+      }
+      this.target._renderer._applyStencilTestIfClipping();
+    }
+
+    /**
+     * Draws to the framebuffer by calling a function that contains drawing
+     * instructions.
+     *
+     * The parameter, `callback`, is a function with the drawing instructions
+     * for the framebuffer. For example, calling `myBuffer.draw(myFunction)`
+     * will call a function named `myFunction()` to draw to the framebuffer.
+     * Doing so has the same effect as the following:
+     *
+     * ```js
+     * myBuffer.begin();
+     * myFunction();
+     * myBuffer.end();
+     * ```
+     *
+     * @param {Function} callback function that draws to the framebuffer.
+     *
+     * @example
+     * <div>
+     * <code>
+     * // Click the canvas to display the framebuffer.
+     *
+     * let myBuffer;
+     *
+     * function setup() {
+     *   createCanvas(100, 100, WEBGL);
+     *
+     *   // Create a p5.Framebuffer object.
+     *   myBuffer = createFramebuffer();
+     *
+     *   describe('An empty gray canvas. The canvas gets darker and a rotating, multicolor torus appears while the user presses and holds the mouse.');
+     * }
+     *
+     * function draw() {
+     *   background(200);
+     *
+     *   // Draw to the p5.Framebuffer object.
+     *   myBuffer.draw(bagel);
+     *
+     *   // Display the p5.Framebuffer object while
+     *   // the user presses the mouse.
+     *   if (mouseIsPressed === true) {
+     *     image(myBuffer, -50, -50);
+     *   }
+     * }
+     *
+     * // Draw a rotating, multicolor torus.
+     * function bagel() {
+     *   background(50);
+     *   rotateY(frameCount * 0.01);
+     *   normalMaterial();
+     *   torus(30);
+     * }
+     * </code>
+     * </div>
+     */
+    draw(callback) {
+      this.begin();
+      callback();
+      this.end();
+    }
+
+    /**
+     * Loads the current value of each pixel in the framebuffer into its
+     * <a href="#/p5.Framebuffer/pixels">pixels</a> array.
+     *
+     * `myBuffer.loadPixels()` must be called before reading from or writing to
+     * <a href="#/p5.Framebuffer/pixels">myBuffer.pixels</a>.
+     *
+     * @method loadPixels
+     *
+     * @example
+     * <div>
+     * <code>
+     * function setup() {
+     *   createCanvas(100, 100, WEBGL);
+     *
+     *   background(200);
+     *
+     *   // Create a p5.Framebuffer object.
+     *   let myBuffer = createFramebuffer();
+     *
+     *   // Load the pixels array.
+     *   myBuffer.loadPixels();
+     *
+     *   // Get the number of pixels in the
+     *   // top half of the framebuffer.
+     *   let numPixels = myBuffer.pixels.length / 2;
+     *
+     *   // Set the framebuffer's top half to pink.
+     *   for (let i = 0; i < numPixels; i += 4) {
+     *     myBuffer.pixels[i] = 255;
+     *     myBuffer.pixels[i + 1] = 102;
+     *     myBuffer.pixels[i + 2] = 204;
+     *     myBuffer.pixels[i + 3] = 255;
+     *   }
+     *
+     *   // Update the pixels array.
+     *   myBuffer.updatePixels();
+     *
+     *   // Draw the p5.Framebuffer object to the canvas.
+     *   image(myBuffer, -50, -50);
+     *
+     *   describe('A pink rectangle above a gray rectangle.');
+     * }
+     * </code>
+     * </div>
+     */
+    loadPixels() {
+      const gl = this.gl;
+      const prevFramebuffer = this.target._renderer.activeFramebuffer();
+      gl.bindFramebuffer(gl.FRAMEBUFFER, this.framebuffer);
+      const colorFormat = this._glColorFormat();
+      this.pixels = readPixelsWebGL(
+        this.pixels,
+        gl,
         this.framebuffer,
-        x * this.density,
-        y * this.density,
+        0,
+        0,
+        this.width * this.density,
+        this.height * this.density,
         colorFormat.format,
         colorFormat.type
       );
-    }
-
-    x = this.target.constrain(x, 0, this.width - 1);
-    y = this.target.constrain(y, 0, this.height - 1);
-    w = this.target.constrain(w, 1, this.width - x);
-    h = this.target.constrain(h, 1, this.height - y);
-
-    const rawData = readPixelsWebGL(
-      undefined,
-      this.gl,
-      this.framebuffer,
-      x * this.density,
-      y * this.density,
-      w * this.density,
-      h * this.density,
-      colorFormat.format,
-      colorFormat.type
-    );
-    // Framebuffer data might be either a Uint8Array or Float32Array
-    // depending on its format, and it may or may not have an alpha channel.
-    // To turn it into an image, we have to normalize the data into a
-    // Uint8ClampedArray with alpha.
-    const fullData = new Uint8ClampedArray(
-      w * h * this.density * this.density * 4
-    );
-
-    // Default channels that aren't in the framebuffer (e.g. alpha, if the
-    // framebuffer is in RGB mode instead of RGBA) to 255
-    fullData.fill(255);
-
-    const channels = colorFormat.type === this.gl.RGB ? 3 : 4;
-    for (let y = 0; y < h * this.density; y++) {
-      for (let x = 0; x < w * this.density; x++) {
-        for (let channel = 0; channel < 4; channel++) {
-          const idx = (y * w * this.density + x) * 4 + channel;
-          if (channel < channels) {
-            // Find the index of this pixel in `rawData`, which might have a
-            // different number of channels
-            const rawDataIdx = channels === 4
-              ? idx
-              : (y * w * this.density + x) * channels + channel;
-            fullData[idx] = rawData[rawDataIdx];
-          }
-        }
-      }
-    }
-
-    // Create an image from the data
-    const region = new p5.Image(w * this.density, h * this.density);
-    region.imageData = region.canvas.getContext('2d').createImageData(
-      region.width,
-      region.height
-    );
-    region.imageData.data.set(fullData);
-    region.pixels = region.imageData.data;
-    region.updatePixels();
-    if (this.density !== 1) {
-      // TODO: support get() at a pixel density > 1
-      region.resize(w, h);
-    }
-    return region;
-  }
-
-  /**
-   * Updates the framebuffer with the RGBA values in the
-   * <a href="#/p5.Framebuffer/pixels">pixels</a> array.
-   *
-   * `myBuffer.updatePixels()` only needs to be called after changing values
-   * in the <a href="#/p5.Framebuffer/pixels">myBuffer.pixels</a> array. Such
-   * changes can be made directly after calling
-   * <a href="#/p5.Framebuffer/loadPixels">myBuffer.loadPixels()</a>.
-   *
-   * @method updatePixels
-   *
-   * @example
-   * <div>
-   * <code>
-   * function setup() {
-   *   createCanvas(100, 100, WEBGL);
-   *
-   *   background(200);
-   *
-   *   // Create a p5.Framebuffer object.
-   *   let myBuffer = createFramebuffer();
-   *
-   *   // Load the pixels array.
-   *   myBuffer.loadPixels();
-   *
-   *   // Get the number of pixels in the
-   *   // top half of the framebuffer.
-   *   let numPixels = myBuffer.pixels.length / 2;
-   *
-   *   // Set the framebuffer's top half to pink.
-   *   for (let i = 0; i < numPixels; i += 4) {
-   *     myBuffer.pixels[i] = 255;
-   *     myBuffer.pixels[i + 1] = 102;
-   *     myBuffer.pixels[i + 2] = 204;
-   *     myBuffer.pixels[i + 3] = 255;
-   *   }
-   *
-   *   // Update the pixels array.
-   *   myBuffer.updatePixels();
-   *
-   *   // Draw the p5.Framebuffer object to the canvas.
-   *   image(myBuffer, -50, -50);
-   *
-   *   describe('A pink rectangle above a gray rectangle.');
-   * }
-   * </code>
-   * </div>
-   */
-  updatePixels() {
-    const gl = this.gl;
-    this.colorP5Texture.bindTexture();
-    const colorFormat = this._glColorFormat();
-
-    const channels = colorFormat.format === gl.RGBA ? 4 : 3;
-    const len =
-      this.width * this.height * this.density * this.density * channels;
-    const TypedArrayClass = colorFormat.type === gl.UNSIGNED_BYTE
-      ? Uint8Array
-      : Float32Array;
-    if (
-      !(this.pixels instanceof TypedArrayClass) || this.pixels.length !== len
-    ) {
-      throw new Error(
-        'The pixels array has not been set correctly. Please call loadPixels() before updatePixels().'
-      );
-    }
-
-    gl.texImage2D(
-      gl.TEXTURE_2D,
-      0,
-      colorFormat.internalFormat,
-      this.width * this.density,
-      this.height * this.density,
-      0,
-      colorFormat.format,
-      colorFormat.type,
-      this.pixels
-    );
-    this.colorP5Texture.unbindTexture();
-
-    const prevFramebuffer = this.target._renderer.activeFramebuffer();
-    if (this.antialias) {
-      // We need to make sure the antialiased framebuffer also has the updated
-      // pixels so that if more is drawn to it, it goes on top of the updated
-      // pixels instead of replacing them.
-      // We can't blit the framebuffer to the multisampled antialias
-      // framebuffer to leave both in the same state, so instead we have
-      // to use image() to put the framebuffer texture onto the antialiased
-      // framebuffer.
-      this.begin();
-      this.target.push();
-      this.target.imageMode(this.target.CENTER);
-      this.target.resetMatrix();
-      this.target.noStroke();
-      this.target.clear();
-      this.target.image(this, 0, 0);
-      this.target.pop();
-      if (this.useDepth) {
-        gl.clearDepth(1);
-        gl.clear(gl.DEPTH_BUFFER_BIT);
-      }
-      this.end();
-    } else {
-      gl.bindFramebuffer(gl.FRAMEBUFFER, this.framebuffer);
-      if (this.useDepth) {
-        gl.clearDepth(1);
-        gl.clear(gl.DEPTH_BUFFER_BIT);
-      }
       if (prevFramebuffer) {
-        gl.bindFramebuffer(
-          gl.FRAMEBUFFER,
-          prevFramebuffer._framebufferToBind()
-        );
+        gl.bindFramebuffer(gl.FRAMEBUFFER, prevFramebuffer._framebufferToBind());
       } else {
         gl.bindFramebuffer(gl.FRAMEBUFFER, null);
       }
     }
-  }
-};
 
-/**
- * An object that stores the framebuffer's color data.
- *
- * Each framebuffer uses a
- * <a href="https://developer.mozilla.org/en-US/docs/Web/API/WebGLTexture" target="_blank">WebGLTexture</a>
- * object internally to store its color data. The `myBuffer.color` property
- * makes it possible to pass this data directly to other functions. For
- * example, calling `texture(myBuffer.color)` or
- * `myShader.setUniform('colorTexture', myBuffer.color)`  may be helpful for
- * advanced use cases.
- *
- * Note: By default, a framebuffer's y-coordinates are flipped compared to
- * images and videos. It's easy to flip a framebuffer's y-coordinates as
- * needed when applying it as a texture. For example, calling
- * `plane(myBuffer.width, -myBuffer.height)` will flip the framebuffer.
- *
- * @property {p5.FramebufferTexture} color
- * @for p5.Framebuffer
- *
- * @example
- * <div>
- * <code>
- * function setup() {
- *   createCanvas(100, 100, WEBGL);
- *
- *   background(200);
- *
- *   // Create a p5.Framebuffer object.
- *   let myBuffer = createFramebuffer();
- *
- *   // Start drawing to the p5.Framebuffer object.
- *   myBuffer.begin();
- *
- *   triangle(-25, 25, 0, -25, 25, 25);
- *
- *   // Stop drawing to the p5.Framebuffer object.
- *   myBuffer.end();
- *
- *   // Use the p5.Framebuffer object's WebGLTexture.
- *   texture(myBuffer.color);
- *
- *   // Style the plane.
- *   noStroke();
- *
- *   // Draw the plane.
- *   plane(myBuffer.width, myBuffer.height);
- *
- *   describe('A white triangle on a gray background.');
- * }
- * </code>
- * </div>
- */
+    /**
+     * Gets a pixel or a region of pixels from the framebuffer.
+     *
+     * `myBuffer.get()` is easy to use but it's not as fast as
+     * <a href="#/p5.Framebuffer/pixels">myBuffer.pixels</a>. Use
+     * <a href="#/p5.Framebuffer/pixels">myBuffer.pixels</a> to read many pixel
+     * values.
+     *
+     * The version of `myBuffer.get()` with no parameters returns the entire
+     * framebuffer as a a <a href="#/p5.Image">p5.Image</a> object.
+     *
+     * The version of `myBuffer.get()` with two parameters interprets them as
+     * coordinates. It returns an array with the `[R, G, B, A]` values of the
+     * pixel at the given point.
+     *
+     * The version of `myBuffer.get()` with four parameters interprets them as
+     * coordinates and dimensions. It returns a subsection of the framebuffer as
+     * a <a href="#/p5.Image">p5.Image</a> object. The first two parameters are
+     * the coordinates for the upper-left corner of the subsection. The last two
+     * parameters are the width and height of the subsection.
+     *
+     * @param  {Number} x x-coordinate of the pixel. Defaults to 0.
+     * @param  {Number} y y-coordinate of the pixel. Defaults to 0.
+     * @param  {Number} w width of the subsection to be returned.
+     * @param  {Number} h height of the subsection to be returned.
+     * @return {p5.Image} subsection as a <a href="#/p5.Image">p5.Image</a> object.
+     */
+    /**
+     * @return {p5.Image} entire framebuffer as a <a href="#/p5.Image">p5.Image</a> object.
+     */
+    /**
+     * @param  {Number} x
+     * @param  {Number} y
+     * @return {Number[]}  color of the pixel at `(x, y)` as an array of color values `[R, G, B, A]`.
+     */
+    get(x, y, w, h) {
+      p5._validateParameters('p5.Framebuffer.get', arguments);
+      const colorFormat = this._glColorFormat();
+      if (x === undefined && y === undefined) {
+        x = 0;
+        y = 0;
+        w = this.width;
+        h = this.height;
+      } else if (w === undefined && h === undefined) {
+        if (x < 0 || y < 0 || x >= this.width || y >= this.height) {
+          console.warn(
+            'The x and y values passed to p5.Framebuffer.get are outside of its range and will be clamped.'
+          );
+          x = this.target.constrain(x, 0, this.width - 1);
+          y = this.target.constrain(y, 0, this.height - 1);
+        }
 
-/**
- * An object that stores the framebuffer's dpeth data.
- *
- * Each framebuffer uses a
- * <a href="https://developer.mozilla.org/en-US/docs/Web/API/WebGLTexture" target="_blank">WebGLTexture</a>
- * object internally to store its depth data. The `myBuffer.depth` property
- * makes it possible to pass this data directly to other functions. For
- * example, calling `texture(myBuffer.depth)` or
- * `myShader.setUniform('depthTexture', myBuffer.depth)`  may be helpful for
- * advanced use cases.
- *
- * Note: By default, a framebuffer's y-coordinates are flipped compared to
- * images and videos. It's easy to flip a framebuffer's y-coordinates as
- * needed when applying it as a texture. For example, calling
- * `plane(myBuffer.width, -myBuffer.height)` will flip the framebuffer.
- *
- * @property {p5.FramebufferTexture} depth
- * @for p5.Framebuffer
- *
- * @example
- * <div>
- * <code>
- * // Note: A "uniform" is a global variable within a shader program.
- *
- * // Create a string with the vertex shader program.
- * // The vertex shader is called for each vertex.
- * let vertSrc = `
- * precision highp float;
- * attribute vec3 aPosition;
- * attribute vec2 aTexCoord;
- * uniform mat4 uModelViewMatrix;
- * uniform mat4 uProjectionMatrix;
- * varying vec2 vTexCoord;
- *
- * void main() {
- *   vec4 viewModelPosition = uModelViewMatrix * vec4(aPosition, 1.0);
- *   gl_Position = uProjectionMatrix * viewModelPosition;
- *   vTexCoord = aTexCoord;
- * }
- * `;
- *
- * // Create a string with the fragment shader program.
- * // The fragment shader is called for each pixel.
- * let fragSrc = `
- * precision highp float;
- * varying vec2 vTexCoord;
- * uniform sampler2D depth;
- *
- * void main() {
- *   // Get the pixel's depth value.
- *   float depthVal = texture2D(depth, vTexCoord).r;
- *
- *   // Set the pixel's color based on its depth.
- *   gl_FragColor = mix(
- *     vec4(0., 0., 0., 1.),
- *     vec4(1., 0., 1., 1.),
- *     depthVal);
- * }
- * `;
- *
- * let myBuffer;
- * let myShader;
- *
- * function setup() {
- *   createCanvas(100, 100, WEBGL);
- *
- *   // Create a p5.Framebuffer object.
- *   myBuffer = createFramebuffer();
- *
- *   // Create a p5.Shader object.
- *   myShader = createShader(vertSrc, fragSrc);
- *
- *   // Compile and apply the shader.
- *   shader(myShader);
- *
- *   describe('The shadow of a box rotates slowly against a magenta background.');
- * }
- *
- * function draw() {
- *   // Draw to the p5.Framebuffer object.
- *   myBuffer.begin();
- *   background(255);
- *   rotateX(frameCount * 0.01);
- *   box(20, 20, 80);
- *   myBuffer.end();
- *
- *   // Set the shader's depth uniform using
- *   // the framebuffer's depth texture.
- *   myShader.setUniform('depth', myBuffer.depth);
- *
- *   // Style the plane.
- *   noStroke();
- *
- *   // Draw the plane.
- *   plane(myBuffer.width, myBuffer.height);
- * }
- * </code>
- * </div>
- */
+        return readPixelWebGL(
+          this.gl,
+          this.framebuffer,
+          x * this.density,
+          y * this.density,
+          colorFormat.format,
+          colorFormat.type
+        );
+      }
 
-/**
- * An array containing the color of each pixel in the framebuffer.
- *
- * <a href="#/p5.Framebuffer/loadPixels">myBuffer.loadPixels()</a> must be
- * called before accessing the `myBuffer.pixels` array.
- * <a href="#/p5.Framebuffer/updatePixels">myBuffer.updatePixels()</a>
- * must be called after any changes are made.
- *
- * Note: Updating pixels via this property is slower than drawing to the
- * framebuffer directly. Consider using a
- * <a href="#/p5.Shader">p5.Shader</a> object instead of looping over
- * `myBuffer.pixels`.
- *
- * @property {Number[]} pixels
- * @for p5.Framebuffer
- *
- * @example
- * <div>
- * <code>
- * function setup() {
- *   createCanvas(100, 100, WEBGL);
- *
- *   background(200);
- *
- *   // Create a p5.Framebuffer object.
- *   let myBuffer = createFramebuffer();
- *
- *   // Load the pixels array.
- *   myBuffer.loadPixels();
- *
- *   // Get the number of pixels in the
- *   // top half of the framebuffer.
- *   let numPixels = myBuffer.pixels.length / 2;
- *
- *   // Set the framebuffer's top half to pink.
- *   for (let i = 0; i < numPixels; i += 4) {
- *     myBuffer.pixels[i] = 255;
- *     myBuffer.pixels[i + 1] = 102;
- *     myBuffer.pixels[i + 2] = 204;
- *     myBuffer.pixels[i + 3] = 255;
- *   }
- *
- *   // Update the pixels array.
- *   myBuffer.updatePixels();
- *
- *   // Draw the p5.Framebuffer object to the canvas.
- *   image(myBuffer, -50, -50);
- *
- *   describe('A pink rectangle above a gray rectangle.');
- * }
- * </code>
- * </div>
- */
+      x = this.target.constrain(x, 0, this.width - 1);
+      y = this.target.constrain(y, 0, this.height - 1);
+      w = this.target.constrain(w, 1, this.width - x);
+      h = this.target.constrain(h, 1, this.height - y);
 
-export default p5.Framebuffer;
+      const rawData = readPixelsWebGL(
+        undefined,
+        this.gl,
+        this.framebuffer,
+        x * this.density,
+        y * this.density,
+        w * this.density,
+        h * this.density,
+        colorFormat.format,
+        colorFormat.type
+      );
+      // Framebuffer data might be either a Uint8Array or Float32Array
+      // depending on its format, and it may or may not have an alpha channel.
+      // To turn it into an image, we have to normalize the data into a
+      // Uint8ClampedArray with alpha.
+      const fullData = new Uint8ClampedArray(
+        w * h * this.density * this.density * 4
+      );
+
+      // Default channels that aren't in the framebuffer (e.g. alpha, if the
+      // framebuffer is in RGB mode instead of RGBA) to 255
+      fullData.fill(255);
+
+      const channels = colorFormat.type === this.gl.RGB ? 3 : 4;
+      for (let y = 0; y < h * this.density; y++) {
+        for (let x = 0; x < w * this.density; x++) {
+          for (let channel = 0; channel < 4; channel++) {
+            const idx = (y * w * this.density + x) * 4 + channel;
+            if (channel < channels) {
+              // Find the index of this pixel in `rawData`, which might have a
+              // different number of channels
+              const rawDataIdx = channels === 4
+                ? idx
+                : (y * w * this.density + x) * channels + channel;
+              fullData[idx] = rawData[rawDataIdx];
+            }
+          }
+        }
+      }
+
+      // Create an image from the data
+      const region = new p5.Image(w * this.density, h * this.density);
+      region.imageData = region.canvas.getContext('2d').createImageData(
+        region.width,
+        region.height
+      );
+      region.imageData.data.set(fullData);
+      region.pixels = region.imageData.data;
+      region.updatePixels();
+      if (this.density !== 1) {
+        // TODO: support get() at a pixel density > 1
+        region.resize(w, h);
+      }
+      return region;
+    }
+
+    /**
+     * Updates the framebuffer with the RGBA values in the
+     * <a href="#/p5.Framebuffer/pixels">pixels</a> array.
+     *
+     * `myBuffer.updatePixels()` only needs to be called after changing values
+     * in the <a href="#/p5.Framebuffer/pixels">myBuffer.pixels</a> array. Such
+     * changes can be made directly after calling
+     * <a href="#/p5.Framebuffer/loadPixels">myBuffer.loadPixels()</a>.
+     *
+     * @method updatePixels
+     *
+     * @example
+     * <div>
+     * <code>
+     * function setup() {
+     *   createCanvas(100, 100, WEBGL);
+     *
+     *   background(200);
+     *
+     *   // Create a p5.Framebuffer object.
+     *   let myBuffer = createFramebuffer();
+     *
+     *   // Load the pixels array.
+     *   myBuffer.loadPixels();
+     *
+     *   // Get the number of pixels in the
+     *   // top half of the framebuffer.
+     *   let numPixels = myBuffer.pixels.length / 2;
+     *
+     *   // Set the framebuffer's top half to pink.
+     *   for (let i = 0; i < numPixels; i += 4) {
+     *     myBuffer.pixels[i] = 255;
+     *     myBuffer.pixels[i + 1] = 102;
+     *     myBuffer.pixels[i + 2] = 204;
+     *     myBuffer.pixels[i + 3] = 255;
+     *   }
+     *
+     *   // Update the pixels array.
+     *   myBuffer.updatePixels();
+     *
+     *   // Draw the p5.Framebuffer object to the canvas.
+     *   image(myBuffer, -50, -50);
+     *
+     *   describe('A pink rectangle above a gray rectangle.');
+     * }
+     * </code>
+     * </div>
+     */
+    updatePixels() {
+      const gl = this.gl;
+      this.colorP5Texture.bindTexture();
+      const colorFormat = this._glColorFormat();
+
+      const channels = colorFormat.format === gl.RGBA ? 4 : 3;
+      const len =
+        this.width * this.height * this.density * this.density * channels;
+      const TypedArrayClass = colorFormat.type === gl.UNSIGNED_BYTE
+        ? Uint8Array
+        : Float32Array;
+      if (
+        !(this.pixels instanceof TypedArrayClass) || this.pixels.length !== len
+      ) {
+        throw new Error(
+          'The pixels array has not been set correctly. Please call loadPixels() before updatePixels().'
+        );
+      }
+
+      gl.texImage2D(
+        gl.TEXTURE_2D,
+        0,
+        colorFormat.internalFormat,
+        this.width * this.density,
+        this.height * this.density,
+        0,
+        colorFormat.format,
+        colorFormat.type,
+        this.pixels
+      );
+      this.colorP5Texture.unbindTexture();
+
+      const prevFramebuffer = this.target._renderer.activeFramebuffer();
+      if (this.antialias) {
+        // We need to make sure the antialiased framebuffer also has the updated
+        // pixels so that if more is drawn to it, it goes on top of the updated
+        // pixels instead of replacing them.
+        // We can't blit the framebuffer to the multisampled antialias
+        // framebuffer to leave both in the same state, so instead we have
+        // to use image() to put the framebuffer texture onto the antialiased
+        // framebuffer.
+        this.begin();
+        this.target.push();
+        this.target.imageMode(this.target.CENTER);
+        this.target.resetMatrix();
+        this.target.noStroke();
+        this.target.clear();
+        this.target.image(this, 0, 0);
+        this.target.pop();
+        if (this.useDepth) {
+          gl.clearDepth(1);
+          gl.clear(gl.DEPTH_BUFFER_BIT);
+        }
+        this.end();
+      } else {
+        gl.bindFramebuffer(gl.FRAMEBUFFER, this.framebuffer);
+        if (this.useDepth) {
+          gl.clearDepth(1);
+          gl.clear(gl.DEPTH_BUFFER_BIT);
+        }
+        if (prevFramebuffer) {
+          gl.bindFramebuffer(
+            gl.FRAMEBUFFER,
+            prevFramebuffer._framebufferToBind()
+          );
+        } else {
+          gl.bindFramebuffer(gl.FRAMEBUFFER, null);
+        }
+      }
+    }
+  };
+
+  /**
+   * An object that stores the framebuffer's color data.
+   *
+   * Each framebuffer uses a
+   * <a href="https://developer.mozilla.org/en-US/docs/Web/API/WebGLTexture" target="_blank">WebGLTexture</a>
+   * object internally to store its color data. The `myBuffer.color` property
+   * makes it possible to pass this data directly to other functions. For
+   * example, calling `texture(myBuffer.color)` or
+   * `myShader.setUniform('colorTexture', myBuffer.color)`  may be helpful for
+   * advanced use cases.
+   *
+   * Note: By default, a framebuffer's y-coordinates are flipped compared to
+   * images and videos. It's easy to flip a framebuffer's y-coordinates as
+   * needed when applying it as a texture. For example, calling
+   * `plane(myBuffer.width, -myBuffer.height)` will flip the framebuffer.
+   *
+   * @property {p5.FramebufferTexture} color
+   * @for p5.Framebuffer
+   *
+   * @example
+   * <div>
+   * <code>
+   * function setup() {
+   *   createCanvas(100, 100, WEBGL);
+   *
+   *   background(200);
+   *
+   *   // Create a p5.Framebuffer object.
+   *   let myBuffer = createFramebuffer();
+   *
+   *   // Start drawing to the p5.Framebuffer object.
+   *   myBuffer.begin();
+   *
+   *   triangle(-25, 25, 0, -25, 25, 25);
+   *
+   *   // Stop drawing to the p5.Framebuffer object.
+   *   myBuffer.end();
+   *
+   *   // Use the p5.Framebuffer object's WebGLTexture.
+   *   texture(myBuffer.color);
+   *
+   *   // Style the plane.
+   *   noStroke();
+   *
+   *   // Draw the plane.
+   *   plane(myBuffer.width, myBuffer.height);
+   *
+   *   describe('A white triangle on a gray background.');
+   * }
+   * </code>
+   * </div>
+   */
+
+  /**
+   * An object that stores the framebuffer's dpeth data.
+   *
+   * Each framebuffer uses a
+   * <a href="https://developer.mozilla.org/en-US/docs/Web/API/WebGLTexture" target="_blank">WebGLTexture</a>
+   * object internally to store its depth data. The `myBuffer.depth` property
+   * makes it possible to pass this data directly to other functions. For
+   * example, calling `texture(myBuffer.depth)` or
+   * `myShader.setUniform('depthTexture', myBuffer.depth)`  may be helpful for
+   * advanced use cases.
+   *
+   * Note: By default, a framebuffer's y-coordinates are flipped compared to
+   * images and videos. It's easy to flip a framebuffer's y-coordinates as
+   * needed when applying it as a texture. For example, calling
+   * `plane(myBuffer.width, -myBuffer.height)` will flip the framebuffer.
+   *
+   * @property {p5.FramebufferTexture} depth
+   * @for p5.Framebuffer
+   *
+   * @example
+   * <div>
+   * <code>
+   * // Note: A "uniform" is a global variable within a shader program.
+   *
+   * // Create a string with the vertex shader program.
+   * // The vertex shader is called for each vertex.
+   * let vertSrc = `
+   * precision highp float;
+   * attribute vec3 aPosition;
+   * attribute vec2 aTexCoord;
+   * uniform mat4 uModelViewMatrix;
+   * uniform mat4 uProjectionMatrix;
+   * varying vec2 vTexCoord;
+   *
+   * void main() {
+   *   vec4 viewModelPosition = uModelViewMatrix * vec4(aPosition, 1.0);
+   *   gl_Position = uProjectionMatrix * viewModelPosition;
+   *   vTexCoord = aTexCoord;
+   * }
+   * `;
+   *
+   * // Create a string with the fragment shader program.
+   * // The fragment shader is called for each pixel.
+   * let fragSrc = `
+   * precision highp float;
+   * varying vec2 vTexCoord;
+   * uniform sampler2D depth;
+   *
+   * void main() {
+   *   // Get the pixel's depth value.
+   *   float depthVal = texture2D(depth, vTexCoord).r;
+   *
+   *   // Set the pixel's color based on its depth.
+   *   gl_FragColor = mix(
+   *     vec4(0., 0., 0., 1.),
+   *     vec4(1., 0., 1., 1.),
+   *     depthVal);
+   * }
+   * `;
+   *
+   * let myBuffer;
+   * let myShader;
+   *
+   * function setup() {
+   *   createCanvas(100, 100, WEBGL);
+   *
+   *   // Create a p5.Framebuffer object.
+   *   myBuffer = createFramebuffer();
+   *
+   *   // Create a p5.Shader object.
+   *   myShader = createShader(vertSrc, fragSrc);
+   *
+   *   // Compile and apply the shader.
+   *   shader(myShader);
+   *
+   *   describe('The shadow of a box rotates slowly against a magenta background.');
+   * }
+   *
+   * function draw() {
+   *   // Draw to the p5.Framebuffer object.
+   *   myBuffer.begin();
+   *   background(255);
+   *   rotateX(frameCount * 0.01);
+   *   box(20, 20, 80);
+   *   myBuffer.end();
+   *
+   *   // Set the shader's depth uniform using
+   *   // the framebuffer's depth texture.
+   *   myShader.setUniform('depth', myBuffer.depth);
+   *
+   *   // Style the plane.
+   *   noStroke();
+   *
+   *   // Draw the plane.
+   *   plane(myBuffer.width, myBuffer.height);
+   * }
+   * </code>
+   * </div>
+   */
+
+  /**
+   * An array containing the color of each pixel in the framebuffer.
+   *
+   * <a href="#/p5.Framebuffer/loadPixels">myBuffer.loadPixels()</a> must be
+   * called before accessing the `myBuffer.pixels` array.
+   * <a href="#/p5.Framebuffer/updatePixels">myBuffer.updatePixels()</a>
+   * must be called after any changes are made.
+   *
+   * Note: Updating pixels via this property is slower than drawing to the
+   * framebuffer directly. Consider using a
+   * <a href="#/p5.Shader">p5.Shader</a> object instead of looping over
+   * `myBuffer.pixels`.
+   *
+   * @property {Number[]} pixels
+   * @for p5.Framebuffer
+   *
+   * @example
+   * <div>
+   * <code>
+   * function setup() {
+   *   createCanvas(100, 100, WEBGL);
+   *
+   *   background(200);
+   *
+   *   // Create a p5.Framebuffer object.
+   *   let myBuffer = createFramebuffer();
+   *
+   *   // Load the pixels array.
+   *   myBuffer.loadPixels();
+   *
+   *   // Get the number of pixels in the
+   *   // top half of the framebuffer.
+   *   let numPixels = myBuffer.pixels.length / 2;
+   *
+   *   // Set the framebuffer's top half to pink.
+   *   for (let i = 0; i < numPixels; i += 4) {
+   *     myBuffer.pixels[i] = 255;
+   *     myBuffer.pixels[i + 1] = 102;
+   *     myBuffer.pixels[i + 2] = 204;
+   *     myBuffer.pixels[i + 3] = 255;
+   *   }
+   *
+   *   // Update the pixels array.
+   *   myBuffer.updatePixels();
+   *
+   *   // Draw the p5.Framebuffer object to the canvas.
+   *   image(myBuffer, -50, -50);
+   *
+   *   describe('A pink rectangle above a gray rectangle.');
+   * }
+   * </code>
+   * </div>
+   */
+}
+
+export default framebuffer;
+
+if(typeof p5 !== 'undefined'){
+  framebuffer(p5, p5.prototype);
+}

--- a/src/webgl/p5.Geometry.js
+++ b/src/webgl/p5.Geometry.js
@@ -8,1157 +8,989 @@
 
 //some of the functions are adjusted from Three.js(http://threejs.org)
 
-import p5 from '../core/main';
 import * as constants from '../core/constants';
-/**
- * A class to describe a 3D shape.
- *
- * Each `p5.Geometry` object represents a 3D shape as a set of connected
- * points called *vertices*. All 3D shapes are made by connecting vertices to
- * form triangles that are stitched together. Each triangular patch on the
- * geometry's surface is called a *face*. The geometry stores information
- * about its vertices and faces for use with effects such as lighting and
- * texture mapping.
- *
- * The first parameter, `detailX`, is optional. If a number is passed, as in
- * `new p5.Geometry(24)`, it sets the number of triangle subdivisions to use
- * along the geometry's x-axis. By default, `detailX` is 1.
- *
- * The second parameter, `detailY`, is also optional. If a number is passed,
- * as in `new p5.Geometry(24, 16)`, it sets the number of triangle
- * subdivisions to use along the geometry's y-axis. By default, `detailX` is
- * 1.
- *
- * The third parameter, `callback`, is also optional. If a function is passed,
- * as in `new p5.Geometry(24, 16, createShape)`, it will be called once to add
- * vertices to the new 3D shape.
- *
- * @class p5.Geometry
- * @param  {Integer} [detailX] number of vertices along the x-axis.
- * @param  {Integer} [detailY] number of vertices along the y-axis.
- * @param {function} [callback] function to call once the geometry is created.
- *
- * @example
- * <div>
- * <code>
- * // Click and drag the mouse to view the scene from different angles.
- *
- * let myGeometry;
- *
- * function setup() {
- *   createCanvas(100, 100, WEBGL);
- *
- *   // Create a p5.Geometry object.
- *   myGeometry = new p5.Geometry();
- *
- *   // Create p5.Vector objects to position the vertices.
- *   let v0 = createVector(-40, 0, 0);
- *   let v1 = createVector(0, -40, 0);
- *   let v2 = createVector(40, 0, 0);
- *
- *   // Add the vertices to the p5.Geometry object's vertices array.
- *   myGeometry.vertices.push(v0, v1, v2);
- *
- *   describe('A white triangle drawn on a gray background.');
- * }
- *
- * function draw() {
- *   background(200);
- *
- *   // Enable orbiting with the mouse.
- *   orbitControl();
- *
- *   // Draw the p5.Geometry object.
- *   model(myGeometry);
- * }
- * </code>
- * </div>
- *
- * <div>
- * <code>
- * // Click and drag the mouse to view the scene from different angles.
- *
- * let myGeometry;
- *
- * function setup() {
- *   createCanvas(100, 100, WEBGL);
- *
- *   // Create a p5.Geometry object using a callback function.
- *   myGeometry = new p5.Geometry(1, 1, createShape);
- *
- *   describe('A white triangle drawn on a gray background.');
- * }
- *
- * function draw() {
- *   background(200);
- *
- *   // Enable orbiting with the mouse.
- *   orbitControl();
- *
- *   // Draw the p5.Geometry object.
- *   model(myGeometry);
- * }
- *
- * function createShape() {
- *   // Create p5.Vector objects to position the vertices.
- *   let v0 = createVector(-40, 0, 0);
- *   let v1 = createVector(0, -40, 0);
- *   let v2 = createVector(40, 0, 0);
- *
- *   // "this" refers to the p5.Geometry object being created.
- *
- *   // Add the vertices to the p5.Geometry object's vertices array.
- *   this.vertices.push(v0, v1, v2);
- *
- *   // Add an array to list which vertices belong to the face.
- *   // Vertices are listed in clockwise "winding" order from
- *   // left to top to right.
- *   this.faces.push([0, 1, 2]);
- * }
- * </code>
- * </div>
- *
- * <div>
- * <code>
- * // Click and drag the mouse to view the scene from different angles.
- *
- * let myGeometry;
- *
- * function setup() {
- *   createCanvas(100, 100, WEBGL);
- *
- *   // Create a p5.Geometry object using a callback function.
- *   myGeometry = new p5.Geometry(1, 1, createShape);
- *
- *   describe('A white triangle drawn on a gray background.');
- * }
- *
- * function draw() {
- *   background(200);
- *
- *   // Enable orbiting with the mouse.
- *   orbitControl();
- *
- *   // Draw the p5.Geometry object.
- *   model(myGeometry);
- * }
- *
- * function createShape() {
- *   // Create p5.Vector objects to position the vertices.
- *   let v0 = createVector(-40, 0, 0);
- *   let v1 = createVector(0, -40, 0);
- *   let v2 = createVector(40, 0, 0);
- *
- *   // "this" refers to the p5.Geometry object being created.
- *
- *   // Add the vertices to the p5.Geometry object's vertices array.
- *   this.vertices.push(v0, v1, v2);
- *
- *   // Add an array to list which vertices belong to the face.
- *   // Vertices are listed in clockwise "winding" order from
- *   // left to top to right.
- *   this.faces.push([0, 1, 2]);
- *
- *   // Compute the surface normals to help with lighting.
- *   this.computeNormals();
- * }
- * </code>
- * </div>
- *
- * <div>
- * <code>
- * // Click and drag the mouse to view the scene from different angles.
- *
- * // Adapted from Paul Wheeler's wonderful p5.Geometry tutorial.
- * // https://www.paulwheeler.us/articles/custom-3d-geometry-in-p5js/
- * // CC-BY-SA 4.0
- *
- * let myGeometry;
- *
- * function setup() {
- *   createCanvas(100, 100, WEBGL);
- *
- *   // Create the p5.Geometry object.
- *   // Set detailX to 48 and detailY to 2.
- *   // >>> try changing them.
- *   myGeometry = new p5.Geometry(48, 2, createShape);
- * }
- *
- * function draw() {
- *   background(50);
- *
- *   // Enable orbiting with the mouse.
- *   orbitControl();
- *
- *   // Turn on the lights.
- *   lights();
- *
- *   // Style the p5.Geometry object.
- *   strokeWeight(0.2);
- *
- *   // Draw the p5.Geometry object.
- *   model(myGeometry);
- * }
- *
- * function createShape() {
- *   // "this" refers to the p5.Geometry object being created.
- *
- *   // Define the Möbius strip with a few parameters.
- *   let spread = 0.1;
- *   let radius = 30;
- *   let stripWidth = 15;
- *   let xInterval = 4 * PI / this.detailX;
- *   let yOffset = -stripWidth / 2;
- *   let yInterval = stripWidth / this.detailY;
- *
- *   for (let j = 0; j <= this.detailY; j += 1) {
- *     // Calculate the "vertical" point along the strip.
- *     let v = yOffset + yInterval * j;
- *
- *     for (let i = 0; i <= this.detailX; i += 1) {
- *       // Calculate the angle of rotation around the strip.
- *       let u = i * xInterval;
- *
- *       // Calculate the coordinates of the vertex.
- *       let x = (radius + v * cos(u / 2)) * cos(u) - sin(u / 2) * 2 * spread;
- *       let y = (radius + v * cos(u / 2)) * sin(u);
- *       if (u < TWO_PI) {
- *         y += sin(u) * spread;
- *       } else {
- *         y -= sin(u) * spread;
- *       }
- *       let z = v * sin(u / 2) + sin(u / 4) * 4 * spread;
- *
- *       // Create a p5.Vector object to position the vertex.
- *       let vert = createVector(x, y, z);
- *
- *       // Add the vertex to the p5.Geometry object's vertices array.
- *       this.vertices.push(vert);
- *     }
- *   }
- *
- *   // Compute the faces array.
- *   this.computeFaces();
- *
- *   // Compute the surface normals to help with lighting.
- *   this.computeNormals();
- * }
- * </code>
- * </div>
- */
-p5.Geometry = class Geometry {
-  constructor(detailX, detailY, callback) {
-    this.vertices = [];
 
-    this.boundingBoxCache = null;
-
-
-    //an array containing every vertex for stroke drawing
-    this.lineVertices = new p5.DataArray();
-
-    // The tangents going into or out of a vertex on a line. Along a straight
-    // line segment, both should be equal. At an endpoint, one or the other
-    // will not exist and will be all 0. In joins between line segments, they
-    // may be different, as they will be the tangents on either side of the join.
-    this.lineTangentsIn = new p5.DataArray();
-    this.lineTangentsOut = new p5.DataArray();
-
-    // When drawing lines with thickness, entries in this buffer represent which
-    // side of the centerline the vertex will be placed. The sign of the number
-    // will represent the side of the centerline, and the absolute value will be
-    // used as an enum to determine which part of the cap or join each vertex
-    // represents. See the doc comments for _addCap and _addJoin for diagrams.
-    this.lineSides = new p5.DataArray();
-
-    this.vertexNormals = [];
-
-    this.faces = [];
-
-    this.uvs = [];
-    // a 2D array containing edge connectivity pattern for create line vertices
-    //based on faces for most objects;
-    this.edges = [];
-    this.vertexColors = [];
-
-    // One color per vertex representing the stroke color at that vertex
-    this.vertexStrokeColors = [];
-
-    this.userVertexProperties = {};
-
-    // One color per line vertex, generated automatically based on
-    // vertexStrokeColors in _edgesToVertices()
-    this.lineVertexColors = new p5.DataArray();
-    this.detailX = detailX !== undefined ? detailX : 1;
-    this.detailY = detailY !== undefined ? detailY : 1;
-    this.dirtyFlags = {};
-
-    this._hasFillTransparency = undefined;
-    this._hasStrokeTransparency = undefined;
-
-    if (callback instanceof Function) {
-      callback.call(this);
-    }
-  }
-
+function geometry(p5, fn){
   /**
- * Calculates the position and size of the smallest box that contains the geometry.
- *
- * A bounding box is the smallest rectangular prism that contains the entire
- * geometry. It's defined by the box's minimum and maximum coordinates along
- * each axis, as well as the size (length) and offset (center).
- *
- * Calling `myGeometry.calculateBoundingBox()` returns an object with four
- * properties that describe the bounding box:
- *
- * ```js
- * // Get myGeometry's bounding box.
- * let bbox = myGeometry.calculateBoundingBox();
- *
- * // Print the bounding box to the console.
- * console.log(bbox);
- *
- * // {
- * //  // The minimum coordinate along each axis.
- * //  min: { x: -1, y: -2, z: -3 },
- * //
- * //  // The maximum coordinate along each axis.
- * //  max: { x: 1, y: 2, z: 3},
- * //
- * //  // The size (length) along each axis.
- * //  size: { x: 2, y: 4, z: 6},
- * //
- * //  // The offset (center) along each axis.
- * //  offset: { x: 0, y: 0, z: 0}
- * // }
- * ```
- *
- * @returns {Object} bounding box of the geometry.
- *
- * @example
- * <div>
- * <code>
- * // Click and drag the mouse to view the scene from different angles.
- *
- * let particles;
- *
- * function setup() {
- *   createCanvas(100, 100, WEBGL);
- *
- *   // Create a new p5.Geometry object with random spheres.
- *   particles = buildGeometry(createParticles);
- *
- *   describe('Ten white spheres placed randomly against a gray background. A box encloses the spheres.');
- * }
- *
- * function draw() {
- *   background(50);
- *
- *   // Enable orbiting with the mouse.
- *   orbitControl();
- *
- *   // Turn on the lights.
- *   lights();
- *
- *   // Style the particles.
- *   noStroke();
- *   fill(255);
- *
- *   // Draw the particles.
- *   model(particles);
- *
- *   // Calculate the bounding box.
- *   let bbox = particles.calculateBoundingBox();
- *
- *   // Translate to the bounding box's center.
- *   translate(bbox.offset.x, bbox.offset.y, bbox.offset.z);
- *
- *   // Style the bounding box.
- *   stroke(255);
- *   noFill();
- *
- *   // Draw the bounding box.
- *   box(bbox.size.x, bbox.size.y, bbox.size.z);
- * }
- *
- * function createParticles() {
- *   for (let i = 0; i < 10; i += 1) {
- *     // Calculate random coordinates.
- *     let x = randomGaussian(0, 15);
- *     let y = randomGaussian(0, 15);
- *     let z = randomGaussian(0, 15);
- *
- *     push();
- *     // Translate to the particle's coordinates.
- *     translate(x, y, z);
- *     // Draw the particle.
- *     sphere(3);
- *     pop();
- *   }
- * }
- * </code>
- * </div>
- */
-  calculateBoundingBox() {
-    if (this.boundingBoxCache) {
-      return this.boundingBoxCache; // Return cached result if available
-    }
-
-    let minVertex = new p5.Vector(
-      Number.MAX_VALUE, Number.MAX_VALUE, Number.MAX_VALUE);
-    let maxVertex = new p5.Vector(
-      Number.MIN_VALUE, Number.MIN_VALUE, Number.MIN_VALUE);
-
-    for (let i = 0; i < this.vertices.length; i++) {
-      let vertex = this.vertices[i];
-      minVertex.x = Math.min(minVertex.x, vertex.x);
-      minVertex.y = Math.min(minVertex.y, vertex.y);
-      minVertex.z = Math.min(minVertex.z, vertex.z);
-
-      maxVertex.x = Math.max(maxVertex.x, vertex.x);
-      maxVertex.y = Math.max(maxVertex.y, vertex.y);
-      maxVertex.z = Math.max(maxVertex.z, vertex.z);
-    }
-    // Calculate size and offset properties
-    let size = new p5.Vector(maxVertex.x - minVertex.x,
-      maxVertex.y - minVertex.y, maxVertex.z - minVertex.z);
-    let offset = new p5.Vector((minVertex.x + maxVertex.x) / 2,
-      (minVertex.y + maxVertex.y) / 2, (minVertex.z + maxVertex.z) / 2);
-
-    // Cache the result for future access
-    this.boundingBoxCache = {
-      min: minVertex,
-      max: maxVertex,
-      size: size,
-      offset: offset
-    };
-
-    return this.boundingBoxCache;
-  }
-
-  reset() {
-    this._hasFillTransparency = undefined;
-    this._hasStrokeTransparency = undefined;
-
-    this.lineVertices.clear();
-    this.lineTangentsIn.clear();
-    this.lineTangentsOut.clear();
-    this.lineSides.clear();
-
-    this.vertices.length = 0;
-    this.edges.length = 0;
-    this.vertexColors.length = 0;
-    this.vertexStrokeColors.length = 0;
-    this.lineVertexColors.clear();
-    this.vertexNormals.length = 0;
-    this.uvs.length = 0;
-
-    for (const propName in this.userVertexProperties){
-      this.userVertexProperties[propName].delete();
-    }
-    this.userVertexProperties = {};
-
-    this.dirtyFlags = {};
-  }
-
-  hasFillTransparency() {
-    if (this._hasFillTransparency === undefined) {
-      this._hasFillTransparency = false;
-      for (let i = 0; i < this.vertexColors.length; i += 4) {
-        if (this.vertexColors[i + 3] < 1) {
-          this._hasFillTransparency = true;
-          break;
-        }
-      }
-    }
-    return this._hasFillTransparency;
-  }
-  hasStrokeTransparency() {
-    if (this._hasStrokeTransparency === undefined) {
-      this._hasStrokeTransparency = false;
-      for (let i = 0; i < this.lineVertexColors.length; i += 4) {
-        if (this.lineVertexColors[i + 3] < 1) {
-          this._hasStrokeTransparency = true;
-          break;
-        }
-      }
-    }
-    return this._hasStrokeTransparency;
-  }
-
-  /**
-   * Removes the geometry’s internal colors.
+   * A class to describe a 3D shape.
    *
-   * `p5.Geometry` objects can be created with "internal colors" assigned to
-   * vertices or the entire shape. When a geometry has internal colors,
-   * <a href="#/p5/fill">fill()</a> has no effect. Calling
-   * `myGeometry.clearColors()` allows the
-   * <a href="#/p5/fill">fill()</a> function to apply color to the geometry.
+   * Each `p5.Geometry` object represents a 3D shape as a set of connected
+   * points called *vertices*. All 3D shapes are made by connecting vertices to
+   * form triangles that are stitched together. Each triangular patch on the
+   * geometry's surface is called a *face*. The geometry stores information
+   * about its vertices and faces for use with effects such as lighting and
+   * texture mapping.
+   *
+   * The first parameter, `detailX`, is optional. If a number is passed, as in
+   * `new p5.Geometry(24)`, it sets the number of triangle subdivisions to use
+   * along the geometry's x-axis. By default, `detailX` is 1.
+   *
+   * The second parameter, `detailY`, is also optional. If a number is passed,
+   * as in `new p5.Geometry(24, 16)`, it sets the number of triangle
+   * subdivisions to use along the geometry's y-axis. By default, `detailX` is
+   * 1.
+   *
+   * The third parameter, `callback`, is also optional. If a function is passed,
+   * as in `new p5.Geometry(24, 16, createShape)`, it will be called once to add
+   * vertices to the new 3D shape.
+   *
+   * @class p5.Geometry
+   * @param  {Integer} [detailX] number of vertices along the x-axis.
+   * @param  {Integer} [detailY] number of vertices along the y-axis.
+   * @param {function} [callback] function to call once the geometry is created.
    *
    * @example
    * <div>
    * <code>
+   * // Click and drag the mouse to view the scene from different angles.
+   *
+   * let myGeometry;
+   *
+   * function setup() {
+   *   createCanvas(100, 100, WEBGL);
+   *
+   *   // Create a p5.Geometry object.
+   *   myGeometry = new p5.Geometry();
+   *
+   *   // Create p5.Vector objects to position the vertices.
+   *   let v0 = createVector(-40, 0, 0);
+   *   let v1 = createVector(0, -40, 0);
+   *   let v2 = createVector(40, 0, 0);
+   *
+   *   // Add the vertices to the p5.Geometry object's vertices array.
+   *   myGeometry.vertices.push(v0, v1, v2);
+   *
+   *   describe('A white triangle drawn on a gray background.');
+   * }
+   *
+   * function draw() {
+   *   background(200);
+   *
+   *   // Enable orbiting with the mouse.
+   *   orbitControl();
+   *
+   *   // Draw the p5.Geometry object.
+   *   model(myGeometry);
+   * }
+   * </code>
+   * </div>
+   *
+   * <div>
+   * <code>
+   * // Click and drag the mouse to view the scene from different angles.
+   *
+   * let myGeometry;
+   *
+   * function setup() {
+   *   createCanvas(100, 100, WEBGL);
+   *
+   *   // Create a p5.Geometry object using a callback function.
+   *   myGeometry = new p5.Geometry(1, 1, createShape);
+   *
+   *   describe('A white triangle drawn on a gray background.');
+   * }
+   *
+   * function draw() {
+   *   background(200);
+   *
+   *   // Enable orbiting with the mouse.
+   *   orbitControl();
+   *
+   *   // Draw the p5.Geometry object.
+   *   model(myGeometry);
+   * }
+   *
+   * function createShape() {
+   *   // Create p5.Vector objects to position the vertices.
+   *   let v0 = createVector(-40, 0, 0);
+   *   let v1 = createVector(0, -40, 0);
+   *   let v2 = createVector(40, 0, 0);
+   *
+   *   // "this" refers to the p5.Geometry object being created.
+   *
+   *   // Add the vertices to the p5.Geometry object's vertices array.
+   *   this.vertices.push(v0, v1, v2);
+   *
+   *   // Add an array to list which vertices belong to the face.
+   *   // Vertices are listed in clockwise "winding" order from
+   *   // left to top to right.
+   *   this.faces.push([0, 1, 2]);
+   * }
+   * </code>
+   * </div>
+   *
+   * <div>
+   * <code>
+   * // Click and drag the mouse to view the scene from different angles.
+   *
+   * let myGeometry;
+   *
+   * function setup() {
+   *   createCanvas(100, 100, WEBGL);
+   *
+   *   // Create a p5.Geometry object using a callback function.
+   *   myGeometry = new p5.Geometry(1, 1, createShape);
+   *
+   *   describe('A white triangle drawn on a gray background.');
+   * }
+   *
+   * function draw() {
+   *   background(200);
+   *
+   *   // Enable orbiting with the mouse.
+   *   orbitControl();
+   *
+   *   // Draw the p5.Geometry object.
+   *   model(myGeometry);
+   * }
+   *
+   * function createShape() {
+   *   // Create p5.Vector objects to position the vertices.
+   *   let v0 = createVector(-40, 0, 0);
+   *   let v1 = createVector(0, -40, 0);
+   *   let v2 = createVector(40, 0, 0);
+   *
+   *   // "this" refers to the p5.Geometry object being created.
+   *
+   *   // Add the vertices to the p5.Geometry object's vertices array.
+   *   this.vertices.push(v0, v1, v2);
+   *
+   *   // Add an array to list which vertices belong to the face.
+   *   // Vertices are listed in clockwise "winding" order from
+   *   // left to top to right.
+   *   this.faces.push([0, 1, 2]);
+   *
+   *   // Compute the surface normals to help with lighting.
+   *   this.computeNormals();
+   * }
+   * </code>
+   * </div>
+   *
+   * <div>
+   * <code>
+   * // Click and drag the mouse to view the scene from different angles.
+   *
+   * // Adapted from Paul Wheeler's wonderful p5.Geometry tutorial.
+   * // https://www.paulwheeler.us/articles/custom-3d-geometry-in-p5js/
+   * // CC-BY-SA 4.0
+   *
+   * let myGeometry;
+   *
+   * function setup() {
+   *   createCanvas(100, 100, WEBGL);
+   *
+   *   // Create the p5.Geometry object.
+   *   // Set detailX to 48 and detailY to 2.
+   *   // >>> try changing them.
+   *   myGeometry = new p5.Geometry(48, 2, createShape);
+   * }
+   *
+   * function draw() {
+   *   background(50);
+   *
+   *   // Enable orbiting with the mouse.
+   *   orbitControl();
+   *
+   *   // Turn on the lights.
+   *   lights();
+   *
+   *   // Style the p5.Geometry object.
+   *   strokeWeight(0.2);
+   *
+   *   // Draw the p5.Geometry object.
+   *   model(myGeometry);
+   * }
+   *
+   * function createShape() {
+   *   // "this" refers to the p5.Geometry object being created.
+   *
+   *   // Define the Möbius strip with a few parameters.
+   *   let spread = 0.1;
+   *   let radius = 30;
+   *   let stripWidth = 15;
+   *   let xInterval = 4 * PI / this.detailX;
+   *   let yOffset = -stripWidth / 2;
+   *   let yInterval = stripWidth / this.detailY;
+   *
+   *   for (let j = 0; j <= this.detailY; j += 1) {
+   *     // Calculate the "vertical" point along the strip.
+   *     let v = yOffset + yInterval * j;
+   *
+   *     for (let i = 0; i <= this.detailX; i += 1) {
+   *       // Calculate the angle of rotation around the strip.
+   *       let u = i * xInterval;
+   *
+   *       // Calculate the coordinates of the vertex.
+   *       let x = (radius + v * cos(u / 2)) * cos(u) - sin(u / 2) * 2 * spread;
+   *       let y = (radius + v * cos(u / 2)) * sin(u);
+   *       if (u < TWO_PI) {
+   *         y += sin(u) * spread;
+   *       } else {
+   *         y -= sin(u) * spread;
+   *       }
+   *       let z = v * sin(u / 2) + sin(u / 4) * 4 * spread;
+   *
+   *       // Create a p5.Vector object to position the vertex.
+   *       let vert = createVector(x, y, z);
+   *
+   *       // Add the vertex to the p5.Geometry object's vertices array.
+   *       this.vertices.push(vert);
+   *     }
+   *   }
+   *
+   *   // Compute the faces array.
+   *   this.computeFaces();
+   *
+   *   // Compute the surface normals to help with lighting.
+   *   this.computeNormals();
+   * }
+   * </code>
+   * </div>
+   */
+  p5.Geometry = class Geometry {
+    constructor(detailX, detailY, callback) {
+      this.vertices = [];
+
+      this.boundingBoxCache = null;
+
+
+      //an array containing every vertex for stroke drawing
+      this.lineVertices = new p5.DataArray();
+
+      // The tangents going into or out of a vertex on a line. Along a straight
+      // line segment, both should be equal. At an endpoint, one or the other
+      // will not exist and will be all 0. In joins between line segments, they
+      // may be different, as they will be the tangents on either side of the join.
+      this.lineTangentsIn = new p5.DataArray();
+      this.lineTangentsOut = new p5.DataArray();
+
+      // When drawing lines with thickness, entries in this buffer represent which
+      // side of the centerline the vertex will be placed. The sign of the number
+      // will represent the side of the centerline, and the absolute value will be
+      // used as an enum to determine which part of the cap or join each vertex
+      // represents. See the doc comments for _addCap and _addJoin for diagrams.
+      this.lineSides = new p5.DataArray();
+
+      this.vertexNormals = [];
+
+      this.faces = [];
+
+      this.uvs = [];
+      // a 2D array containing edge connectivity pattern for create line vertices
+      //based on faces for most objects;
+      this.edges = [];
+      this.vertexColors = [];
+
+      // One color per vertex representing the stroke color at that vertex
+      this.vertexStrokeColors = [];
+
+      this.userVertexProperties = {};
+
+      // One color per line vertex, generated automatically based on
+      // vertexStrokeColors in _edgesToVertices()
+      this.lineVertexColors = new p5.DataArray();
+      this.detailX = detailX !== undefined ? detailX : 1;
+      this.detailY = detailY !== undefined ? detailY : 1;
+      this.dirtyFlags = {};
+
+      this._hasFillTransparency = undefined;
+      this._hasStrokeTransparency = undefined;
+
+      if (callback instanceof Function) {
+        callback.call(this);
+      }
+    }
+
+    /**
+   * Calculates the position and size of the smallest box that contains the geometry.
+   *
+   * A bounding box is the smallest rectangular prism that contains the entire
+   * geometry. It's defined by the box's minimum and maximum coordinates along
+   * each axis, as well as the size (length) and offset (center).
+   *
+   * Calling `myGeometry.calculateBoundingBox()` returns an object with four
+   * properties that describe the bounding box:
+   *
+   * ```js
+   * // Get myGeometry's bounding box.
+   * let bbox = myGeometry.calculateBoundingBox();
+   *
+   * // Print the bounding box to the console.
+   * console.log(bbox);
+   *
+   * // {
+   * //  // The minimum coordinate along each axis.
+   * //  min: { x: -1, y: -2, z: -3 },
+   * //
+   * //  // The maximum coordinate along each axis.
+   * //  max: { x: 1, y: 2, z: 3},
+   * //
+   * //  // The size (length) along each axis.
+   * //  size: { x: 2, y: 4, z: 6},
+   * //
+   * //  // The offset (center) along each axis.
+   * //  offset: { x: 0, y: 0, z: 0}
+   * // }
+   * ```
+   *
+   * @returns {Object} bounding box of the geometry.
+   *
+   * @example
+   * <div>
+   * <code>
+   * // Click and drag the mouse to view the scene from different angles.
+   *
+   * let particles;
+   *
+   * function setup() {
+   *   createCanvas(100, 100, WEBGL);
+   *
+   *   // Create a new p5.Geometry object with random spheres.
+   *   particles = buildGeometry(createParticles);
+   *
+   *   describe('Ten white spheres placed randomly against a gray background. A box encloses the spheres.');
+   * }
+   *
+   * function draw() {
+   *   background(50);
+   *
+   *   // Enable orbiting with the mouse.
+   *   orbitControl();
+   *
+   *   // Turn on the lights.
+   *   lights();
+   *
+   *   // Style the particles.
+   *   noStroke();
+   *   fill(255);
+   *
+   *   // Draw the particles.
+   *   model(particles);
+   *
+   *   // Calculate the bounding box.
+   *   let bbox = particles.calculateBoundingBox();
+   *
+   *   // Translate to the bounding box's center.
+   *   translate(bbox.offset.x, bbox.offset.y, bbox.offset.z);
+   *
+   *   // Style the bounding box.
+   *   stroke(255);
+   *   noFill();
+   *
+   *   // Draw the bounding box.
+   *   box(bbox.size.x, bbox.size.y, bbox.size.z);
+   * }
+   *
+   * function createParticles() {
+   *   for (let i = 0; i < 10; i += 1) {
+   *     // Calculate random coordinates.
+   *     let x = randomGaussian(0, 15);
+   *     let y = randomGaussian(0, 15);
+   *     let z = randomGaussian(0, 15);
+   *
+   *     push();
+   *     // Translate to the particle's coordinates.
+   *     translate(x, y, z);
+   *     // Draw the particle.
+   *     sphere(3);
+   *     pop();
+   *   }
+   * }
+   * </code>
+   * </div>
+   */
+    calculateBoundingBox() {
+      if (this.boundingBoxCache) {
+        return this.boundingBoxCache; // Return cached result if available
+      }
+
+      let minVertex = new p5.Vector(
+        Number.MAX_VALUE, Number.MAX_VALUE, Number.MAX_VALUE);
+      let maxVertex = new p5.Vector(
+        Number.MIN_VALUE, Number.MIN_VALUE, Number.MIN_VALUE);
+
+      for (let i = 0; i < this.vertices.length; i++) {
+        let vertex = this.vertices[i];
+        minVertex.x = Math.min(minVertex.x, vertex.x);
+        minVertex.y = Math.min(minVertex.y, vertex.y);
+        minVertex.z = Math.min(minVertex.z, vertex.z);
+
+        maxVertex.x = Math.max(maxVertex.x, vertex.x);
+        maxVertex.y = Math.max(maxVertex.y, vertex.y);
+        maxVertex.z = Math.max(maxVertex.z, vertex.z);
+      }
+      // Calculate size and offset properties
+      let size = new p5.Vector(maxVertex.x - minVertex.x,
+        maxVertex.y - minVertex.y, maxVertex.z - minVertex.z);
+      let offset = new p5.Vector((minVertex.x + maxVertex.x) / 2,
+        (minVertex.y + maxVertex.y) / 2, (minVertex.z + maxVertex.z) / 2);
+
+      // Cache the result for future access
+      this.boundingBoxCache = {
+        min: minVertex,
+        max: maxVertex,
+        size: size,
+        offset: offset
+      };
+
+      return this.boundingBoxCache;
+    }
+
+    reset() {
+      this._hasFillTransparency = undefined;
+      this._hasStrokeTransparency = undefined;
+
+      this.lineVertices.clear();
+      this.lineTangentsIn.clear();
+      this.lineTangentsOut.clear();
+      this.lineSides.clear();
+
+      this.vertices.length = 0;
+      this.edges.length = 0;
+      this.vertexColors.length = 0;
+      this.vertexStrokeColors.length = 0;
+      this.lineVertexColors.clear();
+      this.vertexNormals.length = 0;
+      this.uvs.length = 0;
+
+      for (const propName in this.userVertexProperties){
+        this.userVertexProperties[propName].delete();
+      }
+      this.userVertexProperties = {};
+
+      this.dirtyFlags = {};
+    }
+
+    hasFillTransparency() {
+      if (this._hasFillTransparency === undefined) {
+        this._hasFillTransparency = false;
+        for (let i = 0; i < this.vertexColors.length; i += 4) {
+          if (this.vertexColors[i + 3] < 1) {
+            this._hasFillTransparency = true;
+            break;
+          }
+        }
+      }
+      return this._hasFillTransparency;
+    }
+    hasStrokeTransparency() {
+      if (this._hasStrokeTransparency === undefined) {
+        this._hasStrokeTransparency = false;
+        for (let i = 0; i < this.lineVertexColors.length; i += 4) {
+          if (this.lineVertexColors[i + 3] < 1) {
+            this._hasStrokeTransparency = true;
+            break;
+          }
+        }
+      }
+      return this._hasStrokeTransparency;
+    }
+
+    /**
+     * Removes the geometry’s internal colors.
+     *
+     * `p5.Geometry` objects can be created with "internal colors" assigned to
+     * vertices or the entire shape. When a geometry has internal colors,
+     * <a href="#/p5/fill">fill()</a> has no effect. Calling
+     * `myGeometry.clearColors()` allows the
+     * <a href="#/p5/fill">fill()</a> function to apply color to the geometry.
+     *
+     * @example
+     * <div>
+     * <code>
+     * function setup() {
+     *   createCanvas(100, 100, WEBGL);
+     *
+     *   background(200);
+     *
+     *   // Create a p5.Geometry object.
+     *   // Set its internal color to red.
+     *   beginGeometry();
+     *   fill(255, 0, 0);
+     *   plane(20);
+     *   let myGeometry = endGeometry();
+     *
+     *   // Style the shape.
+     *   noStroke();
+     *
+     *   // Draw the p5.Geometry object (center).
+     *   model(myGeometry);
+     *
+     *   // Translate the origin to the bottom-right.
+     *   translate(25, 25, 0);
+     *
+     *   // Try to fill the geometry with green.
+     *   fill(0, 255, 0);
+     *
+     *   // Draw the geometry again (bottom-right).
+     *   model(myGeometry);
+     *
+     *   // Clear the geometry's colors.
+     *   myGeometry.clearColors();
+     *
+     *   // Fill the geometry with blue.
+     *   fill(0, 0, 255);
+     *
+     *   // Translate the origin up.
+     *   translate(0, -50, 0);
+     *
+     *   // Draw the geometry again (top-right).
+     *   model(myGeometry);
+     *
+     *   describe(
+     *     'Three squares drawn against a gray background. Red squares are at the center and the bottom-right. A blue square is at the top-right.'
+     *   );
+     * }
+     * </code>
+     * </div>
+     */
+    clearColors() {
+      this.vertexColors = [];
+      return this;
+    }
+
+    /**
+     * The `saveObj()` function exports `p5.Geometry` objects as
+     * 3D models in the Wavefront .obj file format.
+     * This way, you can use the 3D shapes you create in p5.js in other software
+     * for rendering, animation, 3D printing, or more.
+     *
+     * The exported .obj file will include the faces and vertices of the `p5.Geometry`,
+     * as well as its texture coordinates and normals, if it has them.
+     *
+     * @method saveObj
+     * @param {String} [fileName='model.obj'] The name of the file to save the model as.
+     *                                        If not specified, the default file name will be 'model.obj'.
+     * @example
+     * <div>
+     * <code>
+     * let myModel;
+     * let saveBtn;
+     * function setup() {
+     *   createCanvas(200, 200, WEBGL);
+     *   myModel = buildGeometry(() => {
+     *     for (let i = 0; i < 5; i++) {
+     *       push();
+     *       translate(
+     *         random(-75, 75),
+     *         random(-75, 75),
+     *         random(-75, 75)
+     *       );
+     *       sphere(random(5, 50));
+     *       pop();
+     *     }
+     *   });
+     *
+     *   saveBtn = createButton('Save .obj');
+     *   saveBtn.mousePressed(() => myModel.saveObj());
+     *
+     *   describe('A few spheres rotating in space');
+     * }
+     *
+     * function draw() {
+     *   background(0);
+     *   noStroke();
+     *   lights();
+     *   rotateX(millis() * 0.001);
+     *   rotateY(millis() * 0.002);
+     *   model(myModel);
+     * }
+     * </code>
+     * </div>
+     */
+    saveObj(fileName = 'model.obj') {
+      let objStr= '';
+
+
+      // Vertices
+      this.vertices.forEach(v => {
+        objStr += `v ${v.x} ${v.y} ${v.z}\n`;
+      });
+
+      // Texture Coordinates (UVs)
+      if (this.uvs && this.uvs.length > 0) {
+        for (let i = 0; i < this.uvs.length; i += 2) {
+          objStr += `vt ${this.uvs[i]} ${this.uvs[i + 1]}\n`;
+        }
+      }
+
+      // Vertex Normals
+      if (this.vertexNormals && this.vertexNormals.length > 0) {
+        this.vertexNormals.forEach(n => {
+          objStr += `vn ${n.x} ${n.y} ${n.z}\n`;
+        });
+
+      }
+      // Faces, obj vertex indices begin with 1 and not 0
+      // texture coordinate (uvs) and vertexNormal indices
+      // are indicated with trailing ints vertex/normal/uv
+      // ex 1/1/1 or 2//2 for vertices without uvs
+      this.faces.forEach(face => {
+        let faceStr = 'f';
+        face.forEach(index =>{
+          faceStr += ' ';
+          faceStr += index + 1;
+          if (this.vertexNormals.length > 0 || this.uvs.length > 0) {
+            faceStr += '/';
+            if (this.uvs.length > 0) {
+              faceStr += index + 1;
+            }
+            faceStr += '/';
+            if (this.vertexNormals.length > 0) {
+              faceStr += index + 1;
+            }
+          }
+        });
+        objStr += faceStr + '\n';
+      });
+
+      const blob = new Blob([objStr], { type: 'text/plain' });
+      fn.downloadFile(blob, fileName , 'obj');
+
+    }
+
+    /**
+     * The `saveStl()` function exports `p5.Geometry` objects as
+     * 3D models in the STL stereolithography file format.
+     * This way, you can use the 3D shapes you create in p5.js in other software
+     * for rendering, animation, 3D printing, or more.
+     *
+     * The exported .stl file will include the faces, vertices, and normals of the `p5.Geometry`.
+     *
+     * By default, this method saves a text-based .stl file. Alternatively, you can save a more compact
+     * but less human-readable binary .stl file by passing `{ binary: true }` as a second parameter.
+     *
+     * @method saveStl
+     * @param {String} [fileName='model.stl'] The name of the file to save the model as.
+     *                                        If not specified, the default file name will be 'model.stl'.
+     * @param {Object} [options] Optional settings. Options can include a boolean `binary` property, which
+     * controls whether or not a binary .stl file is saved. It defaults to false.
+     * @example
+     * <div>
+     * <code>
+     * let myModel;
+     * let saveBtn1;
+     * let saveBtn2;
+     * function setup() {
+     *   createCanvas(200, 200, WEBGL);
+     *   myModel = buildGeometry(() => {
+     *     for (let i = 0; i < 5; i++) {
+     *       push();
+     *       translate(
+     *         random(-75, 75),
+     *         random(-75, 75),
+     *         random(-75, 75)
+     *       );
+     *       sphere(random(5, 50));
+     *       pop();
+     *     }
+     *   });
+     *
+     *   saveBtn1 = createButton('Save .stl');
+     *   saveBtn1.mousePressed(function() {
+     *     myModel.saveStl();
+     *   });
+     *   saveBtn2 = createButton('Save binary .stl');
+     *   saveBtn2.mousePressed(function() {
+     *     myModel.saveStl('model.stl', { binary: true });
+     *   });
+     *
+     *   describe('A few spheres rotating in space');
+     * }
+     *
+     * function draw() {
+     *   background(0);
+     *   noStroke();
+     *   lights();
+     *   rotateX(millis() * 0.001);
+     *   rotateY(millis() * 0.002);
+     *   model(myModel);
+     * }
+     * </code>
+     * </div>
+     */
+    saveStl(fileName = 'model.stl', { binary = false } = {}){
+      let modelOutput;
+      let name = fileName.substring(0, fileName.lastIndexOf('.'));
+      let faceNormals = [];
+      for (let f of this.faces) {
+        const U = p5.Vector.sub(this.vertices[f[1]], this.vertices[f[0]]);
+        const V = p5.Vector.sub(this.vertices[f[2]], this.vertices[f[0]]);
+        const nx = U.y * V.z - U.z * V.y;
+        const ny = U.z * V.x - U.x * V.z;
+        const nz = U.x * V.y - U.y * V.x;
+        faceNormals.push(new p5.Vector(nx, ny, nz).normalize());
+      }
+      if (binary) {
+        let offset = 80;
+        const bufferLength =
+            this.faces.length * 2 + this.faces.length * 3 * 4 * 4 + 80 + 4;
+        const arrayBuffer = new ArrayBuffer(bufferLength);
+        modelOutput = new DataView(arrayBuffer);
+        modelOutput.setUint32(offset, this.faces.length, true);
+        offset += 4;
+        for (const [key, f] of Object.entries(this.faces)) {
+          const norm = faceNormals[key];
+          modelOutput.setFloat32(offset, norm.x, true);
+          offset += 4;
+          modelOutput.setFloat32(offset, norm.y, true);
+          offset += 4;
+          modelOutput.setFloat32(offset, norm.z, true);
+          offset += 4;
+          for (let vertexIndex of f) {
+            const vert = this.vertices[vertexIndex];
+            modelOutput.setFloat32(offset, vert.x, true);
+            offset += 4;
+            modelOutput.setFloat32(offset, vert.y, true);
+            offset += 4;
+            modelOutput.setFloat32(offset, vert.z, true);
+            offset += 4;
+          }
+          modelOutput.setUint16(offset, 0, true);
+          offset += 2;
+        }
+      } else {
+        modelOutput = 'solid ' + name + '\n';
+
+        for (const [key, f] of Object.entries(this.faces)) {
+          const norm = faceNormals[key];
+          modelOutput +=
+            ' facet norm ' + norm.x + ' ' + norm.y + ' ' + norm.z + '\n';
+          modelOutput += '  outer loop' + '\n';
+          for (let vertexIndex of f) {
+            const vert = this.vertices[vertexIndex];
+            modelOutput +=
+              '   vertex ' + vert.x + ' ' + vert.y + ' ' + vert.z + '\n';
+          }
+          modelOutput += '  endloop' + '\n';
+          modelOutput += ' endfacet' + '\n';
+        }
+        modelOutput += 'endsolid ' + name + '\n';
+      }
+      const blob = new Blob([modelOutput], { type: 'text/plain' });
+      fn.downloadFile(blob, fileName, 'stl');
+    }
+
+    /**
+   * Flips the geometry’s texture u-coordinates.
+   *
+   * In order for <a href="#/p5/texture">texture()</a> to work, the geometry
+   * needs a way to map the points on its surface to the pixels in a rectangular
+   * image that's used as a texture. The geometry's vertex at coordinates
+   * `(x, y, z)` maps to the texture image's pixel at coordinates `(u, v)`.
+   *
+   * The <a href="#/p5.Geometry/uvs">myGeometry.uvs</a> array stores the
+   * `(u, v)` coordinates for each vertex in the order it was added to the
+   * geometry. Calling `myGeometry.flipU()` flips a geometry's u-coordinates
+   * so that the texture appears mirrored horizontally.
+   *
+   * For example, a plane's four vertices are added clockwise starting from the
+   * top-left corner. Here's how calling `myGeometry.flipU()` would change a
+   * plane's texture coordinates:
+   *
+   * ```js
+   * // Print the original texture coordinates.
+   * // Output: [0, 0, 1, 0, 0, 1, 1, 1]
+   * console.log(myGeometry.uvs);
+   *
+   * // Flip the u-coordinates.
+   * myGeometry.flipU();
+   *
+   * // Print the flipped texture coordinates.
+   * // Output: [1, 0, 0, 0, 1, 1, 0, 1]
+   * console.log(myGeometry.uvs);
+   *
+   * // Notice the swaps:
+   * // Top vertices: [0, 0, 1, 0] --> [1, 0, 0, 0]
+   * // Bottom vertices: [0, 1, 1, 1] --> [1, 1, 0, 1]
+   * ```
+   *
+   * @for p5.Geometry
+   *
+   * @example
+   * <div>
+   * <code>
+   * let img;
+   *
+   * function preload() {
+   *   img = loadImage('assets/laDefense.jpg');
+   * }
+   *
    * function setup() {
    *   createCanvas(100, 100, WEBGL);
    *
    *   background(200);
    *
-   *   // Create a p5.Geometry object.
-   *   // Set its internal color to red.
-   *   beginGeometry();
-   *   fill(255, 0, 0);
-   *   plane(20);
-   *   let myGeometry = endGeometry();
+   *   // Create p5.Geometry objects.
+   *   let geom1 = buildGeometry(createShape);
+   *   let geom2 = buildGeometry(createShape);
    *
-   *   // Style the shape.
+   *   // Flip geom2's U texture coordinates.
+   *   geom2.flipU();
+   *
+   *   // Left (original).
+   *   push();
+   *   translate(-25, 0, 0);
+   *   texture(img);
    *   noStroke();
+   *   model(geom1);
+   *   pop();
    *
-   *   // Draw the p5.Geometry object (center).
-   *   model(myGeometry);
-   *
-   *   // Translate the origin to the bottom-right.
-   *   translate(25, 25, 0);
-   *
-   *   // Try to fill the geometry with green.
-   *   fill(0, 255, 0);
-   *
-   *   // Draw the geometry again (bottom-right).
-   *   model(myGeometry);
-   *
-   *   // Clear the geometry's colors.
-   *   myGeometry.clearColors();
-   *
-   *   // Fill the geometry with blue.
-   *   fill(0, 0, 255);
-   *
-   *   // Translate the origin up.
-   *   translate(0, -50, 0);
-   *
-   *   // Draw the geometry again (top-right).
-   *   model(myGeometry);
+   *   // Right (flipped).
+   *   push();
+   *   translate(25, 0, 0);
+   *   texture(img);
+   *   noStroke();
+   *   model(geom2);
+   *   pop();
    *
    *   describe(
-   *     'Three squares drawn against a gray background. Red squares are at the center and the bottom-right. A blue square is at the top-right.'
+   *     'Two photos of a ceiling on a gray background. The photos are mirror images of each other.'
    *   );
    * }
+   *
+   * function createShape() {
+   *   plane(40);
+   * }
    * </code>
    * </div>
    */
-  clearColors() {
-    this.vertexColors = [];
-    return this;
-  }
+    flipU() {
+      this.uvs = this.uvs.flat().map((val, index) => {
+        if (index % 2 === 0) {
+          return 1 - val;
+        } else {
+          return val;
+        }
+      });
+    }
 
-  /**
-   * The `saveObj()` function exports `p5.Geometry` objects as
-   * 3D models in the Wavefront .obj file format.
-   * This way, you can use the 3D shapes you create in p5.js in other software
-   * for rendering, animation, 3D printing, or more.
+    /**
+   * Flips the geometry’s texture v-coordinates.
    *
-   * The exported .obj file will include the faces and vertices of the `p5.Geometry`,
-   * as well as its texture coordinates and normals, if it has them.
+   * In order for <a href="#/p5/texture">texture()</a> to work, the geometry
+   * needs a way to map the points on its surface to the pixels in a rectangular
+   * image that's used as a texture. The geometry's vertex at coordinates
+   * `(x, y, z)` maps to the texture image's pixel at coordinates `(u, v)`.
    *
-   * @method saveObj
-   * @param {String} [fileName='model.obj'] The name of the file to save the model as.
-   *                                        If not specified, the default file name will be 'model.obj'.
+   * The <a href="#/p5.Geometry/uvs">myGeometry.uvs</a> array stores the
+   * `(u, v)` coordinates for each vertex in the order it was added to the
+   * geometry. Calling `myGeometry.flipV()` flips a geometry's v-coordinates
+   * so that the texture appears mirrored vertically.
+   *
+   * For example, a plane's four vertices are added clockwise starting from the
+   * top-left corner. Here's how calling `myGeometry.flipV()` would change a
+   * plane's texture coordinates:
+   *
+   * ```js
+   * // Print the original texture coordinates.
+   * // Output: [0, 0, 1, 0, 0, 1, 1, 1]
+   * console.log(myGeometry.uvs);
+   *
+   * // Flip the v-coordinates.
+   * myGeometry.flipV();
+   *
+   * // Print the flipped texture coordinates.
+   * // Output: [0, 1, 1, 1, 0, 0, 1, 0]
+   * console.log(myGeometry.uvs);
+   *
+   * // Notice the swaps:
+   * // Left vertices: [0, 0] <--> [1, 0]
+   * // Right vertices: [1, 0] <--> [1, 1]
+   * ```
+   *
+   * @for p5.Geometry
+   *
    * @example
    * <div>
    * <code>
-   * let myModel;
-   * let saveBtn;
-   * function setup() {
-   *   createCanvas(200, 200, WEBGL);
-   *   myModel = buildGeometry(() => {
-   *     for (let i = 0; i < 5; i++) {
-   *       push();
-   *       translate(
-   *         random(-75, 75),
-   *         random(-75, 75),
-   *         random(-75, 75)
-   *       );
-   *       sphere(random(5, 50));
-   *       pop();
-   *     }
-   *   });
+   * let img;
    *
-   *   saveBtn = createButton('Save .obj');
-   *   saveBtn.mousePressed(() => myModel.saveObj());
-   *
-   *   describe('A few spheres rotating in space');
+   * function preload() {
+   *   img = loadImage('assets/laDefense.jpg');
    * }
    *
-   * function draw() {
-   *   background(0);
+   * function setup() {
+   *   createCanvas(100, 100, WEBGL);
+   *
+   *   background(200);
+   *
+   *   // Create p5.Geometry objects.
+   *   let geom1 = buildGeometry(createShape);
+   *   let geom2 = buildGeometry(createShape);
+   *
+   *   // Flip geom2's V texture coordinates.
+   *   geom2.flipV();
+   *
+   *   // Left (original).
+   *   push();
+   *   translate(-25, 0, 0);
+   *   texture(img);
    *   noStroke();
-   *   lights();
-   *   rotateX(millis() * 0.001);
-   *   rotateY(millis() * 0.002);
-   *   model(myModel);
+   *   model(geom1);
+   *   pop();
+   *
+   *   // Right (flipped).
+   *   push();
+   *   translate(25, 0, 0);
+   *   texture(img);
+   *   noStroke();
+   *   model(geom2);
+   *   pop();
+   *
+   *   describe(
+   *     'Two photos of a ceiling on a gray background. The photos are mirror images of each other.'
+   *   );
+   * }
+   *
+   * function createShape() {
+   *   plane(40);
    * }
    * </code>
    * </div>
    */
-  saveObj(fileName = 'model.obj') {
-    let objStr= '';
-
-
-    // Vertices
-    this.vertices.forEach(v => {
-      objStr += `v ${v.x} ${v.y} ${v.z}\n`;
-    });
-
-    // Texture Coordinates (UVs)
-    if (this.uvs && this.uvs.length > 0) {
-      for (let i = 0; i < this.uvs.length; i += 2) {
-        objStr += `vt ${this.uvs[i]} ${this.uvs[i + 1]}\n`;
-      }
-    }
-
-    // Vertex Normals
-    if (this.vertexNormals && this.vertexNormals.length > 0) {
-      this.vertexNormals.forEach(n => {
-        objStr += `vn ${n.x} ${n.y} ${n.z}\n`;
-      });
-
-    }
-    // Faces, obj vertex indices begin with 1 and not 0
-    // texture coordinate (uvs) and vertexNormal indices
-    // are indicated with trailing ints vertex/normal/uv
-    // ex 1/1/1 or 2//2 for vertices without uvs
-    this.faces.forEach(face => {
-      let faceStr = 'f';
-      face.forEach(index =>{
-        faceStr += ' ';
-        faceStr += index + 1;
-        if (this.vertexNormals.length > 0 || this.uvs.length > 0) {
-          faceStr += '/';
-          if (this.uvs.length > 0) {
-            faceStr += index + 1;
-          }
-          faceStr += '/';
-          if (this.vertexNormals.length > 0) {
-            faceStr += index + 1;
-          }
+    flipV() {
+      this.uvs = this.uvs.flat().map((val, index) => {
+        if (index % 2 === 0) {
+          return val;
+        } else {
+          return 1 - val;
         }
       });
-      objStr += faceStr + '\n';
-    });
-
-    const blob = new Blob([objStr], { type: 'text/plain' });
-    p5.prototype.downloadFile(blob, fileName , 'obj');
-
-  }
-
-  /**
-   * The `saveStl()` function exports `p5.Geometry` objects as
-   * 3D models in the STL stereolithography file format.
-   * This way, you can use the 3D shapes you create in p5.js in other software
-   * for rendering, animation, 3D printing, or more.
-   *
-   * The exported .stl file will include the faces, vertices, and normals of the `p5.Geometry`.
-   *
-   * By default, this method saves a text-based .stl file. Alternatively, you can save a more compact
-   * but less human-readable binary .stl file by passing `{ binary: true }` as a second parameter.
-   *
-   * @method saveStl
-   * @param {String} [fileName='model.stl'] The name of the file to save the model as.
-   *                                        If not specified, the default file name will be 'model.stl'.
-   * @param {Object} [options] Optional settings. Options can include a boolean `binary` property, which
-   * controls whether or not a binary .stl file is saved. It defaults to false.
-   * @example
-   * <div>
-   * <code>
-   * let myModel;
-   * let saveBtn1;
-   * let saveBtn2;
-   * function setup() {
-   *   createCanvas(200, 200, WEBGL);
-   *   myModel = buildGeometry(() => {
-   *     for (let i = 0; i < 5; i++) {
-   *       push();
-   *       translate(
-   *         random(-75, 75),
-   *         random(-75, 75),
-   *         random(-75, 75)
-   *       );
-   *       sphere(random(5, 50));
-   *       pop();
-   *     }
-   *   });
-   *
-   *   saveBtn1 = createButton('Save .stl');
-   *   saveBtn1.mousePressed(function() {
-   *     myModel.saveStl();
-   *   });
-   *   saveBtn2 = createButton('Save binary .stl');
-   *   saveBtn2.mousePressed(function() {
-   *     myModel.saveStl('model.stl', { binary: true });
-   *   });
-   *
-   *   describe('A few spheres rotating in space');
-   * }
-   *
-   * function draw() {
-   *   background(0);
-   *   noStroke();
-   *   lights();
-   *   rotateX(millis() * 0.001);
-   *   rotateY(millis() * 0.002);
-   *   model(myModel);
-   * }
-   * </code>
-   * </div>
-   */
-  saveStl(fileName = 'model.stl', { binary = false } = {}){
-    let modelOutput;
-    let name = fileName.substring(0, fileName.lastIndexOf('.'));
-    let faceNormals = [];
-    for (let f of this.faces) {
-      const U = p5.Vector.sub(this.vertices[f[1]], this.vertices[f[0]]);
-      const V = p5.Vector.sub(this.vertices[f[2]], this.vertices[f[0]]);
-      const nx = U.y * V.z - U.z * V.y;
-      const ny = U.z * V.x - U.x * V.z;
-      const nz = U.x * V.y - U.y * V.x;
-      faceNormals.push(new p5.Vector(nx, ny, nz).normalize());
     }
-    if (binary) {
-      let offset = 80;
-      const bufferLength =
-          this.faces.length * 2 + this.faces.length * 3 * 4 * 4 + 80 + 4;
-      const arrayBuffer = new ArrayBuffer(bufferLength);
-      modelOutput = new DataView(arrayBuffer);
-      modelOutput.setUint32(offset, this.faces.length, true);
-      offset += 4;
-      for (const [key, f] of Object.entries(this.faces)) {
-        const norm = faceNormals[key];
-        modelOutput.setFloat32(offset, norm.x, true);
-        offset += 4;
-        modelOutput.setFloat32(offset, norm.y, true);
-        offset += 4;
-        modelOutput.setFloat32(offset, norm.z, true);
-        offset += 4;
-        for (let vertexIndex of f) {
-          const vert = this.vertices[vertexIndex];
-          modelOutput.setFloat32(offset, vert.x, true);
-          offset += 4;
-          modelOutput.setFloat32(offset, vert.y, true);
-          offset += 4;
-          modelOutput.setFloat32(offset, vert.z, true);
-          offset += 4;
-        }
-        modelOutput.setUint16(offset, 0, true);
-        offset += 2;
-      }
-    } else {
-      modelOutput = 'solid ' + name + '\n';
 
-      for (const [key, f] of Object.entries(this.faces)) {
-        const norm = faceNormals[key];
-        modelOutput +=
-          ' facet norm ' + norm.x + ' ' + norm.y + ' ' + norm.z + '\n';
-        modelOutput += '  outer loop' + '\n';
-        for (let vertexIndex of f) {
-          const vert = this.vertices[vertexIndex];
-          modelOutput +=
-            '   vertex ' + vert.x + ' ' + vert.y + ' ' + vert.z + '\n';
-        }
-        modelOutput += '  endloop' + '\n';
-        modelOutput += ' endfacet' + '\n';
-      }
-      modelOutput += 'endsolid ' + name + '\n';
-    }
-    const blob = new Blob([modelOutput], { type: 'text/plain' });
-    p5.prototype.downloadFile(blob, fileName, 'stl');
-  }
-
-  /**
- * Flips the geometry’s texture u-coordinates.
- *
- * In order for <a href="#/p5/texture">texture()</a> to work, the geometry
- * needs a way to map the points on its surface to the pixels in a rectangular
- * image that's used as a texture. The geometry's vertex at coordinates
- * `(x, y, z)` maps to the texture image's pixel at coordinates `(u, v)`.
- *
- * The <a href="#/p5.Geometry/uvs">myGeometry.uvs</a> array stores the
- * `(u, v)` coordinates for each vertex in the order it was added to the
- * geometry. Calling `myGeometry.flipU()` flips a geometry's u-coordinates
- * so that the texture appears mirrored horizontally.
- *
- * For example, a plane's four vertices are added clockwise starting from the
- * top-left corner. Here's how calling `myGeometry.flipU()` would change a
- * plane's texture coordinates:
- *
- * ```js
- * // Print the original texture coordinates.
- * // Output: [0, 0, 1, 0, 0, 1, 1, 1]
- * console.log(myGeometry.uvs);
- *
- * // Flip the u-coordinates.
- * myGeometry.flipU();
- *
- * // Print the flipped texture coordinates.
- * // Output: [1, 0, 0, 0, 1, 1, 0, 1]
- * console.log(myGeometry.uvs);
- *
- * // Notice the swaps:
- * // Top vertices: [0, 0, 1, 0] --> [1, 0, 0, 0]
- * // Bottom vertices: [0, 1, 1, 1] --> [1, 1, 0, 1]
- * ```
- *
- * @for p5.Geometry
- *
- * @example
- * <div>
- * <code>
- * let img;
- *
- * function preload() {
- *   img = loadImage('assets/laDefense.jpg');
- * }
- *
- * function setup() {
- *   createCanvas(100, 100, WEBGL);
- *
- *   background(200);
- *
- *   // Create p5.Geometry objects.
- *   let geom1 = buildGeometry(createShape);
- *   let geom2 = buildGeometry(createShape);
- *
- *   // Flip geom2's U texture coordinates.
- *   geom2.flipU();
- *
- *   // Left (original).
- *   push();
- *   translate(-25, 0, 0);
- *   texture(img);
- *   noStroke();
- *   model(geom1);
- *   pop();
- *
- *   // Right (flipped).
- *   push();
- *   translate(25, 0, 0);
- *   texture(img);
- *   noStroke();
- *   model(geom2);
- *   pop();
- *
- *   describe(
- *     'Two photos of a ceiling on a gray background. The photos are mirror images of each other.'
- *   );
- * }
- *
- * function createShape() {
- *   plane(40);
- * }
- * </code>
- * </div>
- */
-  flipU() {
-    this.uvs = this.uvs.flat().map((val, index) => {
-      if (index % 2 === 0) {
-        return 1 - val;
-      } else {
-        return val;
-      }
-    });
-  }
-
-  /**
- * Flips the geometry’s texture v-coordinates.
- *
- * In order for <a href="#/p5/texture">texture()</a> to work, the geometry
- * needs a way to map the points on its surface to the pixels in a rectangular
- * image that's used as a texture. The geometry's vertex at coordinates
- * `(x, y, z)` maps to the texture image's pixel at coordinates `(u, v)`.
- *
- * The <a href="#/p5.Geometry/uvs">myGeometry.uvs</a> array stores the
- * `(u, v)` coordinates for each vertex in the order it was added to the
- * geometry. Calling `myGeometry.flipV()` flips a geometry's v-coordinates
- * so that the texture appears mirrored vertically.
- *
- * For example, a plane's four vertices are added clockwise starting from the
- * top-left corner. Here's how calling `myGeometry.flipV()` would change a
- * plane's texture coordinates:
- *
- * ```js
- * // Print the original texture coordinates.
- * // Output: [0, 0, 1, 0, 0, 1, 1, 1]
- * console.log(myGeometry.uvs);
- *
- * // Flip the v-coordinates.
- * myGeometry.flipV();
- *
- * // Print the flipped texture coordinates.
- * // Output: [0, 1, 1, 1, 0, 0, 1, 0]
- * console.log(myGeometry.uvs);
- *
- * // Notice the swaps:
- * // Left vertices: [0, 0] <--> [1, 0]
- * // Right vertices: [1, 0] <--> [1, 1]
- * ```
- *
- * @for p5.Geometry
- *
- * @example
- * <div>
- * <code>
- * let img;
- *
- * function preload() {
- *   img = loadImage('assets/laDefense.jpg');
- * }
- *
- * function setup() {
- *   createCanvas(100, 100, WEBGL);
- *
- *   background(200);
- *
- *   // Create p5.Geometry objects.
- *   let geom1 = buildGeometry(createShape);
- *   let geom2 = buildGeometry(createShape);
- *
- *   // Flip geom2's V texture coordinates.
- *   geom2.flipV();
- *
- *   // Left (original).
- *   push();
- *   translate(-25, 0, 0);
- *   texture(img);
- *   noStroke();
- *   model(geom1);
- *   pop();
- *
- *   // Right (flipped).
- *   push();
- *   translate(25, 0, 0);
- *   texture(img);
- *   noStroke();
- *   model(geom2);
- *   pop();
- *
- *   describe(
- *     'Two photos of a ceiling on a gray background. The photos are mirror images of each other.'
- *   );
- * }
- *
- * function createShape() {
- *   plane(40);
- * }
- * </code>
- * </div>
- */
-  flipV() {
-    this.uvs = this.uvs.flat().map((val, index) => {
-      if (index % 2 === 0) {
-        return val;
-      } else {
-        return 1 - val;
-      }
-    });
-  }
-
-  /**
- * Computes the geometry's faces using its vertices.
- *
- * All 3D shapes are made by connecting sets of points called *vertices*. A
- * geometry's surface is formed by connecting vertices to form triangles that
- * are stitched together. Each triangular patch on the geometry's surface is
- * called a *face*. `myGeometry.computeFaces()` performs the math needed to
- * define each face based on the distances between vertices.
- *
- * The geometry's vertices are stored as <a href="#/p5.Vector">p5.Vector</a>
- * objects in the <a href="#/p5.Geometry/vertices">myGeometry.vertices</a>
- * array. The geometry's first vertex is the
- * <a href="#/p5.Vector">p5.Vector</a> object at `myGeometry.vertices[0]`,
- * its second vertex is `myGeometry.vertices[1]`, its third vertex is
- * `myGeometry.vertices[2]`, and so on.
- *
- * Calling `myGeometry.computeFaces()` fills the
- * <a href="#/p5.Geometry/faces">myGeometry.faces</a> array with three-element
- * arrays that list the vertices that form each face. For example, a geometry
- * made from a rectangle has two faces because a rectangle is made by joining
- * two triangles. <a href="#/p5.Geometry/faces">myGeometry.faces</a> for a
- * rectangle would be the two-dimensional array
- * `[[0, 1, 2], [2, 1, 3]]`. The first face, `myGeometry.faces[0]`, is the
- * array `[0, 1, 2]` because it's formed by connecting
- * `myGeometry.vertices[0]`, `myGeometry.vertices[1]`,and
- * `myGeometry.vertices[2]`. The second face, `myGeometry.faces[1]`, is the
- * array `[2, 1, 3]` because it's formed by connecting
- * `myGeometry.vertices[2]`, `myGeometry.vertices[1]`, and
- * `myGeometry.vertices[3]`.
- *
- * Note: `myGeometry.computeFaces()` only works when geometries have four or more vertices.
- *
- * @chainable
- *
- * @example
- * <div>
- * <code>
- * // Click and drag the mouse to view the scene from different angles.
- *
- * let myGeometry;
- *
- * function setup() {
- *   createCanvas(100, 100, WEBGL);
- *
- *   // Create a p5.Geometry object.
- *   myGeometry = new p5.Geometry();
- *
- *   // Create p5.Vector objects to position the vertices.
- *   let v0 = createVector(-40, 0, 0);
- *   let v1 = createVector(0, -40, 0);
- *   let v2 = createVector(0, 40, 0);
- *   let v3 = createVector(40, 0, 0);
- *
- *   // Add the vertices to myGeometry's vertices array.
- *   myGeometry.vertices.push(v0, v1, v2, v3);
- *
- *   // Compute myGeometry's faces array.
- *   myGeometry.computeFaces();
- *
- *   describe('A red square drawn on a gray background.');
- * }
- *
- * function draw() {
- *   background(200);
- *
- *   // Enable orbiting with the mouse.
- *   orbitControl();
- *
- *   // Turn on the lights.
- *   lights();
- *
- *   // Style the shape.
- *   noStroke();
- *   fill(255, 0, 0);
- *
- *   // Draw the p5.Geometry object.
- *   model(myGeometry);
- * }
- * </code>
- * </div>
- *
- * <div>
- * <code>
- * // Click and drag the mouse to view the scene from different angles.
- *
- * let myGeometry;
- *
- * function setup() {
- *   createCanvas(100, 100, WEBGL);
- *
- *   // Create a p5.Geometry object using a callback function.
- *   myGeometry = new p5.Geometry(1, 1, createShape);
- *
- *   describe('A red square drawn on a gray background.');
- * }
- *
- * function draw() {
- *   background(200);
- *
- *   // Enable orbiting with the mouse.
- *   orbitControl();
- *
- *   // Turn on the lights.
- *   lights();
- *
- *   // Style the shape.
- *   noStroke();
- *   fill(255, 0, 0);
- *
- *   // Draw the p5.Geometry object.
- *   model(myGeometry);
- * }
- *
- * function createShape() {
- *   // Create p5.Vector objects to position the vertices.
- *   let v0 = createVector(-40, 0, 0);
- *   let v1 = createVector(0, -40, 0);
- *   let v2 = createVector(0, 40, 0);
- *   let v3 = createVector(40, 0, 0);
- *
- *   // Add the vertices to the p5.Geometry object's vertices array.
- *   this.vertices.push(v0, v1, v2, v3);
- *
- *   // Compute the faces array.
- *   this.computeFaces();
- * }
- * </code>
- * </div>
- */
-  computeFaces() {
-    this.faces.length = 0;
-    const sliceCount = this.detailX + 1;
-    let a, b, c, d;
-    for (let i = 0; i < this.detailY; i++) {
-      for (let j = 0; j < this.detailX; j++) {
-        a = i * sliceCount + j; // + offset;
-        b = i * sliceCount + j + 1; // + offset;
-        c = (i + 1) * sliceCount + j + 1; // + offset;
-        d = (i + 1) * sliceCount + j; // + offset;
-        this.faces.push([a, b, d]);
-        this.faces.push([d, b, c]);
-      }
-    }
-    return this;
-  }
-
-  _getFaceNormal(faceId) {
-    //This assumes that vA->vB->vC is a counter-clockwise ordering
-    const face = this.faces[faceId];
-    const vA = this.vertices[face[0]];
-    const vB = this.vertices[face[1]];
-    const vC = this.vertices[face[2]];
-    const ab = p5.Vector.sub(vB, vA);
-    const ac = p5.Vector.sub(vC, vA);
-    const n = p5.Vector.cross(ab, ac);
-    const ln = p5.Vector.mag(n);
-    let sinAlpha = ln / (p5.Vector.mag(ab) * p5.Vector.mag(ac));
-    if (sinAlpha === 0 || isNaN(sinAlpha)) {
-      console.warn(
-        'p5.Geometry.prototype._getFaceNormal:',
-        'face has colinear sides or a repeated vertex'
-      );
-      return n;
-    }
-    if (sinAlpha > 1) sinAlpha = 1; // handle float rounding error
-    return n.mult(Math.asin(sinAlpha) / ln);
-  }
-  /**
-   * Calculates the normal vector for each vertex on the geometry.
+    /**
+   * Computes the geometry's faces using its vertices.
    *
    * All 3D shapes are made by connecting sets of points called *vertices*. A
-   * geometry's surface is formed by connecting vertices to create triangles
-   * that are stitched together. Each triangular patch on the geometry's
-   * surface is called a *face*. `myGeometry.computeNormals()` performs the
-   * math needed to orient each face. Orientation is important for lighting
-   * and other effects.
+   * geometry's surface is formed by connecting vertices to form triangles that
+   * are stitched together. Each triangular patch on the geometry's surface is
+   * called a *face*. `myGeometry.computeFaces()` performs the math needed to
+   * define each face based on the distances between vertices.
    *
-   * A face's orientation is defined by its *normal vector* which points out
-   * of the face and is normal (perpendicular) to the surface. Calling
-   * `myGeometry.computeNormals()` first calculates each face's normal vector.
-   * Then it calculates the normal vector for each vertex by averaging the
-   * normal vectors of the faces surrounding the vertex. The vertex normals
-   * are stored as <a href="#/p5.Vector">p5.Vector</a> objects in the
-   * <a href="#/p5.Geometry/vertexNormals">myGeometry.vertexNormals</a> array.
+   * The geometry's vertices are stored as <a href="#/p5.Vector">p5.Vector</a>
+   * objects in the <a href="#/p5.Geometry/vertices">myGeometry.vertices</a>
+   * array. The geometry's first vertex is the
+   * <a href="#/p5.Vector">p5.Vector</a> object at `myGeometry.vertices[0]`,
+   * its second vertex is `myGeometry.vertices[1]`, its third vertex is
+   * `myGeometry.vertices[2]`, and so on.
    *
-   * The first parameter, `shadingType`, is optional. Passing the constant
-   * `FLAT`, as in `myGeometry.computeNormals(FLAT)`, provides neighboring
-   * faces with their own copies of the vertices they share. Surfaces appear
-   * tiled with flat shading. Passing the constant `SMOOTH`, as in
-   * `myGeometry.computeNormals(SMOOTH)`, makes neighboring faces reuse their
-   * shared vertices. Surfaces appear smoother with smooth shading. By
-   * default, `shadingType` is `FLAT`.
+   * Calling `myGeometry.computeFaces()` fills the
+   * <a href="#/p5.Geometry/faces">myGeometry.faces</a> array with three-element
+   * arrays that list the vertices that form each face. For example, a geometry
+   * made from a rectangle has two faces because a rectangle is made by joining
+   * two triangles. <a href="#/p5.Geometry/faces">myGeometry.faces</a> for a
+   * rectangle would be the two-dimensional array
+   * `[[0, 1, 2], [2, 1, 3]]`. The first face, `myGeometry.faces[0]`, is the
+   * array `[0, 1, 2]` because it's formed by connecting
+   * `myGeometry.vertices[0]`, `myGeometry.vertices[1]`,and
+   * `myGeometry.vertices[2]`. The second face, `myGeometry.faces[1]`, is the
+   * array `[2, 1, 3]` because it's formed by connecting
+   * `myGeometry.vertices[2]`, `myGeometry.vertices[1]`, and
+   * `myGeometry.vertices[3]`.
    *
-   * The second parameter, `options`, is also optional. If an object with a
-   * `roundToPrecision` property is passed, as in
-   * `myGeometry.computeNormals(SMOOTH, { roundToPrecision: 5 })`, it sets the
-   * number of decimal places to use for calculations. By default,
-   * `roundToPrecision` uses 3 decimal places.
+   * Note: `myGeometry.computeFaces()` only works when geometries have four or more vertices.
    *
-   * @param {(FLAT|SMOOTH)} [shadingType=FLAT] shading type. either FLAT or SMOOTH. Defaults to `FLAT`.
-   * @param {Object} [options] shading options.
    * @chainable
    *
    * @example
@@ -1172,15 +1004,1240 @@ p5.Geometry = class Geometry {
    *   createCanvas(100, 100, WEBGL);
    *
    *   // Create a p5.Geometry object.
+   *   myGeometry = new p5.Geometry();
+   *
+   *   // Create p5.Vector objects to position the vertices.
+   *   let v0 = createVector(-40, 0, 0);
+   *   let v1 = createVector(0, -40, 0);
+   *   let v2 = createVector(0, 40, 0);
+   *   let v3 = createVector(40, 0, 0);
+   *
+   *   // Add the vertices to myGeometry's vertices array.
+   *   myGeometry.vertices.push(v0, v1, v2, v3);
+   *
+   *   // Compute myGeometry's faces array.
+   *   myGeometry.computeFaces();
+   *
+   *   describe('A red square drawn on a gray background.');
+   * }
+   *
+   * function draw() {
+   *   background(200);
+   *
+   *   // Enable orbiting with the mouse.
+   *   orbitControl();
+   *
+   *   // Turn on the lights.
+   *   lights();
+   *
+   *   // Style the shape.
+   *   noStroke();
+   *   fill(255, 0, 0);
+   *
+   *   // Draw the p5.Geometry object.
+   *   model(myGeometry);
+   * }
+   * </code>
+   * </div>
+   *
+   * <div>
+   * <code>
+   * // Click and drag the mouse to view the scene from different angles.
+   *
+   * let myGeometry;
+   *
+   * function setup() {
+   *   createCanvas(100, 100, WEBGL);
+   *
+   *   // Create a p5.Geometry object using a callback function.
+   *   myGeometry = new p5.Geometry(1, 1, createShape);
+   *
+   *   describe('A red square drawn on a gray background.');
+   * }
+   *
+   * function draw() {
+   *   background(200);
+   *
+   *   // Enable orbiting with the mouse.
+   *   orbitControl();
+   *
+   *   // Turn on the lights.
+   *   lights();
+   *
+   *   // Style the shape.
+   *   noStroke();
+   *   fill(255, 0, 0);
+   *
+   *   // Draw the p5.Geometry object.
+   *   model(myGeometry);
+   * }
+   *
+   * function createShape() {
+   *   // Create p5.Vector objects to position the vertices.
+   *   let v0 = createVector(-40, 0, 0);
+   *   let v1 = createVector(0, -40, 0);
+   *   let v2 = createVector(0, 40, 0);
+   *   let v3 = createVector(40, 0, 0);
+   *
+   *   // Add the vertices to the p5.Geometry object's vertices array.
+   *   this.vertices.push(v0, v1, v2, v3);
+   *
+   *   // Compute the faces array.
+   *   this.computeFaces();
+   * }
+   * </code>
+   * </div>
+   */
+    computeFaces() {
+      this.faces.length = 0;
+      const sliceCount = this.detailX + 1;
+      let a, b, c, d;
+      for (let i = 0; i < this.detailY; i++) {
+        for (let j = 0; j < this.detailX; j++) {
+          a = i * sliceCount + j; // + offset;
+          b = i * sliceCount + j + 1; // + offset;
+          c = (i + 1) * sliceCount + j + 1; // + offset;
+          d = (i + 1) * sliceCount + j; // + offset;
+          this.faces.push([a, b, d]);
+          this.faces.push([d, b, c]);
+        }
+      }
+      return this;
+    }
+
+    _getFaceNormal(faceId) {
+      //This assumes that vA->vB->vC is a counter-clockwise ordering
+      const face = this.faces[faceId];
+      const vA = this.vertices[face[0]];
+      const vB = this.vertices[face[1]];
+      const vC = this.vertices[face[2]];
+      const ab = p5.Vector.sub(vB, vA);
+      const ac = p5.Vector.sub(vC, vA);
+      const n = p5.Vector.cross(ab, ac);
+      const ln = p5.Vector.mag(n);
+      let sinAlpha = ln / (p5.Vector.mag(ab) * p5.Vector.mag(ac));
+      if (sinAlpha === 0 || isNaN(sinAlpha)) {
+        console.warn(
+          'p5.Geometry.prototype._getFaceNormal:',
+          'face has colinear sides or a repeated vertex'
+        );
+        return n;
+      }
+      if (sinAlpha > 1) sinAlpha = 1; // handle float rounding error
+      return n.mult(Math.asin(sinAlpha) / ln);
+    }
+    /**
+     * Calculates the normal vector for each vertex on the geometry.
+     *
+     * All 3D shapes are made by connecting sets of points called *vertices*. A
+     * geometry's surface is formed by connecting vertices to create triangles
+     * that are stitched together. Each triangular patch on the geometry's
+     * surface is called a *face*. `myGeometry.computeNormals()` performs the
+     * math needed to orient each face. Orientation is important for lighting
+     * and other effects.
+     *
+     * A face's orientation is defined by its *normal vector* which points out
+     * of the face and is normal (perpendicular) to the surface. Calling
+     * `myGeometry.computeNormals()` first calculates each face's normal vector.
+     * Then it calculates the normal vector for each vertex by averaging the
+     * normal vectors of the faces surrounding the vertex. The vertex normals
+     * are stored as <a href="#/p5.Vector">p5.Vector</a> objects in the
+     * <a href="#/p5.Geometry/vertexNormals">myGeometry.vertexNormals</a> array.
+     *
+     * The first parameter, `shadingType`, is optional. Passing the constant
+     * `FLAT`, as in `myGeometry.computeNormals(FLAT)`, provides neighboring
+     * faces with their own copies of the vertices they share. Surfaces appear
+     * tiled with flat shading. Passing the constant `SMOOTH`, as in
+     * `myGeometry.computeNormals(SMOOTH)`, makes neighboring faces reuse their
+     * shared vertices. Surfaces appear smoother with smooth shading. By
+     * default, `shadingType` is `FLAT`.
+     *
+     * The second parameter, `options`, is also optional. If an object with a
+     * `roundToPrecision` property is passed, as in
+     * `myGeometry.computeNormals(SMOOTH, { roundToPrecision: 5 })`, it sets the
+     * number of decimal places to use for calculations. By default,
+     * `roundToPrecision` uses 3 decimal places.
+     *
+     * @param {(FLAT|SMOOTH)} [shadingType=FLAT] shading type. either FLAT or SMOOTH. Defaults to `FLAT`.
+     * @param {Object} [options] shading options.
+     * @chainable
+     *
+     * @example
+     * <div>
+     * <code>
+     * // Click and drag the mouse to view the scene from different angles.
+     *
+     * let myGeometry;
+     *
+     * function setup() {
+     *   createCanvas(100, 100, WEBGL);
+     *
+     *   // Create a p5.Geometry object.
+     *   beginGeometry();
+     *   torus();
+     *   myGeometry = endGeometry();
+     *
+     *   // Compute the vertex normals.
+     *   myGeometry.computeNormals();
+     *
+     *   describe(
+     *     "A white torus drawn on a dark gray background. Red lines extend outward from the torus' vertices."
+     *   );
+     * }
+     *
+     * function draw() {
+     *   background(50);
+     *
+     *   // Enable orbiting with the mouse.
+     *   orbitControl();
+     *
+     *   // Turn on the lights.
+     *   lights();
+     *
+     *   // Rotate the coordinate system.
+     *   rotateX(1);
+     *
+     *   // Style the helix.
+     *   stroke(0);
+     *
+     *   // Display the helix.
+     *   model(myGeometry);
+     *
+     *   // Style the normal vectors.
+     *   stroke(255, 0, 0);
+     *
+     *   // Iterate over the vertices and vertexNormals arrays.
+     *   for (let i = 0; i < myGeometry.vertices.length; i += 1) {
+     *
+     *     // Get the vertex p5.Vector object.
+     *     let v = myGeometry.vertices[i];
+     *
+     *     // Get the vertex normal p5.Vector object.
+     *     let n = myGeometry.vertexNormals[i];
+     *
+     *     // Calculate a point along the vertex normal.
+     *     let p = p5.Vector.mult(n, 5);
+     *
+     *     // Draw the vertex normal as a red line.
+     *     push();
+     *     translate(v);
+     *     line(0, 0, 0, p.x, p.y, p.z);
+     *     pop();
+     *   }
+     * }
+     * </code>
+     * </div>
+     *
+     * <div>
+     * <code>
+     * // Click and drag the mouse to view the scene from different angles.
+     *
+     * let myGeometry;
+     *
+     * function setup() {
+     *   createCanvas(100, 100, WEBGL);
+     *
+     *   // Create a p5.Geometry object using a callback function.
+     *   myGeometry = new p5.Geometry();
+     *
+     *   // Create p5.Vector objects to position the vertices.
+     *   let v0 = createVector(-40, 0, 0);
+     *   let v1 = createVector(0, -40, 0);
+     *   let v2 = createVector(0, 40, 0);
+     *   let v3 = createVector(40, 0, 0);
+     *
+     *   // Add the vertices to the p5.Geometry object's vertices array.
+     *   myGeometry.vertices.push(v0, v1, v2, v3);
+     *
+     *   // Compute the faces array.
+     *   myGeometry.computeFaces();
+     *
+     *   // Compute the surface normals.
+     *   myGeometry.computeNormals();
+     *
+     *   describe('A red square drawn on a gray background.');
+     * }
+     *
+     * function draw() {
+     *   background(200);
+     *
+     *   // Enable orbiting with the mouse.
+     *   orbitControl();
+     *
+     *   // Add a white point light.
+     *   pointLight(255, 255, 255, 0, 0, 10);
+     *
+     *   // Style the p5.Geometry object.
+     *   noStroke();
+     *   fill(255, 0, 0);
+     *
+     *   // Draw the p5.Geometry object.
+     *   model(myGeometry);
+     * }
+     * </code>
+     * </div>
+     *
+     * <div>
+     * <code>
+     * // Click and drag the mouse to view the scene from different angles.
+     *
+     * let myGeometry;
+     *
+     * function setup() {
+     *   createCanvas(100, 100, WEBGL);
+     *
+     *   // Create a p5.Geometry object.
+     *   myGeometry = buildGeometry(createShape);
+     *
+     *   // Compute normals using default (FLAT) shading.
+     *   myGeometry.computeNormals(FLAT);
+     *
+     *   describe('A white, helical structure drawn on a dark gray background. Its faces appear faceted.');
+     * }
+     *
+     * function draw() {
+     *   background(50);
+     *
+     *   // Enable orbiting with the mouse.
+     *   orbitControl();
+     *
+     *   // Turn on the lights.
+     *   lights();
+     *
+     *   // Rotate the coordinate system.
+     *   rotateX(1);
+     *
+     *   // Style the helix.
+     *   noStroke();
+     *
+     *   // Display the helix.
+     *   model(myGeometry);
+     * }
+     *
+     * function createShape() {
+     *   // Create a helical shape.
+     *   beginShape();
+     *   for (let i = 0; i < TWO_PI * 3; i += 0.5) {
+     *     let x = 30 * cos(i);
+     *     let y = 30 * sin(i);
+     *     let z = map(i, 0, TWO_PI * 3, -40, 40);
+     *     vertex(x, y, z);
+     *   }
+     *   endShape();
+     * }
+     * </code>
+     * </div>
+     *
+     * <div>
+     * <code>
+     * // Click and drag the mouse to view the scene from different angles.
+     *
+     * let myGeometry;
+     *
+     * function setup() {
+     *   createCanvas(100, 100, WEBGL);
+     *
+     *   // Create a p5.Geometry object.
+     *   myGeometry = buildGeometry(createShape);
+     *
+     *   // Compute normals using smooth shading.
+     *   myGeometry.computeNormals(SMOOTH);
+     *
+     *   describe('A white, helical structure drawn on a dark gray background.');
+     * }
+     *
+     * function draw() {
+     *   background(50);
+     *
+     *   // Enable orbiting with the mouse.
+     *   orbitControl();
+     *
+     *   // Turn on the lights.
+     *   lights();
+     *
+     *   // Rotate the coordinate system.
+     *   rotateX(1);
+     *
+     *   // Style the helix.
+     *   noStroke();
+     *
+     *   // Display the helix.
+     *   model(myGeometry);
+     * }
+     *
+     * function createShape() {
+     *   // Create a helical shape.
+     *   beginShape();
+     *   for (let i = 0; i < TWO_PI * 3; i += 0.5) {
+     *     let x = 30 * cos(i);
+     *     let y = 30 * sin(i);
+     *     let z = map(i, 0, TWO_PI * 3, -40, 40);
+     *     vertex(x, y, z);
+     *   }
+     *   endShape();
+     * }
+     * </code>
+     * </div>
+     *
+     * <div>
+     * <code>
+     * // Click and drag the mouse to view the scene from different angles.
+     *
+     * let myGeometry;
+     *
+     * function setup() {
+     *   createCanvas(100, 100, WEBGL);
+     *
+     *   // Create a p5.Geometry object.
+     *   myGeometry = buildGeometry(createShape);
+     *
+     *   // Create an options object.
+     *   let options = { roundToPrecision: 5 };
+     *
+     *   // Compute normals using smooth shading.
+     *   myGeometry.computeNormals(SMOOTH, options);
+     *
+     *   describe('A white, helical structure drawn on a dark gray background.');
+     * }
+     *
+     * function draw() {
+     *   background(50);
+     *
+     *   // Enable orbiting with the mouse.
+     *   orbitControl();
+     *
+     *   // Turn on the lights.
+     *   lights();
+     *
+     *   // Rotate the coordinate system.
+     *   rotateX(1);
+     *
+     *   // Style the helix.
+     *   noStroke();
+     *
+     *   // Display the helix.
+     *   model(myGeometry);
+     * }
+     *
+     * function createShape() {
+     *   // Create a helical shape.
+     *   beginShape();
+     *   for (let i = 0; i < TWO_PI * 3; i += 0.5) {
+     *     let x = 30 * cos(i);
+     *     let y = 30 * sin(i);
+     *     let z = map(i, 0, TWO_PI * 3, -40, 40);
+     *     vertex(x, y, z);
+     *   }
+     *   endShape();
+     * }
+     * </code>
+     * </div>
+     */
+    computeNormals(shadingType = constants.FLAT, { roundToPrecision = 3 } = {}) {
+      const vertexNormals = this.vertexNormals;
+      let vertices = this.vertices;
+      const faces = this.faces;
+      let iv;
+
+      if (shadingType === constants.SMOOTH) {
+        const vertexIndices = {};
+        const uniqueVertices = [];
+
+        const power = Math.pow(10, roundToPrecision);
+        const rounded = val => Math.round(val * power) / power;
+        const getKey = vert =>
+          `${rounded(vert.x)},${rounded(vert.y)},${rounded(vert.z)}`;
+
+        // loop through each vertex and add uniqueVertices
+        for (let i = 0; i < vertices.length; i++) {
+          const vertex = vertices[i];
+          const key = getKey(vertex);
+          if (vertexIndices[key] === undefined) {
+            vertexIndices[key] = uniqueVertices.length;
+            uniqueVertices.push(vertex);
+          }
+        }
+
+        // update face indices to use the deduplicated vertex indices
+        faces.forEach(face => {
+          for (let fv = 0; fv < 3; ++fv) {
+            const originalVertexIndex = face[fv];
+            const originalVertex = vertices[originalVertexIndex];
+            const key = getKey(originalVertex);
+            face[fv] = vertexIndices[key];
+          }
+        });
+
+        // update edge indices to use the deduplicated vertex indices
+        this.edges.forEach(edge => {
+          for (let ev = 0; ev < 2; ++ev) {
+            const originalVertexIndex = edge[ev];
+            const originalVertex = vertices[originalVertexIndex];
+            const key = getKey(originalVertex);
+            edge[ev] = vertexIndices[key];
+          }
+        });
+
+        // update the deduplicated vertices
+        this.vertices = vertices = uniqueVertices;
+      }
+
+      // initialize the vertexNormals array with empty vectors
+      vertexNormals.length = 0;
+      for (iv = 0; iv < vertices.length; ++iv) {
+        vertexNormals.push(new p5.Vector());
+      }
+
+      // loop through all the faces adding its normal to the normal
+      // of each of its vertices
+      faces.forEach((face, f) => {
+        const faceNormal = this._getFaceNormal(f);
+
+        // all three vertices get the normal added
+        for (let fv = 0; fv < 3; ++fv) {
+          const vertexIndex = face[fv];
+          vertexNormals[vertexIndex].add(faceNormal);
+        }
+      });
+
+      // normalize the normals
+      for (iv = 0; iv < vertices.length; ++iv) {
+        vertexNormals[iv].normalize();
+      }
+
+      return this;
+    }
+
+    /**
+   * Averages the vertex normals. Used in curved
+   * surfaces
+   * @private
+   * @chainable
+   */
+    averageNormals() {
+      for (let i = 0; i <= this.detailY; i++) {
+        const offset = this.detailX + 1;
+        let temp = p5.Vector.add(
+          this.vertexNormals[i * offset],
+          this.vertexNormals[i * offset + this.detailX]
+        );
+
+        temp = p5.Vector.div(temp, 2);
+        this.vertexNormals[i * offset] = temp;
+        this.vertexNormals[i * offset + this.detailX] = temp;
+      }
+      return this;
+    }
+
+    /**
+   * Averages pole normals.  Used in spherical primitives
+   * @private
+   * @chainable
+   */
+    averagePoleNormals() {
+      //average the north pole
+      let sum = new p5.Vector(0, 0, 0);
+      for (let i = 0; i < this.detailX; i++) {
+        sum.add(this.vertexNormals[i]);
+      }
+      sum = p5.Vector.div(sum, this.detailX);
+
+      for (let i = 0; i < this.detailX; i++) {
+        this.vertexNormals[i] = sum;
+      }
+
+      //average the south pole
+      sum = new p5.Vector(0, 0, 0);
+      for (
+        let i = this.vertices.length - 1;
+        i > this.vertices.length - 1 - this.detailX;
+        i--
+      ) {
+        sum.add(this.vertexNormals[i]);
+      }
+      sum = p5.Vector.div(sum, this.detailX);
+
+      for (
+        let i = this.vertices.length - 1;
+        i > this.vertices.length - 1 - this.detailX;
+        i--
+      ) {
+        this.vertexNormals[i] = sum;
+      }
+      return this;
+    }
+
+    /**
+   * Create a 2D array for establishing stroke connections
+   * @private
+   * @chainable
+   */
+    _makeTriangleEdges() {
+      this.edges.length = 0;
+
+      for (let j = 0; j < this.faces.length; j++) {
+        this.edges.push([this.faces[j][0], this.faces[j][1]]);
+        this.edges.push([this.faces[j][1], this.faces[j][2]]);
+        this.edges.push([this.faces[j][2], this.faces[j][0]]);
+      }
+
+      return this;
+    }
+
+    /**
+   * Converts each line segment into the vertices and vertex attributes needed
+   * to turn the line into a polygon on screen. This will include:
+   * - Two triangles line segment to create a rectangle
+   * - Two triangles per endpoint to create a stroke cap rectangle. A fragment
+   *   shader is responsible for displaying the appropriate cap style within
+   *   that rectangle.
+   * - Four triangles per join between adjacent line segments, creating a quad on
+   *   either side of the join, perpendicular to the lines. A vertex shader will
+   *   discard the quad in the "elbow" of the join, and a fragment shader will
+   *   display the appropriate join style within the remaining quad.
+   *
+   * @private
+   * @chainable
+   */
+    _edgesToVertices() {
+      this.lineVertices.clear();
+      this.lineTangentsIn.clear();
+      this.lineTangentsOut.clear();
+      this.lineSides.clear();
+
+      const potentialCaps = new Map();
+      const connected = new Set();
+      let lastValidDir;
+      for (let i = 0; i < this.edges.length; i++) {
+        const prevEdge = this.edges[i - 1];
+        const currEdge = this.edges[i];
+        const begin = this.vertices[currEdge[0]];
+        const end = this.vertices[currEdge[1]];
+        const fromColor = this.vertexStrokeColors.length > 0
+          ? this.vertexStrokeColors.slice(
+            currEdge[0] * 4,
+            (currEdge[0] + 1) * 4
+          )
+          : [0, 0, 0, 0];
+        const toColor = this.vertexStrokeColors.length > 0
+          ? this.vertexStrokeColors.slice(
+            currEdge[1] * 4,
+            (currEdge[1] + 1) * 4
+          )
+          : [0, 0, 0, 0];
+        const dir = end
+          .copy()
+          .sub(begin)
+          .normalize();
+        const dirOK = dir.magSq() > 0;
+        if (dirOK) {
+          this._addSegment(begin, end, fromColor, toColor, dir);
+        }
+
+        if (i > 0 && prevEdge[1] === currEdge[0]) {
+          if (!connected.has(currEdge[0])) {
+            connected.add(currEdge[0]);
+            potentialCaps.delete(currEdge[0]);
+            // Add a join if this segment shares a vertex with the previous. Skip
+            // actually adding join vertices if either the previous segment or this
+            // one has a length of 0.
+            //
+            // Don't add a join if the tangents point in the same direction, which
+            // would mean the edges line up exactly, and there is no need for a join.
+            if (lastValidDir && dirOK && dir.dot(lastValidDir) < 1 - 1e-8) {
+              this._addJoin(begin, lastValidDir, dir, fromColor);
+            }
+          }
+        } else {
+          // Start a new line
+          if (dirOK && !connected.has(currEdge[0])) {
+            const existingCap = potentialCaps.get(currEdge[0]);
+            if (existingCap) {
+              this._addJoin(
+                begin,
+                existingCap.dir,
+                dir,
+                fromColor
+              );
+              potentialCaps.delete(currEdge[0]);
+              connected.add(currEdge[0]);
+            } else {
+              potentialCaps.set(currEdge[0], {
+                point: begin,
+                dir: dir.copy().mult(-1),
+                color: fromColor
+              });
+            }
+          }
+          if (lastValidDir && !connected.has(prevEdge[1])) {
+            const existingCap = potentialCaps.get(prevEdge[1]);
+            if (existingCap) {
+              this._addJoin(
+                this.vertices[prevEdge[1]],
+                lastValidDir,
+                existingCap.dir.copy().mult(-1),
+                fromColor
+              );
+              potentialCaps.delete(prevEdge[1]);
+              connected.add(prevEdge[1]);
+            } else {
+              // Close off the last segment with a cap
+              potentialCaps.set(prevEdge[1], {
+                point: this.vertices[prevEdge[1]],
+                dir: lastValidDir,
+                color: fromColor
+              });
+            }
+            lastValidDir = undefined;
+          }
+        }
+
+        if (i === this.edges.length - 1 && !connected.has(currEdge[1])) {
+          const existingCap = potentialCaps.get(currEdge[1]);
+          if (existingCap) {
+            this._addJoin(
+              end,
+              dir,
+              existingCap.dir.copy().mult(-1),
+              toColor
+            );
+            potentialCaps.delete(currEdge[1]);
+            connected.add(currEdge[1]);
+          } else {
+            potentialCaps.set(currEdge[1], {
+              point: end,
+              dir,
+              color: toColor
+            });
+          }
+        }
+
+        if (dirOK) {
+          lastValidDir = dir;
+        }
+      }
+      for (const { point, dir, color } of potentialCaps.values()) {
+        this._addCap(point, dir, color);
+      }
+      return this;
+    }
+
+    /**
+   * Adds the vertices and vertex attributes for two triangles making a rectangle
+   * for a straight line segment. A vertex shader is responsible for picking
+   * proper coordinates on the screen given the centerline positions, the tangent,
+   * and the side of the centerline each vertex belongs to. Sides follow the
+   * following scheme:
+   *
+   *  -1            -1
+   *   o-------------o
+   *   |             |
+   *   o-------------o
+   *   1             1
+   *
+   * @private
+   * @chainable
+   */
+    _addSegment(
+      begin,
+      end,
+      fromColor,
+      toColor,
+      dir
+    ) {
+      const a = begin.array();
+      const b = end.array();
+      const dirArr = dir.array();
+      this.lineSides.push(1, 1, -1, 1, -1, -1);
+      for (const tangents of [this.lineTangentsIn, this.lineTangentsOut]) {
+        for (let i = 0; i < 6; i++) {
+          tangents.push(...dirArr);
+        }
+      }
+      this.lineVertices.push(...a, ...b, ...a, ...b, ...b, ...a);
+      this.lineVertexColors.push(
+        ...fromColor,
+        ...toColor,
+        ...fromColor,
+        ...toColor,
+        ...toColor,
+        ...fromColor
+      );
+      return this;
+    }
+
+    /**
+   * Adds the vertices and vertex attributes for two triangles representing the
+   * stroke cap of a line. A fragment shader is responsible for displaying the
+   * appropriate cap style within the rectangle they make.
+   *
+   * The lineSides buffer will include the following values for the points on
+   * the cap rectangle:
+   *
+   *           -1  -2
+   * -----------o---o
+   *            |   |
+   * -----------o---o
+   *            1   2
+   * @private
+   * @chainable
+   */
+    _addCap(point, tangent, color) {
+      const ptArray = point.array();
+      const tanInArray = tangent.array();
+      const tanOutArray = [0, 0, 0];
+      for (let i = 0; i < 6; i++) {
+        this.lineVertices.push(...ptArray);
+        this.lineTangentsIn.push(...tanInArray);
+        this.lineTangentsOut.push(...tanOutArray);
+        this.lineVertexColors.push(...color);
+      }
+      this.lineSides.push(-1, 2, -2, 1, 2, -1);
+      return this;
+    }
+
+    /**
+   * Adds the vertices and vertex attributes for four triangles representing a
+   * join between two adjacent line segments. This creates a quad on either side
+   * of the shared vertex of the two line segments, with each quad perpendicular
+   * to the lines. A vertex shader will discard all but the quad in the "elbow" of
+   * the join, and a fragment shader will display the appropriate join style
+   * within the remaining quad.
+   *
+   * The lineSides buffer will include the following values for the points on
+   * the join rectangles:
+   *
+   *            -1     -2
+   * -------------o----o
+   *              |    |
+   *       1 o----o----o -3
+   *         |    | 0  |
+   * --------o----o    |
+   *        2|    3    |
+   *         |         |
+   *         |         |
+   * @private
+   * @chainable
+   */
+    _addJoin(
+      point,
+      fromTangent,
+      toTangent,
+      color
+    ) {
+      const ptArray = point.array();
+      const tanInArray = fromTangent.array();
+      const tanOutArray = toTangent.array();
+      for (let i = 0; i < 12; i++) {
+        this.lineVertices.push(...ptArray);
+        this.lineTangentsIn.push(...tanInArray);
+        this.lineTangentsOut.push(...tanOutArray);
+        this.lineVertexColors.push(...color);
+      }
+      this.lineSides.push(-1, -3, -2, -1, 0, -3);
+      this.lineSides.push(3, 1, 2, 3, 0, 1);
+      return this;
+    }
+
+    /**
+   * Transforms the geometry's vertices to fit snugly within a 100×100×100 box
+   * centered at the origin.
+   *
+   * Calling `myGeometry.normalize()` translates the geometry's vertices so that
+   * they're centered at the origin `(0, 0, 0)`. Then it scales the vertices so
+   * that they fill a 100×100×100 box. As a result, small geometries will grow
+   * and large geometries will shrink.
+   *
+   * Note: `myGeometry.normalize()` only works when called in the
+   * <a href="#/p5/setup">setup()</a> function.
+   *
+   * @chainable
+   *
+   * @example
+   * <div>
+   * <code>
+   * let myGeometry;
+   *
+   * function setup() {
+   *   createCanvas(100, 100, WEBGL);
+   *
+   *   // Create a very small torus.
    *   beginGeometry();
-   *   torus();
+   *   torus(1, 0.25);
+   *   myGeometry = endGeometry();
+   *
+   *   // Normalize the torus so its vertices fill
+   *   // the range [-100, 100].
+   *   myGeometry.normalize();
+   *
+   *   describe('A white torus rotates slowly against a dark gray background.');
+   * }
+   *
+   * function draw() {
+   *   background(50);
+   *
+   *   // Turn on the lights.
+   *   lights();
+   *
+   *   // Rotate around the y-axis.
+   *   rotateY(frameCount * 0.01);
+   *
+   *   // Style the torus.
+   *   noStroke();
+   *
+   *   // Draw the torus.
+   *   model(myGeometry);
+   * }
+   * </code>
+   * </div>
+   */
+    normalize() {
+      if (this.vertices.length > 0) {
+        // Find the corners of our bounding box
+        const maxPosition = this.vertices[0].copy();
+        const minPosition = this.vertices[0].copy();
+
+        for (let i = 0; i < this.vertices.length; i++) {
+          maxPosition.x = Math.max(maxPosition.x, this.vertices[i].x);
+          minPosition.x = Math.min(minPosition.x, this.vertices[i].x);
+          maxPosition.y = Math.max(maxPosition.y, this.vertices[i].y);
+          minPosition.y = Math.min(minPosition.y, this.vertices[i].y);
+          maxPosition.z = Math.max(maxPosition.z, this.vertices[i].z);
+          minPosition.z = Math.min(minPosition.z, this.vertices[i].z);
+        }
+
+        const center = p5.Vector.lerp(maxPosition, minPosition, 0.5);
+        const dist = p5.Vector.sub(maxPosition, minPosition);
+        const longestDist = Math.max(Math.max(dist.x, dist.y), dist.z);
+        const scale = 200 / longestDist;
+
+        for (let i = 0; i < this.vertices.length; i++) {
+          this.vertices[i].sub(center);
+          this.vertices[i].mult(scale);
+        }
+      }
+      return this;
+    }
+
+  /** Sets the shader's vertex property or attribute variables.
+   *
+   * An vertex property or vertex attribute is a variable belonging to a vertex in a shader. p5.js provides some
+   * default properties, such as `aPosition`, `aNormal`, `aVertexColor`, etc. These are
+   * set using <a href="#/p5/vertex">vertex()</a>, <a href="#/p5/normal">normal()</a>
+   * and <a href="#/p5/fill">fill()</a> respectively. Custom properties can also
+   * be defined within <a href="#/p5/beginShape">beginShape()</a> and
+   * <a href="#/p5/endShape">endShape()</a>.
+   *
+   * The first parameter, `propertyName`, is a string with the property's name.
+   * This is the same variable name which should be declared in the shader, as in
+   * `in vec3 aProperty`, similar to .`setUniform()`.
+   *
+   * The second parameter, `data`, is the value assigned to the shader variable. This value
+   * will be pushed directly onto the Geometry object. There should be the same number
+   * of custom property values as vertices, this method should be invoked once for each
+   * vertex.
+   *
+   * The `data` can be a Number or an array of numbers. Tn the shader program the type
+   * can be declared according to the WebGL specification. Common types include `float`,
+   * `vec2`, `vec3`, `vec4` or matrices.
+   *
+   * See also the global <a href="#/p5/vertexProperty">vertexProperty()</a> function.
+   *
+   * @example
+   * <div>
+   * <code>
+   * let geo;
+   *
+   * function cartesianToSpherical(x, y, z) {
+   *   let r = sqrt(pow(x, x) + pow(y, y) + pow(z, z));
+   *   let theta = acos(z / r);
+   *   let phi = atan2(y, x);
+   *   return { theta, phi };
+   * }
+   *
+   * function setup() {
+   *   createCanvas(100, 100, WEBGL);
+   *
+   *   // Modify the material shader to display roughness.
+   *   const myShader = materialShader().modify({
+   *     vertexDeclarations:`in float aRoughness;
+   *                         out float vRoughness;`,
+   *     fragmentDeclarations: 'in float vRoughness;',
+   *     'void afterVertex': `() {
+   *         vRoughness = aRoughness;
+   *     }`,
+   *     'vec4 combineColors': `(ColorComponents components) {
+   *             vec4 color = vec4(0.);
+   *             color.rgb += components.diffuse * components.baseColor * (1.0-vRoughness);
+   *             color.rgb += components.ambient * components.ambientColor;
+   *             color.rgb += components.specular * components.specularColor * (1.0-vRoughness);
+   *             color.a = components.opacity;
+   *             return color;
+   *     }`
+   *   });
+   *
+   *   // Create the Geometry object.
+   *   beginGeometry();
+   *   fill('hotpink');
+   *   sphere(45, 50, 50);
+   *   geo = endGeometry();
+   *
+   *   // Set the roughness value for every vertex.
+   *   for (let v of geo.vertices){
+   *
+   *     // convert coordinates to spherical coordinates
+   *     let spherical = cartesianToSpherical(v.x, v.y, v.z);
+   *
+   *     // Set the custom roughness vertex property.
+   *     let roughness = noise(spherical.theta*5, spherical.phi*5);
+   *     geo.vertexProperty('aRoughness', roughness);
+   *   }
+   *
+   *   // Use the custom shader.
+   *   shader(myShader);
+   *
+   *   describe('A rough pink sphere rotating on a blue background.');
+   * }
+   *
+   * function draw() {
+   *   // Set some styles and lighting
+   *   background('lightblue');
+   *   noStroke();
+   *
+   *   specularMaterial(255,125,100);
+   *   shininess(2);
+   *
+   *   directionalLight('white', -1, 1, -1);
+   *   ambientLight(320);
+   *
+   *   rotateY(millis()*0.001);
+   *
+   *   // Draw the geometry
+   *   model(geo);
+   * }
+   * </code>
+   * </div>
+   *
+   * @method vertexProperty
+   * @param {String} propertyName the name of the vertex property.
+   * @param {Number|Number[]} data the data tied to the vertex property.
+   * @param {Number} [size] optional size of each unit of data.
+   */
+    vertexProperty(propertyName, data, size){
+      let prop;
+      if (!this.userVertexProperties[propertyName]){
+        prop = this.userVertexProperties[propertyName] =
+          this._userVertexPropertyHelper(propertyName, data, size);
+      }
+      prop = this.userVertexProperties[propertyName];
+      if (size){
+        prop.pushDirect(data);
+      } else{
+        prop.setCurrentData(data);
+        prop.pushCurrentData();
+      }
+    }
+
+    _userVertexPropertyHelper(propertyName, data, size){
+      const geometryInstance = this;
+      const prop = this.userVertexProperties[propertyName] = {
+        name: propertyName,
+        dataSize: size ? size : data.length ? data.length : 1,
+        geometry: geometryInstance,
+        // Getters
+        getName(){
+          return this.name;
+        },
+        getCurrentData(){
+          return this.currentData;
+        },
+        getDataSize() {
+          return this.dataSize;
+        },
+        getSrcName() {
+          const src = this.name.concat('Src');
+          return src;
+        },
+        getDstName() {
+          const dst = this.name.concat('Buffer');
+          return dst;
+        },
+        getSrcArray() {
+          const srcName = this.getSrcName();
+          return this.geometry[srcName];
+        },
+        //Setters
+        setCurrentData(data) {
+          const size = data.length ? data.length : 1;
+          if (size != this.getDataSize()){
+            p5._friendlyError(`Custom vertex property '${this.name}' has been set with various data sizes. You can change it's name, or if it was an accident, set '${this.name}' to have the same number of inputs each time!`, 'vertexProperty()');
+          }
+          this.currentData = data;
+        },
+        // Utilities
+        pushCurrentData(){
+          const data = this.getCurrentData();
+          this.pushDirect(data);
+        },
+        pushDirect(data) {
+          if (data.length){
+            this.getSrcArray().push(...data);
+          } else{
+            this.getSrcArray().push(data);
+          }
+        },
+        resetSrcArray(){
+          this.geometry[this.getSrcName()] = [];
+        },
+        delete() {
+          const srcName = this.getSrcName();
+          delete this.geometry[srcName];
+          delete this;
+        }
+      };
+      this[prop.getSrcName()] = [];
+      return this.userVertexProperties[propertyName];
+    }
+  };
+
+  /**
+   * An array with the geometry's vertices.
+   *
+   * The geometry's vertices are stored as
+   * <a href="#/p5.Vector">p5.Vector</a> objects in the `myGeometry.vertices`
+   * array. The geometry's first vertex is the
+   * <a href="#/p5.Vector">p5.Vector</a> object at `myGeometry.vertices[0]`,
+   * its second vertex is `myGeometry.vertices[1]`, its third vertex is
+   * `myGeometry.vertices[2]`, and so on.
+   *
+   * @property vertices
+   * @for p5.Geometry
+   * @name vertices
+   *
+   * @example
+   * <div>
+   * <code>
+   * // Click and drag the mouse to view the scene from different angles.
+   *
+   * let myGeometry;
+   *
+   * function setup() {
+   *   createCanvas(100, 100, WEBGL);
+   *
+   *   // Create a p5.Geometry object.
+   *   myGeometry = new p5.Geometry();
+   *
+   *   // Create p5.Vector objects to position the vertices.
+   *   let v0 = createVector(-40, 0, 0);
+   *   let v1 = createVector(0, -40, 0);
+   *   let v2 = createVector(40, 0, 0);
+   *
+   *   // Add the vertices to the p5.Geometry object's vertices array.
+   *   myGeometry.vertices.push(v0, v1, v2);
+   *
+   *   describe('A white triangle drawn on a gray background.');
+   * }
+   *
+   * function draw() {
+   *   background(200);
+   *
+   *   // Enable orbiting with the mouse.
+   *   orbitControl();
+   *
+   *   // Draw the p5.Geometry object.
+   *   model(myGeometry);
+   * }
+   * </code>
+   * </div>
+   *
+   * <div>
+   * <code>
+   * // Click and drag the mouse to view the scene from different angles.
+   *
+   * let myGeometry;
+   *
+   * function setup() {
+   *   createCanvas(100, 100, WEBGL);
+   *
+   *   // Create a p5.Geometry object.
+   *   beginGeometry();
+   *   torus(30, 15, 10, 8);
+   *   myGeometry = endGeometry();
+   *
+   *   describe('A white torus rotates slowly against a dark gray background. Red spheres mark its vertices.');
+   * }
+   *
+   * function draw() {
+   *   background(50);
+   *
+   *   // Enable orbiting with the mouse.
+   *   orbitControl();
+   *
+   *   // Turn on the lights.
+   *   lights();
+   *
+   *   // Rotate the coordinate system.
+   *   rotateY(frameCount * 0.01);
+   *
+   *   // Style the p5.Geometry object.
+   *   fill(255);
+   *   stroke(0);
+   *
+   *   // Display the p5.Geometry object.
+   *   model(myGeometry);
+   *
+   *   // Style the vertices.
+   *   fill(255, 0, 0);
+   *   noStroke();
+   *
+   *   // Iterate over the vertices array.
+   *   for (let v of myGeometry.vertices) {
+   *     // Draw a sphere to mark the vertex.
+   *     push();
+   *     translate(v);
+   *     sphere(2.5);
+   *     pop();
+   *   }
+   * }
+   * </code>
+   * </div>
+   */
+
+  /**
+   * An array with the vectors that are normal to the geometry's vertices.
+   *
+   * A face's orientation is defined by its *normal vector* which points out
+   * of the face and is normal (perpendicular) to the surface. Calling
+   * `myGeometry.computeNormals()` first calculates each face's normal
+   * vector. Then it calculates the normal vector for each vertex by
+   * averaging the normal vectors of the faces surrounding the vertex. The
+   * vertex normals are stored as <a href="#/p5.Vector">p5.Vector</a>
+   * objects in the `myGeometry.vertexNormals` array.
+   *
+   * @property vertexNormals
+   * @name vertexNormals
+   * @for p5.Geometry
+   *
+   * @example
+   * <div>
+   * <code>
+   * // Click and drag the mouse to view the scene from different angles.
+   *
+   * let myGeometry;
+   *
+   * function setup() {
+   *   createCanvas(100, 100, WEBGL);
+   *
+   *   // Create a p5.Geometry object.
+   *   beginGeometry();
+   *   torus(30, 15, 10, 8);
    *   myGeometry = endGeometry();
    *
    *   // Compute the vertex normals.
    *   myGeometry.computeNormals();
    *
    *   describe(
-   *     "A white torus drawn on a dark gray background. Red lines extend outward from the torus' vertices."
+   *     'A white torus rotates against a dark gray background. Red lines extend outward from its vertices.'
    *   );
    * }
    *
@@ -1194,12 +2251,12 @@ p5.Geometry = class Geometry {
    *   lights();
    *
    *   // Rotate the coordinate system.
-   *   rotateX(1);
+   *   rotateY(frameCount * 0.01);
    *
-   *   // Style the helix.
+   *   // Style the p5.Geometry object.
    *   stroke(0);
    *
-   *   // Display the helix.
+   *   // Display the p5.Geometry object.
    *   model(myGeometry);
    *
    *   // Style the normal vectors.
@@ -1215,7 +2272,7 @@ p5.Geometry = class Geometry {
    *     let n = myGeometry.vertexNormals[i];
    *
    *     // Calculate a point along the vertex normal.
-   *     let p = p5.Vector.mult(n, 5);
+   *     let p = p5.Vector.mult(n, 8);
    *
    *     // Draw the vertex normal as a red line.
    *     push();
@@ -1236,7 +2293,7 @@ p5.Geometry = class Geometry {
    * function setup() {
    *   createCanvas(100, 100, WEBGL);
    *
-   *   // Create a p5.Geometry object using a callback function.
+   *   // Create a p5.Geometry object.
    *   myGeometry = new p5.Geometry();
    *
    *   // Create p5.Vector objects to position the vertices.
@@ -1270,1224 +2327,172 @@ p5.Geometry = class Geometry {
    *   noStroke();
    *   fill(255, 0, 0);
    *
-   *   // Draw the p5.Geometry object.
+   *   // Display the p5.Geometry object.
    *   model(myGeometry);
-   * }
-   * </code>
-   * </div>
-   *
-   * <div>
-   * <code>
-   * // Click and drag the mouse to view the scene from different angles.
-   *
-   * let myGeometry;
-   *
-   * function setup() {
-   *   createCanvas(100, 100, WEBGL);
-   *
-   *   // Create a p5.Geometry object.
-   *   myGeometry = buildGeometry(createShape);
-   *
-   *   // Compute normals using default (FLAT) shading.
-   *   myGeometry.computeNormals(FLAT);
-   *
-   *   describe('A white, helical structure drawn on a dark gray background. Its faces appear faceted.');
-   * }
-   *
-   * function draw() {
-   *   background(50);
-   *
-   *   // Enable orbiting with the mouse.
-   *   orbitControl();
-   *
-   *   // Turn on the lights.
-   *   lights();
-   *
-   *   // Rotate the coordinate system.
-   *   rotateX(1);
-   *
-   *   // Style the helix.
-   *   noStroke();
-   *
-   *   // Display the helix.
-   *   model(myGeometry);
-   * }
-   *
-   * function createShape() {
-   *   // Create a helical shape.
-   *   beginShape();
-   *   for (let i = 0; i < TWO_PI * 3; i += 0.5) {
-   *     let x = 30 * cos(i);
-   *     let y = 30 * sin(i);
-   *     let z = map(i, 0, TWO_PI * 3, -40, 40);
-   *     vertex(x, y, z);
-   *   }
-   *   endShape();
-   * }
-   * </code>
-   * </div>
-   *
-   * <div>
-   * <code>
-   * // Click and drag the mouse to view the scene from different angles.
-   *
-   * let myGeometry;
-   *
-   * function setup() {
-   *   createCanvas(100, 100, WEBGL);
-   *
-   *   // Create a p5.Geometry object.
-   *   myGeometry = buildGeometry(createShape);
-   *
-   *   // Compute normals using smooth shading.
-   *   myGeometry.computeNormals(SMOOTH);
-   *
-   *   describe('A white, helical structure drawn on a dark gray background.');
-   * }
-   *
-   * function draw() {
-   *   background(50);
-   *
-   *   // Enable orbiting with the mouse.
-   *   orbitControl();
-   *
-   *   // Turn on the lights.
-   *   lights();
-   *
-   *   // Rotate the coordinate system.
-   *   rotateX(1);
-   *
-   *   // Style the helix.
-   *   noStroke();
-   *
-   *   // Display the helix.
-   *   model(myGeometry);
-   * }
-   *
-   * function createShape() {
-   *   // Create a helical shape.
-   *   beginShape();
-   *   for (let i = 0; i < TWO_PI * 3; i += 0.5) {
-   *     let x = 30 * cos(i);
-   *     let y = 30 * sin(i);
-   *     let z = map(i, 0, TWO_PI * 3, -40, 40);
-   *     vertex(x, y, z);
-   *   }
-   *   endShape();
-   * }
-   * </code>
-   * </div>
-   *
-   * <div>
-   * <code>
-   * // Click and drag the mouse to view the scene from different angles.
-   *
-   * let myGeometry;
-   *
-   * function setup() {
-   *   createCanvas(100, 100, WEBGL);
-   *
-   *   // Create a p5.Geometry object.
-   *   myGeometry = buildGeometry(createShape);
-   *
-   *   // Create an options object.
-   *   let options = { roundToPrecision: 5 };
-   *
-   *   // Compute normals using smooth shading.
-   *   myGeometry.computeNormals(SMOOTH, options);
-   *
-   *   describe('A white, helical structure drawn on a dark gray background.');
-   * }
-   *
-   * function draw() {
-   *   background(50);
-   *
-   *   // Enable orbiting with the mouse.
-   *   orbitControl();
-   *
-   *   // Turn on the lights.
-   *   lights();
-   *
-   *   // Rotate the coordinate system.
-   *   rotateX(1);
-   *
-   *   // Style the helix.
-   *   noStroke();
-   *
-   *   // Display the helix.
-   *   model(myGeometry);
-   * }
-   *
-   * function createShape() {
-   *   // Create a helical shape.
-   *   beginShape();
-   *   for (let i = 0; i < TWO_PI * 3; i += 0.5) {
-   *     let x = 30 * cos(i);
-   *     let y = 30 * sin(i);
-   *     let z = map(i, 0, TWO_PI * 3, -40, 40);
-   *     vertex(x, y, z);
-   *   }
-   *   endShape();
    * }
    * </code>
    * </div>
    */
-  computeNormals(shadingType = constants.FLAT, { roundToPrecision = 3 } = {}) {
-    const vertexNormals = this.vertexNormals;
-    let vertices = this.vertices;
-    const faces = this.faces;
-    let iv;
-
-    if (shadingType === constants.SMOOTH) {
-      const vertexIndices = {};
-      const uniqueVertices = [];
-
-      const power = Math.pow(10, roundToPrecision);
-      const rounded = val => Math.round(val * power) / power;
-      const getKey = vert =>
-        `${rounded(vert.x)},${rounded(vert.y)},${rounded(vert.z)}`;
-
-      // loop through each vertex and add uniqueVertices
-      for (let i = 0; i < vertices.length; i++) {
-        const vertex = vertices[i];
-        const key = getKey(vertex);
-        if (vertexIndices[key] === undefined) {
-          vertexIndices[key] = uniqueVertices.length;
-          uniqueVertices.push(vertex);
-        }
-      }
-
-      // update face indices to use the deduplicated vertex indices
-      faces.forEach(face => {
-        for (let fv = 0; fv < 3; ++fv) {
-          const originalVertexIndex = face[fv];
-          const originalVertex = vertices[originalVertexIndex];
-          const key = getKey(originalVertex);
-          face[fv] = vertexIndices[key];
-        }
-      });
-
-      // update edge indices to use the deduplicated vertex indices
-      this.edges.forEach(edge => {
-        for (let ev = 0; ev < 2; ++ev) {
-          const originalVertexIndex = edge[ev];
-          const originalVertex = vertices[originalVertexIndex];
-          const key = getKey(originalVertex);
-          edge[ev] = vertexIndices[key];
-        }
-      });
-
-      // update the deduplicated vertices
-      this.vertices = vertices = uniqueVertices;
-    }
-
-    // initialize the vertexNormals array with empty vectors
-    vertexNormals.length = 0;
-    for (iv = 0; iv < vertices.length; ++iv) {
-      vertexNormals.push(new p5.Vector());
-    }
-
-    // loop through all the faces adding its normal to the normal
-    // of each of its vertices
-    faces.forEach((face, f) => {
-      const faceNormal = this._getFaceNormal(f);
-
-      // all three vertices get the normal added
-      for (let fv = 0; fv < 3; ++fv) {
-        const vertexIndex = face[fv];
-        vertexNormals[vertexIndex].add(faceNormal);
-      }
-    });
-
-    // normalize the normals
-    for (iv = 0; iv < vertices.length; ++iv) {
-      vertexNormals[iv].normalize();
-    }
-
-    return this;
-  }
 
   /**
- * Averages the vertex normals. Used in curved
- * surfaces
- * @private
- * @chainable
- */
-  averageNormals() {
-    for (let i = 0; i <= this.detailY; i++) {
-      const offset = this.detailX + 1;
-      let temp = p5.Vector.add(
-        this.vertexNormals[i * offset],
-        this.vertexNormals[i * offset + this.detailX]
-      );
-
-      temp = p5.Vector.div(temp, 2);
-      this.vertexNormals[i * offset] = temp;
-      this.vertexNormals[i * offset + this.detailX] = temp;
-    }
-    return this;
-  }
-
-  /**
- * Averages pole normals.  Used in spherical primitives
- * @private
- * @chainable
- */
-  averagePoleNormals() {
-    //average the north pole
-    let sum = new p5.Vector(0, 0, 0);
-    for (let i = 0; i < this.detailX; i++) {
-      sum.add(this.vertexNormals[i]);
-    }
-    sum = p5.Vector.div(sum, this.detailX);
-
-    for (let i = 0; i < this.detailX; i++) {
-      this.vertexNormals[i] = sum;
-    }
-
-    //average the south pole
-    sum = new p5.Vector(0, 0, 0);
-    for (
-      let i = this.vertices.length - 1;
-      i > this.vertices.length - 1 - this.detailX;
-      i--
-    ) {
-      sum.add(this.vertexNormals[i]);
-    }
-    sum = p5.Vector.div(sum, this.detailX);
-
-    for (
-      let i = this.vertices.length - 1;
-      i > this.vertices.length - 1 - this.detailX;
-      i--
-    ) {
-      this.vertexNormals[i] = sum;
-    }
-    return this;
-  }
-
-  /**
- * Create a 2D array for establishing stroke connections
- * @private
- * @chainable
- */
-  _makeTriangleEdges() {
-    this.edges.length = 0;
-
-    for (let j = 0; j < this.faces.length; j++) {
-      this.edges.push([this.faces[j][0], this.faces[j][1]]);
-      this.edges.push([this.faces[j][1], this.faces[j][2]]);
-      this.edges.push([this.faces[j][2], this.faces[j][0]]);
-    }
-
-    return this;
-  }
-
-  /**
- * Converts each line segment into the vertices and vertex attributes needed
- * to turn the line into a polygon on screen. This will include:
- * - Two triangles line segment to create a rectangle
- * - Two triangles per endpoint to create a stroke cap rectangle. A fragment
- *   shader is responsible for displaying the appropriate cap style within
- *   that rectangle.
- * - Four triangles per join between adjacent line segments, creating a quad on
- *   either side of the join, perpendicular to the lines. A vertex shader will
- *   discard the quad in the "elbow" of the join, and a fragment shader will
- *   display the appropriate join style within the remaining quad.
- *
- * @private
- * @chainable
- */
-  _edgesToVertices() {
-    this.lineVertices.clear();
-    this.lineTangentsIn.clear();
-    this.lineTangentsOut.clear();
-    this.lineSides.clear();
-
-    const potentialCaps = new Map();
-    const connected = new Set();
-    let lastValidDir;
-    for (let i = 0; i < this.edges.length; i++) {
-      const prevEdge = this.edges[i - 1];
-      const currEdge = this.edges[i];
-      const begin = this.vertices[currEdge[0]];
-      const end = this.vertices[currEdge[1]];
-      const fromColor = this.vertexStrokeColors.length > 0
-        ? this.vertexStrokeColors.slice(
-          currEdge[0] * 4,
-          (currEdge[0] + 1) * 4
-        )
-        : [0, 0, 0, 0];
-      const toColor = this.vertexStrokeColors.length > 0
-        ? this.vertexStrokeColors.slice(
-          currEdge[1] * 4,
-          (currEdge[1] + 1) * 4
-        )
-        : [0, 0, 0, 0];
-      const dir = end
-        .copy()
-        .sub(begin)
-        .normalize();
-      const dirOK = dir.magSq() > 0;
-      if (dirOK) {
-        this._addSegment(begin, end, fromColor, toColor, dir);
-      }
-
-      if (i > 0 && prevEdge[1] === currEdge[0]) {
-        if (!connected.has(currEdge[0])) {
-          connected.add(currEdge[0]);
-          potentialCaps.delete(currEdge[0]);
-          // Add a join if this segment shares a vertex with the previous. Skip
-          // actually adding join vertices if either the previous segment or this
-          // one has a length of 0.
-          //
-          // Don't add a join if the tangents point in the same direction, which
-          // would mean the edges line up exactly, and there is no need for a join.
-          if (lastValidDir && dirOK && dir.dot(lastValidDir) < 1 - 1e-8) {
-            this._addJoin(begin, lastValidDir, dir, fromColor);
-          }
-        }
-      } else {
-        // Start a new line
-        if (dirOK && !connected.has(currEdge[0])) {
-          const existingCap = potentialCaps.get(currEdge[0]);
-          if (existingCap) {
-            this._addJoin(
-              begin,
-              existingCap.dir,
-              dir,
-              fromColor
-            );
-            potentialCaps.delete(currEdge[0]);
-            connected.add(currEdge[0]);
-          } else {
-            potentialCaps.set(currEdge[0], {
-              point: begin,
-              dir: dir.copy().mult(-1),
-              color: fromColor
-            });
-          }
-        }
-        if (lastValidDir && !connected.has(prevEdge[1])) {
-          const existingCap = potentialCaps.get(prevEdge[1]);
-          if (existingCap) {
-            this._addJoin(
-              this.vertices[prevEdge[1]],
-              lastValidDir,
-              existingCap.dir.copy().mult(-1),
-              fromColor
-            );
-            potentialCaps.delete(prevEdge[1]);
-            connected.add(prevEdge[1]);
-          } else {
-            // Close off the last segment with a cap
-            potentialCaps.set(prevEdge[1], {
-              point: this.vertices[prevEdge[1]],
-              dir: lastValidDir,
-              color: fromColor
-            });
-          }
-          lastValidDir = undefined;
-        }
-      }
-
-      if (i === this.edges.length - 1 && !connected.has(currEdge[1])) {
-        const existingCap = potentialCaps.get(currEdge[1]);
-        if (existingCap) {
-          this._addJoin(
-            end,
-            dir,
-            existingCap.dir.copy().mult(-1),
-            toColor
-          );
-          potentialCaps.delete(currEdge[1]);
-          connected.add(currEdge[1]);
-        } else {
-          potentialCaps.set(currEdge[1], {
-            point: end,
-            dir,
-            color: toColor
-          });
-        }
-      }
-
-      if (dirOK) {
-        lastValidDir = dir;
-      }
-    }
-    for (const { point, dir, color } of potentialCaps.values()) {
-      this._addCap(point, dir, color);
-    }
-    return this;
-  }
+   * An array that lists which of the geometry's vertices form each of its
+   * faces.
+   *
+   * All 3D shapes are made by connecting sets of points called *vertices*. A
+   * geometry's surface is formed by connecting vertices to form triangles
+   * that are stitched together. Each triangular patch on the geometry's
+   * surface is called a *face*.
+   *
+   * The geometry's vertices are stored as
+   * <a href="#/p5.Vector">p5.Vector</a> objects in the
+   * <a href="#/p5.Geometry/vertices">myGeometry.vertices</a> array. The
+   * geometry's first vertex is the <a href="#/p5.Vector">p5.Vector</a>
+   * object at `myGeometry.vertices[0]`, its second vertex is
+   * `myGeometry.vertices[1]`, its third vertex is `myGeometry.vertices[2]`,
+   * and so on.
+   *
+   * For example, a geometry made from a rectangle has two faces because a
+   * rectangle is made by joining two triangles. `myGeometry.faces` for a
+   * rectangle would be the two-dimensional array `[[0, 1, 2], [2, 1, 3]]`.
+   * The first face, `myGeometry.faces[0]`, is the array `[0, 1, 2]` because
+   * it's formed by connecting `myGeometry.vertices[0]`,
+   * `myGeometry.vertices[1]`,and `myGeometry.vertices[2]`. The second face,
+   * `myGeometry.faces[1]`, is the array `[2, 1, 3]` because it's formed by
+   * connecting `myGeometry.vertices[2]`, `myGeometry.vertices[1]`,and
+   * `myGeometry.vertices[3]`.
+   *
+   * @property faces
+   * @name faces
+   * @for p5.Geometry
+   *
+   * @example
+   * <div>
+   * <code>
+   * // Click and drag the mouse to view the scene from different angles.
+   *
+   * let myGeometry;
+   *
+   * function setup() {
+   *   createCanvas(100, 100, WEBGL);
+   *
+   *   // Create a p5.Geometry object.
+   *   beginGeometry();
+   *   sphere();
+   *   myGeometry = endGeometry();
+   *
+   *   describe("A sphere drawn on a gray background. The sphere's surface is a grayscale patchwork of triangles.");
+   * }
+   *
+   * function draw() {
+   *   background(200);
+   *
+   *   // Enable orbiting with the mouse.
+   *   orbitControl();
+   *
+   *   // Turn on the lights.
+   *   lights();
+   *
+   *   // Style the p5.Geometry object.
+   *   noStroke();
+   *
+   *   // Set a random seed.
+   *   randomSeed(1234);
+   *
+   *   // Iterate over the faces array.
+   *   for (let face of myGeometry.faces) {
+   *
+   *     // Style the face.
+   *     let g = random(0, 255);
+   *     fill(g);
+   *
+   *     // Draw the face.
+   *     beginShape();
+   *     // Iterate over the vertices that form the face.
+   *     for (let f of face) {
+   *       // Get the vertex's p5.Vector object.
+   *       let v = myGeometry.vertices[f];
+   *       vertex(v.x, v.y, v.z);
+   *     }
+   *     endShape();
+   *
+   *   }
+   * }
+   * </code>
+   * </div>
+   */
 
   /**
- * Adds the vertices and vertex attributes for two triangles making a rectangle
- * for a straight line segment. A vertex shader is responsible for picking
- * proper coordinates on the screen given the centerline positions, the tangent,
- * and the side of the centerline each vertex belongs to. Sides follow the
- * following scheme:
- *
- *  -1            -1
- *   o-------------o
- *   |             |
- *   o-------------o
- *   1             1
- *
- * @private
- * @chainable
- */
-  _addSegment(
-    begin,
-    end,
-    fromColor,
-    toColor,
-    dir
-  ) {
-    const a = begin.array();
-    const b = end.array();
-    const dirArr = dir.array();
-    this.lineSides.push(1, 1, -1, 1, -1, -1);
-    for (const tangents of [this.lineTangentsIn, this.lineTangentsOut]) {
-      for (let i = 0; i < 6; i++) {
-        tangents.push(...dirArr);
-      }
-    }
-    this.lineVertices.push(...a, ...b, ...a, ...b, ...b, ...a);
-    this.lineVertexColors.push(
-      ...fromColor,
-      ...toColor,
-      ...fromColor,
-      ...toColor,
-      ...toColor,
-      ...fromColor
-    );
-    return this;
-  }
+   * An array that lists the texture coordinates for each of the geometry's
+   * vertices.
+   *
+   * In order for <a href="#/p5/texture">texture()</a> to work, the geometry
+   * needs a way to map the points on its surface to the pixels in a
+   * rectangular image that's used as a texture. The geometry's vertex at
+   * coordinates `(x, y, z)` maps to the texture image's pixel at coordinates
+   * `(u, v)`.
+   *
+   * The `myGeometry.uvs` array stores the `(u, v)` coordinates for each
+   * vertex in the order it was added to the geometry. For example, the
+   * first vertex, `myGeometry.vertices[0]`, has its `(u, v)` coordinates
+   * stored at `myGeometry.uvs[0]` and `myGeometry.uvs[1]`.
+   *
+   * @property uvs
+   * @name uvs
+   * @for p5.Geometry
+   *
+   * @example
+   * <div>
+   * <code>
+   * let img;
+   *
+   * // Load the image and create a p5.Image object.
+   * function preload() {
+   *   img = loadImage('assets/laDefense.jpg');
+   * }
+   *
+   * function setup() {
+   *   createCanvas(100, 100, WEBGL);
+   *
+   *   background(200);
+   *
+   *   // Create p5.Geometry objects.
+   *   let geom1 = buildGeometry(createShape);
+   *   let geom2 = buildGeometry(createShape);
+   *
+   *   // Left (original).
+   *   push();
+   *   translate(-25, 0, 0);
+   *   texture(img);
+   *   noStroke();
+   *   model(geom1);
+   *   pop();
+   *
+   *   // Set geom2's texture coordinates.
+   *   geom2.uvs = [0.25, 0.25, 0.75, 0.25, 0.25, 0.75, 0.75, 0.75];
+   *
+   *   // Right (zoomed in).
+   *   push();
+   *   translate(25, 0, 0);
+   *   texture(img);
+   *   noStroke();
+   *   model(geom2);
+   *   pop();
+   *
+   *   describe(
+   *     'Two photos of a ceiling on a gray background. The photo on the right zooms in to the center of the photo.'
+   *   );
+   * }
+   *
+   * function createShape() {
+   *   plane(40);
+   * }
+   * </code>
+   * </div>
+   */
+}
 
-  /**
- * Adds the vertices and vertex attributes for two triangles representing the
- * stroke cap of a line. A fragment shader is responsible for displaying the
- * appropriate cap style within the rectangle they make.
- *
- * The lineSides buffer will include the following values for the points on
- * the cap rectangle:
- *
- *           -1  -2
- * -----------o---o
- *            |   |
- * -----------o---o
- *            1   2
- * @private
- * @chainable
- */
-  _addCap(point, tangent, color) {
-    const ptArray = point.array();
-    const tanInArray = tangent.array();
-    const tanOutArray = [0, 0, 0];
-    for (let i = 0; i < 6; i++) {
-      this.lineVertices.push(...ptArray);
-      this.lineTangentsIn.push(...tanInArray);
-      this.lineTangentsOut.push(...tanOutArray);
-      this.lineVertexColors.push(...color);
-    }
-    this.lineSides.push(-1, 2, -2, 1, 2, -1);
-    return this;
-  }
+export default geometry;
 
-  /**
- * Adds the vertices and vertex attributes for four triangles representing a
- * join between two adjacent line segments. This creates a quad on either side
- * of the shared vertex of the two line segments, with each quad perpendicular
- * to the lines. A vertex shader will discard all but the quad in the "elbow" of
- * the join, and a fragment shader will display the appropriate join style
- * within the remaining quad.
- *
- * The lineSides buffer will include the following values for the points on
- * the join rectangles:
- *
- *            -1     -2
- * -------------o----o
- *              |    |
- *       1 o----o----o -3
- *         |    | 0  |
- * --------o----o    |
- *        2|    3    |
- *         |         |
- *         |         |
- * @private
- * @chainable
- */
-  _addJoin(
-    point,
-    fromTangent,
-    toTangent,
-    color
-  ) {
-    const ptArray = point.array();
-    const tanInArray = fromTangent.array();
-    const tanOutArray = toTangent.array();
-    for (let i = 0; i < 12; i++) {
-      this.lineVertices.push(...ptArray);
-      this.lineTangentsIn.push(...tanInArray);
-      this.lineTangentsOut.push(...tanOutArray);
-      this.lineVertexColors.push(...color);
-    }
-    this.lineSides.push(-1, -3, -2, -1, 0, -3);
-    this.lineSides.push(3, 1, 2, 3, 0, 1);
-    return this;
-  }
-
-  /**
- * Transforms the geometry's vertices to fit snugly within a 100×100×100 box
- * centered at the origin.
- *
- * Calling `myGeometry.normalize()` translates the geometry's vertices so that
- * they're centered at the origin `(0, 0, 0)`. Then it scales the vertices so
- * that they fill a 100×100×100 box. As a result, small geometries will grow
- * and large geometries will shrink.
- *
- * Note: `myGeometry.normalize()` only works when called in the
- * <a href="#/p5/setup">setup()</a> function.
- *
- * @chainable
- *
- * @example
- * <div>
- * <code>
- * let myGeometry;
- *
- * function setup() {
- *   createCanvas(100, 100, WEBGL);
- *
- *   // Create a very small torus.
- *   beginGeometry();
- *   torus(1, 0.25);
- *   myGeometry = endGeometry();
- *
- *   // Normalize the torus so its vertices fill
- *   // the range [-100, 100].
- *   myGeometry.normalize();
- *
- *   describe('A white torus rotates slowly against a dark gray background.');
- * }
- *
- * function draw() {
- *   background(50);
- *
- *   // Turn on the lights.
- *   lights();
- *
- *   // Rotate around the y-axis.
- *   rotateY(frameCount * 0.01);
- *
- *   // Style the torus.
- *   noStroke();
- *
- *   // Draw the torus.
- *   model(myGeometry);
- * }
- * </code>
- * </div>
- */
-  normalize() {
-    if (this.vertices.length > 0) {
-      // Find the corners of our bounding box
-      const maxPosition = this.vertices[0].copy();
-      const minPosition = this.vertices[0].copy();
-
-      for (let i = 0; i < this.vertices.length; i++) {
-        maxPosition.x = Math.max(maxPosition.x, this.vertices[i].x);
-        minPosition.x = Math.min(minPosition.x, this.vertices[i].x);
-        maxPosition.y = Math.max(maxPosition.y, this.vertices[i].y);
-        minPosition.y = Math.min(minPosition.y, this.vertices[i].y);
-        maxPosition.z = Math.max(maxPosition.z, this.vertices[i].z);
-        minPosition.z = Math.min(minPosition.z, this.vertices[i].z);
-      }
-
-      const center = p5.Vector.lerp(maxPosition, minPosition, 0.5);
-      const dist = p5.Vector.sub(maxPosition, minPosition);
-      const longestDist = Math.max(Math.max(dist.x, dist.y), dist.z);
-      const scale = 200 / longestDist;
-
-      for (let i = 0; i < this.vertices.length; i++) {
-        this.vertices[i].sub(center);
-        this.vertices[i].mult(scale);
-      }
-    }
-    return this;
-  }
-
-/** Sets the shader's vertex property or attribute variables.
- * 
- * An vertex property or vertex attribute is a variable belonging to a vertex in a shader. p5.js provides some
- * default properties, such as `aPosition`, `aNormal`, `aVertexColor`, etc. These are
- * set using <a href="#/p5/vertex">vertex()</a>, <a href="#/p5/normal">normal()</a> 
- * and <a href="#/p5/fill">fill()</a> respectively. Custom properties can also
- * be defined within <a href="#/p5/beginShape">beginShape()</a> and 
- * <a href="#/p5/endShape">endShape()</a>.
- * 
- * The first parameter, `propertyName`, is a string with the property's name.
- * This is the same variable name which should be declared in the shader, as in
- * `in vec3 aProperty`, similar to .`setUniform()`.
- * 
- * The second parameter, `data`, is the value assigned to the shader variable. This value
- * will be pushed directly onto the Geometry object. There should be the same number 
- * of custom property values as vertices, this method should be invoked once for each 
- * vertex. 
- * 
- * The `data` can be a Number or an array of numbers. Tn the shader program the type
- * can be declared according to the WebGL specification. Common types include `float`, 
- * `vec2`, `vec3`, `vec4` or matrices.
- * 
- * See also the global <a href="#/p5/vertexProperty">vertexProperty()</a> function.
- * 
- * @example
- * <div>
- * <code>
- * let geo;
- * 
- * function cartesianToSpherical(x, y, z) {
- *   let r = sqrt(pow(x, x) + pow(y, y) + pow(z, z));
- *   let theta = acos(z / r);
- *   let phi = atan2(y, x);
- *   return { theta, phi };
- * }
- * 
- * function setup() {
- *   createCanvas(100, 100, WEBGL);
- * 
- *   // Modify the material shader to display roughness.
- *   const myShader = materialShader().modify({
- *     vertexDeclarations:`in float aRoughness;
- *                         out float vRoughness;`,
- *     fragmentDeclarations: 'in float vRoughness;',
- *     'void afterVertex': `() {
- *         vRoughness = aRoughness;
- *     }`,
- *     'vec4 combineColors': `(ColorComponents components) {
- *             vec4 color = vec4(0.);
- *             color.rgb += components.diffuse * components.baseColor * (1.0-vRoughness);
- *             color.rgb += components.ambient * components.ambientColor;
- *             color.rgb += components.specular * components.specularColor * (1.0-vRoughness);
- *             color.a = components.opacity;
- *             return color;
- *     }`
- *   });
- * 
- *   // Create the Geometry object.
- *   beginGeometry();
- *   fill('hotpink');
- *   sphere(45, 50, 50);
- *   geo = endGeometry();
- * 
- *   // Set the roughness value for every vertex.
- *   for (let v of geo.vertices){
- * 
- *     // convert coordinates to spherical coordinates
- *     let spherical = cartesianToSpherical(v.x, v.y, v.z);
- *
- *     // Set the custom roughness vertex property.
- *     let roughness = noise(spherical.theta*5, spherical.phi*5);
- *     geo.vertexProperty('aRoughness', roughness);
- *   }
- * 
- *   // Use the custom shader.
- *   shader(myShader);
- * 
- *   describe('A rough pink sphere rotating on a blue background.');
- * }
- * 
- * function draw() {
- *   // Set some styles and lighting
- *   background('lightblue');
- *   noStroke();
- * 
- *   specularMaterial(255,125,100);
- *   shininess(2);
- *
- *   directionalLight('white', -1, 1, -1);
- *   ambientLight(320);
- *
- *   rotateY(millis()*0.001);
- *
- *   // Draw the geometry
- *   model(geo);
- * }
- * </code>
- * </div>
- *
- * @method vertexProperty
- * @param {String} propertyName the name of the vertex property.
- * @param {Number|Number[]} data the data tied to the vertex property.
- * @param {Number} [size] optional size of each unit of data. 
- */
-  vertexProperty(propertyName, data, size){
-    let prop;
-    if (!this.userVertexProperties[propertyName]){
-      prop = this.userVertexProperties[propertyName] = 
-        this._userVertexPropertyHelper(propertyName, data, size);
-    }
-    prop = this.userVertexProperties[propertyName];
-    if (size){
-      prop.pushDirect(data);
-    } else{
-      prop.setCurrentData(data);
-      prop.pushCurrentData();
-    }
-  }
-
-  _userVertexPropertyHelper(propertyName, data, size){
-    const geometryInstance = this;
-    const prop = this.userVertexProperties[propertyName] = {
-      name: propertyName,
-      dataSize: size ? size : data.length ? data.length : 1,
-      geometry: geometryInstance,
-      // Getters
-      getName(){
-        return this.name;
-      },
-      getCurrentData(){
-        return this.currentData;
-      },
-      getDataSize() {
-        return this.dataSize;
-      },
-      getSrcName() {
-        const src = this.name.concat('Src');  
-        return src;
-      },
-      getDstName() {
-        const dst = this.name.concat('Buffer');
-        return dst;
-      },
-      getSrcArray() {
-        const srcName = this.getSrcName();
-        return this.geometry[srcName];
-      },
-      //Setters
-      setCurrentData(data) {
-        const size = data.length ? data.length : 1;
-        if (size != this.getDataSize()){
-          p5._friendlyError(`Custom vertex property '${this.name}' has been set with various data sizes. You can change it's name, or if it was an accident, set '${this.name}' to have the same number of inputs each time!`, 'vertexProperty()');
-        }
-        this.currentData = data;
-      },
-      // Utilities
-      pushCurrentData(){
-        const data = this.getCurrentData();
-        this.pushDirect(data);
-      },
-      pushDirect(data) {
-        if (data.length){
-          this.getSrcArray().push(...data);
-        } else{
-          this.getSrcArray().push(data);
-        }
-      },
-      resetSrcArray(){
-        this.geometry[this.getSrcName()] = [];
-      },
-      delete() {
-        const srcName = this.getSrcName();
-        delete this.geometry[srcName];
-        delete this;
-      }
-    };
-    this[prop.getSrcName()] = []; 
-    return this.userVertexProperties[propertyName];
-  }
-};
-
-/**
- * An array with the geometry's vertices.
- *
- * The geometry's vertices are stored as
- * <a href="#/p5.Vector">p5.Vector</a> objects in the `myGeometry.vertices`
- * array. The geometry's first vertex is the
- * <a href="#/p5.Vector">p5.Vector</a> object at `myGeometry.vertices[0]`,
- * its second vertex is `myGeometry.vertices[1]`, its third vertex is
- * `myGeometry.vertices[2]`, and so on.
- *
- * @property vertices
- * @for p5.Geometry
- * @name vertices
- *
- * @example
- * <div>
- * <code>
- * // Click and drag the mouse to view the scene from different angles.
- *
- * let myGeometry;
- *
- * function setup() {
- *   createCanvas(100, 100, WEBGL);
- *
- *   // Create a p5.Geometry object.
- *   myGeometry = new p5.Geometry();
- *
- *   // Create p5.Vector objects to position the vertices.
- *   let v0 = createVector(-40, 0, 0);
- *   let v1 = createVector(0, -40, 0);
- *   let v2 = createVector(40, 0, 0);
- *
- *   // Add the vertices to the p5.Geometry object's vertices array.
- *   myGeometry.vertices.push(v0, v1, v2);
- *
- *   describe('A white triangle drawn on a gray background.');
- * }
- *
- * function draw() {
- *   background(200);
- *
- *   // Enable orbiting with the mouse.
- *   orbitControl();
- *
- *   // Draw the p5.Geometry object.
- *   model(myGeometry);
- * }
- * </code>
- * </div>
- *
- * <div>
- * <code>
- * // Click and drag the mouse to view the scene from different angles.
- *
- * let myGeometry;
- *
- * function setup() {
- *   createCanvas(100, 100, WEBGL);
- *
- *   // Create a p5.Geometry object.
- *   beginGeometry();
- *   torus(30, 15, 10, 8);
- *   myGeometry = endGeometry();
- *
- *   describe('A white torus rotates slowly against a dark gray background. Red spheres mark its vertices.');
- * }
- *
- * function draw() {
- *   background(50);
- *
- *   // Enable orbiting with the mouse.
- *   orbitControl();
- *
- *   // Turn on the lights.
- *   lights();
- *
- *   // Rotate the coordinate system.
- *   rotateY(frameCount * 0.01);
- *
- *   // Style the p5.Geometry object.
- *   fill(255);
- *   stroke(0);
- *
- *   // Display the p5.Geometry object.
- *   model(myGeometry);
- *
- *   // Style the vertices.
- *   fill(255, 0, 0);
- *   noStroke();
- *
- *   // Iterate over the vertices array.
- *   for (let v of myGeometry.vertices) {
- *     // Draw a sphere to mark the vertex.
- *     push();
- *     translate(v);
- *     sphere(2.5);
- *     pop();
- *   }
- * }
- * </code>
- * </div>
- */
-
-/**
- * An array with the vectors that are normal to the geometry's vertices.
- *
- * A face's orientation is defined by its *normal vector* which points out
- * of the face and is normal (perpendicular) to the surface. Calling
- * `myGeometry.computeNormals()` first calculates each face's normal
- * vector. Then it calculates the normal vector for each vertex by
- * averaging the normal vectors of the faces surrounding the vertex. The
- * vertex normals are stored as <a href="#/p5.Vector">p5.Vector</a>
- * objects in the `myGeometry.vertexNormals` array.
- *
- * @property vertexNormals
- * @name vertexNormals
- * @for p5.Geometry
- *
- * @example
- * <div>
- * <code>
- * // Click and drag the mouse to view the scene from different angles.
- *
- * let myGeometry;
- *
- * function setup() {
- *   createCanvas(100, 100, WEBGL);
- *
- *   // Create a p5.Geometry object.
- *   beginGeometry();
- *   torus(30, 15, 10, 8);
- *   myGeometry = endGeometry();
- *
- *   // Compute the vertex normals.
- *   myGeometry.computeNormals();
- *
- *   describe(
- *     'A white torus rotates against a dark gray background. Red lines extend outward from its vertices.'
- *   );
- * }
- *
- * function draw() {
- *   background(50);
- *
- *   // Enable orbiting with the mouse.
- *   orbitControl();
- *
- *   // Turn on the lights.
- *   lights();
- *
- *   // Rotate the coordinate system.
- *   rotateY(frameCount * 0.01);
- *
- *   // Style the p5.Geometry object.
- *   stroke(0);
- *
- *   // Display the p5.Geometry object.
- *   model(myGeometry);
- *
- *   // Style the normal vectors.
- *   stroke(255, 0, 0);
- *
- *   // Iterate over the vertices and vertexNormals arrays.
- *   for (let i = 0; i < myGeometry.vertices.length; i += 1) {
- *
- *     // Get the vertex p5.Vector object.
- *     let v = myGeometry.vertices[i];
- *
- *     // Get the vertex normal p5.Vector object.
- *     let n = myGeometry.vertexNormals[i];
- *
- *     // Calculate a point along the vertex normal.
- *     let p = p5.Vector.mult(n, 8);
- *
- *     // Draw the vertex normal as a red line.
- *     push();
- *     translate(v);
- *     line(0, 0, 0, p.x, p.y, p.z);
- *     pop();
- *   }
- * }
- * </code>
- * </div>
- *
- * <div>
- * <code>
- * // Click and drag the mouse to view the scene from different angles.
- *
- * let myGeometry;
- *
- * function setup() {
- *   createCanvas(100, 100, WEBGL);
- *
- *   // Create a p5.Geometry object.
- *   myGeometry = new p5.Geometry();
- *
- *   // Create p5.Vector objects to position the vertices.
- *   let v0 = createVector(-40, 0, 0);
- *   let v1 = createVector(0, -40, 0);
- *   let v2 = createVector(0, 40, 0);
- *   let v3 = createVector(40, 0, 0);
- *
- *   // Add the vertices to the p5.Geometry object's vertices array.
- *   myGeometry.vertices.push(v0, v1, v2, v3);
- *
- *   // Compute the faces array.
- *   myGeometry.computeFaces();
- *
- *   // Compute the surface normals.
- *   myGeometry.computeNormals();
- *
- *   describe('A red square drawn on a gray background.');
- * }
- *
- * function draw() {
- *   background(200);
- *
- *   // Enable orbiting with the mouse.
- *   orbitControl();
- *
- *   // Add a white point light.
- *   pointLight(255, 255, 255, 0, 0, 10);
- *
- *   // Style the p5.Geometry object.
- *   noStroke();
- *   fill(255, 0, 0);
- *
- *   // Display the p5.Geometry object.
- *   model(myGeometry);
- * }
- * </code>
- * </div>
- */
-
-/**
- * An array that lists which of the geometry's vertices form each of its
- * faces.
- *
- * All 3D shapes are made by connecting sets of points called *vertices*. A
- * geometry's surface is formed by connecting vertices to form triangles
- * that are stitched together. Each triangular patch on the geometry's
- * surface is called a *face*.
- *
- * The geometry's vertices are stored as
- * <a href="#/p5.Vector">p5.Vector</a> objects in the
- * <a href="#/p5.Geometry/vertices">myGeometry.vertices</a> array. The
- * geometry's first vertex is the <a href="#/p5.Vector">p5.Vector</a>
- * object at `myGeometry.vertices[0]`, its second vertex is
- * `myGeometry.vertices[1]`, its third vertex is `myGeometry.vertices[2]`,
- * and so on.
- *
- * For example, a geometry made from a rectangle has two faces because a
- * rectangle is made by joining two triangles. `myGeometry.faces` for a
- * rectangle would be the two-dimensional array `[[0, 1, 2], [2, 1, 3]]`.
- * The first face, `myGeometry.faces[0]`, is the array `[0, 1, 2]` because
- * it's formed by connecting `myGeometry.vertices[0]`,
- * `myGeometry.vertices[1]`,and `myGeometry.vertices[2]`. The second face,
- * `myGeometry.faces[1]`, is the array `[2, 1, 3]` because it's formed by
- * connecting `myGeometry.vertices[2]`, `myGeometry.vertices[1]`,and
- * `myGeometry.vertices[3]`.
- *
- * @property faces
- * @name faces
- * @for p5.Geometry
- *
- * @example
- * <div>
- * <code>
- * // Click and drag the mouse to view the scene from different angles.
- *
- * let myGeometry;
- *
- * function setup() {
- *   createCanvas(100, 100, WEBGL);
- *
- *   // Create a p5.Geometry object.
- *   beginGeometry();
- *   sphere();
- *   myGeometry = endGeometry();
- *
- *   describe("A sphere drawn on a gray background. The sphere's surface is a grayscale patchwork of triangles.");
- * }
- *
- * function draw() {
- *   background(200);
- *
- *   // Enable orbiting with the mouse.
- *   orbitControl();
- *
- *   // Turn on the lights.
- *   lights();
- *
- *   // Style the p5.Geometry object.
- *   noStroke();
- *
- *   // Set a random seed.
- *   randomSeed(1234);
- *
- *   // Iterate over the faces array.
- *   for (let face of myGeometry.faces) {
- *
- *     // Style the face.
- *     let g = random(0, 255);
- *     fill(g);
- *
- *     // Draw the face.
- *     beginShape();
- *     // Iterate over the vertices that form the face.
- *     for (let f of face) {
- *       // Get the vertex's p5.Vector object.
- *       let v = myGeometry.vertices[f];
- *       vertex(v.x, v.y, v.z);
- *     }
- *     endShape();
- *
- *   }
- * }
- * </code>
- * </div>
- */
-
-/**
- * An array that lists the texture coordinates for each of the geometry's
- * vertices.
- *
- * In order for <a href="#/p5/texture">texture()</a> to work, the geometry
- * needs a way to map the points on its surface to the pixels in a
- * rectangular image that's used as a texture. The geometry's vertex at
- * coordinates `(x, y, z)` maps to the texture image's pixel at coordinates
- * `(u, v)`.
- *
- * The `myGeometry.uvs` array stores the `(u, v)` coordinates for each
- * vertex in the order it was added to the geometry. For example, the
- * first vertex, `myGeometry.vertices[0]`, has its `(u, v)` coordinates
- * stored at `myGeometry.uvs[0]` and `myGeometry.uvs[1]`.
- *
- * @property uvs
- * @name uvs
- * @for p5.Geometry
- *
- * @example
- * <div>
- * <code>
- * let img;
- *
- * // Load the image and create a p5.Image object.
- * function preload() {
- *   img = loadImage('assets/laDefense.jpg');
- * }
- *
- * function setup() {
- *   createCanvas(100, 100, WEBGL);
- *
- *   background(200);
- *
- *   // Create p5.Geometry objects.
- *   let geom1 = buildGeometry(createShape);
- *   let geom2 = buildGeometry(createShape);
- *
- *   // Left (original).
- *   push();
- *   translate(-25, 0, 0);
- *   texture(img);
- *   noStroke();
- *   model(geom1);
- *   pop();
- *
- *   // Set geom2's texture coordinates.
- *   geom2.uvs = [0.25, 0.25, 0.75, 0.25, 0.25, 0.75, 0.75, 0.75];
- *
- *   // Right (zoomed in).
- *   push();
- *   translate(25, 0, 0);
- *   texture(img);
- *   noStroke();
- *   model(geom2);
- *   pop();
- *
- *   describe(
- *     'Two photos of a ceiling on a gray background. The photo on the right zooms in to the center of the photo.'
- *   );
- * }
- *
- * function createShape() {
- *   plane(40);
- * }
- * </code>
- * </div>
- */
-
-export default p5.Geometry;
-
+if(typeof p5 !== 'undefined'){
+  geometry(p5, p5.prototype);
+}

--- a/src/webgl/p5.Matrix.js
+++ b/src/webgl/p5.Matrix.js
@@ -7,978 +7,983 @@
  *   Reference/Global_Objects/SIMD
  */
 
-import p5 from '../core/main';
-
-let GLMAT_ARRAY_TYPE = Array;
-let isMatrixArray = x => Array.isArray(x);
-if (typeof Float32Array !== 'undefined') {
-  GLMAT_ARRAY_TYPE = Float32Array;
-  isMatrixArray = x => Array.isArray(x) || x instanceof Float32Array;
-}
-
-/**
- * A class to describe a 4×4 matrix
- * for model and view matrix manipulation in the p5js webgl renderer.
- * @class p5.Matrix
- * @private
- * @param {Array} [mat4] column-major array literal of our 4×4 matrix
- */
-p5.Matrix = class Matrix {
-  constructor(...args){
-
-    // This is default behavior when object
-    // instantiated using createMatrix()
-    // @todo implement createMatrix() in core/math.js
-    if (args.length && args[args.length - 1] instanceof p5) {
-      this.p5 = args[args.length - 1];
-    }
-
-    if (args[0] === 'mat3') {
-      this.mat3 = Array.isArray(args[1])
-        ? args[1]
-        : new GLMAT_ARRAY_TYPE([1, 0, 0, 0, 1, 0, 0, 0, 1]);
-    } else {
-      this.mat4 = Array.isArray(args[0])
-        ? args[0]
-        : new GLMAT_ARRAY_TYPE(
-          [1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1]);
-    }
-    return this;
-  }
-
-  reset() {
-    if (this.mat3) {
-      this.mat3.set([1, 0, 0, 0, 1, 0, 0, 0, 1]);
-    } else if (this.mat4) {
-      this.mat4.set([1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1]);
-    }
-    return this;
+function matrix(p5, fn){
+  let GLMAT_ARRAY_TYPE = Array;
+  let isMatrixArray = x => Array.isArray(x);
+  if (typeof Float32Array !== 'undefined') {
+    GLMAT_ARRAY_TYPE = Float32Array;
+    isMatrixArray = x => Array.isArray(x) || x instanceof Float32Array;
   }
 
   /**
- * Replace the entire contents of a 4x4 matrix.
- * If providing an array or a p5.Matrix, the values will be copied without
- * referencing the source object.
- * Can also provide 16 numbers as individual arguments.
- *
- * @param {p5.Matrix|Float32Array|Number[]} [inMatrix] the input p5.Matrix or
- *                                     an Array of length 16
- * @chainable
- */
-  /**
- * @param {Number[]} elements 16 numbers passed by value to avoid
- *                                     array copying.
- * @chainable
- */
-  set(inMatrix) {
-    let refArray = arguments;
-    if (inMatrix instanceof p5.Matrix) {
-      refArray = inMatrix.mat4;
-    } else if (isMatrixArray(inMatrix)) {
-      refArray = inMatrix;
-    }
-    if (refArray.length !== 16) {
-      p5._friendlyError(
-        `Expected 16 values but received ${refArray.length}.`,
-        'p5.Matrix.set'
-      );
+   * A class to describe a 4×4 matrix
+   * for model and view matrix manipulation in the p5js webgl renderer.
+   * @class p5.Matrix
+   * @private
+   * @param {Array} [mat4] column-major array literal of our 4×4 matrix
+   */
+  p5.Matrix = class Matrix {
+    constructor(...args){
+
+      // This is default behavior when object
+      // instantiated using createMatrix()
+      // @todo implement createMatrix() in core/math.js
+      if (args.length && args[args.length - 1] instanceof p5) {
+        this.p5 = args[args.length - 1];
+      }
+
+      if (args[0] === 'mat3') {
+        this.mat3 = Array.isArray(args[1])
+          ? args[1]
+          : new GLMAT_ARRAY_TYPE([1, 0, 0, 0, 1, 0, 0, 0, 1]);
+      } else {
+        this.mat4 = Array.isArray(args[0])
+          ? args[0]
+          : new GLMAT_ARRAY_TYPE(
+            [1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1]);
+      }
       return this;
     }
-    for (let i = 0; i < 16; i++) {
-      this.mat4[i] = refArray[i];
-    }
-    return this;
-  }
 
-  /**
- * Gets a copy of the vector, returns a p5.Matrix object.
- *
- * @return {p5.Matrix} the copy of the p5.Matrix object
- */
-  get() {
-    return new p5.Matrix(this.mat4, this.p5);
-  }
-
-  /**
- * return a copy of this matrix.
- * If this matrix is 4x4, a 4x4 matrix with exactly the same entries will be
- * generated. The same is true if this matrix is 3x3.
- *
- * @return {p5.Matrix}   the result matrix
- */
-  copy() {
-    if (this.mat3 !== undefined) {
-      const copied3x3 = new p5.Matrix('mat3', this.p5);
-      copied3x3.mat3[0] = this.mat3[0];
-      copied3x3.mat3[1] = this.mat3[1];
-      copied3x3.mat3[2] = this.mat3[2];
-      copied3x3.mat3[3] = this.mat3[3];
-      copied3x3.mat3[4] = this.mat3[4];
-      copied3x3.mat3[5] = this.mat3[5];
-      copied3x3.mat3[6] = this.mat3[6];
-      copied3x3.mat3[7] = this.mat3[7];
-      copied3x3.mat3[8] = this.mat3[8];
-      return copied3x3;
-    }
-    const copied = new p5.Matrix(this.p5);
-    copied.mat4[0] = this.mat4[0];
-    copied.mat4[1] = this.mat4[1];
-    copied.mat4[2] = this.mat4[2];
-    copied.mat4[3] = this.mat4[3];
-    copied.mat4[4] = this.mat4[4];
-    copied.mat4[5] = this.mat4[5];
-    copied.mat4[6] = this.mat4[6];
-    copied.mat4[7] = this.mat4[7];
-    copied.mat4[8] = this.mat4[8];
-    copied.mat4[9] = this.mat4[9];
-    copied.mat4[10] = this.mat4[10];
-    copied.mat4[11] = this.mat4[11];
-    copied.mat4[12] = this.mat4[12];
-    copied.mat4[13] = this.mat4[13];
-    copied.mat4[14] = this.mat4[14];
-    copied.mat4[15] = this.mat4[15];
-    return copied;
-  }
-
-  clone() {
-    return this.copy();
-  }
-
-  /**
- * return an identity matrix
- * @return {p5.Matrix}   the result matrix
- */
-  static identity(pInst){
-    return new p5.Matrix(pInst);
-  }
-
-  /**
- * transpose according to a given matrix
- * @param  {p5.Matrix|Float32Array|Number[]} a  the matrix to be
- *                                               based on to transpose
- * @chainable
- */
-  transpose(a) {
-    let a01, a02, a03, a12, a13, a23;
-    if (a instanceof p5.Matrix) {
-      a01 = a.mat4[1];
-      a02 = a.mat4[2];
-      a03 = a.mat4[3];
-      a12 = a.mat4[6];
-      a13 = a.mat4[7];
-      a23 = a.mat4[11];
-
-      this.mat4[0] = a.mat4[0];
-      this.mat4[1] = a.mat4[4];
-      this.mat4[2] = a.mat4[8];
-      this.mat4[3] = a.mat4[12];
-      this.mat4[4] = a01;
-      this.mat4[5] = a.mat4[5];
-      this.mat4[6] = a.mat4[9];
-      this.mat4[7] = a.mat4[13];
-      this.mat4[8] = a02;
-      this.mat4[9] = a12;
-      this.mat4[10] = a.mat4[10];
-      this.mat4[11] = a.mat4[14];
-      this.mat4[12] = a03;
-      this.mat4[13] = a13;
-      this.mat4[14] = a23;
-      this.mat4[15] = a.mat4[15];
-    } else if (isMatrixArray(a)) {
-      a01 = a[1];
-      a02 = a[2];
-      a03 = a[3];
-      a12 = a[6];
-      a13 = a[7];
-      a23 = a[11];
-
-      this.mat4[0] = a[0];
-      this.mat4[1] = a[4];
-      this.mat4[2] = a[8];
-      this.mat4[3] = a[12];
-      this.mat4[4] = a01;
-      this.mat4[5] = a[5];
-      this.mat4[6] = a[9];
-      this.mat4[7] = a[13];
-      this.mat4[8] = a02;
-      this.mat4[9] = a12;
-      this.mat4[10] = a[10];
-      this.mat4[11] = a[14];
-      this.mat4[12] = a03;
-      this.mat4[13] = a13;
-      this.mat4[14] = a23;
-      this.mat4[15] = a[15];
-    }
-    return this;
-  }
-
-  /**
- * invert  matrix according to a give matrix
- * @param  {p5.Matrix|Float32Array|Number[]} a   the matrix to be
- *                                                based on to invert
- * @chainable
- */
-  invert(a) {
-    let a00, a01, a02, a03, a10, a11, a12, a13;
-    let a20, a21, a22, a23, a30, a31, a32, a33;
-    if (a instanceof p5.Matrix) {
-      a00 = a.mat4[0];
-      a01 = a.mat4[1];
-      a02 = a.mat4[2];
-      a03 = a.mat4[3];
-      a10 = a.mat4[4];
-      a11 = a.mat4[5];
-      a12 = a.mat4[6];
-      a13 = a.mat4[7];
-      a20 = a.mat4[8];
-      a21 = a.mat4[9];
-      a22 = a.mat4[10];
-      a23 = a.mat4[11];
-      a30 = a.mat4[12];
-      a31 = a.mat4[13];
-      a32 = a.mat4[14];
-      a33 = a.mat4[15];
-    } else if (isMatrixArray(a)) {
-      a00 = a[0];
-      a01 = a[1];
-      a02 = a[2];
-      a03 = a[3];
-      a10 = a[4];
-      a11 = a[5];
-      a12 = a[6];
-      a13 = a[7];
-      a20 = a[8];
-      a21 = a[9];
-      a22 = a[10];
-      a23 = a[11];
-      a30 = a[12];
-      a31 = a[13];
-      a32 = a[14];
-      a33 = a[15];
-    }
-    const b00 = a00 * a11 - a01 * a10;
-    const b01 = a00 * a12 - a02 * a10;
-    const b02 = a00 * a13 - a03 * a10;
-    const b03 = a01 * a12 - a02 * a11;
-    const b04 = a01 * a13 - a03 * a11;
-    const b05 = a02 * a13 - a03 * a12;
-    const b06 = a20 * a31 - a21 * a30;
-    const b07 = a20 * a32 - a22 * a30;
-    const b08 = a20 * a33 - a23 * a30;
-    const b09 = a21 * a32 - a22 * a31;
-    const b10 = a21 * a33 - a23 * a31;
-    const b11 = a22 * a33 - a23 * a32;
-
-    // Calculate the determinant
-    let det =
-    b00 * b11 - b01 * b10 + b02 * b09 + b03 * b08 - b04 * b07 + b05 * b06;
-
-    if (!det) {
-      return null;
-    }
-    det = 1.0 / det;
-
-    this.mat4[0] = (a11 * b11 - a12 * b10 + a13 * b09) * det;
-    this.mat4[1] = (a02 * b10 - a01 * b11 - a03 * b09) * det;
-    this.mat4[2] = (a31 * b05 - a32 * b04 + a33 * b03) * det;
-    this.mat4[3] = (a22 * b04 - a21 * b05 - a23 * b03) * det;
-    this.mat4[4] = (a12 * b08 - a10 * b11 - a13 * b07) * det;
-    this.mat4[5] = (a00 * b11 - a02 * b08 + a03 * b07) * det;
-    this.mat4[6] = (a32 * b02 - a30 * b05 - a33 * b01) * det;
-    this.mat4[7] = (a20 * b05 - a22 * b02 + a23 * b01) * det;
-    this.mat4[8] = (a10 * b10 - a11 * b08 + a13 * b06) * det;
-    this.mat4[9] = (a01 * b08 - a00 * b10 - a03 * b06) * det;
-    this.mat4[10] = (a30 * b04 - a31 * b02 + a33 * b00) * det;
-    this.mat4[11] = (a21 * b02 - a20 * b04 - a23 * b00) * det;
-    this.mat4[12] = (a11 * b07 - a10 * b09 - a12 * b06) * det;
-    this.mat4[13] = (a00 * b09 - a01 * b07 + a02 * b06) * det;
-    this.mat4[14] = (a31 * b01 - a30 * b03 - a32 * b00) * det;
-    this.mat4[15] = (a20 * b03 - a21 * b01 + a22 * b00) * det;
-
-    return this;
-  }
-
-  /**
- * Inverts a 3×3 matrix
- * @chainable
- */
-  invert3x3() {
-    const a00 = this.mat3[0];
-    const a01 = this.mat3[1];
-    const a02 = this.mat3[2];
-    const a10 = this.mat3[3];
-    const a11 = this.mat3[4];
-    const a12 = this.mat3[5];
-    const a20 = this.mat3[6];
-    const a21 = this.mat3[7];
-    const a22 = this.mat3[8];
-    const b01 = a22 * a11 - a12 * a21;
-    const b11 = -a22 * a10 + a12 * a20;
-    const b21 = a21 * a10 - a11 * a20;
-
-    // Calculate the determinant
-    let det = a00 * b01 + a01 * b11 + a02 * b21;
-    if (!det) {
-      return null;
-    }
-    det = 1.0 / det;
-    this.mat3[0] = b01 * det;
-    this.mat3[1] = (-a22 * a01 + a02 * a21) * det;
-    this.mat3[2] = (a12 * a01 - a02 * a11) * det;
-    this.mat3[3] = b11 * det;
-    this.mat3[4] = (a22 * a00 - a02 * a20) * det;
-    this.mat3[5] = (-a12 * a00 + a02 * a10) * det;
-    this.mat3[6] = b21 * det;
-    this.mat3[7] = (-a21 * a00 + a01 * a20) * det;
-    this.mat3[8] = (a11 * a00 - a01 * a10) * det;
-    return this;
-  }
-
-  /**
- * This function is only for 3x3 matrices.
- * transposes a 3×3 p5.Matrix by a mat3
- * If there is an array of arguments, the matrix obtained by transposing
- * the 3x3 matrix generated based on that array is set.
- * If no arguments, it transposes itself and returns it.
- *
- * @param  {Number[]} mat3 1-dimensional array
- * @chainable
- */
-  transpose3x3(mat3) {
-    if (mat3 === undefined) {
-      mat3 = this.mat3;
-    }
-    const a01 = mat3[1];
-    const a02 = mat3[2];
-    const a12 = mat3[5];
-    this.mat3[0] = mat3[0];
-    this.mat3[1] = mat3[3];
-    this.mat3[2] = mat3[6];
-    this.mat3[3] = a01;
-    this.mat3[4] = mat3[4];
-    this.mat3[5] = mat3[7];
-    this.mat3[6] = a02;
-    this.mat3[7] = a12;
-    this.mat3[8] = mat3[8];
-
-    return this;
-  }
-
-  /**
- * converts a 4×4 matrix to its 3×3 inverse transform
- * commonly used in MVMatrix to NMatrix conversions.
- * @param  {p5.Matrix} mat4 the matrix to be based on to invert
- * @chainable
- * @todo  finish implementation
- */
-  inverseTranspose({ mat4 }) {
-    if (this.mat3 === undefined) {
-      p5._friendlyError('sorry, this function only works with mat3');
-    } else {
-    //convert mat4 -> mat3
-      this.mat3[0] = mat4[0];
-      this.mat3[1] = mat4[1];
-      this.mat3[2] = mat4[2];
-      this.mat3[3] = mat4[4];
-      this.mat3[4] = mat4[5];
-      this.mat3[5] = mat4[6];
-      this.mat3[6] = mat4[8];
-      this.mat3[7] = mat4[9];
-      this.mat3[8] = mat4[10];
-    }
-
-    const inverse = this.invert3x3();
-    // check inverse succeeded
-    if (inverse) {
-      inverse.transpose3x3(this.mat3);
-    } else {
-    // in case of singularity, just zero the matrix
-      for (let i = 0; i < 9; i++) {
-        this.mat3[i] = 0;
+    reset() {
+      if (this.mat3) {
+        this.mat3.set([1, 0, 0, 0, 1, 0, 0, 0, 1]);
+      } else if (this.mat4) {
+        this.mat4.set([1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1]);
       }
-    }
-    return this;
-  }
-
-  /**
- * inspired by Toji's mat4 determinant
- * @return {Number} Determinant of our 4×4 matrix
- */
-  determinant() {
-    const d00 = this.mat4[0] * this.mat4[5] - this.mat4[1] * this.mat4[4],
-      d01 = this.mat4[0] * this.mat4[6] - this.mat4[2] * this.mat4[4],
-      d02 = this.mat4[0] * this.mat4[7] - this.mat4[3] * this.mat4[4],
-      d03 = this.mat4[1] * this.mat4[6] - this.mat4[2] * this.mat4[5],
-      d04 = this.mat4[1] * this.mat4[7] - this.mat4[3] * this.mat4[5],
-      d05 = this.mat4[2] * this.mat4[7] - this.mat4[3] * this.mat4[6],
-      d06 = this.mat4[8] * this.mat4[13] - this.mat4[9] * this.mat4[12],
-      d07 = this.mat4[8] * this.mat4[14] - this.mat4[10] * this.mat4[12],
-      d08 = this.mat4[8] * this.mat4[15] - this.mat4[11] * this.mat4[12],
-      d09 = this.mat4[9] * this.mat4[14] - this.mat4[10] * this.mat4[13],
-      d10 = this.mat4[9] * this.mat4[15] - this.mat4[11] * this.mat4[13],
-      d11 = this.mat4[10] * this.mat4[15] - this.mat4[11] * this.mat4[14];
-
-    // Calculate the determinant
-    return d00 * d11 - d01 * d10 + d02 * d09 +
-    d03 * d08 - d04 * d07 + d05 * d06;
-  }
-
-  /**
- * multiply two mat4s
- * @param {p5.Matrix|Float32Array|Number[]} multMatrix The matrix
- *                                                we want to multiply by
- * @chainable
- */
-  mult(multMatrix) {
-    let _src;
-
-    if (multMatrix === this || multMatrix === this.mat4) {
-      _src = this.copy().mat4; // only need to allocate in this rare case
-    } else if (multMatrix instanceof p5.Matrix) {
-      _src = multMatrix.mat4;
-    } else if (isMatrixArray(multMatrix)) {
-      _src = multMatrix;
-    } else if (arguments.length === 16) {
-      _src = arguments;
-    } else {
-      return; // nothing to do.
+      return this;
     }
 
-    // each row is used for the multiplier
-    let b0 = this.mat4[0],
-      b1 = this.mat4[1],
-      b2 = this.mat4[2],
-      b3 = this.mat4[3];
-    this.mat4[0] = b0 * _src[0] + b1 * _src[4] + b2 * _src[8] + b3 * _src[12];
-    this.mat4[1] = b0 * _src[1] + b1 * _src[5] + b2 * _src[9] + b3 * _src[13];
-    this.mat4[2] = b0 * _src[2] + b1 * _src[6] + b2 * _src[10] + b3 * _src[14];
-    this.mat4[3] = b0 * _src[3] + b1 * _src[7] + b2 * _src[11] + b3 * _src[15];
-
-    b0 = this.mat4[4];
-    b1 = this.mat4[5];
-    b2 = this.mat4[6];
-    b3 = this.mat4[7];
-    this.mat4[4] = b0 * _src[0] + b1 * _src[4] + b2 * _src[8] + b3 * _src[12];
-    this.mat4[5] = b0 * _src[1] + b1 * _src[5] + b2 * _src[9] + b3 * _src[13];
-    this.mat4[6] = b0 * _src[2] + b1 * _src[6] + b2 * _src[10] + b3 * _src[14];
-    this.mat4[7] = b0 * _src[3] + b1 * _src[7] + b2 * _src[11] + b3 * _src[15];
-
-    b0 = this.mat4[8];
-    b1 = this.mat4[9];
-    b2 = this.mat4[10];
-    b3 = this.mat4[11];
-    this.mat4[8] = b0 * _src[0] + b1 * _src[4] + b2 * _src[8] + b3 * _src[12];
-    this.mat4[9] = b0 * _src[1] + b1 * _src[5] + b2 * _src[9] + b3 * _src[13];
-    this.mat4[10] = b0 * _src[2] + b1 * _src[6] + b2 * _src[10] + b3 * _src[14];
-    this.mat4[11] = b0 * _src[3] + b1 * _src[7] + b2 * _src[11] + b3 * _src[15];
-
-    b0 = this.mat4[12];
-    b1 = this.mat4[13];
-    b2 = this.mat4[14];
-    b3 = this.mat4[15];
-    this.mat4[12] = b0 * _src[0] + b1 * _src[4] + b2 * _src[8] + b3 * _src[12];
-    this.mat4[13] = b0 * _src[1] + b1 * _src[5] + b2 * _src[9] + b3 * _src[13];
-    this.mat4[14] = b0 * _src[2] + b1 * _src[6] + b2 * _src[10] + b3 * _src[14];
-    this.mat4[15] = b0 * _src[3] + b1 * _src[7] + b2 * _src[11] + b3 * _src[15];
-
-    return this;
-  }
-
-  apply(multMatrix) {
-    let _src;
-
-    if (multMatrix === this || multMatrix === this.mat4) {
-      _src = this.copy().mat4; // only need to allocate in this rare case
-    } else if (multMatrix instanceof p5.Matrix) {
-      _src = multMatrix.mat4;
-    } else if (isMatrixArray(multMatrix)) {
-      _src = multMatrix;
-    } else if (arguments.length === 16) {
-      _src = arguments;
-    } else {
-      return; // nothing to do.
+    /**
+   * Replace the entire contents of a 4x4 matrix.
+   * If providing an array or a p5.Matrix, the values will be copied without
+   * referencing the source object.
+   * Can also provide 16 numbers as individual arguments.
+   *
+   * @param {p5.Matrix|Float32Array|Number[]} [inMatrix] the input p5.Matrix or
+   *                                     an Array of length 16
+   * @chainable
+   */
+    /**
+   * @param {Number[]} elements 16 numbers passed by value to avoid
+   *                                     array copying.
+   * @chainable
+   */
+    set(inMatrix) {
+      let refArray = arguments;
+      if (inMatrix instanceof p5.Matrix) {
+        refArray = inMatrix.mat4;
+      } else if (isMatrixArray(inMatrix)) {
+        refArray = inMatrix;
+      }
+      if (refArray.length !== 16) {
+        p5._friendlyError(
+          `Expected 16 values but received ${refArray.length}.`,
+          'p5.Matrix.set'
+        );
+        return this;
+      }
+      for (let i = 0; i < 16; i++) {
+        this.mat4[i] = refArray[i];
+      }
+      return this;
     }
 
-    const mat4 = this.mat4;
-
-    // each row is used for the multiplier
-    const m0 = mat4[0];
-    const m4 = mat4[4];
-    const m8 = mat4[8];
-    const m12 = mat4[12];
-    mat4[0] = _src[0] * m0 + _src[1] * m4 + _src[2] * m8 + _src[3] * m12;
-    mat4[4] = _src[4] * m0 + _src[5] * m4 + _src[6] * m8 + _src[7] * m12;
-    mat4[8] = _src[8] * m0 + _src[9] * m4 + _src[10] * m8 + _src[11] * m12;
-    mat4[12] = _src[12] * m0 + _src[13] * m4 + _src[14] * m8 + _src[15] * m12;
-
-    const m1 = mat4[1];
-    const m5 = mat4[5];
-    const m9 = mat4[9];
-    const m13 = mat4[13];
-    mat4[1] = _src[0] * m1 + _src[1] * m5 + _src[2] * m9 + _src[3] * m13;
-    mat4[5] = _src[4] * m1 + _src[5] * m5 + _src[6] * m9 + _src[7] * m13;
-    mat4[9] = _src[8] * m1 + _src[9] * m5 + _src[10] * m9 + _src[11] * m13;
-    mat4[13] = _src[12] * m1 + _src[13] * m5 + _src[14] * m9 + _src[15] * m13;
-
-    const m2 = mat4[2];
-    const m6 = mat4[6];
-    const m10 = mat4[10];
-    const m14 = mat4[14];
-    mat4[2] = _src[0] * m2 + _src[1] * m6 + _src[2] * m10 + _src[3] * m14;
-    mat4[6] = _src[4] * m2 + _src[5] * m6 + _src[6] * m10 + _src[7] * m14;
-    mat4[10] = _src[8] * m2 + _src[9] * m6 + _src[10] * m10 + _src[11] * m14;
-    mat4[14] = _src[12] * m2 + _src[13] * m6 + _src[14] * m10 + _src[15] * m14;
-
-    const m3 = mat4[3];
-    const m7 = mat4[7];
-    const m11 = mat4[11];
-    const m15 = mat4[15];
-    mat4[3] = _src[0] * m3 + _src[1] * m7 + _src[2] * m11 + _src[3] * m15;
-    mat4[7] = _src[4] * m3 + _src[5] * m7 + _src[6] * m11 + _src[7] * m15;
-    mat4[11] = _src[8] * m3 + _src[9] * m7 + _src[10] * m11 + _src[11] * m15;
-    mat4[15] = _src[12] * m3 + _src[13] * m7 + _src[14] * m11 + _src[15] * m15;
-
-    return this;
-  }
-
-  /**
- * scales a p5.Matrix by scalars or a vector
- * @param  {p5.Vector|Float32Array|Number[]} s vector to scale by
- * @chainable
- */
-  scale(x, y, z) {
-    if (x instanceof p5.Vector) {
-    // x is a vector, extract the components from it.
-      y = x.y;
-      z = x.z;
-      x = x.x; // must be last
-    } else if (x instanceof Array) {
-    // x is an array, extract the components from it.
-      y = x[1];
-      z = x[2];
-      x = x[0]; // must be last
+    /**
+   * Gets a copy of the vector, returns a p5.Matrix object.
+   *
+   * @return {p5.Matrix} the copy of the p5.Matrix object
+   */
+    get() {
+      return new p5.Matrix(this.mat4, this.p5);
     }
 
-    this.mat4[0] *= x;
-    this.mat4[1] *= x;
-    this.mat4[2] *= x;
-    this.mat4[3] *= x;
-    this.mat4[4] *= y;
-    this.mat4[5] *= y;
-    this.mat4[6] *= y;
-    this.mat4[7] *= y;
-    this.mat4[8] *= z;
-    this.mat4[9] *= z;
-    this.mat4[10] *= z;
-    this.mat4[11] *= z;
-
-    return this;
-  }
-
-  /**
- * rotate our Matrix around an axis by the given angle.
- * @param  {Number} a The angle of rotation in radians
- * @param  {p5.Vector|Number[]} axis  the axis(es) to rotate around
- * @chainable
- * inspired by Toji's gl-matrix lib, mat4 rotation
- */
-  rotate(a, x, y, z) {
-    if (x instanceof p5.Vector) {
-    // x is a vector, extract the components from it.
-      y = x.y;
-      z = x.z;
-      x = x.x; //must be last
-    } else if (x instanceof Array) {
-    // x is an array, extract the components from it.
-      y = x[1];
-      z = x[2];
-      x = x[0]; //must be last
+    /**
+   * return a copy of this matrix.
+   * If this matrix is 4x4, a 4x4 matrix with exactly the same entries will be
+   * generated. The same is true if this matrix is 3x3.
+   *
+   * @return {p5.Matrix}   the result matrix
+   */
+    copy() {
+      if (this.mat3 !== undefined) {
+        const copied3x3 = new p5.Matrix('mat3', this.p5);
+        copied3x3.mat3[0] = this.mat3[0];
+        copied3x3.mat3[1] = this.mat3[1];
+        copied3x3.mat3[2] = this.mat3[2];
+        copied3x3.mat3[3] = this.mat3[3];
+        copied3x3.mat3[4] = this.mat3[4];
+        copied3x3.mat3[5] = this.mat3[5];
+        copied3x3.mat3[6] = this.mat3[6];
+        copied3x3.mat3[7] = this.mat3[7];
+        copied3x3.mat3[8] = this.mat3[8];
+        return copied3x3;
+      }
+      const copied = new p5.Matrix(this.p5);
+      copied.mat4[0] = this.mat4[0];
+      copied.mat4[1] = this.mat4[1];
+      copied.mat4[2] = this.mat4[2];
+      copied.mat4[3] = this.mat4[3];
+      copied.mat4[4] = this.mat4[4];
+      copied.mat4[5] = this.mat4[5];
+      copied.mat4[6] = this.mat4[6];
+      copied.mat4[7] = this.mat4[7];
+      copied.mat4[8] = this.mat4[8];
+      copied.mat4[9] = this.mat4[9];
+      copied.mat4[10] = this.mat4[10];
+      copied.mat4[11] = this.mat4[11];
+      copied.mat4[12] = this.mat4[12];
+      copied.mat4[13] = this.mat4[13];
+      copied.mat4[14] = this.mat4[14];
+      copied.mat4[15] = this.mat4[15];
+      return copied;
     }
 
-    const len = Math.sqrt(x * x + y * y + z * z);
-    x *= 1 / len;
-    y *= 1 / len;
-    z *= 1 / len;
-
-    const a00 = this.mat4[0];
-    const a01 = this.mat4[1];
-    const a02 = this.mat4[2];
-    const a03 = this.mat4[3];
-    const a10 = this.mat4[4];
-    const a11 = this.mat4[5];
-    const a12 = this.mat4[6];
-    const a13 = this.mat4[7];
-    const a20 = this.mat4[8];
-    const a21 = this.mat4[9];
-    const a22 = this.mat4[10];
-    const a23 = this.mat4[11];
-
-    //sin,cos, and tan of respective angle
-    const sA = Math.sin(a);
-    const cA = Math.cos(a);
-    const tA = 1 - cA;
-    // Construct the elements of the rotation matrix
-    const b00 = x * x * tA + cA;
-    const b01 = y * x * tA + z * sA;
-    const b02 = z * x * tA - y * sA;
-    const b10 = x * y * tA - z * sA;
-    const b11 = y * y * tA + cA;
-    const b12 = z * y * tA + x * sA;
-    const b20 = x * z * tA + y * sA;
-    const b21 = y * z * tA - x * sA;
-    const b22 = z * z * tA + cA;
-
-    // rotation-specific matrix multiplication
-    this.mat4[0] = a00 * b00 + a10 * b01 + a20 * b02;
-    this.mat4[1] = a01 * b00 + a11 * b01 + a21 * b02;
-    this.mat4[2] = a02 * b00 + a12 * b01 + a22 * b02;
-    this.mat4[3] = a03 * b00 + a13 * b01 + a23 * b02;
-    this.mat4[4] = a00 * b10 + a10 * b11 + a20 * b12;
-    this.mat4[5] = a01 * b10 + a11 * b11 + a21 * b12;
-    this.mat4[6] = a02 * b10 + a12 * b11 + a22 * b12;
-    this.mat4[7] = a03 * b10 + a13 * b11 + a23 * b12;
-    this.mat4[8] = a00 * b20 + a10 * b21 + a20 * b22;
-    this.mat4[9] = a01 * b20 + a11 * b21 + a21 * b22;
-    this.mat4[10] = a02 * b20 + a12 * b21 + a22 * b22;
-    this.mat4[11] = a03 * b20 + a13 * b21 + a23 * b22;
-
-    return this;
-  }
-
-  /**
- * @todo  finish implementing this method!
- * translates
- * @param  {Number[]} v vector to translate by
- * @chainable
- */
-  translate(v) {
-    const x = v[0],
-      y = v[1],
-      z = v[2] || 0;
-    this.mat4[12] += this.mat4[0] * x + this.mat4[4] * y + this.mat4[8] * z;
-    this.mat4[13] += this.mat4[1] * x + this.mat4[5] * y + this.mat4[9] * z;
-    this.mat4[14] += this.mat4[2] * x + this.mat4[6] * y + this.mat4[10] * z;
-    this.mat4[15] += this.mat4[3] * x + this.mat4[7] * y + this.mat4[11] * z;
-  }
-
-  rotateX(a) {
-    this.rotate(a, 1, 0, 0);
-  }
-  rotateY(a) {
-    this.rotate(a, 0, 1, 0);
-  }
-  rotateZ(a) {
-    this.rotate(a, 0, 0, 1);
-  }
-
-  /**
- * sets the perspective matrix
- * @param  {Number} fovy   [description]
- * @param  {Number} aspect [description]
- * @param  {Number} near   near clipping plane
- * @param  {Number} far    far clipping plane
- * @chainable
- */
-  perspective(fovy, aspect, near, far) {
-    const f = 1.0 / Math.tan(fovy / 2),
-      nf = 1 / (near - far);
-
-    this.mat4[0] = f / aspect;
-    this.mat4[1] = 0;
-    this.mat4[2] = 0;
-    this.mat4[3] = 0;
-    this.mat4[4] = 0;
-    this.mat4[5] = f;
-    this.mat4[6] = 0;
-    this.mat4[7] = 0;
-    this.mat4[8] = 0;
-    this.mat4[9] = 0;
-    this.mat4[10] = (far + near) * nf;
-    this.mat4[11] = -1;
-    this.mat4[12] = 0;
-    this.mat4[13] = 0;
-    this.mat4[14] = 2 * far * near * nf;
-    this.mat4[15] = 0;
-
-    return this;
-  }
-
-  /**
- * sets the ortho matrix
- * @param  {Number} left   [description]
- * @param  {Number} right  [description]
- * @param  {Number} bottom [description]
- * @param  {Number} top    [description]
- * @param  {Number} near   near clipping plane
- * @param  {Number} far    far clipping plane
- * @chainable
- */
-  ortho(left, right, bottom, top, near, far) {
-    const lr = 1 / (left - right),
-      bt = 1 / (bottom - top),
-      nf = 1 / (near - far);
-    this.mat4[0] = -2 * lr;
-    this.mat4[1] = 0;
-    this.mat4[2] = 0;
-    this.mat4[3] = 0;
-    this.mat4[4] = 0;
-    this.mat4[5] = -2 * bt;
-    this.mat4[6] = 0;
-    this.mat4[7] = 0;
-    this.mat4[8] = 0;
-    this.mat4[9] = 0;
-    this.mat4[10] = 2 * nf;
-    this.mat4[11] = 0;
-    this.mat4[12] = (left + right) * lr;
-    this.mat4[13] = (top + bottom) * bt;
-    this.mat4[14] = (far + near) * nf;
-    this.mat4[15] = 1;
-
-    return this;
-  }
-
-  /**
- * apply a matrix to a vector with x,y,z,w components
- * get the results in the form of an array
- * @param {Number}
- * @return {Number[]}
- */
-  multiplyVec4(x, y, z, w) {
-    const result = new Array(4);
-    const m = this.mat4;
-
-    result[0] = m[0] * x + m[4] * y + m[8] * z + m[12] * w;
-    result[1] = m[1] * x + m[5] * y + m[9] * z + m[13] * w;
-    result[2] = m[2] * x + m[6] * y + m[10] * z + m[14] * w;
-    result[3] = m[3] * x + m[7] * y + m[11] * z + m[15] * w;
-
-    return result;
-  }
-
-  /**
- * Applies a matrix to a vector.
- * The fourth component is set to 1.
- * Returns a vector consisting of the first
- * through third components of the result.
- *
- * @param {p5.Vector}
- * @return {p5.Vector}
- */
-  multiplyPoint({ x, y, z }) {
-    const array = this.multiplyVec4(x, y, z, 1);
-    return new p5.Vector(array[0], array[1], array[2]);
-  }
-
-  /**
- * Applies a matrix to a vector.
- * The fourth component is set to 1.
- * Returns the result of dividing the 1st to 3rd components
- * of the result by the 4th component as a vector.
- *
- * @param {p5.Vector}
- * @return {p5.Vector}
- */
-  multiplyAndNormalizePoint({ x, y, z }) {
-    const array = this.multiplyVec4(x, y, z, 1);
-    array[0] /= array[3];
-    array[1] /= array[3];
-    array[2] /= array[3];
-    return new p5.Vector(array[0], array[1], array[2]);
-  }
-
-  /**
- * Applies a matrix to a vector.
- * The fourth component is set to 0.
- * Returns a vector consisting of the first
- * through third components of the result.
- *
- * @param {p5.Vector}
- * @return {p5.Vector}
- */
-  multiplyDirection({ x, y, z }) {
-    const array = this.multiplyVec4(x, y, z, 0);
-    return new p5.Vector(array[0], array[1], array[2]);
-  }
-
-  /**
- * This function is only for 3x3 matrices.
- * multiply two mat3s. It is an operation to multiply the 3x3 matrix of
- * the argument from the right. Arguments can be a 3x3 p5.Matrix,
- * a Float32Array of length 9, or a javascript array of length 9.
- * In addition, it can also be done by enumerating 9 numbers.
- *
- * @param {p5.Matrix|Float32Array|Number[]} multMatrix The matrix
- *                                                we want to multiply by
- * @chainable
- */
-  mult3x3(multMatrix) {
-    let _src;
-
-    if (multMatrix === this || multMatrix === this.mat3) {
-      _src = this.copy().mat3; // only need to allocate in this rare case
-    } else if (multMatrix instanceof p5.Matrix) {
-      _src = multMatrix.mat3;
-    } else if (isMatrixArray(multMatrix)) {
-      _src = multMatrix;
-    } else if (arguments.length === 9) {
-      _src = arguments;
-    } else {
-      return; // nothing to do.
+    clone() {
+      return this.copy();
     }
 
-    // each row is used for the multiplier
-    let b0 = this.mat3[0];
-    let b1 = this.mat3[1];
-    let b2 = this.mat3[2];
-    this.mat3[0] = b0 * _src[0] + b1 * _src[3] + b2 * _src[6];
-    this.mat3[1] = b0 * _src[1] + b1 * _src[4] + b2 * _src[7];
-    this.mat3[2] = b0 * _src[2] + b1 * _src[5] + b2 * _src[8];
-
-    b0 = this.mat3[3];
-    b1 = this.mat3[4];
-    b2 = this.mat3[5];
-    this.mat3[3] = b0 * _src[0] + b1 * _src[3] + b2 * _src[6];
-    this.mat3[4] = b0 * _src[1] + b1 * _src[4] + b2 * _src[7];
-    this.mat3[5] = b0 * _src[2] + b1 * _src[5] + b2 * _src[8];
-
-    b0 = this.mat3[6];
-    b1 = this.mat3[7];
-    b2 = this.mat3[8];
-    this.mat3[6] = b0 * _src[0] + b1 * _src[3] + b2 * _src[6];
-    this.mat3[7] = b0 * _src[1] + b1 * _src[4] + b2 * _src[7];
-    this.mat3[8] = b0 * _src[2] + b1 * _src[5] + b2 * _src[8];
-
-    return this;
-  }
-
-  /**
- * This function is only for 3x3 matrices.
- * A function that returns a column vector of a 3x3 matrix.
- *
- * @param {Number} columnIndex matrix column number
- * @return {p5.Vector}
- */
-  column(columnIndex) {
-    return new p5.Vector(
-      this.mat3[3 * columnIndex],
-      this.mat3[3 * columnIndex + 1],
-      this.mat3[3 * columnIndex + 2]
-    );
-  }
-
-  /**
- * This function is only for 3x3 matrices.
- * A function that returns a row vector of a 3x3 matrix.
- *
- * @param {Number} rowIndex matrix row number
- * @return {p5.Vector}
- */
-  row(rowIndex) {
-    return new p5.Vector(
-      this.mat3[rowIndex],
-      this.mat3[rowIndex + 3],
-      this.mat3[rowIndex + 6]
-    );
-  }
-
-  /**
- * Returns the diagonal elements of the matrix in the form of an array.
- * A 3x3 matrix will return an array of length 3.
- * A 4x4 matrix will return an array of length 4.
- *
- * @return {Number[]} An array obtained by arranging the diagonal elements
- *                    of the matrix in ascending order of index
- */
-  diagonal() {
-    if (this.mat3 !== undefined) {
-      return [this.mat3[0], this.mat3[4], this.mat3[8]];
+    /**
+   * return an identity matrix
+   * @return {p5.Matrix}   the result matrix
+   */
+    static identity(pInst){
+      return new p5.Matrix(pInst);
     }
-    return [this.mat4[0], this.mat4[5], this.mat4[10], this.mat4[15]];
-  }
 
-  /**
- * This function is only for 3x3 matrices.
- * Takes a vector and returns the vector resulting from multiplying to
- * that vector by this matrix from left.
- *
- * @param {p5.Vector} multVector the vector to which this matrix applies
- * @param {p5.Vector} [target] The vector to receive the result
- * @return {p5.Vector}
- */
-  multiplyVec3(multVector, target) {
-    if (target === undefined) {
-      target = multVector.copy();
+    /**
+   * transpose according to a given matrix
+   * @param  {p5.Matrix|Float32Array|Number[]} a  the matrix to be
+   *                                               based on to transpose
+   * @chainable
+   */
+    transpose(a) {
+      let a01, a02, a03, a12, a13, a23;
+      if (a instanceof p5.Matrix) {
+        a01 = a.mat4[1];
+        a02 = a.mat4[2];
+        a03 = a.mat4[3];
+        a12 = a.mat4[6];
+        a13 = a.mat4[7];
+        a23 = a.mat4[11];
+
+        this.mat4[0] = a.mat4[0];
+        this.mat4[1] = a.mat4[4];
+        this.mat4[2] = a.mat4[8];
+        this.mat4[3] = a.mat4[12];
+        this.mat4[4] = a01;
+        this.mat4[5] = a.mat4[5];
+        this.mat4[6] = a.mat4[9];
+        this.mat4[7] = a.mat4[13];
+        this.mat4[8] = a02;
+        this.mat4[9] = a12;
+        this.mat4[10] = a.mat4[10];
+        this.mat4[11] = a.mat4[14];
+        this.mat4[12] = a03;
+        this.mat4[13] = a13;
+        this.mat4[14] = a23;
+        this.mat4[15] = a.mat4[15];
+      } else if (isMatrixArray(a)) {
+        a01 = a[1];
+        a02 = a[2];
+        a03 = a[3];
+        a12 = a[6];
+        a13 = a[7];
+        a23 = a[11];
+
+        this.mat4[0] = a[0];
+        this.mat4[1] = a[4];
+        this.mat4[2] = a[8];
+        this.mat4[3] = a[12];
+        this.mat4[4] = a01;
+        this.mat4[5] = a[5];
+        this.mat4[6] = a[9];
+        this.mat4[7] = a[13];
+        this.mat4[8] = a02;
+        this.mat4[9] = a12;
+        this.mat4[10] = a[10];
+        this.mat4[11] = a[14];
+        this.mat4[12] = a03;
+        this.mat4[13] = a13;
+        this.mat4[14] = a23;
+        this.mat4[15] = a[15];
+      }
+      return this;
     }
-    target.x = this.row(0).dot(multVector);
-    target.y = this.row(1).dot(multVector);
-    target.z = this.row(2).dot(multVector);
-    return target;
-  }
 
-  /**
- * This function is only for 4x4 matrices.
- * Creates a 3x3 matrix whose entries are the top left 3x3 part and returns it.
- *
- * @return {p5.Matrix}
- */
-  createSubMatrix3x3() {
-    const result = new p5.Matrix('mat3');
-    result.mat3[0] = this.mat4[0];
-    result.mat3[1] = this.mat4[1];
-    result.mat3[2] = this.mat4[2];
-    result.mat3[3] = this.mat4[4];
-    result.mat3[4] = this.mat4[5];
-    result.mat3[5] = this.mat4[6];
-    result.mat3[6] = this.mat4[8];
-    result.mat3[7] = this.mat4[9];
-    result.mat3[8] = this.mat4[10];
-    return result;
-  }
+    /**
+   * invert  matrix according to a give matrix
+   * @param  {p5.Matrix|Float32Array|Number[]} a   the matrix to be
+   *                                                based on to invert
+   * @chainable
+   */
+    invert(a) {
+      let a00, a01, a02, a03, a10, a11, a12, a13;
+      let a20, a21, a22, a23, a30, a31, a32, a33;
+      if (a instanceof p5.Matrix) {
+        a00 = a.mat4[0];
+        a01 = a.mat4[1];
+        a02 = a.mat4[2];
+        a03 = a.mat4[3];
+        a10 = a.mat4[4];
+        a11 = a.mat4[5];
+        a12 = a.mat4[6];
+        a13 = a.mat4[7];
+        a20 = a.mat4[8];
+        a21 = a.mat4[9];
+        a22 = a.mat4[10];
+        a23 = a.mat4[11];
+        a30 = a.mat4[12];
+        a31 = a.mat4[13];
+        a32 = a.mat4[14];
+        a33 = a.mat4[15];
+      } else if (isMatrixArray(a)) {
+        a00 = a[0];
+        a01 = a[1];
+        a02 = a[2];
+        a03 = a[3];
+        a10 = a[4];
+        a11 = a[5];
+        a12 = a[6];
+        a13 = a[7];
+        a20 = a[8];
+        a21 = a[9];
+        a22 = a[10];
+        a23 = a[11];
+        a30 = a[12];
+        a31 = a[13];
+        a32 = a[14];
+        a33 = a[15];
+      }
+      const b00 = a00 * a11 - a01 * a10;
+      const b01 = a00 * a12 - a02 * a10;
+      const b02 = a00 * a13 - a03 * a10;
+      const b03 = a01 * a12 - a02 * a11;
+      const b04 = a01 * a13 - a03 * a11;
+      const b05 = a02 * a13 - a03 * a12;
+      const b06 = a20 * a31 - a21 * a30;
+      const b07 = a20 * a32 - a22 * a30;
+      const b08 = a20 * a33 - a23 * a30;
+      const b09 = a21 * a32 - a22 * a31;
+      const b10 = a21 * a33 - a23 * a31;
+      const b11 = a22 * a33 - a23 * a32;
 
-  /**
- * PRIVATE
- */
-  // matrix methods adapted from:
-  // https://developer.mozilla.org/en-US/docs/Web/WebGL/
-  // gluPerspective
-  //
-  // function _makePerspective(fovy, aspect, znear, zfar){
-  //    const ymax = znear * Math.tan(fovy * Math.PI / 360.0);
-  //    const ymin = -ymax;
-  //    const xmin = ymin * aspect;
-  //    const xmax = ymax * aspect;
-  //    return _makeFrustum(xmin, xmax, ymin, ymax, znear, zfar);
-  //  }
+      // Calculate the determinant
+      let det =
+      b00 * b11 - b01 * b10 + b02 * b09 + b03 * b08 - b04 * b07 + b05 * b06;
 
-  ////
-  //// glFrustum
-  ////
-  //function _makeFrustum(left, right, bottom, top, znear, zfar){
-  //  const X = 2*znear/(right-left);
-  //  const Y = 2*znear/(top-bottom);
-  //  const A = (right+left)/(right-left);
-  //  const B = (top+bottom)/(top-bottom);
-  //  const C = -(zfar+znear)/(zfar-znear);
-  //  const D = -2*zfar*znear/(zfar-znear);
-  //  const frustrumMatrix =[
-  //  X, 0, A, 0,
-  //  0, Y, B, 0,
-  //  0, 0, C, D,
-  //  0, 0, -1, 0
+      if (!det) {
+        return null;
+      }
+      det = 1.0 / det;
+
+      this.mat4[0] = (a11 * b11 - a12 * b10 + a13 * b09) * det;
+      this.mat4[1] = (a02 * b10 - a01 * b11 - a03 * b09) * det;
+      this.mat4[2] = (a31 * b05 - a32 * b04 + a33 * b03) * det;
+      this.mat4[3] = (a22 * b04 - a21 * b05 - a23 * b03) * det;
+      this.mat4[4] = (a12 * b08 - a10 * b11 - a13 * b07) * det;
+      this.mat4[5] = (a00 * b11 - a02 * b08 + a03 * b07) * det;
+      this.mat4[6] = (a32 * b02 - a30 * b05 - a33 * b01) * det;
+      this.mat4[7] = (a20 * b05 - a22 * b02 + a23 * b01) * det;
+      this.mat4[8] = (a10 * b10 - a11 * b08 + a13 * b06) * det;
+      this.mat4[9] = (a01 * b08 - a00 * b10 - a03 * b06) * det;
+      this.mat4[10] = (a30 * b04 - a31 * b02 + a33 * b00) * det;
+      this.mat4[11] = (a21 * b02 - a20 * b04 - a23 * b00) * det;
+      this.mat4[12] = (a11 * b07 - a10 * b09 - a12 * b06) * det;
+      this.mat4[13] = (a00 * b09 - a01 * b07 + a02 * b06) * det;
+      this.mat4[14] = (a31 * b01 - a30 * b03 - a32 * b00) * det;
+      this.mat4[15] = (a20 * b03 - a21 * b01 + a22 * b00) * det;
+
+      return this;
+    }
+
+    /**
+   * Inverts a 3×3 matrix
+   * @chainable
+   */
+    invert3x3() {
+      const a00 = this.mat3[0];
+      const a01 = this.mat3[1];
+      const a02 = this.mat3[2];
+      const a10 = this.mat3[3];
+      const a11 = this.mat3[4];
+      const a12 = this.mat3[5];
+      const a20 = this.mat3[6];
+      const a21 = this.mat3[7];
+      const a22 = this.mat3[8];
+      const b01 = a22 * a11 - a12 * a21;
+      const b11 = -a22 * a10 + a12 * a20;
+      const b21 = a21 * a10 - a11 * a20;
+
+      // Calculate the determinant
+      let det = a00 * b01 + a01 * b11 + a02 * b21;
+      if (!det) {
+        return null;
+      }
+      det = 1.0 / det;
+      this.mat3[0] = b01 * det;
+      this.mat3[1] = (-a22 * a01 + a02 * a21) * det;
+      this.mat3[2] = (a12 * a01 - a02 * a11) * det;
+      this.mat3[3] = b11 * det;
+      this.mat3[4] = (a22 * a00 - a02 * a20) * det;
+      this.mat3[5] = (-a12 * a00 + a02 * a10) * det;
+      this.mat3[6] = b21 * det;
+      this.mat3[7] = (-a21 * a00 + a01 * a20) * det;
+      this.mat3[8] = (a11 * a00 - a01 * a10) * det;
+      return this;
+    }
+
+    /**
+   * This function is only for 3x3 matrices.
+   * transposes a 3×3 p5.Matrix by a mat3
+   * If there is an array of arguments, the matrix obtained by transposing
+   * the 3x3 matrix generated based on that array is set.
+   * If no arguments, it transposes itself and returns it.
+   *
+   * @param  {Number[]} mat3 1-dimensional array
+   * @chainable
+   */
+    transpose3x3(mat3) {
+      if (mat3 === undefined) {
+        mat3 = this.mat3;
+      }
+      const a01 = mat3[1];
+      const a02 = mat3[2];
+      const a12 = mat3[5];
+      this.mat3[0] = mat3[0];
+      this.mat3[1] = mat3[3];
+      this.mat3[2] = mat3[6];
+      this.mat3[3] = a01;
+      this.mat3[4] = mat3[4];
+      this.mat3[5] = mat3[7];
+      this.mat3[6] = a02;
+      this.mat3[7] = a12;
+      this.mat3[8] = mat3[8];
+
+      return this;
+    }
+
+    /**
+   * converts a 4×4 matrix to its 3×3 inverse transform
+   * commonly used in MVMatrix to NMatrix conversions.
+   * @param  {p5.Matrix} mat4 the matrix to be based on to invert
+   * @chainable
+   * @todo  finish implementation
+   */
+    inverseTranspose({ mat4 }) {
+      if (this.mat3 === undefined) {
+        p5._friendlyError('sorry, this function only works with mat3');
+      } else {
+      //convert mat4 -> mat3
+        this.mat3[0] = mat4[0];
+        this.mat3[1] = mat4[1];
+        this.mat3[2] = mat4[2];
+        this.mat3[3] = mat4[4];
+        this.mat3[4] = mat4[5];
+        this.mat3[5] = mat4[6];
+        this.mat3[6] = mat4[8];
+        this.mat3[7] = mat4[9];
+        this.mat3[8] = mat4[10];
+      }
+
+      const inverse = this.invert3x3();
+      // check inverse succeeded
+      if (inverse) {
+        inverse.transpose3x3(this.mat3);
+      } else {
+      // in case of singularity, just zero the matrix
+        for (let i = 0; i < 9; i++) {
+          this.mat3[i] = 0;
+        }
+      }
+      return this;
+    }
+
+    /**
+   * inspired by Toji's mat4 determinant
+   * @return {Number} Determinant of our 4×4 matrix
+   */
+    determinant() {
+      const d00 = this.mat4[0] * this.mat4[5] - this.mat4[1] * this.mat4[4],
+        d01 = this.mat4[0] * this.mat4[6] - this.mat4[2] * this.mat4[4],
+        d02 = this.mat4[0] * this.mat4[7] - this.mat4[3] * this.mat4[4],
+        d03 = this.mat4[1] * this.mat4[6] - this.mat4[2] * this.mat4[5],
+        d04 = this.mat4[1] * this.mat4[7] - this.mat4[3] * this.mat4[5],
+        d05 = this.mat4[2] * this.mat4[7] - this.mat4[3] * this.mat4[6],
+        d06 = this.mat4[8] * this.mat4[13] - this.mat4[9] * this.mat4[12],
+        d07 = this.mat4[8] * this.mat4[14] - this.mat4[10] * this.mat4[12],
+        d08 = this.mat4[8] * this.mat4[15] - this.mat4[11] * this.mat4[12],
+        d09 = this.mat4[9] * this.mat4[14] - this.mat4[10] * this.mat4[13],
+        d10 = this.mat4[9] * this.mat4[15] - this.mat4[11] * this.mat4[13],
+        d11 = this.mat4[10] * this.mat4[15] - this.mat4[11] * this.mat4[14];
+
+      // Calculate the determinant
+      return d00 * d11 - d01 * d10 + d02 * d09 +
+      d03 * d08 - d04 * d07 + d05 * d06;
+    }
+
+    /**
+   * multiply two mat4s
+   * @param {p5.Matrix|Float32Array|Number[]} multMatrix The matrix
+   *                                                we want to multiply by
+   * @chainable
+   */
+    mult(multMatrix) {
+      let _src;
+
+      if (multMatrix === this || multMatrix === this.mat4) {
+        _src = this.copy().mat4; // only need to allocate in this rare case
+      } else if (multMatrix instanceof p5.Matrix) {
+        _src = multMatrix.mat4;
+      } else if (isMatrixArray(multMatrix)) {
+        _src = multMatrix;
+      } else if (arguments.length === 16) {
+        _src = arguments;
+      } else {
+        return; // nothing to do.
+      }
+
+      // each row is used for the multiplier
+      let b0 = this.mat4[0],
+        b1 = this.mat4[1],
+        b2 = this.mat4[2],
+        b3 = this.mat4[3];
+      this.mat4[0] = b0 * _src[0] + b1 * _src[4] + b2 * _src[8] + b3 * _src[12];
+      this.mat4[1] = b0 * _src[1] + b1 * _src[5] + b2 * _src[9] + b3 * _src[13];
+      this.mat4[2] = b0 * _src[2] + b1 * _src[6] + b2 * _src[10] + b3 * _src[14];
+      this.mat4[3] = b0 * _src[3] + b1 * _src[7] + b2 * _src[11] + b3 * _src[15];
+
+      b0 = this.mat4[4];
+      b1 = this.mat4[5];
+      b2 = this.mat4[6];
+      b3 = this.mat4[7];
+      this.mat4[4] = b0 * _src[0] + b1 * _src[4] + b2 * _src[8] + b3 * _src[12];
+      this.mat4[5] = b0 * _src[1] + b1 * _src[5] + b2 * _src[9] + b3 * _src[13];
+      this.mat4[6] = b0 * _src[2] + b1 * _src[6] + b2 * _src[10] + b3 * _src[14];
+      this.mat4[7] = b0 * _src[3] + b1 * _src[7] + b2 * _src[11] + b3 * _src[15];
+
+      b0 = this.mat4[8];
+      b1 = this.mat4[9];
+      b2 = this.mat4[10];
+      b3 = this.mat4[11];
+      this.mat4[8] = b0 * _src[0] + b1 * _src[4] + b2 * _src[8] + b3 * _src[12];
+      this.mat4[9] = b0 * _src[1] + b1 * _src[5] + b2 * _src[9] + b3 * _src[13];
+      this.mat4[10] = b0 * _src[2] + b1 * _src[6] + b2 * _src[10] + b3 * _src[14];
+      this.mat4[11] = b0 * _src[3] + b1 * _src[7] + b2 * _src[11] + b3 * _src[15];
+
+      b0 = this.mat4[12];
+      b1 = this.mat4[13];
+      b2 = this.mat4[14];
+      b3 = this.mat4[15];
+      this.mat4[12] = b0 * _src[0] + b1 * _src[4] + b2 * _src[8] + b3 * _src[12];
+      this.mat4[13] = b0 * _src[1] + b1 * _src[5] + b2 * _src[9] + b3 * _src[13];
+      this.mat4[14] = b0 * _src[2] + b1 * _src[6] + b2 * _src[10] + b3 * _src[14];
+      this.mat4[15] = b0 * _src[3] + b1 * _src[7] + b2 * _src[11] + b3 * _src[15];
+
+      return this;
+    }
+
+    apply(multMatrix) {
+      let _src;
+
+      if (multMatrix === this || multMatrix === this.mat4) {
+        _src = this.copy().mat4; // only need to allocate in this rare case
+      } else if (multMatrix instanceof p5.Matrix) {
+        _src = multMatrix.mat4;
+      } else if (isMatrixArray(multMatrix)) {
+        _src = multMatrix;
+      } else if (arguments.length === 16) {
+        _src = arguments;
+      } else {
+        return; // nothing to do.
+      }
+
+      const mat4 = this.mat4;
+
+      // each row is used for the multiplier
+      const m0 = mat4[0];
+      const m4 = mat4[4];
+      const m8 = mat4[8];
+      const m12 = mat4[12];
+      mat4[0] = _src[0] * m0 + _src[1] * m4 + _src[2] * m8 + _src[3] * m12;
+      mat4[4] = _src[4] * m0 + _src[5] * m4 + _src[6] * m8 + _src[7] * m12;
+      mat4[8] = _src[8] * m0 + _src[9] * m4 + _src[10] * m8 + _src[11] * m12;
+      mat4[12] = _src[12] * m0 + _src[13] * m4 + _src[14] * m8 + _src[15] * m12;
+
+      const m1 = mat4[1];
+      const m5 = mat4[5];
+      const m9 = mat4[9];
+      const m13 = mat4[13];
+      mat4[1] = _src[0] * m1 + _src[1] * m5 + _src[2] * m9 + _src[3] * m13;
+      mat4[5] = _src[4] * m1 + _src[5] * m5 + _src[6] * m9 + _src[7] * m13;
+      mat4[9] = _src[8] * m1 + _src[9] * m5 + _src[10] * m9 + _src[11] * m13;
+      mat4[13] = _src[12] * m1 + _src[13] * m5 + _src[14] * m9 + _src[15] * m13;
+
+      const m2 = mat4[2];
+      const m6 = mat4[6];
+      const m10 = mat4[10];
+      const m14 = mat4[14];
+      mat4[2] = _src[0] * m2 + _src[1] * m6 + _src[2] * m10 + _src[3] * m14;
+      mat4[6] = _src[4] * m2 + _src[5] * m6 + _src[6] * m10 + _src[7] * m14;
+      mat4[10] = _src[8] * m2 + _src[9] * m6 + _src[10] * m10 + _src[11] * m14;
+      mat4[14] = _src[12] * m2 + _src[13] * m6 + _src[14] * m10 + _src[15] * m14;
+
+      const m3 = mat4[3];
+      const m7 = mat4[7];
+      const m11 = mat4[11];
+      const m15 = mat4[15];
+      mat4[3] = _src[0] * m3 + _src[1] * m7 + _src[2] * m11 + _src[3] * m15;
+      mat4[7] = _src[4] * m3 + _src[5] * m7 + _src[6] * m11 + _src[7] * m15;
+      mat4[11] = _src[8] * m3 + _src[9] * m7 + _src[10] * m11 + _src[11] * m15;
+      mat4[15] = _src[12] * m3 + _src[13] * m7 + _src[14] * m11 + _src[15] * m15;
+
+      return this;
+    }
+
+    /**
+   * scales a p5.Matrix by scalars or a vector
+   * @param  {p5.Vector|Float32Array|Number[]} s vector to scale by
+   * @chainable
+   */
+    scale(x, y, z) {
+      if (x instanceof p5.Vector) {
+      // x is a vector, extract the components from it.
+        y = x.y;
+        z = x.z;
+        x = x.x; // must be last
+      } else if (x instanceof Array) {
+      // x is an array, extract the components from it.
+        y = x[1];
+        z = x[2];
+        x = x[0]; // must be last
+      }
+
+      this.mat4[0] *= x;
+      this.mat4[1] *= x;
+      this.mat4[2] *= x;
+      this.mat4[3] *= x;
+      this.mat4[4] *= y;
+      this.mat4[5] *= y;
+      this.mat4[6] *= y;
+      this.mat4[7] *= y;
+      this.mat4[8] *= z;
+      this.mat4[9] *= z;
+      this.mat4[10] *= z;
+      this.mat4[11] *= z;
+
+      return this;
+    }
+
+    /**
+   * rotate our Matrix around an axis by the given angle.
+   * @param  {Number} a The angle of rotation in radians
+   * @param  {p5.Vector|Number[]} axis  the axis(es) to rotate around
+   * @chainable
+   * inspired by Toji's gl-matrix lib, mat4 rotation
+   */
+    rotate(a, x, y, z) {
+      if (x instanceof p5.Vector) {
+      // x is a vector, extract the components from it.
+        y = x.y;
+        z = x.z;
+        x = x.x; //must be last
+      } else if (x instanceof Array) {
+      // x is an array, extract the components from it.
+        y = x[1];
+        z = x[2];
+        x = x[0]; //must be last
+      }
+
+      const len = Math.sqrt(x * x + y * y + z * z);
+      x *= 1 / len;
+      y *= 1 / len;
+      z *= 1 / len;
+
+      const a00 = this.mat4[0];
+      const a01 = this.mat4[1];
+      const a02 = this.mat4[2];
+      const a03 = this.mat4[3];
+      const a10 = this.mat4[4];
+      const a11 = this.mat4[5];
+      const a12 = this.mat4[6];
+      const a13 = this.mat4[7];
+      const a20 = this.mat4[8];
+      const a21 = this.mat4[9];
+      const a22 = this.mat4[10];
+      const a23 = this.mat4[11];
+
+      //sin,cos, and tan of respective angle
+      const sA = Math.sin(a);
+      const cA = Math.cos(a);
+      const tA = 1 - cA;
+      // Construct the elements of the rotation matrix
+      const b00 = x * x * tA + cA;
+      const b01 = y * x * tA + z * sA;
+      const b02 = z * x * tA - y * sA;
+      const b10 = x * y * tA - z * sA;
+      const b11 = y * y * tA + cA;
+      const b12 = z * y * tA + x * sA;
+      const b20 = x * z * tA + y * sA;
+      const b21 = y * z * tA - x * sA;
+      const b22 = z * z * tA + cA;
+
+      // rotation-specific matrix multiplication
+      this.mat4[0] = a00 * b00 + a10 * b01 + a20 * b02;
+      this.mat4[1] = a01 * b00 + a11 * b01 + a21 * b02;
+      this.mat4[2] = a02 * b00 + a12 * b01 + a22 * b02;
+      this.mat4[3] = a03 * b00 + a13 * b01 + a23 * b02;
+      this.mat4[4] = a00 * b10 + a10 * b11 + a20 * b12;
+      this.mat4[5] = a01 * b10 + a11 * b11 + a21 * b12;
+      this.mat4[6] = a02 * b10 + a12 * b11 + a22 * b12;
+      this.mat4[7] = a03 * b10 + a13 * b11 + a23 * b12;
+      this.mat4[8] = a00 * b20 + a10 * b21 + a20 * b22;
+      this.mat4[9] = a01 * b20 + a11 * b21 + a21 * b22;
+      this.mat4[10] = a02 * b20 + a12 * b21 + a22 * b22;
+      this.mat4[11] = a03 * b20 + a13 * b21 + a23 * b22;
+
+      return this;
+    }
+
+    /**
+   * @todo  finish implementing this method!
+   * translates
+   * @param  {Number[]} v vector to translate by
+   * @chainable
+   */
+    translate(v) {
+      const x = v[0],
+        y = v[1],
+        z = v[2] || 0;
+      this.mat4[12] += this.mat4[0] * x + this.mat4[4] * y + this.mat4[8] * z;
+      this.mat4[13] += this.mat4[1] * x + this.mat4[5] * y + this.mat4[9] * z;
+      this.mat4[14] += this.mat4[2] * x + this.mat4[6] * y + this.mat4[10] * z;
+      this.mat4[15] += this.mat4[3] * x + this.mat4[7] * y + this.mat4[11] * z;
+    }
+
+    rotateX(a) {
+      this.rotate(a, 1, 0, 0);
+    }
+    rotateY(a) {
+      this.rotate(a, 0, 1, 0);
+    }
+    rotateZ(a) {
+      this.rotate(a, 0, 0, 1);
+    }
+
+    /**
+   * sets the perspective matrix
+   * @param  {Number} fovy   [description]
+   * @param  {Number} aspect [description]
+   * @param  {Number} near   near clipping plane
+   * @param  {Number} far    far clipping plane
+   * @chainable
+   */
+    perspective(fovy, aspect, near, far) {
+      const f = 1.0 / Math.tan(fovy / 2),
+        nf = 1 / (near - far);
+
+      this.mat4[0] = f / aspect;
+      this.mat4[1] = 0;
+      this.mat4[2] = 0;
+      this.mat4[3] = 0;
+      this.mat4[4] = 0;
+      this.mat4[5] = f;
+      this.mat4[6] = 0;
+      this.mat4[7] = 0;
+      this.mat4[8] = 0;
+      this.mat4[9] = 0;
+      this.mat4[10] = (far + near) * nf;
+      this.mat4[11] = -1;
+      this.mat4[12] = 0;
+      this.mat4[13] = 0;
+      this.mat4[14] = 2 * far * near * nf;
+      this.mat4[15] = 0;
+
+      return this;
+    }
+
+    /**
+   * sets the ortho matrix
+   * @param  {Number} left   [description]
+   * @param  {Number} right  [description]
+   * @param  {Number} bottom [description]
+   * @param  {Number} top    [description]
+   * @param  {Number} near   near clipping plane
+   * @param  {Number} far    far clipping plane
+   * @chainable
+   */
+    ortho(left, right, bottom, top, near, far) {
+      const lr = 1 / (left - right),
+        bt = 1 / (bottom - top),
+        nf = 1 / (near - far);
+      this.mat4[0] = -2 * lr;
+      this.mat4[1] = 0;
+      this.mat4[2] = 0;
+      this.mat4[3] = 0;
+      this.mat4[4] = 0;
+      this.mat4[5] = -2 * bt;
+      this.mat4[6] = 0;
+      this.mat4[7] = 0;
+      this.mat4[8] = 0;
+      this.mat4[9] = 0;
+      this.mat4[10] = 2 * nf;
+      this.mat4[11] = 0;
+      this.mat4[12] = (left + right) * lr;
+      this.mat4[13] = (top + bottom) * bt;
+      this.mat4[14] = (far + near) * nf;
+      this.mat4[15] = 1;
+
+      return this;
+    }
+
+    /**
+   * apply a matrix to a vector with x,y,z,w components
+   * get the results in the form of an array
+   * @param {Number}
+   * @return {Number[]}
+   */
+    multiplyVec4(x, y, z, w) {
+      const result = new Array(4);
+      const m = this.mat4;
+
+      result[0] = m[0] * x + m[4] * y + m[8] * z + m[12] * w;
+      result[1] = m[1] * x + m[5] * y + m[9] * z + m[13] * w;
+      result[2] = m[2] * x + m[6] * y + m[10] * z + m[14] * w;
+      result[3] = m[3] * x + m[7] * y + m[11] * z + m[15] * w;
+
+      return result;
+    }
+
+    /**
+   * Applies a matrix to a vector.
+   * The fourth component is set to 1.
+   * Returns a vector consisting of the first
+   * through third components of the result.
+   *
+   * @param {p5.Vector}
+   * @return {p5.Vector}
+   */
+    multiplyPoint({ x, y, z }) {
+      const array = this.multiplyVec4(x, y, z, 1);
+      return new p5.Vector(array[0], array[1], array[2]);
+    }
+
+    /**
+   * Applies a matrix to a vector.
+   * The fourth component is set to 1.
+   * Returns the result of dividing the 1st to 3rd components
+   * of the result by the 4th component as a vector.
+   *
+   * @param {p5.Vector}
+   * @return {p5.Vector}
+   */
+    multiplyAndNormalizePoint({ x, y, z }) {
+      const array = this.multiplyVec4(x, y, z, 1);
+      array[0] /= array[3];
+      array[1] /= array[3];
+      array[2] /= array[3];
+      return new p5.Vector(array[0], array[1], array[2]);
+    }
+
+    /**
+   * Applies a matrix to a vector.
+   * The fourth component is set to 0.
+   * Returns a vector consisting of the first
+   * through third components of the result.
+   *
+   * @param {p5.Vector}
+   * @return {p5.Vector}
+   */
+    multiplyDirection({ x, y, z }) {
+      const array = this.multiplyVec4(x, y, z, 0);
+      return new p5.Vector(array[0], array[1], array[2]);
+    }
+
+    /**
+   * This function is only for 3x3 matrices.
+   * multiply two mat3s. It is an operation to multiply the 3x3 matrix of
+   * the argument from the right. Arguments can be a 3x3 p5.Matrix,
+   * a Float32Array of length 9, or a javascript array of length 9.
+   * In addition, it can also be done by enumerating 9 numbers.
+   *
+   * @param {p5.Matrix|Float32Array|Number[]} multMatrix The matrix
+   *                                                we want to multiply by
+   * @chainable
+   */
+    mult3x3(multMatrix) {
+      let _src;
+
+      if (multMatrix === this || multMatrix === this.mat3) {
+        _src = this.copy().mat3; // only need to allocate in this rare case
+      } else if (multMatrix instanceof p5.Matrix) {
+        _src = multMatrix.mat3;
+      } else if (isMatrixArray(multMatrix)) {
+        _src = multMatrix;
+      } else if (arguments.length === 9) {
+        _src = arguments;
+      } else {
+        return; // nothing to do.
+      }
+
+      // each row is used for the multiplier
+      let b0 = this.mat3[0];
+      let b1 = this.mat3[1];
+      let b2 = this.mat3[2];
+      this.mat3[0] = b0 * _src[0] + b1 * _src[3] + b2 * _src[6];
+      this.mat3[1] = b0 * _src[1] + b1 * _src[4] + b2 * _src[7];
+      this.mat3[2] = b0 * _src[2] + b1 * _src[5] + b2 * _src[8];
+
+      b0 = this.mat3[3];
+      b1 = this.mat3[4];
+      b2 = this.mat3[5];
+      this.mat3[3] = b0 * _src[0] + b1 * _src[3] + b2 * _src[6];
+      this.mat3[4] = b0 * _src[1] + b1 * _src[4] + b2 * _src[7];
+      this.mat3[5] = b0 * _src[2] + b1 * _src[5] + b2 * _src[8];
+
+      b0 = this.mat3[6];
+      b1 = this.mat3[7];
+      b2 = this.mat3[8];
+      this.mat3[6] = b0 * _src[0] + b1 * _src[3] + b2 * _src[6];
+      this.mat3[7] = b0 * _src[1] + b1 * _src[4] + b2 * _src[7];
+      this.mat3[8] = b0 * _src[2] + b1 * _src[5] + b2 * _src[8];
+
+      return this;
+    }
+
+    /**
+   * This function is only for 3x3 matrices.
+   * A function that returns a column vector of a 3x3 matrix.
+   *
+   * @param {Number} columnIndex matrix column number
+   * @return {p5.Vector}
+   */
+    column(columnIndex) {
+      return new p5.Vector(
+        this.mat3[3 * columnIndex],
+        this.mat3[3 * columnIndex + 1],
+        this.mat3[3 * columnIndex + 2]
+      );
+    }
+
+    /**
+   * This function is only for 3x3 matrices.
+   * A function that returns a row vector of a 3x3 matrix.
+   *
+   * @param {Number} rowIndex matrix row number
+   * @return {p5.Vector}
+   */
+    row(rowIndex) {
+      return new p5.Vector(
+        this.mat3[rowIndex],
+        this.mat3[rowIndex + 3],
+        this.mat3[rowIndex + 6]
+      );
+    }
+
+    /**
+   * Returns the diagonal elements of the matrix in the form of an array.
+   * A 3x3 matrix will return an array of length 3.
+   * A 4x4 matrix will return an array of length 4.
+   *
+   * @return {Number[]} An array obtained by arranging the diagonal elements
+   *                    of the matrix in ascending order of index
+   */
+    diagonal() {
+      if (this.mat3 !== undefined) {
+        return [this.mat3[0], this.mat3[4], this.mat3[8]];
+      }
+      return [this.mat4[0], this.mat4[5], this.mat4[10], this.mat4[15]];
+    }
+
+    /**
+   * This function is only for 3x3 matrices.
+   * Takes a vector and returns the vector resulting from multiplying to
+   * that vector by this matrix from left.
+   *
+   * @param {p5.Vector} multVector the vector to which this matrix applies
+   * @param {p5.Vector} [target] The vector to receive the result
+   * @return {p5.Vector}
+   */
+    multiplyVec3(multVector, target) {
+      if (target === undefined) {
+        target = multVector.copy();
+      }
+      target.x = this.row(0).dot(multVector);
+      target.y = this.row(1).dot(multVector);
+      target.z = this.row(2).dot(multVector);
+      return target;
+    }
+
+    /**
+   * This function is only for 4x4 matrices.
+   * Creates a 3x3 matrix whose entries are the top left 3x3 part and returns it.
+   *
+   * @return {p5.Matrix}
+   */
+    createSubMatrix3x3() {
+      const result = new p5.Matrix('mat3');
+      result.mat3[0] = this.mat4[0];
+      result.mat3[1] = this.mat4[1];
+      result.mat3[2] = this.mat4[2];
+      result.mat3[3] = this.mat4[4];
+      result.mat3[4] = this.mat4[5];
+      result.mat3[5] = this.mat4[6];
+      result.mat3[6] = this.mat4[8];
+      result.mat3[7] = this.mat4[9];
+      result.mat3[8] = this.mat4[10];
+      return result;
+    }
+
+    /**
+   * PRIVATE
+   */
+    // matrix methods adapted from:
+    // https://developer.mozilla.org/en-US/docs/Web/WebGL/
+    // gluPerspective
+    //
+    // function _makePerspective(fovy, aspect, znear, zfar){
+    //    const ymax = znear * Math.tan(fovy * Math.PI / 360.0);
+    //    const ymin = -ymax;
+    //    const xmin = ymin * aspect;
+    //    const xmax = ymax * aspect;
+    //    return _makeFrustum(xmin, xmax, ymin, ymax, znear, zfar);
+    //  }
+
+    ////
+    //// glFrustum
+    ////
+    //function _makeFrustum(left, right, bottom, top, znear, zfar){
+    //  const X = 2*znear/(right-left);
+    //  const Y = 2*znear/(top-bottom);
+    //  const A = (right+left)/(right-left);
+    //  const B = (top+bottom)/(top-bottom);
+    //  const C = -(zfar+znear)/(zfar-znear);
+    //  const D = -2*zfar*znear/(zfar-znear);
+    //  const frustrumMatrix =[
+    //  X, 0, A, 0,
+    //  0, Y, B, 0,
+    //  0, 0, C, D,
+    //  0, 0, -1, 0
+    //];
+    //return frustrumMatrix;
+    // }
+
+  // function _setMVPMatrices(){
+  ////an identity matrix
+  ////@TODO use the p5.Matrix class to abstract away our MV matrices and
+  ///other math
+  //const _mvMatrix =
+  //[
+  //  1.0,0.0,0.0,0.0,
+  //  0.0,1.0,0.0,0.0,
+  //  0.0,0.0,1.0,0.0,
+  //  0.0,0.0,0.0,1.0
   //];
-  //return frustrumMatrix;
-  // }
+  };
+}
 
-// function _setMVPMatrices(){
-////an identity matrix
-////@TODO use the p5.Matrix class to abstract away our MV matrices and
-///other math
-//const _mvMatrix =
-//[
-//  1.0,0.0,0.0,0.0,
-//  0.0,1.0,0.0,0.0,
-//  0.0,0.0,1.0,0.0,
-//  0.0,0.0,0.0,1.0
-//];
-};
-export default p5.Matrix;
+export default matrix;
+
+if(typeof p5 !== 'undefined'){
+  matrix(p5, p5.prototype);
+}

--- a/src/webgl/p5.Quat.js
+++ b/src/webgl/p5.Quat.js
@@ -3,93 +3,97 @@
  * @submodule Quaternion
  */
 
-import p5 from '../core/main';
-
-/**
- * A class to describe a Quaternion
- * for vector rotations in the p5js webgl renderer.
- * Please refer the following link for details on the implementation
- * https://danceswithcode.net/engineeringnotes/quaternions/quaternions.html
- * @class p5.Quat
- * @constructor
- * @param {Number} [w] Scalar part of the quaternion
- * @param {Number} [x] x component of imaginary part of quaternion
- * @param {Number} [y] y component of imaginary part of quaternion
- * @param {Number} [z] z component of imaginary part of quaternion
- * @private
- */
-p5.Quat = class {
-  constructor(w, x, y, z) {
-    this.w = w;
-    this.vec = new p5.Vector(x, y, z);
-  }
-
+function quat(p5, fn){
   /**
-     * Returns a Quaternion for the
-     * axis angle representation of the rotation
-     *
-     * @method fromAxisAngle
-     * @param {Number} [angle] Angle with which the points needs to be rotated
-     * @param {Number} [x] x component of the axis vector
-     * @param {Number} [y] y component of the axis vector
-     * @param {Number} [z] z component of the axis vector
-     * @chainable
-    */
-  static fromAxisAngle(angle, x, y, z) {
-    const w = Math.cos(angle/2);
-    const vec = new p5.Vector(x, y, z).normalize().mult(Math.sin(angle/2));
-    return new p5.Quat(w, vec.x, vec.y, vec.z);
-  }
-
-  conjugate() {
-    return new p5.Quat(this.w, -this.vec.x, -this.vec.y, -this.vec.z);
-  }
-
-  /**
-     * Multiplies a quaternion with other quaternion.
-     * @method mult
-     * @param  {p5.Quat} [quat] quaternion to multiply with the quaternion calling the method.
-     * @chainable
-     */
-  multiply(quat) {
-    /* eslint-disable max-len */
-    return new p5.Quat(
-      this.w * quat.w - this.vec.x * quat.vec.x - this.vec.y * quat.vec.y - this.vec.z - quat.vec.z,
-      this.w * quat.vec.x + this.vec.x * quat.w + this.vec.y * quat.vec.z - this.vec.z * quat.vec.y,
-      this.w * quat.vec.y - this.vec.x * quat.vec.z + this.vec.y * quat.w + this.vec.z * quat.vec.x,
-      this.w * quat.vec.z + this.vec.x * quat.vec.y - this.vec.y * quat.vec.x + this.vec.z * quat.w
-    );
-    /* eslint-enable max-len */
-  }
-
-  /**
-   * This is similar to quaternion multiplication
-   * but when multipying vector with quaternion
-   * the multiplication can be simplified to the below formula.
-   * This was taken from the below stackexchange link
-   * https://gamedev.stackexchange.com/questions/28395/rotating-vector3-by-a-quaternion/50545#50545
-   * @param {p5.Vector} [p] vector to rotate on the axis quaternion
+   * A class to describe a Quaternion
+   * for vector rotations in the p5js webgl renderer.
+   * Please refer the following link for details on the implementation
+   * https://danceswithcode.net/engineeringnotes/quaternions/quaternions.html
+   * @class p5.Quat
+   * @constructor
+   * @param {Number} [w] Scalar part of the quaternion
+   * @param {Number} [x] x component of imaginary part of quaternion
+   * @param {Number} [y] y component of imaginary part of quaternion
+   * @param {Number} [z] z component of imaginary part of quaternion
+   * @private
    */
-  rotateVector(p) {
-    return p5.Vector.mult( p, this.w*this.w - this.vec.dot(this.vec) )
-      .add( p5.Vector.mult( this.vec, 2 * p.dot(this.vec) ) )
-      .add( p5.Vector.mult( this.vec, 2 * this.w ).cross( p ) )
-      .clampToZero();
-  }
+  p5.Quat = class {
+    constructor(w, x, y, z) {
+      this.w = w;
+      this.vec = new p5.Vector(x, y, z);
+    }
 
-  /**
-     * Rotates the Quaternion by the quaternion passed
-     * which contains the axis of roation and angle of rotation
-     *
-     * @method rotateBy
-     * @param {p5.Quat} [axesQuat] axis quaternion which contains
-     *  the axis of rotation and angle of rotation
-     * @chainable
+    /**
+       * Returns a Quaternion for the
+       * axis angle representation of the rotation
+       *
+       * @method fromAxisAngle
+       * @param {Number} [angle] Angle with which the points needs to be rotated
+       * @param {Number} [x] x component of the axis vector
+       * @param {Number} [y] y component of the axis vector
+       * @param {Number} [z] z component of the axis vector
+       * @chainable
+      */
+    static fromAxisAngle(angle, x, y, z) {
+      const w = Math.cos(angle/2);
+      const vec = new p5.Vector(x, y, z).normalize().mult(Math.sin(angle/2));
+      return new p5.Quat(w, vec.x, vec.y, vec.z);
+    }
+
+    conjugate() {
+      return new p5.Quat(this.w, -this.vec.x, -this.vec.y, -this.vec.z);
+    }
+
+    /**
+       * Multiplies a quaternion with other quaternion.
+       * @method mult
+       * @param  {p5.Quat} [quat] quaternion to multiply with the quaternion calling the method.
+       * @chainable
+       */
+    multiply(quat) {
+      /* eslint-disable max-len */
+      return new p5.Quat(
+        this.w * quat.w - this.vec.x * quat.vec.x - this.vec.y * quat.vec.y - this.vec.z - quat.vec.z,
+        this.w * quat.vec.x + this.vec.x * quat.w + this.vec.y * quat.vec.z - this.vec.z * quat.vec.y,
+        this.w * quat.vec.y - this.vec.x * quat.vec.z + this.vec.y * quat.w + this.vec.z * quat.vec.x,
+        this.w * quat.vec.z + this.vec.x * quat.vec.y - this.vec.y * quat.vec.x + this.vec.z * quat.w
+      );
+      /* eslint-enable max-len */
+    }
+
+    /**
+     * This is similar to quaternion multiplication
+     * but when multipying vector with quaternion
+     * the multiplication can be simplified to the below formula.
+     * This was taken from the below stackexchange link
+     * https://gamedev.stackexchange.com/questions/28395/rotating-vector3-by-a-quaternion/50545#50545
+     * @param {p5.Vector} [p] vector to rotate on the axis quaternion
      */
-  rotateBy(axesQuat) {
-    return axesQuat.multiply(this).multiply(axesQuat.conjugate()).
-      vec.clampToZero();
-  }
-};
+    rotateVector(p) {
+      return p5.Vector.mult( p, this.w*this.w - this.vec.dot(this.vec) )
+        .add( p5.Vector.mult( this.vec, 2 * p.dot(this.vec) ) )
+        .add( p5.Vector.mult( this.vec, 2 * this.w ).cross( p ) )
+        .clampToZero();
+    }
 
-export default p5.Quat;
+    /**
+       * Rotates the Quaternion by the quaternion passed
+       * which contains the axis of roation and angle of rotation
+       *
+       * @method rotateBy
+       * @param {p5.Quat} [axesQuat] axis quaternion which contains
+       *  the axis of rotation and angle of rotation
+       * @chainable
+       */
+    rotateBy(axesQuat) {
+      return axesQuat.multiply(this).multiply(axesQuat.conjugate()).
+        vec.clampToZero();
+    }
+  };
+}
+
+export default quat;
+
+if(typeof p5 !== 'undefined'){
+  quat(p5, p5.prototype);
+}

--- a/src/webgl/p5.RenderBuffer.js
+++ b/src/webgl/p5.RenderBuffer.js
@@ -1,74 +1,78 @@
-import p5 from '../core/main';
-
-p5.RenderBuffer = class {
-  constructor(size, src, dst, attr, renderer, map){
-    this.size = size; // the number of FLOATs in each vertex
-    this.src = src; // the name of the model's source array
-    this.dst = dst; // the name of the geometry's buffer
-    this.attr = attr; // the name of the vertex attribute
-    this._renderer = renderer;
-    this.map = map; // optional, a transformation function to apply to src
-  }
-
-  /**
- * Enables and binds the buffers used by shader when the appropriate data exists in geometry.
- * Must always be done prior to drawing geometry in WebGL.
- * @param {p5.Geometry} geometry Geometry that is going to be drawn
- * @param {p5.Shader} shader Active shader
- * @private
- */
-  _prepareBuffer(geometry, shader) {
-    const attributes = shader.attributes;
-    const gl = this._renderer.GL;
-    let model;
-    if (geometry.model) {
-      model = geometry.model;
-    } else {
-      model = geometry;
+function renderBuffer(p5, fn){
+  p5.RenderBuffer = class {
+    constructor(size, src, dst, attr, renderer, map){
+      this.size = size; // the number of FLOATs in each vertex
+      this.src = src; // the name of the model's source array
+      this.dst = dst; // the name of the geometry's buffer
+      this.attr = attr; // the name of the vertex attribute
+      this._renderer = renderer;
+      this.map = map; // optional, a transformation function to apply to src
     }
 
-    // loop through each of the buffer definitions
-    const attr = attributes[this.attr];
-    if (!attr) {
-      return;
-    }
-    // check if the model has the appropriate source array
-    let buffer = geometry[this.dst];
-    const src = model[this.src];
-    if (!src){
-      return;
-    }
-    if (src.length > 0) {
-    // check if we need to create the GL buffer
-      const createBuffer = !buffer;
-      if (createBuffer) {
-      // create and remember the buffer
-        geometry[this.dst] = buffer = gl.createBuffer();
+    /**
+   * Enables and binds the buffers used by shader when the appropriate data exists in geometry.
+   * Must always be done prior to drawing geometry in WebGL.
+   * @param {p5.Geometry} geometry Geometry that is going to be drawn
+   * @param {p5.Shader} shader Active shader
+   * @private
+   */
+    _prepareBuffer(geometry, shader) {
+      const attributes = shader.attributes;
+      const gl = this._renderer.GL;
+      let model;
+      if (geometry.model) {
+        model = geometry.model;
+      } else {
+        model = geometry;
       }
-      // bind the buffer
-      gl.bindBuffer(gl.ARRAY_BUFFER, buffer);
 
-      // check if we need to fill the buffer with data
-      if (createBuffer || model.dirtyFlags[this.src] !== false) {
-        const map = this.map;
-        // get the values from the model, possibly transformed
-        const values = map ? map(src) : src;
-        // fill the buffer with the values
-        this._renderer._bindBuffer(buffer, gl.ARRAY_BUFFER, values);
-        // mark the model's source array as clean
-        model.dirtyFlags[this.src] = false;
+      // loop through each of the buffer definitions
+      const attr = attributes[this.attr];
+      if (!attr) {
+        return;
       }
-      // enable the attribute
-      shader.enableAttrib(attr, this.size);
-    } else {
-      const loc = attr.location;
-      if (loc === -1 || !this._renderer.registerEnabled.has(loc)) { return; }
-      // Disable register corresponding to unused attribute
-      gl.disableVertexAttribArray(loc);
-      // Record register availability
-      this._renderer.registerEnabled.delete(loc);
-    }
-  }
-};
+      // check if the model has the appropriate source array
+      let buffer = geometry[this.dst];
+      const src = model[this.src];
+      if (!src){
+        return;
+      }
+      if (src.length > 0) {
+      // check if we need to create the GL buffer
+        const createBuffer = !buffer;
+        if (createBuffer) {
+        // create and remember the buffer
+          geometry[this.dst] = buffer = gl.createBuffer();
+        }
+        // bind the buffer
+        gl.bindBuffer(gl.ARRAY_BUFFER, buffer);
 
-export default p5.RenderBuffer;
+        // check if we need to fill the buffer with data
+        if (createBuffer || model.dirtyFlags[this.src] !== false) {
+          const map = this.map;
+          // get the values from the model, possibly transformed
+          const values = map ? map(src) : src;
+          // fill the buffer with the values
+          this._renderer._bindBuffer(buffer, gl.ARRAY_BUFFER, values);
+          // mark the model's source array as clean
+          model.dirtyFlags[this.src] = false;
+        }
+        // enable the attribute
+        shader.enableAttrib(attr, this.size);
+      } else {
+        const loc = attr.location;
+        if (loc === -1 || !this._renderer.registerEnabled.has(loc)) { return; }
+        // Disable register corresponding to unused attribute
+        gl.disableVertexAttribArray(loc);
+        // Record register availability
+        this._renderer.registerEnabled.delete(loc);
+      }
+    }
+  };
+}
+
+export default renderBuffer;
+
+if(typeof p5 !== 'undefined'){
+  renderBuffer(p5, p5.prototype);
+}

--- a/src/webgl/p5.RendererGL.Immediate.js
+++ b/src/webgl/p5.RendererGL.Immediate.js
@@ -13,7 +13,6 @@
  */
 import p5 from '../core/main';
 import * as constants from '../core/constants';
-import './p5.RenderBuffer';
 
 /**
  * Begin shape drawing.  This is a helpful way of generating

--- a/src/webgl/p5.RendererGL.Retained.js
+++ b/src/webgl/p5.RendererGL.Retained.js
@@ -1,8 +1,6 @@
 //Retained Mode. The default mode for rendering 3D primitives
 //in WEBGL.
 import p5 from '../core/main';
-import './p5.RendererGL';
-import './p5.RenderBuffer';
 import * as constants from '../core/constants';
 
 /**

--- a/src/webgl/p5.RendererGL.js
+++ b/src/webgl/p5.RendererGL.js
@@ -2,11 +2,7 @@ import p5 from '../core/main';
 import * as constants from '../core/constants';
 import GeometryBuilder from './GeometryBuilder';
 import libtess from 'libtess'; // Fixed with exporting module from libtess
-import './p5.Shader';
-import './p5.Camera';
 import Renderer from '../core/p5.Renderer';
-import './p5.Matrix';
-import './p5.Framebuffer';
 import { MipmapTexture } from './p5.Texture';
 
 const STROKE_CAP_ENUM = {};

--- a/src/webgl/p5.RendererGL.js
+++ b/src/webgl/p5.RendererGL.js
@@ -3,7 +3,6 @@ import * as constants from '../core/constants';
 import GeometryBuilder from './GeometryBuilder';
 import libtess from 'libtess'; // Fixed with exporting module from libtess
 import Renderer from '../core/p5.Renderer';
-import { MipmapTexture } from './p5.Texture';
 
 const STROKE_CAP_ENUM = {};
 const STROKE_JOIN_ENUM = {};
@@ -2104,7 +2103,7 @@ p5.RendererGL = class RendererGL extends Renderer {
     }
     // Free the Framebuffer
     framebuffer.remove();
-    tex = new MipmapTexture(this, levels, {});
+    tex = new p5.MipmapTexture(this, levels, {});
     this.specularTextures.set(input, tex);
     return tex;
   }

--- a/src/webgl/p5.Shader.js
+++ b/src/webgl/p5.Shader.js
@@ -6,599 +6,62 @@
  * @requires core
  */
 
-import p5 from '../core/main';
-
-/**
- * A class to describe a shader program.
- *
- * Each `p5.Shader` object contains a shader program that runs on the graphics
- * processing unit (GPU). Shaders can process many pixels or vertices at the
- * same time, making them fast for many graphics tasks. They’re written in a
- * language called
- * <a href="https://developer.mozilla.org/en-US/docs/Games/Techniques/3D_on_the_web/GLSL_Shaders" target="_blank">GLSL</a>
- * and run along with the rest of the code in a sketch.
- *
- * A shader program consists of two files, a vertex shader and a fragment
- * shader. The vertex shader affects where 3D geometry is drawn on the screen
- * and the fragment shader affects color. Once the `p5.Shader` object is
- * created, it can be used with the <a href="#/p5/shader">shader()</a>
- * function, as in `shader(myShader)`.
- *
- * A shader can optionally describe *hooks,* which are functions in GLSL that
- * users may choose to provide to customize the behavior of the shader. For the
- * vertex or the fragment shader, users can pass in an object where each key is
- * the type and name of a hook function, and each value is a string with the
- * parameter list and default implementation of the hook. For example, to let users
- * optionally run code at the start of the vertex shader, the options object could
- * include:
- *
- * ```js
- * {
- *   vertex: {
- *     'void beforeVertex': '() {}'
- *   }
- * }
- * ```
- *
- * Then, in your vertex shader source, you can run a hook by calling a function
- * with the same name prefixed by `HOOK_`:
- *
- * ```glsl
- * void main() {
- *   HOOK_beforeVertex();
- *   // Add the rest ofy our shader code here!
- * }
- * ```
- *
- * Note: <a href="#/p5/createShader">createShader()</a>,
- * <a href="#/p5/createFilterShader">createFilterShader()</a>, and
- * <a href="#/p5/loadShader">loadShader()</a> are the recommended ways to
- * create an instance of this class.
- *
- * @class p5.Shader
- * @param {p5.RendererGL} renderer WebGL context for this shader.
- * @param {String} vertSrc source code for the vertex shader program.
- * @param {String} fragSrc source code for the fragment shader program.
- * @param {Object} [options] An optional object describing how this shader can
- * be augmented with hooks. It can include:
- *  - `vertex`: An object describing the available vertex shader hooks.
- *  - `fragment`: An object describing the available frament shader hooks.
- *
- * @example
- * <div>
- * <code>
- * // Note: A "uniform" is a global variable within a shader program.
- *
- * // Create a string with the vertex shader program.
- * // The vertex shader is called for each vertex.
- * let vertSrc = `
- * precision highp float;
- * uniform mat4 uModelViewMatrix;
- * uniform mat4 uProjectionMatrix;
- *
- * attribute vec3 aPosition;
- * attribute vec2 aTexCoord;
- * varying vec2 vTexCoord;
- *
- * void main() {
- *   vTexCoord = aTexCoord;
- *   vec4 positionVec4 = vec4(aPosition, 1.0);
- *   gl_Position = uProjectionMatrix * uModelViewMatrix * positionVec4;
- * }
- * `;
- *
- * // Create a string with the fragment shader program.
- * // The fragment shader is called for each pixel.
- * let fragSrc = `
- * precision highp float;
- *
- * void main() {
- *   // Set each pixel's RGBA value to yellow.
- *   gl_FragColor = vec4(1.0, 1.0, 0.0, 1.0);
- * }
- * `;
- *
- * function setup() {
- *   createCanvas(100, 100, WEBGL);
- *
- *   // Create a p5.Shader object.
- *   let myShader = createShader(vertSrc, fragSrc);
- *
- *   // Apply the p5.Shader object.
- *   shader(myShader);
- *
- *   // Style the drawing surface.
- *   noStroke();
- *
- *   // Add a plane as a drawing surface.
- *   plane(100, 100);
- *
- *   describe('A yellow square.');
- * }
- * </code>
- * </div>
- *
- * <div>
- * <code>
- * // Note: A "uniform" is a global variable within a shader program.
- *
- * let mandelbrot;
- *
- * // Load the shader and create a p5.Shader object.
- * function preload() {
- *   mandelbrot = loadShader('assets/shader.vert', 'assets/shader.frag');
- * }
- *
- * function setup() {
- *   createCanvas(100, 100, WEBGL);
- *
- *   // Use the p5.Shader object.
- *   shader(mandelbrot);
- *
- *   // Set the shader uniform p to an array.
- *   mandelbrot.setUniform('p', [-0.74364388703, 0.13182590421]);
- *
- *   describe('A fractal image zooms in and out of focus.');
- * }
- *
- * function draw() {
- *   // Set the shader uniform r to a value that oscillates between 0 and 2.
- *   mandelbrot.setUniform('r', sin(frameCount * 0.01) + 1);
- *
- *   // Add a quad as a display surface for the shader.
- *   quad(-1, -1, 1, -1, 1, 1, -1, 1);
- * }
- * </code>
- * </div>
- */
-p5.Shader = class Shader {
-  constructor(renderer, vertSrc, fragSrc, options = {}) {
-    // TODO: adapt this to not take ids, but rather,
-    // to take the source for a vertex and fragment shader
-    // to enable custom shaders at some later date
-    this._renderer = renderer;
-    this._vertSrc = vertSrc;
-    this._fragSrc = fragSrc;
-    this._vertShader = -1;
-    this._fragShader = -1;
-    this._glProgram = 0;
-    this._loadedAttributes = false;
-    this.attributes = {};
-    this._loadedUniforms = false;
-    this.uniforms = {};
-    this._bound = false;
-    this.samplers = [];
-    this.hooks = {
-      // These should be passed in by `.modify()` instead of being manually
-      // passed in.
-
-      // Stores uniforms + default values.
-      uniforms: options.uniforms || {},
-
-      // Stores custom uniform + helper declarations as a string.
-      declarations: options.declarations,
-
-      // Stores helper functions to prepend to shaders.
-      helpers: options.helpers || {},
-
-      // Stores the hook implementations
-      vertex: options.vertex || {},
-      fragment: options.fragment || {},
-
-      // Stores whether or not the hook implementation has been modified
-      // from the default. This is supplied automatically by calling
-      // yourShader.modify(...).
-      modified: {
-        vertex: (options.modified && options.modified.vertex) || {},
-        fragment: (options.modified && options.modified.fragment) || {}
-      }
-    };
-  }
-
-  shaderSrc(src, shaderType) {
-    const main = 'void main';
-    const [preMain, postMain] = src.split(main);
-
-    let hooks = '';
-    for (const key in this.hooks.uniforms) {
-      hooks += `uniform ${key};\n`;
-    }
-    if (this.hooks.declarations) {
-      hooks += this.hooks.declarations + '\n';
-    }
-    if (this.hooks[shaderType].declarations) {
-      hooks += this.hooks[shaderType].declarations + '\n';
-    }
-    for (const hookDef in this.hooks.helpers) {
-      hooks += `${hookDef}${this.hooks.helpers[hookDef]}\n`;
-    }
-    for (const hookDef in this.hooks[shaderType]) {
-      if (hookDef === 'declarations') continue;
-      const [hookType, hookName] = hookDef.split(' ');
-
-      // Add a #define so that if the shader wants to use preprocessor directives to
-      // optimize away the extra function calls in main, it can do so
-      if (this.hooks.modified[shaderType][hookDef]) {
-        hooks += '#define AUGMENTED_HOOK_' + hookName + '\n';
-      }
-
-      hooks +=
-        hookType + ' HOOK_' + hookName + this.hooks[shaderType][hookDef] + '\n';
-    }
-
-    return preMain + hooks + main + postMain;
-  }
-
+function shader(p5, fn){
   /**
-   * Shaders are written in <a href="https://developer.mozilla.org/en-US/docs/Games/Techniques/3D_on_the_web/GLSL_Shaders">GLSL</a>, but
-   * there are different versions of GLSL that it might be written in.
+   * A class to describe a shader program.
    *
-   * Calling this method on a `p5.Shader` will return the GLSL version it uses, either `100 es` or `300 es`.
-   * WebGL 1 shaders will only use `100 es`, and WebGL 2 shaders may use either.
+   * Each `p5.Shader` object contains a shader program that runs on the graphics
+   * processing unit (GPU). Shaders can process many pixels or vertices at the
+   * same time, making them fast for many graphics tasks. They’re written in a
+   * language called
+   * <a href="https://developer.mozilla.org/en-US/docs/Games/Techniques/3D_on_the_web/GLSL_Shaders" target="_blank">GLSL</a>
+   * and run along with the rest of the code in a sketch.
    *
-   * @returns {String} The GLSL version used by the shader.
-   */
-  version() {
-    const match = /#version (.+)$/.exec(this.vertSrc());
-    if (match) {
-      return match[1];
-    } else {
-      return '100 es';
-    }
-  }
-
-  vertSrc() {
-    return this.shaderSrc(this._vertSrc, 'vertex');
-  }
-
-  fragSrc() {
-    return this.shaderSrc(this._fragSrc, 'fragment');
-  }
-
-  /**
-   * Logs the hooks available in this shader, and their current implementation.
+   * A shader program consists of two files, a vertex shader and a fragment
+   * shader. The vertex shader affects where 3D geometry is drawn on the screen
+   * and the fragment shader affects color. Once the `p5.Shader` object is
+   * created, it can be used with the <a href="#/p5/shader">shader()</a>
+   * function, as in `shader(myShader)`.
    *
-   * Each shader may let you override bits of its behavior. Each bit is called
-   * a *hook.* A hook is either for the *vertex* shader, if it affects the
-   * position of vertices, or in the *fragment* shader, if it affects the pixel
-   * color. This method logs those values to the console, letting you know what
-   * you are able to use in a call to
-   * <a href="#/p5.Shader/modify">`modify()`</a>.
-   *
-   * For example, this shader will produce the following output:
+   * A shader can optionally describe *hooks,* which are functions in GLSL that
+   * users may choose to provide to customize the behavior of the shader. For the
+   * vertex or the fragment shader, users can pass in an object where each key is
+   * the type and name of a hook function, and each value is a string with the
+   * parameter list and default implementation of the hook. For example, to let users
+   * optionally run code at the start of the vertex shader, the options object could
+   * include:
    *
    * ```js
-   * myShader = baseMaterialShader().modify({
-   *   declarations: 'uniform float time;',
-   *   'vec3 getWorldPosition': `(vec3 pos) {
-   *     pos.y += 20. * sin(time * 0.001 + pos.x * 0.05);
-   *     return pos;
-   *   }`
-   * });
-   * myShader.inspectHooks();
+   * {
+   *   vertex: {
+   *     'void beforeVertex': '() {}'
+   *   }
+   * }
    * ```
    *
-   * ```
-   * ==== Vertex shader hooks: ====
-   * void beforeVertex() {}
-   * vec3 getLocalPosition(vec3 position) { return position; }
-   * [MODIFIED] vec3 getWorldPosition(vec3 pos) {
-   *       pos.y += 20. * sin(time * 0.001 + pos.x * 0.05);
-   *       return pos;
-   *     }
-   * vec3 getLocalNormal(vec3 normal) { return normal; }
-   * vec3 getWorldNormal(vec3 normal) { return normal; }
-   * vec2 getUV(vec2 uv) { return uv; }
-   * vec4 getVertexColor(vec4 color) { return color; }
-   * void afterVertex() {}
+   * Then, in your vertex shader source, you can run a hook by calling a function
+   * with the same name prefixed by `HOOK_`:
    *
-   * ==== Fragment shader hooks: ====
-   * void beforeFragment() {}
-   * Inputs getPixelInputs(Inputs inputs) { return inputs; }
-   * vec4 combineColors(ColorComponents components) {
-   *                 vec4 color = vec4(0.);
-   *                 color.rgb += components.diffuse * components.baseColor;
-   *                 color.rgb += components.ambient * components.ambientColor;
-   *                 color.rgb += components.specular * components.specularColor;
-   *                 color.rgb += components.emissive;
-   *                 color.a = components.opacity;
-   *                 return color;
-   *               }
-   * vec4 getFinalColor(vec4 color) { return color; }
-   * void afterFragment() {}
+   * ```glsl
+   * void main() {
+   *   HOOK_beforeVertex();
+   *   // Add the rest ofy our shader code here!
+   * }
    * ```
    *
-   * @beta
-   */
-  inspectHooks() {
-    console.log('==== Vertex shader hooks: ====');
-    for (const key in this.hooks.vertex) {
-      console.log(
-        (this.hooks.modified.vertex[key] ? '[MODIFIED] ' : '') +
-          key +
-          this.hooks.vertex[key]
-      );
-    }
-    console.log('');
-    console.log('==== Fragment shader hooks: ====');
-    for (const key in this.hooks.fragment) {
-      console.log(
-        (this.hooks.modified.fragment[key] ? '[MODIFIED] ' : '') +
-          key +
-          this.hooks.fragment[key]
-      );
-    }
-    console.log('');
-    console.log('==== Helper functions: ====');
-    for (const key in this.hooks.helpers) {
-      console.log(
-        key +
-        this.hooks.helpers[key]
-      );
-    }
-  }
-
-  /**
-   * Returns a new shader, based on the original, but with custom snippets
-   * of shader code replacing default behaviour.
+   * Note: <a href="#/p5/createShader">createShader()</a>,
+   * <a href="#/p5/createFilterShader">createFilterShader()</a>, and
+   * <a href="#/p5/loadShader">loadShader()</a> are the recommended ways to
+   * create an instance of this class.
    *
-   * Each shader may let you override bits of its behavior. Each bit is called
-   * a *hook.* A hook is either for the *vertex* shader, if it affects the
-   * position of vertices, or in the *fragment* shader, if it affects the pixel
-   * color. You can inspect the different hooks available by calling
-   * <a href="#/p5.Shader/inspectHooks">`yourShader.inspectHooks()`</a>. You can
-   * also read the reference for the default material, normal material, color, line, and point shaders to
-   * see what hooks they have available.
-   *
-   * `modify()` takes one parameter, `hooks`, an object with the hooks you want
-   * to override. Each key of the `hooks` object is the name
-   * of a hook, and the value is a string with the GLSL code for your hook.
-   *
-   * If you supply functions that aren't existing hooks, they will get added at the start of
-   * the shader as helper functions so that you can use them in your hooks.
-   *
-   * To add new <a href="#/p5.Shader/setUniform">uniforms</a> to your shader, you can pass in a `uniforms` object containing
-   * the type and name of the uniform as the key, and a default value or function returning
-   * a default value as its value. These will be automatically set when the shader is set
-   * with `shader(yourShader)`.
-   *
-   * You can also add a `declarations` key, where the value is a GLSL string declaring
-   * custom uniform variables, globals, and functions shared
-   * between hooks. To add declarations just in a vertex or fragment shader, add
-   * `vertexDeclarations` and `fragmentDeclarations` keys.
-   *
-   * @beta
-   * @param {Object} [hooks] The hooks in the shader to replace.
-   * @returns {p5.Shader}
-   *
-   * @example
-   * <div modernizr='webgl'>
-   * <code>
-   * let myShader;
-   *
-   * function setup() {
-   *   createCanvas(200, 200, WEBGL);
-   *   myShader = baseMaterialShader().modify({
-   *     uniforms: {
-   *       'float time': () => millis()
-   *     },
-   *     'vec3 getWorldPosition': `(vec3 pos) {
-   *       pos.y += 20. * sin(time * 0.001 + pos.x * 0.05);
-   *       return pos;
-   *     }`
-   *   });
-   * }
-   *
-   * function draw() {
-   *   background(255);
-   *   shader(myShader);
-   *   lights();
-   *   noStroke();
-   *   fill('red');
-   *   sphere(50);
-   * }
-   * </code>
-   * </div>
-   *
-   * @example
-   * <div modernizr='webgl'>
-   * <code>
-   * let myShader;
-   *
-   * function setup() {
-   *   createCanvas(200, 200, WEBGL);
-   *   myShader = baseMaterialShader().modify({
-   *     // Manually specifying a uniform
-   *     declarations: 'uniform float time;',
-   *     'vec3 getWorldPosition': `(vec3 pos) {
-   *       pos.y += 20. * sin(time * 0.001 + pos.x * 0.05);
-   *       return pos;
-   *     }`
-   *   });
-   * }
-   *
-   * function draw() {
-   *   background(255);
-   *   shader(myShader);
-   *   myShader.setUniform('time', millis());
-   *   lights();
-   *   noStroke();
-   *   fill('red');
-   *   sphere(50);
-   * }
-   * </code>
-   * </div>
-   */
-  modify(hooks) {
-    p5._validateParameters('p5.Shader.modify', arguments);
-    const newHooks = {
-      vertex: {},
-      fragment: {},
-      helpers: {}
-    };
-    for (const key in hooks) {
-      if (key === 'declarations') continue;
-      if (key === 'uniforms') continue;
-      if (key === 'vertexDeclarations') {
-        newHooks.vertex.declarations =
-          (newHooks.vertex.declarations || '') + '\n' + hooks[key];
-      } else if (key === 'fragmentDeclarations') {
-        newHooks.fragment.declarations =
-          (newHooks.fragment.declarations || '') + '\n' + hooks[key];
-      } else if (this.hooks.vertex[key]) {
-        newHooks.vertex[key] = hooks[key];
-      } else if (this.hooks.fragment[key]) {
-        newHooks.fragment[key] = hooks[key];
-      } else {
-        newHooks.helpers[key] = hooks[key];
-      }
-    }
-    const modifiedVertex = Object.assign({}, this.hooks.modified.vertex);
-    const modifiedFragment = Object.assign({}, this.hooks.modified.fragment);
-    for (const key in newHooks.vertex || {}) {
-      if (key === 'declarations') continue;
-      modifiedVertex[key] = true;
-    }
-    for (const key in newHooks.fragment || {}) {
-      if (key === 'declarations') continue;
-      modifiedFragment[key] = true;
-    }
-
-    return new p5.Shader(this._renderer, this._vertSrc, this._fragSrc, {
-      declarations:
-        (this.hooks.declarations || '') + '\n' + (hooks.declarations || ''),
-      uniforms: Object.assign({}, this.hooks.uniforms, hooks.uniforms || {}),
-      fragment: Object.assign({}, this.hooks.fragment, newHooks.fragment || {}),
-      vertex: Object.assign({}, this.hooks.vertex, newHooks.vertex || {}),
-      helpers: Object.assign({}, this.hooks.helpers, newHooks.helpers || {}),
-      modified: {
-        vertex: modifiedVertex,
-        fragment: modifiedFragment
-      }
-    });
-  }
-
-  /**
-   * Creates, compiles, and links the shader based on its
-   * sources for the vertex and fragment shaders (provided
-   * to the constructor). Populates known attributes and
-   * uniforms from the shader.
-   * @chainable
-   * @private
-   */
-  init() {
-    if (this._glProgram === 0 /* or context is stale? */) {
-      const gl = this._renderer.GL;
-
-      // @todo: once custom shading is allowed,
-      // friendly error messages should be used here to share
-      // compiler and linker errors.
-
-      //set up the shader by
-      // 1. creating and getting a gl id for the shader program,
-      // 2. compliling its vertex & fragment sources,
-      // 3. linking the vertex and fragment shaders
-      this._vertShader = gl.createShader(gl.VERTEX_SHADER);
-      //load in our default vertex shader
-      gl.shaderSource(this._vertShader, this.vertSrc());
-      gl.compileShader(this._vertShader);
-      // if our vertex shader failed compilation?
-      if (!gl.getShaderParameter(this._vertShader, gl.COMPILE_STATUS)) {
-        const glError = gl.getShaderInfoLog(this._vertShader);
-        if (typeof IS_MINIFIED !== 'undefined') {
-          console.error(glError);
-        } else {
-          p5._friendlyError(
-            `Yikes! An error occurred compiling the vertex shader:${glError}`
-          );
-        }
-        return null;
-      }
-
-      this._fragShader = gl.createShader(gl.FRAGMENT_SHADER);
-      //load in our material frag shader
-      gl.shaderSource(this._fragShader, this.fragSrc());
-      gl.compileShader(this._fragShader);
-      // if our frag shader failed compilation?
-      if (!gl.getShaderParameter(this._fragShader, gl.COMPILE_STATUS)) {
-        const glError = gl.getShaderInfoLog(this._fragShader);
-        if (typeof IS_MINIFIED !== 'undefined') {
-          console.error(glError);
-        } else {
-          p5._friendlyError(
-            `Darn! An error occurred compiling the fragment shader:${glError}`
-          );
-        }
-        return null;
-      }
-
-      this._glProgram = gl.createProgram();
-      gl.attachShader(this._glProgram, this._vertShader);
-      gl.attachShader(this._glProgram, this._fragShader);
-      gl.linkProgram(this._glProgram);
-      if (!gl.getProgramParameter(this._glProgram, gl.LINK_STATUS)) {
-        p5._friendlyError(
-          `Snap! Error linking shader program: ${gl.getProgramInfoLog(
-            this._glProgram
-          )}`
-        );
-      }
-
-      this._loadAttributes();
-      this._loadUniforms();
-    }
-    return this;
-  }
-
-  /**
-   * @private
-   */
-  setDefaultUniforms() {
-    for (const key in this.hooks.uniforms) {
-      const [, name] = key.split(' ');
-      const initializer = this.hooks.uniforms[key];
-      let value;
-      if (initializer instanceof Function) {
-        value = initializer();
-      } else {
-        value = initializer;
-      }
-
-      if (value !== undefined && value !== null) {
-        this.setUniform(name, value);
-      }
-    }
-  }
-
-  /**
-   * Copies the shader from one drawing context to another.
-   *
-   * Each `p5.Shader` object must be compiled by calling
-   * <a href="#/p5/shader">shader()</a> before it can run. Compilation happens
-   * in a drawing context which is usually the main canvas or an instance of
-   * <a href="#/p5.Graphics">p5.Graphics</a>. A shader can only be used in the
-   * context where it was compiled. The `copyToContext()` method compiles the
-   * shader again and copies it to another drawing context where it can be
-   * reused.
-   *
-   * The parameter, `context`, is the drawing context where the shader will be
-   * used. The shader can be copied to an instance of
-   * <a href="#/p5.Graphics">p5.Graphics</a>, as in
-   * `myShader.copyToContext(pg)`. The shader can also be copied from a
-   * <a href="#/p5.Graphics">p5.Graphics</a> object to the main canvas using
-   * the `window` variable, as in `myShader.copyToContext(window)`.
-   *
-   * Note: A <a href="#/p5.Shader">p5.Shader</a> object created with
-   * <a href="#/p5/createShader">createShader()</a>,
-   * <a href="#/p5/createFilterShader">createFilterShader()</a>, or
-   * <a href="#/p5/loadShader">loadShader()</a>
-   * can be used directly with a <a href="#/p5.Framebuffer">p5.Framebuffer</a>
-   * object created with
-   * <a href="#/p5/createFramebuffer">createFramebuffer()</a>. Both objects
-   * have the same context as the main canvas.
-   *
-   * @param {p5|p5.Graphics} context WebGL context for the copied shader.
-   * @returns {p5.Shader} new shader compiled for the target context.
+   * @class p5.Shader
+   * @param {p5.RendererGL} renderer WebGL context for this shader.
+   * @param {String} vertSrc source code for the vertex shader program.
+   * @param {String} fragSrc source code for the fragment shader program.
+   * @param {Object} [options] An optional object describing how this shader can
+   * be augmented with hooks. It can include:
+   *  - `vertex`: An object describing the available vertex shader hooks.
+   *  - `fragment`: An object describing the available frament shader hooks.
    *
    * @example
    * <div>
@@ -626,416 +89,11 @@ p5.Shader = class Shader {
    * // Create a string with the fragment shader program.
    * // The fragment shader is called for each pixel.
    * let fragSrc = `
-   * precision mediump float;
-   * varying vec2 vTexCoord;
-   *
-   * void main() {
-   *   vec2 uv = vTexCoord;
-   *   vec3 color = vec3(uv.x, uv.y, min(uv.x + uv.y, 1.0));
-   *   gl_FragColor = vec4(color, 1.0);\
-   * }
-   * `;
-   *
-   * let pg;
-   *
-   * function setup() {
-   *   createCanvas(100, 100, WEBGL);
-   *
-   *   background(200);
-   *
-   *   // Create a p5.Shader object.
-   *   let original = createShader(vertSrc, fragSrc);
-   *
-   *   // Compile the p5.Shader object.
-   *   shader(original);
-   *
-   *   // Create a p5.Graphics object.
-   *   pg = createGraphics(50, 50, WEBGL);
-   *
-   *   // Copy the original shader to the p5.Graphics object.
-   *   let copied = original.copyToContext(pg);
-   *
-   *   // Apply the copied shader to the p5.Graphics object.
-   *   pg.shader(copied);
-   *
-   *   // Style the display surface.
-   *   pg.noStroke();
-   *
-   *   // Add a display surface for the shader.
-   *   pg.plane(50, 50);
-   *
-   *   describe('A square with purple-blue gradient on its surface drawn against a gray background.');
-   * }
-   *
-   * function draw() {
-   *   background(200);
-   *
-   *   // Draw the p5.Graphics object to the main canvas.
-   *   image(pg, -25, -25);
-   * }
-   * </code>
-   * </div>
-   *
-   * <div class='notest'>
-   * <code>
-   * // Note: A "uniform" is a global variable within a shader program.
-   *
-   * // Create a string with the vertex shader program.
-   * // The vertex shader is called for each vertex.
-   * let vertSrc = `
    * precision highp float;
-   * uniform mat4 uModelViewMatrix;
-   * uniform mat4 uProjectionMatrix;
-   *
-   * attribute vec3 aPosition;
-   * attribute vec2 aTexCoord;
-   * varying vec2 vTexCoord;
    *
    * void main() {
-   *   vTexCoord = aTexCoord;
-   *   vec4 positionVec4 = vec4(aPosition, 1.0);
-   *   gl_Position = uProjectionMatrix * uModelViewMatrix * positionVec4;
-   * }
-   * `;
-   *
-   * // Create a string with the fragment shader program.
-   * // The fragment shader is called for each pixel.
-   * let fragSrc = `
-   * precision mediump float;
-   *
-   * varying vec2 vTexCoord;
-   *
-   * void main() {
-   *   vec2 uv = vTexCoord;
-   *   vec3 color = vec3(uv.x, uv.y, min(uv.x + uv.y, 1.0));
-   *   gl_FragColor = vec4(color, 1.0);
-   * }
-   * `;
-   *
-   * let copied;
-   *
-   * function setup() {
-   *   createCanvas(100, 100, WEBGL);
-   *
-   *   // Create a p5.Graphics object.
-   *   let pg = createGraphics(25, 25, WEBGL);
-   *
-   *   // Create a p5.Shader object.
-   *   let original = pg.createShader(vertSrc, fragSrc);
-   *
-   *   // Compile the p5.Shader object.
-   *   pg.shader(original);
-   *
-   *   // Copy the original shader to the main canvas.
-   *   copied = original.copyToContext(window);
-   *
-   *   // Apply the copied shader to the main canvas.
-   *   shader(copied);
-   *
-   *   describe('A rotating cube with a purple-blue gradient on its surface drawn against a gray background.');
-   * }
-   *
-   * function draw() {
-   *   background(200);
-   *
-   *   // Rotate around the x-, y-, and z-axes.
-   *   rotateX(frameCount * 0.01);
-   *   rotateY(frameCount * 0.01);
-   *   rotateZ(frameCount * 0.01);
-   *
-   *   // Draw the box.
-   *   box(50);
-   * }
-   * </code>
-   * </div>
-   */
-  copyToContext(context) {
-    const shader = new p5.Shader(
-      context._renderer,
-      this._vertSrc,
-      this._fragSrc
-    );
-    shader.ensureCompiledOnContext(context);
-    return shader;
-  }
-
-  /**
-   * @private
-   */
-  ensureCompiledOnContext(context) {
-    if (this._glProgram !== 0 && this._renderer !== context._renderer) {
-      throw new Error(
-        'The shader being run is attached to a different context. Do you need to copy it to this context first with .copyToContext()?'
-      );
-    } else if (this._glProgram === 0) {
-      this._renderer = context._renderer;
-      this.init();
-    }
-  }
-
-  /**
-   * Queries the active attributes for this shader and loads
-   * their names and locations into the attributes array.
-   * @private
-   */
-  _loadAttributes() {
-    if (this._loadedAttributes) {
-      return;
-    }
-
-    this.attributes = {};
-
-    const gl = this._renderer.GL;
-
-    const numAttributes = gl.getProgramParameter(
-      this._glProgram,
-      gl.ACTIVE_ATTRIBUTES
-    );
-    for (let i = 0; i < numAttributes; ++i) {
-      const attributeInfo = gl.getActiveAttrib(this._glProgram, i);
-      const name = attributeInfo.name;
-      const location = gl.getAttribLocation(this._glProgram, name);
-      const attribute = {};
-      attribute.name = name;
-      attribute.location = location;
-      attribute.index = i;
-      attribute.type = attributeInfo.type;
-      attribute.size = attributeInfo.size;
-      this.attributes[name] = attribute;
-    }
-
-    this._loadedAttributes = true;
-  }
-
-  /**
-   * Queries the active uniforms for this shader and loads
-   * their names and locations into the uniforms array.
-   * @private
-   */
-  _loadUniforms() {
-    if (this._loadedUniforms) {
-      return;
-    }
-
-    const gl = this._renderer.GL;
-
-    // Inspect shader and cache uniform info
-    const numUniforms = gl.getProgramParameter(
-      this._glProgram,
-      gl.ACTIVE_UNIFORMS
-    );
-
-    let samplerIndex = 0;
-    for (let i = 0; i < numUniforms; ++i) {
-      const uniformInfo = gl.getActiveUniform(this._glProgram, i);
-      const uniform = {};
-      uniform.location = gl.getUniformLocation(
-        this._glProgram,
-        uniformInfo.name
-      );
-      uniform.size = uniformInfo.size;
-      let uniformName = uniformInfo.name;
-      //uniforms that are arrays have their name returned as
-      //someUniform[0] which is a bit silly so we trim it
-      //off here. The size property tells us that its an array
-      //so we dont lose any information by doing this
-      if (uniformInfo.size > 1) {
-        uniformName = uniformName.substring(0, uniformName.indexOf('[0]'));
-      }
-      uniform.name = uniformName;
-      uniform.type = uniformInfo.type;
-      uniform._cachedData = undefined;
-      if (uniform.type === gl.SAMPLER_2D) {
-        uniform.samplerIndex = samplerIndex;
-        samplerIndex++;
-        this.samplers.push(uniform);
-      }
-
-      uniform.isArray =
-        uniformInfo.size > 1 ||
-        uniform.type === gl.FLOAT_MAT3 ||
-        uniform.type === gl.FLOAT_MAT4 ||
-        uniform.type === gl.FLOAT_VEC2 ||
-        uniform.type === gl.FLOAT_VEC3 ||
-        uniform.type === gl.FLOAT_VEC4 ||
-        uniform.type === gl.INT_VEC2 ||
-        uniform.type === gl.INT_VEC4 ||
-        uniform.type === gl.INT_VEC3;
-
-      this.uniforms[uniformName] = uniform;
-    }
-    this._loadedUniforms = true;
-  }
-
-  compile() {
-    // TODO
-  }
-
-  /**
-   * initializes (if needed) and binds the shader program.
-   * @private
-   */
-  bindShader() {
-    this.init();
-    if (!this._bound) {
-      this.useProgram();
-      this._bound = true;
-
-      this._setMatrixUniforms();
-
-      this.setUniform('uViewport', this._renderer._viewport);
-    }
-  }
-
-  /**
-   * @chainable
-   * @private
-   */
-  unbindShader() {
-    if (this._bound) {
-      this.unbindTextures();
-      //this._renderer.GL.useProgram(0); ??
-      this._bound = false;
-    }
-    return this;
-  }
-
-  bindTextures() {
-    const gl = this._renderer.GL;
-
-    for (const uniform of this.samplers) {
-      let tex = uniform.texture;
-      if (tex === undefined) {
-        // user hasn't yet supplied a texture for this slot.
-        // (or there may not be one--maybe just lighting),
-        // so we supply a default texture instead.
-        tex = this._renderer._getEmptyTexture();
-      }
-      gl.activeTexture(gl.TEXTURE0 + uniform.samplerIndex);
-      tex.bindTexture();
-      tex.update();
-      gl.uniform1i(uniform.location, uniform.samplerIndex);
-    }
-  }
-
-  updateTextures() {
-    for (const uniform of this.samplers) {
-      const tex = uniform.texture;
-      if (tex) {
-        tex.update();
-      }
-    }
-  }
-
-  unbindTextures() {
-    for (const uniform of this.samplers) {
-      this.setUniform(uniform.name, this._renderer._getEmptyTexture());
-    }
-  }
-
-  _setMatrixUniforms() {
-    const modelMatrix = this._renderer.states.uModelMatrix;
-    const viewMatrix = this._renderer.states.uViewMatrix;
-    const projectionMatrix = this._renderer.states.uPMatrix;
-    const modelViewMatrix = (modelMatrix.copy()).mult(viewMatrix);
-    this._renderer.states.uMVMatrix = modelViewMatrix;
-
-    const modelViewProjectionMatrix = modelViewMatrix.copy();
-    modelViewProjectionMatrix.mult(projectionMatrix);
-
-    if (this.isStrokeShader()) {
-      this.setUniform(
-        'uPerspective',
-        this._renderer.states.curCamera.useLinePerspective ? 1 : 0
-      );
-    }
-    this.setUniform('uViewMatrix', viewMatrix.mat4);
-    this.setUniform('uProjectionMatrix', projectionMatrix.mat4);
-    this.setUniform('uModelMatrix', modelMatrix.mat4);
-    this.setUniform('uModelViewMatrix', modelViewMatrix.mat4);
-    this.setUniform(
-      'uModelViewProjectionMatrix',
-      modelViewProjectionMatrix.mat4
-    );
-    if (this.uniforms.uNormalMatrix) {
-      this._renderer.states.uNMatrix.inverseTranspose(this._renderer.states.uMVMatrix);
-      this.setUniform('uNormalMatrix', this._renderer.states.uNMatrix.mat3);
-    }
-    if (this.uniforms.uCameraRotation) {
-      this._renderer.states.curMatrix.inverseTranspose(this._renderer.states.uViewMatrix);
-      this.setUniform('uCameraRotation', this._renderer.states.curMatrix.mat3);
-    }
-  }
-
-  /**
-   * @chainable
-   * @private
-   */
-  useProgram() {
-    const gl = this._renderer.GL;
-    if (this._renderer._curShader !== this) {
-      gl.useProgram(this._glProgram);
-      this._renderer._curShader = this;
-    }
-    return this;
-  }
-
-  /**
-   * Sets the shader’s uniform (global) variables.
-   *
-   * Shader programs run on the computer’s graphics processing unit (GPU).
-   * They live in part of the computer’s memory that’s completely separate
-   * from the sketch that runs them. Uniforms are global variables within a
-   * shader program. They provide a way to pass values from a sketch running
-   * on the CPU to a shader program running on the GPU.
-   *
-   * The first parameter, `uniformName`, is a string with the uniform’s name.
-   * For the shader above, `uniformName` would be `'r'`.
-   *
-   * The second parameter, `data`, is the value that should be used to set the
-   * uniform. For example, calling `myShader.setUniform('r', 0.5)` would set
-   * the `r` uniform in the shader above to `0.5`. data should match the
-   * uniform’s type. Numbers, strings, booleans, arrays, and many types of
-   * images can all be passed to a shader with `setUniform()`.
-   *
-   * @chainable
-   * @param {String} uniformName name of the uniform. Must match the name
-   *                             used in the vertex and fragment shaders.
-   * @param {Boolean|Number|Number[]|p5.Image|p5.Graphics|p5.MediaElement|p5.Texture}
-   * data value to assign to the uniform. Must match the uniform’s data type.
-   *
-   * @example
-   * <div>
-   * <code>
-   * // Note: A "uniform" is a global variable within a shader program.
-   *
-   * // Create a string with the vertex shader program.
-   * // The vertex shader is called for each vertex.
-   * let vertSrc = `
-   * precision highp float;
-   * uniform mat4 uModelViewMatrix;
-   * uniform mat4 uProjectionMatrix;
-   *
-   * attribute vec3 aPosition;
-   * attribute vec2 aTexCoord;
-   * varying vec2 vTexCoord;
-   *
-   * void main() {
-   *   vTexCoord = aTexCoord;
-   *   vec4 positionVec4 = vec4(aPosition, 1.0);
-   *   gl_Position = uProjectionMatrix * uModelViewMatrix * positionVec4;
-   * }
-   * `;
-   *
-   * // Create a string with the fragment shader program.
-   * // The fragment shader is called for each pixel.
-   * let fragSrc = `
-   * precision mediump float;
-   *
-   * uniform float r;
-   *
-   * void main() {
-   *   gl_FragColor = vec4(r, 1.0, 1.0, 1.0);
+   *   // Set each pixel's RGBA value to yellow.
+   *   gl_FragColor = vec4(1.0, 1.0, 0.0, 1.0);
    * }
    * `;
    *
@@ -1048,80 +106,13 @@ p5.Shader = class Shader {
    *   // Apply the p5.Shader object.
    *   shader(myShader);
    *
-   *   // Set the r uniform to 0.5.
-   *   myShader.setUniform('r', 0.5);
-   *
    *   // Style the drawing surface.
    *   noStroke();
-   *
-   *   // Add a plane as a drawing surface for the shader.
-   *   plane(100, 100);
-   *
-   *   describe('A cyan square.');
-   * }
-   * </code>
-   * </div>
-   *
-   * <div>
-   * <code>
-   * // Note: A "uniform" is a global variable within a shader program.
-   *
-   * // Create a string with the vertex shader program.
-   * // The vertex shader is called for each vertex.
-   * let vertSrc = `
-   * precision highp float;
-   * uniform mat4 uModelViewMatrix;
-   * uniform mat4 uProjectionMatrix;
-   *
-   * attribute vec3 aPosition;
-   * attribute vec2 aTexCoord;
-   * varying vec2 vTexCoord;
-   *
-   * void main() {
-   *   vTexCoord = aTexCoord;
-   *   vec4 positionVec4 = vec4(aPosition, 1.0);
-   *   gl_Position = uProjectionMatrix * uModelViewMatrix * positionVec4;
-   * }
-   * `;
-   *
-   * // Create a string with the fragment shader program.
-   * // The fragment shader is called for each pixel.
-   * let fragSrc = `
-   * precision mediump float;
-   *
-   * uniform float r;
-   *
-   * void main() {
-   *   gl_FragColor = vec4(r, 1.0, 1.0, 1.0);
-   * }
-   * `;
-   *
-   * let myShader;
-   *
-   * function setup() {
-   *   createCanvas(100, 100, WEBGL);
-   *
-   *   // Create a p5.Shader object.
-   *   myShader = createShader(vertSrc, fragSrc);
-   *
-   *   // Compile and apply the p5.Shader object.
-   *   shader(myShader);
-   *
-   *   describe('A square oscillates color between cyan and white.');
-   * }
-   *
-   * function draw() {
-   *   background(200);
-   *
-   *   // Style the drawing surface.
-   *   noStroke();
-   *
-   *   // Update the r uniform.
-   *   let nextR = 0.5 * (sin(frameCount * 0.01) + 1);
-   *   myShader.setUniform('r', nextR);
    *
    *   // Add a plane as a drawing surface.
    *   plane(100, 100);
+   *
+   *   describe('A yellow square.');
    * }
    * </code>
    * </div>
@@ -1130,309 +121,1322 @@ p5.Shader = class Shader {
    * <code>
    * // Note: A "uniform" is a global variable within a shader program.
    *
-   * // Create a string with the vertex shader program.
-   * // The vertex shader is called for each vertex.
-   * let vertSrc = `
-   * precision highp float;
-   * uniform mat4 uModelViewMatrix;
-   * uniform mat4 uProjectionMatrix;
-   *
-   * attribute vec3 aPosition;
-   * attribute vec2 aTexCoord;
-   * varying vec2 vTexCoord;
-   *
-   * void main() {
-   *   vTexCoord = aTexCoord;
-   *   vec4 positionVec4 = vec4(aPosition, 1.0);
-   *   gl_Position = uProjectionMatrix * uModelViewMatrix * positionVec4;
-   * }
-   * `;
-   *
-   * // Create a string with the fragment shader program.
-   * // The fragment shader is called for each pixel.
-   * let fragSrc = `
-   * precision highp float;
-   * uniform vec2 p;
-   * uniform float r;
-   * const int numIterations = 500;
-   * varying vec2 vTexCoord;
-   *
-   * void main() {
-   *   vec2 c = p + gl_FragCoord.xy * r;
-   *   vec2 z = c;
-   *   float n = 0.0;
-   *
-   *   for (int i = numIterations; i > 0; i--) {
-   *     if (z.x * z.x + z.y * z.y > 4.0) {
-   *       n = float(i) / float(numIterations);
-   *       break;
-   *     }
-   *
-   *     z = vec2(z.x * z.x - z.y * z.y, 2.0 * z.x * z.y) + c;
-   *   }
-   *
-   *   gl_FragColor = vec4(
-   *     0.5 - cos(n * 17.0) / 2.0,
-   *     0.5 - cos(n * 13.0) / 2.0,
-   *     0.5 - cos(n * 23.0) / 2.0,
-   *     1.0
-   *   );
-   * }
-   * `;
-   *
    * let mandelbrot;
+   *
+   * // Load the shader and create a p5.Shader object.
+   * function preload() {
+   *   mandelbrot = loadShader('assets/shader.vert', 'assets/shader.frag');
+   * }
    *
    * function setup() {
    *   createCanvas(100, 100, WEBGL);
    *
-   *   // Create a p5.Shader object.
-   *   mandelbrot = createShader(vertSrc, fragSrc);
-   *
-   *   // Compile and apply the p5.Shader object.
+   *   // Use the p5.Shader object.
    *   shader(mandelbrot);
    *
    *   // Set the shader uniform p to an array.
-   *   // p is the center point of the Mandelbrot image.
    *   mandelbrot.setUniform('p', [-0.74364388703, 0.13182590421]);
    *
    *   describe('A fractal image zooms in and out of focus.');
    * }
    *
    * function draw() {
-   *   // Set the shader uniform r to a value that oscillates
-   *   // between 0 and 0.005.
-   *   // r is the size of the image in Mandelbrot-space.
-   *   let radius = 0.005 * (sin(frameCount * 0.01) + 1);
-   *   mandelbrot.setUniform('r', radius);
+   *   // Set the shader uniform r to a value that oscillates between 0 and 2.
+   *   mandelbrot.setUniform('r', sin(frameCount * 0.01) + 1);
    *
-   *   // Style the drawing surface.
-   *   noStroke();
-   *
-   *   // Add a plane as a drawing surface.
-   *   plane(100, 100);
+   *   // Add a quad as a display surface for the shader.
+   *   quad(-1, -1, 1, -1, 1, 1, -1, 1);
    * }
    * </code>
    * </div>
    */
-  setUniform(uniformName, data) {
-    const uniform = this.uniforms[uniformName];
-    if (!uniform) {
-      return;
-    }
-    const gl = this._renderer.GL;
+  p5.Shader = class Shader {
+    constructor(renderer, vertSrc, fragSrc, options = {}) {
+      // TODO: adapt this to not take ids, but rather,
+      // to take the source for a vertex and fragment shader
+      // to enable custom shaders at some later date
+      this._renderer = renderer;
+      this._vertSrc = vertSrc;
+      this._fragSrc = fragSrc;
+      this._vertShader = -1;
+      this._fragShader = -1;
+      this._glProgram = 0;
+      this._loadedAttributes = false;
+      this.attributes = {};
+      this._loadedUniforms = false;
+      this.uniforms = {};
+      this._bound = false;
+      this.samplers = [];
+      this.hooks = {
+        // These should be passed in by `.modify()` instead of being manually
+        // passed in.
 
-    if (uniform.isArray) {
-      if (
-        uniform._cachedData &&
-        this._renderer._arraysEqual(uniform._cachedData, data)
-      ) {
+        // Stores uniforms + default values.
+        uniforms: options.uniforms || {},
+
+        // Stores custom uniform + helper declarations as a string.
+        declarations: options.declarations,
+
+        // Stores helper functions to prepend to shaders.
+        helpers: options.helpers || {},
+
+        // Stores the hook implementations
+        vertex: options.vertex || {},
+        fragment: options.fragment || {},
+
+        // Stores whether or not the hook implementation has been modified
+        // from the default. This is supplied automatically by calling
+        // yourShader.modify(...).
+        modified: {
+          vertex: (options.modified && options.modified.vertex) || {},
+          fragment: (options.modified && options.modified.fragment) || {}
+        }
+      };
+    }
+
+    shaderSrc(src, shaderType) {
+      const main = 'void main';
+      const [preMain, postMain] = src.split(main);
+
+      let hooks = '';
+      for (const key in this.hooks.uniforms) {
+        hooks += `uniform ${key};\n`;
+      }
+      if (this.hooks.declarations) {
+        hooks += this.hooks.declarations + '\n';
+      }
+      if (this.hooks[shaderType].declarations) {
+        hooks += this.hooks[shaderType].declarations + '\n';
+      }
+      for (const hookDef in this.hooks.helpers) {
+        hooks += `${hookDef}${this.hooks.helpers[hookDef]}\n`;
+      }
+      for (const hookDef in this.hooks[shaderType]) {
+        if (hookDef === 'declarations') continue;
+        const [hookType, hookName] = hookDef.split(' ');
+
+        // Add a #define so that if the shader wants to use preprocessor directives to
+        // optimize away the extra function calls in main, it can do so
+        if (this.hooks.modified[shaderType][hookDef]) {
+          hooks += '#define AUGMENTED_HOOK_' + hookName + '\n';
+        }
+
+        hooks +=
+          hookType + ' HOOK_' + hookName + this.hooks[shaderType][hookDef] + '\n';
+      }
+
+      return preMain + hooks + main + postMain;
+    }
+
+    /**
+     * Shaders are written in <a href="https://developer.mozilla.org/en-US/docs/Games/Techniques/3D_on_the_web/GLSL_Shaders">GLSL</a>, but
+     * there are different versions of GLSL that it might be written in.
+     *
+     * Calling this method on a `p5.Shader` will return the GLSL version it uses, either `100 es` or `300 es`.
+     * WebGL 1 shaders will only use `100 es`, and WebGL 2 shaders may use either.
+     *
+     * @returns {String} The GLSL version used by the shader.
+     */
+    version() {
+      const match = /#version (.+)$/.exec(this.vertSrc());
+      if (match) {
+        return match[1];
+      } else {
+        return '100 es';
+      }
+    }
+
+    vertSrc() {
+      return this.shaderSrc(this._vertSrc, 'vertex');
+    }
+
+    fragSrc() {
+      return this.shaderSrc(this._fragSrc, 'fragment');
+    }
+
+    /**
+     * Logs the hooks available in this shader, and their current implementation.
+     *
+     * Each shader may let you override bits of its behavior. Each bit is called
+     * a *hook.* A hook is either for the *vertex* shader, if it affects the
+     * position of vertices, or in the *fragment* shader, if it affects the pixel
+     * color. This method logs those values to the console, letting you know what
+     * you are able to use in a call to
+     * <a href="#/p5.Shader/modify">`modify()`</a>.
+     *
+     * For example, this shader will produce the following output:
+     *
+     * ```js
+     * myShader = baseMaterialShader().modify({
+     *   declarations: 'uniform float time;',
+     *   'vec3 getWorldPosition': `(vec3 pos) {
+     *     pos.y += 20. * sin(time * 0.001 + pos.x * 0.05);
+     *     return pos;
+     *   }`
+     * });
+     * myShader.inspectHooks();
+     * ```
+     *
+     * ```
+     * ==== Vertex shader hooks: ====
+     * void beforeVertex() {}
+     * vec3 getLocalPosition(vec3 position) { return position; }
+     * [MODIFIED] vec3 getWorldPosition(vec3 pos) {
+     *       pos.y += 20. * sin(time * 0.001 + pos.x * 0.05);
+     *       return pos;
+     *     }
+     * vec3 getLocalNormal(vec3 normal) { return normal; }
+     * vec3 getWorldNormal(vec3 normal) { return normal; }
+     * vec2 getUV(vec2 uv) { return uv; }
+     * vec4 getVertexColor(vec4 color) { return color; }
+     * void afterVertex() {}
+     *
+     * ==== Fragment shader hooks: ====
+     * void beforeFragment() {}
+     * Inputs getPixelInputs(Inputs inputs) { return inputs; }
+     * vec4 combineColors(ColorComponents components) {
+     *                 vec4 color = vec4(0.);
+     *                 color.rgb += components.diffuse * components.baseColor;
+     *                 color.rgb += components.ambient * components.ambientColor;
+     *                 color.rgb += components.specular * components.specularColor;
+     *                 color.rgb += components.emissive;
+     *                 color.a = components.opacity;
+     *                 return color;
+     *               }
+     * vec4 getFinalColor(vec4 color) { return color; }
+     * void afterFragment() {}
+     * ```
+     *
+     * @beta
+     */
+    inspectHooks() {
+      console.log('==== Vertex shader hooks: ====');
+      for (const key in this.hooks.vertex) {
+        console.log(
+          (this.hooks.modified.vertex[key] ? '[MODIFIED] ' : '') +
+            key +
+            this.hooks.vertex[key]
+        );
+      }
+      console.log('');
+      console.log('==== Fragment shader hooks: ====');
+      for (const key in this.hooks.fragment) {
+        console.log(
+          (this.hooks.modified.fragment[key] ? '[MODIFIED] ' : '') +
+            key +
+            this.hooks.fragment[key]
+        );
+      }
+      console.log('');
+      console.log('==== Helper functions: ====');
+      for (const key in this.hooks.helpers) {
+        console.log(
+          key +
+          this.hooks.helpers[key]
+        );
+      }
+    }
+
+    /**
+     * Returns a new shader, based on the original, but with custom snippets
+     * of shader code replacing default behaviour.
+     *
+     * Each shader may let you override bits of its behavior. Each bit is called
+     * a *hook.* A hook is either for the *vertex* shader, if it affects the
+     * position of vertices, or in the *fragment* shader, if it affects the pixel
+     * color. You can inspect the different hooks available by calling
+     * <a href="#/p5.Shader/inspectHooks">`yourShader.inspectHooks()`</a>. You can
+     * also read the reference for the default material, normal material, color, line, and point shaders to
+     * see what hooks they have available.
+     *
+     * `modify()` takes one parameter, `hooks`, an object with the hooks you want
+     * to override. Each key of the `hooks` object is the name
+     * of a hook, and the value is a string with the GLSL code for your hook.
+     *
+     * If you supply functions that aren't existing hooks, they will get added at the start of
+     * the shader as helper functions so that you can use them in your hooks.
+     *
+     * To add new <a href="#/p5.Shader/setUniform">uniforms</a> to your shader, you can pass in a `uniforms` object containing
+     * the type and name of the uniform as the key, and a default value or function returning
+     * a default value as its value. These will be automatically set when the shader is set
+     * with `shader(yourShader)`.
+     *
+     * You can also add a `declarations` key, where the value is a GLSL string declaring
+     * custom uniform variables, globals, and functions shared
+     * between hooks. To add declarations just in a vertex or fragment shader, add
+     * `vertexDeclarations` and `fragmentDeclarations` keys.
+     *
+     * @beta
+     * @param {Object} [hooks] The hooks in the shader to replace.
+     * @returns {p5.Shader}
+     *
+     * @example
+     * <div modernizr='webgl'>
+     * <code>
+     * let myShader;
+     *
+     * function setup() {
+     *   createCanvas(200, 200, WEBGL);
+     *   myShader = baseMaterialShader().modify({
+     *     uniforms: {
+     *       'float time': () => millis()
+     *     },
+     *     'vec3 getWorldPosition': `(vec3 pos) {
+     *       pos.y += 20. * sin(time * 0.001 + pos.x * 0.05);
+     *       return pos;
+     *     }`
+     *   });
+     * }
+     *
+     * function draw() {
+     *   background(255);
+     *   shader(myShader);
+     *   lights();
+     *   noStroke();
+     *   fill('red');
+     *   sphere(50);
+     * }
+     * </code>
+     * </div>
+     *
+     * @example
+     * <div modernizr='webgl'>
+     * <code>
+     * let myShader;
+     *
+     * function setup() {
+     *   createCanvas(200, 200, WEBGL);
+     *   myShader = baseMaterialShader().modify({
+     *     // Manually specifying a uniform
+     *     declarations: 'uniform float time;',
+     *     'vec3 getWorldPosition': `(vec3 pos) {
+     *       pos.y += 20. * sin(time * 0.001 + pos.x * 0.05);
+     *       return pos;
+     *     }`
+     *   });
+     * }
+     *
+     * function draw() {
+     *   background(255);
+     *   shader(myShader);
+     *   myShader.setUniform('time', millis());
+     *   lights();
+     *   noStroke();
+     *   fill('red');
+     *   sphere(50);
+     * }
+     * </code>
+     * </div>
+     */
+    modify(hooks) {
+      p5._validateParameters('p5.Shader.modify', arguments);
+      const newHooks = {
+        vertex: {},
+        fragment: {},
+        helpers: {}
+      };
+      for (const key in hooks) {
+        if (key === 'declarations') continue;
+        if (key === 'uniforms') continue;
+        if (key === 'vertexDeclarations') {
+          newHooks.vertex.declarations =
+            (newHooks.vertex.declarations || '') + '\n' + hooks[key];
+        } else if (key === 'fragmentDeclarations') {
+          newHooks.fragment.declarations =
+            (newHooks.fragment.declarations || '') + '\n' + hooks[key];
+        } else if (this.hooks.vertex[key]) {
+          newHooks.vertex[key] = hooks[key];
+        } else if (this.hooks.fragment[key]) {
+          newHooks.fragment[key] = hooks[key];
+        } else {
+          newHooks.helpers[key] = hooks[key];
+        }
+      }
+      const modifiedVertex = Object.assign({}, this.hooks.modified.vertex);
+      const modifiedFragment = Object.assign({}, this.hooks.modified.fragment);
+      for (const key in newHooks.vertex || {}) {
+        if (key === 'declarations') continue;
+        modifiedVertex[key] = true;
+      }
+      for (const key in newHooks.fragment || {}) {
+        if (key === 'declarations') continue;
+        modifiedFragment[key] = true;
+      }
+
+      return new p5.Shader(this._renderer, this._vertSrc, this._fragSrc, {
+        declarations:
+          (this.hooks.declarations || '') + '\n' + (hooks.declarations || ''),
+        uniforms: Object.assign({}, this.hooks.uniforms, hooks.uniforms || {}),
+        fragment: Object.assign({}, this.hooks.fragment, newHooks.fragment || {}),
+        vertex: Object.assign({}, this.hooks.vertex, newHooks.vertex || {}),
+        helpers: Object.assign({}, this.hooks.helpers, newHooks.helpers || {}),
+        modified: {
+          vertex: modifiedVertex,
+          fragment: modifiedFragment
+        }
+      });
+    }
+
+    /**
+     * Creates, compiles, and links the shader based on its
+     * sources for the vertex and fragment shaders (provided
+     * to the constructor). Populates known attributes and
+     * uniforms from the shader.
+     * @chainable
+     * @private
+     */
+    init() {
+      if (this._glProgram === 0 /* or context is stale? */) {
+        const gl = this._renderer.GL;
+
+        // @todo: once custom shading is allowed,
+        // friendly error messages should be used here to share
+        // compiler and linker errors.
+
+        //set up the shader by
+        // 1. creating and getting a gl id for the shader program,
+        // 2. compliling its vertex & fragment sources,
+        // 3. linking the vertex and fragment shaders
+        this._vertShader = gl.createShader(gl.VERTEX_SHADER);
+        //load in our default vertex shader
+        gl.shaderSource(this._vertShader, this.vertSrc());
+        gl.compileShader(this._vertShader);
+        // if our vertex shader failed compilation?
+        if (!gl.getShaderParameter(this._vertShader, gl.COMPILE_STATUS)) {
+          const glError = gl.getShaderInfoLog(this._vertShader);
+          if (typeof IS_MINIFIED !== 'undefined') {
+            console.error(glError);
+          } else {
+            p5._friendlyError(
+              `Yikes! An error occurred compiling the vertex shader:${glError}`
+            );
+          }
+          return null;
+        }
+
+        this._fragShader = gl.createShader(gl.FRAGMENT_SHADER);
+        //load in our material frag shader
+        gl.shaderSource(this._fragShader, this.fragSrc());
+        gl.compileShader(this._fragShader);
+        // if our frag shader failed compilation?
+        if (!gl.getShaderParameter(this._fragShader, gl.COMPILE_STATUS)) {
+          const glError = gl.getShaderInfoLog(this._fragShader);
+          if (typeof IS_MINIFIED !== 'undefined') {
+            console.error(glError);
+          } else {
+            p5._friendlyError(
+              `Darn! An error occurred compiling the fragment shader:${glError}`
+            );
+          }
+          return null;
+        }
+
+        this._glProgram = gl.createProgram();
+        gl.attachShader(this._glProgram, this._vertShader);
+        gl.attachShader(this._glProgram, this._fragShader);
+        gl.linkProgram(this._glProgram);
+        if (!gl.getProgramParameter(this._glProgram, gl.LINK_STATUS)) {
+          p5._friendlyError(
+            `Snap! Error linking shader program: ${gl.getProgramInfoLog(
+              this._glProgram
+            )}`
+          );
+        }
+
+        this._loadAttributes();
+        this._loadUniforms();
+      }
+      return this;
+    }
+
+    /**
+     * @private
+     */
+    setDefaultUniforms() {
+      for (const key in this.hooks.uniforms) {
+        const [, name] = key.split(' ');
+        const initializer = this.hooks.uniforms[key];
+        let value;
+        if (initializer instanceof Function) {
+          value = initializer();
+        } else {
+          value = initializer;
+        }
+
+        if (value !== undefined && value !== null) {
+          this.setUniform(name, value);
+        }
+      }
+    }
+
+    /**
+     * Copies the shader from one drawing context to another.
+     *
+     * Each `p5.Shader` object must be compiled by calling
+     * <a href="#/p5/shader">shader()</a> before it can run. Compilation happens
+     * in a drawing context which is usually the main canvas or an instance of
+     * <a href="#/p5.Graphics">p5.Graphics</a>. A shader can only be used in the
+     * context where it was compiled. The `copyToContext()` method compiles the
+     * shader again and copies it to another drawing context where it can be
+     * reused.
+     *
+     * The parameter, `context`, is the drawing context where the shader will be
+     * used. The shader can be copied to an instance of
+     * <a href="#/p5.Graphics">p5.Graphics</a>, as in
+     * `myShader.copyToContext(pg)`. The shader can also be copied from a
+     * <a href="#/p5.Graphics">p5.Graphics</a> object to the main canvas using
+     * the `window` variable, as in `myShader.copyToContext(window)`.
+     *
+     * Note: A <a href="#/p5.Shader">p5.Shader</a> object created with
+     * <a href="#/p5/createShader">createShader()</a>,
+     * <a href="#/p5/createFilterShader">createFilterShader()</a>, or
+     * <a href="#/p5/loadShader">loadShader()</a>
+     * can be used directly with a <a href="#/p5.Framebuffer">p5.Framebuffer</a>
+     * object created with
+     * <a href="#/p5/createFramebuffer">createFramebuffer()</a>. Both objects
+     * have the same context as the main canvas.
+     *
+     * @param {p5|p5.Graphics} context WebGL context for the copied shader.
+     * @returns {p5.Shader} new shader compiled for the target context.
+     *
+     * @example
+     * <div>
+     * <code>
+     * // Note: A "uniform" is a global variable within a shader program.
+     *
+     * // Create a string with the vertex shader program.
+     * // The vertex shader is called for each vertex.
+     * let vertSrc = `
+     * precision highp float;
+     * uniform mat4 uModelViewMatrix;
+     * uniform mat4 uProjectionMatrix;
+     *
+     * attribute vec3 aPosition;
+     * attribute vec2 aTexCoord;
+     * varying vec2 vTexCoord;
+     *
+     * void main() {
+     *   vTexCoord = aTexCoord;
+     *   vec4 positionVec4 = vec4(aPosition, 1.0);
+     *   gl_Position = uProjectionMatrix * uModelViewMatrix * positionVec4;
+     * }
+     * `;
+     *
+     * // Create a string with the fragment shader program.
+     * // The fragment shader is called for each pixel.
+     * let fragSrc = `
+     * precision mediump float;
+     * varying vec2 vTexCoord;
+     *
+     * void main() {
+     *   vec2 uv = vTexCoord;
+     *   vec3 color = vec3(uv.x, uv.y, min(uv.x + uv.y, 1.0));
+     *   gl_FragColor = vec4(color, 1.0);\
+     * }
+     * `;
+     *
+     * let pg;
+     *
+     * function setup() {
+     *   createCanvas(100, 100, WEBGL);
+     *
+     *   background(200);
+     *
+     *   // Create a p5.Shader object.
+     *   let original = createShader(vertSrc, fragSrc);
+     *
+     *   // Compile the p5.Shader object.
+     *   shader(original);
+     *
+     *   // Create a p5.Graphics object.
+     *   pg = createGraphics(50, 50, WEBGL);
+     *
+     *   // Copy the original shader to the p5.Graphics object.
+     *   let copied = original.copyToContext(pg);
+     *
+     *   // Apply the copied shader to the p5.Graphics object.
+     *   pg.shader(copied);
+     *
+     *   // Style the display surface.
+     *   pg.noStroke();
+     *
+     *   // Add a display surface for the shader.
+     *   pg.plane(50, 50);
+     *
+     *   describe('A square with purple-blue gradient on its surface drawn against a gray background.');
+     * }
+     *
+     * function draw() {
+     *   background(200);
+     *
+     *   // Draw the p5.Graphics object to the main canvas.
+     *   image(pg, -25, -25);
+     * }
+     * </code>
+     * </div>
+     *
+     * <div class='notest'>
+     * <code>
+     * // Note: A "uniform" is a global variable within a shader program.
+     *
+     * // Create a string with the vertex shader program.
+     * // The vertex shader is called for each vertex.
+     * let vertSrc = `
+     * precision highp float;
+     * uniform mat4 uModelViewMatrix;
+     * uniform mat4 uProjectionMatrix;
+     *
+     * attribute vec3 aPosition;
+     * attribute vec2 aTexCoord;
+     * varying vec2 vTexCoord;
+     *
+     * void main() {
+     *   vTexCoord = aTexCoord;
+     *   vec4 positionVec4 = vec4(aPosition, 1.0);
+     *   gl_Position = uProjectionMatrix * uModelViewMatrix * positionVec4;
+     * }
+     * `;
+     *
+     * // Create a string with the fragment shader program.
+     * // The fragment shader is called for each pixel.
+     * let fragSrc = `
+     * precision mediump float;
+     *
+     * varying vec2 vTexCoord;
+     *
+     * void main() {
+     *   vec2 uv = vTexCoord;
+     *   vec3 color = vec3(uv.x, uv.y, min(uv.x + uv.y, 1.0));
+     *   gl_FragColor = vec4(color, 1.0);
+     * }
+     * `;
+     *
+     * let copied;
+     *
+     * function setup() {
+     *   createCanvas(100, 100, WEBGL);
+     *
+     *   // Create a p5.Graphics object.
+     *   let pg = createGraphics(25, 25, WEBGL);
+     *
+     *   // Create a p5.Shader object.
+     *   let original = pg.createShader(vertSrc, fragSrc);
+     *
+     *   // Compile the p5.Shader object.
+     *   pg.shader(original);
+     *
+     *   // Copy the original shader to the main canvas.
+     *   copied = original.copyToContext(window);
+     *
+     *   // Apply the copied shader to the main canvas.
+     *   shader(copied);
+     *
+     *   describe('A rotating cube with a purple-blue gradient on its surface drawn against a gray background.');
+     * }
+     *
+     * function draw() {
+     *   background(200);
+     *
+     *   // Rotate around the x-, y-, and z-axes.
+     *   rotateX(frameCount * 0.01);
+     *   rotateY(frameCount * 0.01);
+     *   rotateZ(frameCount * 0.01);
+     *
+     *   // Draw the box.
+     *   box(50);
+     * }
+     * </code>
+     * </div>
+     */
+    copyToContext(context) {
+      const shader = new p5.Shader(
+        context._renderer,
+        this._vertSrc,
+        this._fragSrc
+      );
+      shader.ensureCompiledOnContext(context);
+      return shader;
+    }
+
+    /**
+     * @private
+     */
+    ensureCompiledOnContext(context) {
+      if (this._glProgram !== 0 && this._renderer !== context._renderer) {
+        throw new Error(
+          'The shader being run is attached to a different context. Do you need to copy it to this context first with .copyToContext()?'
+        );
+      } else if (this._glProgram === 0) {
+        this._renderer = context._renderer;
+        this.init();
+      }
+    }
+
+    /**
+     * Queries the active attributes for this shader and loads
+     * their names and locations into the attributes array.
+     * @private
+     */
+    _loadAttributes() {
+      if (this._loadedAttributes) {
+        return;
+      }
+
+      this.attributes = {};
+
+      const gl = this._renderer.GL;
+
+      const numAttributes = gl.getProgramParameter(
+        this._glProgram,
+        gl.ACTIVE_ATTRIBUTES
+      );
+      for (let i = 0; i < numAttributes; ++i) {
+        const attributeInfo = gl.getActiveAttrib(this._glProgram, i);
+        const name = attributeInfo.name;
+        const location = gl.getAttribLocation(this._glProgram, name);
+        const attribute = {};
+        attribute.name = name;
+        attribute.location = location;
+        attribute.index = i;
+        attribute.type = attributeInfo.type;
+        attribute.size = attributeInfo.size;
+        this.attributes[name] = attribute;
+      }
+
+      this._loadedAttributes = true;
+    }
+
+    /**
+     * Queries the active uniforms for this shader and loads
+     * their names and locations into the uniforms array.
+     * @private
+     */
+    _loadUniforms() {
+      if (this._loadedUniforms) {
+        return;
+      }
+
+      const gl = this._renderer.GL;
+
+      // Inspect shader and cache uniform info
+      const numUniforms = gl.getProgramParameter(
+        this._glProgram,
+        gl.ACTIVE_UNIFORMS
+      );
+
+      let samplerIndex = 0;
+      for (let i = 0; i < numUniforms; ++i) {
+        const uniformInfo = gl.getActiveUniform(this._glProgram, i);
+        const uniform = {};
+        uniform.location = gl.getUniformLocation(
+          this._glProgram,
+          uniformInfo.name
+        );
+        uniform.size = uniformInfo.size;
+        let uniformName = uniformInfo.name;
+        //uniforms that are arrays have their name returned as
+        //someUniform[0] which is a bit silly so we trim it
+        //off here. The size property tells us that its an array
+        //so we dont lose any information by doing this
+        if (uniformInfo.size > 1) {
+          uniformName = uniformName.substring(0, uniformName.indexOf('[0]'));
+        }
+        uniform.name = uniformName;
+        uniform.type = uniformInfo.type;
+        uniform._cachedData = undefined;
+        if (uniform.type === gl.SAMPLER_2D) {
+          uniform.samplerIndex = samplerIndex;
+          samplerIndex++;
+          this.samplers.push(uniform);
+        }
+
+        uniform.isArray =
+          uniformInfo.size > 1 ||
+          uniform.type === gl.FLOAT_MAT3 ||
+          uniform.type === gl.FLOAT_MAT4 ||
+          uniform.type === gl.FLOAT_VEC2 ||
+          uniform.type === gl.FLOAT_VEC3 ||
+          uniform.type === gl.FLOAT_VEC4 ||
+          uniform.type === gl.INT_VEC2 ||
+          uniform.type === gl.INT_VEC4 ||
+          uniform.type === gl.INT_VEC3;
+
+        this.uniforms[uniformName] = uniform;
+      }
+      this._loadedUniforms = true;
+    }
+
+    compile() {
+      // TODO
+    }
+
+    /**
+     * initializes (if needed) and binds the shader program.
+     * @private
+     */
+    bindShader() {
+      this.init();
+      if (!this._bound) {
+        this.useProgram();
+        this._bound = true;
+
+        this._setMatrixUniforms();
+
+        this.setUniform('uViewport', this._renderer._viewport);
+      }
+    }
+
+    /**
+     * @chainable
+     * @private
+     */
+    unbindShader() {
+      if (this._bound) {
+        this.unbindTextures();
+        //this._renderer.GL.useProgram(0); ??
+        this._bound = false;
+      }
+      return this;
+    }
+
+    bindTextures() {
+      const gl = this._renderer.GL;
+
+      for (const uniform of this.samplers) {
+        let tex = uniform.texture;
+        if (tex === undefined) {
+          // user hasn't yet supplied a texture for this slot.
+          // (or there may not be one--maybe just lighting),
+          // so we supply a default texture instead.
+          tex = this._renderer._getEmptyTexture();
+        }
+        gl.activeTexture(gl.TEXTURE0 + uniform.samplerIndex);
+        tex.bindTexture();
+        tex.update();
+        gl.uniform1i(uniform.location, uniform.samplerIndex);
+      }
+    }
+
+    updateTextures() {
+      for (const uniform of this.samplers) {
+        const tex = uniform.texture;
+        if (tex) {
+          tex.update();
+        }
+      }
+    }
+
+    unbindTextures() {
+      for (const uniform of this.samplers) {
+        this.setUniform(uniform.name, this._renderer._getEmptyTexture());
+      }
+    }
+
+    _setMatrixUniforms() {
+      const modelMatrix = this._renderer.states.uModelMatrix;
+      const viewMatrix = this._renderer.states.uViewMatrix;
+      const projectionMatrix = this._renderer.states.uPMatrix;
+      const modelViewMatrix = (modelMatrix.copy()).mult(viewMatrix);
+      this._renderer.states.uMVMatrix = modelViewMatrix;
+
+      const modelViewProjectionMatrix = modelViewMatrix.copy();
+      modelViewProjectionMatrix.mult(projectionMatrix);
+
+      if (this.isStrokeShader()) {
+        this.setUniform(
+          'uPerspective',
+          this._renderer.states.curCamera.useLinePerspective ? 1 : 0
+        );
+      }
+      this.setUniform('uViewMatrix', viewMatrix.mat4);
+      this.setUniform('uProjectionMatrix', projectionMatrix.mat4);
+      this.setUniform('uModelMatrix', modelMatrix.mat4);
+      this.setUniform('uModelViewMatrix', modelViewMatrix.mat4);
+      this.setUniform(
+        'uModelViewProjectionMatrix',
+        modelViewProjectionMatrix.mat4
+      );
+      if (this.uniforms.uNormalMatrix) {
+        this._renderer.states.uNMatrix.inverseTranspose(this._renderer.states.uMVMatrix);
+        this.setUniform('uNormalMatrix', this._renderer.states.uNMatrix.mat3);
+      }
+      if (this.uniforms.uCameraRotation) {
+        this._renderer.states.curMatrix.inverseTranspose(this._renderer.states.uViewMatrix);
+        this.setUniform('uCameraRotation', this._renderer.states.curMatrix.mat3);
+      }
+    }
+
+    /**
+     * @chainable
+     * @private
+     */
+    useProgram() {
+      const gl = this._renderer.GL;
+      if (this._renderer._curShader !== this) {
+        gl.useProgram(this._glProgram);
+        this._renderer._curShader = this;
+      }
+      return this;
+    }
+
+    /**
+     * Sets the shader’s uniform (global) variables.
+     *
+     * Shader programs run on the computer’s graphics processing unit (GPU).
+     * They live in part of the computer’s memory that’s completely separate
+     * from the sketch that runs them. Uniforms are global variables within a
+     * shader program. They provide a way to pass values from a sketch running
+     * on the CPU to a shader program running on the GPU.
+     *
+     * The first parameter, `uniformName`, is a string with the uniform’s name.
+     * For the shader above, `uniformName` would be `'r'`.
+     *
+     * The second parameter, `data`, is the value that should be used to set the
+     * uniform. For example, calling `myShader.setUniform('r', 0.5)` would set
+     * the `r` uniform in the shader above to `0.5`. data should match the
+     * uniform’s type. Numbers, strings, booleans, arrays, and many types of
+     * images can all be passed to a shader with `setUniform()`.
+     *
+     * @chainable
+     * @param {String} uniformName name of the uniform. Must match the name
+     *                             used in the vertex and fragment shaders.
+     * @param {Boolean|Number|Number[]|p5.Image|p5.Graphics|p5.MediaElement|p5.Texture}
+     * data value to assign to the uniform. Must match the uniform’s data type.
+     *
+     * @example
+     * <div>
+     * <code>
+     * // Note: A "uniform" is a global variable within a shader program.
+     *
+     * // Create a string with the vertex shader program.
+     * // The vertex shader is called for each vertex.
+     * let vertSrc = `
+     * precision highp float;
+     * uniform mat4 uModelViewMatrix;
+     * uniform mat4 uProjectionMatrix;
+     *
+     * attribute vec3 aPosition;
+     * attribute vec2 aTexCoord;
+     * varying vec2 vTexCoord;
+     *
+     * void main() {
+     *   vTexCoord = aTexCoord;
+     *   vec4 positionVec4 = vec4(aPosition, 1.0);
+     *   gl_Position = uProjectionMatrix * uModelViewMatrix * positionVec4;
+     * }
+     * `;
+     *
+     * // Create a string with the fragment shader program.
+     * // The fragment shader is called for each pixel.
+     * let fragSrc = `
+     * precision mediump float;
+     *
+     * uniform float r;
+     *
+     * void main() {
+     *   gl_FragColor = vec4(r, 1.0, 1.0, 1.0);
+     * }
+     * `;
+     *
+     * function setup() {
+     *   createCanvas(100, 100, WEBGL);
+     *
+     *   // Create a p5.Shader object.
+     *   let myShader = createShader(vertSrc, fragSrc);
+     *
+     *   // Apply the p5.Shader object.
+     *   shader(myShader);
+     *
+     *   // Set the r uniform to 0.5.
+     *   myShader.setUniform('r', 0.5);
+     *
+     *   // Style the drawing surface.
+     *   noStroke();
+     *
+     *   // Add a plane as a drawing surface for the shader.
+     *   plane(100, 100);
+     *
+     *   describe('A cyan square.');
+     * }
+     * </code>
+     * </div>
+     *
+     * <div>
+     * <code>
+     * // Note: A "uniform" is a global variable within a shader program.
+     *
+     * // Create a string with the vertex shader program.
+     * // The vertex shader is called for each vertex.
+     * let vertSrc = `
+     * precision highp float;
+     * uniform mat4 uModelViewMatrix;
+     * uniform mat4 uProjectionMatrix;
+     *
+     * attribute vec3 aPosition;
+     * attribute vec2 aTexCoord;
+     * varying vec2 vTexCoord;
+     *
+     * void main() {
+     *   vTexCoord = aTexCoord;
+     *   vec4 positionVec4 = vec4(aPosition, 1.0);
+     *   gl_Position = uProjectionMatrix * uModelViewMatrix * positionVec4;
+     * }
+     * `;
+     *
+     * // Create a string with the fragment shader program.
+     * // The fragment shader is called for each pixel.
+     * let fragSrc = `
+     * precision mediump float;
+     *
+     * uniform float r;
+     *
+     * void main() {
+     *   gl_FragColor = vec4(r, 1.0, 1.0, 1.0);
+     * }
+     * `;
+     *
+     * let myShader;
+     *
+     * function setup() {
+     *   createCanvas(100, 100, WEBGL);
+     *
+     *   // Create a p5.Shader object.
+     *   myShader = createShader(vertSrc, fragSrc);
+     *
+     *   // Compile and apply the p5.Shader object.
+     *   shader(myShader);
+     *
+     *   describe('A square oscillates color between cyan and white.');
+     * }
+     *
+     * function draw() {
+     *   background(200);
+     *
+     *   // Style the drawing surface.
+     *   noStroke();
+     *
+     *   // Update the r uniform.
+     *   let nextR = 0.5 * (sin(frameCount * 0.01) + 1);
+     *   myShader.setUniform('r', nextR);
+     *
+     *   // Add a plane as a drawing surface.
+     *   plane(100, 100);
+     * }
+     * </code>
+     * </div>
+     *
+     * <div>
+     * <code>
+     * // Note: A "uniform" is a global variable within a shader program.
+     *
+     * // Create a string with the vertex shader program.
+     * // The vertex shader is called for each vertex.
+     * let vertSrc = `
+     * precision highp float;
+     * uniform mat4 uModelViewMatrix;
+     * uniform mat4 uProjectionMatrix;
+     *
+     * attribute vec3 aPosition;
+     * attribute vec2 aTexCoord;
+     * varying vec2 vTexCoord;
+     *
+     * void main() {
+     *   vTexCoord = aTexCoord;
+     *   vec4 positionVec4 = vec4(aPosition, 1.0);
+     *   gl_Position = uProjectionMatrix * uModelViewMatrix * positionVec4;
+     * }
+     * `;
+     *
+     * // Create a string with the fragment shader program.
+     * // The fragment shader is called for each pixel.
+     * let fragSrc = `
+     * precision highp float;
+     * uniform vec2 p;
+     * uniform float r;
+     * const int numIterations = 500;
+     * varying vec2 vTexCoord;
+     *
+     * void main() {
+     *   vec2 c = p + gl_FragCoord.xy * r;
+     *   vec2 z = c;
+     *   float n = 0.0;
+     *
+     *   for (int i = numIterations; i > 0; i--) {
+     *     if (z.x * z.x + z.y * z.y > 4.0) {
+     *       n = float(i) / float(numIterations);
+     *       break;
+     *     }
+     *
+     *     z = vec2(z.x * z.x - z.y * z.y, 2.0 * z.x * z.y) + c;
+     *   }
+     *
+     *   gl_FragColor = vec4(
+     *     0.5 - cos(n * 17.0) / 2.0,
+     *     0.5 - cos(n * 13.0) / 2.0,
+     *     0.5 - cos(n * 23.0) / 2.0,
+     *     1.0
+     *   );
+     * }
+     * `;
+     *
+     * let mandelbrot;
+     *
+     * function setup() {
+     *   createCanvas(100, 100, WEBGL);
+     *
+     *   // Create a p5.Shader object.
+     *   mandelbrot = createShader(vertSrc, fragSrc);
+     *
+     *   // Compile and apply the p5.Shader object.
+     *   shader(mandelbrot);
+     *
+     *   // Set the shader uniform p to an array.
+     *   // p is the center point of the Mandelbrot image.
+     *   mandelbrot.setUniform('p', [-0.74364388703, 0.13182590421]);
+     *
+     *   describe('A fractal image zooms in and out of focus.');
+     * }
+     *
+     * function draw() {
+     *   // Set the shader uniform r to a value that oscillates
+     *   // between 0 and 0.005.
+     *   // r is the size of the image in Mandelbrot-space.
+     *   let radius = 0.005 * (sin(frameCount * 0.01) + 1);
+     *   mandelbrot.setUniform('r', radius);
+     *
+     *   // Style the drawing surface.
+     *   noStroke();
+     *
+     *   // Add a plane as a drawing surface.
+     *   plane(100, 100);
+     * }
+     * </code>
+     * </div>
+     */
+    setUniform(uniformName, data) {
+      const uniform = this.uniforms[uniformName];
+      if (!uniform) {
+        return;
+      }
+      const gl = this._renderer.GL;
+
+      if (uniform.isArray) {
+        if (
+          uniform._cachedData &&
+          this._renderer._arraysEqual(uniform._cachedData, data)
+        ) {
+          return;
+        } else {
+          uniform._cachedData = data.slice(0);
+        }
+      } else if (uniform._cachedData && uniform._cachedData === data) {
         return;
       } else {
-        uniform._cachedData = data.slice(0);
+        if (Array.isArray(data)) {
+          uniform._cachedData = data.slice(0);
+        } else {
+          uniform._cachedData = data;
+        }
       }
-    } else if (uniform._cachedData && uniform._cachedData === data) {
-      return;
-    } else {
-      if (Array.isArray(data)) {
-        uniform._cachedData = data.slice(0);
-      } else {
-        uniform._cachedData = data;
+
+      const location = uniform.location;
+
+      this.useProgram();
+
+      switch (uniform.type) {
+        case gl.BOOL:
+          if (data === true) {
+            gl.uniform1i(location, 1);
+          } else {
+            gl.uniform1i(location, 0);
+          }
+          break;
+        case gl.INT:
+          if (uniform.size > 1) {
+            data.length && gl.uniform1iv(location, data);
+          } else {
+            gl.uniform1i(location, data);
+          }
+          break;
+        case gl.FLOAT:
+          if (uniform.size > 1) {
+            data.length && gl.uniform1fv(location, data);
+          } else {
+            gl.uniform1f(location, data);
+          }
+          break;
+        case gl.FLOAT_MAT3:
+          gl.uniformMatrix3fv(location, false, data);
+          break;
+        case gl.FLOAT_MAT4:
+          gl.uniformMatrix4fv(location, false, data);
+          break;
+        case gl.FLOAT_VEC2:
+          if (uniform.size > 1) {
+            data.length && gl.uniform2fv(location, data);
+          } else {
+            gl.uniform2f(location, data[0], data[1]);
+          }
+          break;
+        case gl.FLOAT_VEC3:
+          if (uniform.size > 1) {
+            data.length && gl.uniform3fv(location, data);
+          } else {
+            gl.uniform3f(location, data[0], data[1], data[2]);
+          }
+          break;
+        case gl.FLOAT_VEC4:
+          if (uniform.size > 1) {
+            data.length && gl.uniform4fv(location, data);
+          } else {
+            gl.uniform4f(location, data[0], data[1], data[2], data[3]);
+          }
+          break;
+        case gl.INT_VEC2:
+          if (uniform.size > 1) {
+            data.length && gl.uniform2iv(location, data);
+          } else {
+            gl.uniform2i(location, data[0], data[1]);
+          }
+          break;
+        case gl.INT_VEC3:
+          if (uniform.size > 1) {
+            data.length && gl.uniform3iv(location, data);
+          } else {
+            gl.uniform3i(location, data[0], data[1], data[2]);
+          }
+          break;
+        case gl.INT_VEC4:
+          if (uniform.size > 1) {
+            data.length && gl.uniform4iv(location, data);
+          } else {
+            gl.uniform4i(location, data[0], data[1], data[2], data[3]);
+          }
+          break;
+        case gl.SAMPLER_2D:
+          gl.activeTexture(gl.TEXTURE0 + uniform.samplerIndex);
+          uniform.texture =
+            data instanceof p5.Texture ? data : this._renderer.getTexture(data);
+          gl.uniform1i(location, uniform.samplerIndex);
+          if (uniform.texture.src.gifProperties) {
+            uniform.texture.src._animateGif(this._renderer._pInst);
+          }
+          break;
+        //@todo complete all types
       }
+      return this;
     }
 
-    const location = uniform.location;
+    /* NONE OF THIS IS FAST OR EFFICIENT BUT BEAR WITH ME
+     *
+     * these shader "type" query methods are used by various
+     * facilities of the renderer to determine if changing
+     * the shader type for the required action (for example,
+     * do we need to load the default lighting shader if the
+     * current shader cannot handle lighting?)
+     *
+     **/
 
-    this.useProgram();
-
-    switch (uniform.type) {
-      case gl.BOOL:
-        if (data === true) {
-          gl.uniform1i(location, 1);
-        } else {
-          gl.uniform1i(location, 0);
-        }
-        break;
-      case gl.INT:
-        if (uniform.size > 1) {
-          data.length && gl.uniform1iv(location, data);
-        } else {
-          gl.uniform1i(location, data);
-        }
-        break;
-      case gl.FLOAT:
-        if (uniform.size > 1) {
-          data.length && gl.uniform1fv(location, data);
-        } else {
-          gl.uniform1f(location, data);
-        }
-        break;
-      case gl.FLOAT_MAT3:
-        gl.uniformMatrix3fv(location, false, data);
-        break;
-      case gl.FLOAT_MAT4:
-        gl.uniformMatrix4fv(location, false, data);
-        break;
-      case gl.FLOAT_VEC2:
-        if (uniform.size > 1) {
-          data.length && gl.uniform2fv(location, data);
-        } else {
-          gl.uniform2f(location, data[0], data[1]);
-        }
-        break;
-      case gl.FLOAT_VEC3:
-        if (uniform.size > 1) {
-          data.length && gl.uniform3fv(location, data);
-        } else {
-          gl.uniform3f(location, data[0], data[1], data[2]);
-        }
-        break;
-      case gl.FLOAT_VEC4:
-        if (uniform.size > 1) {
-          data.length && gl.uniform4fv(location, data);
-        } else {
-          gl.uniform4f(location, data[0], data[1], data[2], data[3]);
-        }
-        break;
-      case gl.INT_VEC2:
-        if (uniform.size > 1) {
-          data.length && gl.uniform2iv(location, data);
-        } else {
-          gl.uniform2i(location, data[0], data[1]);
-        }
-        break;
-      case gl.INT_VEC3:
-        if (uniform.size > 1) {
-          data.length && gl.uniform3iv(location, data);
-        } else {
-          gl.uniform3i(location, data[0], data[1], data[2]);
-        }
-        break;
-      case gl.INT_VEC4:
-        if (uniform.size > 1) {
-          data.length && gl.uniform4iv(location, data);
-        } else {
-          gl.uniform4i(location, data[0], data[1], data[2], data[3]);
-        }
-        break;
-      case gl.SAMPLER_2D:
-        gl.activeTexture(gl.TEXTURE0 + uniform.samplerIndex);
-        uniform.texture =
-          data instanceof p5.Texture ? data : this._renderer.getTexture(data);
-        gl.uniform1i(location, uniform.samplerIndex);
-        if (uniform.texture.src.gifProperties) {
-          uniform.texture.src._animateGif(this._renderer._pInst);
-        }
-        break;
-      //@todo complete all types
+    isLightShader() {
+      return [
+        this.attributes.aNormal,
+        this.uniforms.uUseLighting,
+        this.uniforms.uAmbientLightCount,
+        this.uniforms.uDirectionalLightCount,
+        this.uniforms.uPointLightCount,
+        this.uniforms.uAmbientColor,
+        this.uniforms.uDirectionalDiffuseColors,
+        this.uniforms.uDirectionalSpecularColors,
+        this.uniforms.uPointLightLocation,
+        this.uniforms.uPointLightDiffuseColors,
+        this.uniforms.uPointLightSpecularColors,
+        this.uniforms.uLightingDirection,
+        this.uniforms.uSpecular
+      ].some(x => x !== undefined);
     }
-    return this;
-  }
 
-  /* NONE OF THIS IS FAST OR EFFICIENT BUT BEAR WITH ME
-   *
-   * these shader "type" query methods are used by various
-   * facilities of the renderer to determine if changing
-   * the shader type for the required action (for example,
-   * do we need to load the default lighting shader if the
-   * current shader cannot handle lighting?)
-   *
-   **/
+    isNormalShader() {
+      return this.attributes.aNormal !== undefined;
+    }
 
-  isLightShader() {
-    return [
-      this.attributes.aNormal,
-      this.uniforms.uUseLighting,
-      this.uniforms.uAmbientLightCount,
-      this.uniforms.uDirectionalLightCount,
-      this.uniforms.uPointLightCount,
-      this.uniforms.uAmbientColor,
-      this.uniforms.uDirectionalDiffuseColors,
-      this.uniforms.uDirectionalSpecularColors,
-      this.uniforms.uPointLightLocation,
-      this.uniforms.uPointLightDiffuseColors,
-      this.uniforms.uPointLightSpecularColors,
-      this.uniforms.uLightingDirection,
-      this.uniforms.uSpecular
-    ].some(x => x !== undefined);
-  }
+    isTextureShader() {
+      return this.samplers.length > 0;
+    }
 
-  isNormalShader() {
-    return this.attributes.aNormal !== undefined;
-  }
+    isColorShader() {
+      return (
+        this.attributes.aVertexColor !== undefined ||
+        this.uniforms.uMaterialColor !== undefined
+      );
+    }
 
-  isTextureShader() {
-    return this.samplers.length > 0;
-  }
+    isTexLightShader() {
+      return this.isLightShader() && this.isTextureShader();
+    }
 
-  isColorShader() {
-    return (
-      this.attributes.aVertexColor !== undefined ||
-      this.uniforms.uMaterialColor !== undefined
-    );
-  }
+    isStrokeShader() {
+      return this.uniforms.uStrokeWeight !== undefined;
+    }
 
-  isTexLightShader() {
-    return this.isLightShader() && this.isTextureShader();
-  }
-
-  isStrokeShader() {
-    return this.uniforms.uStrokeWeight !== undefined;
-  }
-
-  /**
-   * @chainable
-   * @private
-   */
-  enableAttrib(attr, size, type, normalized, stride, offset) {
-    if (attr) {
-      if (
-        typeof IS_MINIFIED === 'undefined' &&
-        this.attributes[attr.name] !== attr
-      ) {
-        console.warn(
-          `The attribute "${attr.name}"passed to enableAttrib does not belong to this shader.`
-        );
-      }
-      const loc = attr.location;
-      if (loc !== -1) {
-        const gl = this._renderer.GL;
-        // Enable register even if it is disabled
-        if (!this._renderer.registerEnabled.has(loc)) {
-          gl.enableVertexAttribArray(loc);
-          // Record register availability
-          this._renderer.registerEnabled.add(loc);
+    /**
+     * @chainable
+     * @private
+     */
+    enableAttrib(attr, size, type, normalized, stride, offset) {
+      if (attr) {
+        if (
+          typeof IS_MINIFIED === 'undefined' &&
+          this.attributes[attr.name] !== attr
+        ) {
+          console.warn(
+            `The attribute "${attr.name}"passed to enableAttrib does not belong to this shader.`
+          );
         }
-        this._renderer.GL.vertexAttribPointer(
-          loc,
-          size,
-          type || gl.FLOAT,
-          normalized || false,
-          stride || 0,
-          offset || 0
-        );
+        const loc = attr.location;
+        if (loc !== -1) {
+          const gl = this._renderer.GL;
+          // Enable register even if it is disabled
+          if (!this._renderer.registerEnabled.has(loc)) {
+            gl.enableVertexAttribArray(loc);
+            // Record register availability
+            this._renderer.registerEnabled.add(loc);
+          }
+          this._renderer.GL.vertexAttribPointer(
+            loc,
+            size,
+            type || gl.FLOAT,
+            normalized || false,
+            stride || 0,
+            offset || 0
+          );
+        }
+      }
+      return this;
+    }
+
+    /**
+     * Once all buffers have been bound, this checks to see if there are any
+     * remaining active attributes, likely left over from previous renders,
+     * and disables them so that they don't affect rendering.
+     * @private
+     */
+    disableRemainingAttributes() {
+      for (const location of this._renderer.registerEnabled.values()) {
+        if (
+          !Object.keys(this.attributes).some(
+            key => this.attributes[key].location === location
+          )
+        ) {
+          this._renderer.GL.disableVertexAttribArray(location);
+          this._renderer.registerEnabled.delete(location);
+        }
       }
     }
-    return this;
-  }
+  };
+}
 
-  /**
-   * Once all buffers have been bound, this checks to see if there are any
-   * remaining active attributes, likely left over from previous renders,
-   * and disables them so that they don't affect rendering.
-   * @private
-   */
-  disableRemainingAttributes() {
-    for (const location of this._renderer.registerEnabled.values()) {
-      if (
-        !Object.keys(this.attributes).some(
-          key => this.attributes[key].location === location
-        )
-      ) {
-        this._renderer.GL.disableVertexAttribArray(location);
-        this._renderer.registerEnabled.delete(location);
-      }
-    }
-  }
-};
+export default shader;
 
-export default p5.Shader;
+if(typeof p5 !== 'undefined'){
+  shader(p5, p5.prototype);
+}

--- a/src/webgl/p5.Texture.js
+++ b/src/webgl/p5.Texture.js
@@ -6,497 +6,499 @@
  * @requires core
  */
 
-import p5 from '../core/main';
+// import p5 from '../core/main';
 import * as constants from '../core/constants';
 import Renderer from '../core/p5.Renderer';
 
-/**
- * Texture class for WEBGL Mode
- * @private
- * @class p5.Texture
- * @param {p5.RendererGL} renderer an instance of p5.RendererGL that
- * will provide the GL context for this new p5.Texture
- * @param {p5.Image|p5.Graphics|p5.Element|p5.MediaElement|ImageData|p5.Framebuffer|p5.FramebufferTexture|ImageData} [obj] the
- * object containing the image data to store in the texture.
- * @param {Object} [settings] optional A javascript object containing texture
- * settings.
- * @param {Number} [settings.format] optional The internal color component
- * format for the texture. Possible values for format include gl.RGBA,
- * gl.RGB, gl.ALPHA, gl.LUMINANCE, gl.LUMINANCE_ALPHA. Defaults to gl.RBGA
- * @param {Number} [settings.minFilter] optional The texture minification
- * filter setting. Possible values are gl.NEAREST or gl.LINEAR. Defaults
- * to gl.LINEAR. Note, Mipmaps are not implemented in p5.
- * @param {Number} [settings.magFilter] optional The texture magnification
- * filter setting. Possible values are gl.NEAREST or gl.LINEAR. Defaults
- * to gl.LINEAR. Note, Mipmaps are not implemented in p5.
- * @param {Number} [settings.wrapS] optional The texture wrap settings for
- * the s coordinate, or x axis. Possible values are gl.CLAMP_TO_EDGE,
- * gl.REPEAT, and gl.MIRRORED_REPEAT. The mirror settings are only available
- * when using a power of two sized texture. Defaults to gl.CLAMP_TO_EDGE
- * @param {Number} [settings.wrapT] optional The texture wrap settings for
- * the t coordinate, or y axis. Possible values are gl.CLAMP_TO_EDGE,
- * gl.REPEAT, and gl.MIRRORED_REPEAT. The mirror settings are only available
- * when using a power of two sized texture. Defaults to gl.CLAMP_TO_EDGE
- * @param {Number} [settings.dataType] optional The data type of the texel
- * data. Possible values are gl.UNSIGNED_BYTE or gl.FLOAT. There are more
- * formats that are not implemented in p5. Defaults to gl.UNSIGNED_BYTE.
- */
-p5.Texture = class Texture {
-  constructor (renderer, obj, settings) {
-    this._renderer = renderer;
-
-    const gl = this._renderer.GL;
-
-    settings = settings || {};
-
-    this.src = obj;
-    this.glTex = undefined;
-    this.glTarget = gl.TEXTURE_2D;
-    this.glFormat = settings.format || gl.RGBA;
-    this.mipmaps = false;
-    this.glMinFilter = settings.minFilter || gl.LINEAR;
-    this.glMagFilter = settings.magFilter || gl.LINEAR;
-    this.glWrapS = settings.wrapS || gl.CLAMP_TO_EDGE;
-    this.glWrapT = settings.wrapT || gl.CLAMP_TO_EDGE;
-    this.glDataType = settings.dataType || gl.UNSIGNED_BYTE;
-
-    const support = checkWebGLCapabilities(renderer);
-    if (this.glFormat === gl.HALF_FLOAT && !support.halfFloat) {
-      console.log('This device does not support dataType HALF_FLOAT. Falling back to FLOAT.');
-      this.glDataType = gl.FLOAT;
-    }
-    if (
-      this.glFormat === gl.HALF_FLOAT &&
-      (this.glMinFilter === gl.LINEAR || this.glMagFilter === gl.LINEAR) &&
-      !support.halfFloatLinear
-    ) {
-      console.log('This device does not support linear filtering for dataType FLOAT. Falling back to NEAREST.');
-      if (this.glMinFilter === gl.LINEAR) this.glMinFilter = gl.NEAREST;
-      if (this.glMagFilter === gl.LINEAR) this.glMagFilter = gl.NEAREST;
-    }
-    if (this.glFormat === gl.FLOAT && !support.float) {
-      console.log('This device does not support dataType FLOAT. Falling back to UNSIGNED_BYTE.');
-      this.glDataType = gl.UNSIGNED_BYTE;
-    }
-    if (
-      this.glFormat === gl.FLOAT &&
-      (this.glMinFilter === gl.LINEAR || this.glMagFilter === gl.LINEAR) &&
-      !support.floatLinear
-    ) {
-      console.log('This device does not support linear filtering for dataType FLOAT. Falling back to NEAREST.');
-      if (this.glMinFilter === gl.LINEAR) this.glMinFilter = gl.NEAREST;
-      if (this.glMagFilter === gl.LINEAR) this.glMagFilter = gl.NEAREST;
-    }
-
-    // used to determine if this texture might need constant updating
-    // because it is a video or gif.
-    this.isSrcMediaElement =
-      typeof p5.MediaElement !== 'undefined' && obj instanceof p5.MediaElement;
-    this._videoPrevUpdateTime = 0;
-    this.isSrcHTMLElement =
-      typeof p5.Element !== 'undefined' &&
-      obj instanceof p5.Element &&
-      !(obj instanceof p5.Graphics) &&
-      !(obj instanceof Renderer);
-    this.isSrcP5Image = obj instanceof p5.Image;
-    this.isSrcP5Graphics = obj instanceof p5.Graphics;
-    this.isSrcP5Renderer = obj instanceof Renderer;
-    this.isImageData =
-      typeof ImageData !== 'undefined' && obj instanceof ImageData;
-    this.isFramebufferTexture = obj instanceof p5.FramebufferTexture;
-
-    const textureData = this._getTextureDataFromSource();
-    this.width = textureData.width;
-    this.height = textureData.height;
-
-    this.init(textureData);
-    return this;
-  }
-
-  _getTextureDataFromSource () {
-    let textureData;
-    if (this.isFramebufferTexture) {
-      textureData = this.src.rawTexture();
-    } else if (this.isSrcP5Image) {
-    // param is a p5.Image
-      textureData = this.src.canvas;
-    } else if (
-      this.isSrcMediaElement ||
-    this.isSrcP5Graphics ||
-    this.isSrcHTMLElement
-    ) {
-    // if param is a video HTML element
-      textureData = this.src.elt;
-    } else if (this.isSrcP5Renderer) {
-      textureData = this.src.canvas;
-    } else if (this.isImageData) {
-      textureData = this.src;
-    }
-    return textureData;
-  }
-
+function texture(p5, fn){
   /**
-   * Initializes common texture parameters, creates a gl texture,
-   * tries to upload the texture for the first time if data is
-   * already available.
+   * Texture class for WEBGL Mode
    * @private
-   * @method init
+   * @class p5.Texture
+   * @param {p5.RendererGL} renderer an instance of p5.RendererGL that
+   * will provide the GL context for this new p5.Texture
+   * @param {p5.Image|p5.Graphics|p5.Element|p5.MediaElement|ImageData|p5.Framebuffer|p5.FramebufferTexture|ImageData} [obj] the
+   * object containing the image data to store in the texture.
+   * @param {Object} [settings] optional A javascript object containing texture
+   * settings.
+   * @param {Number} [settings.format] optional The internal color component
+   * format for the texture. Possible values for format include gl.RGBA,
+   * gl.RGB, gl.ALPHA, gl.LUMINANCE, gl.LUMINANCE_ALPHA. Defaults to gl.RBGA
+   * @param {Number} [settings.minFilter] optional The texture minification
+   * filter setting. Possible values are gl.NEAREST or gl.LINEAR. Defaults
+   * to gl.LINEAR. Note, Mipmaps are not implemented in p5.
+   * @param {Number} [settings.magFilter] optional The texture magnification
+   * filter setting. Possible values are gl.NEAREST or gl.LINEAR. Defaults
+   * to gl.LINEAR. Note, Mipmaps are not implemented in p5.
+   * @param {Number} [settings.wrapS] optional The texture wrap settings for
+   * the s coordinate, or x axis. Possible values are gl.CLAMP_TO_EDGE,
+   * gl.REPEAT, and gl.MIRRORED_REPEAT. The mirror settings are only available
+   * when using a power of two sized texture. Defaults to gl.CLAMP_TO_EDGE
+   * @param {Number} [settings.wrapT] optional The texture wrap settings for
+   * the t coordinate, or y axis. Possible values are gl.CLAMP_TO_EDGE,
+   * gl.REPEAT, and gl.MIRRORED_REPEAT. The mirror settings are only available
+   * when using a power of two sized texture. Defaults to gl.CLAMP_TO_EDGE
+   * @param {Number} [settings.dataType] optional The data type of the texel
+   * data. Possible values are gl.UNSIGNED_BYTE or gl.FLOAT. There are more
+   * formats that are not implemented in p5. Defaults to gl.UNSIGNED_BYTE.
    */
-  init (data) {
-    const gl = this._renderer.GL;
-    if (!this.isFramebufferTexture) {
-      this.glTex = gl.createTexture();
-    }
+  p5.Texture = class Texture {
+    constructor (renderer, obj, settings) {
+      this._renderer = renderer;
 
-    this.glWrapS = this._renderer.textureWrapX;
-    this.glWrapT = this._renderer.textureWrapY;
+      const gl = this._renderer.GL;
 
-    this.setWrapMode(this.glWrapS, this.glWrapT);
-    this.bindTexture();
+      settings = settings || {};
 
-    //gl.pixelStorei(gl.UNPACK_FLIP_Y_WEBGL, true);
-    gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MAG_FILTER, this.glMagFilter);
-    gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MIN_FILTER, this.glMinFilter);
+      this.src = obj;
+      this.glTex = undefined;
+      this.glTarget = gl.TEXTURE_2D;
+      this.glFormat = settings.format || gl.RGBA;
+      this.mipmaps = false;
+      this.glMinFilter = settings.minFilter || gl.LINEAR;
+      this.glMagFilter = settings.magFilter || gl.LINEAR;
+      this.glWrapS = settings.wrapS || gl.CLAMP_TO_EDGE;
+      this.glWrapT = settings.wrapT || gl.CLAMP_TO_EDGE;
+      this.glDataType = settings.dataType || gl.UNSIGNED_BYTE;
 
-    if (this.isFramebufferTexture) {
-      // Do nothing, the framebuffer manages its own content
-    } else if (
-      this.width === 0 ||
-      this.height === 0 ||
-      (this.isSrcMediaElement && !this.src.loadedmetadata)
-    ) {
-    // assign a 1×1 empty texture initially, because data is not yet ready,
-    // so that no errors occur in gl console!
-      const tmpdata = new Uint8Array([1, 1, 1, 1]);
-      gl.texImage2D(
-        this.glTarget,
-        0,
-        gl.RGBA,
-        1,
-        1,
-        0,
-        this.glFormat,
-        this.glDataType,
-        tmpdata
-      );
-    } else {
-    // data is ready: just push the texture!
-      gl.texImage2D(
-        this.glTarget,
-        0,
-        this.glFormat,
-        this.glFormat,
-        this.glDataType,
-        data
-      );
-    }
-  }
-
-  /**
-   * Checks if the source data for this texture has changed (if it's
-   * easy to do so) and reuploads the texture if necessary. If it's not
-   * possible or to expensive to do a calculation to determine wheter or
-   * not the data has occurred, this method simply re-uploads the texture.
-   * @method update
-   */
-  update () {
-    const data = this.src;
-    if (data.width === 0 || data.height === 0) {
-      return false; // nothing to do!
-    }
-
-    // FramebufferTexture instances wrap raw WebGL textures already, which
-    // don't need any extra updating, as they already live on the GPU
-    if (this.isFramebufferTexture) {
-      return false;
-    }
-
-    const textureData = this._getTextureDataFromSource();
-    let updated = false;
-
-    const gl = this._renderer.GL;
-    // pull texture from data, make sure width & height are appropriate
-    if (
-      textureData.width !== this.width ||
-      textureData.height !== this.height
-    ) {
-      updated = true;
-
-      // make sure that if the width and height of this.src have changed
-      // for some reason, we update our metadata and upload the texture again
-      this.width = textureData.width || data.width;
-      this.height = textureData.height || data.height;
-
-      if (this.isSrcP5Image) {
-        data.setModified(false);
-      } else if (this.isSrcMediaElement || this.isSrcHTMLElement) {
-        // on the first frame the metadata comes in, the size will be changed
-        // from 0 to actual size, but pixels may not be available.
-        // flag for update in a future frame.
-        // if we don't do this, a paused video, for example, may not
-        // send the first frame to texture memory.
-        data.setModified(true);
+      const support = checkWebGLCapabilities(renderer);
+      if (this.glFormat === gl.HALF_FLOAT && !support.halfFloat) {
+        console.log('This device does not support dataType HALF_FLOAT. Falling back to FLOAT.');
+        this.glDataType = gl.FLOAT;
       }
-    } else if (this.isSrcP5Image) {
-      // for an image, we only update if the modified field has been set,
-      // for example, by a call to p5.Image.set
-      if (data.isModified()) {
-        updated = true;
-        data.setModified(false);
+      if (
+        this.glFormat === gl.HALF_FLOAT &&
+        (this.glMinFilter === gl.LINEAR || this.glMagFilter === gl.LINEAR) &&
+        !support.halfFloatLinear
+      ) {
+        console.log('This device does not support linear filtering for dataType FLOAT. Falling back to NEAREST.');
+        if (this.glMinFilter === gl.LINEAR) this.glMinFilter = gl.NEAREST;
+        if (this.glMagFilter === gl.LINEAR) this.glMagFilter = gl.NEAREST;
       }
-    } else if (this.isSrcMediaElement) {
-      // for a media element (video), we'll check if the current time in
-      // the video frame matches the last time. if it doesn't match, the
-      // video has advanced or otherwise been taken to a new frame,
-      // and we need to upload it.
-      if (data.isModified()) {
-        // p5.MediaElement may have also had set/updatePixels, etc. called
-        // on it and should be updated, or may have been set for the first
-        // time!
+      if (this.glFormat === gl.FLOAT && !support.float) {
+        console.log('This device does not support dataType FLOAT. Falling back to UNSIGNED_BYTE.');
+        this.glDataType = gl.UNSIGNED_BYTE;
+      }
+      if (
+        this.glFormat === gl.FLOAT &&
+        (this.glMinFilter === gl.LINEAR || this.glMagFilter === gl.LINEAR) &&
+        !support.floatLinear
+      ) {
+        console.log('This device does not support linear filtering for dataType FLOAT. Falling back to NEAREST.');
+        if (this.glMinFilter === gl.LINEAR) this.glMinFilter = gl.NEAREST;
+        if (this.glMagFilter === gl.LINEAR) this.glMagFilter = gl.NEAREST;
+      }
+
+      // used to determine if this texture might need constant updating
+      // because it is a video or gif.
+      this.isSrcMediaElement =
+        typeof p5.MediaElement !== 'undefined' && obj instanceof p5.MediaElement;
+      this._videoPrevUpdateTime = 0;
+      this.isSrcHTMLElement =
+        typeof p5.Element !== 'undefined' &&
+        obj instanceof p5.Element &&
+        !(obj instanceof p5.Graphics) &&
+        !(obj instanceof Renderer);
+      this.isSrcP5Image = obj instanceof p5.Image;
+      this.isSrcP5Graphics = obj instanceof p5.Graphics;
+      this.isSrcP5Renderer = obj instanceof Renderer;
+      this.isImageData =
+        typeof ImageData !== 'undefined' && obj instanceof ImageData;
+      this.isFramebufferTexture = obj instanceof p5.FramebufferTexture;
+
+      const textureData = this._getTextureDataFromSource();
+      this.width = textureData.width;
+      this.height = textureData.height;
+
+      this.init(textureData);
+      return this;
+    }
+
+    _getTextureDataFromSource () {
+      let textureData;
+      if (this.isFramebufferTexture) {
+        textureData = this.src.rawTexture();
+      } else if (this.isSrcP5Image) {
+      // param is a p5.Image
+        textureData = this.src.canvas;
+      } else if (
+        this.isSrcMediaElement ||
+      this.isSrcP5Graphics ||
+      this.isSrcHTMLElement
+      ) {
+      // if param is a video HTML element
+        textureData = this.src.elt;
+      } else if (this.isSrcP5Renderer) {
+        textureData = this.src.canvas;
+      } else if (this.isImageData) {
+        textureData = this.src;
+      }
+      return textureData;
+    }
+
+    /**
+     * Initializes common texture parameters, creates a gl texture,
+     * tries to upload the texture for the first time if data is
+     * already available.
+     * @private
+     * @method init
+     */
+    init (data) {
+      const gl = this._renderer.GL;
+      if (!this.isFramebufferTexture) {
+        this.glTex = gl.createTexture();
+      }
+
+      this.glWrapS = this._renderer.textureWrapX;
+      this.glWrapT = this._renderer.textureWrapY;
+
+      this.setWrapMode(this.glWrapS, this.glWrapT);
+      this.bindTexture();
+
+      //gl.pixelStorei(gl.UNPACK_FLIP_Y_WEBGL, true);
+      gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MAG_FILTER, this.glMagFilter);
+      gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MIN_FILTER, this.glMinFilter);
+
+      if (this.isFramebufferTexture) {
+        // Do nothing, the framebuffer manages its own content
+      } else if (
+        this.width === 0 ||
+        this.height === 0 ||
+        (this.isSrcMediaElement && !this.src.loadedmetadata)
+      ) {
+      // assign a 1×1 empty texture initially, because data is not yet ready,
+      // so that no errors occur in gl console!
+        const tmpdata = new Uint8Array([1, 1, 1, 1]);
+        gl.texImage2D(
+          this.glTarget,
+          0,
+          gl.RGBA,
+          1,
+          1,
+          0,
+          this.glFormat,
+          this.glDataType,
+          tmpdata
+        );
+      } else {
+      // data is ready: just push the texture!
+        gl.texImage2D(
+          this.glTarget,
+          0,
+          this.glFormat,
+          this.glFormat,
+          this.glDataType,
+          data
+        );
+      }
+    }
+
+    /**
+     * Checks if the source data for this texture has changed (if it's
+     * easy to do so) and reuploads the texture if necessary. If it's not
+     * possible or to expensive to do a calculation to determine wheter or
+     * not the data has occurred, this method simply re-uploads the texture.
+     * @method update
+     */
+    update () {
+      const data = this.src;
+      if (data.width === 0 || data.height === 0) {
+        return false; // nothing to do!
+      }
+
+      // FramebufferTexture instances wrap raw WebGL textures already, which
+      // don't need any extra updating, as they already live on the GPU
+      if (this.isFramebufferTexture) {
+        return false;
+      }
+
+      const textureData = this._getTextureDataFromSource();
+      let updated = false;
+
+      const gl = this._renderer.GL;
+      // pull texture from data, make sure width & height are appropriate
+      if (
+        textureData.width !== this.width ||
+        textureData.height !== this.height
+      ) {
         updated = true;
-        data.setModified(false);
-      } else if (data.loadedmetadata) {
-        // if the meta data has been loaded, we can ask the video
-        // what it's current position (in time) is.
-        if (this._videoPrevUpdateTime !== data.time()) {
-          // update the texture in gpu mem only if the current
-          // video timestamp does not match the timestamp of the last
-          // time we uploaded this texture (and update the time we
-          // last uploaded, too)
-          this._videoPrevUpdateTime = data.time();
+
+        // make sure that if the width and height of this.src have changed
+        // for some reason, we update our metadata and upload the texture again
+        this.width = textureData.width || data.width;
+        this.height = textureData.height || data.height;
+
+        if (this.isSrcP5Image) {
+          data.setModified(false);
+        } else if (this.isSrcMediaElement || this.isSrcHTMLElement) {
+          // on the first frame the metadata comes in, the size will be changed
+          // from 0 to actual size, but pixels may not be available.
+          // flag for update in a future frame.
+          // if we don't do this, a paused video, for example, may not
+          // send the first frame to texture memory.
+          data.setModified(true);
+        }
+      } else if (this.isSrcP5Image) {
+        // for an image, we only update if the modified field has been set,
+        // for example, by a call to p5.Image.set
+        if (data.isModified()) {
+          updated = true;
+          data.setModified(false);
+        }
+      } else if (this.isSrcMediaElement) {
+        // for a media element (video), we'll check if the current time in
+        // the video frame matches the last time. if it doesn't match, the
+        // video has advanced or otherwise been taken to a new frame,
+        // and we need to upload it.
+        if (data.isModified()) {
+          // p5.MediaElement may have also had set/updatePixels, etc. called
+          // on it and should be updated, or may have been set for the first
+          // time!
+          updated = true;
+          data.setModified(false);
+        } else if (data.loadedmetadata) {
+          // if the meta data has been loaded, we can ask the video
+          // what it's current position (in time) is.
+          if (this._videoPrevUpdateTime !== data.time()) {
+            // update the texture in gpu mem only if the current
+            // video timestamp does not match the timestamp of the last
+            // time we uploaded this texture (and update the time we
+            // last uploaded, too)
+            this._videoPrevUpdateTime = data.time();
+            updated = true;
+          }
+        }
+      } else if (this.isImageData) {
+        if (data._dirty) {
+          data._dirty = false;
           updated = true;
         }
-      }
-    } else if (this.isImageData) {
-      if (data._dirty) {
-        data._dirty = false;
+      } else {
+        /* data instanceof p5.Graphics, probably */
+        // there is not enough information to tell if the texture can be
+        // conditionally updated; so to be safe, we just go ahead and upload it.
         updated = true;
       }
-    } else {
-      /* data instanceof p5.Graphics, probably */
-      // there is not enough information to tell if the texture can be
-      // conditionally updated; so to be safe, we just go ahead and upload it.
-      updated = true;
+
+      if (updated) {
+        this.bindTexture();
+        gl.texImage2D(
+          this.glTarget,
+          0,
+          this.glFormat,
+          this.glFormat,
+          this.glDataType,
+          textureData
+        );
+      }
+
+      return updated;
     }
 
-    if (updated) {
+    /**
+     * Binds the texture to the appropriate GL target.
+     * @method bindTexture
+     */
+    bindTexture () {
+      // bind texture using gl context + glTarget and
+      // generated gl texture object
+      const gl = this._renderer.GL;
+      gl.bindTexture(this.glTarget, this.getTexture());
+
+      return this;
+    }
+
+    /**
+     * Unbinds the texture from the appropriate GL target.
+     * @method unbindTexture
+     */
+    unbindTexture () {
+      // unbind per above, disable texturing on glTarget
+      const gl = this._renderer.GL;
+      gl.bindTexture(this.glTarget, null);
+    }
+
+    getTexture() {
+      if (this.isFramebufferTexture) {
+        return this.src.rawTexture();
+      } else {
+        return this.glTex;
+      }
+    }
+
+    /**
+     * Sets how a texture is be interpolated when upscaled or downscaled.
+     * Nearest filtering uses nearest neighbor scaling when interpolating
+     * Linear filtering uses WebGL's linear scaling when interpolating
+     * @method setInterpolation
+     * @param {String} downScale Specifies the texture filtering when
+     *                           textures are shrunk. Options are LINEAR or NEAREST
+     * @param {String} upScale Specifies the texture filtering when
+     *                         textures are magnified. Options are LINEAR or NEAREST
+     * @todo implement mipmapping filters
+     */
+    setInterpolation (downScale, upScale) {
+      const gl = this._renderer.GL;
+
+      this.glMinFilter = this.glFilter(downScale);
+      this.glMagFilter = this.glFilter(upScale);
+
       this.bindTexture();
-      gl.texImage2D(
-        this.glTarget,
-        0,
-        this.glFormat,
-        this.glFormat,
-        this.glDataType,
-        textureData
-      );
+      gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MIN_FILTER, this.glMinFilter);
+      gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MAG_FILTER, this.glMagFilter);
+      this.unbindTexture();
     }
 
-    return updated;
-  }
-
-  /**
-   * Binds the texture to the appropriate GL target.
-   * @method bindTexture
-   */
-  bindTexture () {
-    // bind texture using gl context + glTarget and
-    // generated gl texture object
-    const gl = this._renderer.GL;
-    gl.bindTexture(this.glTarget, this.getTexture());
-
-    return this;
-  }
-
-  /**
-   * Unbinds the texture from the appropriate GL target.
-   * @method unbindTexture
-   */
-  unbindTexture () {
-    // unbind per above, disable texturing on glTarget
-    const gl = this._renderer.GL;
-    gl.bindTexture(this.glTarget, null);
-  }
-
-  getTexture() {
-    if (this.isFramebufferTexture) {
-      return this.src.rawTexture();
-    } else {
-      return this.glTex;
-    }
-  }
-
-  /**
-   * Sets how a texture is be interpolated when upscaled or downscaled.
-   * Nearest filtering uses nearest neighbor scaling when interpolating
-   * Linear filtering uses WebGL's linear scaling when interpolating
-   * @method setInterpolation
-   * @param {String} downScale Specifies the texture filtering when
-   *                           textures are shrunk. Options are LINEAR or NEAREST
-   * @param {String} upScale Specifies the texture filtering when
-   *                         textures are magnified. Options are LINEAR or NEAREST
-   * @todo implement mipmapping filters
-   */
-  setInterpolation (downScale, upScale) {
-    const gl = this._renderer.GL;
-
-    this.glMinFilter = this.glFilter(downScale);
-    this.glMagFilter = this.glFilter(upScale);
-
-    this.bindTexture();
-    gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MIN_FILTER, this.glMinFilter);
-    gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MAG_FILTER, this.glMagFilter);
-    this.unbindTexture();
-  }
-
-  glFilter(filter) {
-    const gl = this._renderer.GL;
-    if (filter === constants.NEAREST) {
-      return gl.NEAREST;
-    } else {
-      return gl.LINEAR;
-    }
-  }
-
-  /**
-   * Sets the texture wrapping mode. This controls how textures behave
-   * when their uv's go outside of the 0 - 1 range. There are three options:
-   * CLAMP, REPEAT, and MIRROR. REPEAT & MIRROR are only available if the texture
-   * is a power of two size (128, 256, 512, 1024, etc.).
-   * @method setWrapMode
-   * @param {String} wrapX Controls the horizontal texture wrapping behavior
-   * @param {String} wrapY Controls the vertical texture wrapping behavior
-   */
-  setWrapMode (wrapX, wrapY) {
-    const gl = this._renderer.GL;
-
-    // for webgl 1 we need to check if the texture is power of two
-    // if it isn't we will set the wrap mode to CLAMP
-    // webgl2 will support npot REPEAT and MIRROR but we don't check for it yet
-    const isPowerOfTwo = x => (x & (x - 1)) === 0;
-    const textureData = this._getTextureDataFromSource();
-
-    let wrapWidth;
-    let wrapHeight;
-
-    if (textureData.naturalWidth && textureData.naturalHeight) {
-      wrapWidth = textureData.naturalWidth;
-      wrapHeight = textureData.naturalHeight;
-    } else {
-      wrapWidth = this.width;
-      wrapHeight = this.height;
-    }
-
-    const widthPowerOfTwo = isPowerOfTwo(wrapWidth);
-    const heightPowerOfTwo = isPowerOfTwo(wrapHeight);
-
-    if (wrapX === constants.REPEAT) {
-      if (
-        this._renderer.webglVersion === constants.WEBGL2 ||
-      (widthPowerOfTwo && heightPowerOfTwo)
-      ) {
-        this.glWrapS = gl.REPEAT;
+    glFilter(filter) {
+      const gl = this._renderer.GL;
+      if (filter === constants.NEAREST) {
+        return gl.NEAREST;
       } else {
-        console.warn(
-          'You tried to set the wrap mode to REPEAT but the texture size is not a power of two. Setting to CLAMP instead'
-        );
+        return gl.LINEAR;
+      }
+    }
+
+    /**
+     * Sets the texture wrapping mode. This controls how textures behave
+     * when their uv's go outside of the 0 - 1 range. There are three options:
+     * CLAMP, REPEAT, and MIRROR. REPEAT & MIRROR are only available if the texture
+     * is a power of two size (128, 256, 512, 1024, etc.).
+     * @method setWrapMode
+     * @param {String} wrapX Controls the horizontal texture wrapping behavior
+     * @param {String} wrapY Controls the vertical texture wrapping behavior
+     */
+    setWrapMode (wrapX, wrapY) {
+      const gl = this._renderer.GL;
+
+      // for webgl 1 we need to check if the texture is power of two
+      // if it isn't we will set the wrap mode to CLAMP
+      // webgl2 will support npot REPEAT and MIRROR but we don't check for it yet
+      const isPowerOfTwo = x => (x & (x - 1)) === 0;
+      const textureData = this._getTextureDataFromSource();
+
+      let wrapWidth;
+      let wrapHeight;
+
+      if (textureData.naturalWidth && textureData.naturalHeight) {
+        wrapWidth = textureData.naturalWidth;
+        wrapHeight = textureData.naturalHeight;
+      } else {
+        wrapWidth = this.width;
+        wrapHeight = this.height;
+      }
+
+      const widthPowerOfTwo = isPowerOfTwo(wrapWidth);
+      const heightPowerOfTwo = isPowerOfTwo(wrapHeight);
+
+      if (wrapX === constants.REPEAT) {
+        if (
+          this._renderer.webglVersion === constants.WEBGL2 ||
+        (widthPowerOfTwo && heightPowerOfTwo)
+        ) {
+          this.glWrapS = gl.REPEAT;
+        } else {
+          console.warn(
+            'You tried to set the wrap mode to REPEAT but the texture size is not a power of two. Setting to CLAMP instead'
+          );
+          this.glWrapS = gl.CLAMP_TO_EDGE;
+        }
+      } else if (wrapX === constants.MIRROR) {
+        if (
+          this._renderer.webglVersion === constants.WEBGL2 ||
+        (widthPowerOfTwo && heightPowerOfTwo)
+        ) {
+          this.glWrapS = gl.MIRRORED_REPEAT;
+        } else {
+          console.warn(
+            'You tried to set the wrap mode to MIRROR but the texture size is not a power of two. Setting to CLAMP instead'
+          );
+          this.glWrapS = gl.CLAMP_TO_EDGE;
+        }
+      } else {
+        // falling back to default if didn't get a proper mode
         this.glWrapS = gl.CLAMP_TO_EDGE;
       }
-    } else if (wrapX === constants.MIRROR) {
-      if (
-        this._renderer.webglVersion === constants.WEBGL2 ||
-      (widthPowerOfTwo && heightPowerOfTwo)
-      ) {
-        this.glWrapS = gl.MIRRORED_REPEAT;
-      } else {
-        console.warn(
-          'You tried to set the wrap mode to MIRROR but the texture size is not a power of two. Setting to CLAMP instead'
-        );
-        this.glWrapS = gl.CLAMP_TO_EDGE;
-      }
-    } else {
-      // falling back to default if didn't get a proper mode
-      this.glWrapS = gl.CLAMP_TO_EDGE;
-    }
 
-    if (wrapY === constants.REPEAT) {
-      if (
-        this._renderer.webglVersion === constants.WEBGL2 ||
-      (widthPowerOfTwo && heightPowerOfTwo)
-      ) {
-        this.glWrapT = gl.REPEAT;
+      if (wrapY === constants.REPEAT) {
+        if (
+          this._renderer.webglVersion === constants.WEBGL2 ||
+        (widthPowerOfTwo && heightPowerOfTwo)
+        ) {
+          this.glWrapT = gl.REPEAT;
+        } else {
+          console.warn(
+            'You tried to set the wrap mode to REPEAT but the texture size is not a power of two. Setting to CLAMP instead'
+          );
+          this.glWrapT = gl.CLAMP_TO_EDGE;
+        }
+      } else if (wrapY === constants.MIRROR) {
+        if (
+          this._renderer.webglVersion === constants.WEBGL2 ||
+        (widthPowerOfTwo && heightPowerOfTwo)
+        ) {
+          this.glWrapT = gl.MIRRORED_REPEAT;
+        } else {
+          console.warn(
+            'You tried to set the wrap mode to MIRROR but the texture size is not a power of two. Setting to CLAMP instead'
+          );
+          this.glWrapT = gl.CLAMP_TO_EDGE;
+        }
       } else {
-        console.warn(
-          'You tried to set the wrap mode to REPEAT but the texture size is not a power of two. Setting to CLAMP instead'
-        );
+        // falling back to default if didn't get a proper mode
         this.glWrapT = gl.CLAMP_TO_EDGE;
       }
-    } else if (wrapY === constants.MIRROR) {
-      if (
-        this._renderer.webglVersion === constants.WEBGL2 ||
-      (widthPowerOfTwo && heightPowerOfTwo)
-      ) {
-        this.glWrapT = gl.MIRRORED_REPEAT;
-      } else {
-        console.warn(
-          'You tried to set the wrap mode to MIRROR but the texture size is not a power of two. Setting to CLAMP instead'
-        );
-        this.glWrapT = gl.CLAMP_TO_EDGE;
+
+      this.bindTexture();
+      gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_WRAP_S, this.glWrapS);
+      gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_WRAP_T, this.glWrapT);
+      this.unbindTexture();
+    }
+  };
+
+  p5.MipmapTexture = class MipmapTexture extends p5.Texture {
+    constructor(renderer, levels, settings) {
+      super(renderer, levels, settings);
+      const gl = this._renderer.GL;
+      if (this.glMinFilter === gl.LINEAR) {
+        this.glMinFilter = gl.LINEAR_MIPMAP_LINEAR;
       }
-    } else {
-      // falling back to default if didn't get a proper mode
-      this.glWrapT = gl.CLAMP_TO_EDGE;
     }
 
-    this.bindTexture();
-    gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_WRAP_S, this.glWrapS);
-    gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_WRAP_T, this.glWrapT);
-    this.unbindTexture();
-  }
-};
+    glFilter(_filter) {
+      const gl = this._renderer.GL;
+      // TODO: support others
+      return gl.LINEAR_MIPMAP_LINEAR;
+    }
 
-export class MipmapTexture extends p5.Texture {
-  constructor(renderer, levels, settings) {
-    super(renderer, levels, settings);
-    const gl = this._renderer.GL;
-    if (this.glMinFilter === gl.LINEAR) {
+    _getTextureDataFromSource() {
+      return this.src;
+    }
+
+    init(levels) {
+      const gl = this._renderer.GL;
+      this.glTex = gl.createTexture();
+
+      this.bindTexture();
+      for (let level = 0; level < levels.length; level++) {
+        gl.texImage2D(
+          this.glTarget,
+          level,
+          this.glFormat,
+          this.glFormat,
+          this.glDataType,
+          levels[level]
+        );
+      }
+
       this.glMinFilter = gl.LINEAR_MIPMAP_LINEAR;
-    }
-  }
+      gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MAG_FILTER, this.glMagFilter);
+      gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MIN_FILTER, this.glMinFilter);
 
-  glFilter(_filter) {
-    const gl = this._renderer.GL;
-    // TODO: support others
-    return gl.LINEAR_MIPMAP_LINEAR;
-  }
-
-  _getTextureDataFromSource() {
-    return this.src;
-  }
-
-  init(levels) {
-    const gl = this._renderer.GL;
-    this.glTex = gl.createTexture();
-
-    this.bindTexture();
-    for (let level = 0; level < levels.length; level++) {
-      gl.texImage2D(
-        this.glTarget,
-        level,
-        this.glFormat,
-        this.glFormat,
-        this.glDataType,
-        levels[level]
-      );
+      this.unbindTexture();
     }
 
-    this.glMinFilter = gl.LINEAR_MIPMAP_LINEAR;
-    gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MAG_FILTER, this.glMagFilter);
-    gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MIN_FILTER, this.glMinFilter);
-
-    this.unbindTexture();
-  }
-
-  update() {}
+    update() {}
+  };
 }
 
 export function checkWebGLCapabilities({ GL, webglVersion }) {
@@ -520,4 +522,5 @@ export function checkWebGLCapabilities({ GL, webglVersion }) {
   };
 }
 
-export default p5.Texture;
+export default texture;
+

--- a/src/webgl/text.js
+++ b/src/webgl/text.js
@@ -1,761 +1,762 @@
-import p5 from '../core/main';
 import * as constants from '../core/constants';
-import './p5.Shader';
-import './p5.RendererGL.Retained';
 
-// Text/Typography
-// @TODO:
-p5.RendererGL.prototype._applyTextProperties = function() {
-  //@TODO finish implementation
-  //console.error('text commands not yet implemented in webgl');
-};
+function text(p5, fn){
+  // Text/Typography
+  // @TODO:
+  p5.RendererGL.prototype._applyTextProperties = function() {
+    //@TODO finish implementation
+    //console.error('text commands not yet implemented in webgl');
+  };
 
-p5.RendererGL.prototype.textWidth = function(s) {
-  if (this._isOpenType()) {
-    return this._textFont._textWidth(s, this._textSize);
-  }
+  p5.RendererGL.prototype.textWidth = function(s) {
+    if (this._isOpenType()) {
+      return this._textFont._textWidth(s, this._textSize);
+    }
 
-  return 0; // TODO: error
-};
+    return 0; // TODO: error
+  };
 
-// rendering constants
+  // rendering constants
 
-// the number of rows/columns dividing each glyph
-const charGridWidth = 9;
-const charGridHeight = charGridWidth;
+  // the number of rows/columns dividing each glyph
+  const charGridWidth = 9;
+  const charGridHeight = charGridWidth;
 
-// size of the image holding the bezier stroke info
-const strokeImageWidth = 64;
-const strokeImageHeight = 64;
+  // size of the image holding the bezier stroke info
+  const strokeImageWidth = 64;
+  const strokeImageHeight = 64;
 
-// size of the image holding the stroke indices for each row/col
-const gridImageWidth = 64;
-const gridImageHeight = 64;
+  // size of the image holding the stroke indices for each row/col
+  const gridImageWidth = 64;
+  const gridImageHeight = 64;
 
-// size of the image holding the offset/length of each row/col stripe
-const cellImageWidth = 64;
-const cellImageHeight = 64;
+  // size of the image holding the offset/length of each row/col stripe
+  const cellImageWidth = 64;
+  const cellImageHeight = 64;
 
-/**
- * @private
- * @class ImageInfos
- * @param {Integer} width
- * @param {Integer} height
- *
- * the ImageInfos class holds a list of ImageDatas of a given size.
- */
-class ImageInfos {
-  constructor(width, height) {
-    this.width = width;
-    this.height = height;
-    this.infos = []; // the list of images
-  }
   /**
-     *
-     * @param {Integer} space
-     * @return {Object} contains the ImageData, and pixel index into that
-     *                  ImageData where the free space was allocated.
-     *
-     * finds free space of a given size in the ImageData list
-     */
-  findImage (space) {
-    const imageSize = this.width * this.height;
-    if (space > imageSize)
-      throw new Error('font is too complex to render in 3D');
-
-    // search through the list of images, looking for one with
-    // anough unused space.
-    let imageInfo, imageData;
-    for (let ii = this.infos.length - 1; ii >= 0; --ii) {
-      const imageInfoTest = this.infos[ii];
-      if (imageInfoTest.index + space < imageSize) {
-        // found one
-        imageInfo = imageInfoTest;
-        imageData = imageInfoTest.imageData;
-        break;
-      }
+   * @private
+   * @class ImageInfos
+   * @param {Integer} width
+   * @param {Integer} height
+   *
+   * the ImageInfos class holds a list of ImageDatas of a given size.
+   */
+  class ImageInfos {
+    constructor(width, height) {
+      this.width = width;
+      this.height = height;
+      this.infos = []; // the list of images
     }
-
-    if (!imageInfo) {
-      try {
-        // create a new image
-        imageData = new ImageData(this.width, this.height);
-      } catch (err) {
-        // for browsers that don't support ImageData constructors (ie IE11)
-        // create an ImageData using the old method
-        let canvas = document.getElementsByTagName('canvas')[0];
-        const created = !canvas;
-        if (!canvas) {
-          // create a temporary canvas
-          canvas = document.createElement('canvas');
-          canvas.style.display = 'none';
-          document.body.appendChild(canvas);
-        }
-        const ctx = canvas.getContext('2d');
-        if (ctx) {
-          imageData = ctx.createImageData(this.width, this.height);
-        }
-        if (created) {
-          // distroy the temporary canvas, if necessary
-          document.body.removeChild(canvas);
-        }
-      }
-      // construct & dd the new image info
-      imageInfo = { index: 0, imageData };
-      this.infos.push(imageInfo);
-    }
-
-    const index = imageInfo.index;
-    imageInfo.index += space; // move to the start of the next image
-    imageData._dirty = true;
-    return { imageData, index };
-  }
-}
-
-/**
- * @function setPixel
- * @param {Object} imageInfo
- * @param {Number} r
- * @param {Number} g
- * @param {Number} b
- * @param {Number} a
- *
- * writes the next pixel into an indexed ImageData
- */
-function setPixel(imageInfo, r, g, b, a) {
-  const imageData = imageInfo.imageData;
-  const pixels = imageData.data;
-  let index = imageInfo.index++ * 4;
-  pixels[index++] = r;
-  pixels[index++] = g;
-  pixels[index++] = b;
-  pixels[index++] = a;
-}
-
-const SQRT3 = Math.sqrt(3);
-
-/**
- * @private
- * @class FontInfo
- * @param {Object} font an opentype.js font object
- *
- * contains cached images and glyph information for an opentype font
- */
-class FontInfo {
-  constructor(font) {
-    this.font = font;
-    // the bezier curve coordinates
-    this.strokeImageInfos = new ImageInfos(strokeImageWidth, strokeImageHeight);
-    // lists of curve indices for each row/column slice
-    this.colDimImageInfos = new ImageInfos(gridImageWidth, gridImageHeight);
-    this.rowDimImageInfos = new ImageInfos(gridImageWidth, gridImageHeight);
-    // the offset & length of each row/col slice in the glyph
-    this.colCellImageInfos = new ImageInfos(cellImageWidth, cellImageHeight);
-    this.rowCellImageInfos = new ImageInfos(cellImageWidth, cellImageHeight);
-
-    // the cached information for each glyph
-    this.glyphInfos = {};
-  }
-  /**
-     * @param {Glyph} glyph the x positions of points in the curve
-     * @returns {Object} the glyphInfo for that glyph
-     *
-     * calculates rendering info for a glyph, including the curve information,
-     * row & column stripes compiled into textures.
-     */
-  getGlyphInfo (glyph) {
-    // check the cache
-    let gi = this.glyphInfos[glyph.index];
-    if (gi) return gi;
-
-    // get the bounding box of the glyph from opentype.js
-    const bb = glyph.getBoundingBox();
-    const xMin = bb.x1;
-    const yMin = bb.y1;
-    const gWidth = bb.x2 - xMin;
-    const gHeight = bb.y2 - yMin;
-    const cmds = glyph.path.commands;
-    // don't bother rendering invisible glyphs
-    if (gWidth === 0 || gHeight === 0 || !cmds.length) {
-      return (this.glyphInfos[glyph.index] = {});
-    }
-
-    let i;
-    const strokes = []; // the strokes in this glyph
-    const rows = []; // the indices of strokes in each row
-    const cols = []; // the indices of strokes in each column
-    for (i = charGridWidth - 1; i >= 0; --i) cols.push([]);
-    for (i = charGridHeight - 1; i >= 0; --i) rows.push([]);
-
     /**
-       * @function push
-       * @param {Number[]} xs the x positions of points in the curve
-       * @param {Number[]} ys the y positions of points in the curve
-       * @param {Object} v    the curve information
        *
-       * adds a curve to the rows & columns that it intersects with
+       * @param {Integer} space
+       * @return {Object} contains the ImageData, and pixel index into that
+       *                  ImageData where the free space was allocated.
+       *
+       * finds free space of a given size in the ImageData list
        */
-    function push(xs, ys, v) {
-      const index = strokes.length; // the index of this stroke
-      strokes.push(v); // add this stroke to the list
+    findImage (space) {
+      const imageSize = this.width * this.height;
+      if (space > imageSize)
+        throw new Error('font is too complex to render in 3D');
+
+      // search through the list of images, looking for one with
+      // anough unused space.
+      let imageInfo, imageData;
+      for (let ii = this.infos.length - 1; ii >= 0; --ii) {
+        const imageInfoTest = this.infos[ii];
+        if (imageInfoTest.index + space < imageSize) {
+          // found one
+          imageInfo = imageInfoTest;
+          imageData = imageInfoTest.imageData;
+          break;
+        }
+      }
+
+      if (!imageInfo) {
+        try {
+          // create a new image
+          imageData = new ImageData(this.width, this.height);
+        } catch (err) {
+          // for browsers that don't support ImageData constructors (ie IE11)
+          // create an ImageData using the old method
+          let canvas = document.getElementsByTagName('canvas')[0];
+          const created = !canvas;
+          if (!canvas) {
+            // create a temporary canvas
+            canvas = document.createElement('canvas');
+            canvas.style.display = 'none';
+            document.body.appendChild(canvas);
+          }
+          const ctx = canvas.getContext('2d');
+          if (ctx) {
+            imageData = ctx.createImageData(this.width, this.height);
+          }
+          if (created) {
+            // distroy the temporary canvas, if necessary
+            document.body.removeChild(canvas);
+          }
+        }
+        // construct & dd the new image info
+        imageInfo = { index: 0, imageData };
+        this.infos.push(imageInfo);
+      }
+
+      const index = imageInfo.index;
+      imageInfo.index += space; // move to the start of the next image
+      imageData._dirty = true;
+      return { imageData, index };
+    }
+  }
+
+  /**
+   * @function setPixel
+   * @param {Object} imageInfo
+   * @param {Number} r
+   * @param {Number} g
+   * @param {Number} b
+   * @param {Number} a
+   *
+   * writes the next pixel into an indexed ImageData
+   */
+  function setPixel(imageInfo, r, g, b, a) {
+    const imageData = imageInfo.imageData;
+    const pixels = imageData.data;
+    let index = imageInfo.index++ * 4;
+    pixels[index++] = r;
+    pixels[index++] = g;
+    pixels[index++] = b;
+    pixels[index++] = a;
+  }
+
+  const SQRT3 = Math.sqrt(3);
+
+  /**
+   * @private
+   * @class FontInfo
+   * @param {Object} font an opentype.js font object
+   *
+   * contains cached images and glyph information for an opentype font
+   */
+  class FontInfo {
+    constructor(font) {
+      this.font = font;
+      // the bezier curve coordinates
+      this.strokeImageInfos = new ImageInfos(strokeImageWidth, strokeImageHeight);
+      // lists of curve indices for each row/column slice
+      this.colDimImageInfos = new ImageInfos(gridImageWidth, gridImageHeight);
+      this.rowDimImageInfos = new ImageInfos(gridImageWidth, gridImageHeight);
+      // the offset & length of each row/col slice in the glyph
+      this.colCellImageInfos = new ImageInfos(cellImageWidth, cellImageHeight);
+      this.rowCellImageInfos = new ImageInfos(cellImageWidth, cellImageHeight);
+
+      // the cached information for each glyph
+      this.glyphInfos = {};
+    }
+    /**
+       * @param {Glyph} glyph the x positions of points in the curve
+       * @returns {Object} the glyphInfo for that glyph
+       *
+       * calculates rendering info for a glyph, including the curve information,
+       * row & column stripes compiled into textures.
+       */
+    getGlyphInfo (glyph) {
+      // check the cache
+      let gi = this.glyphInfos[glyph.index];
+      if (gi) return gi;
+
+      // get the bounding box of the glyph from opentype.js
+      const bb = glyph.getBoundingBox();
+      const xMin = bb.x1;
+      const yMin = bb.y1;
+      const gWidth = bb.x2 - xMin;
+      const gHeight = bb.y2 - yMin;
+      const cmds = glyph.path.commands;
+      // don't bother rendering invisible glyphs
+      if (gWidth === 0 || gHeight === 0 || !cmds.length) {
+        return (this.glyphInfos[glyph.index] = {});
+      }
+
+      let i;
+      const strokes = []; // the strokes in this glyph
+      const rows = []; // the indices of strokes in each row
+      const cols = []; // the indices of strokes in each column
+      for (i = charGridWidth - 1; i >= 0; --i) cols.push([]);
+      for (i = charGridHeight - 1; i >= 0; --i) rows.push([]);
 
       /**
-         * @function minMax
-         * @param {Number[]} rg the list of values to compare
-         * @param {Number} min the initial minimum value
-         * @param {Number} max the initial maximum value
+         * @function push
+         * @param {Number[]} xs the x positions of points in the curve
+         * @param {Number[]} ys the y positions of points in the curve
+         * @param {Object} v    the curve information
          *
-         * find the minimum & maximum value in a list of values
+         * adds a curve to the rows & columns that it intersects with
          */
-      function minMax(rg, min, max) {
-        for (let i = rg.length; i-- > 0; ) {
-          const v = rg[i];
-          if (min > v) min = v;
-          if (max < v) max = v;
-        }
-        return { min, max };
-      }
+      function push(xs, ys, v) {
+        const index = strokes.length; // the index of this stroke
+        strokes.push(v); // add this stroke to the list
 
-      // Expand the bounding box of the glyph by the number of cells below
-      // before rounding. Curves only partially through a cell won't be added
-      // to adjacent cells, but ones that are close will be. This helps fix
-      // small visual glitches that occur when curves are close to grid cell
-      // boundaries.
-      const cellOffset = 0.5;
-
-      // loop through the rows & columns that the curve intersects
-      // adding the curve to those slices
-      const mmX = minMax(xs, 1, 0);
-      const ixMin = Math.max(
-        Math.floor(mmX.min * charGridWidth - cellOffset),
-        0
-      );
-      const ixMax = Math.min(
-        Math.ceil(mmX.max * charGridWidth + cellOffset),
-        charGridWidth
-      );
-      for (let iCol = ixMin; iCol < ixMax; ++iCol) cols[iCol].push(index);
-
-      const mmY = minMax(ys, 1, 0);
-      const iyMin = Math.max(
-        Math.floor(mmY.min * charGridHeight - cellOffset),
-        0
-      );
-      const iyMax = Math.min(
-        Math.ceil(mmY.max * charGridHeight + cellOffset),
-        charGridHeight
-      );
-      for (let iRow = iyMin; iRow < iyMax; ++iRow) rows[iRow].push(index);
-    }
-
-    /**
-       * @function clamp
-       * @param {Number} v the value to clamp
-       * @param {Number} min the minimum value
-       * @param {Number} max the maxmimum value
-       *
-       * clamps a value between a minimum & maximum value
-       */
-    function clamp(v, min, max) {
-      if (v < min) return min;
-      if (v > max) return max;
-      return v;
-    }
-
-    /**
-       * @function byte
-       * @param {Number} v the value to scale
-       *
-       * converts a floating-point number in the range 0-1 to a byte 0-255
-       */
-    function byte(v) {
-      return clamp(255 * v, 0, 255);
-    }
-
-    /**
-       * @private
-       * @class Cubic
-       * @param {Number} p0 the start point of the curve
-       * @param {Number} c0 the first control point
-       * @param {Number} c1 the second control point
-       * @param {Number} p1 the end point
-       *
-       * a cubic curve
-       */
-    class Cubic {
-      constructor(p0, c0, c1, p1) {
-        this.p0 = p0;
-        this.c0 = c0;
-        this.c1 = c1;
-        this.p1 = p1;
-      }
-      /**
-           * @return {Object} the quadratic approximation
+        /**
+           * @function minMax
+           * @param {Number[]} rg the list of values to compare
+           * @param {Number} min the initial minimum value
+           * @param {Number} max the initial maximum value
            *
-           * converts the cubic to a quadtratic approximation by
-           * picking an appropriate quadratic control point
+           * find the minimum & maximum value in a list of values
            */
-      toQuadratic () {
+        function minMax(rg, min, max) {
+          for (let i = rg.length; i-- > 0; ) {
+            const v = rg[i];
+            if (min > v) min = v;
+            if (max < v) max = v;
+          }
+          return { min, max };
+        }
+
+        // Expand the bounding box of the glyph by the number of cells below
+        // before rounding. Curves only partially through a cell won't be added
+        // to adjacent cells, but ones that are close will be. This helps fix
+        // small visual glitches that occur when curves are close to grid cell
+        // boundaries.
+        const cellOffset = 0.5;
+
+        // loop through the rows & columns that the curve intersects
+        // adding the curve to those slices
+        const mmX = minMax(xs, 1, 0);
+        const ixMin = Math.max(
+          Math.floor(mmX.min * charGridWidth - cellOffset),
+          0
+        );
+        const ixMax = Math.min(
+          Math.ceil(mmX.max * charGridWidth + cellOffset),
+          charGridWidth
+        );
+        for (let iCol = ixMin; iCol < ixMax; ++iCol) cols[iCol].push(index);
+
+        const mmY = minMax(ys, 1, 0);
+        const iyMin = Math.max(
+          Math.floor(mmY.min * charGridHeight - cellOffset),
+          0
+        );
+        const iyMax = Math.min(
+          Math.ceil(mmY.max * charGridHeight + cellOffset),
+          charGridHeight
+        );
+        for (let iRow = iyMin; iRow < iyMax; ++iRow) rows[iRow].push(index);
+      }
+
+      /**
+         * @function clamp
+         * @param {Number} v the value to clamp
+         * @param {Number} min the minimum value
+         * @param {Number} max the maxmimum value
+         *
+         * clamps a value between a minimum & maximum value
+         */
+      function clamp(v, min, max) {
+        if (v < min) return min;
+        if (v > max) return max;
+        return v;
+      }
+
+      /**
+         * @function byte
+         * @param {Number} v the value to scale
+         *
+         * converts a floating-point number in the range 0-1 to a byte 0-255
+         */
+      function byte(v) {
+        return clamp(255 * v, 0, 255);
+      }
+
+      /**
+         * @private
+         * @class Cubic
+         * @param {Number} p0 the start point of the curve
+         * @param {Number} c0 the first control point
+         * @param {Number} c1 the second control point
+         * @param {Number} p1 the end point
+         *
+         * a cubic curve
+         */
+      class Cubic {
+        constructor(p0, c0, c1, p1) {
+          this.p0 = p0;
+          this.c0 = c0;
+          this.c1 = c1;
+          this.p1 = p1;
+        }
+        /**
+             * @return {Object} the quadratic approximation
+             *
+             * converts the cubic to a quadtratic approximation by
+             * picking an appropriate quadratic control point
+             */
+        toQuadratic () {
+          return {
+            x: this.p0.x,
+            y: this.p0.y,
+            x1: this.p1.x,
+            y1: this.p1.y,
+            cx: ((this.c0.x + this.c1.x) * 3 - (this.p0.x + this.p1.x)) / 4,
+            cy: ((this.c0.y + this.c1.y) * 3 - (this.p0.y + this.p1.y)) / 4
+          };
+        }
+
+        /**
+             * @return {Number} the error
+             *
+             * calculates the magnitude of error of this curve's
+             * quadratic approximation.
+             */
+        quadError () {
+          return (
+            p5.Vector.sub(
+              p5.Vector.sub(this.p1, this.p0),
+              p5.Vector.mult(p5.Vector.sub(this.c1, this.c0), 3)
+            ).mag() / 2
+          );
+        }
+
+        /**
+             * @param {Number} t the value (0-1) at which to split
+             * @return {Cubic} the second part of the curve
+             *
+             * splits the cubic into two parts at a point 't' along the curve.
+             * this cubic keeps its start point and its end point becomes the
+             * point at 't'. the 'end half is returned.
+             */
+        split (t) {
+          const m1 = p5.Vector.lerp(this.p0, this.c0, t);
+          const m2 = p5.Vector.lerp(this.c0, this.c1, t);
+          const mm1 = p5.Vector.lerp(m1, m2, t);
+
+          this.c1 = p5.Vector.lerp(this.c1, this.p1, t);
+          this.c0 = p5.Vector.lerp(m2, this.c1, t);
+          const pt = p5.Vector.lerp(mm1, this.c0, t);
+          const part1 = new Cubic(this.p0, m1, mm1, pt);
+          this.p0 = pt;
+          return part1;
+        }
+
+        /**
+             * @return {Cubic[]} the non-inflecting pieces of this cubic
+             *
+             * returns an array containing 0, 1 or 2 cubics split resulting
+             * from splitting this cubic at its inflection points.
+             * this cubic is (potentially) altered and returned in the list.
+             */
+        splitInflections () {
+          const a = p5.Vector.sub(this.c0, this.p0);
+          const b = p5.Vector.sub(p5.Vector.sub(this.c1, this.c0), a);
+          const c = p5.Vector.sub(
+            p5.Vector.sub(p5.Vector.sub(this.p1, this.c1), a),
+            p5.Vector.mult(b, 2)
+          );
+
+          const cubics = [];
+
+          // find the derivative coefficients
+          let A = b.x * c.y - b.y * c.x;
+          if (A !== 0) {
+            let B = a.x * c.y - a.y * c.x;
+            let C = a.x * b.y - a.y * b.x;
+            const disc = B * B - 4 * A * C;
+            if (disc >= 0) {
+              if (A < 0) {
+                A = -A;
+                B = -B;
+                C = -C;
+              }
+
+              const Q = Math.sqrt(disc);
+              const t0 = (-B - Q) / (2 * A); // the first inflection point
+              let t1 = (-B + Q) / (2 * A); // the second inflection point
+
+              // test if the first inflection point lies on the curve
+              if (t0 > 0 && t0 < 1) {
+                // split at the first inflection point
+                cubics.push(this.split(t0));
+                // scale t2 into the second part
+                t1 = 1 - (1 - t1) / (1 - t0);
+              }
+
+              // test if the second inflection point lies on the curve
+              if (t1 > 0 && t1 < 1) {
+                // split at the second inflection point
+                cubics.push(this.split(t1));
+              }
+            }
+          }
+
+          cubics.push(this);
+          return cubics;
+        }
+      }
+
+      /**
+         * @function cubicToQuadratics
+         * @param {Number} x0
+         * @param {Number} y0
+         * @param {Number} cx0
+         * @param {Number} cy0
+         * @param {Number} cx1
+         * @param {Number} cy1
+         * @param {Number} x1
+         * @param {Number} y1
+         * @returns {Cubic[]} an array of cubics whose quadratic approximations
+         *                    closely match the civen cubic.
+         *
+         * converts a cubic curve to a list of quadratics.
+         */
+      function cubicToQuadratics(x0, y0, cx0, cy0, cx1, cy1, x1, y1) {
+        // create the Cubic object and split it at its inflections
+        const cubics = new Cubic(
+          new p5.Vector(x0, y0),
+          new p5.Vector(cx0, cy0),
+          new p5.Vector(cx1, cy1),
+          new p5.Vector(x1, y1)
+        ).splitInflections();
+
+        const qs = []; // the final list of quadratics
+        const precision = 30 / SQRT3;
+
+        // for each of the non-inflected pieces of the original cubic
+        for (let cubic of cubics) {
+          // the cubic is iteratively split in 3 pieces:
+          // the first piece is accumulated in 'qs', the result.
+          // the last piece is accumulated in 'tail', temporarily.
+          // the middle piece is repeatedly split again, while necessary.
+          const tail = [];
+
+          let t3;
+          for (;;) {
+            // calculate this cubic's precision
+            t3 = precision / cubic.quadError();
+            if (t3 >= 0.5 * 0.5 * 0.5) {
+              break; // not too bad, we're done
+            }
+
+            // find a split point based on the error
+            const t = Math.pow(t3, 1.0 / 3.0);
+            // split the cubic in 3
+            const start = cubic.split(t);
+            const middle = cubic.split(1 - t / (1 - t));
+
+            qs.push(start); // the first part
+            tail.push(cubic); // the last part
+            cubic = middle; // iterate on the middle piece
+          }
+
+          if (t3 < 1) {
+            // a little excess error, split the middle in two
+            qs.push(cubic.split(0.5));
+          }
+          // add the middle piece to the result
+          qs.push(cubic);
+
+          // finally add the tail, reversed, onto the result
+          Array.prototype.push.apply(qs, tail.reverse());
+        }
+
+        return qs;
+      }
+
+      /**
+         * @function pushLine
+         * @param {Number} x0
+         * @param {Number} y0
+         * @param {Number} x1
+         * @param {Number} y1
+         *
+         * add a straight line to the row/col grid of a glyph
+         */
+      function pushLine(x0, y0, x1, y1) {
+        const mx = (x0 + x1) / 2;
+        const my = (y0 + y1) / 2;
+        push([x0, x1], [y0, y1], { x: x0, y: y0, cx: mx, cy: my });
+      }
+
+      /**
+         * @function samePoint
+         * @param {Number} x0
+         * @param {Number} y0
+         * @param {Number} x1
+         * @param {Number} y1
+         * @return {Boolean} true if the two points are sufficiently close
+         *
+         * tests if two points are close enough to be considered the same
+         */
+      function samePoint(x0, y0, x1, y1) {
+        return Math.abs(x1 - x0) < 0.00001 && Math.abs(y1 - y0) < 0.00001;
+      }
+
+      let x0, y0, xs, ys;
+
+      for (const cmd of cmds) {
+        // scale the coordinates to the range 0-1
+        const x1 = (cmd.x - xMin) / gWidth;
+        const y1 = (cmd.y - yMin) / gHeight;
+
+        // don't bother if this point is the same as the last
+        if (samePoint(x0, y0, x1, y1)) continue;
+
+        switch (cmd.type) {
+          case 'M': {
+            // move
+            xs = x1;
+            ys = y1;
+            break;
+          }
+          case 'L': {
+            // line
+            pushLine(x0, y0, x1, y1);
+            break;
+          }
+          case 'Q': {
+            // quadratic
+            const cx = (cmd.x1 - xMin) / gWidth;
+            const cy = (cmd.y1 - yMin) / gHeight;
+            push([x0, x1, cx], [y0, y1, cy], { x: x0, y: y0, cx, cy });
+            break;
+          }
+          case 'Z': {
+            // end
+            if (!samePoint(x0, y0, xs, ys)) {
+              // add an extra line closing the loop, if necessary
+              pushLine(x0, y0, xs, ys);
+              strokes.push({ x: xs, y: ys });
+            } else {
+              strokes.push({ x: x0, y: y0 });
+            }
+            break;
+          }
+          case 'C': {
+            // cubic
+            const cx1 = (cmd.x1 - xMin) / gWidth;
+            const cy1 = (cmd.y1 - yMin) / gHeight;
+            const cx2 = (cmd.x2 - xMin) / gWidth;
+            const cy2 = (cmd.y2 - yMin) / gHeight;
+            const qs = cubicToQuadratics(x0, y0, cx1, cy1, cx2, cy2, x1, y1);
+            for (let iq = 0; iq < qs.length; iq++) {
+              const q = qs[iq].toQuadratic();
+              push([q.x, q.x1, q.cx], [q.y, q.y1, q.cy], q);
+            }
+            break;
+          }
+          default:
+            throw new Error(`unknown command type: ${cmd.type}`);
+        }
+        x0 = x1;
+        y0 = y1;
+      }
+
+      // allocate space for the strokes
+      const strokeCount = strokes.length;
+      const strokeImageInfo = this.strokeImageInfos.findImage(strokeCount);
+      const strokeOffset = strokeImageInfo.index;
+
+      // fill the stroke image
+      for (let il = 0; il < strokeCount; ++il) {
+        const s = strokes[il];
+        setPixel(strokeImageInfo, byte(s.x), byte(s.y), byte(s.cx), byte(s.cy));
+      }
+
+      /**
+         * @function layout
+         * @param {Number[][]} dim
+         * @param {ImageInfo[]} dimImageInfos
+         * @param {ImageInfo[]} cellImageInfos
+         * @return {Object}
+         *
+         * lays out the curves in a dimension (row or col) into two
+         * images, one for the indices of the curves themselves, and
+         * one containing the offset and length of those index spans.
+         */
+      function layout(dim, dimImageInfos, cellImageInfos) {
+        const dimLength = dim.length; // the number of slices in this dimension
+        const dimImageInfo = dimImageInfos.findImage(dimLength);
+        const dimOffset = dimImageInfo.index;
+        // calculate the total number of stroke indices in this dimension
+        let totalStrokes = 0;
+        for (let id = 0; id < dimLength; ++id) {
+          totalStrokes += dim[id].length;
+        }
+
+        // allocate space for the stroke indices
+        const cellImageInfo = cellImageInfos.findImage(totalStrokes);
+
+        // for each slice in the glyph
+        for (let i = 0; i < dimLength; ++i) {
+          const strokeIndices = dim[i];
+          const strokeCount = strokeIndices.length;
+          const cellLineIndex = cellImageInfo.index;
+
+          // write the offset and count into the glyph slice image
+          setPixel(
+            dimImageInfo,
+            cellLineIndex >> 7,
+            cellLineIndex & 0x7f,
+            strokeCount >> 7,
+            strokeCount & 0x7f
+          );
+
+          // for each stroke index in that slice
+          for (let iil = 0; iil < strokeCount; ++iil) {
+            // write the stroke index into the slice's image
+            const strokeIndex = strokeIndices[iil] + strokeOffset;
+            setPixel(cellImageInfo, strokeIndex >> 7, strokeIndex & 0x7f, 0, 0);
+          }
+        }
+
         return {
-          x: this.p0.x,
-          y: this.p0.y,
-          x1: this.p1.x,
-          y1: this.p1.y,
-          cx: ((this.c0.x + this.c1.x) * 3 - (this.p0.x + this.p1.x)) / 4,
-          cy: ((this.c0.y + this.c1.y) * 3 - (this.p0.y + this.p1.y)) / 4
+          cellImageInfo,
+          dimOffset,
+          dimImageInfo
         };
       }
 
-      /**
-           * @return {Number} the error
-           *
-           * calculates the magnitude of error of this curve's
-           * quadratic approximation.
-           */
-      quadError () {
-        return (
-          p5.Vector.sub(
-            p5.Vector.sub(this.p1, this.p0),
-            p5.Vector.mult(p5.Vector.sub(this.c1, this.c0), 3)
-          ).mag() / 2
-        );
-      }
-
-      /**
-           * @param {Number} t the value (0-1) at which to split
-           * @return {Cubic} the second part of the curve
-           *
-           * splits the cubic into two parts at a point 't' along the curve.
-           * this cubic keeps its start point and its end point becomes the
-           * point at 't'. the 'end half is returned.
-           */
-      split (t) {
-        const m1 = p5.Vector.lerp(this.p0, this.c0, t);
-        const m2 = p5.Vector.lerp(this.c0, this.c1, t);
-        const mm1 = p5.Vector.lerp(m1, m2, t);
-
-        this.c1 = p5.Vector.lerp(this.c1, this.p1, t);
-        this.c0 = p5.Vector.lerp(m2, this.c1, t);
-        const pt = p5.Vector.lerp(mm1, this.c0, t);
-        const part1 = new Cubic(this.p0, m1, mm1, pt);
-        this.p0 = pt;
-        return part1;
-      }
-
-      /**
-           * @return {Cubic[]} the non-inflecting pieces of this cubic
-           *
-           * returns an array containing 0, 1 or 2 cubics split resulting
-           * from splitting this cubic at its inflection points.
-           * this cubic is (potentially) altered and returned in the list.
-           */
-      splitInflections () {
-        const a = p5.Vector.sub(this.c0, this.p0);
-        const b = p5.Vector.sub(p5.Vector.sub(this.c1, this.c0), a);
-        const c = p5.Vector.sub(
-          p5.Vector.sub(p5.Vector.sub(this.p1, this.c1), a),
-          p5.Vector.mult(b, 2)
-        );
-
-        const cubics = [];
-
-        // find the derivative coefficients
-        let A = b.x * c.y - b.y * c.x;
-        if (A !== 0) {
-          let B = a.x * c.y - a.y * c.x;
-          let C = a.x * b.y - a.y * b.x;
-          const disc = B * B - 4 * A * C;
-          if (disc >= 0) {
-            if (A < 0) {
-              A = -A;
-              B = -B;
-              C = -C;
-            }
-
-            const Q = Math.sqrt(disc);
-            const t0 = (-B - Q) / (2 * A); // the first inflection point
-            let t1 = (-B + Q) / (2 * A); // the second inflection point
-
-            // test if the first inflection point lies on the curve
-            if (t0 > 0 && t0 < 1) {
-              // split at the first inflection point
-              cubics.push(this.split(t0));
-              // scale t2 into the second part
-              t1 = 1 - (1 - t1) / (1 - t0);
-            }
-
-            // test if the second inflection point lies on the curve
-            if (t1 > 0 && t1 < 1) {
-              // split at the second inflection point
-              cubics.push(this.split(t1));
-            }
-          }
-        }
-
-        cubics.push(this);
-        return cubics;
-      }
-    }
-
-    /**
-       * @function cubicToQuadratics
-       * @param {Number} x0
-       * @param {Number} y0
-       * @param {Number} cx0
-       * @param {Number} cy0
-       * @param {Number} cx1
-       * @param {Number} cy1
-       * @param {Number} x1
-       * @param {Number} y1
-       * @returns {Cubic[]} an array of cubics whose quadratic approximations
-       *                    closely match the civen cubic.
-       *
-       * converts a cubic curve to a list of quadratics.
-       */
-    function cubicToQuadratics(x0, y0, cx0, cy0, cx1, cy1, x1, y1) {
-      // create the Cubic object and split it at its inflections
-      const cubics = new Cubic(
-        new p5.Vector(x0, y0),
-        new p5.Vector(cx0, cy0),
-        new p5.Vector(cx1, cy1),
-        new p5.Vector(x1, y1)
-      ).splitInflections();
-
-      const qs = []; // the final list of quadratics
-      const precision = 30 / SQRT3;
-
-      // for each of the non-inflected pieces of the original cubic
-      for (let cubic of cubics) {
-        // the cubic is iteratively split in 3 pieces:
-        // the first piece is accumulated in 'qs', the result.
-        // the last piece is accumulated in 'tail', temporarily.
-        // the middle piece is repeatedly split again, while necessary.
-        const tail = [];
-
-        let t3;
-        for (;;) {
-          // calculate this cubic's precision
-          t3 = precision / cubic.quadError();
-          if (t3 >= 0.5 * 0.5 * 0.5) {
-            break; // not too bad, we're done
-          }
-
-          // find a split point based on the error
-          const t = Math.pow(t3, 1.0 / 3.0);
-          // split the cubic in 3
-          const start = cubic.split(t);
-          const middle = cubic.split(1 - t / (1 - t));
-
-          qs.push(start); // the first part
-          tail.push(cubic); // the last part
-          cubic = middle; // iterate on the middle piece
-        }
-
-        if (t3 < 1) {
-          // a little excess error, split the middle in two
-          qs.push(cubic.split(0.5));
-        }
-        // add the middle piece to the result
-        qs.push(cubic);
-
-        // finally add the tail, reversed, onto the result
-        Array.prototype.push.apply(qs, tail.reverse());
-      }
-
-      return qs;
-    }
-
-    /**
-       * @function pushLine
-       * @param {Number} x0
-       * @param {Number} y0
-       * @param {Number} x1
-       * @param {Number} y1
-       *
-       * add a straight line to the row/col grid of a glyph
-       */
-    function pushLine(x0, y0, x1, y1) {
-      const mx = (x0 + x1) / 2;
-      const my = (y0 + y1) / 2;
-      push([x0, x1], [y0, y1], { x: x0, y: y0, cx: mx, cy: my });
-    }
-
-    /**
-       * @function samePoint
-       * @param {Number} x0
-       * @param {Number} y0
-       * @param {Number} x1
-       * @param {Number} y1
-       * @return {Boolean} true if the two points are sufficiently close
-       *
-       * tests if two points are close enough to be considered the same
-       */
-    function samePoint(x0, y0, x1, y1) {
-      return Math.abs(x1 - x0) < 0.00001 && Math.abs(y1 - y0) < 0.00001;
-    }
-
-    let x0, y0, xs, ys;
-
-    for (const cmd of cmds) {
-      // scale the coordinates to the range 0-1
-      const x1 = (cmd.x - xMin) / gWidth;
-      const y1 = (cmd.y - yMin) / gHeight;
-
-      // don't bother if this point is the same as the last
-      if (samePoint(x0, y0, x1, y1)) continue;
-
-      switch (cmd.type) {
-        case 'M': {
-          // move
-          xs = x1;
-          ys = y1;
-          break;
-        }
-        case 'L': {
-          // line
-          pushLine(x0, y0, x1, y1);
-          break;
-        }
-        case 'Q': {
-          // quadratic
-          const cx = (cmd.x1 - xMin) / gWidth;
-          const cy = (cmd.y1 - yMin) / gHeight;
-          push([x0, x1, cx], [y0, y1, cy], { x: x0, y: y0, cx, cy });
-          break;
-        }
-        case 'Z': {
-          // end
-          if (!samePoint(x0, y0, xs, ys)) {
-            // add an extra line closing the loop, if necessary
-            pushLine(x0, y0, xs, ys);
-            strokes.push({ x: xs, y: ys });
-          } else {
-            strokes.push({ x: x0, y: y0 });
-          }
-          break;
-        }
-        case 'C': {
-          // cubic
-          const cx1 = (cmd.x1 - xMin) / gWidth;
-          const cy1 = (cmd.y1 - yMin) / gHeight;
-          const cx2 = (cmd.x2 - xMin) / gWidth;
-          const cy2 = (cmd.y2 - yMin) / gHeight;
-          const qs = cubicToQuadratics(x0, y0, cx1, cy1, cx2, cy2, x1, y1);
-          for (let iq = 0; iq < qs.length; iq++) {
-            const q = qs[iq].toQuadratic();
-            push([q.x, q.x1, q.cx], [q.y, q.y1, q.cy], q);
-          }
-          break;
-        }
-        default:
-          throw new Error(`unknown command type: ${cmd.type}`);
-      }
-      x0 = x1;
-      y0 = y1;
-    }
-
-    // allocate space for the strokes
-    const strokeCount = strokes.length;
-    const strokeImageInfo = this.strokeImageInfos.findImage(strokeCount);
-    const strokeOffset = strokeImageInfo.index;
-
-    // fill the stroke image
-    for (let il = 0; il < strokeCount; ++il) {
-      const s = strokes[il];
-      setPixel(strokeImageInfo, byte(s.x), byte(s.y), byte(s.cx), byte(s.cy));
-    }
-
-    /**
-       * @function layout
-       * @param {Number[][]} dim
-       * @param {ImageInfo[]} dimImageInfos
-       * @param {ImageInfo[]} cellImageInfos
-       * @return {Object}
-       *
-       * lays out the curves in a dimension (row or col) into two
-       * images, one for the indices of the curves themselves, and
-       * one containing the offset and length of those index spans.
-       */
-    function layout(dim, dimImageInfos, cellImageInfos) {
-      const dimLength = dim.length; // the number of slices in this dimension
-      const dimImageInfo = dimImageInfos.findImage(dimLength);
-      const dimOffset = dimImageInfo.index;
-      // calculate the total number of stroke indices in this dimension
-      let totalStrokes = 0;
-      for (let id = 0; id < dimLength; ++id) {
-        totalStrokes += dim[id].length;
-      }
-
-      // allocate space for the stroke indices
-      const cellImageInfo = cellImageInfos.findImage(totalStrokes);
-
-      // for each slice in the glyph
-      for (let i = 0; i < dimLength; ++i) {
-        const strokeIndices = dim[i];
-        const strokeCount = strokeIndices.length;
-        const cellLineIndex = cellImageInfo.index;
-
-        // write the offset and count into the glyph slice image
-        setPixel(
-          dimImageInfo,
-          cellLineIndex >> 7,
-          cellLineIndex & 0x7f,
-          strokeCount >> 7,
-          strokeCount & 0x7f
-        );
-
-        // for each stroke index in that slice
-        for (let iil = 0; iil < strokeCount; ++iil) {
-          // write the stroke index into the slice's image
-          const strokeIndex = strokeIndices[iil] + strokeOffset;
-          setPixel(cellImageInfo, strokeIndex >> 7, strokeIndex & 0x7f, 0, 0);
-        }
-      }
-
-      return {
-        cellImageInfo,
-        dimOffset,
-        dimImageInfo
+      // initialize the info for this glyph
+      gi = this.glyphInfos[glyph.index] = {
+        glyph,
+        uGlyphRect: [bb.x1, -bb.y1, bb.x2, -bb.y2],
+        strokeImageInfo,
+        strokes,
+        colInfo: layout(cols, this.colDimImageInfos, this.colCellImageInfos),
+        rowInfo: layout(rows, this.rowDimImageInfos, this.rowCellImageInfos)
       };
+      gi.uGridOffset = [gi.colInfo.dimOffset, gi.rowInfo.dimOffset];
+      return gi;
+    }
+  }
+
+  p5.RendererGL.prototype._renderText = function(p, line, x, y, maxY) {
+    if (!this._textFont || typeof this._textFont === 'string') {
+      console.log(
+        'WEBGL: you must load and set a font before drawing text. See `loadFont` and `textFont` for more details.'
+      );
+      return;
+    }
+    if (y >= maxY || !this.states.doFill) {
+      return; // don't render lines beyond our maxY position
     }
 
-    // initialize the info for this glyph
-    gi = this.glyphInfos[glyph.index] = {
-      glyph,
-      uGlyphRect: [bb.x1, -bb.y1, bb.x2, -bb.y2],
-      strokeImageInfo,
-      strokes,
-      colInfo: layout(cols, this.colDimImageInfos, this.colCellImageInfos),
-      rowInfo: layout(rows, this.rowDimImageInfos, this.rowCellImageInfos)
-    };
-    gi.uGridOffset = [gi.colInfo.dimOffset, gi.rowInfo.dimOffset];
-    return gi;
-  }
+    if (!this._isOpenType()) {
+      console.log(
+        'WEBGL: only Opentype (.otf) and Truetype (.ttf) fonts are supported'
+      );
+      return p;
+    }
+
+    p.push(); // fix to #803
+
+    // remember this state, so it can be restored later
+    const doStroke = this.states.doStroke;
+    const drawMode = this.states.drawMode;
+
+    this.states.doStroke = false;
+    this.states.drawMode = constants.TEXTURE;
+
+    // get the cached FontInfo object
+    const font = this._textFont.font;
+    let fontInfo = this._textFont._fontInfo;
+    if (!fontInfo) {
+      fontInfo = this._textFont._fontInfo = new FontInfo(font);
+    }
+
+    // calculate the alignment and move/scale the view accordingly
+    const pos = this._textFont._handleAlignment(this, line, x, y);
+    const fontSize = this._textSize;
+    const scale = fontSize / font.unitsPerEm;
+    this.translate(pos.x, pos.y, 0);
+    this.scale(scale, scale, 1);
+
+    // initialize the font shader
+    const gl = this.GL;
+    const initializeShader = !this._defaultFontShader;
+    const sh = this._getFontShader();
+    sh.init();
+    sh.bindShader(); // first time around, bind the shader fully
+
+    if (initializeShader) {
+      // these are constants, really. just initialize them one-time.
+      sh.setUniform('uGridImageSize', [gridImageWidth, gridImageHeight]);
+      sh.setUniform('uCellsImageSize', [cellImageWidth, cellImageHeight]);
+      sh.setUniform('uStrokeImageSize', [strokeImageWidth, strokeImageHeight]);
+      sh.setUniform('uGridSize', [charGridWidth, charGridHeight]);
+    }
+    this._applyColorBlend(this.states.curFillColor);
+
+    let g = this.retainedMode.geometry['glyph'];
+    if (!g) {
+      // create the geometry for rendering a quad
+      const geom = (this._textGeom = new p5.Geometry(1, 1, function() {
+        for (let i = 0; i <= 1; i++) {
+          for (let j = 0; j <= 1; j++) {
+            this.vertices.push(new p5.Vector(j, i, 0));
+            this.uvs.push(j, i);
+          }
+        }
+      }));
+      geom.computeFaces().computeNormals();
+      g = this.createBuffers('glyph', geom);
+    }
+
+    // bind the shader buffers
+    for (const buff of this.retainedMode.buffers.text) {
+      buff._prepareBuffer(g, sh);
+    }
+    this._bindBuffer(g.indexBuffer, gl.ELEMENT_ARRAY_BUFFER);
+
+    // this will have to do for now...
+    sh.setUniform('uMaterialColor', this.states.curFillColor);
+    gl.pixelStorei(gl.UNPACK_PREMULTIPLY_ALPHA_WEBGL, false);
+
+    try {
+      let dx = 0; // the x position in the line
+      let glyphPrev = null; // the previous glyph, used for kerning
+      // fetch the glyphs in the line of text
+      const glyphs = font.stringToGlyphs(line);
+
+      for (const glyph of glyphs) {
+        // kern
+        if (glyphPrev) dx += font.getKerningValue(glyphPrev, glyph);
+
+        const gi = fontInfo.getGlyphInfo(glyph);
+        if (gi.uGlyphRect) {
+          const rowInfo = gi.rowInfo;
+          const colInfo = gi.colInfo;
+          sh.setUniform('uSamplerStrokes', gi.strokeImageInfo.imageData);
+          sh.setUniform('uSamplerRowStrokes', rowInfo.cellImageInfo.imageData);
+          sh.setUniform('uSamplerRows', rowInfo.dimImageInfo.imageData);
+          sh.setUniform('uSamplerColStrokes', colInfo.cellImageInfo.imageData);
+          sh.setUniform('uSamplerCols', colInfo.dimImageInfo.imageData);
+          sh.setUniform('uGridOffset', gi.uGridOffset);
+          sh.setUniform('uGlyphRect', gi.uGlyphRect);
+          sh.setUniform('uGlyphOffset', dx);
+
+          sh.bindTextures(); // afterwards, only textures need updating
+
+          // draw it
+          gl.drawElements(gl.TRIANGLES, 6, this.GL.UNSIGNED_SHORT, 0);
+        }
+        dx += glyph.advanceWidth;
+        glyphPrev = glyph;
+      }
+    } finally {
+      // clean up
+      sh.unbindShader();
+
+      this.states.doStroke = doStroke;
+      this.states.drawMode = drawMode;
+      gl.pixelStorei(gl.UNPACK_PREMULTIPLY_ALPHA_WEBGL, true);
+
+      p.pop();
+    }
+
+    return p;
+  };
 }
 
-p5.RendererGL.prototype._renderText = function(p, line, x, y, maxY) {
-  if (!this._textFont || typeof this._textFont === 'string') {
-    console.log(
-      'WEBGL: you must load and set a font before drawing text. See `loadFont` and `textFont` for more details.'
-    );
-    return;
-  }
-  if (y >= maxY || !this.states.doFill) {
-    return; // don't render lines beyond our maxY position
-  }
-
-  if (!this._isOpenType()) {
-    console.log(
-      'WEBGL: only Opentype (.otf) and Truetype (.ttf) fonts are supported'
-    );
-    return p;
-  }
-
-  p.push(); // fix to #803
-
-  // remember this state, so it can be restored later
-  const doStroke = this.states.doStroke;
-  const drawMode = this.states.drawMode;
-
-  this.states.doStroke = false;
-  this.states.drawMode = constants.TEXTURE;
-
-  // get the cached FontInfo object
-  const font = this._textFont.font;
-  let fontInfo = this._textFont._fontInfo;
-  if (!fontInfo) {
-    fontInfo = this._textFont._fontInfo = new FontInfo(font);
-  }
-
-  // calculate the alignment and move/scale the view accordingly
-  const pos = this._textFont._handleAlignment(this, line, x, y);
-  const fontSize = this._textSize;
-  const scale = fontSize / font.unitsPerEm;
-  this.translate(pos.x, pos.y, 0);
-  this.scale(scale, scale, 1);
-
-  // initialize the font shader
-  const gl = this.GL;
-  const initializeShader = !this._defaultFontShader;
-  const sh = this._getFontShader();
-  sh.init();
-  sh.bindShader(); // first time around, bind the shader fully
-
-  if (initializeShader) {
-    // these are constants, really. just initialize them one-time.
-    sh.setUniform('uGridImageSize', [gridImageWidth, gridImageHeight]);
-    sh.setUniform('uCellsImageSize', [cellImageWidth, cellImageHeight]);
-    sh.setUniform('uStrokeImageSize', [strokeImageWidth, strokeImageHeight]);
-    sh.setUniform('uGridSize', [charGridWidth, charGridHeight]);
-  }
-  this._applyColorBlend(this.states.curFillColor);
-
-  let g = this.retainedMode.geometry['glyph'];
-  if (!g) {
-    // create the geometry for rendering a quad
-    const geom = (this._textGeom = new p5.Geometry(1, 1, function() {
-      for (let i = 0; i <= 1; i++) {
-        for (let j = 0; j <= 1; j++) {
-          this.vertices.push(new p5.Vector(j, i, 0));
-          this.uvs.push(j, i);
-        }
-      }
-    }));
-    geom.computeFaces().computeNormals();
-    g = this.createBuffers('glyph', geom);
-  }
-
-  // bind the shader buffers
-  for (const buff of this.retainedMode.buffers.text) {
-    buff._prepareBuffer(g, sh);
-  }
-  this._bindBuffer(g.indexBuffer, gl.ELEMENT_ARRAY_BUFFER);
-
-  // this will have to do for now...
-  sh.setUniform('uMaterialColor', this.states.curFillColor);
-  gl.pixelStorei(gl.UNPACK_PREMULTIPLY_ALPHA_WEBGL, false);
-
-  try {
-    let dx = 0; // the x position in the line
-    let glyphPrev = null; // the previous glyph, used for kerning
-    // fetch the glyphs in the line of text
-    const glyphs = font.stringToGlyphs(line);
-
-    for (const glyph of glyphs) {
-      // kern
-      if (glyphPrev) dx += font.getKerningValue(glyphPrev, glyph);
-
-      const gi = fontInfo.getGlyphInfo(glyph);
-      if (gi.uGlyphRect) {
-        const rowInfo = gi.rowInfo;
-        const colInfo = gi.colInfo;
-        sh.setUniform('uSamplerStrokes', gi.strokeImageInfo.imageData);
-        sh.setUniform('uSamplerRowStrokes', rowInfo.cellImageInfo.imageData);
-        sh.setUniform('uSamplerRows', rowInfo.dimImageInfo.imageData);
-        sh.setUniform('uSamplerColStrokes', colInfo.cellImageInfo.imageData);
-        sh.setUniform('uSamplerCols', colInfo.dimImageInfo.imageData);
-        sh.setUniform('uGridOffset', gi.uGridOffset);
-        sh.setUniform('uGlyphRect', gi.uGlyphRect);
-        sh.setUniform('uGlyphOffset', dx);
-
-        sh.bindTextures(); // afterwards, only textures need updating
-
-        // draw it
-        gl.drawElements(gl.TRIANGLES, 6, this.GL.UNSIGNED_SHORT, 0);
-      }
-      dx += glyph.advanceWidth;
-      glyphPrev = glyph;
-    }
-  } finally {
-    // clean up
-    sh.unbindShader();
-
-    this.states.doStroke = doStroke;
-    this.states.drawMode = drawMode;
-    gl.pixelStorei(gl.UNPACK_PREMULTIPLY_ALPHA_WEBGL, true);
-
-    p.pop();
-  }
-
-  return p;
-};
+export default text;


### PR DESCRIPTION
@davepagurek Most of the files are converted to use the new syntax but there are a few snagging issues remaining:

* Some of the classes like `p5.DataArray` seems largely internal, although they do have a public documentation, are they public API? If not they can have the same treatment as the `GeometryBuilder` class as a standalone class without being attached to `p5`.
* In p5.Texture.js, the `MipmapTexture` class have a compatibility issue with the new system. At `export` time, there is not `p5` available for `MipmapTexture` to be able to extend `p5.Texture`, we can move the `class Texture` into the file scope (ie. not in the new library syntax `function(p5, fn){...`) but the `Texture` class itself needs a reference to `p5` at definition which is only available in the new library syntax function. We also cannot export `MipmapTexture` from the library syntax function since export need to be at root. I'm not sure what would be the best way to handle this so if you have some ideas that would be great.
* The actual `p5.RendererGL` class might need `p5.Texture` to be solved first and I think you were mentioning wanting to refactor this part. I'll defer this one for now as I also have not converted `p5.Renderer2D` so there's no rush to do it just yet.