### PR TITLE
Set FontFace weight ranges based on Typr info

### DIFF
--- a/src/type/p5.Font.js
+++ b/src/type/p5.Font.js
@@ -684,7 +684,7 @@ export class Font {
     let axs;
     if ((this.data?.fvar?.length ?? 0) > 0) {
       const fontAxes = this.data.fvar[0];
-      axs = fontAxes.map(([tag, minVal, maxVal, defaultVal, flags, name]) => {
+      axs = fontAxes.map(([tag, minVal, defaultVal, maxVal, flags, name]) => {
         if (!renderer) return defaultVal;
         if (tag === 'wght') {
           return renderer.states.fontWeight;
@@ -973,7 +973,7 @@ function createFontFace(name, path, descriptors, rawFont) {
 
   if ((rawFont?.fvar?.length ?? 0) > 0) {
     descriptors = descriptors || {};
-    for (const [tag, minVal, maxVal, defaultVal, flags, name] of rawFont.fvar[0]) {
+    for (const [tag, minVal, defaultVal, maxVal, flags, name] of rawFont.fvar[0]) {
       if (tag === 'wght') {
         descriptors.weight = `${minVal} ${maxVal}`;
       } else if (tag === 'wdth') {

--- a/src/type/p5.Font.js
+++ b/src/type/p5.Font.js
@@ -691,7 +691,7 @@ export class Font {
         } else if (tag === 'wdth') {
           // TODO: map from keywords (normal, ultra-condensed, etc) to values
           // return renderer.states.fontStretch
-          return defaultVal;
+          return 100;
         } else if (renderer.textCanvas().style.fontVariationSettings) {
           const match = new RegExp(`\\b${tag}\s+(\d+)`)
             .exec(renderer.textCanvas().style.fontVariationSettings);
@@ -977,7 +977,7 @@ function createFontFace(name, path, descriptors, rawFont) {
       if (tag === 'wght') {
         descriptors.weight = `${minVal} ${maxVal}`;
       } else if (tag === 'wdth') {
-        descriptors.stretch = `${minVal} ${maxVal}`;
+        descriptors.stretch = `${minVal}% ${maxVal}%`;
       }
       // TODO add other descriptors
     }

--- a/src/type/p5.Font.js
+++ b/src/type/p5.Font.js
@@ -971,6 +971,18 @@ function createFontFace(name, path, descriptors, rawFont) {
     fontArg = path;
   }
 
+  if ((rawFont?.fvar?.length ?? 0) > 0) {
+    descriptors = descriptors || {};
+    for (const [tag, minVal, maxVal, defaultVal, flags, name] of rawFont.fvar[0]) {
+      if (tag === 'wght') {
+        descriptors.weight = `${minVal} ${maxVal}`;
+      } else if (tag === 'wdth') {
+        descriptors.stretch = `${minVal} ${maxVal}`;
+      }
+      // TODO add other descriptors
+    }
+  }
+
   // create/return the FontFace object
   let face = new FontFace(name, fontArg, descriptors);
   if (face.status === 'error') {

--- a/test/unit/visual/cases/typography.js
+++ b/test/unit/visual/cases/typography.js
@@ -113,7 +113,6 @@ visualSuite("Typography", function () {
       p5.createCanvas(100, 100);
       const font = await p5.loadFont(
         '/unit/assets/BricolageGrotesque-Variable.ttf',
-        { weight: '200 800' }
       );
       for (let weight = 400; weight <= 800; weight += 100) {
         p5.background(255);
@@ -130,7 +129,6 @@ visualSuite("Typography", function () {
       p5.createCanvas(100, 100, p5.WEBGL);
       const font = await p5.loadFont(
         '/unit/assets/BricolageGrotesque-Variable.ttf',
-        { weight: '200 800' }
       );
       for (let weight = 400; weight <= 800; weight += 100) {
         p5.push();


### PR DESCRIPTION
Resolves https://github.com/processing/p5.js/issues/7725

Previously, animating variable fonts in Firefox would be jerky or would not happen at all for some fonts. It turns out this is because, while the font supports variables, the `FontFace` we were creating out of the Typr-parsed data did not include a range of values for the weight (it was just `normal`).

To fix this, we can grab the range of values per axis from Typr and pass them in to the new `FontFace` as descriptors.

Live: https://editor.p5js.org/davepagurek/sketches/dXMFTL1Fs

#### PR Checklist
<!--
  To check any option, replace the "[ ]" with a "[x]". Be sure to check out how it looks in the Preview tab! Feel free to remove any portion of the template that is not relevant for your issue.
-->

- [ ] `npm run lint` passes
- [ ] [Inline reference] is included / updated
- [ ] [Unit tests] are included / updated

[Inline reference]: https://p5js.org/contribute/contributing_to_the_p5js_reference/
[Unit tests]: https://github.com/processing/p5.js/tree/main/contributor_docs#unit-tests
