### PR TITLE
Fix typo in image.js docs

### DIFF
--- a/src/image/image.js
+++ b/src/image/image.js
@@ -565,7 +565,7 @@ p5.prototype.encodeAndDownloadGif = function(pImg, filename) {
  * an object with its file type, file name, and image data as a string. For
  * example, the first saved frame might have the following properties:
  *
- * `{ ext: 'png', filenmame: 'frame0', imageData: 'data:image/octet-stream;base64, abc123' }`.
+ * `{ ext: 'png', filename: 'frame0', imageData: 'data:image/octet-stream;base64, abc123' }`.
  *
  * The first parameter, `filename`, sets the prefix for the file names. For
  * example, setting the prefix to `'frame'` would generate the image files


### PR DESCRIPTION



 Changes:
Fixes a typo in the docs from `filenmame` to `filename`

#### PR Checklist
<!--
  To check any option, replace the "[ ]" with a "[x]". Be sure to check out how it looks in the Preview tab! Feel free to remove any portion of the template that is not relevant for your issue.
-->

- [x] [Inline documentation] is included / updated
