### PR TITLE
added instance of video in callback

### DIFF
--- a/src/dom/dom.js
+++ b/src/dom/dom.js
@@ -2082,15 +2082,6 @@ function createMedia(pInst, type, src, callback) {
     elt.appendChild(sourceEl);
   }
 
-  // If callback is provided, attach to element
-  if (typeof callback === 'function') {
-    const callbackHandler = () => {
-      callback();
-      elt.removeEventListener('canplaythrough', callbackHandler);
-    };
-    elt.addEventListener('canplaythrough', callbackHandler);
-  }
-
   const mediaEl = addElement(elt, pInst, true);
   mediaEl.loadedmetadata = false;
 
@@ -2108,6 +2099,15 @@ function createMedia(pInst, type, src, callback) {
     }
     mediaEl.loadedmetadata = true;
   });
+
+  // If callback is provided, attach to element
+  if (typeof callback === 'function') {
+    const callbackHandler = () => {
+      callback(mediaEl);
+      elt.removeEventListener('canplaythrough', callbackHandler);
+    };
+    elt.addEventListener('canplaythrough', callbackHandler);
+  }
 
   return mediaEl;
 }


### PR DESCRIPTION
<!--
  Thank you for contributing! Please use this pull request (PR) template.


 In the description field of this PR, include "resolves #XXXX" tagging the issue you are fixing. If this PR addresses the issue but doesn't completely resolve it (ie the issue should remain open after your PR is merged), write "addresses #XXXX".-->
Resolves #7468 

 Changes:
<!-- Add here what changes were made in this pull request and if possible provide links showcasing the changes. -->
The callback to create video now returns the video instance that can be used to control `loop`, `hide`, `volume`

 Screenshots of the change:
<!-- If applicable, add screenshots depicting the changes. -->

#### PR Checklist
<!--
  To check any option, replace the "[ ]" with a "[x]". Be sure to check out how it looks in the Preview tab! Feel free to remove any portion of the template that is not relevant for your issue.
-->

- [x] `npm run lint` passes
- [ ] [Inline reference] is included / updated
- [ ] [Unit tests] are included / updated

[Inline reference]: https://p5js.org/contribute/contributing_to_the_p5js_reference/
[Unit tests]: https://github.com/processing/p5.js/tree/main/contributor_docs#unit-tests
