### PR TITLE
Refactor 2.0 Typography code to work with WebGL

### DIFF
--- a/preview/index.html
+++ b/preview/index.html
@@ -25,7 +25,7 @@
 
       p.setup = async function () {
         // TODO: make this work without a name
-        f = await p.loadFont('font/BricolageGrotesque-Variable.ttf', 'Bricolage')
+        f = await p.loadFont('font/Lato-Black.ttf', 'Lato')
         p.createCanvas(200, 200, testWebgl ? p.WEBGL : undefined);
       };
 
@@ -34,15 +34,16 @@
         if (testWebgl) p.translate(-p.width/2, -p.height/2);
 
         p.fill('white');
-        p.textSize(80);
-        p.textAlign(p.LEFT, p.TOP)
+        p.textSize(60);
+        p.textAlign(p.RIGHT, p.CENTER)
         p.textFont(f)
-        p.text('hello, world!', 10, 30, p.width);
+        p.text('hello, world!', 0, p.height/2, p.width);
       };
     };
 
     new p5(sketch);
   </script>
+  <p style="font-family: Lato">hello, world!</p>
 </body>
 
 </html>

--- a/preview/index.html
+++ b/preview/index.html
@@ -20,25 +20,21 @@
     import p5 from '../src/app.js';
 
     const sketch = function (p) {
-      let g, f;
+      let f;
 
-      p.setup = function () {
-        p.createCanvas(200, 200);
-        g = p.createGraphics(200, 200);
-        f = p.createGraphics(200, 200, p.WEBGL);
+      p.setup = async function () {
+        // TODO: make this work without a name
+        f = await p.loadFont('font/BricolageGrotesque-Variable.ttf', 'Bricolage')
+        p.createCanvas(200, 200, p.WEBGL);
       };
 
       p.draw = function () {
         p.background(0, 50, 50);
-        p.circle(100, 100, 50);
 
         p.fill('white');
         p.textSize(30);
+        p.textFont(f)
         p.text('hello', 10, 30);
-
-        // f.fill('red');
-        f.sphere();
-        p.image(f, 0, 0);
       };
     };
 

--- a/preview/index.html
+++ b/preview/index.html
@@ -21,20 +21,23 @@
 
     const sketch = function (p) {
       let f;
+      const testWebgl = true
 
       p.setup = async function () {
         // TODO: make this work without a name
         f = await p.loadFont('font/BricolageGrotesque-Variable.ttf', 'Bricolage')
-        p.createCanvas(200, 200, p.WEBGL);
+        p.createCanvas(200, 200, testWebgl ? p.WEBGL : undefined);
       };
 
       p.draw = function () {
         p.background(0, 50, 50);
+        if (testWebgl) p.translate(-p.width/2, -p.height/2);
 
         p.fill('white');
-        p.textSize(30);
+        p.textSize(80);
+        p.textAlign(p.LEFT, p.TOP)
         p.textFont(f)
-        p.text('hello', 10, 30);
+        p.text('hello,\nworld!', 10, 30, p.width);
       };
     };
 

--- a/preview/index.html
+++ b/preview/index.html
@@ -37,7 +37,7 @@
         p.textSize(80);
         p.textAlign(p.LEFT, p.TOP)
         p.textFont(f)
-        p.text('hello,\nworld!', 10, 30, p.width);
+        p.text('hello, world!', 10, 30, p.width);
       };
     };
 

--- a/src/app.js
+++ b/src/app.js
@@ -49,10 +49,6 @@ io(p5);
 import math from './math';
 math(p5);
 
-// typography
-import type from './type'
-type(p5);
-
 // utilities
 import utilities from './utilities';
 utilities(p5);
@@ -60,6 +56,10 @@ utilities(p5);
 // webgl
 import webgl from './webgl';
 webgl(p5);
+
+// typography
+import type from './type'
+type(p5);
 
 import './core/init';
 

