### PR TITLE
fixed repeated key presses when a modifier key is held

### DIFF
--- a/src/events/keyboard.js
+++ b/src/events/keyboard.js
@@ -631,7 +631,7 @@ p5.prototype._onkeyup = function(e) {
   this._setProperty('_lastKeyCodePressed', this._keyCode);
   this._downKeys[e.which] = false;
 
-  if (e.which === 91 || e.which === 93) { // Meta key codes
+  if (e.key === 'Meta') { // Meta key codes
     // When meta key is released, clear all keys pressed with it
     if (this._metaKeys) {
       this._metaKeys.forEach(key => {


### PR DESCRIPTION
<!--
  Thank you for contributing! Please use this pull request (PR) template.


 In the description field of this PR, include "resolves #XXXX" tagging the issue you are fixing. If this PR addresses the issue but doesn't completely resolve it (ie the issue should remain open after your PR is merged), write "addresses #XXXX".-->
Resolves #7282 

 Changes:
As @davepagurek proposed above, I have used .repeat check to make sure we can capture repeated presses and recording which keys were pressed in combination with the meta key, and then when the meta key is released, manually update _downkeys so that they're all set to false

<!-- Add here what changes were made in this pull request and if possible provide links showcasing the changes. -->


 Screenshots of the change:
<!-- If applicable, add screenshots depicting the changes. -->
![img](https://res.cloudinary.com/dhodvtp0u/image/upload/fl_preserve_transparency/v1734622872/x6t2b7qszkt1x0jzizzc.jpg?_s=public-apps)

#### PR Checklist
<!--
  To check any option, replace the "[ ]" with a "[x]". Be sure to check out how it looks in the Preview tab! Feel free to remove any portion of the template that is not relevant for your issue.
-->

- [x] `npm run lint` passes
- [ ] [Inline documentation] is included / updated
- [ ] [Unit tests] are included / updated

[Inline documentation]: https://github.com/processing/p5.js/blob/main/contributor_docs/inline_documentation.md
[Unit tests]: https://github.com/processing/p5.js/tree/main/contributor_docs#unit-tests
