### PR TITLE
mouseY reference first example issue fixed

### DIFF
--- a/src/events/mouse.js
+++ b/src/events/mouse.js
@@ -247,7 +247,7 @@ p5.prototype.mouseX = 0;
  *   background(200);
  *
  *   // Draw a horizontal line that follows the mouse's y-coordinate.
- *   line(0, mouseY, 0, mouseY);
+ *   line(0, mouseY, 100, mouseY);
  * }
  * </code>
  * </div>


### PR DESCRIPTION
Resolves issue [#583](https://github.com/processing/p5.js-website/issues/583) of [p5.js website repo](https://github.com/processing/p5.js-website).

### **Changes:**

- Added a horizontal black line that moves up and down following the mouse's Y-position in the first example for [mouseY](https://p5js.org/reference/p5/mouseY/), where it was previously missing.

### **Screenshots of the change:**

Before:

https://github.com/user-attachments/assets/2fc37a41-9db6-4056-8d4f-b81b091ba2a3

After:

https://github.com/user-attachments/assets/d53b91ec-37cb-4824-89a3-c0d4d1f534d4





