### PR TITLE
Fix: Update arc() documentation to reflect angleMode() setting #7562

### DIFF
--- a/src/core/shape/2d_primitives.js
+++ b/src/core/shape/2d_primitives.js
@@ -110,7 +110,8 @@ p5.prototype._normalizeArcAngles = (
  *
  * The fifth and sixth parameters, `start` and `stop`, set the angles
  * between which to draw the arc. Arcs are always drawn clockwise from
- * `start` to `stop`. Angles are always given in radians.
+ * `start` to `stop`. By default, angles are in radians, but they follow
+ * the current `angleMode()` setting (`RADIANS` or `DEGREES`).
  *
  * The seventh parameter, `mode`, is optional. It determines the arc's fill
  * style. The fill modes are a semi-circle (`OPEN`), a closed semi-circle


### PR DESCRIPTION
Resolves #7562  

### Changes:  
- Updated the documentation for the `arc()` function to clarify that it respects `angleMode()`.  
- Reviewed and ensured consistency in related math function documentation (e.g., `sin()`, `cos()`, `tan()`).  

### Screenshots of the change:  
N/A (as this is a documentation update).  

#### PR Checklist:  
- [ ] `npm run lint` passes  
- [ ] Inline reference is included/updated  
- [ ] Unit tests are included/updated  

@davepagurek 