### PR TITLE
 Fix: Update sin(), cos(), and tan() docs to respect angleMode() & cl…

### DIFF
--- a/src/core/shape/2d_primitives.js
+++ b/src/core/shape/2d_primitives.js
@@ -110,7 +110,10 @@ p5.prototype._normalizeArcAngles = (
  *
  * The fifth and sixth parameters, `start` and `stop`, set the angles
  * between which to draw the arc. Arcs are always drawn clockwise from
- * `start` to `stop`. Angles are always given in radians.
+ * `start` to `stop`. The fifth and sixth parameters, start and stop, set the
+ * angles between which to draw the arc. Arcs are always drawn clockwise from
+ * start to stop. By default, angles are given in radians, but if angleMode
+ * (DEGREES) is set, the function interprets the values in degrees.
  *
  * The seventh parameter, `mode`, is optional. It determines the arc's fill
  * style. The fill modes are a semi-circle (`OPEN`), a closed semi-circle

--- a/src/math/trigonometry.js
+++ b/src/math/trigonometry.js
@@ -283,10 +283,12 @@ p5.prototype.atan2 = function(y, x) {
  *
  * `cos()` is useful for many geometric tasks in creative coding. The values
  * returned oscillate between -1 and 1 as the input angle increases. `cos()`
- * takes into account the current <a href="#/p5/angleMode">angleMode()</a>.
+ * calculates the cosine of an angle, using radians by default, or according to
+ * if <a href="#/p5/angleMode">angleMode()</a> setting (RADIANS or DEGREES).
  *
  * @method cos
- * @param  {Number} angle the angle in radians unless specified by <a href="/reference/p5/angleMode/">angleMode()</a>.
+ * @param  {Number} angle the angle, in radians by default, or according to
+ * if <a href="/reference/p5/angleMode/">angleMode()</a> setting (RADIANS or DEGREES).
  * @return {Number}       cosine of the angle.
  *
  * @example
@@ -363,10 +365,12 @@ p5.prototype.cos = function(angle) {
  *
  * `sin()` is useful for many geometric tasks in creative coding. The values
  * returned oscillate between -1 and 1 as the input angle increases. `sin()`
- * takes into account the current <a href="#/p5/angleMode">angleMode()</a>.
+ * calculates the sine of an angle, using radians by default, or according to
+ * if <a href="#/p5/angleMode">angleMode()</a> setting (RADIANS or DEGREES).
  *
  * @method sin
- * @param  {Number} angle the angle in radians unless specified by <a href="/reference/p5/angleMode/">angleMode()</a>.
+ * @param  {Number} angle the angle, in radians by default, or according to
+ * if <a href="/reference/p5/angleMode/">angleMode()</a> setting (RADIANS or DEGREES).
  * @return {Number}       sine of the angle.
  *
  * @example
@@ -443,11 +447,13 @@ p5.prototype.sin = function(angle) {
  *
  * `tan()` is useful for many geometric tasks in creative coding. The values
  * returned range from -Infinity to Infinity and repeat periodically as the
- * input angle increases. `tan()` takes into account the current
- * <a href="#/p5/angleMode">angleMode()</a>.
+ * input angle increases. `tan()` calculates the tan of an angle, using radians
+ * by default, or according to
+ * if <a href="#/p5/angleMode">angleMode()</a> setting (RADIANS or DEGREES).
  *
  * @method tan
- * @param  {Number} angle the angle in radians unless specified by <a href="/reference/p5/angleMode/">angleMode()</a>.
+ * @param  {Number} angle the angle, in radians by default, or according to
+ * if <a href="/reference/p5/angleMode/">angleMode()</a> setting (RADIANS or DEGREES).
  * @return {Number}       tangent of the angle.
  *
  * @example


### PR DESCRIPTION
<!--
  Thank you for contributing! Please use this pull request (PR) template.


 In the description field of this PR, include "resolves #7562" tagging the issue you are fixing. If this PR addresses the issue but doesn't completely resolve it (ie the issue should remain open after your PR is merged), write "addresses #XXXX".-->
Resolves #7562
This PR updates the documentation for trigonometric functions (sin(), cos(), tan()) and the arc() function to correctly reflect their behavior with angleMode().
 Changes:
<!-- Add here what changes were made in this pull request and if possible provide links showcasing the changes. -->
Changes Made:
✅ Updated sin(), cos(), and tan() docs to specify that they respect angleMode(DEGREES).
✅ Clarified that arc() uses both radians and degrees depending on angleMode().
✅ Ensured consistency in documentation for trigonometric functions.

 Screenshots of the change:
<!-- If applicable, add screenshots depicting the changes. -->

#### PR Checklist
<!--
  To check any option, replace the "[ ]" with a "[x]". Be sure to check out how it looks in the Preview tab! Feel free to remove any portion of the template that is not relevant for your issue.
-->

- [x] `npm run lint` passes
- [x] [Inline reference] is included / updated
- [x] [Unit tests] are included / updated

[Inline reference]: https://p5js.org/contribute/contributing_to_the_p5js_reference/
[Unit tests]: https://github.com/processing/p5.js/tree/main/contributor_docs#unit-tests
