### PR TITLE
fixing keyReleased() function. 

### DIFF
--- a/src/events/keyboard.js
+++ b/src/events/keyboard.js
@@ -636,6 +636,15 @@ function keyboard(p5, fn){
    * </div>
    */
   fn._onkeyup = function(e) {
+
+    const context = this._isGlobal ? window : this;
+    if (typeof context.keyReleased === 'function') {
+      const executeDefault = context.keyReleased(e);
+      if (executeDefault === false) {
+        e.preventDefault();
+      }
+    }
+    
     delete this._downKeyCodes[e.code];
     delete this._downKeys[e.key];
 
@@ -652,14 +661,8 @@ function keyboard(p5, fn){
       this.key = lastPressedKey;
     }
 
-    const context = this._isGlobal ? window : this;
-    if (typeof context.keyReleased === 'function') {
-      const executeDefault = context.keyReleased(e);
-      if (executeDefault === false) {
-        e.preventDefault();
-      }
-    }
   };
+
 
   /**
    * A function that's called once when keys with printable characters are pressed.


### PR DESCRIPTION
Fixes : #7759 

**_PROBLEM:_**
Inside our custom _onkeyup handler we cleared `this.key` (and other state) before calling the user‑defined `keyReleased()` callback. By the time the sketch’s `keyReleased()` ran, key had already been wiped, so console.log(key) showed an empty string.

**_SOLUTION:_**

Move the user‑callback block to the very top so it doesn’t touch key until the sketch has read it, letting sketches read the correct key.
