### PR TITLE
Create Graphics fixing in dev-2.0 branch.   

### DIFF
--- a/lib/empty-example/index.html
+++ b/lib/empty-example/index.html
@@ -12,7 +12,7 @@
       background-color: #1b1b1b;
     }
   </style>
-  <script src="../p5.rollup.min.js"></script>
+  <script src="../p5.min.js"></script>
   <!-- <script src="../addons/p5.sound.js"></script> -->
   <script src="sketch.js"></script>
 </head>

--- a/src/core/p5.Graphics.js
+++ b/src/core/p5.Graphics.js
@@ -30,7 +30,7 @@ class Graphics {
     const r = renderer || constants.P2D;
 
     this._pInst = pInst;
-    this._renderer = new renderers[r](this._pInst, w, h, false, canvas);
+    this._renderer = new renderers[r](this, w, h, false, canvas);
 
     this._initializeInstanceVariables(this);
 
@@ -696,3 +696,6 @@ function graphics(p5, fn){
 
 export default graphics;
 export { Graphics };
+if (typeof p5 !== 'undefined') {
+  graphics(p5, p5.prototype);
+}

--- a/src/core/p5.Renderer2D.js
+++ b/src/core/p5.Renderer2D.js
@@ -179,8 +179,8 @@ class Renderer2D extends Renderer {
       const color = this._pInst.color(...args);
 
       //accessible Outputs
-      if (this._pInst._addAccsOutput()) {
-        this._pInst._accsBackground(color._getRGBA([255, 255, 255, 255]));
+      if (this._pInst._addAccsOutput?.()) {
+        this._pInst._accsBackground?.(color._getRGBA([255, 255, 255, 255]));
       }
 
       const newFill = color.toString();
@@ -212,8 +212,8 @@ class Renderer2D extends Renderer {
     this._setFill(color.toString());
 
     //accessible Outputs
-    if (this._pInst._addAccsOutput()) {
-      this._pInst._accsCanvasColors('fill', color._getRGBA([255, 255, 255, 255]));
+    if (this._pInst._addAccsOutput?.()) {
+      this._pInst._accsCanvasColors?.('fill', color._getRGBA([255, 255, 255, 255]));
     }
   }
 
@@ -223,8 +223,8 @@ class Renderer2D extends Renderer {
     this._setStroke(color.toString());
 
     //accessible Outputs
-    if (this._pInst._addAccsOutput()) {
-      this._pInst._accsCanvasColors('stroke', color._getRGBA([255, 255, 255, 255]));
+    if (this._pInst._addAccsOutput?.()) {
+      this._pInst._accsCanvasColors?.('stroke', color._getRGBA([255, 255, 255, 255]));
     }
   }
 


### PR DESCRIPTION
The renderer writes to `this._pInst.canvas`. With the old code `this._pInst` pointed at the main sketch, so Bézier drawing went to the main canvas. By passing the wrapper instead, `this._pInst.canvas` is the off-screen canvas, so every draw call `(including Bézier, spline, filters, …)` ends up in the right place.