### PR TITLE
Fix FES check for image() not accepting some valid types

### DIFF
--- a/docs/parameterData.json
+++ b/docs/parameterData.json
@@ -934,7 +934,7 @@
     "image": {
       "overloads": [
         [
-          "p5.Image|p5.Element|p5.Texture|p5.Framebuffer|p5.FramebufferTexture",
+          "p5.Image|p5.Element|p5.Texture|p5.Framebuffer|p5.FramebufferTexture|p5.Renderer|p5.Graphics",
           "Number",
           "Number",
           "Number?",
@@ -1431,13 +1431,6 @@
         ]
       ]
     },
-    "createMatrix": {
-      "overloads": [
-        [
-          "Number[]"
-        ]
-      ]
-    },
     "noise": {
       "overloads": [
         [
@@ -1856,14 +1849,23 @@
     },
     "bezierOrder": {
       "overloads": [
-        [],
         [
           "Number"
-        ]
+        ],
+        []
       ]
     },
     "splineVertex": {
       "overloads": [
+        [
+          "Number",
+          "Number"
+        ],
+        [
+          "Number",
+          "Number",
+          "Number?"
+        ],
         [
           "Number",
           "Number",
@@ -1882,20 +1884,20 @@
     "splineProperty": {
       "overloads": [
         [
-          "String"
-        ],
-        [
           "String",
           null
+        ],
+        [
+          "String"
         ]
       ]
     },
     "splineProperties": {
       "overloads": [
-        [],
         [
           "Object"
-        ]
+        ],
+        []
       ]
     },
     "vertex": {
@@ -1951,19 +1953,6 @@
           "Number",
           "Number",
           "Number?",
-          "Number?"
-        ]
-      ]
-    },
-    "curveVertex": {
-      "overloads": [
-        [
-          "Number",
-          "Number"
-        ],
-        [
-          "Number",
-          "Number",
           "Number?"
         ]
       ]
@@ -2753,36 +2742,6 @@
           "Boolean?",
           "Boolean?"
         ]
-      ]
-    },
-    "parseObj": {
-      "overloads": [
-        []
-      ]
-    },
-    "parseSTL": {
-      "overloads": [
-        []
-      ]
-    },
-    "isBinary": {
-      "overloads": [
-        []
-      ]
-    },
-    "matchDataViewAt": {
-      "overloads": [
-        []
-      ]
-    },
-    "parseBinarySTL": {
-      "overloads": [
-        []
-      ]
-    },
-    "parseASCIISTL": {
-      "overloads": [
-        []
       ]
     },
     "model": {

--- a/src/image/loading_displaying.js
+++ b/src/image/loading_displaying.js
@@ -903,7 +903,7 @@ function loadingDisplaying(p5, fn){
    * are set to `CENTER`.
    *
    * @method image
-   * @param  {p5.Image|p5.Element|p5.Texture|p5.Framebuffer|p5.FramebufferTexture} img image to display.
+   * @param  {p5.Image|p5.Element|p5.Texture|p5.Framebuffer|p5.FramebufferTexture|p5.Renderer|p5.Graphics} img image to display.
    * @param  {Number}   x x-coordinate of the top-left corner of the image.
    * @param  {Number}   y y-coordinate of the top-left corner of the image.
    * @param  {Number}   [width]  width to draw the image.

--- a/test/unit/core/param_errors.js
+++ b/test/unit/core/param_errors.js
@@ -22,6 +22,12 @@ suite('Validate Params', function () {
     FramebufferTexture: function() {
       return 'mock p5.FramebufferTexture';
     },
+    Renderer: function() {
+      return 'mock p5.Renderer';
+    },
+    Graphics: function() {
+      return 'mock p5.Graphics';
+    },
     _error: () => {},
   };
   const mockP5Prototype = {};
@@ -124,7 +130,7 @@ suite('Validate Params', function () {
       console.log(result);
       assert.equal(
         result.error,
-        '🌸 p5.js says: Did you mean to put `await` before a loading function? An unexpected Promise was found. Expected Image or Element or Texture or Framebuffer or FramebufferTexture at the first parameter in p5.image().'
+        '🌸 p5.js says: Did you mean to put `await` before a loading function? An unexpected Promise was found. Expected Image or Element or Texture or Framebuffer or FramebufferTexture or Renderer or Graphics at the first parameter in p5.image().'
       );
     });
   });


### PR DESCRIPTION
<!--
  Thank you for contributing! Please use this pull request (PR) template.


 In the description field of this PR, include "resolves #XXXX" tagging the issue you are fixing. If this PR addresses the issue but doesn't completely resolve it (ie the issue should remain open after your PR is merged), write "addresses #XXXX".-->
Resolves #7579

 Changes:
<!-- Add here what changes were made in this pull request and if possible provide links showcasing the changes. -->
Add `p5.Renderer` and `p5.Graphics` to acceptable types to argument of `image()`, they are the return types of `createCanvas()` and `createGraphics()` respectively.

