### PR TITLE
textureData updated to fix flipping property for webgl

### DIFF
--- a/src/webgl/p5.Texture.js
+++ b/src/webgl/p5.Texture.js
@@ -126,7 +126,12 @@ p5.Texture = class Texture {
     this.isSrcHTMLElement
     ) {
     // if param is a video HTML element
-      textureData = this.src.elt;
+      // UPDATED:
+      if (this.src._ensureCanvas) {
+        this.src._ensureCanvas()
+      }
+      textureData = this.src.canvas || this.src.elt;
+      // End update
     } else if (this.isImageData) {
       textureData = this.src;
     }

--- a/src/webgl/p5.Texture.js
+++ b/src/webgl/p5.Texture.js
@@ -126,12 +126,10 @@ p5.Texture = class Texture {
     this.isSrcHTMLElement
     ) {
     // if param is a video HTML element
-      // UPDATED:
       if (this.src._ensureCanvas) {
-        this.src._ensureCanvas()
+        this.src._ensureCanvas();
       }
       textureData = this.src.canvas || this.src.elt;
-      // End update
     } else if (this.isImageData) {
       textureData = this.src;
     }


### PR DESCRIPTION
Resolves #7300

**Changes:**

https://github.com/processing/p5.js/blob/75c0bfb49dc3202cda0ca847653aae008399a906/src/webgl/p5.Texture.js#L129C7-L132C53

- New Check (this.src._ensureCanvas): The update introduces a check for this.src._ensureCanvas. If this method exists, it gets called. This ensures that a canvas is available for the source before proceeding.

- New Assignment (this.src.canvas || this.src.elt): Instead of directly using this.src.elt, the code now assigns textureData from this.src.canvas (if available) or defaults to this.src.elt. This allows for the possibility of capturing the canvas representation of the source when necessary, when flipping has to be applied to video or images.

(I wasn't able to commit changes in my old pr and due to some glitch it isn't shown to me so I pulled a new request)
