### PR TITLE
"Fix typo in directionalLight reference (main branch)" - #7743

### DIFF
--- a/src/webgl/light.js
+++ b/src/webgl/light.js
@@ -482,7 +482,7 @@ p5.prototype.specularColor = function (v1, v2, v3) {
  * three parameters, `v1`, `v2`, and `v3`, set the light’s color using the
  * current <a href="#/p5/colorMode">colorMode()</a>. The last parameter,
  * `direction` sets the light’s direction using a
- * <a href="#/p5.Geometry">p5.Geometry</a> object. For example,
+ *  <a href="#/p5.Vector">p5.Vector</a> object. For example,
  * `directionalLight(255, 0, 0, lightDir)` creates a red `(255, 0, 0)` light
  * that shines in the direction the `lightDir` vector points.
  *


### PR DESCRIPTION
## Title
Fix incorrect reference to `p5.Geometry` in `directionalLight()` documentation

## Description
This PR corrects a typo in the documentation comment for the `directionalLight()` function.

- **Before**: `direction` sets the light’s direction using a `p5.Geometry` object.
- **After**: `direction` sets the light’s direction using a `p5.Vector` object.

Since `p5.Vector` is the correct type used for directional light direction, this change improves the accuracy and clarity of the reference documentation in version 1.11.