### PR TITLE
 Fix: Added checks before removing event listeners

### DIFF
--- a/src/core/main.js
+++ b/src/core/main.js
@@ -615,12 +615,12 @@ class p5 {
 
         // unregister events sketch-wide
         for (const ev in this._events) {
-          if (this._events[ev]) window.removeEventListener(ev, this._events[ev]);
+          if(this._events[ev])window.removeEventListener(ev, this._events[ev]);
         }
 
         // remove DOM elements created by p5, and listeners
         for (const e of this._elements) {
-          if (e.elt && e.elt.parentNode) {
+          if(e.elt && e.elt.parentNode) {
             e.elt.parentNode.removeChild(e.elt);
           }
           for (const elt_ev in e._events) {

--- a/src/core/main.js
+++ b/src/core/main.js
@@ -615,7 +615,7 @@ class p5 {
 
         // unregister events sketch-wide
         for (const ev in this._events) {
-          window.removeEventListener(ev, this._events[ev]);
+          if (this._events[ev]) window.removeEventListener(ev, this._events[ev]);
         }
 
         // remove DOM elements created by p5, and listeners
@@ -624,7 +624,7 @@ class p5 {
             e.elt.parentNode.removeChild(e.elt);
           }
           for (const elt_ev in e._events) {
-            e.elt.removeEventListener(elt_ev, e._events[elt_ev]);
+            if (e.elt && e._events[elt_ev]) e.elt.removeEventListener(elt_ev, e._events[elt_ev]);
           }
         }
 


### PR DESCRIPTION
<!--
  Thank you for contributing! Please use this pull request (PR) template.

  In the description field of this PR, include "resolves #XXXX" tagging the issue you are fixing. If this PR addresses the issue but doesn't completely resolve it (ie the issue should remain open after your PR is merged), write "addresses #XXXX".
-->

Resolves #618

### Changes:
- Fixed potential runtime errors by ensuring `removeEventListener` is only called when the target element and handler exist.
- Added checks to prevent calling `removeEventListener` on `undefined` values in the `main.js` file.

### Screenshots of the change:
<!-- Not applicable for backend or logic-only changes -->
_Not applicable_

---

#### PR Checklist

- [x] `npm run lint` passes
- [x] [Inline reference] is included / updated
- [x] [Unit tests] are included / updated

[Inline reference]: https://p5js.org/contribute/contributing_to_the_p5js_reference/  
[Unit tests]: https://github.com/processing/p5.js/tree/main/contributor_docs#unit-tests
