### PR TITLE
fix: push() ignoring the ColorMode #7402

### DIFF
--- a/src/core/p5.Renderer.js
+++ b/src/core/p5.Renderer.js
@@ -86,7 +86,9 @@ class Renderer extends p5.Element {
         _textAlign: this._textAlign,
         _textBaseline: this._textBaseline,
         _textStyle: this._textStyle,
-        _textWrap: this._textWrap
+        _textWrap: this._textWrap,
+        _colorMode: this._colorMode,
+        _colorMaxes: this._colorMaxes.slice()
       }
     };
   }


### PR DESCRIPTION
Resolves #7402 

 Changes:
Updated the push() function to save the current color mode (_colorMode) and its maximum values (_colorMaxes), and ensure pop() restores them.


 Screenshots of the change:
None

#### PR Checklist
<!--
  To check any option, replace the "[ ]" with a "[x]". Be sure to check out how it looks in the Preview tab! Feel free to remove any portion of the template that is not relevant for your issue.
-->

- [x] `npm run lint` passes
- [ ] [Inline reference] is included / updated
- [x] [Unit tests] are included / updated

[Inline reference]: https://p5js.org/contribute/contributing_to_the_p5js_reference/
[Unit tests]: https://github.com/processing/p5.js/tree/main/contributor_docs#unit-tests
