### PR TITLE
Fix spline() with z values + initial beginShape colors not updating

### DIFF
--- a/src/core/p5.Renderer.js
+++ b/src/core/p5.Renderer.js
@@ -184,6 +184,7 @@ class Renderer {
 
   beginShape(...args) {
     this.currentShape.reset();
+    this.updateShapeVertexProperties();
     this.currentShape.beginShape(...args);
   }
 
@@ -224,13 +225,24 @@ class Renderer {
     return this;
   }
 
-  spline(x1, y1, x2, y2, x3, y3, x4, y4) {
-    this._pInst.beginShape();
-    this._pInst.splineVertex(x1, y1);
-    this._pInst.splineVertex(x2, y2);
-    this._pInst.splineVertex(x3, y3);
-    this._pInst.splineVertex(x4, y4);
-    this._pInst.endShape();
+  spline(...args) {
+    if (args.length === 2 * 4) {
+      const [x1, y1, x2, y2, x3, y3, x4, y4] = args;
+      this._pInst.beginShape();
+      this._pInst.splineVertex(x1, y1);
+      this._pInst.splineVertex(x2, y2);
+      this._pInst.splineVertex(x3, y3);
+      this._pInst.splineVertex(x4, y4);
+      this._pInst.endShape();
+    } else if (args.length === 3 * 4) {
+      const [x1, y1, z1, x2, y2, z2, x3, y3, z3, x4, y4, z4] = args;
+      this._pInst.beginShape();
+      this._pInst.splineVertex(x1, y1, z1);
+      this._pInst.splineVertex(x2, y2, z2);
+      this._pInst.splineVertex(x3, y3, z3);
+      this._pInst.splineVertex(x4, y4, z4);
+      this._pInst.endShape();
+    }
     return this;
   }
 

--- a/src/webgl/material.js
+++ b/src/webgl/material.js
@@ -3117,7 +3117,9 @@ function material(p5, fn){
     this._renderer.states.setValue('curAmbientColor', color._array);
     this._renderer.states.setValue('_useNormalMaterial', false);
     this._renderer.states.setValue('enableLighting', true);
-    this._renderer.states.setValue('fillColor', true);
+    if (!this._renderer.states.fillColor) {
+      this._renderer.states.setValue('fillColor', new Color([1, 1, 1]));
+    }
     return this;
   };
 

--- a/src/webgl/p5.RendererGL.js
+++ b/src/webgl/p5.RendererGL.js
@@ -1174,7 +1174,6 @@ class RendererGL extends Renderer {
   }
 
   getCommonVertexProperties() {
-    if (!this.states) debugger;
     return {
       ...super.getCommonVertexProperties(),
       stroke: this.states.strokeColor,


### PR DESCRIPTION
- spline() wasn't handling the WEBGL case with z coordinates
- `beginShape()` also resets colors, so colors set before `beginShape` weren't applying
- Fixes a bug where the fill color is getting set to `true` instead of a real color