### PR TITLE
[2.0] Fix touch event not updating mouse coordinates

### DIFF
--- a/src/events/pointer.js
+++ b/src/events/pointer.js
@@ -912,25 +912,25 @@ function pointer(p5, fn){
 
   fn._updatePointerCoords = function (e) {
     if (this._curElement !== null) {
-       const canvas = this._curElement.elt;
-       const sx = canvas.scrollWidth / this.width || 1;
-       const sy = canvas.scrollHeight / this.height || 1;
+      const canvas = this._curElement.elt;
+      const sx = canvas.scrollWidth / this.width || 1;
+      const sy = canvas.scrollHeight / this.height || 1;
 
-       if (e.pointerType == 'touch') {
+      if (e.pointerType == 'touch') {
           const touches = [];
           for (const touch of this._activePointers.values()) {
-             touches.push(getTouchInfo(canvas, sx, sy, touch));
+            touches.push(getTouchInfo(canvas, sx, sy, touch));
           }
           this.touches = touches;
-       } else {
-          const mousePos = getMouseInfo(canvas, sx, sy, e);
-          this.movedX = e.movementX || 0;
-          this.movedY = e.movementY || 0;
-          this.mouseX = mousePos.x;
-          this.mouseY = mousePos.y;
-          this.winMouseX = mousePos.winX;
-          this.winMouseY = mousePos.winY;
-       }
+      } 
+
+      const mousePos = getMouseInfo(canvas, sx, sy, e);
+      this.movedX = e.movementX || 0;
+      this.movedY = e.movementY || 0;
+      this.mouseX = mousePos.x;
+      this.mouseY = mousePos.y;
+      this.winMouseX = mousePos.winX;
+      this.winMouseY = mousePos.winY;
 
        if (!this._hasMouseInteracted) {
           this._updateMouseCoords();


### PR DESCRIPTION
<!--
  Thank you for contributing! Please use this pull request (PR) template.


 In the description field of this PR, include "resolves #XXXX" tagging the issue you are fixing. If this PR addresses the issue but doesn't completely resolve it (ie the issue should remain open after your PR is merged), write "addresses #XXXX".-->
Resolves #7760

 Changes:
<!-- Add here what changes were made in this pull request and if possible provide links showcasing the changes. -->
Move mouse coordinate updates out of conditionals which fixes the linked issue. 

The unit test can potentially be reenabled for mouse events but there are a few tests not passing with the current implementation that I still need to check. Specifically `pmouseX/Y` test for touch is failing although in example sketch it seems to be working as intended.