### PR TITLE
Add back WebGL matrices via getters

### DIFF
--- a/src/webgl/p5.RendererGL.js
+++ b/src/webgl/p5.RendererGL.js
@@ -550,41 +550,6 @@ class RendererGL extends Renderer {
     super.endShape(mode, count);
   }
 
-  legacyEndShape(
-    mode,
-    isCurve,
-    isBezier,
-    isQuadratic,
-    isContour,
-    shapeKind,
-    count = 1
-  ) {
-    this.shapeBuilder.endShape(
-      mode,
-      isCurve,
-      isBezier,
-      isQuadratic,
-      isContour,
-      shapeKind
-    );
-
-    if (this.geometryBuilder) {
-      this.geometryBuilder.addImmediate(
-        this.shapeBuilder.geometry,
-        this.shapeBuilder.shapeMode
-      );
-    } else if (this.states.fillColor || this.states.strokeColor) {
-      this._drawGeometry(this.shapeBuilder.geometry, {
-        mode: this.shapeBuilder.shapeMode,
-        count,
-      });
-    }
-  }
-
-  legacyVertex(...args) {
-    this.shapeBuilder.vertex(...args);
-  }
-
   vertexProperty(...args) {
     this.currentShape.vertexProperty(...args);
   }
@@ -1051,6 +1016,27 @@ class RendererGL extends Renderer {
     this.clear(..._col._getRGBA());
   }
 
+  //////////////////////////////////////////////
+  // Positioning
+  //////////////////////////////////////////////
+
+  get uModelMatrix() {
+    return this.states.uModelMatrix;
+  }
+
+  get uViewMatrix() {
+    return this.states.uViewMatrix;
+  }
+
+  get uPMatrix() {
+    return this.states.uPMatrix;
+  }
+
+  get uMVMatrix() {
+    const m = this.uModelMatrix.copy();
+    m.mult(this.uViewMatrix);
+    return m;
+  }
 
   /**
    * Get a matrix from world-space to screen-space

--- a/test/unit/webgl/p5.RendererGL.js
+++ b/test/unit/webgl/p5.RendererGL.js
@@ -2702,5 +2702,85 @@ suite('p5.RendererGL', function() {
         expect(logs.join('\n')).to.match(/One of the geometries has a custom vertex property 'aCustom' with fewer values than vertices./);
       }
     );
-  })
+  });
+
+  suite('Matrix getters', function() {
+    test('uModelMatrix', function() {
+      p5.registerAddon(function (p5, fn) {
+        fn.checkModelMatrix = function() {
+          assert.deepEqual(
+            [...this._renderer.uModelMatrix.mat4],
+            [
+              1, 0, 0, 0,
+              0, 1, 0, 0,
+              0, 0, 1, 0,
+              5, 0, 0, 1
+            ]
+          );
+        }
+      });
+      myp5.createCanvas(50, 50, myp5.WEBGL);
+      myp5.translate(5, 0);
+      myp5.camera(0, 0, 500, 0, 0, 0);
+      myp5.checkModelMatrix();
+    });
+
+    test('uViewMatrix', function() {
+      p5.registerAddon(function (p5, fn) {
+        fn.checkViewMatrix = function() {
+          assert.deepEqual(
+            [...this._renderer.uViewMatrix.mat4],
+            [
+              1, 0, 0, 0,
+              0, 1, 0, 0,
+              0, 0, 1, 0,
+              0, 0, -500, 1
+            ]
+          );
+        }
+      });
+      myp5.createCanvas(50, 50, myp5.WEBGL);
+      myp5.translate(5, 0);
+      myp5.camera(0, 0, 500, 0, 0, 0);
+      myp5.checkViewMatrix();
+    });
+
+    test('uMVMatrix', function() {
+      p5.registerAddon(function (p5, fn) {
+        fn.checkMVMatrix = function() {
+          assert.deepEqual(
+            [...this._renderer.uMVMatrix.mat4],
+            [
+              1, 0, 0, 0,
+              0, 1, 0, 0,
+              0, 0, 1, 0,
+              5, 0, -500, 1
+            ]
+          );
+        }
+      });
+      myp5.createCanvas(50, 50, myp5.WEBGL);
+      myp5.translate(5, 0);
+      myp5.camera(0, 0, 500, 0, 0, 0);
+      myp5.checkMVMatrix();
+    });
+
+    test('uPMatrix', function() {
+      p5.registerAddon(function (p5, fn) {
+        fn.checkPMatrix = function() {
+          assert.deepEqual(
+            [...this._renderer.uPMatrix.mat4],
+            [
+              32, 0, 0, 0,
+              0, -32, 0, 0,
+              0, 0, -1.0202020406723022, -1,
+              0, 0, -161.6161651611328, 0
+            ]
+          );
+        }
+      });
+      myp5.createCanvas(50, 50, myp5.WEBGL);
+      myp5.checkPMatrix();
+    });
+  });
 });


### PR DESCRIPTION
Resolves https://github.com/processing/p5.js/issues/7342

### Changes
While we already have `worldToScreen` and `screenToWorld`, WebGL addons occasionally need to access the matrices that position things onscreen. This adds them back to the renderer via getters.


#### PR Checklist
<!--
  To check any option, replace the "[ ]" with a "[x]". Be sure to check out how it looks in the Preview tab! Feel free to remove any portion of the template that is not relevant for your issue.
-->

- [x] `npm run lint` passes
- [ ] [Inline reference] is included / updated
- [x] [Unit tests] are included / updated

[Inline reference]: https://p5js.org/contribute/contributing_to_the_p5js_reference/
[Unit tests]: https://github.com/processing/p5.js/tree/main/contributor_docs#unit-tests
