### PR TITLE
Fix: keyTyped() can now accept the same char consecutively

### DIFF
--- a/src/events/keyboard.js
+++ b/src/events/keyboard.js
@@ -441,11 +441,13 @@ p5.prototype.keyCode = 0;
  * </div>
  */
 p5.prototype._onkeydown = function(e) {
+  // Ignore repeated key events when holding down a key
   if (e.repeat) {
-    // Ignore repeated key events when holding down a key
+    this._setProperty('isKeyRepeated', true);
     return;
   }
 
+  this._setProperty('isKeyRepeated', false);
   this._setProperty('isKeyPressed', true);
   this._setProperty('keyIsPressed', true);
   this._setProperty('keyCode', e.which);
@@ -781,7 +783,7 @@ p5.prototype._onkeyup = function(e) {
  * </div>
  */
 p5.prototype._onkeypress = function(e) {
-  if (e.which === this._lastKeyCodeTyped) {
+  if (e.which === this._lastKeyCodeTyped && this.isKeyRepeated) {
     // prevent multiple firings
     return;
   }


### PR DESCRIPTION

Resolves #7805

 Changes:
 instead of completely ignore the key when it equals to the previous key, ensure first it's repeated (holding down) then you can ignore it.
 ```javascript
if (e.which === this._lastKeyCodeTyped && this.isKeyRepeated) {
    // prevent multiple firings
    return;
  }
  ```
why not just using `e.repeat` instead of setting `isKeyRepeated` property?
because the `repeat` property in the `keypress` event always equals to false.



#### PR Checklist
<!--
  To check any option, replace the "[ ]" with a "[x]". Be sure to check out how it looks in the Preview tab! Feel free to remove any portion of the template that is not relevant for your issue.
-->

- [x] `npm run lint` passes
- [x] `npm test` passed
- [ ] [Unit tests] are included / updated

