### PR TITLE
fix missing example tag in documentation for color's toString method

### DIFF
--- a/src/color/p5.Color.js
+++ b/src/color/p5.Color.js
@@ -379,6 +379,7 @@ p5.Color = class Color {
    * 'rgb%' 'hsb%' 'hsl%' 'rgba%' 'hsba%' and 'hsla%' format as percentages.
    * @return {String} the formatted string.
    *
+   * @example
    * <div>
    * <code>
    * function setup() {


### PR DESCRIPTION
<!--
  Thank you for contributing! Please use this pull request (PR) template.


 In the description field of this PR, include "resolves #XXXX" tagging the issue you are fixing. If this PR addresses the issue but doesn't completely resolve it (ie the issue should remain open after your PR is merged), write "addresses #XXXX".-->
Have not created an issue for this as it is a very small change

 Changes:
<!-- Add here what changes were made in this pull request and if possible provide links showcasing the changes. -->

The example code for `toString` method on p5.Color class was missing `@example` tag which was causing example code to show up as simple text, this PR fixes it.



 Screenshots of the change:
<!-- If applicable, add screenshots depicting the changes. -->
- existing view
![Screenshot 2024-10-08 at 7 37 07 PM](https://github.com/user-attachments/assets/d562419c-d50f-4400-85fc-514349a72b6b)
- after change
![Screenshot 2024-10-08 at 7 37 36 PM](https://github.com/user-attachments/assets/7e083115-fb08-486e-837d-b76c27246242)

#### PR Checklist
<!--
  To check any option, replace the "[ ]" with a "[x]". Be sure to check out how it looks in the Preview tab! Feel free to remove any portion of the template that is not relevant for your issue.
-->

- [ ] `npm run lint` passes
- [ ] [Inline documentation] is included / updated
- [ ] [Unit tests] are included / updated

[Inline documentation]: https://github.com/processing/p5.js/blob/main/contributor_docs/inline_documentation.md
[Unit tests]: https://github.com/processing/p5.js/tree/main/contributor_docs#unit-tests
