### PR TITLE
Fix endShape() to Properly Close Paths and Prevent Shape Merging

### DIFF
--- a/src/core/p5.Renderer2D.js
+++ b/src/core/p5.Renderer2D.js
@@ -272,6 +272,7 @@ class Renderer2D extends Renderer {
         this.drawingContext.stroke(visitor.path);
       }
     }
+  this.clipPath.closePath();
   }
 
   beginClip(options = {}) {

--- a/src/core/p5.Renderer2D.js
+++ b/src/core/p5.Renderer2D.js
@@ -264,6 +264,7 @@ class Renderer2D extends Renderer {
     shape.accept(visitor);
     if (this._clipping) {
       this.clipPath.addPath(visitor.path);
+      this.clipPath.closePath();      
     } else {
       if (this.states.fillColor) {
         this.drawingContext.fill(visitor.path);
@@ -272,7 +273,6 @@ class Renderer2D extends Renderer {
         this.drawingContext.stroke(visitor.path);
       }
     }
-  this.clipPath.closePath();
   }
 
   beginClip(options = {}) {


### PR DESCRIPTION
<!--
  Thank you for contributing! Please use this pull request (PR) template.


 In the description field of this PR, include "resolves #XXXX" tagging the issue you are fixing. If this PR addresses the issue but doesn't completely resolve it (ie the issue should remain open after your PR is merged), write "addresses #XXXX".-->
Resolves #7532

 Changes:
Ensures `this.clipPath.closePath` happens on `drawShape()` before any new shape starts.
<!-- Add here what changes were made in this pull request and if possible provide links showcasing the changes. -->


 Screenshots of the change:
<!-- If applicable, add screenshots depicting the changes. -->

before:

![Screenshot from 2025-03-04 20-44-57](https://github.com/user-attachments/assets/fa52abc1-5013-44e0-aace-7e25b5a468b2)

after:

![Screenshot from 2025-03-04 20-46-07](https://github.com/user-attachments/assets/98319b90-7523-40a2-8e23-ee157be81ec8)

snippet:

```js
var myImg;


async function setup() {
  createCanvas(400, 400);
  noSmooth();
  myImg = await loadImage("Stone_Retaining_wall.jpg");

}

function draw() {
  background(220);
  
  beginClip();
  beginShape();
  vertex(100,100);
  vertex(200,100);
  vertex(200,200);
  vertex(100,200);
  endShape();
  beginShape();
  vertex(200,150);
  vertex(300,150);
  vertex(300,250);
  vertex(200,250);
  endShape();
  
  circle(200,250,50);
  
  endClip();
  
  image(myImg,0,0);
}
```

#### PR Checklist
<!--
  To check any option, replace the "[ ]" with a "[x]". Be sure to check out how it looks in the Preview tab! Feel free to remove any portion of the template that is not relevant for your issue.
-->

- [x] `npm run lint` passes
- [ ] [Inline reference] is included / updated
- [ ] [Unit tests] are included / updated

[Inline reference]: https://p5js.org/contribute/contributing_to_the_p5js_reference/
[Unit tests]: https://github.com/processing/p5.js/tree/main/contributor_docs#unit-tests
