### PR TITLE
Add 0 check before dividing color by alpha

### DIFF
--- a/src/webgl/shaders/phong.frag
+++ b/src/webgl/shaders/phong.frag
@@ -49,7 +49,7 @@ void main(void) {
   inputs.color = isTexture
       ? TEXTURE(uSampler, vTexCoord) * uTint/255.
       : vColor;
-  if (isTexture) {
+  if (isTexture && inputs.color.a > 0.0) {
     // Textures come in with premultiplied alpha. Temporarily unpremultiply it
     // so hooks users don't have to think about premultiplied alpha.
     inputs.color.rgb /= inputs.color.a;


### PR DESCRIPTION
Resolves https://github.com/processing/p5.js/issues/7477

### Changes:
- Checks if alpha is > 0 before dividing by alpha to avoid NaNs

### Screenshots of the change:

The test sketch in the issue now looks like this:
![image](https://github.com/user-attachments/assets/51bd6d8f-a4be-43ec-a6a5-27ce163f140d)
