### PR TITLE
Fix example of createModel function.

### DIFF
--- a/src/webgl/loading.js
+++ b/src/webgl/loading.js
@@ -1176,15 +1176,14 @@ p5.prototype.model = function(model) {
  * f     6 5 4
  * f     6 4 3
  * f     6 3 2
- * f     6 2 1
- * f     6 1 5
+ * f     6 2 5
  * `;
  * //draw a spinning octahedron
  * let octahedron;
  *
  * function setup() {
  *   createCanvas(100, 100, WEBGL);
- *   octahedron = createModel(octahedron_model);
+ *   octahedron = createModel(octahedron_model, '.obj');
  *   describe('Vertically rotating 3D octahedron.');
  * }
  *


### PR DESCRIPTION
Resolves #7297 

 Changes:
fix example source of createModel function.
- The shape of the object was not octahedral, so it was corrected.
- The file type was not specified, so '.obj' was specified.

 Screenshots of the change:
 If the p5.js website is built based on this source, it should look like the following: 
![スクリーンショット 2024-10-03 20 09 35](https://github.com/user-attachments/assets/8b28c8eb-89cb-48d1-99a0-c2fb51d19359)
