### PR TITLE
fix: text() swallows characters in CHAR wrap mode #7437

### DIFF
--- a/src/core/p5.Renderer.js
+++ b/src/core/p5.Renderer.js
@@ -390,9 +390,9 @@ class Renderer extends p5.Element {
               line = `${chars[charIndex]}`;
             }
           }
+          nlines.push(line);
         }
 
-        nlines.push(line);
         let offset = 0;
         if (this._textBaseline === constants.CENTER) {
           offset = (nlines.length - 1) * p.textLeading() / 2;
@@ -423,16 +423,16 @@ class Renderer extends p5.Element {
               line = `${chars[charIndex]}`;
             }
           }
+          this._renderText(
+            p,
+            line.trim(),
+            x,
+            y - offset,
+            finalMaxHeight,
+            finalMinHeight
+          );
+          y += p.textLeading();
         }
-        this._renderText(
-          p,
-          line.trim(),
-          x,
-          y - offset,
-          finalMaxHeight,
-          finalMinHeight
-        );
-        y += p.textLeading();
       }
     } else {
     // Offset to account for vertically centering multiple lines of text - no


### PR DESCRIPTION
<!--
  Thank you for contributing! Please use this pull request (PR) template.


 In the description field of this PR, include "resolves #XXXX" tagging the issue you are fixing. If this PR addresses the issue but doesn't completely resolve it (ie the issue should remain open after your PR is merged), write "addresses #XXXX".-->
Resolves #7437

 Changes:
<!-- Add here what changes were made in this pull request and if possible provide links showcasing the changes. -->
```
diff --git a/src/core/p5.Renderer.js b/src/core/p5.Renderer.js
index 21ce3bd64..a08966639 100644
--- a/src/core/p5.Renderer.js
+++ b/src/core/p5.Renderer.js
@@ -390,9 +390,9 @@ class Renderer extends p5.Element {
               line = `${chars[charIndex]}`;
             }
           }
+          nlines.push(line);
         }
 
-        nlines.push(line);
         let offset = 0;
         if (this._textBaseline === constants.CENTER) {
           offset = (nlines.length - 1) * p.textLeading() / 2;
@@ -423,16 +423,16 @@ class Renderer extends p5.Element {
               line = `${chars[charIndex]}`;
             }
           }
+          this._renderText(
+            p,
+            line.trim(),
+            x,
+            y - offset,
+            finalMaxHeight,
+            finalMinHeight
+          );
+          y += p.textLeading();
         }
-        this._renderText(
-          p,
-          line.trim(),
-          x,
-          y - offset,
-          finalMaxHeight,
-          finalMinHeight
-        );
-        y += p.textLeading();
       }
     } else {
     // Offset to account for vertically centering multiple lines of text - no
```

 Screenshots of the change:
<!-- If applicable, add screenshots depicting the changes. -->
![Screenshot from 2024-12-21 08-06-30](https://github.com/user-attachments/assets/6b706bbc-062e-4de3-b5fe-b1b42164eb9c)
#### PR Check

list
<!--
  To check any option, replace the "[ ]" with a "[x]". Be sure to check out how it looks in the Preview tab! Feel free to remove any portion of the template that is not relevant for your issue.
-->

- [x] `npm run lint` passes
- [ ] [Inline documentation] is included / updated
- [ ] [Unit tests] are included / updated

[Inline documentation]: https://github.com/processing/p5.js/blob/main/contributor_docs/inline_documentation.md
[Unit tests]: https://github.com/processing/p5.js/tree/main/contributor_docs#unit-tests
