### PR TITLE
fix: add splineVertex to p5.Graphics prototype and fix unit test error

### DIFF
--- a/src/core/p5.Graphics.js
+++ b/src/core/p5.Graphics.js
@@ -23,6 +23,7 @@ import material from '../webgl/material';
 import creatingReading from '../color/creating_reading';
 import trigonometry from '../math/trigonometry';
 import { renderers } from './rendering';
+import customShapes from '../shape/custom_shapes';
 
 class Graphics {
   constructor(w, h, renderer, pInst, canvas) {
@@ -677,6 +678,7 @@ function graphics(p5, fn){
   attributes(p5, p5.Graphics.prototype);
   curves(p5, p5.Graphics.prototype);
   vertex(p5, p5.Graphics.prototype);
+  customShapes(p5, p5.Graphics.prototype);
 
   setting(p5, p5.Graphics.prototype);
   loadingDisplaying(p5, p5.Graphics.prototype);

--- a/test/unit/core/p5.Graphics.js
+++ b/test/unit/core/p5.Graphics.js
@@ -117,6 +117,14 @@ suite('Graphics', function() {
     });
   });
 
+  suite('p5.Graphics.prototype.splineVertex', function() {
+    test('should be a function in graphics', function() {
+      let g = myp5.createGraphics(10, 10);
+      assert.ok(g.splineVertex);
+      assert.typeOf(g.splineVertex, 'function');
+    });
+  });
+  
   suite('p5.Graphics.resizeCanvas', function() {
     let glStub;
 


### PR DESCRIPTION
<!--
  Thank you for contributing! Please use this pull request (PR) template.


 In the description field of this PR, include "resolves #XXXX" tagging the issue you are fixing. If this PR addresses the issue but doesn't completely resolve it (ie the issue should remain open after your PR is merged), write "addresses #XXXX".-->
Resolves #7755

<!-- Add here what changes were made in this pull request and if possible provide links showcasing the changes. -->
This pull request introduces a fix to the p5.Graphics prototype by adding the splineVertex method, which allows for more flexible spline drawing in the graphics context. Additionally, the corresponding unit test has been updated to reflect this change, addressing a previously encountered error in the test suite.

Changes:

- Added splineVertex method to p5.Graphics prototype.

- Fixed unit test error related to the splineVertex method.
- testing using this 
```
suite('p5.Graphics.prototype.splineVertex', function() {
    test('should be a function in graphics', function() {
      let g = myp5.createGraphics(10, 10);
      assert.ok(g.splineVertex);
      assert.typeOf(g.splineVertex, 'function');
    });
  });
```
<!-- If applicable, add screenshots depicting the changes. -->

#### PR Checklist
<!--
  To check any option, replace the "[ ]" with a "[x]". Be sure to check out how it looks in the Preview tab! Feel free to remove any portion of the template that is not relevant for your issue.
-->

- [ ] `npm run lint` passes
- [ ] [Inline reference] is included / updated
- [ ] [Unit tests] are included / updated

[Inline reference]: https://p5js.org/contribute/contributing_to_the_p5js_reference/
[Unit tests]: https://github.com/processing/p5.js/tree/main/contributor_docs#unit-tests
