### PR TITLE
Fix Load Function to Accept a callback without triggering a warning

### DIFF
--- a/src/core/friendly_errors/validate_params.js
+++ b/src/core/friendly_errors/validate_params.js
@@ -722,6 +722,10 @@ if (typeof IS_MINIFIED !== 'undefined') {
 
     let argCount = args.length;
 
+    // Allow loadFont() to accept a callback without triggering a warning
+    if (func === 'loadFont' && argCount === 2 && typeof args[1] === 'function') {
+      return;
+    }
     // the following line ignores trailing undefined arguments, commenting
     // it to resolve https://github.com/processing/p5.js/issues/4571
     // '== null' checks for 'null' and typeof 'undefined'


### PR DESCRIPTION

Resolves #[7541](https://github.com/processing/p5.js/issues/7541) 

 Changes:
Allow loadFont() to accept a callback without triggering a warning by adding up the condition statement. which checks the load function arguments and the function

#### PR Checklist
<!--
  To check any option, replace the "[ ]" with a "[x]". Be sure to check out how it looks in the Preview tab! Feel free to remove any portion of the template that is not relevant for your issue.
-->

- [x] `npm run lint` passes
- [x] [Inline reference] is included / updated
- [x] [Unit tests] are included / updated

[Inline reference]: https://p5js.org/contribute/contributing_to_the_p5js_reference/
[Unit tests]: https://github.com/processing/p5.js/tree/main/contributor_docs#unit-tests
