### PR TITLE
Fix endShape() to Properly Close Paths and Prevent Shape Merging

### DIFF
--- a/src/core/p5.Renderer2D.js
+++ b/src/core/p5.Renderer2D.js
@@ -855,6 +855,7 @@ class Renderer2D extends p5.Renderer {
           this.drawingContext.lineTo(vertices[i + 1][0], vertices[i + 1][1]);
         }
         this._doFillStrokeClose(closeShape);
+        this.drawingContext.closePath();
       }
     } else if (
       isBezier &&


### PR DESCRIPTION
This PR resolves an issue where endShape() could unintentionally merge with subsequent shapes (e.g., ellipse()), causing unintended dragging effects.
<!--
  Thank you for contributing! Please use this pull request (PR) template.


 In the description field of this PR, include "resolves #XXXX" tagging the issue you are fixing. If this PR addresses the issue but doesn't completely resolve it (ie the issue should remain open after your PR is merged), write "addresses #XXXX".-->
Resolves #7532

 Changes:
<!-- Add here what changes were made in this pull request and if possible provide links showcasing the changes. -->
Ensures `this.drawingContext.closePath();` happens on `endClip()` before any new shape starts.

 Screenshots of the change:
<!-- If applicable, add screenshots depicting the changes. -->
*before*

![before](https://github.com/user-attachments/assets/b2410c1a-036c-4edb-8527-a46dc279501e)

*after*

![after](https://github.com/user-attachments/assets/06b129cb-9532-477f-b73b-a7c862c9b2ad)


#### PR Checklist
<!--
  To check any option, replace the "[ ]" with a "[x]". Be sure to check out how it looks in the Preview tab! Feel free to remove any portion of the template that is not relevant for your issue.
-->

- [x] `npm run lint` passes
- [ ] [Inline reference] is included / updated
- [ ] [Unit tests] are included / updated

[Inline reference]: https://p5js.org/contribute/contributing_to_the_p5js_reference/
[Unit tests]: https://github.com/processing/p5.js/tree/main/contributor_docs#unit-tests
