### PR TITLE
Update gridOutput.js

### DIFF
--- a/src/accessibility/gridOutput.js
+++ b/src/accessibility/gridOutput.js
@@ -65,7 +65,9 @@ function _gridMap(idT, ingredients) {
 
       // Check if shape is in canvas, skip if not
       if(
+        ingredients[x][y].loc.locY >= 0 &&
         ingredients[x][y].loc.locY < cells.length &&
+        ingredients[x][y].loc.locX >= 0 &&
         ingredients[x][y].loc.locX < cells[ingredients[x][y].loc.locY].length
       ){
         //if empty cell of location of shape is undefined


### PR DESCRIPTION
Resolves #7259 

Changes:

Some shapes located outside of the canvas and the current check in _gridMap only applies to positive locX and locY but not negative values. The fix is to check for negative values and hence avoiding a negative indexing to an array which causes the issue.

 Screenshots of the change:
<!-- If applicable, add screenshots depicting the changes. -->

#### PR Checklist

- [x] `npm run lint` passes
- [ ] [Inline reference] is included / updated
- [ ] [Unit tests] are included / updated

[Inline reference]: https://p5js.org/contribute/contributing_to_the_p5js_reference/
[Unit tests]: https://github.com/processing/p5.js/tree/main/contributor_docs#unit-tests
