### PR TITLE
Added support for other WebGL sampler types

### DIFF
--- a/src/webgl/p5.Shader.js
+++ b/src/webgl/p5.Shader.js
@@ -1352,6 +1352,39 @@ p5.Shader = class {
           }
         }
         break;
+      case gl.SAMPLER_2D:
+      case gl.SAMPLER_CUBE: 
+      case gl.SAMPLER_3D:
+      case gl.SAMPLER_2D_SHADOW:
+      case gl.SAMPLER_2D_ARRAY:
+      case gl.SAMPLER_2D_ARRAY_SHADOW:
+      case gl.SAMPLER_CUBE_SHADOW:
+      case gl.INT_SAMPLER_2D:
+      case gl.INT_SAMPLER_3D:
+      case gl.INT_SAMPLER_CUBE:
+      case gl.INT_SAMPLER_2D_ARRAY:
+      case gl.UNSIGNED_INT_SAMPLER_2D:
+      case gl.UNSIGNED_INT_SAMPLER_3D:
+      case gl.UNSIGNED_INT_SAMPLER_CUBE:
+      case gl.UNSIGNED_INT_SAMPLER_2D_ARRAY:
+        if (typeof data !== 'number') {
+          break;
+        }
+        if (
+          data < gl.TEXTURE0 ||
+          data > gl.TEXTURE31 ||
+          data !== Math.ceil(data)
+        ) {
+          console.log(
+            '🌸 p5.js says: ' +
+            'You\'re trying to use a number as the data for a texture.' +
+            'Please use a texture.'
+          );
+          break;
+        }
+        gl.activeTexture(data);
+        gl.uniform1i(location, data);
+        break;
       //@todo complete all types
     }
     return this;

--- a/src/webgl/p5.Shader.js
+++ b/src/webgl/p5.Shader.js
@@ -1352,7 +1352,6 @@ p5.Shader = class {
           }
         }
         break;
-      case gl.SAMPLER_2D:
       case gl.SAMPLER_CUBE: 
       case gl.SAMPLER_3D:
       case gl.SAMPLER_2D_SHADOW:

--- a/src/webgl/p5.Shader.js
+++ b/src/webgl/p5.Shader.js
@@ -1352,7 +1352,7 @@ p5.Shader = class {
           }
         }
         break;
-      case gl.SAMPLER_CUBE: 
+      case gl.SAMPLER_CUBE:
       case gl.SAMPLER_3D:
       case gl.SAMPLER_2D_SHADOW:
       case gl.SAMPLER_2D_ARRAY:


### PR DESCRIPTION
<!--
  Thank you for contributing! Please use this pull request (PR) template.


 In the description field of this PR, include "resolves #XXXX" tagging the issue you are fixing. If this PR addresses the issue but doesn't completely resolve it (ie the issue should remain open after your PR is merged), write "addresses #XXXX".-->
Resolves #7410

 Changes:
<!-- Add here what changes were made in this pull request and if possible provide links showcasing the changes. -->
Added the option to use `setUniform` by texture slot for the other uniform data types like what was done in https://github.com/processing/p5.js/issues/7394.

<!-- If applicable, add screenshots depicting the changes. -->

#### PR Checklist
<!--
  To check any option, replace the "[ ]" with a "[x]". Be sure to check out how it looks in the Preview tab! Feel free to remove any portion of the template that is not relevant for your issue.
-->

- [x] `npm run lint` passes
- [x] [Inline documentation] is included / updated
- [x] [Unit tests] are included / updated

[Inline documentation]: https://github.com/processing/p5.js/blob/main/contributor_docs/inline_documentation.md
[Unit tests]: https://github.com/processing/p5.js/tree/main/contributor_docs#unit-tests
