### PR TITLE
Fix binding of texture()

### DIFF
--- a/src/webgl/p5.RendererGL.js
+++ b/src/webgl/p5.RendererGL.js
@@ -1036,7 +1036,7 @@ class RendererGL extends Renderer {
     if (!this._userEnabledStencil) {
       this._internalDisable.call(this.GL, this.GL.STENCIL_TEST);
     }
-  
+
   }
 
   /**
@@ -1781,7 +1781,7 @@ class RendererGL extends Renderer {
       if (!this._userEnabledStencil) {
         this._internalDisable.call(this.GL, this.GL.STENCIL_TEST);
       }
-    
+
     // Reset saved state
     // this._userEnabledStencil = this._savedStencilTestState;
     }
@@ -2349,6 +2349,7 @@ class RendererGL extends Renderer {
 
   _setFillUniforms(fillShader) {
     this.mixedSpecularColor = [...this.states.curSpecularColor];
+    const empty = this._getEmptyTexture();
 
     if (this.states._useMetalness > 0) {
       this.mixedSpecularColor = this.mixedSpecularColor.map(
@@ -2362,9 +2363,12 @@ class RendererGL extends Renderer {
     fillShader.setUniform("uUseVertexColor", this._useVertexColor);
     fillShader.setUniform("uMaterialColor", this.states.curFillColor);
     fillShader.setUniform("isTexture", !!this.states._tex);
-    if (this.states._tex) {
-      fillShader.setUniform("uSampler", this.states._tex);
-    }
+    // We need to explicitly set uSampler back to an empty texture here.
+    // In general, we record the last set texture so we can re-apply it
+    // the next time a shader is used. However, the texture() function
+    // works differently and is global p5 state. If the p5 state has
+    // been cleared, we also need to clear the value in uSampler to match.
+    fillShader.setUniform("uSampler", this.states._tex || empty);
     fillShader.setUniform("uTint", this.states.tint);
 
     fillShader.setUniform("uHasSetAmbient", this.states._hasSetAmbient);

--- a/test/unit/webgl/p5.RendererGL.js
+++ b/test/unit/webgl/p5.RendererGL.js
@@ -119,7 +119,8 @@ suite('p5.RendererGL', function() {
 
       // It should be red
       assert.deepEqual(myp5.get(5, 5), [255, 0, 0, 255]);
-    })
+    });
+
     test('textures remain bound after each draw call', function() {
       myp5.createCanvas(20, 10, myp5.WEBGL);
       myp5.background(255);
@@ -132,7 +133,7 @@ suite('p5.RendererGL', function() {
           inputs.color = texture(myTex, inputs.texCoord);
           return inputs;
         }`
-      })
+      });
 
       // Make a red texture
       const tex = myp5.createFramebuffer();
@@ -154,7 +155,33 @@ suite('p5.RendererGL', function() {
       // Both rectangles should be red
       assert.deepEqual(myp5.get(5, 5), [255, 0, 0, 255]);
       assert.deepEqual(myp5.get(15, 5), [255, 0, 0, 255]);
-    })
+    });
+
+    test('texture() does not remain bound', function() {
+      myp5.createCanvas(20, 10, myp5.WEBGL);
+      myp5.background(255);
+
+      const myShader = myp5.baseMaterialShader().modify({});
+
+      // Make a red texture
+      const tex = myp5.createFramebuffer();
+      tex.draw(() => myp5.background('red'));
+
+      myp5.shader(myShader);
+      const uSampler = myShader.samplers.find((s) => s.name === 'uSampler');
+
+      myp5.push();
+      myp5.texture(tex);
+      myp5.circle(0, 0, 20);
+      expect(uSampler.texture.isFramebufferTexture).toBeTruthy();
+      myp5.pop();
+
+      myp5.push();
+      // Texture should be unbound now
+      myp5.circle(0, 0, 20);
+      expect(uSampler.texture.isFramebufferTexture).toBeFalsy();
+      myp5.pop();
+    });
   });
 
   suite('default stroke shader', function() {
@@ -2711,23 +2738,23 @@ suite('p5.RendererGL', function() {
         myp5.createCanvas(50, 50, myp5.WEBGL);
         const gl = myp5._renderer.GL;
         const isEnabled = gl.isEnabled(gl.STENCIL_TEST);
-        
+
         assert.equal(isEnabled, false);
         assert.equal(myp5._renderer._userEnabledStencil, false);
       }
     );
-    
+
     test('Tracks when user manually enables stencil test',
       function() {
         myp5.createCanvas(50, 50, myp5.WEBGL);
         const gl = myp5._renderer.GL;
-        
+
         gl.enable(gl.STENCIL_TEST);
         assert.equal(myp5._renderer._userEnabledStencil, true);
         assert.equal(gl.isEnabled(gl.STENCIL_TEST), true);
       }
     );
-    
+
     test('Tracks when user manually disables stencil test',
       function() {
         myp5.createCanvas(50, 50, myp5.WEBGL);
@@ -2735,24 +2762,24 @@ suite('p5.RendererGL', function() {
 
         gl.enable(gl.STENCIL_TEST);
         gl.disable(gl.STENCIL_TEST);
-        
+
         assert.equal(myp5._renderer._userEnabledStencil, false);
         assert.equal(gl.isEnabled(gl.STENCIL_TEST), false);
       }
     );
-    
+
     test('Maintains stencil test state across draw cycles when user enabled',
       function() {
         let drawCalled = false;
 
         myp5.createCanvas(50, 50, myp5.WEBGL);
         const originalDraw = myp5.draw;
-        
+
         myp5.draw = function() {
           drawCalled = true;
           if (originalDraw) originalDraw.call(myp5);
         };
-        
+
         const gl = myp5._renderer.GL;
         gl.enable(gl.STENCIL_TEST);
         assert.equal(gl.isEnabled(gl.STENCIL_TEST), true)
@@ -2764,7 +2791,7 @@ suite('p5.RendererGL', function() {
         myp5.draw = originalDraw;
       }
     );
-    
+
     test('Internal clip operations preserve user stencil test setting',
       function() {
         myp5.createCanvas(50, 50, myp5.WEBGL);
@@ -2783,7 +2810,7 @@ suite('p5.RendererGL', function() {
         assert.equal(gl.isEnabled(gl.STENCIL_TEST), true);
       }
     );
-    
+
     test('Internal clip operations do not enable stencil test for future draw cycles',
       function() {
         myp5.createCanvas(50, 50, myp5.WEBGL);


### PR DESCRIPTION
<!--
  Thank you for contributing! Please use this pull request (PR) template.


 In the description field of this PR, include "resolves #XXXX" tagging the issue you are fixing. If this PR addresses the issue but doesn't completely resolve it (ie the issue should remain open after your PR is merged), write "addresses #XXXX".-->
Resolves #7665

### Changes
Previously, we fixed a bug where a texture bound to a shader would unbind after its first use. So, textures stay bound. This lead to a scenario where if you draw using a framebuffer as a texture once:
```js
texture(myFramebuffer)
```
...then if you later try to draw to that framebuffer, even without a texture applied, it would cause a feedback cycle since the framebuffer is still bound to the shader:
```js
myFramebuffer.draw(() => {
  lights()
  circle(0, 0, 20) // Logs an error, doesn't draw anything in firefox
})
```
The problem is that we were using `texture()` to bind a texture, but when no texture is applied (e.g. after a `pop()`), we we're unbinding.

#### PR Checklist
<!--
  To check any option, replace the "[ ]" with a "[x]". Be sure to check out how it looks in the Preview tab! Feel free to remove any portion of the template that is not relevant for your issue.
-->

- [x] `npm run lint` passes
- [ ] [Inline reference] is included / updated
- [x] [Unit tests] are included / updated

[Inline reference]: https://p5js.org/contribute/contributing_to_the_p5js_reference/
[Unit tests]: https://github.com/processing/p5.js/tree/main/contributor_docs#unit-tests
