### PR TITLE
Uses canvas dimensions instead of arbitrary constants for `noise()` and `noiseDetail()`

### DIFF
--- a/src/math/noise.js
+++ b/src/math/noise.js
@@ -168,7 +168,7 @@ let perlin; // will be initialized lazily by noise() or noiseSeed()
  *   let noiseScale = 0.002;
  *
  *   // Iterate from left to right.
- *   for (let x = 0; x < 100; x += 1) {
+ *   for (let x = 0; x < width; x += 1) {
  *     // Scale the input coordinates.
  *     let nx = noiseScale * x;
  *     let nt = noiseScale * frameCount;
@@ -195,9 +195,9 @@ let perlin; // will be initialized lazily by noise() or noiseSeed()
  *   let noiseScale = 0.01;
  *
  *   // Iterate from top to bottom.
- *   for (let y = 0; y < 100; y += 1) {
+ *   for (let y = 0; y < height; y += 1) {
  *     // Iterate from left to right.
- *     for (let x = 0; x < 100; x += 1) {
+ *     for (let x = 0; x < width; x += 1) {
  *       // Scale the input coordinates.
  *       let nx = noiseScale * x;
  *       let ny = noiseScale * y;
@@ -230,7 +230,7 @@ let perlin; // will be initialized lazily by noise() or noiseSeed()
  *   let noiseScale = 0.009;
  *
  *   // Iterate from top to bottom.
- *   for (let y = 0; y < 100; y += 1) {
+ *   for (let y = 0; y < height; y += 1) {
  *     // Iterate from left to right.
  *     for (let x = 0; x < width; x += 1) {
  *       // Scale the input coordinates.
@@ -361,9 +361,9 @@ p5.prototype.noise = function(x, y = 0, z = 0) {
  *   let noiseScale = 0.02;
  *
  *   // Iterate from top to bottom.
- *   for (let y = 0; y < 100; y += 1) {
+ *   for (let y = 0; y < height; y += 1) {
  *     // Iterate from left to right.
- *     for (let x = 0; x < 50; x += 1) {
+ *     for (let x = 0; x < width / 2; x += 1) {
  *       // Scale the input coordinates.
  *       let nx = noiseScale * x;
  *       let ny = noiseScale * y;


### PR DESCRIPTION
<!--
  Thank you for contributing! Please use this pull request (PR) template.


 In the description field of this PR, include "resolves #XXXX" tagging the issue you are fixing. If this PR addresses the issue but doesn't completely resolve it (ie the issue should remain open after your PR is merged), write "addresses #XXXX".-->
Resolves #7329

Changes:
Replaces instances of arbitrary constants in `noise()` and `noiseDetail()` doc iterators with the canvas dimensions that they're meant to follow.

#### PR Checklist
<!--
  To check any option, replace the "[ ]" with a "[x]". Be sure to check out how it looks in the Preview tab! Feel free to remove any portion of the template that is not relevant for your issue.
-->

- [x] `npm run lint` passes
- [x] [Inline documentation] is included / updated
- [x] [Unit tests] are included / updated

[Inline documentation]: https://github.com/processing/p5.js/blob/main/contributor_docs/inline_documentation.md
[Unit tests]: https://github.com/processing/p5.js/tree/main/contributor_docs#unit-tests
