### PR TITLE
Clamp color() to maxes

### DIFF
--- a/src/color/creating_reading.js
+++ b/src/color/creating_reading.js
@@ -408,7 +408,8 @@ function creatingReading(p5, fn){
     return new Color(
       arg,
       this._renderer.states.colorMode,
-      this._renderer.states.colorMaxes[this._renderer.states.colorMode]
+      this._renderer.states.colorMaxes[this._renderer.states.colorMode],
+      { clamp: true }
     );
   };
 

--- a/test/unit/color/creating_reading.js
+++ b/test/unit/color/creating_reading.js
@@ -31,6 +31,25 @@ suite('color/CreatingReading', function() {
     });
   });
 
+  suite('constructor clamping', function() {
+    test('should work on multi channels', function() {
+      const myColor = mockP5Prototype.color(1000, 1000, 1000, 1000);
+      assert.deepEqual(myColor.array(), [1, 1, 1, 1]);
+    });
+    test('should work on gray + alpha', function() {
+      const myColor = mockP5Prototype.color(1000, 1000);
+      assert.deepEqual(myColor.array(), [1, 1, 1, 1]);
+    });
+    test('should work on gray', function() {
+      const myColor = mockP5Prototype.color(1000);
+      assert.deepEqual(myColor.array(), [1, 1, 1, 1]);
+    });
+    test('normal values work', function() {
+      const myColor = mockP5Prototype.color(255 / 2);
+      assert.deepEqual(myColor.array(), [0.5, 0.5, 0.5, 1]);
+    });
+  });
+
   suite('p5.prototype.lerpColor', function() {
     beforeEach(function() {
       mockP5Prototype.colorMode(mockP5Prototype.RGB);


### PR DESCRIPTION
Found in https://github.com/processing/p5.js-website/issues/780: color channels go beyond their maxes and look different than in 1.x.

This adds clamping, but only when created with `color()` (which includes colors passed to `fill()`, `stroke()`, `background()`, etc.) This is because WebGL mode internally creates a color with negative values to represent a null color in geometry that should be replaced with the active fill color.

Live: https://editor.p5js.org/davepagurek/sketches/xsXcVJSMO