### PR TITLE
[p5.js 2.0] Attach p5.Element methods to WebGL canvas

### DIFF
--- a/src/webgl/p5.RendererGL.js
+++ b/src/webgl/p5.RendererGL.js
@@ -138,6 +138,20 @@ class RendererGL extends Renderer {
     this.elt.id = "defaultCanvas0";
     this.elt.classList.add("p5Canvas");
 
+    // Set and return p5.Element
+    this.wrappedElt = new Element(this.elt, this._pInst);
+
+    // Extend renderer with methods of p5.Element with getters
+    for (const p of Object.getOwnPropertyNames(Element.prototype)) {
+      if (p !== 'constructor' && p[0] !== '_') {
+        Object.defineProperty(this, p, {
+          get() {
+            return this.wrappedElt[p];
+          }
+        })
+      }
+    }
+
     const dimensions = this._adjustDimensions(w, h);
     w = dimensions.adjustedWidth;
     h = dimensions.adjustedHeight;


### PR DESCRIPTION
<!--
  Thank you for contributing! Please use this pull request (PR) template.


 In the description field of this PR, include "resolves #XXXX" tagging the issue you are fixing. If this PR addresses the issue but doesn't completely resolve it (ie the issue should remain open after your PR is merged), write "addresses #XXXX".-->
Resolves #7566

Changes:
Restore methods and properties of p5.Element onto value returned from `createCanvas` when mode is set to `WEBGL`.
