### PR TITLE
Fix default fill color blowing out lighting in WebGL mode

### DIFF
--- a/src/color/p5.Color.js
+++ b/src/color/p5.Color.js
@@ -169,7 +169,7 @@ class Color {
 
   // Get raw coordinates of underlying library, can differ between libraries
   get _array() {
-    return [...this._color.coords, this._color.alpha];
+    return this._getRGBA();
   }
 
   array(){

--- a/src/core/p5.Renderer.js
+++ b/src/core/p5.Renderer.js
@@ -74,7 +74,7 @@ class Renderer {
     this.states = new States(Renderer.states);
 
     this.states.strokeColor = new Color([0, 0, 0]);
-    this.states.fillColor = new Color([255, 255, 255]);
+    this.states.fillColor = new Color([1, 1, 1]);
 
     this._pushPopStack = [];
     // NOTE: can use the length of the push pop stack instead


### PR DESCRIPTION
The `buildGeometry` example in the Creating Custom Geometry tutorial wasn't rendering anything. Turns out this is because the default fill color is defined as `new Color([255, 255, 255])`, but this is with assumed maxes of 1, not 255, so the lighting gets super blown out.

This corrects it to be in the correct scale, and corrects the implementation of `color._array`, which assumed RGB mode previously.