### PR TITLE
fixed vertexproperty to work with single values

### DIFF
--- a/src/shape/custom_shapes.js
+++ b/src/shape/custom_shapes.js
@@ -810,11 +810,14 @@ class Shape {
   vertexProperty(name, data) {
     this.userVertexProperties = this.userVertexProperties || {};
     const key = this.vertexPropertyKey(name);
+    
+    const dataArray = Array.isArray(data) ? data : [data];
+    
     if (!this.userVertexProperties[key]) {
-      this.userVertexProperties[key] = data.length ? data.length : 1;
+      this.userVertexProperties[key] = dataArray.length;
     }
-    this.#vertexProperties[key] = data;
-  }
+    this.#vertexProperties[key] = dataArray;
+}
   vertexPropertyName(key) {
     return key.replace(/Src$/, '');
   }


### PR DESCRIPTION
<!--
  Thank you for contributing! Please use this pull request (PR) template.


 In the description field of this PR, include "resolves #XXXX" tagging the issue you are fixing. If this PR addresses the issue but doesn't completely resolve it (ie the issue should remain open after your PR is merged), write "addresses #XXXX".-->
Resolves #7518 

 Changes:
<!-- Add here what changes were made in this pull request and if possible provide links showcasing the changes. -->
Modified the method to automatically convert single value inputs into arrays, making the method more flexible and user-friendly. This change maintains backward compatibility with array inputs while adding support for single values.

 Screenshots of the change:
<!-- If applicable, add screenshots depicting the changes. -->

#### PR Checklist
<!--
  To check any option, replace the "[ ]" with a "[x]". Be sure to check out how it looks in the Preview tab! Feel free to remove any portion of the template that is not relevant for your issue.
-->

- [x] `npm run lint` passes
- [ ] [Inline reference] is included / updated
- [ ] [Unit tests] are included / updated

[Inline reference]: https://p5js.org/contribute/contributing_to_the_p5js_reference/
[Unit tests]: https://github.com/processing/p5.js/tree/main/contributor_docs#unit-tests