--- a/src/core/p5.Renderer.js
+++ b/src/core/p5.Renderer.js
@@ -34,7 +34,7 @@ class Renderer {
       rectMode: constants.CORNER,
       ellipseMode: constants.CENTER,
 
-      textFont: 'sans-serif',
+      textFont: { family: 'sans-serif' },
       textLeading: 15,
       leadingSet: false,
       textSize: 12,
@@ -485,7 +485,7 @@ class Renderer {
   /**
  * Helper function to check font type (system or otf)
  */
-  _isOpenType(f = this.states.textFont) {
+  _isOpenType({ font: f } = this.states.textFont) {
     return typeof f === 'object' && f.data;
   }
 

--- a/src/core/p5.Renderer.js
+++ b/src/core/p5.Renderer.js
@@ -486,7 +486,7 @@ class Renderer {
  * Helper function to check font type (system or otf)
  */
   _isOpenType(f = this.states.textFont) {
-    return typeof f === 'object' && f.font && f.font.supported;
+    return typeof f === 'object' && f.data;
   }
 
   _updateTextMetrics() {

--- a/src/core/p5.Renderer2D.js
+++ b/src/core/p5.Renderer2D.js
@@ -1405,7 +1405,7 @@ class Renderer2D extends Renderer {
     return p;
   }
 
-  _applyTextProperties() {
+  /*_applyTextProperties() {
     let font;
     const p = this._pInst;
 
@@ -1435,7 +1435,7 @@ class Renderer2D extends Renderer {
     }
 
     return p;
-  }
+  }*/
 
   //////////////////////////////////////////////
   // STRUCTURE

--- a/src/type/p5.Font.js
+++ b/src/type/p5.Font.js
@@ -53,6 +53,16 @@ function font(p5, fn) {
       this.face = fontFace;
     }
 
+    verticalAlign(size) {
+      const { sCapHeight } = this.data?.['OS/2'] || {};
+      const { unitsPerEm = 1000 } = this.data?.head || {};
+      const { ascender = 0, descender = 0 } = this.data?.hhea || {};
+      const current = ascender / 2;
+      const target = (sCapHeight || (ascender + descender)) / 2;
+      const offset = target - current;
+      return offset * size / unitsPerEm;
+    }
+
     variations() {
       let vars = {};
       if (this.data) {

--- a/src/type/text2d.js
+++ b/src/type/text2d.js
@@ -103,7 +103,7 @@ function text2d(p5, fn) {
   const RendererTextProps = {
     textAlign: { default: fn.LEFT, type: 'Context2d' },
     textBaseline: { default: fn.BASELINE, type: 'Context2d' },
-    textFont: { default: 'sans-serif' },
+    textFont: { default: { family: 'sans-serif' } },
     textLeading: { default: 15 },
     textSize: { default: 12 },
     textWrap: { default: fn.WORD },
@@ -301,7 +301,7 @@ function text2d(p5, fn) {
     }
 
     // update font properties in this.states
-    this.states.textFont = this.textFontState(font, family, size);
+    this.states.textFont = { font, family, size };
 
     // convert/update the size in this.states
     if (typeof size !== 'undefined') {
@@ -703,7 +703,7 @@ function text2d(p5, fn) {
     @param {string} size - the font-size string to compute
     @returns {number} - the computed font-size in pixels
    */
-  Renderer.prototype._fontSizePx = function (theSize, family = this.states.textFont) {
+  Renderer.prototype._fontSizePx = function (theSize, { family } = this.states.textFont) {
 
     const isNumString = (num) => !isNaN(num) && num.trim() !== '';
 
@@ -1088,7 +1088,7 @@ function text2d(p5, fn) {
       - font-family must be the last value specified.
     */
     let { textFont, textSize, lineHeight, fontStyle, fontWeight, fontVariant } = this.states;
-    let family = this._parseFontFamily(textFont);
+    let family = this._parseFontFamily(textFont.family);
     let style = fontStyle !== fn.NORMAL ? `${fontStyle} ` : '';
     let weight = fontWeight !== fn.NORMAL ? `${fontWeight} ` : '';
     let variant = fontVariant !== fn.NORMAL ? `${fontVariant} ` : '';
@@ -1152,9 +1152,6 @@ function text2d(p5, fn) {
     p5.Renderer2D.prototype.textDrawingContext = function() {
       return this.drawingContext;
     };
-    p5.Renderer2D.prototype.textFontState = function(font, family, size) {
-      return family;
-    };
     p5.Renderer2D.prototype._renderText = function (text, x, y, maxY, minY) {
       let states = this.states;
 
@@ -1192,14 +1189,6 @@ function text2d(p5, fn) {
         this._textDrawingContext = this._textCanvas.getContext('2d');
       }
       return this._textDrawingContext;
-    };
-    p5.RendererGL.prototype.textFontState = function(font, family, size) {
-      if (typeof font === 'string' || font instanceof String) {
-        throw new Error(
-          'In WebGL mode, textFont() needs to be given the result of loadFont() instead of a font family name.'
-        );
-      }
-      return font;
     };
   }
 }

--- a/src/webgl/shaders/font.vert
+++ b/src/webgl/shaders/font.vert
@@ -24,7 +24,7 @@ void main() {
     1. / length(newOrigin - newDX),
     1. / length(newOrigin - newDY)
   );
-  vec2 offset = pixelScale * normalize(aTexCoord - vec2(0.5, 0.5)) * vec2(1., -1.);
+  vec2 offset = pixelScale * normalize(aTexCoord - vec2(0.5, 0.5));
   vec2 textureOffset = offset * (1. / vec2(
     uGlyphRect.z - uGlyphRect.x,
     uGlyphRect.w - uGlyphRect.y

--- a/src/webgl/text.js
+++ b/src/webgl/text.js
@@ -7,14 +7,14 @@ import { Geometry } from './p5.Geometry';
 function text(p5, fn){
   // Text/Typography
   // @TODO:
-  RendererGL.prototype._applyTextProperties = function() {
+  //RendererGL.prototype._applyTextProperties = function() {
     //@TODO finish implementation
     //console.error('text commands not yet implemented in webgl');
-  };
+  //};
 
   RendererGL.prototype.textWidth = function(s) {
     if (this._isOpenType()) {
-      return this.states.textFont._textWidth(s, this.states.textSize);
+      return this.states.textFont.font._textWidth(s, this.states.textSize);
     }
 
     return 0; // TODO: error
@@ -700,7 +700,12 @@ function text(p5, fn){
     this.states.drawMode = constants.TEXTURE;
 
     // get the cached FontInfo object
-    const font = this.states.textFont;
+    const { font } = this.states.textFont;
+    if (!font) {
+      throw new Error(
+        'In WebGL mode, textFont() needs to be given the result of loadFont() instead of a font family name.'
+      );
+    }
     let fontInfo = this.states.textFont._fontInfo;
     if (!fontInfo) {
       fontInfo = this.states.textFont._fontInfo = new FontInfo(font);

--- a/src/webgl/text.js
+++ b/src/webgl/text.js
@@ -207,11 +207,11 @@ function text(p5, fn){
           }
           case 'Q': {
             const [, x1, y1, x, y] = command;
-            return { type, x, y, x1, y1 };
+            return { type, x1, y1, x, y };
           }
           case 'C': {
             const [, x1, y1, x2, y2, x, y] = command;
-            return { type, x, y, x1, y1, x2, y2 };
+            return { type, x1, y1, x2, y2, x, y };
           }
           default: {
             throw new Error(`Unexpected path command: ${type}`);


### PR DESCRIPTION
- [x] Give WebGL mode a small 2D canvas to use for text measurement
  - [x] Fully get text measurement working
- [x] Move most Renderer2D functions to the base renderer
- [x] Make renderers separately implement functionality to get the text measurement context
- [x] Connect Typr glyph info to WebGL text shader
- [x] Connect WebGL glyph positioning to Typr positioning info
- [x] Fix bug: text wrapping not working in WebGL
- [x] Fix bug: text alignment not working in WebGL
- [ ] Fix bug: Fonts loaded from file don't seem to work without a manual name supplied
- [ ] Fix bug: 2D canvas extracts a different set of default parameters for variable fonts than Typr does, leading to misaligned WebGL text