### PR TITLE
Fix #7259 TypeError for Offscreen Shapes

### DIFF
--- a/src/accessibility/outputs.js
+++ b/src/accessibility/outputs.js
@@ -579,8 +579,13 @@ p5.prototype._getPos = function (x, y) {
 function _canvasLocator(args, canvasWidth, canvasHeight) {
   const noRows = 10;
   const noCols = 10;
-  let locX = Math.floor(args[0] / canvasWidth * noRows);
-  let locY = Math.floor(args[1] / canvasHeight * noCols);
+  let x = args[0];
+  let y = args[1];
+  if (x < 0 || x >= canvasWidth || y < 0 || y >= canvasHeight) {
+    return null;
+  }
+  let locX = Math.floor(x / canvasWidth * noRows);
+  let locY = Math.floor(y / canvasHeight * noCols);
   if (locX === noRows) {
     locX = locX - 1;
   }


### PR DESCRIPTION
Resolves #7259

Fixes "TypeError: Cannot read properties of undefined" when drawing offscreen primitive shapes (`ellipse()`, `line()`, `rect()`) in p5.js. 

This error occurs when we change y-coordinate to offscreen value like -1. The error is specific to y-coordinate changes and does not occur with x-coordinate changes.
Error message "Cannot read properties of undefined", pointing to an attempt to access an undefined object.


Changes:
Modify the `_canvasLocator()` in `outputs.js` to return `null` if a shape’s center is outside the canvas.
`_canvasLocator()` checks if the shape’s center (args[0], args[1]) is within 0 <= args[0] < canvasWidth and 0 <= args[1] < canvasHeight. If not, return null.


#### PR Checklist

- [x] `npm run lint` passes
- [ ] [Inline reference] is included / updated
- [ ] [Unit tests] are included / updated

[Inline reference]: https://p5js.org/contribute/contributing_to_the_p5js_reference/
[Unit tests]: https://github.com/processing/p5.js/tree/main/contributor_docs#unit-tests
