### PR TITLE
[p5.js 2.0] Expose global drawingContext

### DIFF
--- a/src/core/main.js
+++ b/src/core/main.js
@@ -190,6 +190,10 @@ class p5 {
     return this._renderer.pixels;
   }
 
+  get drawingContext(){
+    return this._renderer.drawingContext;
+  }
+
   static registerAddon(addon) {
     const lifecycles = {};
     addon(p5, p5.prototype, lifecycles);

--- a/src/core/p5.Renderer2D.js
+++ b/src/core/p5.Renderer2D.js
@@ -68,9 +68,6 @@ class Renderer2D extends Renderer {
     if(attributes.colorSpace === 'display-p3'){
       this.states.colorMode = RGBHDR;
     }
-    if (isMainCanvas) {
-      this._pInst.drawingContext = this.drawingContext;
-    }
     this.scale(this._pixelDensity, this._pixelDensity);
 
     if(!this.filterRenderer){

--- a/src/webgl/p5.RendererGL.js
+++ b/src/webgl/p5.RendererGL.js
@@ -123,9 +123,6 @@ class RendererGL extends Renderer {
     // This redundant property is useful in reminding you that you are
     // interacting with WebGLRenderingContext, still worth considering future removal
     this.GL = this.drawingContext;
-    if (isMainCanvas) {
-      this._pInst.drawingContext = this.drawingContext;
-    }
 
     if (this._isMainCanvas) {
       // for pixel method sharing with pimage


### PR DESCRIPTION
<!--
  Thank you for contributing! Please use this pull request (PR) template.


 In the description field of this PR, include "resolves #XXXX" tagging the issue you are fixing. If this PR addresses the issue but doesn't completely resolve it (ie the issue should remain open after your PR is merged), write "addresses #XXXX".-->
Resolves #7564

Changes:
`drawingContext` is now also exposed to global mode per the documentation. There probably don't need to be a setter as it can potentially breaking things unexpectedly.