### PR TITLE
fixing get() in p5.Table

### DIFF
--- a/src/io/p5.Table.js
+++ b/src/io/p5.Table.js
@@ -1028,7 +1028,11 @@ class Table {
    * </div>
    */
   get (row, column) {
-    return this.rows[row].get(column);
+    if(typeof column === 'string'){
+      return this.rows[row].get(this.columns.indexOf(column));
+    } else {
+      return this.rows[row].get(column);
+    }
   }
 
   /**


### PR DESCRIPTION
Fixing get() function in p5.Table.

get() was not working when we had a string as a column. table.get(0, 'species'). This fixes the issue. Feel free to merge.