### PR TITLE
Fix: prevent unnecessary webgl canvas recreation in noSmooth()

### DIFF
--- a/src/core/shape/attributes.js
+++ b/src/core/shape/attributes.js
@@ -176,7 +176,10 @@ p5.prototype.noSmooth = function() {
       this.drawingContext.imageSmoothingEnabled = false;
     }
   } else {
-    this.setAttributes('antialias', false);
+      // Only change if necessary to prevent canvas recreation
+      if (this._renderer.attributes.antialias !== false) {
+        this.setAttributes('antialias', false);
+      }
   }
   return this;
 };


### PR DESCRIPTION
**Resolve #7548** 


**Issue**
Calling noSmooth() inside draw() in WebGL mode recreates the canvas because setAttributes('antialias', false) is called every time. This causes unexpected behavior, including loss of canvas positioning and state.

**Fix:**
Before setting antialias to false, we check if it's already false.
If it's already disabled, we skip calling setAttributes(), preventing unnecessary canvas recreation.

**Why This Fix?**
Optimizes performance: Avoids reinitializing the WebGL canvas every frame.
Prevents unintended side effects: Keeps canvas position and other properties intact.
Aligns with expected behavior: In 2D mode, noSmooth() doesn’t recreate the canvas, so WebGL should behave similarly.

**Before**
**Output with noSmooth()**
Not display any output..

**Output without noSmooth()**
![After](https://github.com/user-attachments/assets/9d73d9a9-7e7e-4eb2-86b9-75e98a25685e)


**After**
After fix issue.
Output with noSmooth() as well as without noSmooth().
![After](https://github.com/user-attachments/assets/4c1b578b-c0af-4b06-82b0-ea4cecb5abd5)


**Alternative Solution Considered**
Updating the documentation to explicitly state that calling noSmooth() after initialization will recreate the canvas. This can still be done in addition to this fix.

**Testing**
✅ Verified in both 2D and WebGL renderers.
✅ noSmooth() works correctly in setup() and draw().
✅ No canvas recreation occurs unless truly necessary.
