### PR TITLE
Consistent `movedX` and `movedY` behaviour across zoom levels

### DIFF
--- a/src/events/mouse.js
+++ b/src/events/mouse.js
@@ -819,8 +819,6 @@ p5.prototype.mouseIsPressed = false;
 
 p5.prototype._updateNextMouseCoords = function(e) {
   if (this._curElement !== null && (!e.touches || e.touches.length > 0)) {
-    this._updateMouseCoords();
-
     const mousePos = getMousePos(
       this._curElement.elt,
       this.width,

--- a/src/events/mouse.js
+++ b/src/events/mouse.js
@@ -819,21 +819,27 @@ p5.prototype.mouseIsPressed = false;
 
 p5.prototype._updateNextMouseCoords = function(e) {
   if (this._curElement !== null && (!e.touches || e.touches.length > 0)) {
+    this._updateMouseCoords();
+
     const mousePos = getMousePos(
       this._curElement.elt,
       this.width,
       this.height,
       e
     );
-    this._setProperty('movedX', e.movementX);
-    this._setProperty('movedY', e.movementY);
+
     this._setProperty('mouseX', mousePos.x);
     this._setProperty('mouseY', mousePos.y);
     this._setProperty('winMouseX', mousePos.winX);
     this._setProperty('winMouseY', mousePos.winY);
+
+    const deltaX = this.mouseX - this.pmouseX;
+    const deltaY = this.mouseY - this.pmouseY;
+    this._setProperty('movedX', deltaX);
+    this._setProperty('movedY', deltaY);
   }
+
   if (!this._hasMouseInteracted) {
-    // For first draw, make previous and next equal
     this._updateMouseCoords();
     this._setProperty('_hasMouseInteracted', true);
   }


### PR DESCRIPTION
Resolves #7790 

### Approach Used:
- `_updateMouseCoords()` is called at the beginning of the existing function to store the previous frame’s positions.
- After computing the new `mouseX`, `mouseY`, the `movedX` and `movedY` values are derived in terms of `deltaX` and `deltaY` using `pmouseX` and `pmouseY` values and the current values of X and Y.

### Alternative Approach:
Instead of calling `_updateMouseCoords()` at the beginning , we could use variables to store previous values which could then be used to find delta.

```js
// Store previous mouseX and mouseY for calculating movedX/Y
    const prevMouseX = this.mouseX;
    const prevMouseY = this.mouseY;

// Calculate movedX/Y based on delta between current and previous positions
    const deltaX = mousePos.x - prevMouseX;
    const deltaY = mousePos.y - prevMouseY;

```

But, In my opinion there is no point in using extra variable to track the previous values. So, to avoid this manual tracking and leveraging the existing function, used the approach given earlier.

### Observations:
_**Previously, the behaviour was:**_

[Screencast from 07-05-25 12:12:39 AM IST.webm](https://github.com/user-attachments/assets/cccdb2bf-9a9f-422e-9e64-ab26cf55de4a)

**_Now, after fixing,_**

[Screencast from 07-05-25 12:08:48 AM IST.webm](https://github.com/user-attachments/assets/ace08fb4-db1b-415e-b3b3-83f96fc2661c)

### Browser Tested:
- Chrome
- Firefox

- [x] `npm run lint` passes

