### PR TITLE
Remove wrong rendererGL textWidth function

### DIFF
--- a/src/webgl/text.js
+++ b/src/webgl/text.js
@@ -5,7 +5,8 @@ import { Geometry } from './p5.Geometry';
 import { arrayCommandsToObjects } from '../type/p5.Font';
 
 function text(p5, fn){
-  // Text/Typography
+  // Text/Typography (see src/type/textCore.js)
+  /*
   RendererGL.prototype.textWidth = function(s) {
     if (this._isOpenType()) {
       return this.states.textFont.font._textWidth(s, this.states.textSize);
@@ -13,6 +14,7 @@ function text(p5, fn){
 
     return 0; // TODO: error
   };
+  */
 
   // rendering constants
 


### PR DESCRIPTION
Remove `textWidth` typo function into `src/webgl/text.js` to prevent error when WEBGL is used.  
(related to https://github.com/processing/p5.js/issues/7491)

Screenshot of the error :
![image](https://github.com/user-attachments/assets/b5255906-d9ad-466a-953a-1615d1c8f4c1)