### PR TITLE
Fix incorrect text weight for variable fonts in Safari

### DIFF
--- a/src/io/files.js
+++ b/src/io/files.js
@@ -491,7 +491,7 @@ function files(p5, fn){
    * async function setup() {
    *   // Create a 200x200 canvas
    *   createCanvas(200, 200);
-   *   
+   *
    *   // Load the CSV file with a header row
    *   table = await loadTable('assets/mammals.csv', ',', 'header');
    *
@@ -501,7 +501,7 @@ function files(p5, fn){
    *   // Set text properties
    *   fill(0);       // Set text color to black
    *   textSize(16);  // Adjust text size as needed
-   *   
+   *
    *   // Display each column value in the row on the canvas.
    *   // Using an offset for y-position so each value appears on a new line.
    *   for (let c = 0; c < table.getColumnCount(); c++) {
@@ -748,7 +748,7 @@ function files(p5, fn){
    * @returns {Promise<Uint8Array>} a Uint8Array containing the loaded buffer
    *
    * @example
-   * 
+   *
    * <div>
    * <code>
    * let data;
@@ -787,7 +787,7 @@ function files(p5, fn){
       }
     }
   };
-  
+
   /**
    * Loads a file at the given path as a Blob, then returns the resulting data or
    * passes it to a success callback function, if provided. On load, this function
@@ -2187,7 +2187,10 @@ function files(p5, fn){
    *  @private
    */
   fn._isSafari = function () {
-    return window.HTMLElement.toString().includes('Constructor');
+    // Thanks to user Fregante on StackOverflow for the
+    // one-liner below (CC BY SA 3.0)
+    // https://stackoverflow.com/a/23522755
+    return /^((?!chrome|android).)*safari/i.test(navigator.userAgent);
   };
 
   /**

--- a/src/io/files.js
+++ b/src/io/files.js
@@ -2187,9 +2187,7 @@ function files(p5, fn){
    *  @private
    */
   fn._isSafari = function () {
-    // Thanks to user Fregante on StackOverflow for the
-    // one-liner below (CC BY SA 3.0)
-    // https://stackoverflow.com/a/23522755
+    // The following line is CC BY SA 3 by user Fregante https://stackoverflow.com/a/23522755
     return /^((?!chrome|android).)*safari/i.test(navigator.userAgent);
   };
 

--- a/src/type/textCore.js
+++ b/src/type/textCore.js
@@ -1665,7 +1665,13 @@ function textCore(p5, fn) {
     if (typeof weight === 'number') {
       this.states.setValue('fontWeight', weight);
       this._applyTextProperties();
-      this._setCanvasStyleProperty('font-variation-settings', `"wght" ${weight}`);
+
+      // Safari works without weight set in the canvas style attribute, and actually
+      // has buggy behavior if it is present, using the wrong weight when drawing
+      // multiple times with different weights
+      if (!p5.prototype._isSafari()) {
+        this._setCanvasStyleProperty('font-variation-settings', `"wght" ${weight}`);
+      }
       return;
     }
     // the getter


### PR DESCRIPTION
<!--
  Thank you for contributing! Please use this pull request (PR) template.


 In the description field of this PR, include "resolves #XXXX" tagging the issue you are fixing. If this PR addresses the issue but doesn't completely resolve it (ie the issue should remain open after your PR is merged), write "addresses #XXXX".-->
Resolves #7736

### Changes
- No longer sets `canvas.style.fontVariationSettings` with the font weight in Safari, as it seems to cache this value incorrectly when setting and resetting this value multiple times per frame
- Updates the `isSafari` check because the old one was returning false on modern Safari


### Screenshots of the change

This is what this sketch https://editor.p5js.org/davepagurek/sketches/iHyp1r92r looks like in Safari now for me, matching Chrome/Firefox:
https://github.com/user-attachments/assets/b40f2f4c-445e-4c0b-bbc0-16125fd70ed4



#### PR Checklist
<!--
  To check any option, replace the "[ ]" with a "[x]". Be sure to check out how it looks in the Preview tab! Feel free to remove any portion of the template that is not relevant for your issue.
-->

- [x] `npm run lint` passes
- [ ] [Inline reference] is included / updated
- [ ] [Unit tests] are included / updated

[Inline reference]: https://p5js.org/contribute/contributing_to_the_p5js_reference/
[Unit tests]: https://github.com/processing/p5.js/tree/main/contributor_docs#unit-tests
