### PR TITLE
Added ability to use setUniform for textures by texture slot rather than by p5.Texture

### DIFF
--- a/src/webgl/p5.Shader.js
+++ b/src/webgl/p5.Shader.js
@@ -1327,8 +1327,16 @@ p5.Shader = class {
         break;
       case gl.SAMPLER_2D:
         if (typeof data == 'number') {
-          if (data < gl.TEXTURE0 || data > gl.TEXTURE31 || data === Math.ceil(data)) {
-            console.log('🌸 p5.js says: You\'re trying to use a number as the data for a texture. Please use a texture.');
+          if (
+            data < gl.TEXTURE0 ||
+            data > gl.TEXTURE31 ||
+            data === Math.ceil(data)
+          ) {
+            console.log(
+              '🌸 p5.js says: ' +
+              'You\'re trying to use a number as the data for a texture.' +
+              'Please use a texture.'
+            );
             return this;
           }
           gl.activeTexture(data);

--- a/src/webgl/p5.Shader.js
+++ b/src/webgl/p5.Shader.js
@@ -1330,7 +1330,7 @@ p5.Shader = class {
           if (
             data < gl.TEXTURE0 ||
             data > gl.TEXTURE31 ||
-            data === Math.ceil(data)
+            data !== Math.ceil(data)
           ) {
             console.log(
               '🌸 p5.js says: ' +

--- a/src/webgl/p5.Shader.js
+++ b/src/webgl/p5.Shader.js
@@ -1326,12 +1326,18 @@ p5.Shader = class {
         }
         break;
       case gl.SAMPLER_2D:
-        gl.activeTexture(gl.TEXTURE0 + uniform.samplerIndex);
-        uniform.texture =
-          data instanceof p5.Texture ? data : this._renderer.getTexture(data);
-        gl.uniform1i(location, uniform.samplerIndex);
-        if (uniform.texture.src.gifProperties) {
-          uniform.texture.src._animateGif(this._renderer._pInst);
+        if (typeof data == 'number') {
+          gl.activeTexture(gl.TEXTURE0 + data);
+          gl.uniform1i(location, data);
+        }
+        else {
+          gl.activeTexture(gl.TEXTURE0 + uniform.samplerIndex);
+          uniform.texture =
+            data instanceof p5.Texture ? data : this._renderer.getTexture(data);
+          gl.uniform1i(location, uniform.samplerIndex);
+          if (uniform.texture.src.gifProperties) {
+            uniform.texture.src._animateGif(this._renderer._pInst);
+          }
         }
         break;
       //@todo complete all types

--- a/src/webgl/p5.Shader.js
+++ b/src/webgl/p5.Shader.js
@@ -1327,7 +1327,11 @@ p5.Shader = class {
         break;
       case gl.SAMPLER_2D:
         if (typeof data == 'number') {
-          gl.activeTexture(gl.TEXTURE0 + data);
+          if (data < gl.TEXTURE0 && data > gl.TEXTURE31 && data === Math.ceil(data)) {
+            console.log('🌸 p5.js says: You\'re trying to use a number as the data for a texture. Please use a texture.');
+            return this;
+          }
+          gl.activeTexture(data);
           gl.uniform1i(location, data);
         }
         else {

--- a/src/webgl/p5.Shader.js
+++ b/src/webgl/p5.Shader.js
@@ -1327,7 +1327,7 @@ p5.Shader = class {
         break;
       case gl.SAMPLER_2D:
         if (typeof data == 'number') {
-          if (data < gl.TEXTURE0 && data > gl.TEXTURE31 && data === Math.ceil(data)) {
+          if (data < gl.TEXTURE0 || data > gl.TEXTURE31 || data === Math.ceil(data)) {
             console.log('🌸 p5.js says: You\'re trying to use a number as the data for a texture. Please use a texture.');
             return this;
           }


### PR DESCRIPTION


<!--
  Thank you for contributing! Please use this pull request (PR) template.


 In the description field of this PR, include "resolves #XXXX" tagging the issue you are fixing. If this PR addresses the issue but doesn't completely resolve it (ie the issue should remain open after your PR is merged), write "addresses #XXXX".-->
Resolves #7394

 Changes:
<!-- Add here what changes were made in this pull request and if possible provide links showcasing the changes. -->
Adds the option to use `setUniform` by texture slot instead of by p5.Texture.

#### PR Checklist
<!--
  To check any option, replace the "[ ]" with a "[x]". Be sure to check out how it looks in the Preview tab! Feel free to remove any portion of the template that is not relevant for your issue.
-->

- [x] `npm run lint` passes
- [x] [Inline documentation] is included / updated
- [x] [Unit tests] are included / updated

[Inline documentation]: https://github.com/processing/p5.js/blob/main/contributor_docs/inline_documentation.md
[Unit tests]: https://github.com/processing/p5.js/tree/main/contributor_docs#unit-tests
