### PR TITLE
Switch all-contributor shield styling to match other shields

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 [![npm version](https://badge.fury.io/js/p5.svg)](https://www.npmjs.com/package/p5)
-[![All Contributors](https://img.shields.io/github/all-contributors/processing/p5.js?color=ee8449&style=flat-square)](#contributors)
+[![All Contributors](https://img.shields.io/github/all-contributors/processing/p5.js?color=ee8449)](#contributors)
 [![Total Downloads](https://img.shields.io/npm/dt/p5)](https://www.npmjs.com/package/p5)
 
 # [p5.js](https://p5js.org)


### PR DESCRIPTION
On the `README.md`, the shield style for `all-contributors` uses `&style=flat-square`. This doesn't match the styling on the `npm-package` and `downloads` shields which use rounded corners.

### Change
Removed `&style=flat-square` from the shield link to set the corners to rounded.

### Before
<img width="531" alt="image" src="https://github.com/user-attachments/assets/7bb9d0ca-b412-49c5-a57c-face31fcc868">

### After
<img width="528" alt="image" src="https://github.com/user-attachments/assets/71c906cb-87c8-470d-b8da-e942c1bc8b7b">