### PR TITLE
Rename uv in vertex shader hooks to texCoord for consistency

### DIFF
--- a/src/webgl/material.js
+++ b/src/webgl/material.js
@@ -1622,7 +1622,7 @@ function material(p5, fn){
    * Update the vertex data of the model being drawn before any positioning has been applied. It takes in a `Vertex` struct, which includes:
    * - `vec3 position`, the position of the vertex
    * - `vec3 normal`, the direction facing out of the surface
-   * - `vec2 uv`, the texture coordinates associeted with the vertex
+   * - `vec2 texCoord`, the texture coordinates associeted with the vertex
    * - `vec4 color`, the per-vertex color
    * The struct can be modified and returned.
    *
@@ -1788,7 +1788,7 @@ function material(p5, fn){
    * Update the vertex data of the model being drawn before any positioning has been applied. It takes in a `Vertex` struct, which includes:
    * - `vec3 position`, the position of the vertex
    * - `vec3 normal`, the direction facing out of the surface
-   * - `vec2 uv`, the texture coordinates associeted with the vertex
+   * - `vec2 texCoord`, the texture coordinates associeted with the vertex
    * - `vec4 color`, the per-vertex color
    * The struct can be modified and returned.
    *

--- a/src/webgl/shaders/normal.vert
+++ b/src/webgl/shaders/normal.vert
@@ -26,7 +26,7 @@ OUT vec4 vColor;
 struct Vertex {
   vec3 position;
   vec3 normal;
-  vec2 uv;
+  vec2 texCoord;
   vec4 color;
 };
 
@@ -36,7 +36,7 @@ void main(void) {
   Vertex inputs;
   inputs.position = aPosition;
   inputs.normal = aNormal;
-  inputs.uv = aTexCoord;
+  inputs.texCoord = aTexCoord;
   inputs.color = (uUseVertexColor && aVertexColor.x >= 0.0) ? aVertexColor : uMaterialColor;
 #ifdef AUGMENTED_HOOK_getObjectInputs
   inputs = HOOK_getObjectInputs(inputs);
@@ -62,7 +62,7 @@ void main(void) {
 #endif
 
   // Pass varyings to fragment shader
-  vVertTexCoord = inputs.uv;
+  vVertTexCoord = inputs.texCoord;
   vVertexNormal = normalize(inputs.normal);
   vColor = inputs.color;
 

--- a/src/webgl/shaders/phong.vert
+++ b/src/webgl/shaders/phong.vert
@@ -33,7 +33,7 @@ OUT vec4 vColor;
 struct Vertex {
   vec3 position;
   vec3 normal;
-  vec2 uv;
+  vec2 texCoord;
   vec4 color;
 };
 
@@ -43,7 +43,7 @@ void main(void) {
   Vertex inputs;
   inputs.position = aPosition;
   inputs.normal = aNormal;
-  inputs.uv = aTexCoord;
+  inputs.texCoord = aTexCoord;
   inputs.color = (uUseVertexColor && aVertexColor.x >= 0.0) ? aVertexColor : uMaterialColor;
 #ifdef AUGMENTED_HOOK_getObjectInputs
   inputs = HOOK_getObjectInputs(inputs);
@@ -70,7 +70,7 @@ void main(void) {
 
   // Pass varyings to fragment shader
   vViewPosition = inputs.position;
-  vTexCoord = inputs.uv;
+  vTexCoord = inputs.texCoord;
   vNormal = inputs.normal;
   vColor = inputs.color;
 


### PR DESCRIPTION
@lukeplowden noticed that in fragment shader hooks, we call the texture coords `vec2 texCoord`, but in vertex shader hooks, they're `vec2 uv`. This renames them all to `texCoord` for consistency.

cc @perminder-17 in case this affects any docs/examples