### PR TITLE
fix: mouseWheel example fixed while drawing the circle

### DIFF
--- a/src/events/mouse.js
+++ b/src/events/mouse.js
@@ -1802,7 +1802,7 @@ p5.prototype._pmouseWheelDeltaY = 0;
  *   background(200);
  *
  *   // Draw the circle
- *   circle(circleSize, 50, 50);
+ *   circle(50, 50, circleSize);
  * }
  *
  * // Increment circleSize when the user scrolls the mouse wheel.


### PR DESCRIPTION
Resolves #7613 

 Changes:
Fixed the mouseWheel function changing the X axis of circle


 Screenshots of the change:
 none

#### PR Checklist
<!--
  To check any option, replace the "[ ]" with a "[x]". Be sure to check out how it looks in the Preview tab! Feel free to remove any portion of the template that is not relevant for your issue.
-->

- [x] `npm run lint` passes
- [x] [Inline reference] is included / updated
- [ ] [Unit tests] are included / updated

[Inline reference]: https://p5js.org/contribute/contributing_to_the_p5js_reference/
[Unit tests]: https://github.com/processing/p5.js/tree/main/contributor_docs#unit-tests
