### PR TITLE
Replace p5.Element mouse/touch events with pointer events

### DIFF
--- a/src/dom/p5.Element.js
+++ b/src/dom/p5.Element.js
@@ -1571,12 +1571,14 @@ class Element {
     // For details, see https://github.com/processing/p5.js/issues/3087.
     const eventPrependedFxn = function (event) {
       this._pInst.mouseIsPressed = true;
+      this._pInst._activePointers.set(e.pointerId, e);
       this._pInst._setMouseButton(event);
+      this._pInst._updatePointerCoords(e);
       // Pass along the return-value of the callback:
       return fxn.call(this, event);
     };
     // Pass along the event-prepended form of the callback.
-    Element._adjustListener('mousedown', eventPrependedFxn, this);
+    Element._adjustListener('pointerdown', eventPrependedFxn, this);
     return this;
   }
 
@@ -1746,7 +1748,7 @@ class Element {
    * </div>
    */
   mouseReleased(fxn) {
-    Element._adjustListener('mouseup', fxn, this);
+    Element._adjustListener('pointerup', fxn, this);
     return this;
   }
 
@@ -1831,7 +1833,7 @@ class Element {
    * </div>
    */
   mouseMoved(fxn) {
-    Element._adjustListener('mousemove', fxn, this);
+    Element._adjustListener('pointermove', fxn, this);
     return this;
   }
 
@@ -1872,7 +1874,7 @@ class Element {
    * </div>
    */
   mouseOver(fxn) {
-    Element._adjustListener('mouseover', fxn, this);
+    Element._adjustListener('pointerover', fxn, this);
     return this;
   }
 
@@ -1913,140 +1915,11 @@ class Element {
    * </div>
    */
   mouseOut(fxn) {
-    Element._adjustListener('mouseout', fxn, this);
+    Element._adjustListener('pointerout', fxn, this);
     return this;
   }
 
-  /**
-   * Calls a function when the element is touched.
-   *
-   * Calling `myElement.touchStarted(false)` disables the function.
-   *
-   * Note: Touch functions only work on mobile devices.
-   *
-   * @param  {Function|Boolean} fxn function to call when the touch
-   *                                starts.
-   *                                `false` disables the function.
-   * @chainable
-   *
-   * @example
-   * <div>
-   * <code>
-   * function setup() {
-   *   // Create a canvas element and
-   *   // assign it to cnv.
-   *   let cnv = createCanvas(100, 100);
-   *
-   *   background(200);
-   *
-   *   // Call randomColor() when the
-   *   // user touches the canvas.
-   *   cnv.touchStarted(randomColor);
-   *
-   *   describe('A gray square changes color when the user touches the canvas.');
-   * }
-   *
-   * // Paint the background either
-   * // red, yellow, blue, or green.
-   * function randomColor() {
-   *   let c = random(['red', 'yellow', 'blue', 'green']);
-   *   background(c);
-   * }
-   * </code>
-   * </div>
-   */
-  touchStarted(fxn) {
-    Element._adjustListener('touchstart', fxn, this);
-    return this;
-  }
-
-  /**
-   * Calls a function when the user touches the element and moves.
-   *
-   * Calling `myElement.touchMoved(false)` disables the function.
-   *
-   * Note: Touch functions only work on mobile devices.
-   *
-   * @param  {Function|Boolean} fxn function to call when the touch
-   *                                moves over the element.
-   *                                `false` disables the function.
-   * @chainable
-   * @example
-   * <div>
-   * <code>
-   * function setup() {
-   *   // Create a canvas element and
-   *   // assign it to cnv.
-   *   let cnv = createCanvas(100, 100);
-   *
-   *   background(200);
-   *
-   *   // Call randomColor() when the
-   *   // user touches the canvas
-   *   // and moves.
-   *   cnv.touchMoved(randomColor);
-   *
-   *   describe('A gray square changes color when the user touches the canvas and moves.');
-   * }
-   *
-   * // Paint the background either
-   * // red, yellow, blue, or green.
-   * function randomColor() {
-   *   let c = random(['red', 'yellow', 'blue', 'green']);
-   *   background(c);
-   * }
-   * </code>
-   * </div>
-   */
-  touchMoved(fxn) {
-    Element._adjustListener('touchmove', fxn, this);
-    return this;
-  }
-
-  /**
-   * Calls a function when the user stops touching the element.
-   *
-   * Calling `myElement.touchMoved(false)` disables the function.
-   *
-   * Note: Touch functions only work on mobile devices.
-   *
-   * @param  {Function|Boolean} fxn function to call when the touch
-   *                                ends.
-   *                                `false` disables the function.
-   * @chainable
-   * @example
-   * <div>
-   * <code>
-   * function setup() {
-   *   // Create a canvas element and
-   *   // assign it to cnv.
-   *   let cnv = createCanvas(100, 100);
-   *
-   *   background(200);
-   *
-   *   // Call randomColor() when the
-   *   // user touches the canvas,
-   *   // then lifts their finger.
-   *   cnv.touchEnded(randomColor);
-   *
-   *   describe('A gray square changes color when the user touches the canvas, then lifts their finger.');
-   * }
-   *
-   * // Paint the background either
-   * // red, yellow, blue, or green.
-   * function randomColor() {
-   *   let c = random(['red', 'yellow', 'blue', 'green']);
-   *   background(c);
-   * }
-   * </code>
-   * </div>
-   */
-  touchEnded(fxn) {
-    Element._adjustListener('touchend', fxn, this);
-    return this;
-  }
-
-  /**
+    /**
    * Calls a function when a file is dragged over the element.
    *
    * Calling `myElement.dragOver(false)` disables the function.

--- a/test/unit/dom/p5.Element.js
+++ b/test/unit/dom/p5.Element.js
@@ -254,159 +254,6 @@ suite('p5.Element', function() {
     });
   });
 
-  suite('p5.Element.prototype.touchStarted', function() {
-    test('attaches and gets events', function() {
-      // setup
-      const elt = mockP5Prototype.createDiv('hello');
-      var myFnCounter = 0;
-      var myFn = function(event) {
-        myFnCounter++;
-      };
-
-      elt.touchStarted(myFn);
-      assert.isFunction(elt._events.touchstart);
-      elt.elt.dispatchEvent(new Event('touchstart'));
-      assert.equal(myFnCounter, 1);
-    });
-
-    test('attaches multiple handlers and only latest gets events', function() {
-      // setup
-      const elt = mockP5Prototype.createDiv('hello');
-      var myFnCounter = 0;
-      var myFn = function() {
-        myFnCounter++;
-      };
-      var myFnCounterOther = 0;
-      var myFnOther = function() {
-        myFnCounterOther++;
-      };
-
-      elt.touchStarted(myFn);
-      elt.touchStarted(myFnOther);
-      assert.isFunction(elt._events.touchstart);
-      elt.elt.dispatchEvent(new Event('touchstart'));
-      assert.equal(myFnCounter, 0);
-      assert.equal(myFnCounterOther, 1);
-    });
-
-    test('detaches and does not get events', function() {
-      // setup
-      const elt = mockP5Prototype.createDiv('hello');
-      var myFnCounter = 0;
-      var myFn = function() {
-        myFnCounter++;
-      };
-
-      elt.touchStarted(myFn);
-      elt.touchStarted(false);
-      assert.isNull(elt._events.touchstart);
-      elt.elt.dispatchEvent(new Event('touchstart'));
-      assert.equal(myFnCounter, 0);
-    });
-  });
-
-  suite('p5.Element.prototype.touchMoved', function() {
-    test('attaches and gets events', function() {
-      // setup
-      const elt = mockP5Prototype.createDiv('hello');
-      var myFnCounter = 0;
-      var myFn = function(event) {
-        myFnCounter++;
-      };
-
-      elt.touchMoved(myFn);
-      assert.isFunction(elt._events.touchmove);
-      elt.elt.dispatchEvent(new Event('touchmove'));
-      assert.equal(myFnCounter, 1);
-    });
-
-    test('attaches multiple handlers and only latest gets events', function() {
-      // setup
-      const elt = mockP5Prototype.createDiv('hello');
-      var myFnCounter = 0;
-      var myFn = function() {
-        myFnCounter++;
-      };
-      var myFnCounterOther = 0;
-      var myFnOther = function() {
-        myFnCounterOther++;
-      };
-
-      elt.touchMoved(myFn);
-      elt.touchMoved(myFnOther);
-      assert.isFunction(elt._events.touchmove);
-      elt.elt.dispatchEvent(new Event('touchmove'));
-      assert.equal(myFnCounter, 0);
-      assert.equal(myFnCounterOther, 1);
-    });
-
-    test('detaches and does not get events', function() {
-      // setup
-      const elt = mockP5Prototype.createDiv('hello');
-      var myFnCounter = 0;
-      var myFn = function() {
-        myFnCounter++;
-      };
-
-      elt.touchMoved(myFn);
-      elt.touchMoved(false);
-      assert.isNull(elt._events.touchmove);
-      elt.elt.dispatchEvent(new Event('touchmove'));
-      assert.equal(myFnCounter, 0);
-    });
-  });
-
-  suite('p5.Element.prototype.touchEnded', function() {
-    test('attaches and gets events', function() {
-      // setup
-      const elt = mockP5Prototype.createDiv('hello');
-      var myFnCounter = 0;
-      var myFn = function(event) {
-        myFnCounter++;
-      };
-
-      elt.touchEnded(myFn);
-      assert.isFunction(elt._events.touchend);
-      elt.elt.dispatchEvent(new Event('touchend'));
-      assert.equal(myFnCounter, 1);
-    });
-
-    test('attaches multiple handlers and only latest gets events', function() {
-      // setup
-      const elt = mockP5Prototype.createDiv('hello');
-      var myFnCounter = 0;
-      var myFn = function() {
-        myFnCounter++;
-      };
-      var myFnCounterOther = 0;
-      var myFnOther = function() {
-        myFnCounterOther++;
-      };
-
-      elt.touchEnded(myFn);
-      elt.touchEnded(myFnOther);
-      assert.isFunction(elt._events.touchend);
-      elt.elt.dispatchEvent(new Event('touchend'));
-      assert.equal(myFnCounter, 0);
-      assert.equal(myFnCounterOther, 1);
-    });
-
-    test('detaches and does not get events', function() {
-      // setup
-      const elt = mockP5Prototype.createDiv('hello');
-      var myFnCounter = 0;
-      var myFn = function() {
-        myFnCounter++;
-      };
-
-      elt.touchEnded(myFn);
-      elt.touchEnded(false);
-      assert.isNull(elt._events.touchend);
-      elt.elt.dispatchEvent(new Event('touchend'));
-      assert.equal(myFnCounter, 0);
-    });
-  });
-
   suite('p5.Element.prototype.mouseReleased', function() {
     test('attaches and gets events', function() {
       // setup
@@ -417,8 +264,8 @@ suite('p5.Element', function() {
       };
 
       elt.mouseReleased(myFn);
-      assert.isFunction(elt._events.mouseup);
-      elt.elt.dispatchEvent(new Event('mouseup'));
+      assert.isFunction(elt._events.pointerup);
+      elt.elt.dispatchEvent(new Event('pointerup'));
       assert.equal(myFnCounter, 1);
     });
 
@@ -436,8 +283,8 @@ suite('p5.Element', function() {
 
       elt.mouseReleased(myFn);
       elt.mouseReleased(myFnOther);
-      assert.isFunction(elt._events.mouseup);
-      elt.elt.dispatchEvent(new Event('mouseup'));
+      assert.isFunction(elt._events.pointerup);
+      elt.elt.dispatchEvent(new Event('pointerup'));
       assert.equal(myFnCounter, 0);
       assert.equal(myFnCounterOther, 1);
     });
@@ -452,8 +299,8 @@ suite('p5.Element', function() {
 
       elt.mouseReleased(myFn);
       elt.mouseReleased(false);
-      assert.isNull(elt._events.mouseup);
-      elt.elt.dispatchEvent(new Event('mouseup'));
+      assert.isNull(elt._events.pointerup);
+      elt.elt.dispatchEvent(new Event('pointerup'));
       assert.equal(myFnCounter, 0);
     });
   });
@@ -468,8 +315,8 @@ suite('p5.Element', function() {
       };
 
       elt.mouseMoved(myFn);
-      assert.isFunction(elt._events.mousemove);
-      elt.elt.dispatchEvent(new Event('mousemove'));
+      assert.isFunction(elt._events.pointermove);
+      elt.elt.dispatchEvent(new Event('pointermove'));
       assert.equal(myFnCounter, 1);
     });
 
@@ -487,8 +334,8 @@ suite('p5.Element', function() {
 
       elt.mouseMoved(myFn);
       elt.mouseMoved(myFnOther);
-      assert.isFunction(elt._events.mousemove);
-      elt.elt.dispatchEvent(new Event('mousemove'));
+      assert.isFunction(elt._events.pointermove);
+      elt.elt.dispatchEvent(new Event('pointermove'));
       assert.equal(myFnCounter, 0);
       assert.equal(myFnCounterOther, 1);
     });
@@ -503,8 +350,8 @@ suite('p5.Element', function() {
 
       elt.mouseMoved(myFn);
       elt.mouseMoved(false);
-      assert.isNull(elt._events.mousemove);
-      elt.elt.dispatchEvent(new Event('mousemove'));
+      assert.isNull(elt._events.pointermove);
+      elt.elt.dispatchEvent(new Event('pointermove'));
       assert.equal(myFnCounter, 0);
     });
   });
@@ -519,8 +366,8 @@ suite('p5.Element', function() {
       };
 
       elt.mouseOver(myFn);
-      assert.isFunction(elt._events.mouseover);
-      elt.elt.dispatchEvent(new Event('mouseover'));
+      assert.isFunction(elt._events.pointerover);
+      elt.elt.dispatchEvent(new Event('pointerover'));
       assert.equal(myFnCounter, 1);
     });
 
@@ -538,8 +385,8 @@ suite('p5.Element', function() {
 
       elt.mouseOver(myFn);
       elt.mouseOver(myFnOther);
-      assert.isFunction(elt._events.mouseover);
-      elt.elt.dispatchEvent(new Event('mouseover'));
+      assert.isFunction(elt._events.pointerover);
+      elt.elt.dispatchEvent(new Event('pointerover'));
       assert.equal(myFnCounter, 0);
       assert.equal(myFnCounterOther, 1);
     });
@@ -554,8 +401,8 @@ suite('p5.Element', function() {
 
       elt.mouseOver(myFn);
       elt.mouseOver(false);
-      assert.isNull(elt._events.mouseover);
-      elt.elt.dispatchEvent(new Event('mouseover'));
+      assert.isNull(elt._events.pointerover);
+      elt.elt.dispatchEvent(new Event('pointerover'));
       assert.equal(myFnCounter, 0);
     });
   });
@@ -570,8 +417,8 @@ suite('p5.Element', function() {
       };
 
       elt.mouseOut(myFn);
-      assert.isFunction(elt._events.mouseout);
-      elt.elt.dispatchEvent(new Event('mouseout'));
+      assert.isFunction(elt._events.pointerout);
+      elt.elt.dispatchEvent(new Event('pointerout'));
       assert.equal(myFnCounter, 1);
     });
 
@@ -589,8 +436,8 @@ suite('p5.Element', function() {
 
       elt.mouseOut(myFn);
       elt.mouseOut(myFnOther);
-      assert.isFunction(elt._events.mouseout);
-      elt.elt.dispatchEvent(new Event('mouseout'));
+      assert.isFunction(elt._events.pointerout);
+      elt.elt.dispatchEvent(new Event('pointerout'));
       assert.equal(myFnCounter, 0);
       assert.equal(myFnCounterOther, 1);
     });
@@ -605,8 +452,8 @@ suite('p5.Element', function() {
 
       elt.mouseOut(myFn);
       elt.mouseOut(false);
-      assert.isNull(elt._events.mouseout);
-      elt.elt.dispatchEvent(new Event('mouseout'));
+      assert.isNull(elt._events.pointerout);
+      elt.elt.dispatchEvent(new Event('pointerout'));
       assert.equal(myFnCounter, 0);
     });
   });


### PR DESCRIPTION
Resolves https://github.com/processing/p5.js/issues/7603

Changes:
- Makes `p5.Element` mouse events use the pointer API so that they handle mouse and touch
- Removes `p5.Element` touch event handlers, as everything should go through the mouse ones now


#### PR Checklist
<!--
  To check any option, replace the "[ ]" with a "[x]". Be sure to check out how it looks in the Preview tab! Feel free to remove any portion of the template that is not relevant for your issue.
-->

- [x] `npm run lint` passes
- [ ] [Inline reference] is included / updated
- [x] [Unit tests] are included / updated

[Inline reference]: https://p5js.org/contribute/contributing_to_the_p5js_reference/
[Unit tests]: https://github.com/processing/p5.js/tree/main/contributor_docs#unit-tests
