### PR TITLE
Update bezier() to use new bezierVetext

### DIFF
--- a/src/core/p5.Renderer.js
+++ b/src/core/p5.Renderer.js
@@ -213,9 +213,13 @@ class Renderer {
   }
 
   bezier(x1, y1, x2, y2, x3, y3, x4, y4) {
+    const oldOrder = this._pInst.bezierOrder();
+    this._pInst.bezierOrder(oldOrder);
     this._pInst.beginShape();
-    this._pInst.vertex(x1, y1);
-    this._pInst.bezierVertex(x2, y2, x3, y3, x4, y4);
+    this._pInst.bezierVertex(x1, y1);
+    this._pInst.bezierVertex(x2, y2);
+    this._pInst.bezierVertex(x3, y3);
+    this._pInst.bezierVertex(x4, y4);
     this._pInst.endShape();
     return this;
   }


### PR DESCRIPTION
Between beta.4 and beta.5, `bezier()` stopped working.

Can be observed here with code from the Bezier example: https://editor.p5js.org/ksen0/sketches/lpoiyxpez

I would like to add a visual test for `bezier` as I couldn't find it in `test/unit/visual/cases/shapes.js` or in the diff [https://github.com/processing/p5.js/compare/v1.11.3...v2.0.0-beta.5](https://github.com/processing/p5.js/compare/v1.11.3...v2.0.0-beta.5)