### PR TITLE
[p5.js 2.0] Fix p5.Table.getColumn does not work with named columns

### DIFF
--- a/src/io/p5.Table.js
+++ b/src/io/p5.Table.js
@@ -500,7 +500,7 @@ class Table {
     const ret = [];
     if (typeof value === 'string') {
       for (let i = 0; i < this.rows.length; i++) {
-        ret.push(this.rows[i].obj[value]);
+        ret.push(this.rows[i].obj[this.columns.indexOf(value)]);
       }
     } else {
       for (let j = 0; j < this.rows.length; j++) {


### PR DESCRIPTION
<!--
  Thank you for contributing! Please use this pull request (PR) template.


 In the description field of this PR, include "resolves #XXXX" tagging the issue you are fixing. If this PR addresses the issue but doesn't completely resolve it (ie the issue should remain open after your PR is merged), write "addresses #XXXX".-->
Resolves #7642

Changes:
<!-- Add here what changes were made in this pull request and if possible provide links showcasing the changes. -->
Fix to work correctly with named columns. Table must be loaded with headers in the first place.