### PR TITLE
Remove dayjs dependency and update date formatting in banner

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -35,7 +35,6 @@
         "@vitest/browser": "^2.1.5",
         "all-contributors-cli": "^6.19.0",
         "concurrently": "^8.2.2",
-        "dayjs": "^1.11.10",
         "documentation": "^14.0.3",
         "eslint": "^8.54.0",
         "glob": "^11.0.1",
@@ -3796,13 +3795,6 @@
         "type": "opencollective",
         "url": "https://opencollective.com/date-fns"
       }
-    },
-    "node_modules/dayjs": {
-      "version": "1.11.13",
-      "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.11.13.tgz",
-      "integrity": "sha512-oaMBel6gjolK862uaPQOVTA7q3TZhuSvuMQAAglQDOWYO9A91IrAOUJEyKVlqJlHE0vq5p5UXxzdPfMH/x6xNg==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/de-indent": {
       "version": "1.0.2",

--- a/package.json
+++ b/package.json
@@ -51,7 +51,6 @@
     "@vitest/browser": "^2.1.5",
     "all-contributors-cli": "^6.19.0",
     "concurrently": "^8.2.2",
-    "dayjs": "^1.11.10",
     "documentation": "^14.0.3",
     "eslint": "^8.54.0",
     "glob": "^11.0.1",

--- a/rollup.config.mjs
+++ b/rollup.config.mjs
@@ -4,7 +4,6 @@ import { string } from 'rollup-plugin-string';
 import commonjs from '@rollup/plugin-commonjs';
 import terser from '@rollup/plugin-terser';
 import pkg from './package.json' with { type: 'json' };
-import dayjs from 'dayjs';
 import { visualizer } from 'rollup-plugin-visualizer';
 import replace from '@rollup/plugin-replace';
 import alias from '@rollup/plugin-alias';
@@ -27,7 +26,7 @@ const plugins = [
     preventAssignment: true
   })
 ];
-const banner = `/*! p5.js v${pkg.version} ${dayjs().format('MMMM D, YYYY')} */`;
+const banner = `/*! p5.js v${pkg.version} ${new Intl.DateTimeFormat('en-US', { month: 'long', day: 'numeric', year: 'numeric' }).format(new Date())} */`;
 const bundleSize = (name, sourcemap) => {
   return visualizer({
     filename: `analyzer/${name}.html`,
@@ -80,7 +79,7 @@ const generateModuleBuild = () => {
       plugins: [
         ...plugins
       ]
-    }
+    };
   });
 };
 


### PR DESCRIPTION
adresses #7761 

 Changes:
Replaced `dayjs` with built-in `Intl.DateTimeFormat`

- [x] `npm run lint` passes