### PR TITLE
Fix duplicate p5.js init by checking window.p5 and skipping if alread…

### DIFF
--- a/src/core/init.js
+++ b/src/core/init.js
@@ -16,7 +16,7 @@ export const _globalInit = () => {
   // Could have been any property defined within the p5 constructor.
   // If that property is already a part of the global object,
   // this code has already run before, likely due to a duplicate import
-  if (typeof window._setupDone !== 'undefined') {
+  if (typeof window.p5 !== 'undefined') {
     console.warn(
       'p5.js seems to have been imported multiple times. Please remove the duplicate import'
     );

--- a/src/core/main.js
+++ b/src/core/main.js
@@ -125,7 +125,12 @@ class p5 {
     // If the user has created a global setup or draw function,
     // assume "global" mode and make everything global (i.e. on the window)
     if (!sketch) {
+      if (window.p5 instanceof p5) {
+        console.warn('p5.js appears to have been imported multiple times. This could cause errors.');
+        return;
+      }
       this._isGlobal = true;
+      window.p5 = this;
       if (window.hitCriticalError) {
         return;
       }

--- a/src/core/main.js
+++ b/src/core/main.js
@@ -135,6 +135,7 @@ class p5 {
         return;
       }
       p5.instance = this;
+      window.p5 = p5;
 
       // Loop through methods on the prototype and attach them to the window
       // All methods and properties with name starting with '_' will be skipped

--- a/src/core/main.js
+++ b/src/core/main.js
@@ -125,12 +125,12 @@ class p5 {
     // If the user has created a global setup or draw function,
     // assume "global" mode and make everything global (i.e. on the window)
     if (!sketch) {
-      if (window.p5 instanceof p5) {
+      if (typeof window.p5 !== 'undefined') {
         console.warn('p5.js appears to have been imported multiple times. This could cause errors.');
         return;
       }
       this._isGlobal = true;
-      window.p5 = this;
+      window._p5Instance = this;
       if (window.hitCriticalError) {
         return;
       }


### PR DESCRIPTION
…y loaded

<!--
  Thank you for contributing! Please use this pull request (PR) template.


 In the description field of this PR, include "resolves #XXXX" tagging the issue you are fixing. If this PR addresses the issue but doesn't completely resolve it (ie the issue should remain open after your PR is merged), write "addresses #XXXX".-->
Resolves #7687

 Changes:
<!-- Add here what changes were made in this pull request and if possible provide links showcasing the changes. -->
- Add check for `window.p5 instanceof p5` before global binding  
- Skip initialization and warn if p5.js was already loaded  
- Avoids errors from `Object.defineProperty` redefinition  
- Fixes issue where multiple p5.js imports cause failures  

 Screenshots of the change:
<!-- If applicable, add screenshots depicting the changes. -->

#### PR Checklist
<!--
  To check any option, replace the "[ ]" with a "[x]". Be sure to check out how it looks in the Preview tab! Feel free to remove any portion of the template that is not relevant for your issue.
-->

- [x ] `npm run lint` passes
- [ ] [Inline reference] is included / updated
- [ ] [Unit tests] are included / updated

[Inline reference]: https://p5js.org/contribute/contributing_to_the_p5js_reference/
[Unit tests]: https://github.com/processing/p5.js/tree/main/contributor_docs#unit-tests
