### PR TITLE
Fix division by 0 in textToPoints

### DIFF
--- a/src/type/p5.Font.js
+++ b/src/type/p5.Font.js
@@ -1016,13 +1016,17 @@ function pathToPoints(cmds, options, font) {
     simplifyThreshold: 0
   });
 
-  const totalPoints = Math.ceil(path.getTotalLength() * opts.sampleFactor);
+  const totalPoints = Math.max(1, Math.ceil(path.getTotalLength() * opts.sampleFactor));
   let points = [];
 
   const mode = font._pInst.angleMode();
   const DEGREES = font._pInst.DEGREES;
   for (let i = 0; i < totalPoints; i++) {
-    const length = path.getTotalLength() * (i / (totalPoints - 1));
+    const length = path.getTotalLength() * (
+      totalPoints === 1
+        ? 0
+        : (i / (totalPoints - 1))
+    );
     points.push({
       ...path.getPointAtLength(length),
       get angle() {

--- a/test/unit/type/p5.Font.js
+++ b/test/unit/type/p5.Font.js
@@ -39,4 +39,15 @@ suite('p5.Font', function () {
     assert.property(bbox, 'w');
     assert.property(bbox, 'h');
   });
+
+  suite('textToPoints', () => {
+    test('contains no NaNs', async () => {
+      const pFont = await myp5.loadFont(fontFile);
+      const pts = pFont.textToPoints('hello, world!', 0, 0);
+      for (const pt of pts) {
+        expect(pt.x).not.toBeNaN();
+        expect(pt.y).not.toBeNaN();
+      }
+    });
+  });
 });


### PR DESCRIPTION
Sometimes when text is small, `textToPoints` returns NaNs: https://editor.p5js.org/davepagurek/sketches/kKW--HATP

Turns out this was due to a division by 0 when the number of sample points per path ends up too small. This updates the sampling to avoid that division by 0 when there are too few sample points.

#### PR Checklist
<!--
  To check any option, replace the "[ ]" with a "[x]". Be sure to check out how it looks in the Preview tab! Feel free to remove any portion of the template that is not relevant for your issue.
-->

- [x] `npm run lint` passes
- [ ] [Inline reference] is included / updated
- [x] [Unit tests] are included / updated

[Inline reference]: https://p5js.org/contribute/contributing_to_the_p5js_reference/
[Unit tests]: https://github.com/processing/p5.js/tree/main/contributor_docs#unit-tests
