### PR TITLE
2.0 bug fixes

### DIFF
--- a/src/color/color_spaces/hsb.js
+++ b/src/color/color_spaces/hsb.js
@@ -57,7 +57,7 @@ export default new ColorSpace({
   toBase,
 
   formats: {
-    default :{
+    default: {
       type: 'custom',
       serialize: (coords, alpha) => {
         const rgb = toBase(coords);

--- a/src/dom/dom.js
+++ b/src/dom/dom.js
@@ -1755,7 +1755,7 @@ function dom(p5, fn){
       inst.push();
       if (value) {
         if (value.mode) {
-          inst.colorMode(value.mode, ...value?.maxes[value.mode]);
+          inst.colorMode(value.mode, ...(value?.maxes ? value.maxes[value.mode] || [] : []));
         }
       }
       const c = inst.color(this.elt.value);

--- a/src/image/p5.Image.js
+++ b/src/image/p5.Image.js
@@ -13,6 +13,8 @@
 import Filters from './filters';
 import { Renderer } from '../core/p5.Renderer';
 
+let fnRef;
+
 class Image {
   constructor(width, height) {
     this.width = width;
@@ -939,7 +941,7 @@ class Image {
    * @param  {Integer} dh
    */
   copy(...args) {
-    fn.copy.apply(this, args);
+    fnRef.copy.apply(this, args);
   }
 
   /**
@@ -1373,7 +1375,7 @@ class Image {
    */
   blend(...args) {
     // p5._validateParameters('p5.Image.blend', arguments);
-    fn.blend.apply(this, args);
+    fnRef.blend.apply(this, args);
     this.setModified(true);
   }
 
@@ -1459,9 +1461,9 @@ class Image {
    */
   save(filename, extension) {
     if (this.gifProperties) {
-      fn.encodeAndDownloadGif(this, filename);
+      fnRef.encodeAndDownloadGif(this, filename);
     } else {
-      fn.saveCanvas(this.canvas, filename, extension);
+      fnRef.saveCanvas(this.canvas, filename, extension);
     }
   }
 
@@ -1820,6 +1822,8 @@ class Image {
 };
 
 function image(p5, fn){
+  fnRef = fn;
+
   /**
    * A class to describe an image.
    *


### PR DESCRIPTION
- Fixes a bug where `colorPicker.color()` would throw an error
- Fixes a bug where `copy()`, `blend()`, and `save()` on `p5.Image` throw errors