### PR TITLE
Add screenToWorld function mirroring worldToScreen

### DIFF
--- a/src/accessibility/outputs.js
+++ b/src/accessibility/outputs.js
@@ -540,14 +540,9 @@ function outputs(p5, fn){
 
   //gets position of shape in the canvas
   fn._getPos = function (x, y) {
-    const untransformedPosition = new DOMPointReadOnly(x, y);
-    const currentTransform = this._renderer.isP3D ?
-      new DOMMatrix(this._renderer.calculateCombinedMatrix()) :
-      this.drawingContext.getTransform();
-    const { x: transformedX, y: transformedY } = untransformedPosition
-      .matrixTransform(currentTransform);
-    const canvasWidth = this.width * this._renderer._pixelDensity;
-    const canvasHeight = this.height * this._renderer._pixelDensity;
+    const { x: transformedX, y: transformedY } = this.worldToScreen(new this.Vector(x, y));
+    const canvasWidth = this.width;
+    const canvasHeight = this.height;
     if (transformedX < 0.4 * canvasWidth) {
       if (transformedY < 0.4 * canvasHeight) {
         return 'top left';

--- a/src/core/p5.Renderer2D.js
+++ b/src/core/p5.Renderer2D.js
@@ -7,6 +7,7 @@ import { Element } from '../dom/p5.Element';
 import { MediaElement } from '../dom/p5.MediaElement';
 import { RGBHDR } from '../color/creating_reading';
 import FilterRenderer2D from '../image/filterRenderer2D';
+import { Matrix } from '../math/p5.Matrix';
 import { PrimitiveToPath2DConverter } from '../shape/custom_shapes';
 
 
@@ -997,6 +998,13 @@ class Renderer2D extends Renderer {
 
   applyMatrix(a, b, c, d, e, f) {
     this.drawingContext.transform(a, b, c, d, e, f);
+  }
+
+  getWorldToScreenMatrix() {
+    let domMatrix = new DOMMatrix()
+      .scale(1 / this._pixelDensity)
+      .multiply(this.drawingContext.getTransform());
+    return new Matrix(domMatrix.toFloat32Array());
   }
 
   resetMatrix() {

--- a/src/math/p5.Vector.js
+++ b/src/math/p5.Vector.js
@@ -34,7 +34,6 @@ class Vector {
   // This is how it comes in with createVector()
   // This check if the first argument is a function
   constructor(...args) {
-    let dimensions = args.length; // TODO: make default 3 if no arguments
     let values = args.map((arg) => arg || 0);
     if (typeof args[0] === "function") {
       this.isPInst = true;
@@ -42,6 +41,7 @@ class Vector {
       this._toRadians = args[1];
       values = args.slice(2).map((arg) => arg || 0);
     }
+    let dimensions = values.length; // TODO: make default 3 if no arguments
     if (dimensions === 0) {
       this.dimensions = 2;
       this._values = [0, 0, 0];

--- a/src/webgl/p5.RendererGL.js
+++ b/src/webgl/p5.RendererGL.js
@@ -1024,12 +1024,23 @@ class RendererGL extends Renderer {
     this.clear(..._col._getRGBA());
   }
 
-  // Combines the model and view matrices to get the uMVMatrix
-  // This method will be reusable wherever you need to update the combined matrix.
-  calculateCombinedMatrix() {
+
+  /**
+   * Get a matrix from world-space to screen-space
+   */
+  getWorldToScreenMatrix() {
     const modelMatrix = this.states.uModelMatrix;
     const viewMatrix = this.states.uViewMatrix;
-    return modelMatrix.copy().mult(viewMatrix);
+    const projectionMatrix = this.states.uPMatrix;
+    const projectedToScreenMatrix = new Matrix(4);
+    projectedToScreenMatrix.scale(this.width, this.height, 1);
+    projectedToScreenMatrix.translate([0.5, 0.5, 0.5]);
+    projectedToScreenMatrix.scale(0.5, -0.5, 0.5);
+
+    const modelViewMatrix = modelMatrix.copy().mult(viewMatrix);
+    const modelViewProjectionMatrix = modelViewMatrix.mult(projectionMatrix);
+    const worldToScreenMatrix = modelViewProjectionMatrix.mult(projectedToScreenMatrix);
+    return worldToScreenMatrix;
   }
 
   //////////////////////////////////////////////
@@ -2204,7 +2215,7 @@ class RendererGL extends Renderer {
     const modelMatrix = this.states.uModelMatrix;
     const viewMatrix = this.states.uViewMatrix;
     const projectionMatrix = this.states.uPMatrix;
-    const modelViewMatrix = this.calculateCombinedMatrix();
+    const modelViewMatrix = modelMatrix.copy().mult(viewMatrix);
 
     shader.setUniform(
       "uPerspective",

--- a/test/unit/core/environment.js
+++ b/test/unit/core/environment.js
@@ -249,6 +249,15 @@ suite('Environment', function() {
       assert.closeTo(screenPos.y, 50, 0.1);
     });
 
+    test('worldToScreen accepts numbers with translation in 2D', function() {
+      myp5.push();
+      myp5.translate(50, 50);
+      let screenPos = myp5.worldToScreen(0, 0);
+      myp5.pop();
+      assert.closeTo(screenPos.x, 50, 0.1);
+      assert.closeTo(screenPos.y, 50, 0.1);
+    });
+
     test('worldToScreen with rotation in 2D', function() {
       myp5.push();
       myp5.translate(50, 50);
@@ -265,6 +274,15 @@ suite('Environment', function() {
       let worldPos = myp5.screenToWorld(screenPos);
       assert.closeTo(worldPos.x, 50, 0.1);
       assert.closeTo(worldPos.y, 50, 0.1);
+    });
+
+    test('screenToWorld accepts numbers with translation in 2D', function() {
+      myp5.push();
+      myp5.translate(50, 50);
+      let worldPos = myp5.screenToWorld(50, 50);
+      myp5.pop();
+      assert.closeTo(worldPos.x, 0, 0.1);
+      assert.closeTo(worldPos.y, 0, 0.1);
     });
 
     test('screenToWorld with rotation in 2D', function() {
@@ -304,6 +322,15 @@ suite('Environment', function() {
       assert.closeTo(screenPos.y, 50, 0.1);
     });
 
+    test('worldToScreen accepts numbers with translation in 3D', function() {
+      myp5.push();
+      myp5.translate(50, 50, 0);
+      let screenPos = myp5.worldToScreen(0, 0, 0);
+      myp5.pop();
+      assert.closeTo(screenPos.x, 100, 0.1);
+      assert.closeTo(screenPos.y, 100, 0.1);
+    });
+
     test('worldToScreen with rotation in 3D around Y-axis', function() {
       myp5.push();
       myp5.rotateY(myp5.PI / 2);
@@ -329,12 +356,22 @@ suite('Environment', function() {
       let worldPos = myp5.screenToWorld(screenPos);
       assert.closeTo(worldPos.x, 0, 0.1);
       assert.closeTo(worldPos.y, 0, 0.1);
+      assert.closeTo(worldPos.z, 0, 0.1);
+    });
+
+    test('screenToWorld accepts numbers with translation in 3D', function() {
+      myp5.push();
+      myp5.translate(50, 50);
+      let worldPos = myp5.screenToWorld(100, 100);
+      myp5.pop();
+      assert.closeTo(worldPos.x, 0, 0.1);
+      assert.closeTo(worldPos.y, 0, 0.1);
     });
 
     test('screenToWorld with rotation in 3D around Y-axis', function() {
       myp5.push();
       myp5.rotateY(myp5.PI / 2);
-      let screenPos = myp5.createVector(50, 50, 10/11);
+      let screenPos = myp5.createVector(50, 50);
       let worldPos = myp5.screenToWorld(screenPos);
       myp5.pop();
       assert.closeTo(worldPos.y, 0, 0.1);
@@ -343,7 +380,7 @@ suite('Environment', function() {
     test('screenToWorld with rotation in 3D around Z-axis', function() {
       myp5.push();
       myp5.rotateZ(myp5.PI / 2);
-      let screenPos = myp5.createVector(50, 60, 10/11);
+      let screenPos = myp5.createVector(50, 60);
       let worldPos = myp5.screenToWorld(screenPos);
       myp5.pop();
       assert.closeTo(worldPos.x, 10, 0.1);

--- a/test/unit/core/environment.js
+++ b/test/unit/core/environment.js
@@ -259,6 +259,37 @@ suite('Environment', function() {
       assert.closeTo(screenPos.x, 50, 0.1);
       assert.closeTo(screenPos.y, 60, 0.1);
     });
+
+    test('screenToWorld for 2D context', function() {
+      let screenPos = myp5.createVector(50, 50);
+      let worldPos = myp5.screenToWorld(screenPos);
+      assert.closeTo(worldPos.x, 50, 0.1);
+      assert.closeTo(worldPos.y, 50, 0.1);
+    });
+
+    test('screenToWorld with rotation in 2D', function() {
+      myp5.push();
+      myp5.translate(50, 50);
+      myp5.rotate(myp5.PI / 2);
+      let screenPos = myp5.createVector(50, 60);
+      let worldPos = myp5.screenToWorld(screenPos);
+      myp5.pop();
+      assert.closeTo(worldPos.x, 10, 0.1);
+      assert.closeTo(worldPos.y, 0, 0.1);
+    });
+
+    test('screenToWorld is inverse of worldToScreen in 2D', function() {
+      myp5.push();
+      // Arbitrary rotation
+      myp5.translate(10, 10);
+      myp5.rotate(myp5.PI / 8);
+      let origWorldPos = myp5.createVector(20, 20);
+      let screenPos = myp5.worldToScreen(origWorldPos);
+      let worldPos = myp5.screenToWorld(screenPos);
+      myp5.pop();
+      assert.closeTo(worldPos.x, origWorldPos.x, 0.1);
+      assert.closeTo(worldPos.y, origWorldPos.y, 0.1);
+    });
   });
 
   suite('3D context test', function() {
@@ -291,6 +322,48 @@ suite('Environment', function() {
       myp5.pop();
       assert.closeTo(screenPos.x, 50, 0.1);
       assert.closeTo(screenPos.y, 60, 0.1);
+    });
+
+    test('screenToWorld for 3D context', function() {
+      let screenPos = myp5.createVector(50, 50);
+      let worldPos = myp5.screenToWorld(screenPos);
+      assert.closeTo(worldPos.x, 0, 0.1);
+      assert.closeTo(worldPos.y, 0, 0.1);
+    });
+
+    test('screenToWorld with rotation in 3D around Y-axis', function() {
+      myp5.push();
+      myp5.rotateY(myp5.PI / 2);
+      let screenPos = myp5.createVector(50, 50, 10/11);
+      let worldPos = myp5.screenToWorld(screenPos);
+      myp5.pop();
+      assert.closeTo(worldPos.y, 0, 0.1);
+    });
+
+    test('screenToWorld with rotation in 3D around Z-axis', function() {
+      myp5.push();
+      myp5.rotateZ(myp5.PI / 2);
+      let screenPos = myp5.createVector(50, 60, 10/11);
+      let worldPos = myp5.screenToWorld(screenPos);
+      myp5.pop();
+      assert.closeTo(worldPos.x, 10, 0.1);
+      assert.closeTo(worldPos.y, 0, 0.1);
+    });
+
+    test('screenToWorld is inverse of worldToScreen in 3D', function() {
+      myp5.push();
+      // Arbitrary rotation
+      myp5.translate(10, 10);
+      myp5.rotateX(myp5.PI / 3);
+      myp5.rotateY(myp5.PI / 4);
+      myp5.rotateZ(myp5.PI / 8);
+      let origWorldPos = myp5.createVector(20, 20, 0);
+      let screenPos = myp5.worldToScreen(origWorldPos);
+      let worldPos = myp5.screenToWorld(screenPos);
+      myp5.pop();
+      assert.closeTo(worldPos.x, origWorldPos.x, 0.1);
+      assert.closeTo(worldPos.y, origWorldPos.y, 0.1);
+      assert.closeTo(worldPos.z, origWorldPos.z, 0.1);
     });
   });
 });

--- a/test/unit/math/p5.Vector.js
+++ b/test/unit/math/p5.Vector.js
@@ -52,6 +52,10 @@ suite("p5.Vector", function () {
       assert.equal(v.y, 0);
       assert.equal(v.z, 0);
     });
+
+    test("should have dimensions initialized to 2", function () {
+      assert.equal(v.dimensions, 2);
+    });
   });
 
   suite.todo("p5.prototype.createVector(1, 2, 3)", function () {
@@ -63,6 +67,10 @@ suite("p5.Vector", function () {
       assert.equal(v.x, 1);
       assert.equal(v.y, 2);
       assert.equal(v.z, 3);
+    });
+
+    test("should have dimensions initialized to 3", function () {
+      assert.equal(v.dimensions, 3);
     });
   });
 


### PR DESCRIPTION
Resolves #7342

Changes:
This PR adds a `screenToWorld` function, which is the inverse of the `worldToScreen` function added by @Garima3110 in #7113. (In fact, this PR closely mirrors the changes made in Garima's PR.)

In 2D, this function should allow users to make transformed shapes interactive, and e.g. detect mouse clicks inside rotated rectangles without extra trigonometry.
Sadly, the function is not too useful for 3D as-is, since in 3D one would need actual ray-casting (or at least plane-ray intersection) to calculate the correct depth of the point.

 Screenshots of the change:
<!-- If applicable, add screenshots depicting the changes. -->

#### PR Checklist

- [x] `npm run lint` passes
- [x] [Inline reference] is included / updated
- [x] [Unit tests] are included / updated

[Inline reference]: https://p5js.org/contribute/contributing_to_the_p5js_reference/
[Unit tests]: https://github.com/processing/p5.js/tree/main/contributor_docs#unit-tests
