### PR TITLE
Changed the contributor docs, removed the broken link

### DIFF
--- a/contributor_docs/documentation_style_guide.md
+++ b/contributor_docs/documentation_style_guide.md
@@ -1225,9 +1225,7 @@ class Mover {
 - Always load assets from a folder called "assets".
 
 > Why? It models good project organization. It's also required for assets to load on the p5.js website. Place assets in the following folders to include them in our online documentation:
-- Examples: [src/data/examples/assets](https://github.com/processing/p5.js-website/tree/main/src/data/examples)
-- Reference Pages: [src/templates/pages/reference/assets](https://github.com/processing/p5.js-website/tree/main/src/templates/pages/reference/assets)
-- Learn Pages: [src/assets/learn](https://github.com/processing/p5.js-website/tree/main/src/assets/learn)
+- [public/assets](https://github.com/processing/p5.js-website/tree/main/public)
 
 ```javascript
 let img;

--- a/contributor_docs/documentation_style_guide.md
+++ b/contributor_docs/documentation_style_guide.md
@@ -1225,7 +1225,7 @@ class Mover {
 - Always load assets from a folder called "assets".
 
 > Why? It models good project organization. It's also required for assets to load on the p5.js website. Place assets in the following folders to include them in our online documentation:
-- [public/assets](https://github.com/processing/p5.js-website/tree/main/public)
+- Reference Pages: [public/assets](https://github.com/processing/p5.js-website/tree/main/public/assets)
 
 ```javascript
 let img;


### PR DESCRIPTION
<!--
  Thank you for contributing! Please use this pull request (PR) template.


 In the description field of this PR, include "resolves #XXXX" tagging the issue you are fixing. If this PR addresses the issue but doesn't completely resolve it (ie the issue should remain open after your PR is merged), write "addresses #XXXX".-->
Resolves [#7220](https://github.com/processing/p5.js/issues/7220)

 Changes:
<!-- Add here what changes were made in this pull request and if possible provide links showcasing the changes. -->
I resolved this by locating the image used in the example within the public/assets folder and replaced all three links which are broken with a single link to the assets folder.

 Screenshots of the change:
<!-- If applicable, add screenshots depicting the changes. -->
- Before
![before](https://github.com/user-attachments/assets/15dc871e-cbee-4790-9061-99dc7462d363)

- After
![after](https://github.com/user-attachments/assets/d48c1bd9-9b2e-40e2-b565-822e0eb4fde1)



#### PR Checklist
<!--
  To check any option, replace the "[ ]" with a "[x]". Be sure to check out how it looks in the Preview tab! Feel free to remove any portion of the template that is not relevant for your issue.
-->

- [ ] `npm run lint` passes
- [ ] [Inline documentation] is included / updated
- [ ] [Unit tests] are included / updated

[Inline documentation]: https://github.com/processing/p5.js/blob/main/contributor_docs/inline_documentation.md
[Unit tests]: https://github.com/processing/p5.js/tree/main/contributor_docs#unit-tests
