### PR TITLE
Fix a few camera bugs

### DIFF
--- a/src/webgl/p5.Camera.js
+++ b/src/webgl/p5.Camera.js
@@ -159,6 +159,9 @@ class Camera {
    *   // Point the camera at the origin.
    *   cam.lookAt(0, 0, 0);
    *
+   *   // Set the camera.
+   *   setCamera(cam);
+   *
    *   describe(
    *     'A white cube on a gray background. The text "eyeY: -400" is written in black beneath it.'
    *   );
@@ -180,7 +183,7 @@ class Camera {
    *   fill(0);
    *
    *   // Display the value of eyeY, rounded to the nearest integer.
-   *   text(`eyeX: ${round(cam.eyeY)}`, 0, 55);
+   *   text(`eyeY: ${round(cam.eyeY)}`, 0, 55);
    * }
    * </code>
    * </div>
@@ -2197,6 +2200,9 @@ class Camera {
    *   // Point it at the origin.
    *   cam.lookAt(0, 0, 0);
    *
+   *   // Set the camera.
+   *   setCamera(cam);
+   *
    *   describe(
    *     'A white cube drawn against a gray background. The cube appears to move when the user presses certain keys.'
    *   );
@@ -2449,6 +2455,9 @@ class Camera {
    *
    *   // Copy cam1's configuration.
    *   cam2.set(cam1);
+   *
+   *   // Set the camera.
+   *   setCamera(cam2);
    *
    *   describe(
    *     'A white cube drawn against a gray background. The camera slowly moves forward. The camera resets when the user double-clicks.'
@@ -3458,7 +3467,7 @@ function camera(p5, fn){
     if (!(this._renderer instanceof RendererGL)) {
       throw new Error('linePerspective() must be called in WebGL mode.');
     }
-    this._renderer.linePerspective(enable);
+    return this._renderer.linePerspective(enable);
   };
 
 


### PR DESCRIPTION
Picks up a few lingering issues from https://github.com/processing/p5.js/pull/7607 + some other unrelated fixes in the same docs:
- There were a few examples missing `setCamera`
- The `linePerspective()` getter stopped returning values in 2.0
- A label in the `eyeY` page still said `eyeX`

#### PR Checklist
<!--
  To check any option, replace the "[ ]" with a "[x]". Be sure to check out how it looks in the Preview tab! Feel free to remove any portion of the template that is not relevant for your issue.
-->

- [x] `npm run lint` passes
- [x] [Inline reference] is included / updated
- [ ] [Unit tests] are included / updated

[Inline reference]: https://p5js.org/contribute/contributing_to_the_p5js_reference/
[Unit tests]: https://github.com/processing/p5.js/tree/main/contributor_docs#unit-tests
