### PR TITLE
 Fix camera tilt function to prevent orientation flipping

### DIFF
--- a/src/webgl/p5.Camera.js
+++ b/src/webgl/p5.Camera.js
@@ -2459,7 +2459,6 @@ p5.Camera = class Camera {
     let right = p5.Vector.cross(forward, up).normalize(); // Right vector
     up = p5.Vector.cross(right, forward).normalize(); // Corrected up vector
     
-    
     this.camera(
       this.eyeX,
       this.eyeY,

--- a/src/webgl/p5.Camera.js
+++ b/src/webgl/p5.Camera.js
@@ -2458,7 +2458,7 @@ p5.Camera = class Camera {
     let up = createVector(this.upX, this.upY, this.upZ);
     let right = p5.Vector.cross(forward, up).normalize(); // Right vector
     up = p5.Vector.cross(right, forward).normalize(); // Corrected up vector
-    
+
     this.camera(
       this.eyeX,
       this.eyeY,

--- a/src/webgl/p5.Camera.js
+++ b/src/webgl/p5.Camera.js
@@ -2435,6 +2435,7 @@ p5.Camera = class Camera {
     const rotation = p5.Matrix.identity(this._renderer._pInst);
     rotation.rotate(this._renderer._pInst._toRadians(a), x, y, z);
 
+    // Apply the rotation matrix to the center vector
     /* eslint-disable max-len */
     const rotatedCenter = [
       centerX * rotation.mat4[0] + centerY * rotation.mat4[4] + centerZ * rotation.mat4[8],
@@ -2443,21 +2444,17 @@ p5.Camera = class Camera {
     ];
     /* eslint-enable max-len */
 
-    // add eye position back into center
+    // Translate the rotated center back to world coordinates
     rotatedCenter[0] += this.eyeX;
     rotatedCenter[1] += this.eyeY;
     rotatedCenter[2] += this.eyeZ;
 
-    // Compute new up vector to prevent flipping
-    let forward = createVector(
-      rotatedCenter[0] - this.eyeX,
-      rotatedCenter[1] - this.eyeY,
-      rotatedCenter[2] - this.eyeZ
-    ).normalize();
-
-    let up = createVector(this.upX, this.upY, this.upZ);
-    let right = p5.Vector.cross(forward, up).normalize(); // Right vector
-    up = p5.Vector.cross(right, forward).normalize(); // Corrected up vector
+    // Rotate the up vector to keep the correct camera orientation
+    /* eslint-disable max-len */
+    const upX = this.upX * rotation.mat4[0] + this.upY * rotation.mat4[4] + this.upZ * rotation.mat4[8];
+    const upY = this.upX * rotation.mat4[1] + this.upY * rotation.mat4[5] + this.upZ * rotation.mat4[9];
+    const upZ = this.upX * rotation.mat4[2] + this.upY * rotation.mat4[6] + this.upZ * rotation.mat4[10];
+    /* eslint-enable max-len */
 
     this.camera(
       this.eyeX,
@@ -2466,15 +2463,10 @@ p5.Camera = class Camera {
       rotatedCenter[0],
       rotatedCenter[1],
       rotatedCenter[2],
-      this.up.x,
-      this.up.y,
-      this.up.z
+      upX,
+      upY,
+      upZ
     );
-
-    // Update up vector
-    this.upX = up.x;
-    this.upY = up.y;
-    this.upZ = up.z;
   }
 
   /**

--- a/src/webgl/p5.Camera.js
+++ b/src/webgl/p5.Camera.js
@@ -2450,9 +2450,9 @@ p5.Camera = class Camera {
 
     // Compute new up vector to prevent flipping
     let forward = createVector(
-        rotatedCenter[0] - this.eyeX,
-        rotatedCenter[1] - this.eyeY,
-        rotatedCenter[2] - this.eyeZ
+      rotatedCenter[0] - this.eyeX,
+      rotatedCenter[1] - this.eyeY,
+      rotatedCenter[2] - this.eyeZ
     ).normalize();
 
     let up = createVector(this.upX, this.upY, this.upZ);

--- a/src/webgl/p5.Camera.js
+++ b/src/webgl/p5.Camera.js
@@ -2448,6 +2448,18 @@ p5.Camera = class Camera {
     rotatedCenter[1] += this.eyeY;
     rotatedCenter[2] += this.eyeZ;
 
+    // Compute new up vector to prevent flipping
+    let forward = createVector(
+        rotatedCenter[0] - this.eyeX,
+        rotatedCenter[1] - this.eyeY,
+        rotatedCenter[2] - this.eyeZ
+    ).normalize();
+
+    let up = createVector(this.upX, this.upY, this.upZ);
+    let right = p5.Vector.cross(forward, up).normalize(); // Right vector
+    up = p5.Vector.cross(right, forward).normalize(); // Corrected up vector
+    
+    
     this.camera(
       this.eyeX,
       this.eyeY,
@@ -2455,10 +2467,15 @@ p5.Camera = class Camera {
       rotatedCenter[0],
       rotatedCenter[1],
       rotatedCenter[2],
-      this.upX,
-      this.upY,
-      this.upZ
+      this.up.x,
+      this.up.y,
+      this.up.z
     );
+
+    // Update up vector
+    this.upX = up.x;
+    this.upY = up.y;
+    this.upZ = up.z;
   }
 
   /**

--- a/test/unit/webgl/p5.Camera.js
+++ b/test/unit/webgl/p5.Camera.js
@@ -277,6 +277,61 @@ suite('p5.Camera', function() {
       assert.strictEqual(myCam.upY, orig.uy, 'up Y pos changed');
       assert.strictEqual(myCam.upZ, orig.uz, 'up Z pos changed');
     });
+
+    suite('Camera Tilt and Up Vector', function() {
+      test('Tilt() correctly updates the up vector', function() {
+        var orig = getVals(myCam); // Store original camera values
+
+        // Apply tilt to the camera
+        myCam.tilt(30); // Tilt by 30 degrees
+
+        // Compute expected up vector (normalized)
+        let forward = myp5.createVector(
+          myCam.centerX - myCam.eyeX,
+          myCam.centerY - myCam.eyeY,
+          myCam.centerZ - myCam.eyeZ
+        );
+        let up = myp5.createVector(orig.ux, orig.uy, orig.uz);
+        let right = p5.Vector.cross(forward, up);
+        let expectedUp = p5.Vector.cross(right, forward).normalize();
+
+        // Verify that the up vector has changed
+        assert.notStrictEqual(myCam.upX, orig.ux, 'upX should be updated');
+        assert.notStrictEqual(myCam.upY, orig.uy, 'upY should be updated');
+        assert.notStrictEqual(myCam.upZ, orig.uz, 'upZ should be updated');
+
+        // Verify up vector matches expected values within a small margin of error
+        assert.closeTo(myCam.upX, expectedUp.x, 0.001, 'upX mismatch');
+        assert.closeTo(myCam.upY, expectedUp.y, 0.001, 'upY mismatch');
+        assert.closeTo(myCam.upZ, expectedUp.z, 0.001, 'upZ mismatch');
+      });
+
+      test('Tilt() with negative angle correctly updates the up vector', function() {
+        var orig = getVals(myCam); // Store original camera values
+
+        myCam.tilt(-30); // Tilt by -30 degrees
+
+        // Compute expected up vector (normalized)
+        let forward = myp5.createVector(
+          myCam.centerX - myCam.eyeX,
+          myCam.centerY - myCam.eyeY,
+          myCam.centerZ - myCam.eyeZ
+        );
+        let up = myp5.createVector(orig.ux, orig.uy, orig.uz);
+        let right = p5.Vector.cross(forward, up);
+        let expectedUp = p5.Vector.cross(right, forward).normalize();
+
+        // Verify that the up vector has changed
+        assert.notStrictEqual(myCam.upX, orig.ux, 'upX should be updated');
+        assert.notStrictEqual(myCam.upY, orig.uy, 'upY should be updated');
+        assert.notStrictEqual(myCam.upZ, orig.uz, 'upZ should be updated');
+
+        // Verify up vector matches expected values within a small margin of error
+        assert.closeTo(myCam.upX, expectedUp.x, 0.001, 'upX mismatch');
+        assert.closeTo(myCam.upY, expectedUp.y, 0.001, 'upY mismatch');
+        assert.closeTo(myCam.upZ, expectedUp.z, 0.001, 'upZ mismatch');
+      });
+    }); 
   });
 
   suite('Rotation with angleMode(DEGREES)', function() {

--- a/test/unit/webgl/p5.Camera.js
+++ b/test/unit/webgl/p5.Camera.js
@@ -331,7 +331,7 @@ suite('p5.Camera', function() {
         assert.closeTo(myCam.upY, expectedUp.y, 0.001, 'upY mismatch');
         assert.closeTo(myCam.upZ, expectedUp.z, 0.001, 'upZ mismatch');
       });
-    }); 
+    });
   });
 
   suite('Rotation with angleMode(DEGREES)', function() {


### PR DESCRIPTION
<!--
  Thank you for contributing! Please use this pull request (PR) template.


 In the description field of this PR, include "resolves #XXXX" tagging the issue you are fixing. If this PR addresses the issue but doesn't completely resolve it (ie the issue should remain open after your PR is merged), write "addresses #XXXX".-->
Resolves #7377

 Changes:
- Fixed an issue where `p5.Camera.tilt()` did not update the up vector.
- Prevents rapid orientation flipping when tilting too far.
- Ensures the up vector remains perpendicular by recalculating it dynamically.

<!-- Add here what changes were made in this pull request and if possible provide links showcasing the changes. -->


 Screenshots of the change:
<!-- If applicable, add screenshots depicting the changes. -->
**before** 

https://github.com/user-attachments/assets/f15a1d2d-5344-4696-a22a-557f50e626b5

**after**

https://github.com/user-attachments/assets/ce3b0c06-0254-47e4-9ec4-5160e117c8f5

**snippet**
```js

let cam;

function setup() {
  angleMode(DEGREES);
  createCanvas(400, 400, WEBGL);
  cam = createCamera();
  cam.setPosition(0,0,0);
}

function draw() {
  background(220);
  let d = 800;

  drawBox(0, d, 0);
}

function drawBox(x, y, z) {
  push();
  stroke("red");
  strokeWeight(10);
  translate(x, y, z);
  line(0, 0, 0, 0, 0, 200);
  stroke("black");
  strokeWeight(1); 
  rotateY(45);
  box(100);
  pop();
}

function mouseMoved(event) {  
  cam.tilt((mouseY-pmouseY)/2);
  
  // Hold down control key to set cam.up correctly:
  if (event.ctrlKey) {
    let forward = createVector(
      cam.centerX - cam.eyeX,
      cam.centerY - cam.eyeY,
      cam.centerZ - cam.eyeZ
    );
    let up = createVector(cam.upX, cam.upY, cam.upZ);
    let right = p5.Vector.cross(forward, up);
    up = p5.Vector.cross(right, forward).normalize();
    cam.camera(
      cam.eyeX, cam.eyeY, cam.eyeZ,
      cam.centerX, cam.centerY, cam.centerZ,
      up.x, up.y, up.z
    );
  }
  
  console.log(cam.upX, cam.upY, cam.upZ);
}
```

#### PR Checklist
<!--
  To check any option, replace the "[ ]" with a "[x]". Be sure to check out how it looks in the Preview tab! Feel free to remove any portion of the template that is not relevant for your issue.
-->

- [x] `npm run lint` passes
- [ ] [Inline reference] is included / updated
- [x] [Unit tests] are included / updated

[Inline reference]: https://p5js.org/contribute/contributing_to_the_p5js_reference/
[Unit tests]: https://github.com/processing/p5.js/tree/main/contributor_docs#unit-tests
