### PR TITLE
Fix a typo (dpeth -> depth) in webgl/p5.Framebuffer.js

### DIFF
--- a/src/webgl/p5.Framebuffer.js
+++ b/src/webgl/p5.Framebuffer.js
@@ -1752,7 +1752,7 @@ class Framebuffer {
  */
 
 /**
- * An object that stores the framebuffer's dpeth data.
+ * An object that stores the framebuffer's depth data.
  *
  * Each framebuffer uses a
  * <a href="https://developer.mozilla.org/en-US/docs/Web/API/WebGLTexture" target="_blank">WebGLTexture</a>


### PR DESCRIPTION
Hi! Apologies if I'm doing something incorrectly, but I spotted a simple typo on the online reference ([p5.Framebuffer](https://p5js.org/reference/p5/p5.Framebuffer/) & [depth](https://p5js.org/reference/p5.Framebuffer/depth/)), and so made this PR (as well as one on [p5.js-website](https://github.com/processing/p5.js-website/pull/620)).

Resolves: N/A (didn't create a separate issue just for this).

Changes: Corrected "dpeth" to "depth".

#### PR Checklist

- [ ] `npm run lint` passes
- [x] [Inline documentation] is included / updated (btw this link is dead)
- [ ] [Unit tests] are included / updated

[Inline documentation]: https://github.com/processing/p5.js/blob/main/contributor_docs/inline_documentation.md
[Unit tests]: https://github.com/processing/p5.js/tree/main/contributor_docs#unit-tests
