### PR TITLE
Don't continue loop for paused sketches

### DIFF
--- a/src/image/loading_displaying.js
+++ b/src/image/loading_displaying.js
@@ -393,6 +393,9 @@ p5.prototype.saveGif = async function(
     pixels = new Uint8Array(gl.drawingBufferWidth * gl.drawingBufferHeight * 4);
   }
 
+  // store current looping status
+  const wasLooping = this.isLooping();
+
   // stop the loop since we are going to manually redraw
   this.noLoop();
 
@@ -452,7 +455,10 @@ p5.prototype.saveGif = async function(
   }
   if (!silent) p.html('Frames processed, generating color palette...');
 
-  this.loop();
+  if (wasLooping) {
+    this.loop();
+  }
+
   this.pixelDensity(lastPixelDensity);
 
   // create the gif encoder and the colorspace format
@@ -552,7 +558,10 @@ p5.prototype.saveGif = async function(
 
   frames = [];
   this._recording = false;
-  this.loop();
+
+  if (wasLooping) {
+    this.loop();
+  }
 
   if (!silent){
     p.html('Done. Downloading your gif!🌸');

--- a/test/unit/image/downloading.js
+++ b/test/unit/image/downloading.js
@@ -370,6 +370,22 @@ suite('p5.prototype.saveGif', function() {
     });
   });
 
+  test('should continue looping sketch after saveGif', function(done) {
+    myp5.saveGif('mySketch', 2).then(() => {
+      assert.equal(myp5.isLooping(), true, 'Should still be looping');
+      done();
+    });
+  });
+
+  test('should not continue looping paused sketch after saveGif',
+    function(done) {
+      myp5.noLoop();
+      myp5.saveGif('mySketch', 2).then(() => {
+        assert.equal(myp5.isLooping(), false, 'Should not be looping');
+        done();
+      });
+    });
+
   testWithDownload('should download a GIF', async function(blobContainer) {
     myp5.saveGif(myGif, 3, 2);
     await waitForBlob(blobContainer);


### PR DESCRIPTION
Resolves n/a

Changes:

- Updated `saveGif` to respect the animation’s paused (noLoop) state if it is paused when `saveGif` is called, preventing it from automatically resuming.

- This update is similar to the existing handling of pixel density preservation:

```js
const lastPixelDensity = this._pixelDensity;
```

Motivation: In resource-intensive sketches where noLoop is used, saveGif previously restarted the loop, leading to unnecessary slowdowns during the "Rendering" stage. 

Screenshots of the change:

#### PR Checklist

- [x] `npm run lint` passes
- [x] [Inline documentation] is included / updated
- [x] [Unit tests] are included / updated

[Inline documentation]: https://github.com/processing/p5.js/blob/main/contributor_docs/inline_documentation.md
[Unit tests]: https://github.com/processing/p5.js/tree/main/contributor_docs#unit-tests
