### PR TITLE
[dev-2.0] fix bug in textAscent/Descent

### DIFF
--- a/src/type/textCore.js
+++ b/src/type/textCore.js
@@ -315,7 +315,7 @@ function textCore(p5, fn) {
    */
   Renderer.prototype.textAscent = function (txt = '') {
     if (!txt.length) return this.fontAscent();
-    return this.textDrawingContext().measureText(txt)[prop];
+    return this.textDrawingContext().measureText(txt).actualBoundingBoxAscent;
   };
 
   /**
@@ -334,7 +334,7 @@ function textCore(p5, fn) {
    */
   Renderer.prototype.textDescent = function (txt = '') {
     if (!txt.length) return this.fontDescent();
-    return this.textDrawingContext().measureText(txt)[prop];
+    return this.textDrawingContext().measureText(txt).actualBoundingBoxDescent;
   };
 
   /**


### PR DESCRIPTION
fix missing property name in textAscent and textDescent functions, when passed a specific string