### PR TITLE
Add "init" lifecycle hook

### DIFF
--- a/src/core/main.js
+++ b/src/core/main.js
@@ -139,7 +139,7 @@ class p5 {
         bindGlobal(p);
       }
 
-      this._runLifecycleHook('init');
+      this._runLifecycleHookSync('init');
 
       const protectedProperties = ['constructor', 'length'];
       // Attach its properties to the window
@@ -425,8 +425,14 @@ class p5 {
   }
 
   async _runLifecycleHook(hookName) {
-    for(const hook of p5.lifecycleHooks[hookName]){
+    for (const hook of p5.lifecycleHooks[hookName]) {
       await hook.call(this);
+    }
+  }
+
+  _runLifecycleHookSync(hookName) {
+    for (const hook of p5.lifecycleHooks[hookName]) {
+      hook.call(this);
     }
   }
 

--- a/src/core/main.js
+++ b/src/core/main.js
@@ -36,6 +36,7 @@ class p5 {
   // global mode.
   static instance = null;
   static lifecycleHooks = {
+    init: [],
     presetup: [],
     postsetup: [],
     predraw: [],
@@ -137,6 +138,8 @@ class p5 {
         if(p[0] === '_') continue;
         bindGlobal(p);
       }
+
+      this._runLifecycleHook('init');
 
       const protectedProperties = ['constructor', 'length'];
       // Attach its properties to the window


### PR DESCRIPTION
Added two lines of code that implement the "init" lifecycle hook in p5 v2.

This is needed for preload system compatibility. Issue #7742 can't be fixed by moving the current "presetup" hook.