### PR TITLE
Match the Text Wrapping Behavior to p5.js Documentation

### DIFF
--- a/src/typography/loading_displaying.js
+++ b/src/typography/loading_displaying.js
@@ -180,8 +180,29 @@ p5.prototype.loadFont = function(path, onSuccess, onError) {
 };
 
 /**
- * Draws text to the canvas.
+ * Specifies how text should wrap when displayed inside a text box using the text() function.
+ * 
+ * When you use text() with width and height parameters, the text will wrap automatically.
+ * By default, p5.js wraps text based on whole words — it moves entire words to the next line
+ * when they don’t fit in the given width.
+ * 
+ * If your text contains very long words or no spaces (like long URLs or technical terms),
+ * and you want it to wrap at the character level instead, use textWrap(CHAR).
+ * 
+ * You can switch between word-based or character-based wrapping by passing either WORD or CHAR.
+ * 
+ * @method textWrap
+ * @param {Constant} mode either WORD or CHAR
  *
+ * @example 
+ * textWrap(CHAR);
+ * text("TheQuickBrownFoxJumpsOverTheLazyDogWithoutAnySpaces", 10, 30, 150, 100);
+ *
+ * @example 
+ * textWrap(WORD);
+ * text("This is a sentence that wraps based on word boundaries.", 10, 30, 150, 100);
+ */
+ /** 
  * The first parameter, `str`, is the text to be drawn. The second and third
  * parameters, `x` and `y`, set the coordinates of the text's bottom-left
  * corner. See <a href="#/p5/textAlign">textAlign()</a> for other ways to


### PR DESCRIPTION
<!--
  Thank you for contributing! Please use this pull request (PR) template.


 In the description field of this PR, include "resolves #XXXX" tagging the issue you are fixing. If this PR addresses the issue but doesn't completely resolve it (ie the issue should remain open after your PR is merged), write "addresses #XXXX".-->
Resolves #7163 

 Changes:

1. Added documentation for the `textWrap()` function in `src/typography/loading_displaying.js`.
 
3. Included examples showing how to use `textWrap(CHAR)` and `textWrap(WORD)`.
 

 <!--Screenshots of the change:
 If applicable, add screenshots depicting the changes. -->

#### PR Checklist
<!--
  To check any option, replace the "[ ]" with a "[x]". Be sure to check out how it looks in the Preview tab! Feel free to remove any portion of the template that is not relevant for your issue.
-->

- [ ] `npm run lint` passes
- [ ] [Inline reference] is included / updated
- [ ] [Unit tests] are included / updated

[Inline reference]: https://p5js.org/contribute/contributing_to_the_p5js_reference/
[Unit tests]: https://github.com/processing/p5.js/tree/main/contributor_docs#unit-tests
