### PR TITLE
Fix: noSmooth() breaking positioned WEBGL

### DIFF
--- a/src/core/shape/2d_primitives.js
+++ b/src/core/shape/2d_primitives.js
@@ -124,8 +124,8 @@ p5.prototype._normalizeArcAngles = (
  * @param  {Number} y      y-coordinate of the arc's ellipse.
  * @param  {Number} w      width of the arc's ellipse by default.
  * @param  {Number} h      height of the arc's ellipse by default.
- * @param  {Number} start  angle to start the arc, specified in radians.
- * @param  {Number} stop   angle to stop the arc, specified in radians.
+ * @param  {Number} start  angle to start the arc, specified in radians(or degrees if angleMode(DEGREES) is used).
+ * @param  {Number} stop   angle to stop the arc, specified in radians(or degrees if angleMode(DEGREES) is used).
  * @param  {Constant} [mode] optional parameter to determine the way of drawing
  *                         the arc. either CHORD, PIE, or OPEN.
  * @param  {Integer} [detail] optional parameter for WebGL mode only. This is to
@@ -133,7 +133,7 @@ p5.prototype._normalizeArcAngles = (
  *                         perimeter of the arc. Default value is 25. Won't
  *                         draw a stroke for a detail of more than 50.
  * @chainable
- *
+ *s
  * @example
  * <div>
  * <code>

--- a/src/core/shape/attributes.js
+++ b/src/core/shape/attributes.js
@@ -176,10 +176,13 @@ p5.prototype.noSmooth = function() {
       this.drawingContext.imageSmoothingEnabled = false;
     }
   } else {
-    this.setAttributes('antialias', false);
+    // Check if disabling antialiasing breaks positioning before applying
+    if (this._renderer && this._renderer.GL) {
+      this.setAttributes('antialias', false);
+    }
   }
-  return this;
 };
+
 
 /**
  * Changes where rectangles and squares are drawn.


### PR DESCRIPTION
<This PR updates the noSmooth() function to correctly handle positioned WEBGL mode. This was done by updating noSmooth9) to properly check and apply imageSmoothingEnabled and antialias settings in WEBGL mode, ensuring correct behaviour>

