### PR TITLE
Rename curvePoint/curveTangent to splinePoint/splineTangent

### DIFF
--- a/src/shape/curves.js
+++ b/src/shape/curves.js
@@ -505,7 +505,7 @@ function curves(p5, fn){
    *   noFill();
    *   strokeWeight(1);
    *   stroke(0);
-   *   curve(5, 26, 73, 24, 73, 61, 15, 65);
+   *   spline(5, 26, 73, 24, 73, 61, 15, 65);
    *
    *   // Draw red spline curves from the anchor points to the control points.
    *   stroke(255, 0, 0);
@@ -653,8 +653,6 @@ function curves(p5, fn){
    * @chainable
    */
   fn.spline = function(...args) {
-    // p5._validateParameters('curve', args);
-
     if (!this._renderer.states.strokeColor && !this._renderer.states.fillColor) {
       return this;
     }
@@ -666,9 +664,9 @@ function curves(p5, fn){
   /**
    * Calculates coordinates along a spline curve using interpolation.
    *
-   * `curvePoint()` calculates coordinates along a spline curve using the
+   * `splinePoint()` calculates coordinates along a spline curve using the
    * anchor and control points. It expects points in the same order as the
-   * <a href="#/p5/curve">curve()</a> function. `curvePoint()` works one axis
+   * <a href="#/p5/spline">spline()</a> function. `splinePoint()` works one axis
    * at a time. Passing the anchor and control points' x-coordinates will
    * calculate the x-coordinate of a point on the curve. Passing the anchor and
    * control points' y-coordinates will calculate the y-coordinate of a point on
@@ -685,7 +683,7 @@ function curves(p5, fn){
    * is the first anchor point, 1 is the second anchor point, and 0.5 is halfway
    * between them.
    *
-   * @method curvePoint
+   * @method splinePoint
    * @param {Number} a coordinate of first anchor point.
    * @param {Number} b coordinate of first control point.
    * @param {Number} c coordinate of second control point.
@@ -713,24 +711,24 @@ function curves(p5, fn){
    *
    *   // Draw the curve.
    *   noFill();
-   *   curve(x1, y1, x2, y2, x3, y3, x4, y4);
+   *   spline(x1, y1, x2, y2, x3, y3, x4, y4);
    *
    *   // Draw circles along the curve's path.
    *   fill(255);
    *
    *   // Top.
-   *   let x = curvePoint(x1, x2, x3, x4, 0);
-   *   let y = curvePoint(y1, y2, y3, y4, 0);
+   *   let x = splinePoint(x1, x2, x3, x4, 0);
+   *   let y = splinePoint(y1, y2, y3, y4, 0);
    *   circle(x, y, 5);
    *
    *   // Center.
-   *   x = curvePoint(x1, x2, x3, x4, 0.5);
-   *   y = curvePoint(y1, y2, y3, y4, 0.5);
+   *   x = splinePoint(x1, x2, x3, x4, 0.5);
+   *   y = splinePoint(y1, y2, y3, y4, 0.5);
    *   circle(x, y, 5);
    *
    *   // Bottom.
-   *   x = curvePoint(x1, x2, x3, x4, 1);
-   *   y = curvePoint(y1, y2, y3, y4, 1);
+   *   x = splinePoint(x1, x2, x3, x4, 1);
+   *   y = splinePoint(y1, y2, y3, y4, 1);
    *   circle(x, y, 5);
    *
    *   describe('A black curve on a gray square. The endpoints and center of the curve are marked with white circles.');
@@ -761,12 +759,12 @@ function curves(p5, fn){
    *
    *   // Draw the curve.
    *   noFill();
-   *   curve(x1, y1, x2, y2, x3, y3, x4, y4);
+   *   spline(x1, y1, x2, y2, x3, y3, x4, y4);
    *
    *   // Calculate the circle's coordinates.
    *   let t = 0.5 * sin(frameCount * 0.01) + 0.5;
-   *   let x = curvePoint(x1, x2, x3, x4, t);
-   *   let y = curvePoint(y1, y2, y3, y4, t);
+   *   let x = splinePoint(x1, x2, x3, x4, t);
+   *   let y = splinePoint(y1, y2, y3, y4, t);
    *
    *   // Draw the circle.
    *   fill(255);
@@ -775,8 +773,7 @@ function curves(p5, fn){
    * </code>
    * </div>
    */
-  fn.curvePoint = function(a, b, c, d, t) {
-    // p5._validateParameters('curvePoint', arguments);
+  fn.splinePoint = function(a, b, c, d, t) {
     const s = this._renderer.states.splineProperties.tightness,
       t3 = t * t * t,
       t2 = t * t,
@@ -793,9 +790,9 @@ function curves(p5, fn){
    * Tangent lines skim the surface of a curve. A tangent line's slope equals
    * the curve's slope at the point where it intersects.
    *
-   * `curveTangent()` calculates coordinates along a tangent line using the
+   * `splineTangent()` calculates coordinates along a tangent line using the
    * spline curve's anchor and control points. It expects points in the same
-   * order as the <a href="#/p5/curve">curve()</a> function. `curveTangent()`
+   * order as the <a href="#/p5/spline">spline()</a> function. `splineTangent()`
    * works one axis at a time. Passing the anchor and control points'
    * x-coordinates will calculate the x-coordinate of a point on the tangent
    * line. Passing the anchor and control points' y-coordinates will calculate
@@ -812,7 +809,7 @@ function curves(p5, fn){
    * is the first anchor point, 1 is the second anchor point, and 0.5 is halfway
    * between them.
    *
-   * @method curveTangent
+   * @method splineTangent
    * @param {Number} a coordinate of first control point.
    * @param {Number} b coordinate of first anchor point.
    * @param {Number} c coordinate of second anchor point.
@@ -840,48 +837,48 @@ function curves(p5, fn){
    *
    *   // Draw the curve.
    *   noFill();
-   *   curve(x1, y1, x2, y2, x3, y3, x4, y4);
+   *   spline(x1, y1, x2, y2, x3, y3, x4, y4);
    *
    *   // Draw tangents along the curve's path.
    *   fill(255);
    *
    *   // Top circle.
    *   stroke(0);
-   *   let x = curvePoint(x1, x2, x3, x4, 0);
-   *   let y = curvePoint(y1, y2, y3, y4, 0);
+   *   let x = splinePoint(x1, x2, x3, x4, 0);
+   *   let y = splinePoint(y1, y2, y3, y4, 0);
    *   circle(x, y, 5);
    *
    *   // Top tangent line.
    *   // Scale the tangent point to draw a shorter line.
    *   stroke(255, 0, 0);
-   *   let tx = 0.2 * curveTangent(x1, x2, x3, x4, 0);
-   *   let ty = 0.2 * curveTangent(y1, y2, y3, y4, 0);
+   *   let tx = 0.2 * splineTangent(x1, x2, x3, x4, 0);
+   *   let ty = 0.2 * splineTangent(y1, y2, y3, y4, 0);
    *   line(x + tx, y + ty, x - tx, y - ty);
    *
    *   // Center circle.
    *   stroke(0);
-   *   x = curvePoint(x1, x2, x3, x4, 0.5);
-   *   y = curvePoint(y1, y2, y3, y4, 0.5);
+   *   x = splinePoint(x1, x2, x3, x4, 0.5);
+   *   y = splinePoint(y1, y2, y3, y4, 0.5);
    *   circle(x, y, 5);
    *
    *   // Center tangent line.
    *   // Scale the tangent point to draw a shorter line.
    *   stroke(255, 0, 0);
-   *   tx = 0.2 * curveTangent(x1, x2, x3, x4, 0.5);
-   *   ty = 0.2 * curveTangent(y1, y2, y3, y4, 0.5);
+   *   tx = 0.2 * splineTangent(x1, x2, x3, x4, 0.5);
+   *   ty = 0.2 * splineTangent(y1, y2, y3, y4, 0.5);
    *   line(x + tx, y + ty, x - tx, y - ty);
    *
    *   // Bottom circle.
    *   stroke(0);
-   *   x = curvePoint(x1, x2, x3, x4, 1);
-   *   y = curvePoint(y1, y2, y3, y4, 1);
+   *   x = splinePoint(x1, x2, x3, x4, 1);
+   *   y = splinePoint(y1, y2, y3, y4, 1);
    *   circle(x, y, 5);
    *
    *   // Bottom tangent line.
    *   // Scale the tangent point to draw a shorter line.
    *   stroke(255, 0, 0);
-   *   tx = 0.2 * curveTangent(x1, x2, x3, x4, 1);
-   *   ty = 0.2 * curveTangent(y1, y2, y3, y4, 1);
+   *   tx = 0.2 * splineTangent(x1, x2, x3, x4, 1);
+   *   ty = 0.2 * splineTangent(y1, y2, y3, y4, 1);
    *   line(x + tx, y + ty, x - tx, y - ty);
    *
    *   describe(
@@ -891,9 +888,7 @@ function curves(p5, fn){
    * </code>
    * </div>
    */
-  fn.curveTangent = function(a, b, c, d, t) {
-    // p5._validateParameters('curveTangent', arguments);
-
+  fn.splineTangent = function(a, b, c, d, t) {
     const s = this._renderer.states.splineProperties.tightness,
       tt3 = t * t * 3,
       t2 = t * 2,

--- a/test/unit/core/curves.js
+++ b/test/unit/core/curves.js
@@ -57,27 +57,27 @@ suite('Curves', function() {
     });
   });
 
-  suite('p5.prototype.curvePoint', function() {
+  suite('p5.prototype.splinePoint', function() {
     var result;
     test('should be a function', function() {
-      assert.ok(mockP5Prototype.curvePoint);
-      assert.typeOf(mockP5Prototype.curvePoint, 'function');
+      assert.ok(mockP5Prototype.splinePoint);
+      assert.typeOf(mockP5Prototype.splinePoint, 'function');
     });
     test('should return the correct point on a Catmull-Rom Curve', function() {
-      result = mockP5Prototype.curvePoint(5, 5, 73, 73, 0.5);
+      result = mockP5Prototype.splinePoint(5, 5, 73, 73, 0.5);
       assert.equal(result, 39);
       assert.notEqual(result, -1);
     });
   });
 
-  suite('p5.prototype.curveTangent', function() {
+  suite('p5.prototype.splineTangent', function() {
     var result;
     test('should be a function', function() {
-      assert.ok(mockP5Prototype.curveTangent);
-      assert.typeOf(mockP5Prototype.curveTangent, 'function');
+      assert.ok(mockP5Prototype.splineTangent);
+      assert.typeOf(mockP5Prototype.splineTangent, 'function');
     });
     test('should return the correct point on a Catmull-Rom Curve', function() {
-      result = mockP5Prototype.curveTangent(95, 73, 73, 15, 0.5);
+      result = mockP5Prototype.splineTangent(95, 73, 73, 15, 0.5);
       assert.equal(result, 10);
       assert.notEqual(result, -1);
     });


### PR DESCRIPTION
A few lingering instances of `curve*` methods that need to be renamed to `spline*`.

I've also double checked that the examples for these two methods still work on the website:
![image](https://github.com/user-attachments/assets/bdc34c3a-e5bd-4000-8736-182bc0c8ccc8)
