### PR TITLE
Will high precision floats make lines render on top?

### DIFF
--- a/src/webgl/shaders/line.frag
+++ b/src/webgl/shaders/line.frag
@@ -1,4 +1,5 @@
-precision mediump int;
+precision highp int;
+precision highp float;
 
 uniform vec4 uMaterialColor;
 uniform int uStrokeCap;

--- a/src/webgl/shaders/line.vert
+++ b/src/webgl/shaders/line.vert
@@ -18,7 +18,8 @@
 
 #define PROCESSING_LINE_SHADER
 
-precision mediump int;
+precision highp int;
+precision highp float;
 
 uniform mat4 uModelViewMatrix;
 uniform mat4 uProjectionMatrix;


### PR DESCRIPTION
On some machines, for some tests, lines are rendering behind fills in WebGL.

This is a test to see if maybe the precision being different in the line shader from the fill shader is the problem.