### PR TITLE
fixes issue #7366: Adjust Option Orientation in CreateRadio() reference.

### DIFF
--- a/src/dom/dom.js
+++ b/src/dom/dom.js
@@ -1463,15 +1463,28 @@ p5.prototype.createSelect = function(...args) {
  * @example
  * <div>
  * <code>
+ * let style = document.createElement('style');
+ * style.innerHTML = `
+ * .p5-radio label {
+ *    display: flex;
+ *    align-items: center;
+ *  }
+ *  .p5-radio input {
+ *    margin-right: 5px;
+ *  }
+ *  `;
+ * document.head.appendChild(style);
+ *
  * let myRadio;
  *
  * function setup() {
  *   createCanvas(100, 100);
  *
  *   // Create a radio button element and place it
- *   // in the top-left corner.
+ *   // in the top-right corner.
  *   myRadio = createRadio();
  *   myRadio.position(0, 0);
+ *   myRadio.class('p5-radio');
  *   myRadio.size(60);
  *
  *   // Add a few color options.
@@ -1535,9 +1548,10 @@ p5.prototype.createSelect = function(...args) {
  *   createCanvas(100, 100);
  *
  *   // Create a radio button element and place it
- *   // in the top-left corner.
+ *   // in the top-right corner.
  *   myRadio = createRadio();
  *   myRadio.position(0, 0);
+ *   myRadio.class('p5-radio');
  *   myRadio.size(50);
  *
  *   // Add a few color options.

--- a/src/dom/dom.js
+++ b/src/dom/dom.js
@@ -1481,7 +1481,7 @@ p5.prototype.createSelect = function(...args) {
  *   createCanvas(100, 100);
  *
  *   // Create a radio button element and place it
- *   // in the top-right corner.
+ *   // in the top-left corner.
  *   myRadio = createRadio();
  *   myRadio.position(0, 0);
  *   myRadio.class('p5-radio');
@@ -1548,7 +1548,7 @@ p5.prototype.createSelect = function(...args) {
  *   createCanvas(100, 100);
  *
  *   // Create a radio button element and place it
- *   // in the top-right corner.
+ *   // in the top-left corner.
  *   myRadio = createRadio();
  *   myRadio.position(0, 0);
  *   myRadio.class('p5-radio');


### PR DESCRIPTION
Resolves #7366 

 Changes:
Added styling to the radio, hence aligning them one below the other.

 Screenshots of the change:
<img width="100" alt="Screenshot 2024-11-08 at 5 10 49 PM" src="https://github.com/user-attachments/assets/d4839dac-967e-4dfd-ad3a-e16cbdba75a6">


#### PR Checklist
<!--
  To check any option, replace the "[ ]" with a "[x]". Be sure to check out how it looks in the Preview tab! Feel free to remove any portion of the template that is not relevant for your issue.
-->

- [x] `npm run lint` passes
- [x] [Inline documentation] is included / updated
- [x] [Unit tests] are included / updated

[Inline documentation]: https://github.com/processing/p5.js/blob/main/contributor_docs/inline_documentation.md
[Unit tests]: https://github.com/processing/p5.js/tree/main/contributor_docs#unit-tests
