### PR TITLE
Add splineProperties

### DIFF
--- a/src/core/p5.Renderer.js
+++ b/src/core/p5.Renderer.js
@@ -170,6 +170,16 @@ class Renderer {
     this.updateShapeProperties();
   }
 
+  splineProperties(values) {
+    if (values) {
+      for (const key in values) {
+        this.splineProperty(key, values[key]);
+      }
+    } else {
+      return { ...this.states.splineProperties };
+    }
+  }
+
   splineVertex(x, y, z = 0, u = 0, v = 0) {
     const position = new Vector(x, y, z);
     const textureCoordinates = this.getSupportedIndividualVertexProperties().textureCoordinates

--- a/src/shape/custom_shapes.js
+++ b/src/shape/custom_shapes.js
@@ -836,6 +836,16 @@ class Shape {
     this._splineProperties[key] = value;
   }
 
+  splineProperties(values) {
+    if (values) {
+      for (const key in values) {
+        this.splineProperty(key, values[key]);
+      }
+    } else {
+      return this._splineProperties;
+    }
+  }
+
   /*
   To-do: Maybe refactor #createVertex() since this has side effects that aren't advertised
   in the method name?
@@ -1597,10 +1607,18 @@ function customShapes(p5, fn) {
   /**
    * TODO: documentation
    * @param {String} key
-   * @param value
+   * @param [value]
    */
   fn.splineProperty = function(key, value) {
     return this._renderer.splineProperty(key, value);
+  };
+
+  /**
+   * TODO: documentation
+   * @param {Object} [values]
+   */
+  fn.splineProperties = function(values) {
+    return this._renderer.splineProperties(values);
   };
 
   /**

--- a/test/unit/core/rendering.js
+++ b/test/unit/core/rendering.js
@@ -1,5 +1,5 @@
 import p5 from '../../../src/app.js';
-import { vi } from 'vitest';
+import { vi, expect } from 'vitest';
 
 suite('Rendering', function() {
   var myp5;
@@ -185,7 +185,7 @@ suite('Rendering', function() {
             try {
               expect(function() {
                 myp5[webglMethod].call(myp5);
-              }).to.throw(Error, /is only supported in WEBGL mode/);
+              }).toThrow(Error, /is only supported in WEBGL mode/);
             } finally {
               myp5.validateParameters = validateParamters;
             }
@@ -193,5 +193,19 @@ suite('Rendering', function() {
         })(webglMethod)
       );
     }
+  });
+
+  suite('spline functions', function() {
+    test('setting via splineProperty()', function() {
+      myp5.splineProperty('tightness', 2);
+      expect(myp5.splineProperty('tightness')).toEqual(2);
+      expect(myp5.splineProperties()).toMatchObject({ tightness: 2 });
+    });
+
+    test('setting via splineProperties()', function() {
+      myp5.splineProperties({ tightness: 2 });
+      expect(myp5.splineProperty('tightness')).toEqual(2);
+      expect(myp5.splineProperties()).toMatchObject({ tightness: 2 });
+    });
   });
 });


### PR DESCRIPTION
Addresses https://github.com/processing/p5.js/issues/6766

Specifically, the discussion in https://github.com/processing/p5.js/issues/6766#issuecomment-2636736306

### Changes:
- Adds a `splineProperties()` method that can be used to set multiple values at once, or return all the spline properties



#### PR Checklist
<!--
  To check any option, replace the "[ ]" with a "[x]". Be sure to check out how it looks in the Preview tab! Feel free to remove any portion of the template that is not relevant for your issue.
-->

- [x] `npm run lint` passes
- [ ] [Inline reference] is included / updated
- [x] [Unit tests] are included / updated

[Inline reference]: https://p5js.org/contribute/contributing_to_the_p5js_reference/
[Unit tests]: https://github.com/processing/p5.js/tree/main/contributor_docs#unit-tests
