### PR TITLE
Add angle param clarification to sin(), cos(), and tan()

### DIFF
--- a/src/math/trigonometry.js
+++ b/src/math/trigonometry.js
@@ -286,7 +286,7 @@ p5.prototype.atan2 = function(y, x) {
  * takes into account the current <a href="#/p5/angleMode">angleMode()</a>.
  *
  * @method cos
- * @param  {Number} angle the angle.
+ * @param  {Number} angle the angle in radians unless specified by <a href="#/p5/angleMode">angleMode()</a>.
  * @return {Number}       cosine of the angle.
  *
  * @example
@@ -366,7 +366,7 @@ p5.prototype.cos = function(angle) {
  * takes into account the current <a href="#/p5/angleMode">angleMode()</a>.
  *
  * @method sin
- * @param  {Number} angle the angle.
+ * @param  {Number} angle the angle in radians unless specified by <a href="#/p5/angleMode">angleMode()</a>.
  * @return {Number}       sine of the angle.
  *
  * @example
@@ -447,7 +447,7 @@ p5.prototype.sin = function(angle) {
  * <a href="#/p5/angleMode">angleMode()</a>.
  *
  * @method tan
- * @param  {Number} angle the angle.
+ * @param  {Number} angle the angle in radians unless specified by <a href="#/p5/angleMode">angleMode()</a>.
  * @return {Number}       tangent of the angle.
  *
  * @example

--- a/src/math/trigonometry.js
+++ b/src/math/trigonometry.js
@@ -286,7 +286,7 @@ p5.prototype.atan2 = function(y, x) {
  * takes into account the current <a href="#/p5/angleMode">angleMode()</a>.
  *
  * @method cos
- * @param  {Number} angle the angle in radians unless specified by <a href="#/p5/angleMode">angleMode()</a>.
+ * @param  {Number} angle the angle in radians unless specified by <a href="/reference/p5/angleMode/">angleMode()</a>.
  * @return {Number}       cosine of the angle.
  *
  * @example
@@ -366,7 +366,7 @@ p5.prototype.cos = function(angle) {
  * takes into account the current <a href="#/p5/angleMode">angleMode()</a>.
  *
  * @method sin
- * @param  {Number} angle the angle in radians unless specified by <a href="#/p5/angleMode">angleMode()</a>.
+ * @param  {Number} angle the angle in radians unless specified by <a href="/reference/p5/angleMode/">angleMode()</a>.
  * @return {Number}       sine of the angle.
  *
  * @example
@@ -447,7 +447,7 @@ p5.prototype.sin = function(angle) {
  * <a href="#/p5/angleMode">angleMode()</a>.
  *
  * @method tan
- * @param  {Number} angle the angle in radians unless specified by <a href="#/p5/angleMode">angleMode()</a>.
+ * @param  {Number} angle the angle in radians unless specified by <a href="/reference/p5/angleMode/">angleMode()</a>.
  * @return {Number}       tangent of the angle.
  *
  * @example


### PR DESCRIPTION
<!--
  Thank you for contributing! Please use this pull request (PR) template.


 In the description field of this PR, include "resolves #XXXX" tagging the issue you are fixing. If this PR addresses the issue but doesn't completely resolve it (ie the issue should remain open after your PR is merged), write "addresses #XXXX".-->
Resolves processing/p5.js-website#671

#### Changes:
<!-- Add here what changes were made in this pull request and if possible provide links showcasing the changes. -->

- Adds clarification to the documentation `@param` for sin(), cos(), and tan() in src/math/trigonometry.js : `angle in radians unless specified by <a href="#/p5/angleMode">angleMode()</a>.`


#### PR Checklist
<!--
  To check any option, replace the "[ ]" with a "[x]". Be sure to check out how it looks in the Preview tab! Feel free to remove any portion of the template that is not relevant for your issue.
-->

- [x] `npm run lint` passes
- [x] [Inline documentation] is included / updated
- [ ] [Unit tests] are included / updated

[Inline documentation]: https://github.com/processing/p5.js/blob/main/contributor_docs/inline_documentation.md
[Unit tests]: https://github.com/processing/p5.js/tree/main/contributor_docs#unit-tests
