### PR TITLE
Docs: "A maximum of 5 directional lights can be active at once."

### DIFF
--- a/src/webgl/light.js
+++ b/src/webgl/light.js
@@ -465,7 +465,8 @@ p5.prototype.specularColor = function (v1, v2, v3) {
  * that shines from somewhere offscreen. The light’s direction is set using
  * three `(x, y, z)` values between -1 and 1. For example, setting a light’s
  * direction as `(1, 0, 0)` will light <a href="#/p5.Geometry">p5.Geometry</a>
- * objects from the left since the light faces directly to the right.
+ * objects from the left since the light faces directly to the right. A
+ * maximum of 5 directional lights can be active at once.
  *
  * There are four ways to call `directionalLight()` with parameters to set the
  * light’s color and direction.


### PR DESCRIPTION
Documentation for other light source types already says this. I found the limit by experimentation.

Resolves #4234 

 Changes:
Included missing detail in docs.


#### PR Checklist
- [x] [Inline documentation] is included / updated

[Inline documentation]: https://github.com/processing/p5.js/blob/main/contributor_docs/inline_documentation.md
[Unit tests]: https://github.com/processing/p5.js/tree/main/contributor_docs#unit-tests
