### PR TITLE
Model params updated for YUIDocs

### DIFF
--- a/docs/parameterData.json
+++ b/docs/parameterData.json
@@ -2740,11 +2740,8 @@
     "model": {
       "overloads": [
         [
-          "p5.Geometry"
-        ],
-        [
           "p5.Geometry",
-          "Number"
+          "Number?"
         ]
       ]
     },

--- a/src/webgl/loading.js
+++ b/src/webgl/loading.js
@@ -987,7 +987,7 @@ function loading(p5, fn){
    * @method model
    * @param  {p5.Geometry} model 3D shape to be drawn.
    *
-   * @param {Number} count number of instances to draw.
+   * @param {Number} [count=1] number of instances to draw.
    * @example
    * <div>
    * <code>


### PR DESCRIPTION
Changes:
Amending #7832 to make the YUIDocs for `model()` count parameter optional.

#### PR Checklist

- [ ] `npm run lint` passes
- [ ] [Inline reference] is included / updated
- [ ] [Unit tests] are included / updated