### PR TITLE
Fix: Prevent unnecessary WebGL canvas recreation in noSmooth() in dev-2.0

### DIFF
--- a/src/shape/attributes.js
+++ b/src/shape/attributes.js
@@ -173,7 +173,10 @@ function attributes(p5, fn){
         this.drawingContext.imageSmoothingEnabled = false;
       }
     } else {
-      this.setAttributes('antialias', false);
+      // Only change if necessary to prevent canvas recreation
+      if (this._renderer.attributes.antialias !== false) {
+        this.setAttributes('antialias', false);
+      }
     }
     return this;
   };


### PR DESCRIPTION
**Resolve #7548 
Issue**
Calling noSmooth() inside draw() in WebGL mode recreates the canvas because setAttributes('antialias', false) is called every time. This causes unexpected behavior, including loss of canvas positioning and state.

**Fix:**
Before setting antialias to false, we check if it's already false.
If it's already disabled, we skip calling setAttributes(), preventing unnecessary canvas recreation.

**Why This Fix?**
Optimizes performance: Avoids reinitializing the WebGL canvas every frame.
Prevents unintended side effects: Keeps canvas position and other properties intact.
Aligns with expected behavior: In 2D mode, noSmooth() doesn’t recreate the canvas, so WebGL should behave similarly.

**Before**
Output with noSmooth()
Not display any output..

**Output without noSmooth()**
![After](https://github.com/user-attachments/assets/8dac0a5c-6053-4e6f-b2de-e534284fa6d7)

**After**
After fix issue.
Output with noSmooth() as well as without noSmooth().
![After](https://github.com/user-attachments/assets/25307110-6cb5-4370-bcc8-2db31ad92cdf)


**Alternative Solution Considered**
Updating the documentation to explicitly state that calling noSmooth() after initialization will recreate the canvas. This can still be done in addition to this fix.

Testing
✅ Verified in both 2D and WebGL renderers.
✅ noSmooth() works correctly in setup() and draw().
✅ No canvas recreation occurs unless truly necessary.