### PR TITLE
Prevent FES from checking nested properties

### DIFF
--- a/docs/parameterData.json
+++ b/docs/parameterData.json
@@ -1991,7 +1991,6 @@
           "String",
           "String?",
           "Object?",
-          "String|String[]?",
           "Function?",
           "Function?"
         ],
@@ -2734,13 +2733,7 @@
         ],
         [
           "String|Request",
-          "Object?",
-          "String?",
-          "function(p5.Geometry)?",
-          "function(Event)?",
-          "Boolean?",
-          "Boolean?",
-          "Boolean?"
+          "Object?"
         ]
       ]
     },
@@ -2769,12 +2762,7 @@
         [
           "String",
           "String?",
-          "Object?",
-          "function(p5.Geometry)?",
-          "function(Event)?",
-          "boolean?",
-          "boolean?",
-          "boolean?"
+          "Object?"
         ]
       ]
     },
@@ -4474,9 +4462,7 @@
           "Number",
           "Number",
           "Number",
-          "Object?",
-          "Number?",
-          "Number?"
+          "Object?"
         ]
       ]
     }

--- a/utils/convert.mjs
+++ b/utils/convert.mjs
@@ -231,23 +231,22 @@ function getParams(entry) {
   // instead convert it to a string. We want a slightly different conversion to
   // string, so we match these params to the Documentation.js-provided `params`
   // array and grab the description from those.
-  return (entry.tags || []).filter(t => t.title === 'param').map(node => {
-    const param = entry.params.find(param => param.name === node.name);
-    if (param) {
+  return (entry.tags || [])
+  
+    // Filter out the nested parameters (eg. options.extrude),
+    // to be treated as part of parent parameters (eg. options)
+    // and not separate entries
+    .filter(t => t.title === 'param' && !t.name.includes('.')) 
+    .map(node => {
+      const param = (entry.params || []).find(param => param.name === node.name);
       return {
         ...node,
-        description: param.description
-      };
-    } else {
-      return {
-        ...node,
-        description: {
+        description: param?.description || {
           type: 'html',
           value: node.description
         }
       };
-    }
-  });
+    });
 }
 
 // ============================================================================


### PR DESCRIPTION
Addresses #7752

#### Approach:
1. Filtering out the nested properties of a parameter, which to be treated as a part of parameter and not separate positional parameters by  using the `.includes()` string method. If the parameter name contains a (`.`) (like `options.extrude`), we assume it’s nested, so skip it.
2. Keep the top-level parameters by including only those where `t.name` does not include a dot (`.`). Eg.`options` will be included, but `options.extrude` will be ignored. 
  
#### Additional Issues Fix/ Changes Made:
1. The `entry.params` is checked with fallback now to prevent run time errors to throw in case of missing (i.e., `undefined`)
2. The `if-else` block is reduced to avoid redundancy.

#### Observations/ Results

Consider the list of `params` as below:
```js
/**
   * @method createModel
   * @param  {String} modelString
   * @param  {String} [fileType]
   * @param  {Object} [options]
   * @param  {function(p5.Geometry)} [options.successCallback]
   * @param  {function(Event)} [options.failureCallback]
   * @param  {boolean} [options.normalize]
   * @param  {boolean} [options.flipU]
   * @param  {boolean} [options.flipV]
   * @return {p5.Geometry} the <a href="#/p5.Geometry">p5.Geometry</a> object
   */
```
**_Before with the existing code_**,
```json
"createModel": {
      "overloads": [
          "String",
          "String?",
          "Object?",
          "function(p5.Geometry)?",
          "function(Event)?",
          "boolean?",
          "boolean?",
          "boolean?"
      ]
    }
```
**_After modifications, it will get documented as:_**
```json
"createModel": {
      "overloads": [
          "String",
          "String?",
          "Object?"
      ]
    }
```