### PR TITLE
Fix MTL color loading when vertices are shared across different faces

### DIFF
--- a/src/webgl/loading.js
+++ b/src/webgl/loading.js
@@ -556,7 +556,6 @@ function loading(p5, fn){
     // Map from source index → Map of material → destination index
     const usedVerts = {}; // Track colored vertices
     let currentMaterial = null;
-    const coloredVerts = new Set(); //unique vertices with color
     let hasColoredVertices = false;
     let hasColorlessVertices = false;
     for (let line = 0; line < lines.length; ++line) {
@@ -622,8 +621,15 @@ function loading(p5, fn){
                 if (currentMaterial
                   && materials[currentMaterial]
                   && materials[currentMaterial].diffuseColor) {
-                  // Mark this vertex as colored
-                  coloredVerts.add(loadedVerts.v[vertParts[0]]); //since a set would only push unique values
+                  hasColoredVertices = true;
+                  const materialDiffuseColor =
+                    materials[currentMaterial].diffuseColor;
+                  model.vertexColors.push(materialDiffuseColor[0]);
+                  model.vertexColors.push(materialDiffuseColor[1]);
+                  model.vertexColors.push(materialDiffuseColor[2]);
+                  model.vertexColors.push(1);
+                } else {
+                  hasColorlessVertices = true;
                 }
               } else {
                 face.push(usedVerts[vertString][currentMaterial]);
@@ -636,24 +642,6 @@ function loading(p5, fn){
               face[1] !== face[2]
             ) {
               model.faces.push(face);
-              //same material for all vertices in a particular face
-              if (currentMaterial
-                && materials[currentMaterial]
-                && materials[currentMaterial].diffuseColor) {
-                hasColoredVertices = true;
-                //flag to track color or no color model
-                hasColoredVertices = true;
-                const materialDiffuseColor =
-                  materials[currentMaterial].diffuseColor;
-                for (let i = 0; i < face.length; i++) {
-                  model.vertexColors.push(materialDiffuseColor[0]);
-                  model.vertexColors.push(materialDiffuseColor[1]);
-                  model.vertexColors.push(materialDiffuseColor[2]);
-                  model.vertexColors.push(1);
-                }
-              } else {
-                hasColorlessVertices = true;
-              }
             }
           }
         }


### PR DESCRIPTION
### Changes:
A user on Discord discovered that their obj + mtl combo was not rendering correctly:

![image](https://github.com/user-attachments/assets/da40b3da-9cd7-4cca-92fa-579a662b0847)

[Zipped obj + mtl here](https://github.com/user-attachments/files/18219966/mariohead.zip)


It turns out this can happen when vertices are reused between faces. Previously, when a vertex is used by a face for the first time, it adds the vertices to the `p5.Geometry` **only if it has not been used in that color before.** Then, when the face is added, it adds colors once per vertex, regardless of whether it is new or not. This means we might add a color to the color buffer a second time for a vertex that already exists in the buffer, pushing all subsequent colors out of sync.

Now, colors are added at the same time as other vertex properties. This all-or-nothing structure will hopefully help prevent some properties from going out of sync.

![image](https://github.com/user-attachments/assets/dbfedeb0-502e-4f24-a556-66243482f367)


#### PR Checklist
<!--
  To check any option, replace the "[ ]" with a "[x]". Be sure to check out how it looks in the Preview tab! Feel free to remove any portion of the template that is not relevant for your issue.
-->

- [ ] `npm run lint` passes
- [ ] [Inline documentation] is included / updated
- [ ] [Unit tests] are included / updated

[Inline documentation]: https://github.com/processing/p5.js/blob/main/contributor_docs/inline_documentation.md
[Unit tests]: https://github.com/processing/p5.js/tree/main/contributor_docs#unit-tests
