### PR TITLE
add OPEN option for endShape

### DIFF
--- a/src/core/shape/vertex.js
+++ b/src/core/shape/vertex.js
@@ -1379,8 +1379,8 @@ p5.prototype.endContour = function() {
  * <a href="#/p5/beginShape">beginShape()</a> and `endShape()`.
  *
  * @method endShape
- * @param  {CLOSE} [mode] use CLOSE to close the shape
- * @param  {Integer} [count] number of times you want to draw/instance the shape (for WebGL mode).
+ * @param  {CLOSE|OPEN} [mode=OPEN] use CLOSE or OPEN to close or open the shape
+ * @param  {Integer} [count=1] number of times you want to draw/instance the shape (for WebGL mode).
  * @chainable
  *
  * @example
@@ -1504,7 +1504,7 @@ p5.prototype.endContour = function() {
  * </code>
  * </div>
  */
-p5.prototype.endShape = function(mode, count = 1) {
+p5.prototype.endShape = function(mode = constants.OPEN, count = 1) {
   p5._validateParameters('endShape', arguments);
   if (count < 1) {
     console.log('🌸 p5.js says: You can not have less than one instance');
@@ -1532,7 +1532,7 @@ p5.prototype.endShape = function(mode, count = 1) {
       return this;
     }
 
-    const closeShape = mode === constants.CLOSE;
+    const closeShape = mode != constants.OPEN;
 
     // if the shape is closed, the first element is also the last element
     if (closeShape && !isContour) {


### PR DESCRIPTION
<!--
  Thank you for contributing! Please use this pull request (PR) template.
-->
addresses #6679 

 Changes:
<!-- make OPEN parameter explicit instead of implied, updated documentation comments, made documentation default parameter match javascript default parameter. -->


 Screenshots of the change:
<!-- If applicable, add screenshots depicting the changes. -->

#### PR Checklist
<!--
  To check any option, replace the "[ ]" with a "[x]". Be sure to check out how it looks in the Preview tab! Feel free to remove any portion of the template that is not relevant for your issue.
-->

- [ ] `npm run lint` passes
- [ ] [Inline documentation] is included / updated
- [ ] [Unit tests] are included / updated

[Inline documentation]: https://github.com/processing/p5.js/blob/main/contributor_docs/inline_documentation.md
[Unit tests]: https://github.com/processing/p5.js/tree/main/contributor_docs#unit-tests
