### PR TITLE
Add and adjust alpha parameter description

### DIFF
--- a/src/color/setting.js
+++ b/src/color/setting.js
@@ -1000,7 +1000,7 @@ p5.prototype.colorMode = function(mode, max1, max2, max3, maxA) {
  * @param  {Number}        v1      red value if color mode is RGB or hue value if color mode is HSB.
  * @param  {Number}        v2      green value if color mode is RGB or saturation value if color mode is HSB.
  * @param  {Number}        v3      blue value if color mode is RGB or brightness value if color mode is HSB.
- * @param  {Number}        [alpha] optional alpha value, controls transparency (0 - transparent, 255 - opaque).
+ * @param  {Number}        [alpha] alpha value, controls transparency (0 - transparent, 255 - opaque).
  * @chainable
  * @example
  * <div>
@@ -1360,7 +1360,7 @@ p5.prototype.noStroke = function() {
  * @param  {Number}        v1      red value if color mode is RGB or hue value if color mode is HSB.
  * @param  {Number}        v2      green value if color mode is RGB or saturation value if color mode is HSB.
  * @param  {Number}        v3      blue value if color mode is RGB or brightness value if color mode is HSB.
- * @param  {Number}        [alpha]
+ * @param  {Number}        [alpha] alpha value, controls transparency (0 - transparent, 255 - opaque).
  * @chainable
  *
  * @example


### PR DESCRIPTION
Addresses #657

 Changes:

1. Remove the word 'optional' from the description of the alpha parameter of fill()
2. Add description of alpha parameter of stroke()

(1) is done because '(Optional)' is added to the description automatically.
(2) is done because the description was missing.

 Screenshots of the change:
![Screenshot 2024-12-11 at 16 19 37](https://github.com/user-attachments/assets/d87e561e-8a05-4c2d-a475-3b99d25b3c37)
![Screenshot 2024-12-11 at 16 21 01](https://github.com/user-attachments/assets/7bec7ac8-570a-44a4-a15e-a26c75b7e2b1)

#### PR Checklist
- [x] `npm run lint` passes
- [ ] [Inline documentation] is included / updated
- [ ] [Unit tests] are included / updated

[Inline documentation]: https://github.com/processing/p5.js/blob/main/contributor_docs/inline_documentation.md
[Unit tests]: https://github.com/processing/p5.js/tree/main/contributor_docs#unit-tests