### PR TITLE
More Structured format for parameters and Enhanced FES 

### DIFF
--- a/docs/parameterData.json
+++ b/docs/parameterData.json
@@ -3,142 +3,414 @@
     "describe": {
       "overloads": [
         [
-          "String",
-          "FALLBACK|LABEL?"
+          {
+            "type": "String"
+          },
+          {
+            "type": "union",
+            "elements": [
+              {
+                "type": "FALLBACK",
+                "optional": true
+              },
+              {
+                "type": "LABEL",
+                "optional": true
+              }
+            ],
+            "optional": true
+          }
         ]
       ]
     },
     "describeElement": {
       "overloads": [
         [
-          "String",
-          "String",
-          "FALLBACK|LABEL?"
+          {
+            "type": "String"
+          },
+          {
+            "type": "String"
+          },
+          {
+            "type": "union",
+            "elements": [
+              {
+                "type": "FALLBACK",
+                "optional": true
+              },
+              {
+                "type": "LABEL",
+                "optional": true
+              }
+            ],
+            "optional": true
+          }
         ]
       ]
     },
     "textOutput": {
       "overloads": [
         [
-          "FALLBACK|LABEL?"
+          {
+            "type": "union",
+            "elements": [
+              {
+                "type": "FALLBACK",
+                "optional": true
+              },
+              {
+                "type": "LABEL",
+                "optional": true
+              }
+            ],
+            "optional": true
+          }
         ]
       ]
     },
     "gridOutput": {
       "overloads": [
         [
-          "FALLBACK|LABEL?"
+          {
+            "type": "union",
+            "elements": [
+              {
+                "type": "FALLBACK",
+                "optional": true
+              },
+              {
+                "type": "LABEL",
+                "optional": true
+              }
+            ],
+            "optional": true
+          }
         ]
       ]
     },
     "p5": {
       "overloads": [
         [
-          "Object",
-          "String|HTMLElement"
+          {
+            "type": "Object"
+          },
+          {
+            "type": "union",
+            "elements": [
+              {
+                "type": "String",
+                "optional": true
+              },
+              {
+                "type": "HTMLElement",
+                "optional": true
+              }
+            ]
+          }
         ]
       ]
     },
     "color": {
       "overloads": [
         [
-          "Number",
-          "Number?"
+          {
+            "type": "Number"
+          },
+          {
+            "type": "Number",
+            "optional": true
+          }
         ],
         [
-          "Number",
-          "Number",
-          "Number",
-          "Number?"
+          {
+            "type": "Number"
+          },
+          {
+            "type": "Number"
+          },
+          {
+            "type": "Number"
+          },
+          {
+            "type": "Number",
+            "optional": true
+          }
         ],
         [
-          "String"
+          {
+            "type": "String"
+          }
         ],
         [
-          "Number[]"
+          {
+            "type": "Array",
+            "element": "Number"
+          }
         ],
         [
-          "p5.Color"
+          {
+            "type": "p5.Color"
+          }
         ]
       ]
     },
     "red": {
       "overloads": [
         [
-          "p5.Color|Number[]|String"
+          {
+            "type": "union",
+            "elements": [
+              {
+                "type": "p5.Color",
+                "optional": true
+              },
+              {
+                "type": "Array",
+                "element": "Number",
+                "optional": true
+              },
+              {
+                "type": "String",
+                "optional": true
+              }
+            ]
+          }
         ]
       ]
     },
     "green": {
       "overloads": [
         [
-          "p5.Color|Number[]|String"
+          {
+            "type": "union",
+            "elements": [
+              {
+                "type": "p5.Color",
+                "optional": true
+              },
+              {
+                "type": "Array",
+                "element": "Number",
+                "optional": true
+              },
+              {
+                "type": "String",
+                "optional": true
+              }
+            ]
+          }
         ]
       ]
     },
     "blue": {
       "overloads": [
         [
-          "p5.Color|Number[]|String"
+          {
+            "type": "union",
+            "elements": [
+              {
+                "type": "p5.Color",
+                "optional": true
+              },
+              {
+                "type": "Array",
+                "element": "Number",
+                "optional": true
+              },
+              {
+                "type": "String",
+                "optional": true
+              }
+            ]
+          }
         ]
       ]
     },
     "alpha": {
       "overloads": [
         [
-          "p5.Color|Number[]|String"
+          {
+            "type": "union",
+            "elements": [
+              {
+                "type": "p5.Color",
+                "optional": true
+              },
+              {
+                "type": "Array",
+                "element": "Number",
+                "optional": true
+              },
+              {
+                "type": "String",
+                "optional": true
+              }
+            ]
+          }
         ]
       ]
     },
     "hue": {
       "overloads": [
         [
-          "p5.Color|Number[]|String"
+          {
+            "type": "union",
+            "elements": [
+              {
+                "type": "p5.Color",
+                "optional": true
+              },
+              {
+                "type": "Array",
+                "element": "Number",
+                "optional": true
+              },
+              {
+                "type": "String",
+                "optional": true
+              }
+            ]
+          }
         ]
       ]
     },
     "saturation": {
       "overloads": [
         [
-          "p5.Color|Number[]|String"
+          {
+            "type": "union",
+            "elements": [
+              {
+                "type": "p5.Color",
+                "optional": true
+              },
+              {
+                "type": "Array",
+                "element": "Number",
+                "optional": true
+              },
+              {
+                "type": "String",
+                "optional": true
+              }
+            ]
+          }
         ]
       ]
     },
     "brightness": {
       "overloads": [
         [
-          "p5.Color|Number[]|String"
+          {
+            "type": "union",
+            "elements": [
+              {
+                "type": "p5.Color",
+                "optional": true
+              },
+              {
+                "type": "Array",
+                "element": "Number",
+                "optional": true
+              },
+              {
+                "type": "String",
+                "optional": true
+              }
+            ]
+          }
         ]
       ]
     },
     "lightness": {
       "overloads": [
         [
-          "p5.Color|Number[]|String"
+          {
+            "type": "union",
+            "elements": [
+              {
+                "type": "p5.Color",
+                "optional": true
+              },
+              {
+                "type": "Array",
+                "element": "Number",
+                "optional": true
+              },
+              {
+                "type": "String",
+                "optional": true
+              }
+            ]
+          }
         ]
       ]
     },
     "lerpColor": {
       "overloads": [
         [
-          "p5.Color",
-          "p5.Color",
-          "Number"
+          {
+            "type": "p5.Color"
+          },
+          {
+            "type": "p5.Color"
+          },
+          {
+            "type": "Number"
+          }
         ]
       ]
     },
     "paletteLerp": {
       "overloads": [
         [
-          "[p5.Color|String|Number|Number[], Number][]",
-          "Number"
+          {
+            "type": "Array",
+            "element": {
+              "type": "Tuple",
+              "elements": [
+                {
+                  "type": "union",
+                  "elements": [
+                    {
+                      "type": "p5.Color",
+                      "optional": true
+                    },
+                    {
+                      "type": "String",
+                      "optional": true
+                    },
+                    {
+                      "type": "Number",
+                      "optional": true
+                    },
+                    {
+                      "type": "Array",
+                      "element": "Number",
+                      "optional": true
+                    }
+                  ]
+                },
+                {
+                  "type": "Number"
+                }
+              ]
+            }
+          },
+          {
+            "type": "Number"
+          }
         ]
       ]
     },
     "beginClip": {
       "overloads": [
         [
-          "Object?"
+          {
+            "type": "Object",
+            "optional": true
+          }
         ]
       ]
     },
@@ -150,46 +422,92 @@
     "clip": {
       "overloads": [
         [
-          "Function",
-          "Object?"
+          {
+            "type": "Function"
+          },
+          {
+            "type": "Object",
+            "optional": true
+          }
         ]
       ]
     },
     "background": {
       "overloads": [
         [
-          "p5.Color"
+          {
+            "type": "p5.Color"
+          }
         ],
         [
-          "String",
-          "Number?"
+          {
+            "type": "String"
+          },
+          {
+            "type": "Number",
+            "optional": true
+          }
         ],
         [
-          "Number",
-          "Number?"
+          {
+            "type": "Number"
+          },
+          {
+            "type": "Number",
+            "optional": true
+          }
         ],
         [
-          "Number",
-          "Number",
-          "Number",
-          "Number?"
+          {
+            "type": "Number"
+          },
+          {
+            "type": "Number"
+          },
+          {
+            "type": "Number"
+          },
+          {
+            "type": "Number",
+            "optional": true
+          }
         ],
         [
-          "Number[]"
+          {
+            "type": "Array",
+            "element": "Number"
+          }
         ],
         [
-          "p5.Image",
-          "Number?"
+          {
+            "type": "p5.Image"
+          },
+          {
+            "type": "Number",
+            "optional": true
+          }
         ]
       ]
     },
     "clear": {
       "overloads": [
         [
-          "Number?",
-          "Number?",
-          "Number?",
-          "Number?"
+          {
+            "type": "Number",
+            "optional": true
+          },
+          {
+            "type": "Number",
+            "optional": true
+          },
+          {
+            "type": "Number",
+            "optional": true
+          },
+          {
+            "type": "Number",
+            "optional": true
+          }
         ],
         []
       ]
@@ -197,38 +515,151 @@
     "colorMode": {
       "overloads": [
         [
-          "RGB|HSB|HSL|RGBHDR|HWB|LAB|LCH|OKLAB|OKLCH",
-          "Number?"
+          {
+            "type": "union",
+            "elements": [
+              {
+                "type": "RGB",
+                "optional": true
+              },
+              {
+                "type": "HSB",
+                "optional": true
+              },
+              {
+                "type": "HSL",
+                "optional": true
+              },
+              {
+                "type": "RGBHDR",
+                "optional": true
+              },
+              {
+                "type": "HWB",
+                "optional": true
+              },
+              {
+                "type": "LAB",
+                "optional": true
+              },
+              {
+                "type": "LCH",
+                "optional": true
+              },
+              {
+                "type": "OKLAB",
+                "optional": true
+              },
+              {
+                "type": "OKLCH",
+                "optional": true
+              }
+            ]
+          },
+          {
+            "type": "Number",
+            "optional": true
+          }
         ],
         [
-          "RGB|HSB|HSL|RGBHDR|HWB|LAB|LCH|OKLAB|OKLCH",
-          "Number",
-          "Number",
-          "Number",
-          "Number?"
+          {
+            "type": "union",
+            "elements": [
+              {
+                "type": "RGB",
+                "optional": true
+              },
+              {
+                "type": "HSB",
+                "optional": true
+              },
+              {
+                "type": "HSL",
+                "optional": true
+              },
+              {
+                "type": "RGBHDR",
+                "optional": true
+              },
+              {
+                "type": "HWB",
+                "optional": true
+              },
+              {
+                "type": "LAB",
+                "optional": true
+              },
+              {
+                "type": "LCH",
+                "optional": true
+              },
+              {
+                "type": "OKLAB",
+                "optional": true
+              },
+              {
+                "type": "OKLCH",
+                "optional": true
+              }
+            ]
+          },
+          {
+            "type": "Number"
+          },
+          {
+            "type": "Number"
+          },
+          {
+            "type": "Number"
+          },
+          {
+            "type": "Number",
+            "optional": true
+          }
         ]
       ]
     },
     "fill": {
       "overloads": [
         [
-          "Number",
-          "Number",
-          "Number",
-          "Number?"
+          {
+            "type": "Number"
+          },
+          {
+            "type": "Number"
+          },
+          {
+            "type": "Number"
+          },
+          {
+            "type": "Number",
+            "optional": true
+          }
         ],
         [
-          "String"
+          {
+            "type": "String"
+          }
         ],
         [
-          "Number",
-          "Number?"
+          {
+            "type": "Number"
+          },
+          {
+            "type": "Number",
+            "optional": true
+          }
         ],
         [
-          "Number[]"
+          {
+            "type": "Array",
+            "element": "Number"
+          }
         ],
         [
-          "p5.Color"
+          {
+            "type": "p5.Color"
+          }
         ]
       ]
     },
@@ -245,31 +676,58 @@
     "stroke": {
       "overloads": [
         [
-          "Number",
-          "Number",
-          "Number",
-          "Number?"
+          {
+            "type": "Number"
+          },
+          {
+            "type": "Number"
+          },
+          {
+            "type": "Number"
+          },
+          {
+            "type": "Number",
+            "optional": true
+          }
         ],
         [
-          "String"
+          {
+            "type": "String"
+          }
         ],
         [
-          "Number",
-          "Number?"
+          {
+            "type": "Number"
+          },
+          {
+            "type": "Number",
+            "optional": true
+          }
         ],
         [
-          "Number[]"
+          {
+            "type": "Array",
+            "element": "Number"
+          }
         ],
         [
-          "p5.Color"
+          {
+            "type": "p5.Color"
+          }
         ]
       ]
     },
     "erase": {
       "overloads": [
         [
-          "Number?",
-          "Number?"
+          {
+            "type": "Number",
+            "optional": true
+          },
+          {
+            "type": "Number",
+            "optional": true
+          }
         ]
       ]
     },
@@ -281,33 +739,159 @@
     "blendMode": {
       "overloads": [
         [
-          "BLEND|DARKEST|LIGHTEST|DIFFERENCE|MULTIPLY|EXCLUSION|SCREEN|REPLACE|OVERLAY|HARD_LIGHT|SOFT_LIGHT|DODGE|BURN|ADD|REMOVE|SUBTRACT"
+          {
+            "type": "union",
+            "elements": [
+              {
+                "type": "BLEND",
+                "optional": true
+              },
+              {
+                "type": "DARKEST",
+                "optional": true
+              },
+              {
+                "type": "LIGHTEST",
+                "optional": true
+              },
+              {
+                "type": "DIFFERENCE",
+                "optional": true
+              },
+              {
+                "type": "MULTIPLY",
+                "optional": true
+              },
+              {
+                "type": "EXCLUSION",
+                "optional": true
+              },
+              {
+                "type": "SCREEN",
+                "optional": true
+              },
+              {
+                "type": "REPLACE",
+                "optional": true
+              },
+              {
+                "type": "OVERLAY",
+                "optional": true
+              },
+              {
+                "type": "HARD_LIGHT",
+                "optional": true
+              },
+              {
+                "type": "SOFT_LIGHT",
+                "optional": true
+              },
+              {
+                "type": "DODGE",
+                "optional": true
+              },
+              {
+                "type": "BURN",
+                "optional": true
+              },
+              {
+                "type": "ADD",
+                "optional": true
+              },
+              {
+                "type": "REMOVE",
+                "optional": true
+              },
+              {
+                "type": "SUBTRACT",
+                "optional": true
+              }
+            ]
+          }
         ]
       ]
     },
     "print": {
       "overloads": [
         [
-          "Any"
+          {
+            "type": "Any"
+          }
         ],
         [
-          "String|Number|Array"
+          {
+            "type": "union",
+            "elements": [
+              {
+                "type": "String",
+                "optional": true
+              },
+              {
+                "type": "Number",
+                "optional": true
+              },
+              {
+                "type": "Array",
+                "optional": true
+              }
+            ]
+          }
         ]
       ]
     },
     "cursor": {
       "overloads": [
         [
-          "ARROW|CROSS|HAND|MOVE|TEXT|WAIT|String",
-          "Number?",
-          "Number?"
+          {
+            "type": "union",
+            "elements": [
+              {
+                "type": "ARROW",
+                "optional": true
+              },
+              {
+                "type": "CROSS",
+                "optional": true
+              },
+              {
+                "type": "HAND",
+                "optional": true
+              },
+              {
+                "type": "MOVE",
+                "optional": true
+              },
+              {
+                "type": "TEXT",
+                "optional": true
+              },
+              {
+                "type": "WAIT",
+                "optional": true
+              },
+              {
+                "type": "String",
+                "optional": true
+              }
+            ]
+          },
+          {
+            "type": "Number",
+            "optional": true
+          },
+          {
+            "type": "Number",
+            "optional": true
+          }
         ]
       ]
     },
     "frameRate": {
       "overloads": [
         [
-          "Number"
+          {
+            "type": "Number"
+          }
         ],
         []
       ]
@@ -325,21 +909,30 @@
     "windowResized": {
       "overloads": [
         [
-          "UIEvent?"
+          {
+            "type": "UIEvent",
+            "optional": true
+          }
         ]
       ]
     },
     "fullscreen": {
       "overloads": [
         [
-          "Boolean?"
+          {
+            "type": "Boolean",
+            "optional": true
+          }
         ]
       ]
     },
     "pixelDensity": {
       "overloads": [
         [
-          "Number?"
+          {
+            "type": "Number",
+            "optional": true
+          }
         ],
         []
       ]
@@ -367,18 +960,52 @@
     "worldToScreen": {
       "overloads": [
         [
-          "Number|p5.Vector",
-          "Number",
-          "Number?"
+          {
+            "type": "union",
+            "elements": [
+              {
+                "type": "Number",
+                "optional": true
+              },
+              {
+                "type": "p5.Vector",
+                "optional": true
+              }
+            ]
+          },
+          {
+            "type": "Number"
+          },
+          {
+            "type": "Number",
+            "optional": true
+          }
         ]
       ]
     },
     "screenToWorld": {
       "overloads": [
         [
-          "Number|p5.Vector",
-          "Number",
-          "Number?"
+          {
+            "type": "union",
+            "elements": [
+              {
+                "type": "Number",
+                "optional": true
+              },
+              {
+                "type": "p5.Vector",
+                "optional": true
+              }
+            ]
+          },
+          {
+            "type": "Number"
+          },
+          {
+            "type": "Number",
+            "optional": true
+          }
         ]
       ]
     },
@@ -395,24 +1022,66 @@
     "createCanvas": {
       "overloads": [
         [
-          "Number?",
-          "Number?",
-          "P2D|WEBGL|P2DHDR?",
-          "HTMLCanvasElement?"
+          {
+            "type": "Number",
+            "optional": true
+          },
+          {
+            "type": "Number",
+            "optional": true
+          },
+          {
+            "type": "union",
+            "elements": [
+              {
+                "type": "P2D",
+                "optional": true
+              },
+              {
+                "type": "WEBGL",
+                "optional": true
+              },
+              {
+                "type": "P2DHDR",
+                "optional": true
+              }
+            ],
+            "optional": true
+          },
+          {
+            "type": "HTMLCanvasElement",
+            "optional": true
+          }
         ],
         [
-          "Number?",
-          "Number?",
-          "HTMLCanvasElement?"
+          {
+            "type": "Number",
+            "optional": true
+          },
+          {
+            "type": "Number",
+            "optional": true
+          },
+          {
+            "type": "HTMLCanvasElement",
+            "optional": true
+          }
         ]
       ]
     },
     "resizeCanvas": {
       "overloads": [
         [
-          "Number",
-          "Number",
-          "Boolean?"
+          {
+            "type": "Number"
+          },
+          {
+            "type": "Number"
+          },
+          {
+            "type": "Boolean",
+            "optional": true
+          }
         ]
       ]
     },
@@ -424,29 +1093,62 @@
     "createGraphics": {
       "overloads": [
         [
-          "Number",
-          "Number",
-          "P2D|WEBGL?",
-          "HTMLCanvasElement?"
+          {
+            "type": "Number"
+          },
+          {
+            "type": "Number"
+          },
+          {
+            "type": "union",
+            "elements": [
+              {
+                "type": "P2D",
+                "optional": true
+              },
+              {
+                "type": "WEBGL",
+                "optional": true
+              }
+            ],
+            "optional": true
+          },
+          {
+            "type": "HTMLCanvasElement",
+            "optional": true
+          }
         ],
         [
-          "Number",
-          "Number",
-          "HTMLCanvasElement?"
+          {
+            "type": "Number"
+          },
+          {
+            "type": "Number"
+          },
+          {
+            "type": "HTMLCanvasElement",
+            "optional": true
+          }
         ]
       ]
     },
     "createFramebuffer": {
       "overloads": [
         [
-          "Object?"
+          {
+            "type": "Object",
+            "optional": true
+          }
         ]
       ]
     },
     "clearDepth": {
       "overloads": [
         [
-          "Number?"
+          {
+            "type": "Number",
+            "optional": true
+          }
         ]
       ]
     },
@@ -468,40 +1170,89 @@
     "redraw": {
       "overloads": [
         [
-          "Integer?"
+          {
+            "type": "Integer",
+            "optional": true
+          }
         ]
       ]
     },
     "applyMatrix": {
       "overloads": [
         [
-          "Array"
+          {
+            "type": "Array"
+          }
         ],
         [
-          "Number",
-          "Number",
-          "Number",
-          "Number",
-          "Number",
-          "Number"
+          {
+            "type": "Number"
+          },
+          {
+            "type": "Number"
+          },
+          {
+            "type": "Number"
+          },
+          {
+            "type": "Number"
+          },
+          {
+            "type": "Number"
+          },
+          {
+            "type": "Number"
+          }
         ],
         [
-          "Number",
-          "Number",
-          "Number",
-          "Number",
-          "Number",
-          "Number",
-          "Number",
-          "Number",
-          "Number",
-          "Number",
-          "Number",
-          "Number",
-          "Number",
-          "Number",
-          "Number",
-          "Number"
+          {
+            "type": "Number"
+          },
+          {
+            "type": "Number"
+          },
+          {
+            "type": "Number"
+          },
+          {
+            "type": "Number"
+          },
+          {
+            "type": "Number"
+          },
+          {
+            "type": "Number"
+          },
+          {
+            "type": "Number"
+          },
+          {
+            "type": "Number"
+          },
+          {
+            "type": "Number"
+          },
+          {
+            "type": "Number"
+          },
+          {
+            "type": "Number"
+          },
+          {
+            "type": "Number"
+          },
+          {
+            "type": "Number"
+          },
+          {
+            "type": "Number"
+          },
+          {
+            "type": "Number"
+          },
+          {
+            "type": "Number"
+          }
         ]
       ]
     },
@@ -513,67 +1264,138 @@
     "rotate": {
       "overloads": [
         [
-          "Number",
-          "p5.Vector|Number[]?"
+          {
+            "type": "Number"
+          },
+          {
+            "type": "union",
+            "elements": [
+              {
+                "type": "p5.Vector",
+                "optional": true
+              },
+              {
+                "type": "Array",
+                "element": "Number",
+                "optional": true
+              }
+            ],
+            "optional": true
+          }
         ]
       ]
     },
     "rotateX": {
       "overloads": [
         [
-          "Number"
+          {
+            "type": "Number"
+          }
         ]
       ]
     },
     "rotateY": {
       "overloads": [
         [
-          "Number"
+          {
+            "type": "Number"
+          }
         ]
       ]
     },
     "rotateZ": {
       "overloads": [
         [
-          "Number"
+          {
+            "type": "Number"
+          }
         ]
       ]
     },
     "scale": {
       "overloads": [
         [
-          "Number|p5.Vector|Number[]",
-          "Number?",
-          "Number?"
+          {
+            "type": "union",
+            "elements": [
+              {
+                "type": "Number",
+                "optional": true
+              },
+              {
+                "type": "p5.Vector",
+                "optional": true
+              },
+              {
+                "type": "Array",
+                "element": "Number",
+                "optional": true
+              }
+            ]
+          },
+          {
+            "type": "Number",
+            "optional": true
+          },
+          {
+            "type": "Number",
+            "optional": true
+          }
         ],
         [
-          "p5.Vector|Number[]"
+          {
+            "type": "union",
+            "elements": [
+              {
+                "type": "p5.Vector",
+                "optional": true
+              },
+              {
+                "type": "Array",
+                "element": "Number",
+                "optional": true
+              }
+            ]
+          }
         ]
       ]
     },
     "shearX": {
       "overloads": [
         [
-          "Number"
+          {
+            "type": "Number"
+          }
         ]
       ]
     },
     "shearY": {
       "overloads": [
         [
-          "Number"
+          {
+            "type": "Number"
+          }
         ]
       ]
     },
     "translate": {
       "overloads": [
         [
-          "Number",
-          "Number",
-          "Number?"
+          {
+            "type": "Number"
+          },
+          {
+            "type": "Number"
+          },
+          {
+            "type": "Number",
+            "optional": true
+          }
         ],
         [
-          "p5.Vector"
+          {
+            "type": "p5.Vector"
+          }
         ]
       ]
     },
@@ -590,15 +1412,43 @@
     "storeItem": {
       "overloads": [
         [
-          "String",
-          "String|Number|Boolean|Object|Array"
+          {
+            "type": "String"
+          },
+          {
+            "type": "union",
+            "elements": [
+              {
+                "type": "String",
+                "optional": true
+              },
+              {
+                "type": "Number",
+                "optional": true
+              },
+              {
+                "type": "Boolean",
+                "optional": true
+              },
+              {
+                "type": "Object",
+                "optional": true
+              },
+              {
+                "type": "Array",
+                "optional": true
+              }
+            ]
+          }
         ]
       ]
     },
     "getItem": {
       "overloads": [
         [
-          "String"
+          {
+            "type": "String"
+          }
         ]
       ]
     },
@@ -610,31 +1460,76 @@
     "removeItem": {
       "overloads": [
         [
-          "String"
+          {
+            "type": "String"
+          }
         ]
       ]
     },
     "select": {
       "overloads": [
         [
-          "String",
-          "String|p5.Element|HTMLElement?"
+          {
+            "type": "String"
+          },
+          {
+            "type": "union",
+            "elements": [
+              {
+                "type": "String",
+                "optional": true
+              },
+              {
+                "type": "p5.Element",
+                "optional": true
+              },
+              {
+                "type": "HTMLElement",
+                "optional": true
+              }
+            ],
+            "optional": true
+          }
         ]
       ]
     },
     "selectAll": {
       "overloads": [
         [
-          "String",
-          "String|p5.Element|HTMLElement?"
+          {
+            "type": "String"
+          },
+          {
+            "type": "union",
+            "elements": [
+              {
+                "type": "String",
+                "optional": true
+              },
+              {
+                "type": "p5.Element",
+                "optional": true
+              },
+              {
+                "type": "HTMLElement",
+                "optional": true
+              }
+            ],
+            "optional": true
+          }
         ]
       ]
     },
     "createElement": {
       "overloads": [
         [
-          "String",
-          "String?"
+          {
+            "type": "String"
+          },
+          {
+            "type": "String",
+            "optional": true
+          }
         ]
       ]
     },
@@ -651,90 +1546,152 @@
     "createDiv": {
       "overloads": [
         [
-          "String?"
+          {
+            "type": "String",
+            "optional": true
+          }
         ]
       ]
     },
     "createP": {
       "overloads": [
         [
-          "String?"
+          {
+            "type": "String",
+            "optional": true
+          }
         ]
       ]
     },
     "createSpan": {
       "overloads": [
         [
-          "String?"
+          {
+            "type": "String",
+            "optional": true
+          }
         ]
       ]
     },
     "createImg": {
       "overloads": [
         [
-          "String",
-          "String"
+          {
+            "type": "String"
+          },
+          {
+            "type": "String"
+          }
         ],
         [
-          "String",
-          "String",
-          "String?",
-          "Function?"
+          {
+            "type": "String"
+          },
+          {
+            "type": "String"
+          },
+          {
+            "type": "String",
+            "optional": true
+          },
+          {
+            "type": "Function",
+            "optional": true
+          }
         ]
       ]
     },
     "createA": {
       "overloads": [
         [
-          "String",
-          "String",
-          "String?"
+          {
+            "type": "String"
+          },
+          {
+            "type": "String"
+          },
+          {
+            "type": "String",
+            "optional": true
+          }
         ]
       ]
     },
     "createSlider": {
       "overloads": [
         [
-          "Number",
-          "Number",
-          "Number?",
-          "Number?"
+          {
+            "type": "Number"
+          },
+          {
+            "type": "Number"
+          },
+          {
+            "type": "Number",
+            "optional": true
+          },
+          {
+            "type": "Number",
+            "optional": true
+          }
         ]
       ]
     },
     "createButton": {
       "overloads": [
         [
-          "String",
-          "String?"
+          {
+            "type": "String"
+          },
+          {
+            "type": "String",
+            "optional": true
+          }
         ]
       ]
     },
     "createCheckbox": {
       "overloads": [
         [
-          "String?",
-          "Boolean?"
+          {
+            "type": "String",
+            "optional": true
+          },
+          {
+            "type": "Boolean",
+            "optional": true
+          }
         ]
       ]
     },
     "createSelect": {
       "overloads": [
         [
-          "Boolean?"
+          {
+            "type": "Boolean",
+            "optional": true
+          }
         ],
         [
-          "Object"
+          {
+            "type": "Object"
+          }
         ]
       ]
     },
     "createRadio": {
       "overloads": [
         [
-          "Object?"
+          {
+            "type": "Object",
+            "optional": true
+          }
         ],
         [
-          "String?"
+          {
+            "type": "String",
+            "optional": true
+          }
         ],
         []
       ]
@@ -742,40 +1699,71 @@
     "createColorPicker": {
       "overloads": [
         [
-          "String|p5.Color?"
+          {
+            "type": "union",
+            "elements": [
+              {
+                "type": "String",
+                "optional": true
+              },
+              {
+                "type": "p5.Color",
+                "optional": true
+              }
+            ],
+            "optional": true
+          }
         ]
       ]
     },
     "createInput": {
       "overloads": [
         [
-          "String?",
-          "String?"
+          {
+            "type": "String",
+            "optional": true
+          },
+          {
+            "type": "String",
+            "optional": true
+          }
         ],
         [
-          "String?"
+          {
+            "type": "String",
+            "optional": true
+          }
         ]
       ]
     },
     "createFileInput": {
       "overloads": [
         [
-          "Function",
-          "Boolean?"
+          {
+            "type": "Function"
+          },
+          {
+            "type": "Boolean",
+            "optional": true
+          }
         ]
       ]
     },
     "setMoveThreshold": {
       "overloads": [
         [
-          "Number"
+          {
+            "type": "Number"
+          }
         ]
       ]
     },
     "setShakeThreshold": {
       "overloads": [
         [
-          "Number"
+          {
+            "type": "Number"
+          }
         ]
       ]
     },
@@ -797,77 +1785,119 @@
     "keyPressed": {
       "overloads": [
         [
-          "KeyboardEvent?"
+          {
+            "type": "KeyboardEvent",
+            "optional": true
+          }
         ]
       ]
     },
     "keyReleased": {
       "overloads": [
         [
-          "KeyboardEvent?"
+          {
+            "type": "KeyboardEvent",
+            "optional": true
+          }
         ]
       ]
     },
     "keyTyped": {
       "overloads": [
         [
-          "KeyboardEvent?"
+          {
+            "type": "KeyboardEvent",
+            "optional": true
+          }
         ]
       ]
     },
     "keyIsDown": {
       "overloads": [
         [
-          "Number|String"
+          {
+            "type": "union",
+            "elements": [
+              {
+                "type": "Number",
+                "optional": true
+              },
+              {
+                "type": "String",
+                "optional": true
+              }
+            ]
+          }
         ]
       ]
     },
     "mouseMoved": {
       "overloads": [
         [
-          "MouseEvent?"
+          {
+            "type": "MouseEvent",
+            "optional": true
+          }
         ]
       ]
     },
     "mouseDragged": {
       "overloads": [
         [
-          "MouseEvent?"
+          {
+            "type": "MouseEvent",
+            "optional": true
+          }
         ]
       ]
     },
     "mousePressed": {
       "overloads": [
         [
-          "MouseEvent?"
+          {
+            "type": "MouseEvent",
+            "optional": true
+          }
         ]
       ]
     },
     "mouseReleased": {
       "overloads": [
         [
-          "MouseEvent?"
+          {
+            "type": "MouseEvent",
+            "optional": true
+          }
         ]
       ]
     },
     "mouseClicked": {
       "overloads": [
         [
-          "MouseEvent?"
+          {
+            "type": "MouseEvent",
+            "optional": true
+          }
         ]
       ]
     },
     "doubleClicked": {
       "overloads": [
         [
-          "MouseEvent?"
+          {
+            "type": "MouseEvent",
+            "optional": true
+          }
         ]
       ]
     },
     "mouseWheel": {
       "overloads": [
         [
-          "WheelEvent?"
+          {
+            "type": "WheelEvent",
+            "optional": true
+          }
         ]
       ]
     },
@@ -884,98 +1914,333 @@
     "createImage": {
       "overloads": [
         [
-          "Integer",
-          "Integer"
+          {
+            "type": "Integer"
+          },
+          {
+            "type": "Integer"
+          }
         ]
       ]
     },
     "saveCanvas": {
       "overloads": [
         [
-          "p5.Framebuffer|p5.Element|HTMLCanvasElement",
-          "String?",
-          "String?"
+          {
+            "type": "union",
+            "elements": [
+              {
+                "type": "p5.Framebuffer",
+                "optional": true
+              },
+              {
+                "type": "p5.Element",
+                "optional": true
+              },
+              {
+                "type": "HTMLCanvasElement",
+                "optional": true
+              }
+            ]
+          },
+          {
+            "type": "String",
+            "optional": true
+          },
+          {
+            "type": "String",
+            "optional": true
+          }
         ],
         [
-          "String?",
-          "String?"
+          {
+            "type": "String",
+            "optional": true
+          },
+          {
+            "type": "String",
+            "optional": true
+          }
         ]
       ]
     },
     "saveFrames": {
       "overloads": [
         [
-          "String",
-          "String",
-          "Number",
-          "Number",
-          "function(Array)?"
+          {
+            "type": "String"
+          },
+          {
+            "type": "String"
+          },
+          {
+            "type": "Number"
+          },
+          {
+            "type": "Number"
+          },
+          {
+            "type": "Function",
+            "parameters": [
+              {
+                "type": "Array"
+              }
+            ],
+            "optional": true
+          }
         ]
       ]
     },
     "loadImage": {
       "overloads": [
         [
-          "String|Request",
-          "function(p5.Image)?",
-          "function(Event)?"
+          {
+            "type": "union",
+            "elements": [
+              {
+                "type": "String",
+                "optional": true
+              },
+              {
+                "type": "Request",
+                "optional": true
+              }
+            ]
+          },
+          {
+            "type": "Function",
+            "parameters": [
+              {
+                "type": "p5.Image"
+              }
+            ],
+            "optional": true
+          },
+          {
+            "type": "Function",
+            "parameters": [
+              {
+                "type": "Event"
+              }
+            ],
+            "optional": true
+          }
         ]
       ]
     },
     "saveGif": {
       "overloads": [
         [
-          "String",
-          "Number",
-          "Object?"
+          {
+            "type": "String"
+          },
+          {
+            "type": "Number"
+          },
+          {
+            "type": "Object",
+            "optional": true
+          }
         ]
       ]
     },
     "image": {
       "overloads": [
         [
-          "p5.Image|p5.Element|p5.Texture|p5.Framebuffer|p5.FramebufferTexture|p5.Renderer|p5.Graphics",
-          "Number",
-          "Number",
-          "Number?",
-          "Number?"
+          {
+            "type": "union",
+            "elements": [
+              {
+                "type": "p5.Image",
+                "optional": true
+              },
+              {
+                "type": "p5.Element",
+                "optional": true
+              },
+              {
+                "type": "p5.Texture",
+                "optional": true
+              },
+              {
+                "type": "p5.Framebuffer",
+                "optional": true
+              },
+              {
+                "type": "p5.FramebufferTexture",
+                "optional": true
+              },
+              {
+                "type": "p5.Renderer",
+                "optional": true
+              },
+              {
+                "type": "p5.Graphics",
+                "optional": true
+              }
+            ]
+          },
+          {
+            "type": "Number"
+          },
+          {
+            "type": "Number"
+          },
+          {
+            "type": "Number",
+            "optional": true
+          },
+          {
+            "type": "Number",
+            "optional": true
+          }
         ],
         [
-          "p5.Image|p5.Element|p5.Texture|p5.Framebuffer|p5.FramebufferTexture",
-          "Number",
-          "Number",
-          "Number",
-          "Number",
-          "Number",
-          "Number",
-          "Number?",
-          "Number?",
-          "CONTAIN|COVER?",
-          "LEFT|RIGHT|CENTER?",
-          "TOP|BOTTOM|CENTER?"
+          {
+            "type": "union",
+            "elements": [
+              {
+                "type": "p5.Image",
+                "optional": true
+              },
+              {
+                "type": "p5.Element",
+                "optional": true
+              },
+              {
+                "type": "p5.Texture",
+                "optional": true
+              },
+              {
+                "type": "p5.Framebuffer",
+                "optional": true
+              },
+              {
+                "type": "p5.FramebufferTexture",
+                "optional": true
+              }
+            ]
+          },
+          {
+            "type": "Number"
+          },
+          {
+            "type": "Number"
+          },
+          {
+            "type": "Number"
+          },
+          {
+            "type": "Number"
+          },
+          {
+            "type": "Number"
+          },
+          {
+            "type": "Number"
+          },
+          {
+            "type": "Number",
+            "optional": true
+          },
+          {
+            "type": "Number",
+            "optional": true
+          },
+          {
+            "type": "union",
+            "elements": [
+              {
+                "type": "CONTAIN",
+                "optional": true
+              },
+              {
+                "type": "COVER",
+                "optional": true
+              }
+            ],
+            "optional": true
+          },
+          {
+            "type": "union",
+            "elements": [
+              {
+                "type": "LEFT",
+                "optional": true
+              },
+              {
+                "type": "RIGHT",
+                "optional": true
+              },
+              {
+                "type": "CENTER",
+                "optional": true
+              }
+            ],
+            "optional": true
+          },
+          {
+            "type": "union",
+            "elements": [
+              {
+                "type": "TOP",
+                "optional": true
+              },
+              {
+                "type": "BOTTOM",
+                "optional": true
+              },
+              {
+                "type": "CENTER",
+                "optional": true
+              }
+            ],
+            "optional": true
+          }
         ]
       ]
     },
     "tint": {
       "overloads": [
         [
-          "Number",
-          "Number",
-          "Number",
-          "Number?"
+          {
+            "type": "Number"
+          },
+          {
+            "type": "Number"
+          },
+          {
+            "type": "Number"
+          },
+          {
+            "type": "Number",
+            "optional": true
+          }
         ],
         [
-          "String"
+          {
+            "type": "String"
+          }
         ],
         [
-          "Number",
-          "Number?"
+          {
+            "type": "Number"
+          },
+          {
+            "type": "Number",
+            "optional": true
+          }
         ],
         [
-          "Number[]"
+          {
+            "type": "Array",
+            "element": "Number"
+          }
         ],
         [
-          "p5.Color"
+          {
+            "type": "p5.Color"
+          }
         ]
       ]
     },
@@ -987,86 +2252,368 @@
     "imageMode": {
       "overloads": [
         [
-          "CORNER|CORNERS|CENTER"
+          {
+            "type": "union",
+            "elements": [
+              {
+                "type": "CORNER",
+                "optional": true
+              },
+              {
+                "type": "CORNERS",
+                "optional": true
+              },
+              {
+                "type": "CENTER",
+                "optional": true
+              }
+            ]
+          }
         ]
       ]
     },
     "blend": {
       "overloads": [
         [
-          "p5.Image",
-          "Integer",
-          "Integer",
-          "Integer",
-          "Integer",
-          "Integer",
-          "Integer",
-          "Integer",
-          "Integer",
-          "BLEND|DARKEST|LIGHTEST|DIFFERENCE|MULTIPLY|EXCLUSION|SCREEN|REPLACE|OVERLAY|HARD_LIGHT|SOFT_LIGHT|DODGE|BURN|ADD|NORMAL"
+          {
+            "type": "p5.Image"
+          },
+          {
+            "type": "Integer"
+          },
+          {
+            "type": "Integer"
+          },
+          {
+            "type": "Integer"
+          },
+          {
+            "type": "Integer"
+          },
+          {
+            "type": "Integer"
+          },
+          {
+            "type": "Integer"
+          },
+          {
+            "type": "Integer"
+          },
+          {
+            "type": "Integer"
+          },
+          {
+            "type": "union",
+            "elements": [
+              {
+                "type": "BLEND",
+                "optional": true
+              },
+              {
+                "type": "DARKEST",
+                "optional": true
+              },
+              {
+                "type": "LIGHTEST",
+                "optional": true
+              },
+              {
+                "type": "DIFFERENCE",
+                "optional": true
+              },
+              {
+                "type": "MULTIPLY",
+                "optional": true
+              },
+              {
+                "type": "EXCLUSION",
+                "optional": true
+              },
+              {
+                "type": "SCREEN",
+                "optional": true
+              },
+              {
+                "type": "REPLACE",
+                "optional": true
+              },
+              {
+                "type": "OVERLAY",
+                "optional": true
+              },
+              {
+                "type": "HARD_LIGHT",
+                "optional": true
+              },
+              {
+                "type": "SOFT_LIGHT",
+                "optional": true
+              },
+              {
+                "type": "DODGE",
+                "optional": true
+              },
+              {
+                "type": "BURN",
+                "optional": true
+              },
+              {
+                "type": "ADD",
+                "optional": true
+              },
+              {
+                "type": "NORMAL",
+                "optional": true
+              }
+            ]
+          }
         ],
         [
-          "Integer",
-          "Integer",
-          "Integer",
-          "Integer",
-          "Integer",
-          "Integer",
-          "Integer",
-          "Integer",
-          "BLEND|DARKEST|LIGHTEST|DIFFERENCE|MULTIPLY|EXCLUSION|SCREEN|REPLACE|OVERLAY|HARD_LIGHT|SOFT_LIGHT|DODGE|BURN|ADD|NORMAL"
+          {
+            "type": "Integer"
+          },
+          {
+            "type": "Integer"
+          },
+          {
+            "type": "Integer"
+          },
+          {
+            "type": "Integer"
+          },
+          {
+            "type": "Integer"
+          },
+          {
+            "type": "Integer"
+          },
+          {
+            "type": "Integer"
+          },
+          {
+            "type": "Integer"
+          },
+          {
+            "type": "union",
+            "elements": [
+              {
+                "type": "BLEND",
+                "optional": true
+              },
+              {
+                "type": "DARKEST",
+                "optional": true
+              },
+              {
+                "type": "LIGHTEST",
+                "optional": true
+              },
+              {
+                "type": "DIFFERENCE",
+                "optional": true
+              },
+              {
+                "type": "MULTIPLY",
+                "optional": true
+              },
+              {
+                "type": "EXCLUSION",
+                "optional": true
+              },
+              {
+                "type": "SCREEN",
+                "optional": true
+              },
+              {
+                "type": "REPLACE",
+                "optional": true
+              },
+              {
+                "type": "OVERLAY",
+                "optional": true
+              },
+              {
+                "type": "HARD_LIGHT",
+                "optional": true
+              },
+              {
+                "type": "SOFT_LIGHT",
+                "optional": true
+              },
+              {
+                "type": "DODGE",
+                "optional": true
+              },
+              {
+                "type": "BURN",
+                "optional": true
+              },
+              {
+                "type": "ADD",
+                "optional": true
+              },
+              {
+                "type": "NORMAL",
+                "optional": true
+              }
+            ]
+          }
         ]
       ]
     },
     "copy": {
       "overloads": [
         [
-          "p5.Image|p5.Element",
-          "Integer",
-          "Integer",
-          "Integer",
-          "Integer",
-          "Integer",
-          "Integer",
-          "Integer",
-          "Integer"
+          {
+            "type": "union",
+            "elements": [
+              {
+                "type": "p5.Image",
+                "optional": true
+              },
+              {
+                "type": "p5.Element",
+                "optional": true
+              }
+            ]
+          },
+          {
+            "type": "Integer"
+          },
+          {
+            "type": "Integer"
+          },
+          {
+            "type": "Integer"
+          },
+          {
+            "type": "Integer"
+          },
+          {
+            "type": "Integer"
+          },
+          {
+            "type": "Integer"
+          },
+          {
+            "type": "Integer"
+          },
+          {
+            "type": "Integer"
+          }
         ],
         [
-          "Integer",
-          "Integer",
-          "Integer",
-          "Integer",
-          "Integer",
-          "Integer",
-          "Integer",
-          "Integer"
+          {
+            "type": "Integer"
+          },
+          {
+            "type": "Integer"
+          },
+          {
+            "type": "Integer"
+          },
+          {
+            "type": "Integer"
+          },
+          {
+            "type": "Integer"
+          },
+          {
+            "type": "Integer"
+          },
+          {
+            "type": "Integer"
+          },
+          {
+            "type": "Integer"
+          }
         ]
       ]
     },
     "filter": {
       "overloads": [
         [
-          "THRESHOLD|GRAY|OPAQUE|INVERT|POSTERIZE|BLUR|ERODE|DILATE|BLUR",
-          "Number?",
-          "Boolean?"
+          {
+            "type": "union",
+            "elements": [
+              {
+                "type": "THRESHOLD",
+                "optional": true
+              },
+              {
+                "type": "GRAY",
+                "optional": true
+              },
+              {
+                "type": "OPAQUE",
+                "optional": true
+              },
+              {
+                "type": "INVERT",
+                "optional": true
+              },
+              {
+                "type": "POSTERIZE",
+                "optional": true
+              },
+              {
+                "type": "BLUR",
+                "optional": true
+              },
+              {
+                "type": "ERODE",
+                "optional": true
+              },
+              {
+                "type": "DILATE",
+                "optional": true
+              },
+              {
+                "type": "BLUR",
+                "optional": true
+              }
+            ]
+          },
+          {
+            "type": "Number",
+            "optional": true
+          },
+          {
+            "type": "Boolean",
+            "optional": true
+          }
         ],
         [
-          "p5.Shader"
+          {
+            "type": "p5.Shader"
+          }
         ]
       ]
     },
     "get": {
       "overloads": [
         [
-          "Number",
-          "Number",
-          "Number",
-          "Number"
+          {
+            "type": "Number"
+          },
+          {
+            "type": "Number"
+          },
+          {
+            "type": "Number"
+          },
+          {
+            "type": "Number"
+          }
         ],
         [],
         [
-          "Number",
-          "Number"
+          {
+            "type": "Number"
+          },
+          {
+            "type": "Number"
+          }
         ]
       ]
     },
@@ -1078,19 +2625,52 @@
     "set": {
       "overloads": [
         [
-          "Number",
-          "Number",
-          "Number|Number[]|Object"
+          {
+            "type": "Number"
+          },
+          {
+            "type": "Number"
+          },
+          {
+            "type": "union",
+            "elements": [
+              {
+                "type": "Number",
+                "optional": true
+              },
+              {
+                "type": "Array",
+                "element": "Number",
+                "optional": true
+              },
+              {
+                "type": "Object",
+                "optional": true
+              }
+            ]
+          }
         ]
       ]
     },
     "updatePixels": {
       "overloads": [
         [
-          "Number?",
-          "Number?",
-          "Number?",
-          "Number?"
+          {
+            "type": "Number",
+            "optional": true
+          },
+          {
+            "type": "Number",
+            "optional": true
+          },
+          {
+            "type": "Number",
+            "optional": true
+          },
+          {
+            "type": "Number",
+            "optional": true
+          }
         ],
         []
       ]
@@ -1098,125 +2678,425 @@
     "loadJSON": {
       "overloads": [
         [
-          "String|Request",
-          "Function?",
-          "Function?"
+          {
+            "type": "union",
+            "elements": [
+              {
+                "type": "String",
+                "optional": true
+              },
+              {
+                "type": "Request",
+                "optional": true
+              }
+            ]
+          },
+          {
+            "type": "Function",
+            "optional": true
+          },
+          {
+            "type": "Function",
+            "optional": true
+          }
         ]
       ]
     },
     "loadStrings": {
       "overloads": [
         [
-          "String|Request",
-          "Function?",
-          "Function?"
+          {
+            "type": "union",
+            "elements": [
+              {
+                "type": "String",
+                "optional": true
+              },
+              {
+                "type": "Request",
+                "optional": true
+              }
+            ]
+          },
+          {
+            "type": "Function",
+            "optional": true
+          },
+          {
+            "type": "Function",
+            "optional": true
+          }
         ]
       ]
     },
     "loadTable": {
       "overloads": [
         [
-          "String|Request",
-          "String?",
-          "String?",
-          "Function?",
-          "Function?"
+          {
+            "type": "union",
+            "elements": [
+              {
+                "type": "String",
+                "optional": true
+              },
+              {
+                "type": "Request",
+                "optional": true
+              }
+            ]
+          },
+          {
+            "type": "String",
+            "optional": true
+          },
+          {
+            "type": "String",
+            "optional": true
+          },
+          {
+            "type": "Function",
+            "optional": true
+          },
+          {
+            "type": "Function",
+            "optional": true
+          }
         ]
       ]
     },
     "loadXML": {
       "overloads": [
         [
-          "String|Request",
-          "Function?",
-          "Function?"
+          {
+            "type": "union",
+            "elements": [
+              {
+                "type": "String",
+                "optional": true
+              },
+              {
+                "type": "Request",
+                "optional": true
+              }
+            ]
+          },
+          {
+            "type": "Function",
+            "optional": true
+          },
+          {
+            "type": "Function",
+            "optional": true
+          }
         ]
       ]
     },
     "loadBytes": {
       "overloads": [
         [
-          "String|Request",
-          "Function?",
-          "Function?"
+          {
+            "type": "union",
+            "elements": [
+              {
+                "type": "String",
+                "optional": true
+              },
+              {
+                "type": "Request",
+                "optional": true
+              }
+            ]
+          },
+          {
+            "type": "Function",
+            "optional": true
+          },
+          {
+            "type": "Function",
+            "optional": true
+          }
         ]
       ]
     },
     "loadBlob": {
       "overloads": [
         [
-          "String|Request",
-          "Function?",
-          "Function?"
+          {
+            "type": "union",
+            "elements": [
+              {
+                "type": "String",
+                "optional": true
+              },
+              {
+                "type": "Request",
+                "optional": true
+              }
+            ]
+          },
+          {
+            "type": "Function",
+            "optional": true
+          },
+          {
+            "type": "Function",
+            "optional": true
+          }
         ]
       ]
     },
     "httpGet": {
       "overloads": [
         [
-          "String|Request",
-          "String?",
-          "Function?",
-          "Function?"
+          {
+            "type": "union",
+            "elements": [
+              {
+                "type": "String",
+                "optional": true
+              },
+              {
+                "type": "Request",
+                "optional": true
+              }
+            ]
+          },
+          {
+            "type": "String",
+            "optional": true
+          },
+          {
+            "type": "Function",
+            "optional": true
+          },
+          {
+            "type": "Function",
+            "optional": true
+          }
         ],
         [
-          "String|Request",
-          "Function",
-          "Function?"
+          {
+            "type": "union",
+            "elements": [
+              {
+                "type": "String",
+                "optional": true
+              },
+              {
+                "type": "Request",
+                "optional": true
+              }
+            ]
+          },
+          {
+            "type": "Function"
+          },
+          {
+            "type": "Function",
+            "optional": true
+          }
         ]
       ]
     },
     "httpPost": {
       "overloads": [
         [
-          "String|Request",
-          "Object|Boolean?",
-          "String?",
-          "Function?",
-          "Function?"
+          {
+            "type": "union",
+            "elements": [
+              {
+                "type": "String",
+                "optional": true
+              },
+              {
+                "type": "Request",
+                "optional": true
+              }
+            ]
+          },
+          {
+            "type": "union",
+            "elements": [
+              {
+                "type": "Object",
+                "optional": true
+              },
+              {
+                "type": "Boolean",
+                "optional": true
+              }
+            ],
+            "optional": true
+          },
+          {
+            "type": "String",
+            "optional": true
+          },
+          {
+            "type": "Function",
+            "optional": true
+          },
+          {
+            "type": "Function",
+            "optional": true
+          }
         ],
         [
-          "String|Request",
-          "Object|Boolean",
-          "Function?",
-          "Function?"
+          {
+            "type": "union",
+            "elements": [
+              {
+                "type": "String",
+                "optional": true
+              },
+              {
+                "type": "Request",
+                "optional": true
+              }
+            ]
+          },
+          {
+            "type": "union",
+            "elements": [
+              {
+                "type": "Object",
+                "optional": true
+              },
+              {
+                "type": "Boolean",
+                "optional": true
+              }
+            ]
+          },
+          {
+            "type": "Function",
+            "optional": true
+          },
+          {
+            "type": "Function",
+            "optional": true
+          }
         ],
         [
-          "String|Request",
-          "Function?",
-          "Function?"
+          {
+            "type": "union",
+            "elements": [
+              {
+                "type": "String",
+                "optional": true
+              },
+              {
+                "type": "Request",
+                "optional": true
+              }
+            ]
+          },
+          {
+            "type": "Function",
+            "optional": true
+          },
+          {
+            "type": "Function",
+            "optional": true
+          }
         ]
       ]
     },
     "httpDo": {
       "overloads": [
         [
-          "String|Request",
-          "String?",
-          "String?",
-          "Object?",
-          "Function?",
-          "Function?"
+          {
+            "type": "union",
+            "elements": [
+              {
+                "type": "String",
+                "optional": true
+              },
+              {
+                "type": "Request",
+                "optional": true
+              }
+            ]
+          },
+          {
+            "type": "String",
+            "optional": true
+          },
+          {
+            "type": "String",
+            "optional": true
+          },
+          {
+            "type": "Object",
+            "optional": true
+          },
+          {
+            "type": "Function",
+            "optional": true
+          },
+          {
+            "type": "Function",
+            "optional": true
+          }
         ],
         [
-          "String|Request",
-          "Function?",
-          "Function?"
+          {
+            "type": "union",
+            "elements": [
+              {
+                "type": "String",
+                "optional": true
+              },
+              {
+                "type": "Request",
+                "optional": true
+              }
+            ]
+          },
+          {
+            "type": "Function",
+            "optional": true
+          },
+          {
+            "type": "Function",
+            "optional": true
+          }
         ]
       ]
     },
     "createWriter": {
       "overloads": [
         [
-          "String",
-          "String?"
+          {
+            "type": "String"
+          },
+          {
+            "type": "String",
+            "optional": true
+          }
         ]
       ]
     },
     "write": {
       "overloads": [
         [
-          "String|Number|Array"
+          {
+            "type": "union",
+            "elements": [
+              {
+                "type": "String",
+                "optional": true
+              },
+              {
+                "type": "Number",
+                "optional": true
+              },
+              {
+                "type": "Array",
+                "optional": true
+              }
+            ]
+          }
         ]
       ]
     },
@@ -1228,327 +3108,552 @@
     "save": {
       "overloads": [
         [
-          "Object|String?",
-          "String?",
-          "Boolean|String?"
+          {
+            "type": "union",
+            "elements": [
+              {
+                "type": "Object",
+                "optional": true
+              },
+              {
+                "type": "String",
+                "optional": true
+              }
+            ],
+            "optional": true
+          },
+          {
+            "type": "String",
+            "optional": true
+          },
+          {
+            "type": "union",
+            "elements": [
+              {
+                "type": "Boolean",
+                "optional": true
+              },
+              {
+                "type": "String",
+                "optional": true
+              }
+            ],
+            "optional": true
+          }
         ]
       ]
     },
     "saveJSON": {
       "overloads": [
         [
-          "Array|Object",
-          "String",
-          "Boolean?"
+          {
+            "type": "union",
+            "elements": [
+              {
+                "type": "Array",
+                "optional": true
+              },
+              {
+                "type": "Object",
+                "optional": true
+              }
+            ]
+          },
+          {
+            "type": "String"
+          },
+          {
+            "type": "Boolean",
+            "optional": true
+          }
         ]
       ]
     },
     "saveStrings": {
       "overloads": [
         [
-          "String[]",
-          "String",
-          "String?",
-          "Boolean?"
+          {
+            "type": "Array",
+            "element": "String"
+          },
+          {
+            "type": "String"
+          },
+          {
+            "type": "String",
+            "optional": true
+          },
+          {
+            "type": "Boolean",
+            "optional": true
+          }
         ]
       ]
     },
     "saveTable": {
       "overloads": [
         [
-          "p5.Table",
-          "String",
-          "String?"
+          {
+            "type": "p5.Table"
+          },
+          {
+            "type": "String"
+          },
+          {
+            "type": "String",
+            "optional": true
+          }
         ]
       ]
     },
     "abs": {
       "overloads": [
         [
-          "Number"
+          {
+            "type": "Number"
+          }
         ]
       ]
     },
     "ceil": {
       "overloads": [
         [
-          "Number"
+          {
+            "type": "Number"
+          }
         ]
       ]
     },
     "constrain": {
       "overloads": [
         [
-          "Number",
-          "Number",
-          "Number"
+          {
+            "type": "Number"
+          },
+          {
+            "type": "Number"
+          },
+          {
+            "type": "Number"
+          }
         ]
       ]
     },
     "dist": {
       "overloads": [
         [
-          "Number",
-          "Number",
-          "Number",
-          "Number"
+          {
+            "type": "Number"
+          },
+          {
+            "type": "Number"
+          },
+          {
+            "type": "Number"
+          },
+          {
+            "type": "Number"
+          }
         ],
         [
-          "Number",
-          "Number",
-          "Number",
-          "Number",
-          "Number",
-          "Number"
+          {
+            "type": "Number"
+          },
+          {
+            "type": "Number"
+          },
+          {
+            "type": "Number"
+          },
+          {
+            "type": "Number"
+          },
+          {
+            "type": "Number"
+          },
+          {
+            "type": "Number"
+          }
         ],
         [
-          "p5.Vector"
+          {
+            "type": "p5.Vector"
+          }
         ]
       ]
     },
     "exp": {
       "overloads": [
         [
-          "Number"
+          {
+            "type": "Number"
+          }
         ]
       ]
     },
     "floor": {
       "overloads": [
         [
-          "Number"
+          {
+            "type": "Number"
+          }
         ]
       ]
     },
     "lerp": {
       "overloads": [
         [
-          "Number",
-          "Number",
-          "Number"
+          {
+            "type": "Number"
+          },
+          {
+            "type": "Number"
+          },
+          {
+            "type": "Number"
+          }
         ]
       ]
     },
     "log": {
       "overloads": [
         [
-          "Number"
+          {
+            "type": "Number"
+          }
         ]
       ]
     },
     "mag": {
       "overloads": [
         [
-          "Number",
-          "Number"
+          {
+            "type": "Number"
+          },
+          {
+            "type": "Number"
+          }
         ]
       ]
     },
     "map": {
       "overloads": [
         [
-          "Number",
-          "Number",
-          "Number",
-          "Number",
-          "Number",
-          "Boolean?"
+          {
+            "type": "Number"
+          },
+          {
+            "type": "Number"
+          },
+          {
+            "type": "Number"
+          },
+          {
+            "type": "Number"
+          },
+          {
+            "type": "Number"
+          },
+          {
+            "type": "Boolean",
+            "optional": true
+          }
         ]
       ]
     },
     "max": {
       "overloads": [
         [
-          "Number",
-          "Number"
+          {
+            "type": "Number"
+          },
+          {
+            "type": "Number"
+          }
         ],
         [
-          "Number[]"
+          {
+            "type": "Array",
+            "element": "Number"
+          }
         ]
       ]
     },
     "min": {
       "overloads": [
         [
-          "Number",
-          "Number"
+          {
+            "type": "Number"
+          },
+          {
+            "type": "Number"
+          }
         ],
         [
-          "Number[]"
+          {
+            "type": "Array",
+            "element": "Number"
+          }
         ]
       ]
     },
     "norm": {
       "overloads": [
         [
-          "Number",
-          "Number",
-          "Number"
+          {
+            "type": "Number"
+          },
+          {
+            "type": "Number"
+          },
+          {
+            "type": "Number"
+          }
         ]
       ]
     },
     "pow": {
       "overloads": [
         [
-          "Number",
-          "Number"
+          {
+            "type": "Number"
+          },
+          {
+            "type": "Number"
+          }
         ]
       ]
     },
     "round": {
       "overloads": [
         [
-          "Number",
-          "Number?"
+          {
+            "type": "Number"
+          },
+          {
+            "type": "Number",
+            "optional": true
+          }
         ]
       ]
     },
     "sq": {
       "overloads": [
         [
-          "Number"
+          {
+            "type": "Number"
+          }
         ]
       ]
     },
     "sqrt": {
       "overloads": [
         [
-          "Number"
+          {
+            "type": "Number"
+          }
         ]
       ]
     },
     "fract": {
       "overloads": [
         [
-          "Number"
+          {
+            "type": "Number"
+          }
         ]
       ]
     },
     "createVector": {
       "overloads": [
         [
-          "...Number[]"
+          {
+            "type": "Number",
+            "rest": true
+          }
         ]
       ]
     },
     "noise": {
       "overloads": [
         [
-          "Number",
-          "Number?",
-          "Number?"
+          {
+            "type": "Number"
+          },
+          {
+            "type": "Number",
+            "optional": true
+          },
+          {
+            "type": "Number",
+            "optional": true
+          }
         ]
       ]
     },
     "noiseDetail": {
       "overloads": [
         [
-          "Number",
-          "Number"
+          {
+            "type": "Number"
+          },
+          {
+            "type": "Number"
+          }
         ]
       ]
     },
     "noiseSeed": {
       "overloads": [
         [
-          "Number"
+          {
+            "type": "Number"
+          }
         ]
       ]
     },
     "randomSeed": {
       "overloads": [
         [
-          "Number"
+          {
+            "type": "Number"
+          }
         ]
       ]
     },
     "random": {
       "overloads": [
         [
-          "Number?",
-          "Number?"
+          {
+            "type": "Number",
+            "optional": true
+          },
+          {
+            "type": "Number",
+            "optional": true
+          }
         ],
         [
-          "Array"
+          {
+            "type": "Array"
+          }
         ]
       ]
     },
     "randomGaussian": {
       "overloads": [
         [
-          "Number?",
-          "Number?"
+          {
+            "type": "Number",
+            "optional": true
+          },
+          {
+            "type": "Number",
+            "optional": true
+          }
         ]
       ]
     },
     "acos": {
       "overloads": [
         [
-          "Number"
+          {
+            "type": "Number"
+          }
         ]
       ]
     },
     "asin": {
       "overloads": [
         [
-          "Number"
+          {
+            "type": "Number"
+          }
         ]
       ]
     },
     "atan": {
       "overloads": [
         [
-          "Number"
+          {
+            "type": "Number"
+          }
         ]
       ]
     },
     "atan2": {
       "overloads": [
         [
-          "Number",
-          "Number"
+          {
+            "type": "Number"
+          },
+          {
+            "type": "Number"
+          }
         ]
       ]
     },
     "cos": {
       "overloads": [
         [
-          "Number"
+          {
+            "type": "Number"
+          }
         ]
       ]
     },
     "sin": {
       "overloads": [
         [
-          "Number"
+          {
+            "type": "Number"
+          }
         ]
       ]
     },
     "tan": {
       "overloads": [
         [
-          "Number"
+          {
+            "type": "Number"
+          }
         ]
       ]
     },
     "degrees": {
       "overloads": [
         [
-          "Number"
+          {
+            "type": "Number"
+          }
         ]
       ]
     },
     "radians": {
       "overloads": [
         [
-          "Number"
+          {
+            "type": "Number"
+          }
         ]
       ]
     },
     "angleMode": {
       "overloads": [
         [
-          "RADIANS|DEGREES"
+          {
+            "type": "union",
+            "elements": [
+              {
+                "type": "RADIANS",
+                "optional": true
+              },
+              {
+                "type": "DEGREES",
+                "optional": true
+              }
+            ]
+          }
         ],
         []
       ]
@@ -1556,156 +3661,380 @@
     "arc": {
       "overloads": [
         [
-          "Number",
-          "Number",
-          "Number",
-          "Number",
-          "Number",
-          "Number",
-          "CHORD|PIE|OPEN?",
-          "Integer?"
+          {
+            "type": "Number"
+          },
+          {
+            "type": "Number"
+          },
+          {
+            "type": "Number"
+          },
+          {
+            "type": "Number"
+          },
+          {
+            "type": "Number"
+          },
+          {
+            "type": "Number"
+          },
+          {
+            "type": "union",
+            "elements": [
+              {
+                "type": "CHORD",
+                "optional": true
+              },
+              {
+                "type": "PIE",
+                "optional": true
+              },
+              {
+                "type": "OPEN",
+                "optional": true
+              }
+            ],
+            "optional": true
+          },
+          {
+            "type": "Integer",
+            "optional": true
+          }
         ]
       ]
     },
     "ellipse": {
       "overloads": [
         [
-          "Number",
-          "Number",
-          "Number",
-          "Number?"
+          {
+            "type": "Number"
+          },
+          {
+            "type": "Number"
+          },
+          {
+            "type": "Number"
+          },
+          {
+            "type": "Number",
+            "optional": true
+          }
         ],
         [
-          "Number",
-          "Number",
-          "Number",
-          "Number",
-          "Integer?"
+          {
+            "type": "Number"
+          },
+          {
+            "type": "Number"
+          },
+          {
+            "type": "Number"
+          },
+          {
+            "type": "Number"
+          },
+          {
+            "type": "Integer",
+            "optional": true
+          }
         ]
       ]
     },
     "circle": {
       "overloads": [
         [
-          "Number",
-          "Number",
-          "Number"
+          {
+            "type": "Number"
+          },
+          {
+            "type": "Number"
+          },
+          {
+            "type": "Number"
+          }
         ]
       ]
     },
     "line": {
       "overloads": [
         [
-          "Number",
-          "Number",
-          "Number",
-          "Number"
+          {
+            "type": "Number"
+          },
+          {
+            "type": "Number"
+          },
+          {
+            "type": "Number"
+          },
+          {
+            "type": "Number"
+          }
         ],
         [
-          "Number",
-          "Number",
-          "Number",
-          "Number",
-          "Number",
-          "Number"
+          {
+            "type": "Number"
+          },
+          {
+            "type": "Number"
+          },
+          {
+            "type": "Number"
+          },
+          {
+            "type": "Number"
+          },
+          {
+            "type": "Number"
+          },
+          {
+            "type": "Number"
+          }
         ]
       ]
     },
     "point": {
       "overloads": [
         [
-          "Number",
-          "Number",
-          "Number?"
+          {
+            "type": "Number"
+          },
+          {
+            "type": "Number"
+          },
+          {
+            "type": "Number",
+            "optional": true
+          }
         ],
         [
-          "p5.Vector"
+          {
+            "type": "p5.Vector"
+          }
         ]
       ]
     },
     "quad": {
       "overloads": [
         [
-          "Number",
-          "Number",
-          "Number",
-          "Number",
-          "Number",
-          "Number",
-          "Number",
-          "Number",
-          "Integer?",
-          "Integer?"
+          {
+            "type": "Number"
+          },
+          {
+            "type": "Number"
+          },
+          {
+            "type": "Number"
+          },
+          {
+            "type": "Number"
+          },
+          {
+            "type": "Number"
+          },
+          {
+            "type": "Number"
+          },
+          {
+            "type": "Number"
+          },
+          {
+            "type": "Number"
+          },
+          {
+            "type": "Integer",
+            "optional": true
+          },
+          {
+            "type": "Integer",
+            "optional": true
+          }
         ],
         [
-          "Number",
-          "Number",
-          "Number",
-          "Number",
-          "Number",
-          "Number",
-          "Number",
-          "Number",
-          "Number",
-          "Number",
-          "Number",
-          "Number",
-          "Integer?",
-          "Integer?"
+          {
+            "type": "Number"
+          },
+          {
+            "type": "Number"
+          },
+          {
+            "type": "Number"
+          },
+          {
+            "type": "Number"
+          },
+          {
+            "type": "Number"
+          },
+          {
+            "type": "Number"
+          },
+          {
+            "type": "Number"
+          },
+          {
+            "type": "Number"
+          },
+          {
+            "type": "Number"
+          },
+          {
+            "type": "Number"
+          },
+          {
+            "type": "Number"
+          },
+          {
+            "type": "Number"
+          },
+          {
+            "type": "Integer",
+            "optional": true
+          },
+          {
+            "type": "Integer",
+            "optional": true
+          }
         ]
       ]
     },
     "rect": {
       "overloads": [
         [
-          "Number",
-          "Number",
-          "Number",
-          "Number?",
-          "Number?",
-          "Number?",
-          "Number?",
-          "Number?"
+          {
+            "type": "Number"
+          },
+          {
+            "type": "Number"
+          },
+          {
+            "type": "Number"
+          },
+          {
+            "type": "Number",
+            "optional": true
+          },
+          {
+            "type": "Number",
+            "optional": true
+          },
+          {
+            "type": "Number",
+            "optional": true
+          },
+          {
+            "type": "Number",
+            "optional": true
+          },
+          {
+            "type": "Number",
+            "optional": true
+          }
         ],
         [
-          "Number",
-          "Number",
-          "Number",
-          "Number",
-          "Integer?",
-          "Integer?"
+          {
+            "type": "Number"
+          },
+          {
+            "type": "Number"
+          },
+          {
+            "type": "Number"
+          },
+          {
+            "type": "Number"
+          },
+          {
+            "type": "Integer",
+            "optional": true
+          },
+          {
+            "type": "Integer",
+            "optional": true
+          }
         ]
       ]
     },
     "square": {
       "overloads": [
         [
-          "Number",
-          "Number",
-          "Number",
-          "Number?",
-          "Number?",
-          "Number?",
-          "Number?"
+          {
+            "type": "Number"
+          },
+          {
+            "type": "Number"
+          },
+          {
+            "type": "Number"
+          },
+          {
+            "type": "Number",
+            "optional": true
+          },
+          {
+            "type": "Number",
+            "optional": true
+          },
+          {
+            "type": "Number",
+            "optional": true
+          },
+          {
+            "type": "Number",
+            "optional": true
+          }
         ]
       ]
     },
     "triangle": {
       "overloads": [
         [
-          "Number",
-          "Number",
-          "Number",
-          "Number",
-          "Number",
-          "Number"
+          {
+            "type": "Number"
+          },
+          {
+            "type": "Number"
+          },
+          {
+            "type": "Number"
+          },
+          {
+            "type": "Number"
+          },
+          {
+            "type": "Number"
+          },
+          {
+            "type": "Number"
+          }
         ]
       ]
     },
     "ellipseMode": {
       "overloads": [
         [
-          "CENTER|RADIUS|CORNER|CORNERS"
+          {
+            "type": "union",
+            "elements": [
+              {
+                "type": "CENTER",
+                "optional": true
+              },
+              {
+                "type": "RADIUS",
+                "optional": true
+              },
+              {
+                "type": "CORNER",
+                "optional": true
+              },
+              {
+                "type": "CORNERS",
+                "optional": true
+              }
+            ]
+          }
         ]
       ]
     },
@@ -1717,7 +4046,27 @@
     "rectMode": {
       "overloads": [
         [
-          "CENTER|RADIUS|CORNER|CORNERS"
+          {
+            "type": "union",
+            "elements": [
+              {
+                "type": "CENTER",
+                "optional": true
+              },
+              {
+                "type": "RADIUS",
+                "optional": true
+              },
+              {
+                "type": "CORNER",
+                "optional": true
+              },
+              {
+                "type": "CORNERS",
+                "optional": true
+              }
+            ]
+          }
         ]
       ]
     },
@@ -1729,128 +4078,284 @@
     "strokeCap": {
       "overloads": [
         [
-          "ROUND|SQUARE|PROJECT"
+          {
+            "type": "union",
+            "elements": [
+              {
+                "type": "ROUND",
+                "optional": true
+              },
+              {
+                "type": "SQUARE",
+                "optional": true
+              },
+              {
+                "type": "PROJECT",
+                "optional": true
+              }
+            ]
+          }
         ]
       ]
     },
     "strokeJoin": {
       "overloads": [
         [
-          "MITER|BEVEL|ROUND"
+          {
+            "type": "union",
+            "elements": [
+              {
+                "type": "MITER",
+                "optional": true
+              },
+              {
+                "type": "BEVEL",
+                "optional": true
+              },
+              {
+                "type": "ROUND",
+                "optional": true
+              }
+            ]
+          }
         ]
       ]
     },
     "strokeWeight": {
       "overloads": [
         [
-          "Number"
+          {
+            "type": "Number"
+          }
         ]
       ]
     },
     "bezier": {
       "overloads": [
         [
-          "Number",
-          "Number",
-          "Number",
-          "Number",
-          "Number",
-          "Number",
-          "Number",
-          "Number"
+          {
+            "type": "Number"
+          },
+          {
+            "type": "Number"
+          },
+          {
+            "type": "Number"
+          },
+          {
+            "type": "Number"
+          },
+          {
+            "type": "Number"
+          },
+          {
+            "type": "Number"
+          },
+          {
+            "type": "Number"
+          },
+          {
+            "type": "Number"
+          }
         ],
         [
-          "Number",
-          "Number",
-          "Number",
-          "Number",
-          "Number",
-          "Number",
-          "Number",
-          "Number",
-          "Number",
-          "Number",
-          "Number",
-          "Number"
+          {
+            "type": "Number"
+          },
+          {
+            "type": "Number"
+          },
+          {
+            "type": "Number"
+          },
+          {
+            "type": "Number"
+          },
+          {
+            "type": "Number"
+          },
+          {
+            "type": "Number"
+          },
+          {
+            "type": "Number"
+          },
+          {
+            "type": "Number"
+          },
+          {
+            "type": "Number"
+          },
+          {
+            "type": "Number"
+          },
+          {
+            "type": "Number"
+          },
+          {
+            "type": "Number"
+          }
         ]
       ]
     },
     "bezierPoint": {
       "overloads": [
         [
-          "Number",
-          "Number",
-          "Number",
-          "Number",
-          "Number"
+          {
+            "type": "Number"
+          },
+          {
+            "type": "Number"
+          },
+          {
+            "type": "Number"
+          },
+          {
+            "type": "Number"
+          },
+          {
+            "type": "Number"
+          }
         ]
       ]
     },
     "bezierTangent": {
       "overloads": [
         [
-          "Number",
-          "Number",
-          "Number",
-          "Number",
-          "Number"
+          {
+            "type": "Number"
+          },
+          {
+            "type": "Number"
+          },
+          {
+            "type": "Number"
+          },
+          {
+            "type": "Number"
+          },
+          {
+            "type": "Number"
+          }
         ]
       ]
     },
     "spline": {
       "overloads": [
         [
-          "Number",
-          "Number",
-          "Number",
-          "Number",
-          "Number",
-          "Number",
-          "Number",
-          "Number"
+          {
+            "type": "Number"
+          },
+          {
+            "type": "Number"
+          },
+          {
+            "type": "Number"
+          },
+          {
+            "type": "Number"
+          },
+          {
+            "type": "Number"
+          },
+          {
+            "type": "Number"
+          },
+          {
+            "type": "Number"
+          },
+          {
+            "type": "Number"
+          }
         ],
         [
-          "Number",
-          "Number",
-          "Number",
-          "Number",
-          "Number",
-          "Number",
-          "Number",
-          "Number",
-          "Number",
-          "Number",
-          "Number",
-          "Number"
+          {
+            "type": "Number"
+          },
+          {
+            "type": "Number"
+          },
+          {
+            "type": "Number"
+          },
+          {
+            "type": "Number"
+          },
+          {
+            "type": "Number"
+          },
+          {
+            "type": "Number"
+          },
+          {
+            "type": "Number"
+          },
+          {
+            "type": "Number"
+          },
+          {
+            "type": "Number"
+          },
+          {
+            "type": "Number"
+          },
+          {
+            "type": "Number"
+          },
+          {
+            "type": "Number"
+          }
         ]
       ]
     },
     "splinePoint": {
       "overloads": [
         [
-          "Number",
-          "Number",
-          "Number",
-          "Number",
-          "Number"
+          {
+            "type": "Number"
+          },
+          {
+            "type": "Number"
+          },
+          {
+            "type": "Number"
+          },
+          {
+            "type": "Number"
+          },
+          {
+            "type": "Number"
+          }
         ]
       ]
     },
     "splineTangent": {
       "overloads": [
         [
-          "Number",
-          "Number",
-          "Number",
-          "Number",
-          "Number"
+          {
+            "type": "Number"
+          },
+          {
+            "type": "Number"
+          },
+          {
+            "type": "Number"
+          },
+          {
+            "type": "Number"
+          },
+          {
+            "type": "Number"
+          }
         ]
       ]
     },
     "bezierOrder": {
       "overloads": [
         [
-          "Number"
+          {
+            "type": "Number"
+          }
         ],
         []
       ]
@@ -1858,44 +4363,83 @@
     "splineVertex": {
       "overloads": [
         [
-          "Number",
-          "Number"
+          {
+            "type": "Number"
+          },
+          {
+            "type": "Number"
+          }
         ],
         [
-          "Number",
-          "Number",
-          "Number?"
+          {
+            "type": "Number"
+          },
+          {
+            "type": "Number"
+          },
+          {
+            "type": "Number",
+            "optional": true
+          }
         ],
         [
-          "Number",
-          "Number",
-          "Number?",
-          "Number?"
+          {
+            "type": "Number"
+          },
+          {
+            "type": "Number"
+          },
+          {
+            "type": "Number",
+            "optional": true
+          },
+          {
+            "type": "Number",
+            "optional": true
+          }
         ],
         [
-          "Number",
-          "Number",
-          "Number",
-          "Number?",
-          "Number?"
+          {
+            "type": "Number"
+          },
+          {
+            "type": "Number"
+          },
+          {
+            "type": "Number"
+          },
+          {
+            "type": "Number",
+            "optional": true
+          },
+          {
+            "type": "Number",
+            "optional": true
+          }
         ]
       ]
     },
     "splineProperty": {
       "overloads": [
         [
-          "String",
-          null
+          {
+            "type": "String"
+          },
+          {}
         ],
         [
-          "String"
+          {
+            "type": "String"
+          }
         ]
       ]
     },
     "splineProperties": {
       "overloads": [
         [
-          "Object"
+          {
+            "type": "Object"
+          }
         ],
         []
       ]
@@ -1903,21 +4447,47 @@
     "vertex": {
       "overloads": [
         [
-          "Number",
-          "Number"
+          {
+            "type": "Number"
+          },
+          {
+            "type": "Number"
+          }
         ],
         [
-          "Number",
-          "Number",
-          "Number?",
-          "Number?"
+          {
+            "type": "Number"
+          },
+          {
+            "type": "Number"
+          },
+          {
+            "type": "Number",
+            "optional": true
+          },
+          {
+            "type": "Number",
+            "optional": true
+          }
         ],
         [
-          "Number",
-          "Number",
-          "Number",
-          "Number?",
-          "Number?"
+          {
+            "type": "Number"
+          },
+          {
+            "type": "Number"
+          },
+          {
+            "type": "Number"
+          },
+          {
+            "type": "Number",
+            "optional": true
+          },
+          {
+            "type": "Number",
+            "optional": true
+          }
         ]
       ]
     },
@@ -1929,130 +4499,370 @@
     "endContour": {
       "overloads": [
         [
-          "OPEN|CLOSE?"
+          {
+            "type": "union",
+            "elements": [
+              {
+                "type": "OPEN",
+                "optional": true
+              },
+              {
+                "type": "CLOSE",
+                "optional": true
+              }
+            ],
+            "optional": true
+          }
         ]
       ]
     },
     "beginShape": {
       "overloads": [
         [
-          "POINTS|LINES|TRIANGLES|TRIANGLE_FAN|TRIANGLE_STRIP|QUADS|QUAD_STRIP|PATH?"
+          {
+            "type": "union",
+            "elements": [
+              {
+                "type": "POINTS",
+                "optional": true
+              },
+              {
+                "type": "LINES",
+                "optional": true
+              },
+              {
+                "type": "TRIANGLES",
+                "optional": true
+              },
+              {
+                "type": "TRIANGLE_FAN",
+                "optional": true
+              },
+              {
+                "type": "TRIANGLE_STRIP",
+                "optional": true
+              },
+              {
+                "type": "QUADS",
+                "optional": true
+              },
+              {
+                "type": "QUAD_STRIP",
+                "optional": true
+              },
+              {
+                "type": "PATH",
+                "optional": true
+              }
+            ],
+            "optional": true
+          }
         ]
       ]
     },
     "bezierVertex": {
       "overloads": [
         [
-          "Number",
-          "Number",
-          "Number?",
-          "Number?"
+          {
+            "type": "Number"
+          },
+          {
+            "type": "Number"
+          },
+          {
+            "type": "Number",
+            "optional": true
+          },
+          {
+            "type": "Number",
+            "optional": true
+          }
         ],
         [
-          "Number",
-          "Number",
-          "Number",
-          "Number?",
-          "Number?"
+          {
+            "type": "Number"
+          },
+          {
+            "type": "Number"
+          },
+          {
+            "type": "Number"
+          },
+          {
+            "type": "Number",
+            "optional": true
+          },
+          {
+            "type": "Number",
+            "optional": true
+          }
         ]
       ]
     },
     "endShape": {
       "overloads": [
         [
-          "CLOSE?",
-          "Integer?"
+          {
+            "type": "CLOSE",
+            "optional": true
+          },
+          {
+            "type": "Integer",
+            "optional": true
+          }
         ]
       ]
     },
     "normal": {
       "overloads": [
         [
-          "p5.Vector"
+          {
+            "type": "p5.Vector"
+          }
         ],
         [
-          "Number",
-          "Number",
-          "Number"
+          {
+            "type": "Number"
+          },
+          {
+            "type": "Number"
+          },
+          {
+            "type": "Number"
+          }
         ]
       ]
     },
     "vertexProperty": {
       "overloads": [
         [
-          "String",
-          "Number|Number[]"
+          {
+            "type": "String"
+          },
+          {
+            "type": "union",
+            "elements": [
+              {
+                "type": "Number",
+                "optional": true
+              },
+              {
+                "type": "Array",
+                "element": "Number",
+                "optional": true
+              }
+            ]
+          }
         ]
       ]
     },
     "loadFont": {
       "overloads": [
         [
-          "String",
-          "String?",
-          "Object?",
-          "Function?",
-          "Function?"
+          {
+            "type": "String"
+          },
+          {
+            "type": "String",
+            "optional": true
+          },
+          {
+            "type": "Object",
+            "properties": {
+              "sets": {
+                "type": "union",
+                "elements": [
+                  {
+                    "type": "String",
+                    "optional": true
+                  },
+                  {
+                    "type": "Array",
+                    "element": "String",
+                    "optional": true
+                  }
+                ],
+                "optional": true
+              }
+            },
+            "optional": true
+          },
+          {
+            "type": "Function",
+            "optional": true
+          },
+          {
+            "type": "Function",
+            "optional": true
+          }
         ],
         [
-          "String",
-          "Function?",
-          "Function?"
+          {
+            "type": "String"
+          },
+          {
+            "type": "Function",
+            "optional": true
+          },
+          {
+            "type": "Function",
+            "optional": true
+          }
         ]
       ]
     },
     "text": {
       "overloads": [
         [
-          "String|Object|Array|Number|Boolean",
-          "Number",
-          "Number",
-          "Number?",
-          "Number?"
+          {
+            "type": "union",
+            "elements": [
+              {
+                "type": "String",
+                "optional": true
+              },
+              {
+                "type": "Object",
+                "optional": true
+              },
+              {
+                "type": "Array",
+                "optional": true
+              },
+              {
+                "type": "Number",
+                "optional": true
+              },
+              {
+                "type": "Boolean",
+                "optional": true
+              }
+            ]
+          },
+          {
+            "type": "Number"
+          },
+          {
+            "type": "Number"
+          },
+          {
+            "type": "Number",
+            "optional": true
+          },
+          {
+            "type": "Number",
+            "optional": true
+          }
         ]
       ]
     },
     "textAlign": {
       "overloads": [
         [
-          "LEFT|CENTER|RIGHT",
-          "TOP|BOTTOM|CENTER|BASELINE?"
+          {
+            "type": "union",
+            "elements": [
+              {
+                "type": "LEFT",
+                "optional": true
+              },
+              {
+                "type": "CENTER",
+                "optional": true
+              },
+              {
+                "type": "RIGHT",
+                "optional": true
+              }
+            ]
+          },
+          {
+            "type": "union",
+            "elements": [
+              {
+                "type": "TOP",
+                "optional": true
+              },
+              {
+                "type": "BOTTOM",
+                "optional": true
+              },
+              {
+                "type": "CENTER",
+                "optional": true
+              },
+              {
+                "type": "BASELINE",
+                "optional": true
+              }
+            ],
+            "optional": true
+          }
         ]
       ]
     },
     "textAscent": {
       "overloads": [
         [
-          "String?"
+          {
+            "type": "String",
+            "optional": true
+          }
         ]
       ]
     },
     "textDescent": {
       "overloads": [
         [
-          "String?"
+          {
+            "type": "String",
+            "optional": true
+          }
         ]
       ]
     },
     "textLeading": {
       "overloads": [
         [
-          "Number"
+          {
+            "type": "Number"
+          }
         ]
       ]
     },
     "textFont": {
       "overloads": [
         [
-          "p5.Font|String|Object",
-          "Number?"
+          {
+            "type": "union",
+            "elements": [
+              {
+                "type": "p5.Font",
+                "optional": true
+              },
+              {
+                "type": "String",
+                "optional": true
+              },
+              {
+                "type": "Object",
+                "optional": true
+              }
+            ]
+          },
+          {
+            "type": "Number",
+            "optional": true
+          }
         ]
       ]
     },
     "textSize": {
       "overloads": [
         [
-          "Number"
+          {
+            "type": "Number"
+          }
         ],
         []
       ]
@@ -2060,7 +4870,27 @@
     "textStyle": {
       "overloads": [
         [
-          "NORMAL|ITALIC|BOLD|BOLDITALIC"
+          {
+            "type": "union",
+            "elements": [
+              {
+                "type": "NORMAL",
+                "optional": true
+              },
+              {
+                "type": "ITALIC",
+                "optional": true
+              },
+              {
+                "type": "BOLD",
+                "optional": true
+              },
+              {
+                "type": "BOLDITALIC",
+                "optional": true
+              }
+            ]
+          }
         ],
         []
       ]
@@ -2068,14 +4898,28 @@
     "textWidth": {
       "overloads": [
         [
-          "String"
+          {
+            "type": "String"
+          }
         ]
       ]
     },
     "textWrap": {
       "overloads": [
         [
-          "WORD|CHAR"
+          {
+            "type": "union",
+            "elements": [
+              {
+                "type": "WORD",
+                "optional": true
+              },
+              {
+                "type": "CHAR",
+                "optional": true
+              }
+            ]
+          }
         ],
         []
       ]
@@ -2083,18 +4927,32 @@
     "textBounds": {
       "overloads": [
         [
-          "String",
-          "Number",
-          "Number",
-          "Number?",
-          "Number?"
+          {
+            "type": "String"
+          },
+          {
+            "type": "Number"
+          },
+          {
+            "type": "Number"
+          },
+          {
+            "type": "Number",
+            "optional": true
+          },
+          {
+            "type": "Number",
+            "optional": true
+          }
         ]
       ]
     },
     "textDirection": {
       "overloads": [
         [
-          "String"
+          {
+            "type": "String"
+          }
         ],
         []
       ]
@@ -2102,18 +4960,24 @@
     "textProperty": {
       "overloads": [
         [
-          "String",
-          null
+          {
+            "type": "String"
+          },
+          {}
         ],
         [
-          "String"
+          {
+            "type": "String"
+          }
         ]
       ]
     },
     "textProperties": {
       "overloads": [
         [
-          "Object"
+          {
+            "type": "Object"
+          }
         ],
         []
       ]
@@ -2121,18 +4985,32 @@
     "fontBounds": {
       "overloads": [
         [
-          "String",
-          "Number",
-          "Number",
-          "Number?",
-          "Number?"
+          {
+            "type": "String"
+          },
+          {
+            "type": "Number"
+          },
+          {
+            "type": "Number"
+          },
+          {
+            "type": "Number",
+            "optional": true
+          },
+          {
+            "type": "Number",
+            "optional": true
+          }
         ]
       ]
     },
     "fontWidth": {
       "overloads": [
         [
-          "String"
+          {
+            "type": "String"
+          }
         ]
       ]
     },
@@ -2149,7 +5027,9 @@
     "textWeight": {
       "overloads": [
         [
-          "Number"
+          {
+            "type": "Number"
+          }
         ],
         []
       ]
@@ -2157,89 +5037,199 @@
     "float": {
       "overloads": [
         [
-          "String"
+          {
+            "type": "String"
+          }
         ],
         [
-          "String[]"
+          {
+            "type": "Array",
+            "element": "String"
+          }
         ]
       ]
     },
     "int": {
       "overloads": [
         [
-          "String|Boolean|Number"
+          {
+            "type": "union",
+            "elements": [
+              {
+                "type": "String",
+                "optional": true
+              },
+              {
+                "type": "Boolean",
+                "optional": true
+              },
+              {
+                "type": "Number",
+                "optional": true
+              }
+            ]
+          }
         ],
         [
-          "Array"
+          {
+            "type": "Array"
+          }
         ]
       ]
     },
     "str": {
       "overloads": [
         [
-          "String|Boolean|Number"
+          {
+            "type": "union",
+            "elements": [
+              {
+                "type": "String",
+                "optional": true
+              },
+              {
+                "type": "Boolean",
+                "optional": true
+              },
+              {
+                "type": "Number",
+                "optional": true
+              }
+            ]
+          }
         ]
       ]
     },
     "boolean": {
       "overloads": [
         [
-          "String|Boolean|Number"
+          {
+            "type": "union",
+            "elements": [
+              {
+                "type": "String",
+                "optional": true
+              },
+              {
+                "type": "Boolean",
+                "optional": true
+              },
+              {
+                "type": "Number",
+                "optional": true
+              }
+            ]
+          }
         ],
         [
-          "Array"
+          {
+            "type": "Array"
+          }
         ]
       ]
     },
     "byte": {
       "overloads": [
         [
-          "String|Boolean|Number"
+          {
+            "type": "union",
+            "elements": [
+              {
+                "type": "String",
+                "optional": true
+              },
+              {
+                "type": "Boolean",
+                "optional": true
+              },
+              {
+                "type": "Number",
+                "optional": true
+              }
+            ]
+          }
         ],
         [
-          "Array"
+          {
+            "type": "Array"
+          }
         ]
       ]
     },
     "char": {
       "overloads": [
         [
-          "String|Number"
+          {
+            "type": "union",
+            "elements": [
+              {
+                "type": "String",
+                "optional": true
+              },
+              {
+                "type": "Number",
+                "optional": true
+              }
+            ]
+          }
         ],
         [
-          "Array"
+          {
+            "type": "Array"
+          }
         ]
       ]
     },
     "unchar": {
       "overloads": [
         [
-          "String"
+          {
+            "type": "String"
+          }
         ],
         [
-          "String[]"
+          {
+            "type": "Array",
+            "element": "String"
+          }
         ]
       ]
     },
     "hex": {
       "overloads": [
         [
-          "Number",
-          "Number?"
+          {
+            "type": "Number"
+          },
+          {
+            "type": "Number",
+            "optional": true
+          }
         ],
         [
-          "Number[]",
-          "Number?"
+          {
+            "type": "Array",
+            "element": "Number"
+          },
+          {
+            "type": "Number",
+            "optional": true
+          }
         ]
       ]
     },
     "unhex": {
       "overloads": [
         [
-          "String"
+          {
+            "type": "String"
+          }
         ],
         [
-          "String[]"
+          {
+            "type": "Array",
+            "element": "String"
+          }
         ]
       ]
     },
@@ -2281,182 +5271,449 @@
     "nf": {
       "overloads": [
         [
-          "Number|String",
-          "Integer|String?",
-          "Integer|String?"
+          {
+            "type": "union",
+            "elements": [
+              {
+                "type": "Number",
+                "optional": true
+              },
+              {
+                "type": "String",
+                "optional": true
+              }
+            ]
+          },
+          {
+            "type": "union",
+            "elements": [
+              {
+                "type": "Integer",
+                "optional": true
+              },
+              {
+                "type": "String",
+                "optional": true
+              }
+            ],
+            "optional": true
+          },
+          {
+            "type": "union",
+            "elements": [
+              {
+                "type": "Integer",
+                "optional": true
+              },
+              {
+                "type": "String",
+                "optional": true
+              }
+            ],
+            "optional": true
+          }
         ],
         [
-          "Number[]",
-          "Integer|String?",
-          "Integer|String?"
+          {
+            "type": "Array",
+            "element": "Number"
+          },
+          {
+            "type": "union",
+            "elements": [
+              {
+                "type": "Integer",
+                "optional": true
+              },
+              {
+                "type": "String",
+                "optional": true
+              }
+            ],
+            "optional": true
+          },
+          {
+            "type": "union",
+            "elements": [
+              {
+                "type": "Integer",
+                "optional": true
+              },
+              {
+                "type": "String",
+                "optional": true
+              }
+            ],
+            "optional": true
+          }
         ]
       ]
     },
     "nfc": {
       "overloads": [
         [
-          "Number|String",
-          "Integer|String?"
+          {
+            "type": "union",
+            "elements": [
+              {
+                "type": "Number",
+                "optional": true
+              },
+              {
+                "type": "String",
+                "optional": true
+              }
+            ]
+          },
+          {
+            "type": "union",
+            "elements": [
+              {
+                "type": "Integer",
+                "optional": true
+              },
+              {
+                "type": "String",
+                "optional": true
+              }
+            ],
+            "optional": true
+          }
         ],
         [
-          "Number[]",
-          "Integer|String?"
+          {
+            "type": "Array",
+            "element": "Number"
+          },
+          {
+            "type": "union",
+            "elements": [
+              {
+                "type": "Integer",
+                "optional": true
+              },
+              {
+                "type": "String",
+                "optional": true
+              }
+            ],
+            "optional": true
+          }
         ]
       ]
     },
     "nfp": {
       "overloads": [
         [
-          "Number",
-          "Integer?",
-          "Integer?"
+          {
+            "type": "Number"
+          },
+          {
+            "type": "Integer",
+            "optional": true
+          },
+          {
+            "type": "Integer",
+            "optional": true
+          }
         ],
         [
-          "Number[]",
-          "Integer?",
-          "Integer?"
+          {
+            "type": "Array",
+            "element": "Number"
+          },
+          {
+            "type": "Integer",
+            "optional": true
+          },
+          {
+            "type": "Integer",
+            "optional": true
+          }
         ]
       ]
     },
     "nfs": {
       "overloads": [
         [
-          "Number",
-          "Integer?",
-          "Integer?"
+          {
+            "type": "Number"
+          },
+          {
+            "type": "Integer",
+            "optional": true
+          },
+          {
+            "type": "Integer",
+            "optional": true
+          }
         ],
         [
-          "Array",
-          "Integer?",
-          "Integer?"
+          {
+            "type": "Array"
+          },
+          {
+            "type": "Integer",
+            "optional": true
+          },
+          {
+            "type": "Integer",
+            "optional": true
+          }
         ]
       ]
     },
     "splitTokens": {
       "overloads": [
         [
-          "String",
-          "String?"
+          {
+            "type": "String"
+          },
+          {
+            "type": "String",
+            "optional": true
+          }
         ]
       ]
     },
     "shuffle": {
       "overloads": [
         [
-          "Array",
-          "Boolean?"
+          {
+            "type": "Array"
+          },
+          {
+            "type": "Boolean",
+            "optional": true
+          }
         ]
       ]
     },
     "strokeMode": {
       "overloads": [
         [
-          "String"
+          {
+            "type": "String"
+          }
         ]
       ]
     },
     "buildGeometry": {
       "overloads": [
         [
-          "Function"
+          {
+            "type": "Function"
+          }
         ]
       ]
     },
     "freeGeometry": {
       "overloads": [
         [
-          "p5.Geometry"
+          {
+            "type": "p5.Geometry"
+          }
         ]
       ]
     },
     "plane": {
       "overloads": [
         [
-          "Number?",
-          "Number?",
-          "Integer?",
-          "Integer?"
+          {
+            "type": "Number",
+            "optional": true
+          },
+          {
+            "type": "Number",
+            "optional": true
+          },
+          {
+            "type": "Integer",
+            "optional": true
+          },
+          {
+            "type": "Integer",
+            "optional": true
+          }
         ]
       ]
     },
     "box": {
       "overloads": [
         [
-          "Number?",
-          "Number?",
-          "Number?",
-          "Integer?",
-          "Integer?"
+          {
+            "type": "Number",
+            "optional": true
+          },
+          {
+            "type": "Number",
+            "optional": true
+          },
+          {
+            "type": "Number",
+            "optional": true
+          },
+          {
+            "type": "Integer",
+            "optional": true
+          },
+          {
+            "type": "Integer",
+            "optional": true
+          }
         ]
       ]
     },
     "sphere": {
       "overloads": [
         [
-          "Number?",
-          "Integer?",
-          "Integer?"
+          {
+            "type": "Number",
+            "optional": true
+          },
+          {
+            "type": "Integer",
+            "optional": true
+          },
+          {
+            "type": "Integer",
+            "optional": true
+          }
         ]
       ]
     },
     "cylinder": {
       "overloads": [
         [
-          "Number?",
-          "Number?",
-          "Integer?",
-          "Integer?",
-          "Boolean?",
-          "Boolean?"
+          {
+            "type": "Number",
+            "optional": true
+          },
+          {
+            "type": "Number",
+            "optional": true
+          },
+          {
+            "type": "Integer",
+            "optional": true
+          },
+          {
+            "type": "Integer",
+            "optional": true
+          },
+          {
+            "type": "Boolean",
+            "optional": true
+          },
+          {
+            "type": "Boolean",
+            "optional": true
+          }
         ]
       ]
     },
     "cone": {
       "overloads": [
         [
-          "Number?",
-          "Number?",
-          "Integer?",
-          "Integer?",
-          "Boolean?"
+          {
+            "type": "Number",
+            "optional": true
+          },
+          {
+            "type": "Number",
+            "optional": true
+          },
+          {
+            "type": "Integer",
+            "optional": true
+          },
+          {
+            "type": "Integer",
+            "optional": true
+          },
+          {
+            "type": "Boolean",
+            "optional": true
+          }
         ]
       ]
     },
     "ellipsoid": {
       "overloads": [
         [
-          "Number?",
-          "Number?",
-          "Number?",
-          "Integer?",
-          "Integer?"
+          {
+            "type": "Number",
+            "optional": true
+          },
+          {
+            "type": "Number",
+            "optional": true
+          },
+          {
+            "type": "Number",
+            "optional": true
+          },
+          {
+            "type": "Integer",
+            "optional": true
+          },
+          {
+            "type": "Integer",
+            "optional": true
+          }
         ]
       ]
     },
     "torus": {
       "overloads": [
         [
-          "Number?",
-          "Number?",
-          "Integer?",
-          "Integer?"
+          {
+            "type": "Number",
+            "optional": true
+          },
+          {
+            "type": "Number",
+            "optional": true
+          },
+          {
+            "type": "Integer",
+            "optional": true
+          },
+          {
+            "type": "Integer",
+            "optional": true
+          }
         ]
       ]
     },
     "curveDetail": {
       "overloads": [
         [
-          "Number"
+          {
+            "type": "Number"
+          }
         ]
       ]
     },
     "orbitControl": {
       "overloads": [
         [
-          "Number?",
-          "Number?",
-          "Number?",
-          "Object?"
+          {
+            "type": "Number",
+            "optional": true
+          },
+          {
+            "type": "Number",
+            "optional": true
+          },
+          {
+            "type": "Number",
+            "optional": true
+          },
+          {
+            "type": "Object",
+            "optional": true
+          }
         ]
       ]
     },
@@ -2464,33 +5721,123 @@
       "overloads": [
         [],
         [
-          "GRID|AXES"
+          {
+            "type": "union",
+            "elements": [
+              {
+                "type": "GRID",
+                "optional": true
+              },
+              {
+                "type": "AXES",
+                "optional": true
+              }
+            ]
+          }
         ],
         [
-          "GRID|AXES",
-          "Number?",
-          "Number?",
-          "Number?",
-          "Number?",
-          "Number?"
+          {
+            "type": "union",
+            "elements": [
+              {
+                "type": "GRID",
+                "optional": true
+              },
+              {
+                "type": "AXES",
+                "optional": true
+              }
+            ]
+          },
+          {
+            "type": "Number",
+            "optional": true
+          },
+          {
+            "type": "Number",
+            "optional": true
+          },
+          {
+            "type": "Number",
+            "optional": true
+          },
+          {
+            "type": "Number",
+            "optional": true
+          },
+          {
+            "type": "Number",
+            "optional": true
+          }
         ],
         [
-          "GRID|AXES",
-          "Number?",
-          "Number?",
-          "Number?",
-          "Number?"
+          {
+            "type": "union",
+            "elements": [
+              {
+                "type": "GRID",
+                "optional": true
+              },
+              {
+                "type": "AXES",
+                "optional": true
+              }
+            ]
+          },
+          {
+            "type": "Number",
+            "optional": true
+          },
+          {
+            "type": "Number",
+            "optional": true
+          },
+          {
+            "type": "Number",
+            "optional": true
+          },
+          {
+            "type": "Number",
+            "optional": true
+          }
         ],
         [
-          "Number?",
-          "Number?",
-          "Number?",
-          "Number?",
-          "Number?",
-          "Number?",
-          "Number?",
-          "Number?",
-          "Number?"
+          {
+            "type": "Number",
+            "optional": true
+          },
+          {
+            "type": "Number",
+            "optional": true
+          },
+          {
+            "type": "Number",
+            "optional": true
+          },
+          {
+            "type": "Number",
+            "optional": true
+          },
+          {
+            "type": "Number",
+            "optional": true
+          },
+          {
+            "type": "Number",
+            "optional": true
+          },
+          {
+            "type": "Number",
+            "optional": true
+          },
+          {
+            "type": "Number",
+            "optional": true
+          },
+          {
+            "type": "Number",
+            "optional": true
+          }
         ]
       ]
     },
@@ -2502,114 +5849,278 @@
     "ambientLight": {
       "overloads": [
         [
-          "Number",
-          "Number",
-          "Number",
-          "Number?"
+          {
+            "type": "Number"
+          },
+          {
+            "type": "Number"
+          },
+          {
+            "type": "Number"
+          },
+          {
+            "type": "Number",
+            "optional": true
+          }
         ],
         [
-          "Number",
-          "Number?"
+          {
+            "type": "Number"
+          },
+          {
+            "type": "Number",
+            "optional": true
+          }
         ],
         [
-          "String"
+          {
+            "type": "String"
+          }
         ],
         [
-          "Number[]"
+          {
+            "type": "Array",
+            "element": "Number"
+          }
         ],
         [
-          "p5.Color"
+          {
+            "type": "p5.Color"
+          }
         ]
       ]
     },
     "specularColor": {
       "overloads": [
         [
-          "Number",
-          "Number",
-          "Number"
+          {
+            "type": "Number"
+          },
+          {
+            "type": "Number"
+          },
+          {
+            "type": "Number"
+          }
         ],
         [
-          "Number"
+          {
+            "type": "Number"
+          }
         ],
         [
-          "String"
+          {
+            "type": "String"
+          }
         ],
         [
-          "Number[]"
+          {
+            "type": "Array",
+            "element": "Number"
+          }
         ],
         [
-          "p5.Color"
+          {
+            "type": "p5.Color"
+          }
         ]
       ]
     },
     "directionalLight": {
       "overloads": [
         [
-          "Number",
-          "Number",
-          "Number",
-          "Number",
-          "Number",
-          "Number"
+          {
+            "type": "Number"
+          },
+          {
+            "type": "Number"
+          },
+          {
+            "type": "Number"
+          },
+          {
+            "type": "Number"
+          },
+          {
+            "type": "Number"
+          },
+          {
+            "type": "Number"
+          }
         ],
         [
-          "Number",
-          "Number",
-          "Number",
-          "p5.Vector"
+          {
+            "type": "Number"
+          },
+          {
+            "type": "Number"
+          },
+          {
+            "type": "Number"
+          },
+          {
+            "type": "p5.Vector"
+          }
         ],
         [
-          "p5.Color|Number[]|String",
-          "Number",
-          "Number",
-          "Number"
+          {
+            "type": "union",
+            "elements": [
+              {
+                "type": "p5.Color",
+                "optional": true
+              },
+              {
+                "type": "Array",
+                "element": "Number",
+                "optional": true
+              },
+              {
+                "type": "String",
+                "optional": true
+              }
+            ]
+          },
+          {
+            "type": "Number"
+          },
+          {
+            "type": "Number"
+          },
+          {
+            "type": "Number"
+          }
         ],
         [
-          "p5.Color|Number[]|String",
-          "p5.Vector"
+          {
+            "type": "union",
+            "elements": [
+              {
+                "type": "p5.Color",
+                "optional": true
+              },
+              {
+                "type": "Array",
+                "element": "Number",
+                "optional": true
+              },
+              {
+                "type": "String",
+                "optional": true
+              }
+            ]
+          },
+          {
+            "type": "p5.Vector"
+          }
         ]
       ]
     },
     "pointLight": {
       "overloads": [
         [
-          "Number",
-          "Number",
-          "Number",
-          "Number",
-          "Number",
-          "Number"
+          {
+            "type": "Number"
+          },
+          {
+            "type": "Number"
+          },
+          {
+            "type": "Number"
+          },
+          {
+            "type": "Number"
+          },
+          {
+            "type": "Number"
+          },
+          {
+            "type": "Number"
+          }
         ],
         [
-          "Number",
-          "Number",
-          "Number",
-          "p5.Vector"
+          {
+            "type": "Number"
+          },
+          {
+            "type": "Number"
+          },
+          {
+            "type": "Number"
+          },
+          {
+            "type": "p5.Vector"
+          }
         ],
         [
-          "p5.Color|Number[]|String",
-          "Number",
-          "Number",
-          "Number"
+          {
+            "type": "union",
+            "elements": [
+              {
+                "type": "p5.Color",
+                "optional": true
+              },
+              {
+                "type": "Array",
+                "element": "Number",
+                "optional": true
+              },
+              {
+                "type": "String",
+                "optional": true
+              }
+            ]
+          },
+          {
+            "type": "Number"
+          },
+          {
+            "type": "Number"
+          },
+          {
+            "type": "Number"
+          }
         ],
         [
-          "p5.Color|Number[]|String",
-          "p5.Vector"
+          {
+            "type": "union",
+            "elements": [
+              {
+                "type": "p5.Color",
+                "optional": true
+              },
+              {
+                "type": "Array",
+                "element": "Number",
+                "optional": true
+              },
+              {
+                "type": "String",
+                "optional": true
+              }
+            ]
+          },
+          {
+            "type": "p5.Vector"
+          }
         ]
       ]
     },
     "imageLight": {
       "overloads": [
         [
-          "p5.image"
+          {
+            "type": "p5.image"
+          }
         ]
       ]
     },
     "panorama": {
       "overloads": [
         [
-          "p5.Image"
+          {
+            "type": "p5.Image"
+          }
         ]
       ]
     },
@@ -2621,93 +6132,303 @@
     "lightFalloff": {
       "overloads": [
         [
-          "Number",
-          "Number",
-          "Number"
+          {
+            "type": "Number"
+          },
+          {
+            "type": "Number"
+          },
+          {
+            "type": "Number"
+          }
         ]
       ]
     },
     "spotLight": {
       "overloads": [
         [
-          "Number",
-          "Number",
-          "Number",
-          "Number",
-          "Number",
-          "Number",
-          "Number",
-          "Number",
-          "Number",
-          "Number?",
-          "Number?"
+          {
+            "type": "Number"
+          },
+          {
+            "type": "Number"
+          },
+          {
+            "type": "Number"
+          },
+          {
+            "type": "Number"
+          },
+          {
+            "type": "Number"
+          },
+          {
+            "type": "Number"
+          },
+          {
+            "type": "Number"
+          },
+          {
+            "type": "Number"
+          },
+          {
+            "type": "Number"
+          },
+          {
+            "type": "Number",
+            "optional": true
+          },
+          {
+            "type": "Number",
+            "optional": true
+          }
         ],
         [
-          "p5.Color|Number[]|String",
-          "p5.Vector",
-          "p5.Vector",
-          "Number?",
-          "Number?"
+          {
+            "type": "union",
+            "elements": [
+              {
+                "type": "p5.Color",
+                "optional": true
+              },
+              {
+                "type": "Array",
+                "element": "Number",
+                "optional": true
+              },
+              {
+                "type": "String",
+                "optional": true
+              }
+            ]
+          },
+          {
+            "type": "p5.Vector"
+          },
+          {
+            "type": "p5.Vector"
+          },
+          {
+            "type": "Number",
+            "optional": true
+          },
+          {
+            "type": "Number",
+            "optional": true
+          }
         ],
         [
-          "Number",
-          "Number",
-          "Number",
-          "p5.Vector",
-          "p5.Vector",
-          "Number?",
-          "Number?"
+          {
+            "type": "Number"
+          },
+          {
+            "type": "Number"
+          },
+          {
+            "type": "Number"
+          },
+          {
+            "type": "p5.Vector"
+          },
+          {
+            "type": "p5.Vector"
+          },
+          {
+            "type": "Number",
+            "optional": true
+          },
+          {
+            "type": "Number",
+            "optional": true
+          }
         ],
         [
-          "p5.Color|Number[]|String",
-          "Number",
-          "Number",
-          "Number",
-          "p5.Vector",
-          "Number?",
-          "Number?"
+          {
+            "type": "union",
+            "elements": [
+              {
+                "type": "p5.Color",
+                "optional": true
+              },
+              {
+                "type": "Array",
+                "element": "Number",
+                "optional": true
+              },
+              {
+                "type": "String",
+                "optional": true
+              }
+            ]
+          },
+          {
+            "type": "Number"
+          },
+          {
+            "type": "Number"
+          },
+          {
+            "type": "Number"
+          },
+          {
+            "type": "p5.Vector"
+          },
+          {
+            "type": "Number",
+            "optional": true
+          },
+          {
+            "type": "Number",
+            "optional": true
+          }
         ],
         [
-          "p5.Color|Number[]|String",
-          "p5.Vector",
-          "Number",
-          "Number",
-          "Number",
-          "Number?",
-          "Number?"
+          {
+            "type": "union",
+            "elements": [
+              {
+                "type": "p5.Color",
+                "optional": true
+              },
+              {
+                "type": "Array",
+                "element": "Number",
+                "optional": true
+              },
+              {
+                "type": "String",
+                "optional": true
+              }
+            ]
+          },
+          {
+            "type": "p5.Vector"
+          },
+          {
+            "type": "Number"
+          },
+          {
+            "type": "Number"
+          },
+          {
+            "type": "Number"
+          },
+          {
+            "type": "Number",
+            "optional": true
+          },
+          {
+            "type": "Number",
+            "optional": true
+          }
         ],
         [
-          "Number",
-          "Number",
-          "Number",
-          "Number",
-          "Number",
-          "Number",
-          "p5.Vector",
-          "Number?",
-          "Number?"
+          {
+            "type": "Number"
+          },
+          {
+            "type": "Number"
+          },
+          {
+            "type": "Number"
+          },
+          {
+            "type": "Number"
+          },
+          {
+            "type": "Number"
+          },
+          {
+            "type": "Number"
+          },
+          {
+            "type": "p5.Vector"
+          },
+          {
+            "type": "Number",
+            "optional": true
+          },
+          {
+            "type": "Number",
+            "optional": true
+          }
         ],
         [
-          "Number",
-          "Number",
-          "Number",
-          "p5.Vector",
-          "Number",
-          "Number",
-          "Number",
-          "Number?",
-          "Number?"
+          {
+            "type": "Number"
+          },
+          {
+            "type": "Number"
+          },
+          {
+            "type": "Number"
+          },
+          {
+            "type": "p5.Vector"
+          },
+          {
+            "type": "Number"
+          },
+          {
+            "type": "Number"
+          },
+          {
+            "type": "Number"
+          },
+          {
+            "type": "Number",
+            "optional": true
+          },
+          {
+            "type": "Number",
+            "optional": true
+          }
         ],
         [
-          "p5.Color|Number[]|String",
-          "Number",
-          "Number",
-          "Number",
-          "Number",
-          "Number",
-          "Number",
-          "Number?",
-          "Number?"
+          {
+            "type": "union",
+            "elements": [
+              {
+                "type": "p5.Color",
+                "optional": true
+              },
+              {
+                "type": "Array",
+                "element": "Number",
+                "optional": true
+              },
+              {
+                "type": "String",
+                "optional": true
+              }
+            ]
+          },
+          {
+            "type": "Number"
+          },
+          {
+            "type": "Number"
+          },
+          {
+            "type": "Number"
+          },
+          {
+            "type": "Number"
+          },
+          {
+            "type": "Number"
+          },
+          {
+            "type": "Number"
+          },
+          {
+            "type": "Number",
+            "optional": true
+          },
+          {
+            "type": "Number",
+            "optional": true
+          }
         ]
       ]
     },
@@ -2719,107 +6440,364 @@
     "loadModel": {
       "overloads": [
         [
-          "String|Request",
-          "String?",
-          "Boolean",
-          "function(p5.Geometry)?",
-          "function(Event)?"
+          {
+            "type": "union",
+            "elements": [
+              {
+                "type": "String",
+                "optional": true
+              },
+              {
+                "type": "Request",
+                "optional": true
+              }
+            ]
+          },
+          {
+            "type": "String",
+            "optional": true
+          },
+          {
+            "type": "Boolean"
+          },
+          {
+            "type": "Function",
+            "parameters": [
+              {
+                "type": "p5.Geometry"
+              }
+            ],
+            "optional": true
+          },
+          {
+            "type": "Function",
+            "parameters": [
+              {
+                "type": "Event"
+              }
+            ],
+            "optional": true
+          }
         ],
         [
-          "String|Request",
-          "String?",
-          "function(p5.Geometry)?",
-          "function(Event)?"
+          {
+            "type": "union",
+            "elements": [
+              {
+                "type": "String",
+                "optional": true
+              },
+              {
+                "type": "Request",
+                "optional": true
+              }
+            ]
+          },
+          {
+            "type": "String",
+            "optional": true
+          },
+          {
+            "type": "Function",
+            "parameters": [
+              {
+                "type": "p5.Geometry"
+              }
+            ],
+            "optional": true
+          },
+          {
+            "type": "Function",
+            "parameters": [
+              {
+                "type": "Event"
+              }
+            ],
+            "optional": true
+          }
         ],
         [
-          "String|Request",
-          "Object?"
+          {
+            "type": "union",
+            "elements": [
+              {
+                "type": "String",
+                "optional": true
+              },
+              {
+                "type": "Request",
+                "optional": true
+              }
+            ]
+          },
+          {
+            "type": "Object",
+            "properties": {
+              "fileType": {
+                "type": "String",
+                "optional": true
+              },
+              "successCallback": {
+                "type": "Function",
+                "parameters": [
+                  {
+                    "type": "p5.Geometry"
+                  }
+                ],
+                "optional": true
+              },
+              "failureCallback": {
+                "type": "Function",
+                "parameters": [
+                  {
+                    "type": "Event"
+                  }
+                ],
+                "optional": true
+              },
+              "normalize": {
+                "type": "Boolean",
+                "optional": true
+              },
+              "flipU": {
+                "type": "Boolean",
+                "optional": true
+              },
+              "flipV": {
+                "type": "Boolean",
+                "optional": true
+              }
+            },
+            "optional": true
+          }
         ]
       ]
     },
     "model": {
       "overloads": [
         [
-          "p5.Geometry",
-          "Number?"
+          {
+            "type": "p5.Geometry"
+          },
+          {
+            "type": "Number",
+            "optional": true
+          }
         ]
       ]
     },
     "createModel": {
       "overloads": [
         [
-          "String",
-          "String?",
-          "Boolean",
-          "function(p5.Geometry)?",
-          "function(Event)?"
+          {
+            "type": "String"
+          },
+          {
+            "type": "String",
+            "optional": true
+          },
+          {
+            "type": "Boolean"
+          },
+          {
+            "type": "Function",
+            "parameters": [
+              {
+                "type": "p5.Geometry"
+              }
+            ],
+            "optional": true
+          },
+          {
+            "type": "Function",
+            "parameters": [
+              {
+                "type": "Event"
+              }
+            ],
+            "optional": true
+          }
         ],
         [
-          "String",
-          "String?",
-          "function(p5.Geometry)?",
-          "function(Event)?"
+          {
+            "type": "String"
+          },
+          {
+            "type": "String",
+            "optional": true
+          },
+          {
+            "type": "Function",
+            "parameters": [
+              {
+                "type": "p5.Geometry"
+              }
+            ],
+            "optional": true
+          },
+          {
+            "type": "Function",
+            "parameters": [
+              {
+                "type": "Event"
+              }
+            ],
+            "optional": true
+          }
         ],
         [
-          "String",
-          "String?",
-          "Object?"
+          {
+            "type": "String"
+          },
+          {
+            "type": "String",
+            "optional": true
+          },
+          {
+            "type": "Object",
+            "properties": {
+              "successCallback": {
+                "type": "Function",
+                "parameters": [
+                  {
+                    "type": "p5.Geometry"
+                  }
+                ],
+                "optional": true
+              },
+              "failureCallback": {
+                "type": "Function",
+                "parameters": [
+                  {
+                    "type": "Event"
+                  }
+                ],
+                "optional": true
+              },
+              "normalize": {
+                "type": "boolean",
+                "optional": true
+              },
+              "flipU": {
+                "type": "boolean",
+                "optional": true
+              },
+              "flipV": {
+                "type": "boolean",
+                "optional": true
+              }
+            },
+            "optional": true
+          }
         ]
       ]
     },
     "loadShader": {
       "overloads": [
         [
-          "String|Request",
-          "String|Request",
-          "Function?",
-          "Function?"
+          {
+            "type": "union",
+            "elements": [
+              {
+                "type": "String",
+                "optional": true
+              },
+              {
+                "type": "Request",
+                "optional": true
+              }
+            ]
+          },
+          {
+            "type": "union",
+            "elements": [
+              {
+                "type": "String",
+                "optional": true
+              },
+              {
+                "type": "Request",
+                "optional": true
+              }
+            ]
+          },
+          {
+            "type": "Function",
+            "optional": true
+          },
+          {
+            "type": "Function",
+            "optional": true
+          }
         ]
       ]
     },
     "createShader": {
       "overloads": [
         [
-          "String",
-          "String",
-          "Object?"
+          {
+            "type": "String"
+          },
+          {
+            "type": "String"
+          },
+          {
+            "type": "Object",
+            "optional": true
+          }
         ]
       ]
     },
     "loadFilterShader": {
       "overloads": [
         [
-          "String",
-          "Function?",
-          "Function?"
+          {
+            "type": "String"
+          },
+          {
+            "type": "Function",
+            "optional": true
+          },
+          {
+            "type": "Function",
+            "optional": true
+          }
         ]
       ]
     },
     "createFilterShader": {
       "overloads": [
         [
-          "String"
+          {
+            "type": "String"
+          }
         ]
       ]
     },
     "shader": {
       "overloads": [
         [
-          "p5.Shader"
+          {
+            "type": "p5.Shader"
+          }
         ]
       ]
     },
     "strokeShader": {
       "overloads": [
         [
-          "p5.Shader"
+          {
+            "type": "p5.Shader"
+          }
         ]
       ]
     },
     "imageShader": {
       "overloads": [
         [
-          "p5.Shader"
+          {
+            "type": "p5.Shader"
+          }
         ]
       ]
     },
@@ -2856,22 +6834,95 @@
     "texture": {
       "overloads": [
         [
-          "p5.Image|p5.MediaElement|p5.Graphics|p5.Texture|p5.Framebuffer|p5.FramebufferTexture"
+          {
+            "type": "union",
+            "elements": [
+              {
+                "type": "p5.Image",
+                "optional": true
+              },
+              {
+                "type": "p5.MediaElement",
+                "optional": true
+              },
+              {
+                "type": "p5.Graphics",
+                "optional": true
+              },
+              {
+                "type": "p5.Texture",
+                "optional": true
+              },
+              {
+                "type": "p5.Framebuffer",
+                "optional": true
+              },
+              {
+                "type": "p5.FramebufferTexture",
+                "optional": true
+              }
+            ]
+          }
         ]
       ]
     },
     "textureMode": {
       "overloads": [
         [
-          "IMAGE|NORMAL"
+          {
+            "type": "union",
+            "elements": [
+              {
+                "type": "IMAGE",
+                "optional": true
+              },
+              {
+                "type": "NORMAL",
+                "optional": true
+              }
+            ]
+          }
         ]
       ]
     },
     "textureWrap": {
       "overloads": [
         [
-          "CLAMP|REPEAT|MIRROR",
-          "CLAMP|REPEAT|MIRROR?"
+          {
+            "type": "union",
+            "elements": [
+              {
+                "type": "CLAMP",
+                "optional": true
+              },
+              {
+                "type": "REPEAT",
+                "optional": true
+              },
+              {
+                "type": "MIRROR",
+                "optional": true
+              }
+            ]
+          },
+          {
+            "type": "union",
+            "elements": [
+              {
+                "type": "CLAMP",
+                "optional": true
+              },
+              {
+                "type": "REPEAT",
+                "optional": true
+              },
+              {
+                "type": "MIRROR",
+                "optional": true
+              }
+            ],
+            "optional": true
+          }
         ]
       ]
     },
@@ -2883,94 +6934,223 @@
     "ambientMaterial": {
       "overloads": [
         [
-          "Number",
-          "Number",
-          "Number"
+          {
+            "type": "Number"
+          },
+          {
+            "type": "Number"
+          },
+          {
+            "type": "Number"
+          }
         ],
         [
-          "Number"
+          {
+            "type": "Number"
+          }
         ],
         [
-          "p5.Color|Number[]|String"
+          {
+            "type": "union",
+            "elements": [
+              {
+                "type": "p5.Color",
+                "optional": true
+              },
+              {
+                "type": "Array",
+                "element": "Number",
+                "optional": true
+              },
+              {
+                "type": "String",
+                "optional": true
+              }
+            ]
+          }
         ]
       ]
     },
     "emissiveMaterial": {
       "overloads": [
         [
-          "Number",
-          "Number",
-          "Number",
-          "Number?"
+          {
+            "type": "Number"
+          },
+          {
+            "type": "Number"
+          },
+          {
+            "type": "Number"
+          },
+          {
+            "type": "Number",
+            "optional": true
+          }
         ],
         [
-          "Number"
+          {
+            "type": "Number"
+          }
         ],
         [
-          "p5.Color|Number[]|String"
+          {
+            "type": "union",
+            "elements": [
+              {
+                "type": "p5.Color",
+                "optional": true
+              },
+              {
+                "type": "Array",
+                "element": "Number",
+                "optional": true
+              },
+              {
+                "type": "String",
+                "optional": true
+              }
+            ]
+          }
         ]
       ]
     },
     "specularMaterial": {
       "overloads": [
         [
-          "Number",
-          "Number?"
+          {
+            "type": "Number"
+          },
+          {
+            "type": "Number",
+            "optional": true
+          }
         ],
         [
-          "Number",
-          "Number",
-          "Number",
-          "Number?"
+          {
+            "type": "Number"
+          },
+          {
+            "type": "Number"
+          },
+          {
+            "type": "Number"
+          },
+          {
+            "type": "Number",
+            "optional": true
+          }
         ],
         [
-          "p5.Color|Number[]|String"
+          {
+            "type": "union",
+            "elements": [
+              {
+                "type": "p5.Color",
+                "optional": true
+              },
+              {
+                "type": "Array",
+                "element": "Number",
+                "optional": true
+              },
+              {
+                "type": "String",
+                "optional": true
+              }
+            ]
+          }
         ]
       ]
     },
     "shininess": {
       "overloads": [
         [
-          "Number"
+          {
+            "type": "Number"
+          }
         ]
       ]
     },
     "metalness": {
       "overloads": [
         [
-          "Number"
+          {
+            "type": "Number"
+          }
         ]
       ]
     },
     "camera": {
       "overloads": [
         [
-          "Number?",
-          "Number?",
-          "Number?",
-          "Number?",
-          "Number?",
-          "Number?",
-          "Number?",
-          "Number?",
-          "Number?"
+          {
+            "type": "Number",
+            "optional": true
+          },
+          {
+            "type": "Number",
+            "optional": true
+          },
+          {
+            "type": "Number",
+            "optional": true
+          },
+          {
+            "type": "Number",
+            "optional": true
+          },
+          {
+            "type": "Number",
+            "optional": true
+          },
+          {
+            "type": "Number",
+            "optional": true
+          },
+          {
+            "type": "Number",
+            "optional": true
+          },
+          {
+            "type": "Number",
+            "optional": true
+          },
+          {
+            "type": "Number",
+            "optional": true
+          }
         ]
       ]
     },
     "perspective": {
       "overloads": [
         [
-          "Number?",
-          "Number?",
-          "Number?",
-          "Number?"
+          {
+            "type": "Number",
+            "optional": true
+          },
+          {
+            "type": "Number",
+            "optional": true
+          },
+          {
+            "type": "Number",
+            "optional": true
+          },
+          {
+            "type": "Number",
+            "optional": true
+          }
         ]
       ]
     },
     "linePerspective": {
       "overloads": [
         [
-          "Boolean"
+          {
+            "type": "Boolean"
+          }
         ],
         []
       ]
@@ -2978,24 +7158,60 @@
     "ortho": {
       "overloads": [
         [
-          "Number?",
-          "Number?",
-          "Number?",
-          "Number?",
-          "Number?",
-          "Number?"
+          {
+            "type": "Number",
+            "optional": true
+          },
+          {
+            "type": "Number",
+            "optional": true
+          },
+          {
+            "type": "Number",
+            "optional": true
+          },
+          {
+            "type": "Number",
+            "optional": true
+          },
+          {
+            "type": "Number",
+            "optional": true
+          },
+          {
+            "type": "Number",
+            "optional": true
+          }
         ]
       ]
     },
     "frustum": {
       "overloads": [
         [
-          "Number?",
-          "Number?",
-          "Number?",
-          "Number?",
-          "Number?",
-          "Number?"
+          {
+            "type": "Number",
+            "optional": true
+          },
+          {
+            "type": "Number",
+            "optional": true
+          },
+          {
+            "type": "Number",
+            "optional": true
+          },
+          {
+            "type": "Number",
+            "optional": true
+          },
+          {
+            "type": "Number",
+            "optional": true
+          },
+          {
+            "type": "Number",
+            "optional": true
+          }
         ]
       ]
     },
@@ -3007,33 +7223,50 @@
     "setCamera": {
       "overloads": [
         [
-          "p5.Camera"
+          {
+            "type": "p5.Camera"
+          }
         ]
       ]
     },
     "saveObj": {
       "overloads": [
         [
-          "String?"
+          {
+            "type": "String",
+            "optional": true
+          }
         ]
       ]
     },
     "saveStl": {
       "overloads": [
         [
-          "String?",
-          "Object?"
+          {
+            "type": "String",
+            "optional": true
+          },
+          {
+            "type": "Object",
+            "optional": true
+          }
         ]
       ]
     },
     "setAttributes": {
       "overloads": [
         [
-          "String",
-          "Boolean"
+          {
+            "type": "String"
+          },
+          {
+            "type": "Boolean"
+          }
         ],
         [
-          "Object"
+          {
+            "type": "Object"
+          }
         ]
       ]
     },
@@ -3045,8 +7278,24 @@
     "createVideo": {
       "overloads": [
         [
-          "String|String[]",
-          "Function?"
+          {
+            "type": "union",
+            "elements": [
+              {
+                "type": "String",
+                "optional": true
+              },
+              {
+                "type": "Array",
+                "element": "String",
+                "optional": true
+              }
+            ]
+          },
+          {
+            "type": "Function",
+            "optional": true
+          }
         ]
       ]
     },
@@ -3054,17 +7303,57 @@
       "overloads": [
         [],
         [
-          "String|String[]?",
-          "Function?"
+          {
+            "type": "union",
+            "elements": [
+              {
+                "type": "String",
+                "optional": true
+              },
+              {
+                "type": "Array",
+                "element": "String",
+                "optional": true
+              }
+            ],
+            "optional": true
+          },
+          {
+            "type": "Function",
+            "optional": true
+          }
         ]
       ]
     },
     "createCapture": {
       "overloads": [
         [
-          "AUDIO|VIDEO|Object?",
-          "Object?",
-          "Function?"
+          {
+            "type": "union",
+            "elements": [
+              {
+                "type": "AUDIO",
+                "optional": true
+              },
+              {
+                "type": "VIDEO",
+                "optional": true
+              },
+              {
+                "type": "Object",
+                "optional": true
+              }
+            ],
+            "optional": true
+          },
+          {
+            "type": "Object",
+            "optional": true
+          },
+          {
+            "type": "Function",
+            "optional": true
+          }
         ]
       ]
     }
@@ -3098,8 +7387,24 @@
     "computeNormals": {
       "overloads": [
         [
-          "FLAT|SMOOTH?",
-          "Object?"
+          {
+            "type": "union",
+            "elements": [
+              {
+                "type": "FLAT",
+                "optional": true
+              },
+              {
+                "type": "SMOOTH",
+                "optional": true
+              }
+            ],
+            "optional": true
+          },
+          {
+            "type": "Object",
+            "optional": true
+          }
         ]
       ]
     },
@@ -3116,9 +7421,27 @@
     "vertexProperty": {
       "overloads": [
         [
-          "String",
-          "Number|Number[]",
-          "Number?"
+          {
+            "type": "String"
+          },
+          {
+            "type": "union",
+            "elements": [
+              {
+                "type": "Number",
+                "optional": true
+              },
+              {
+                "type": "Array",
+                "element": "Number",
+                "optional": true
+              }
+            ]
+          },
+          {
+            "type": "Number",
+            "optional": true
+          }
         ]
       ]
     }
@@ -3127,35 +7450,46 @@
     "toString": {
       "overloads": [
         [
-          "String?"
+          {
+            "type": "String",
+            "optional": true
+          }
         ]
       ]
     },
     "setRed": {
       "overloads": [
         [
-          "Number"
+          {
+            "type": "Number"
+          }
         ]
       ]
     },
     "setGreen": {
       "overloads": [
         [
-          "Number"
+          {
+            "type": "Number"
+          }
         ]
       ]
     },
     "setBlue": {
       "overloads": [
         [
-          "Number"
+          {
+            "type": "Number"
+          }
         ]
       ]
     },
     "setAlpha": {
       "overloads": [
         [
-          "Number"
+          {
+            "type": "Number"
+          }
         ]
       ]
     }
@@ -3174,7 +7508,10 @@
     "createFramebuffer": {
       "overloads": [
         [
-          "Object?"
+          {
+            "type": "Object",
+            "optional": true
+          }
         ]
       ]
     }
@@ -3188,7 +7525,23 @@
     "parent": {
       "overloads": [
         [
-          "String|p5.Element|Object"
+          {
+            "type": "union",
+            "elements": [
+              {
+                "type": "String",
+                "optional": true
+              },
+              {
+                "type": "p5.Element",
+                "optional": true
+              },
+              {
+                "type": "Object",
+                "optional": true
+              }
+            ]
+          }
         ],
         []
       ]
@@ -3197,7 +7550,20 @@
       "overloads": [
         [],
         [
-          "String|p5.Element?"
+          {
+            "type": "union",
+            "elements": [
+              {
+                "type": "String",
+                "optional": true
+              },
+              {
+                "type": "p5.Element",
+                "optional": true
+              }
+            ],
+            "optional": true
+          }
         ]
       ]
     },
@@ -3205,15 +7571,23 @@
       "overloads": [
         [],
         [
-          "String?",
-          "Boolean?"
+          {
+            "type": "String",
+            "optional": true
+          },
+          {
+            "type": "Boolean",
+            "optional": true
+          }
         ]
       ]
     },
     "id": {
       "overloads": [
         [
-          "String"
+          {
+            "type": "String"
+          }
         ],
         []
       ]
@@ -3221,7 +7595,9 @@
     "class": {
       "overloads": [
         [
-          "String"
+          {
+            "type": "String"
+          }
         ],
         []
       ]
@@ -3229,35 +7605,42 @@
     "addClass": {
       "overloads": [
         [
-          "String"
+          {
+            "type": "String"
+          }
         ]
       ]
     },
     "removeClass": {
       "overloads": [
         [
-          "String"
+          {
+            "type": "String"
+          }
         ]
       ]
     },
     "hasClass": {
       "overloads": [
         [
-          null
+          {}
         ]
       ]
     },
     "toggleClass": {
       "overloads": [
         [
-          null
+          {}
         ]
       ]
     },
     "center": {
       "overloads": [
         [
-          "String?"
+          {
+            "type": "String",
+            "optional": true
+          }
         ]
       ]
     },
@@ -3265,9 +7648,18 @@
       "overloads": [
         [],
         [
-          "Number?",
-          "Number?",
-          "String?"
+          {
+            "type": "Number",
+            "optional": true
+          },
+          {
+            "type": "Number",
+            "optional": true
+          },
+          {
+            "type": "String",
+            "optional": true
+          }
         ]
       ]
     },
@@ -3285,19 +7677,61 @@
       "overloads": [
         [],
         [
-          "Number|AUTO?",
-          "Number|AUTO?"
+          {
+            "type": "union",
+            "elements": [
+              {
+                "type": "Number",
+                "optional": true
+              },
+              {
+                "type": "AUTO",
+                "optional": true
+              }
+            ],
+            "optional": true
+          },
+          {
+            "type": "union",
+            "elements": [
+              {
+                "type": "Number",
+                "optional": true
+              },
+              {
+                "type": "AUTO",
+                "optional": true
+              }
+            ],
+            "optional": true
+          }
         ]
       ]
     },
     "style": {
       "overloads": [
         [
-          "String"
+          {
+            "type": "String"
+          }
         ],
         [
-          "String",
-          "String|p5.Color"
+          {
+            "type": "String"
+          },
+          {
+            "type": "union",
+            "elements": [
+              {
+                "type": "String",
+                "optional": true
+              },
+              {
+                "type": "p5.Color",
+                "optional": true
+              }
+            ]
+          }
         ]
       ]
     },
@@ -3305,15 +7739,21 @@
       "overloads": [
         [],
         [
-          "String",
-          "String"
+          {
+            "type": "String"
+          },
+          {
+            "type": "String"
+          }
         ]
       ]
     },
     "removeAttribute": {
       "overloads": [
         [
-          "String"
+          {
+            "type": "String"
+          }
         ]
       ]
     },
@@ -3321,106 +7761,270 @@
       "overloads": [
         [],
         [
-          "String|Number"
+          {
+            "type": "union",
+            "elements": [
+              {
+                "type": "String",
+                "optional": true
+              },
+              {
+                "type": "Number",
+                "optional": true
+              }
+            ]
+          }
         ]
       ]
     },
     "mousePressed": {
       "overloads": [
         [
-          "Function|Boolean"
+          {
+            "type": "union",
+            "elements": [
+              {
+                "type": "Function",
+                "optional": true
+              },
+              {
+                "type": "Boolean",
+                "optional": true
+              }
+            ]
+          }
         ]
       ]
     },
     "doubleClicked": {
       "overloads": [
         [
-          "Function|Boolean"
+          {
+            "type": "union",
+            "elements": [
+              {
+                "type": "Function",
+                "optional": true
+              },
+              {
+                "type": "Boolean",
+                "optional": true
+              }
+            ]
+          }
         ]
       ]
     },
     "mouseWheel": {
       "overloads": [
         [
-          "Function|Boolean"
+          {
+            "type": "union",
+            "elements": [
+              {
+                "type": "Function",
+                "optional": true
+              },
+              {
+                "type": "Boolean",
+                "optional": true
+              }
+            ]
+          }
         ]
       ]
     },
     "mouseReleased": {
       "overloads": [
         [
-          "Function|Boolean"
+          {
+            "type": "union",
+            "elements": [
+              {
+                "type": "Function",
+                "optional": true
+              },
+              {
+                "type": "Boolean",
+                "optional": true
+              }
+            ]
+          }
         ]
       ]
     },
     "mouseClicked": {
       "overloads": [
         [
-          "Function|Boolean"
+          {
+            "type": "union",
+            "elements": [
+              {
+                "type": "Function",
+                "optional": true
+              },
+              {
+                "type": "Boolean",
+                "optional": true
+              }
+            ]
+          }
         ]
       ]
     },
     "mouseMoved": {
       "overloads": [
         [
-          "Function|Boolean"
+          {
+            "type": "union",
+            "elements": [
+              {
+                "type": "Function",
+                "optional": true
+              },
+              {
+                "type": "Boolean",
+                "optional": true
+              }
+            ]
+          }
         ]
       ]
     },
     "mouseOver": {
       "overloads": [
         [
-          "Function|Boolean"
+          {
+            "type": "union",
+            "elements": [
+              {
+                "type": "Function",
+                "optional": true
+              },
+              {
+                "type": "Boolean",
+                "optional": true
+              }
+            ]
+          }
         ]
       ]
     },
     "mouseOut": {
       "overloads": [
         [
-          "Function|Boolean"
+          {
+            "type": "union",
+            "elements": [
+              {
+                "type": "Function",
+                "optional": true
+              },
+              {
+                "type": "Boolean",
+                "optional": true
+              }
+            ]
+          }
         ]
       ]
     },
     "dragOver": {
       "overloads": [
         [
-          "Function|Boolean"
+          {
+            "type": "union",
+            "elements": [
+              {
+                "type": "Function",
+                "optional": true
+              },
+              {
+                "type": "Boolean",
+                "optional": true
+              }
+            ]
+          }
         ]
       ]
     },
     "dragLeave": {
       "overloads": [
         [
-          "Function|Boolean"
+          {
+            "type": "union",
+            "elements": [
+              {
+                "type": "Function",
+                "optional": true
+              },
+              {
+                "type": "Boolean",
+                "optional": true
+              }
+            ]
+          }
         ]
       ]
     },
     "changed": {
       "overloads": [
         [
-          "Function|Boolean"
+          {
+            "type": "union",
+            "elements": [
+              {
+                "type": "Function",
+                "optional": true
+              },
+              {
+                "type": "Boolean",
+                "optional": true
+              }
+            ]
+          }
         ]
       ]
     },
     "input": {
       "overloads": [
         [
-          "Function|Boolean"
+          {
+            "type": "union",
+            "elements": [
+              {
+                "type": "Function",
+                "optional": true
+              },
+              {
+                "type": "Boolean",
+                "optional": true
+              }
+            ]
+          }
         ]
       ]
     },
     "drop": {
       "overloads": [
         [
-          "Function",
-          "Function?"
+          {
+            "type": "Function"
+          },
+          {
+            "type": "Function",
+            "optional": true
+          }
         ]
       ]
     },
     "draggable": {
       "overloads": [
         [
-          "p5.Element?"
+          {
+            "type": "p5.Element",
+            "optional": true
+          }
         ]
       ]
     }
@@ -3454,7 +8058,10 @@
     "autoplay": {
       "overloads": [
         [
-          "Boolean?"
+          {
+            "type": "Boolean",
+            "optional": true
+          }
         ]
       ]
     },
@@ -3462,7 +8069,9 @@
       "overloads": [
         [],
         [
-          "Number"
+          {
+            "type": "Number"
+          }
         ]
       ]
     },
@@ -3470,7 +8079,9 @@
       "overloads": [
         [],
         [
-          "Number"
+          {
+            "type": "Number"
+          }
         ]
       ]
     },
@@ -3478,7 +8089,9 @@
       "overloads": [
         [],
         [
-          "Number"
+          {
+            "type": "Number"
+          }
         ]
       ]
     },
@@ -3490,14 +8103,28 @@
     "onended": {
       "overloads": [
         [
-          "Function"
+          {
+            "type": "Function"
+          }
         ]
       ]
     },
     "connect": {
       "overloads": [
         [
-          "AudioNode|Object"
+          {
+            "type": "union",
+            "elements": [
+              {
+                "type": "AudioNode",
+                "optional": true
+              },
+              {
+                "type": "Object",
+                "optional": true
+              }
+            ]
+          }
         ]
       ]
     },
@@ -3519,16 +8146,25 @@
     "addCue": {
       "overloads": [
         [
-          "Number",
-          "Function",
-          "Object?"
+          {
+            "type": "Number"
+          },
+          {
+            "type": "Function"
+          },
+          {
+            "type": "Object",
+            "optional": true
+          }
         ]
       ]
     },
     "removeCue": {
       "overloads": [
         [
-          "Number"
+          {
+            "type": "Number"
+          }
         ]
       ]
     },
@@ -3542,7 +8178,10 @@
     "pixelDensity": {
       "overloads": [
         [
-          "Number?"
+          {
+            "type": "Number",
+            "optional": true
+          }
         ]
       ]
     },
@@ -3554,117 +8193,414 @@
     "updatePixels": {
       "overloads": [
         [
-          "Integer",
-          "Integer",
-          "Integer",
-          "Integer"
+          {
+            "type": "Integer"
+          },
+          {
+            "type": "Integer"
+          },
+          {
+            "type": "Integer"
+          },
+          {
+            "type": "Integer"
+          }
         ]
       ]
     },
     "get": {
       "overloads": [
         [
-          "Number",
-          "Number",
-          "Number",
-          "Number"
+          {
+            "type": "Number"
+          },
+          {
+            "type": "Number"
+          },
+          {
+            "type": "Number"
+          },
+          {
+            "type": "Number"
+          }
         ],
         [],
         [
-          "Number",
-          "Number"
+          {
+            "type": "Number"
+          },
+          {
+            "type": "Number"
+          }
         ]
       ]
     },
     "set": {
       "overloads": [
         [
-          "Number",
-          "Number",
-          "Number|Number[]|Object"
+          {
+            "type": "Number"
+          },
+          {
+            "type": "Number"
+          },
+          {
+            "type": "union",
+            "elements": [
+              {
+                "type": "Number",
+                "optional": true
+              },
+              {
+                "type": "Array",
+                "element": "Number",
+                "optional": true
+              },
+              {
+                "type": "Object",
+                "optional": true
+              }
+            ]
+          }
         ]
       ]
     },
     "resize": {
       "overloads": [
         [
-          "Number",
-          "Number"
+          {
+            "type": "Number"
+          },
+          {
+            "type": "Number"
+          }
         ]
       ]
     },
     "copy": {
       "overloads": [
         [
-          "p5.Image|p5.Element",
-          "Integer",
-          "Integer",
-          "Integer",
-          "Integer",
-          "Integer",
-          "Integer",
-          "Integer",
-          "Integer"
+          {
+            "type": "union",
+            "elements": [
+              {
+                "type": "p5.Image",
+                "optional": true
+              },
+              {
+                "type": "p5.Element",
+                "optional": true
+              }
+            ]
+          },
+          {
+            "type": "Integer"
+          },
+          {
+            "type": "Integer"
+          },
+          {
+            "type": "Integer"
+          },
+          {
+            "type": "Integer"
+          },
+          {
+            "type": "Integer"
+          },
+          {
+            "type": "Integer"
+          },
+          {
+            "type": "Integer"
+          },
+          {
+            "type": "Integer"
+          }
         ],
         [
-          "Integer",
-          "Integer",
-          "Integer",
-          "Integer",
-          "Integer",
-          "Integer",
-          "Integer",
-          "Integer"
+          {
+            "type": "Integer"
+          },
+          {
+            "type": "Integer"
+          },
+          {
+            "type": "Integer"
+          },
+          {
+            "type": "Integer"
+          },
+          {
+            "type": "Integer"
+          },
+          {
+            "type": "Integer"
+          },
+          {
+            "type": "Integer"
+          },
+          {
+            "type": "Integer"
+          }
         ]
       ]
     },
     "mask": {
       "overloads": [
         [
-          "p5.Image"
+          {
+            "type": "p5.Image"
+          }
         ]
       ]
     },
     "filter": {
       "overloads": [
         [
-          "THRESHOLD|GRAY|OPAQUE|INVERT|POSTERIZE|ERODE|DILATE|BLUR",
-          "Number?"
+          {
+            "type": "union",
+            "elements": [
+              {
+                "type": "THRESHOLD",
+                "optional": true
+              },
+              {
+                "type": "GRAY",
+                "optional": true
+              },
+              {
+                "type": "OPAQUE",
+                "optional": true
+              },
+              {
+                "type": "INVERT",
+                "optional": true
+              },
+              {
+                "type": "POSTERIZE",
+                "optional": true
+              },
+              {
+                "type": "ERODE",
+                "optional": true
+              },
+              {
+                "type": "DILATE",
+                "optional": true
+              },
+              {
+                "type": "BLUR",
+                "optional": true
+              }
+            ]
+          },
+          {
+            "type": "Number",
+            "optional": true
+          }
         ]
       ]
     },
     "blend": {
       "overloads": [
         [
-          "p5.Image",
-          "Integer",
-          "Integer",
-          "Integer",
-          "Integer",
-          "Integer",
-          "Integer",
-          "Integer",
-          "Integer",
-          "BLEND|DARKEST|LIGHTEST|DIFFERENCE|MULTIPLY|EXCLUSION|SCREEN|REPLACE|OVERLAY|HARD_LIGHT|SOFT_LIGHT|DODGE|BURN|ADD|NORMAL"
+          {
+            "type": "p5.Image"
+          },
+          {
+            "type": "Integer"
+          },
+          {
+            "type": "Integer"
+          },
+          {
+            "type": "Integer"
+          },
+          {
+            "type": "Integer"
+          },
+          {
+            "type": "Integer"
+          },
+          {
+            "type": "Integer"
+          },
+          {
+            "type": "Integer"
+          },
+          {
+            "type": "Integer"
+          },
+          {
+            "type": "union",
+            "elements": [
+              {
+                "type": "BLEND",
+                "optional": true
+              },
+              {
+                "type": "DARKEST",
+                "optional": true
+              },
+              {
+                "type": "LIGHTEST",
+                "optional": true
+              },
+              {
+                "type": "DIFFERENCE",
+                "optional": true
+              },
+              {
+                "type": "MULTIPLY",
+                "optional": true
+              },
+              {
+                "type": "EXCLUSION",
+                "optional": true
+              },
+              {
+                "type": "SCREEN",
+                "optional": true
+              },
+              {
+                "type": "REPLACE",
+                "optional": true
+              },
+              {
+                "type": "OVERLAY",
+                "optional": true
+              },
+              {
+                "type": "HARD_LIGHT",
+                "optional": true
+              },
+              {
+                "type": "SOFT_LIGHT",
+                "optional": true
+              },
+              {
+                "type": "DODGE",
+                "optional": true
+              },
+              {
+                "type": "BURN",
+                "optional": true
+              },
+              {
+                "type": "ADD",
+                "optional": true
+              },
+              {
+                "type": "NORMAL",
+                "optional": true
+              }
+            ]
+          }
         ],
         [
-          "Integer",
-          "Integer",
-          "Integer",
-          "Integer",
-          "Integer",
-          "Integer",
-          "Integer",
-          "Integer",
-          "BLEND|DARKEST|LIGHTEST|DIFFERENCE|MULTIPLY|EXCLUSION|SCREEN|REPLACE|OVERLAY|HARD_LIGHT|SOFT_LIGHT|DODGE|BURN|ADD|NORMAL"
+          {
+            "type": "Integer"
+          },
+          {
+            "type": "Integer"
+          },
+          {
+            "type": "Integer"
+          },
+          {
+            "type": "Integer"
+          },
+          {
+            "type": "Integer"
+          },
+          {
+            "type": "Integer"
+          },
+          {
+            "type": "Integer"
+          },
+          {
+            "type": "Integer"
+          },
+          {
+            "type": "union",
+            "elements": [
+              {
+                "type": "BLEND",
+                "optional": true
+              },
+              {
+                "type": "DARKEST",
+                "optional": true
+              },
+              {
+                "type": "LIGHTEST",
+                "optional": true
+              },
+              {
+                "type": "DIFFERENCE",
+                "optional": true
+              },
+              {
+                "type": "MULTIPLY",
+                "optional": true
+              },
+              {
+                "type": "EXCLUSION",
+                "optional": true
+              },
+              {
+                "type": "SCREEN",
+                "optional": true
+              },
+              {
+                "type": "REPLACE",
+                "optional": true
+              },
+              {
+                "type": "OVERLAY",
+                "optional": true
+              },
+              {
+                "type": "HARD_LIGHT",
+                "optional": true
+              },
+              {
+                "type": "SOFT_LIGHT",
+                "optional": true
+              },
+              {
+                "type": "DODGE",
+                "optional": true
+              },
+              {
+                "type": "BURN",
+                "optional": true
+              },
+              {
+                "type": "ADD",
+                "optional": true
+              },
+              {
+                "type": "NORMAL",
+                "optional": true
+              }
+            ]
+          }
         ]
       ]
     },
     "save": {
       "overloads": [
         [
-          "String",
-          "String?"
+          {
+            "type": "String"
+          },
+          {
+            "type": "String",
+            "optional": true
+          }
         ]
       ]
     },
@@ -3681,7 +8617,9 @@
     "setFrame": {
       "overloads": [
         [
-          "Number"
+          {
+            "type": "Number"
+          }
         ]
       ]
     },
@@ -3703,8 +8641,13 @@
     "delay": {
       "overloads": [
         [
-          "Number",
-          "Number?"
+          {
+            "type": "Number"
+          },
+          {
+            "type": "Number",
+            "optional": true
+          }
         ]
       ]
     }
@@ -3713,21 +8656,28 @@
     "addRow": {
       "overloads": [
         [
-          "p5.TableRow?"
+          {
+            "type": "p5.TableRow",
+            "optional": true
+          }
         ]
       ]
     },
     "removeRow": {
       "overloads": [
         [
-          "Integer"
+          {
+            "type": "Integer"
+          }
         ]
       ]
     },
     "getRow": {
       "overloads": [
         [
-          "Integer"
+          {
+            "type": "Integer"
+          }
         ]
       ]
     },
@@ -3739,39 +8689,118 @@
     "findRow": {
       "overloads": [
         [
-          "String",
-          "Integer|String"
+          {
+            "type": "String"
+          },
+          {
+            "type": "union",
+            "elements": [
+              {
+                "type": "Integer",
+                "optional": true
+              },
+              {
+                "type": "String",
+                "optional": true
+              }
+            ]
+          }
         ]
       ]
     },
     "findRows": {
       "overloads": [
         [
-          "String",
-          "Integer|String"
+          {
+            "type": "String"
+          },
+          {
+            "type": "union",
+            "elements": [
+              {
+                "type": "Integer",
+                "optional": true
+              },
+              {
+                "type": "String",
+                "optional": true
+              }
+            ]
+          }
         ]
       ]
     },
     "matchRow": {
       "overloads": [
         [
-          "String|RegExp",
-          "String|Integer"
+          {
+            "type": "union",
+            "elements": [
+              {
+                "type": "String",
+                "optional": true
+              },
+              {
+                "type": "RegExp",
+                "optional": true
+              }
+            ]
+          },
+          {
+            "type": "union",
+            "elements": [
+              {
+                "type": "String",
+                "optional": true
+              },
+              {
+                "type": "Integer",
+                "optional": true
+              }
+            ]
+          }
         ]
       ]
     },
     "matchRows": {
       "overloads": [
         [
-          "String",
-          "String|Integer?"
+          {
+            "type": "String"
+          },
+          {
+            "type": "union",
+            "elements": [
+              {
+                "type": "String",
+                "optional": true
+              },
+              {
+                "type": "Integer",
+                "optional": true
+              }
+            ],
+            "optional": true
+          }
         ]
       ]
     },
     "getColumn": {
       "overloads": [
         [
-          "String|Number"
+          {
+            "type": "union",
+            "elements": [
+              {
+                "type": "String",
+                "optional": true
+              },
+              {
+                "type": "Number",
+                "optional": true
+              }
+            ]
+          }
         ]
       ]
     },
@@ -3783,7 +8812,10 @@
     "addColumn": {
       "overloads": [
         [
-          "String?"
+          {
+            "type": "String",
+            "optional": true
+          }
         ]
       ]
     },
@@ -3800,80 +8832,223 @@
     "removeTokens": {
       "overloads": [
         [
-          "String",
-          "String|Integer?"
+          {
+            "type": "String"
+          },
+          {
+            "type": "union",
+            "elements": [
+              {
+                "type": "String",
+                "optional": true
+              },
+              {
+                "type": "Integer",
+                "optional": true
+              }
+            ],
+            "optional": true
+          }
         ]
       ]
     },
     "trim": {
       "overloads": [
         [
-          "String|Integer?"
+          {
+            "type": "union",
+            "elements": [
+              {
+                "type": "String",
+                "optional": true
+              },
+              {
+                "type": "Integer",
+                "optional": true
+              }
+            ],
+            "optional": true
+          }
         ]
       ]
     },
     "removeColumn": {
       "overloads": [
         [
-          "String|Integer"
+          {
+            "type": "union",
+            "elements": [
+              {
+                "type": "String",
+                "optional": true
+              },
+              {
+                "type": "Integer",
+                "optional": true
+              }
+            ]
+          }
         ]
       ]
     },
     "set": {
       "overloads": [
         [
-          "Integer",
-          "String|Integer",
-          "String|Number"
+          {
+            "type": "Integer"
+          },
+          {
+            "type": "union",
+            "elements": [
+              {
+                "type": "String",
+                "optional": true
+              },
+              {
+                "type": "Integer",
+                "optional": true
+              }
+            ]
+          },
+          {
+            "type": "union",
+            "elements": [
+              {
+                "type": "String",
+                "optional": true
+              },
+              {
+                "type": "Number",
+                "optional": true
+              }
+            ]
+          }
         ]
       ]
     },
     "setNum": {
       "overloads": [
         [
-          "Integer",
-          "String|Integer",
-          "Number"
+          {
+            "type": "Integer"
+          },
+          {
+            "type": "union",
+            "elements": [
+              {
+                "type": "String",
+                "optional": true
+              },
+              {
+                "type": "Integer",
+                "optional": true
+              }
+            ]
+          },
+          {
+            "type": "Number"
+          }
         ]
       ]
     },
     "setString": {
       "overloads": [
         [
-          "Integer",
-          "String|Integer",
-          "String"
+          {
+            "type": "Integer"
+          },
+          {
+            "type": "union",
+            "elements": [
+              {
+                "type": "String",
+                "optional": true
+              },
+              {
+                "type": "Integer",
+                "optional": true
+              }
+            ]
+          },
+          {
+            "type": "String"
+          }
         ]
       ]
     },
     "get": {
       "overloads": [
         [
-          "Integer",
-          "String|Integer"
+          {
+            "type": "Integer"
+          },
+          {
+            "type": "union",
+            "elements": [
+              {
+                "type": "String",
+                "optional": true
+              },
+              {
+                "type": "Integer",
+                "optional": true
+              }
+            ]
+          }
         ]
       ]
     },
     "getNum": {
       "overloads": [
         [
-          "Integer",
-          "String|Integer"
+          {
+            "type": "Integer"
+          },
+          {
+            "type": "union",
+            "elements": [
+              {
+                "type": "String",
+                "optional": true
+              },
+              {
+                "type": "Integer",
+                "optional": true
+              }
+            ]
+          }
         ]
       ]
     },
     "getString": {
       "overloads": [
         [
-          "Integer",
-          "String|Integer"
+          {
+            "type": "Integer"
+          },
+          {
+            "type": "union",
+            "elements": [
+              {
+                "type": "String",
+                "optional": true
+              },
+              {
+                "type": "Integer",
+                "optional": true
+              }
+            ]
+          }
         ]
       ]
     },
     "getObject": {
       "overloads": [
         [
-          "String?"
+          {
+            "type": "String",
+            "optional": true
+          }
         ]
       ]
     },
@@ -3887,45 +9062,161 @@
     "set": {
       "overloads": [
         [
-          "String|Integer",
-          "String|Number"
+          {
+            "type": "union",
+            "elements": [
+              {
+                "type": "String",
+                "optional": true
+              },
+              {
+                "type": "Integer",
+                "optional": true
+              }
+            ]
+          },
+          {
+            "type": "union",
+            "elements": [
+              {
+                "type": "String",
+                "optional": true
+              },
+              {
+                "type": "Number",
+                "optional": true
+              }
+            ]
+          }
         ]
       ]
     },
     "setNum": {
       "overloads": [
         [
-          "String|Integer",
-          "Number|String"
+          {
+            "type": "union",
+            "elements": [
+              {
+                "type": "String",
+                "optional": true
+              },
+              {
+                "type": "Integer",
+                "optional": true
+              }
+            ]
+          },
+          {
+            "type": "union",
+            "elements": [
+              {
+                "type": "Number",
+                "optional": true
+              },
+              {
+                "type": "String",
+                "optional": true
+              }
+            ]
+          }
         ]
       ]
     },
     "setString": {
       "overloads": [
         [
-          "String|Integer",
-          "String|Number|Boolean|Object"
+          {
+            "type": "union",
+            "elements": [
+              {
+                "type": "String",
+                "optional": true
+              },
+              {
+                "type": "Integer",
+                "optional": true
+              }
+            ]
+          },
+          {
+            "type": "union",
+            "elements": [
+              {
+                "type": "String",
+                "optional": true
+              },
+              {
+                "type": "Number",
+                "optional": true
+              },
+              {
+                "type": "Boolean",
+                "optional": true
+              },
+              {
+                "type": "Object",
+                "optional": true
+              }
+            ]
+          }
         ]
       ]
     },
     "get": {
       "overloads": [
         [
-          "String|Integer"
+          {
+            "type": "union",
+            "elements": [
+              {
+                "type": "String",
+                "optional": true
+              },
+              {
+                "type": "Integer",
+                "optional": true
+              }
+            ]
+          }
         ]
       ]
     },
     "getNum": {
       "overloads": [
         [
-          "String|Integer"
+          {
+            "type": "union",
+            "elements": [
+              {
+                "type": "String",
+                "optional": true
+              },
+              {
+                "type": "Integer",
+                "optional": true
+              }
+            ]
+          }
         ]
       ]
     },
     "getString": {
       "overloads": [
         [
-          "String|Integer"
+          {
+            "type": "union",
+            "elements": [
+              {
+                "type": "String",
+                "optional": true
+              },
+              {
+                "type": "Integer",
+                "optional": true
+              }
+            ]
+          }
         ]
       ]
     }
@@ -3944,7 +9235,9 @@
     "setName": {
       "overloads": [
         [
-          "String"
+          {
+            "type": "String"
+          }
         ]
       ]
     },
@@ -3961,28 +9254,57 @@
     "getChildren": {
       "overloads": [
         [
-          "String?"
+          {
+            "type": "String",
+            "optional": true
+          }
         ]
       ]
     },
     "getChild": {
       "overloads": [
         [
-          "String|Integer"
+          {
+            "type": "union",
+            "elements": [
+              {
+                "type": "String",
+                "optional": true
+              },
+              {
+                "type": "Integer",
+                "optional": true
+              }
+            ]
+          }
         ]
       ]
     },
     "addChild": {
       "overloads": [
         [
-          "p5.XML"
+          {
+            "type": "p5.XML"
+          }
         ]
       ]
     },
     "removeChild": {
       "overloads": [
         [
-          "String|Integer"
+          {
+            "type": "union",
+            "elements": [
+              {
+                "type": "String",
+                "optional": true
+              },
+              {
+                "type": "Integer",
+                "optional": true
+              }
+            ]
+          }
         ]
       ]
     },
@@ -3999,38 +9321,71 @@
     "hasAttribute": {
       "overloads": [
         [
-          "String"
+          {
+            "type": "String"
+          }
         ]
       ]
     },
     "getNum": {
       "overloads": [
         [
-          "String",
-          "Number?"
+          {
+            "type": "String"
+          },
+          {
+            "type": "Number",
+            "optional": true
+          }
         ]
       ]
     },
     "getString": {
       "overloads": [
         [
-          "String",
-          "Number?"
+          {
+            "type": "String"
+          },
+          {
+            "type": "Number",
+            "optional": true
+          }
         ]
       ]
     },
     "setAttribute": {
       "overloads": [
         [
-          "String",
-          "Number|String|Boolean"
+          {
+            "type": "String"
+          },
+          {
+            "type": "union",
+            "elements": [
+              {
+                "type": "Number",
+                "optional": true
+              },
+              {
+                "type": "String",
+                "optional": true
+              },
+              {
+                "type": "Boolean",
+                "optional": true
+              }
+            ]
+          }
         ]
       ]
     },
     "getContent": {
       "overloads": [
         [
-          "String?"
+          {
+            "type": "String",
+            "optional": true
+          }
         ]
       ]
     },
@@ -4044,27 +9399,55 @@
     "getValue": {
       "overloads": [
         [
-          "Number"
+          {
+            "type": "Number"
+          }
         ]
       ]
     },
     "setValue": {
       "overloads": [
         [
-          "Number",
-          "Number"
+          {
+            "type": "Number"
+          },
+          {
+            "type": "Number"
+          }
         ]
       ]
     },
     "set": {
       "overloads": [
         [
-          "Number?",
-          "Number?",
-          "Number?"
+          {
+            "type": "Number",
+            "optional": true
+          },
+          {
+            "type": "Number",
+            "optional": true
+          },
+          {
+            "type": "Number",
+            "optional": true
+          }
         ],
         [
-          "p5.Vector|Number[]"
+          {
+            "type": "union",
+            "elements": [
+              {
+                "type": "p5.Vector",
+                "optional": true
+              },
+              {
+                "type": "Array",
+                "element": "Number",
+                "optional": true
+              }
+            ]
+          }
         ]
       ]
     },
@@ -4072,122 +9455,283 @@
       "overloads": [
         [],
         [
-          "p5.Vector"
+          {
+            "type": "p5.Vector"
+          }
         ]
       ]
     },
     "add": {
       "overloads": [
         [
-          "Number|Array",
-          "Number?",
-          "Number?"
+          {
+            "type": "union",
+            "elements": [
+              {
+                "type": "Number",
+                "optional": true
+              },
+              {
+                "type": "Array",
+                "optional": true
+              }
+            ]
+          },
+          {
+            "type": "Number",
+            "optional": true
+          },
+          {
+            "type": "Number",
+            "optional": true
+          }
         ],
         [
-          "p5.Vector|Number[]"
+          {
+            "type": "union",
+            "elements": [
+              {
+                "type": "p5.Vector",
+                "optional": true
+              },
+              {
+                "type": "Array",
+                "element": "Number",
+                "optional": true
+              }
+            ]
+          }
         ],
         [
-          "p5.Vector",
-          "p5.Vector",
-          "p5.Vector?"
+          {
+            "type": "p5.Vector"
+          },
+          {
+            "type": "p5.Vector"
+          },
+          {
+            "type": "p5.Vector",
+            "optional": true
+          }
         ]
       ]
     },
     "rem": {
       "overloads": [
         [
-          "Number",
-          "Number",
-          "Number"
+          {
+            "type": "Number"
+          },
+          {
+            "type": "Number"
+          },
+          {
+            "type": "Number"
+          }
         ],
         [
-          "p5.Vector|Number[]"
+          {
+            "type": "union",
+            "elements": [
+              {
+                "type": "p5.Vector",
+                "optional": true
+              },
+              {
+                "type": "Array",
+                "element": "Number",
+                "optional": true
+              }
+            ]
+          }
         ],
         [
-          "p5.Vector",
-          "p5.Vector"
+          {
+            "type": "p5.Vector"
+          },
+          {
+            "type": "p5.Vector"
+          }
         ]
       ]
     },
     "sub": {
       "overloads": [
         [
-          "Number",
-          "Number?",
-          "Number?"
+          {
+            "type": "Number"
+          },
+          {
+            "type": "Number",
+            "optional": true
+          },
+          {
+            "type": "Number",
+            "optional": true
+          }
         ],
         [
-          "p5.Vector|Number[]"
+          {
+            "type": "union",
+            "elements": [
+              {
+                "type": "p5.Vector",
+                "optional": true
+              },
+              {
+                "type": "Array",
+                "element": "Number",
+                "optional": true
+              }
+            ]
+          }
         ],
         [
-          "p5.Vector",
-          "p5.Vector",
-          "p5.Vector?"
+          {
+            "type": "p5.Vector"
+          },
+          {
+            "type": "p5.Vector"
+          },
+          {
+            "type": "p5.Vector",
+            "optional": true
+          }
         ]
       ]
     },
     "mult": {
       "overloads": [
         [
-          "Number",
-          "Number",
-          "Number?"
+          {
+            "type": "Number"
+          },
+          {
+            "type": "Number"
+          },
+          {
+            "type": "Number",
+            "optional": true
+          }
         ],
         [
-          "Number[]"
+          {
+            "type": "Array",
+            "element": "Number"
+          }
         ],
         [
-          "p5.Vector"
+          {
+            "type": "p5.Vector"
+          }
         ],
         [],
         [
-          "p5.Vector",
-          "Number",
-          "p5.Vector?"
+          {
+            "type": "p5.Vector"
+          },
+          {
+            "type": "Number"
+          },
+          {
+            "type": "p5.Vector",
+            "optional": true
+          }
         ],
         [
-          "p5.Vector",
-          "p5.Vector",
-          "p5.Vector?"
+          {
+            "type": "p5.Vector"
+          },
+          {
+            "type": "p5.Vector"
+          },
+          {
+            "type": "p5.Vector",
+            "optional": true
+          }
         ],
         [
-          "p5.Vector",
-          "Number[]",
-          "p5.Vector?"
+          {
+            "type": "p5.Vector"
+          },
+          {
+            "type": "Array",
+            "element": "Number"
+          },
+          {
+            "type": "p5.Vector",
+            "optional": true
+          }
         ]
       ]
     },
     "div": {
       "overloads": [
         [
-          "Number"
+          {
+            "type": "Number"
+          }
         ],
         [
-          "Number",
-          "Number",
-          "Number?"
+          {
+            "type": "Number"
+          },
+          {
+            "type": "Number"
+          },
+          {
+            "type": "Number",
+            "optional": true
+          }
         ],
         [
-          "Number[]"
+          {
+            "type": "Array",
+            "element": "Number"
+          }
         ],
         [
-          "p5.Vector"
+          {
+            "type": "p5.Vector"
+          }
         ],
         [],
         [
-          "p5.Vector",
-          "Number",
-          "p5.Vector?"
+          {
+            "type": "p5.Vector"
+          },
+          {
+            "type": "Number"
+          },
+          {
+            "type": "p5.Vector",
+            "optional": true
+          }
         ],
         [
-          "p5.Vector",
-          "p5.Vector",
-          "p5.Vector?"
+          {
+            "type": "p5.Vector"
+          },
+          {
+            "type": "p5.Vector"
+          },
+          {
+            "type": "p5.Vector",
+            "optional": true
+          }
         ],
         [
-          "p5.Vector",
-          "Number[]",
-          "p5.Vector?"
+          {
+            "type": "p5.Vector"
+          },
+          {
+            "type": "Array",
+            "element": "Number"
+          },
+          {
+            "type": "p5.Vector",
+            "optional": true
+          }
         ]
       ]
     },
@@ -4195,7 +9739,9 @@
       "overloads": [
         [],
         [
-          "p5.Vector"
+          {
+            "type": "p5.Vector"
+          }
         ]
       ]
     },
@@ -4203,36 +9749,58 @@
       "overloads": [
         [],
         [
-          "p5.Vector"
+          {
+            "type": "p5.Vector"
+          }
         ]
       ]
     },
     "dot": {
       "overloads": [
         [
-          "Number",
-          "Number?",
-          "Number?"
+          {
+            "type": "Number"
+          },
+          {
+            "type": "Number",
+            "optional": true
+          },
+          {
+            "type": "Number",
+            "optional": true
+          }
         ],
         [
-          "p5.Vector"
+          {
+            "type": "p5.Vector"
+          }
         ],
         [],
         [
-          "p5.Vector",
-          "p5.Vector"
+          {
+            "type": "p5.Vector"
+          },
+          {
+            "type": "p5.Vector"
+          }
         ]
       ]
     },
     "cross": {
       "overloads": [
         [
-          "p5.Vector"
+          {
+            "type": "p5.Vector"
+          }
         ],
         [],
         [
-          "p5.Vector",
-          "p5.Vector"
+          {
+            "type": "p5.Vector"
+          },
+          {
+            "type": "p5.Vector"
+          }
         ]
       ]
     },
@@ -4240,34 +9808,57 @@
       "overloads": [
         [],
         [
-          "p5.Vector",
-          "p5.Vector?"
+          {
+            "type": "p5.Vector"
+          },
+          {
+            "type": "p5.Vector",
+            "optional": true
+          }
         ]
       ]
     },
     "limit": {
       "overloads": [
         [
-          "Number"
+          {
+            "type": "Number"
+          }
         ],
         [],
         [
-          "p5.Vector",
-          "Number",
-          "p5.Vector?"
+          {
+            "type": "p5.Vector"
+          },
+          {
+            "type": "Number"
+          },
+          {
+            "type": "p5.Vector",
+            "optional": true
+          }
         ]
       ]
     },
     "setMag": {
       "overloads": [
         [
-          "Number"
+          {
+            "type": "Number"
+          }
         ],
         [],
         [
-          "p5.Vector",
-          "Number",
-          "p5.Vector?"
+          {
+            "type": "p5.Vector"
+          },
+          {
+            "type": "Number"
+          },
+          {
+            "type": "p5.Vector",
+            "optional": true
+          }
         ]
       ]
     },
@@ -4275,88 +9866,150 @@
       "overloads": [
         [],
         [
-          "p5.Vector"
+          {
+            "type": "p5.Vector"
+          }
         ]
       ]
     },
     "setHeading": {
       "overloads": [
         [
-          "Number"
+          {
+            "type": "Number"
+          }
         ]
       ]
     },
     "rotate": {
       "overloads": [
         [
-          "Number"
+          {
+            "type": "Number"
+          }
         ],
         [],
         [
-          "p5.Vector",
-          "Number",
-          "p5.Vector?"
+          {
+            "type": "p5.Vector"
+          },
+          {
+            "type": "Number"
+          },
+          {
+            "type": "p5.Vector",
+            "optional": true
+          }
         ]
       ]
     },
     "angleBetween": {
       "overloads": [
         [
-          "p5.Vector"
+          {
+            "type": "p5.Vector"
+          }
         ],
         [],
         [
-          "p5.Vector",
-          "p5.Vector"
+          {
+            "type": "p5.Vector"
+          },
+          {
+            "type": "p5.Vector"
+          }
         ]
       ]
     },
     "lerp": {
       "overloads": [
         [
-          "Number",
-          "Number",
-          "Number",
-          "Number"
+          {
+            "type": "Number"
+          },
+          {
+            "type": "Number"
+          },
+          {
+            "type": "Number"
+          },
+          {
+            "type": "Number"
+          }
         ],
         [
-          "p5.Vector",
-          "Number"
+          {
+            "type": "p5.Vector"
+          },
+          {
+            "type": "Number"
+          }
         ],
         [],
         [
-          "p5.Vector",
-          "p5.Vector",
-          "Number",
-          "p5.Vector?"
+          {
+            "type": "p5.Vector"
+          },
+          {
+            "type": "p5.Vector"
+          },
+          {
+            "type": "Number"
+          },
+          {
+            "type": "p5.Vector",
+            "optional": true
+          }
         ]
       ]
     },
     "slerp": {
       "overloads": [
         [
-          "p5.Vector",
-          "Number"
+          {
+            "type": "p5.Vector"
+          },
+          {
+            "type": "Number"
+          }
         ],
         [],
         [
-          "p5.Vector",
-          "p5.Vector",
-          "Number",
-          "p5.Vector?"
+          {
+            "type": "p5.Vector"
+          },
+          {
+            "type": "p5.Vector"
+          },
+          {
+            "type": "Number"
+          },
+          {
+            "type": "p5.Vector",
+            "optional": true
+          }
         ]
       ]
     },
     "reflect": {
       "overloads": [
         [
-          "p5.Vector"
+          {
+            "type": "p5.Vector"
+          }
         ],
         [],
         [
-          "p5.Vector",
-          "p5.Vector",
-          "p5.Vector?"
+          {
+            "type": "p5.Vector"
+          },
+          {
+            "type": "p5.Vector"
+          },
+          {
+            "type": "p5.Vector",
+            "optional": true
+          }
         ]
       ]
     },
@@ -4364,41 +10017,100 @@
       "overloads": [
         [],
         [
-          "p5.Vector"
+          {
+            "type": "p5.Vector"
+          }
         ]
       ]
     },
     "equals": {
       "overloads": [
         [
-          "Number?",
-          "Number?",
-          "Number?"
+          {
+            "type": "Number",
+            "optional": true
+          },
+          {
+            "type": "Number",
+            "optional": true
+          },
+          {
+            "type": "Number",
+            "optional": true
+          }
         ],
         [
-          "p5.Vector|Array"
+          {
+            "type": "union",
+            "elements": [
+              {
+                "type": "p5.Vector",
+                "optional": true
+              },
+              {
+                "type": "Array",
+                "optional": true
+              }
+            ]
+          }
         ],
         [],
         [
-          "p5.Vector|Array",
-          "p5.Vector|Array"
+          {
+            "type": "union",
+            "elements": [
+              {
+                "type": "p5.Vector",
+                "optional": true
+              },
+              {
+                "type": "Array",
+                "optional": true
+              }
+            ]
+          },
+          {
+            "type": "union",
+            "elements": [
+              {
+                "type": "p5.Vector",
+                "optional": true
+              },
+              {
+                "type": "Array",
+                "optional": true
+              }
+            ]
+          }
         ]
       ]
     },
     "fromAngle": {
       "overloads": [
         [
-          "Number",
-          "Number?"
+          {
+            "type": "Number"
+          },
+          {
+            "type": "Number",
+            "optional": true
+          }
         ]
       ]
     },
     "fromAngles": {
       "overloads": [
         [
-          "Number",
-          "Number",
-          "Number?"
+          {
+            "type": "Number"
+          },
+          {
+            "type": "Number"
+          },
+          {
+            "type": "Number",
+            "optional": true
+          }
         ]
       ]
     },
@@ -4416,8 +10128,12 @@
       "overloads": [
         [],
         [
-          "p5.Vector",
-          "p5.Vector"
+          {
+            "type": "p5.Vector"
+          },
+          {
+            "type": "p5.Vector"
+          }
         ]
       ]
     }
@@ -4426,44 +10142,100 @@
     "textToPaths": {
       "overloads": [
         [
-          "String",
-          "Number",
-          "Number",
-          "Number?",
-          "Number?",
-          "Object?"
+          {
+            "type": "String"
+          },
+          {
+            "type": "Number"
+          },
+          {
+            "type": "Number"
+          },
+          {
+            "type": "Number",
+            "optional": true
+          },
+          {
+            "type": "Number",
+            "optional": true
+          },
+          {
+            "type": "Object",
+            "optional": true
+          }
         ]
       ]
     },
     "textToPoints": {
       "overloads": [
         [
-          "String",
-          "Number",
-          "Number",
-          "Object?"
+          {
+            "type": "String"
+          },
+          {
+            "type": "Number"
+          },
+          {
+            "type": "Number"
+          },
+          {
+            "type": "Object",
+            "optional": true
+          }
         ]
       ]
     },
     "textToContours": {
       "overloads": [
         [
-          "String",
-          "Number",
-          "Number",
-          "Object?"
+          {
+            "type": "String"
+          },
+          {
+            "type": "Number"
+          },
+          {
+            "type": "Number"
+          },
+          {
+            "type": "Object",
+            "optional": true
+          }
         ]
       ]
     },
     "textToModel": {
       "overloads": [
         [
-          "String",
-          "Number",
-          "Number",
-          "Number",
-          "Number",
-          "Object?"
+          {
+            "type": "String"
+          },
+          {
+            "type": "Number"
+          },
+          {
+            "type": "Number"
+          },
+          {
+            "type": "Number"
+          },
+          {
+            "type": "Number"
+          },
+          {
+            "type": "Object",
+            "properties": {
+              "extrude": {
+                "type": "Number",
+                "optional": true
+              },
+              "sampleFactor": {
+                "type": "Number",
+                "optional": true
+              }
+            },
+            "optional": true
+          }
         ]
       ]
     }
@@ -4472,106 +10244,211 @@
     "perspective": {
       "overloads": [
         [
-          "Number?",
-          "Number?",
-          "Number?",
-          "Number?"
+          {
+            "type": "Number",
+            "optional": true
+          },
+          {
+            "type": "Number",
+            "optional": true
+          },
+          {
+            "type": "Number",
+            "optional": true
+          },
+          {
+            "type": "Number",
+            "optional": true
+          }
         ]
       ]
     },
     "ortho": {
       "overloads": [
         [
-          "Number?",
-          "Number?",
-          "Number?",
-          "Number?",
-          "Number?",
-          "Number?"
+          {
+            "type": "Number",
+            "optional": true
+          },
+          {
+            "type": "Number",
+            "optional": true
+          },
+          {
+            "type": "Number",
+            "optional": true
+          },
+          {
+            "type": "Number",
+            "optional": true
+          },
+          {
+            "type": "Number",
+            "optional": true
+          },
+          {
+            "type": "Number",
+            "optional": true
+          }
         ]
       ]
     },
     "frustum": {
       "overloads": [
         [
-          "Number?",
-          "Number?",
-          "Number?",
-          "Number?",
-          "Number?",
-          "Number?"
+          {
+            "type": "Number",
+            "optional": true
+          },
+          {
+            "type": "Number",
+            "optional": true
+          },
+          {
+            "type": "Number",
+            "optional": true
+          },
+          {
+            "type": "Number",
+            "optional": true
+          },
+          {
+            "type": "Number",
+            "optional": true
+          },
+          {
+            "type": "Number",
+            "optional": true
+          }
         ]
       ]
     },
     "pan": {
       "overloads": [
         [
-          "Number"
+          {
+            "type": "Number"
+          }
         ]
       ]
     },
     "tilt": {
       "overloads": [
         [
-          "Number"
+          {
+            "type": "Number"
+          }
         ]
       ]
     },
     "lookAt": {
       "overloads": [
         [
-          "Number",
-          "Number",
-          "Number"
+          {
+            "type": "Number"
+          },
+          {
+            "type": "Number"
+          },
+          {
+            "type": "Number"
+          }
         ]
       ]
     },
     "camera": {
       "overloads": [
         [
-          "Number?",
-          "Number?",
-          "Number?",
-          "Number?",
-          "Number?",
-          "Number?",
-          "Number?",
-          "Number?",
-          "Number?"
+          {
+            "type": "Number",
+            "optional": true
+          },
+          {
+            "type": "Number",
+            "optional": true
+          },
+          {
+            "type": "Number",
+            "optional": true
+          },
+          {
+            "type": "Number",
+            "optional": true
+          },
+          {
+            "type": "Number",
+            "optional": true
+          },
+          {
+            "type": "Number",
+            "optional": true
+          },
+          {
+            "type": "Number",
+            "optional": true
+          },
+          {
+            "type": "Number",
+            "optional": true
+          },
+          {
+            "type": "Number",
+            "optional": true
+          }
         ]
       ]
     },
     "move": {
       "overloads": [
         [
-          "Number",
-          "Number",
-          "Number"
+          {
+            "type": "Number"
+          },
+          {
+            "type": "Number"
+          },
+          {
+            "type": "Number"
+          }
         ]
       ]
     },
     "setPosition": {
       "overloads": [
         [
-          "Number",
-          "Number",
-          "Number"
+          {
+            "type": "Number"
+          },
+          {
+            "type": "Number"
+          },
+          {
+            "type": "Number"
+          }
         ]
       ]
     },
     "set": {
       "overloads": [
         [
-          "p5.Camera"
+          {
+            "type": "p5.Camera"
+          }
         ]
       ]
     },
     "slerp": {
       "overloads": [
         [
-          "p5.Camera",
-          "p5.Camera",
-          "Number"
+          {
+            "type": "p5.Camera"
+          },
+          {
+            "type": "p5.Camera"
+          },
+          {
+            "type": "Number"
+          }
         ]
       ]
     }
@@ -4580,22 +10457,32 @@
     "resize": {
       "overloads": [
         [
-          "Number",
-          "Number"
+          {
+            "type": "Number"
+          },
+          {
+            "type": "Number"
+          }
         ]
       ]
     },
     "pixelDensity": {
       "overloads": [
         [
-          "Number?"
+          {
+            "type": "Number",
+            "optional": true
+          }
         ]
       ]
     },
     "autoSized": {
       "overloads": [
         [
-          "Boolean?"
+          {
+            "type": "Boolean",
+            "optional": true
+          }
         ]
       ]
     },
@@ -4622,22 +10509,36 @@
     "draw": {
       "overloads": [
         [
-          "Function"
+          {
+            "type": "Function"
+          }
         ]
       ]
     },
     "get": {
       "overloads": [
         [
-          "Number",
-          "Number",
-          "Number",
-          "Number"
+          {
+            "type": "Number"
+          },
+          {
+            "type": "Number"
+          },
+          {
+            "type": "Number"
+          },
+          {
+            "type": "Number"
+          }
         ],
         [],
         [
-          "Number",
-          "Number"
+          {
+            "type": "Number"
+          },
+          {
+            "type": "Number"
+          }
         ]
       ]
     }
@@ -4656,22 +10557,72 @@
     "modify": {
       "overloads": [
         [
-          "Object?"
+          {
+            "type": "Object",
+            "optional": true
+          }
         ]
       ]
     },
     "copyToContext": {
       "overloads": [
         [
-          "p5|p5.Graphics"
+          {
+            "type": "union",
+            "elements": [
+              {
+                "type": "p5",
+                "optional": true
+              },
+              {
+                "type": "p5.Graphics",
+                "optional": true
+              }
+            ]
+          }
         ]
       ]
     },
     "setUniform": {
       "overloads": [
         [
-          "String",
-          "Boolean|Number|Number[]|p5.Image|p5.Graphics|p5.MediaElement|p5.Texture"
+          {
+            "type": "String"
+          },
+          {
+            "type": "union",
+            "elements": [
+              {
+                "type": "Boolean",
+                "optional": true
+              },
+              {
+                "type": "Number",
+                "optional": true
+              },
+              {
+                "type": "Array",
+                "element": "Number",
+                "optional": true
+              },
+              {
+                "type": "p5.Image",
+                "optional": true
+              },
+              {
+                "type": "p5.Graphics",
+                "optional": true
+              },
+              {
+                "type": "p5.MediaElement",
+                "optional": true
+              },
+              {
+                "type": "p5.Texture",
+                "optional": true
+              }
+            ]
+          }
         ]
       ]
     }


### PR DESCRIPTION
Resolves #7752 

#### Overall Description
This PR deals with generating more structured and informative `parameterData.json` in order to get a clear and accurate idea of the various parameters involved in overloads of methods. Additionally, as a part of the enhancement process, this PR also resolves and enhances the ability to check the `types` of the nested as well as positional parameters efficiently at run time, which is also one of the critical aspect of the issue.

#### Approach Used
- **Enhancements made to be able to build more structural format to `parameterData.json`**
  - The parameters of  `FunctionType` node are extracted and preserved for further processing 
  - Traversed more deeper to build more informative structure for supporting nested params
  - Used appropriate regular expression as required at appropriate places
  - Efficient handling of:
    - Array Types
    - Union Types
    - Tuple Types
    - Function Parameters
    - Nested Object Parameters
    - Rest Parameters
    - **_Array of Tuples consisting of nested union and other params_**
  
- **Modified FES to parse and check the types at run time via generated `Zod schema`** 
  - Now, string checking via the presence of (`?`) as `endsWith('?')` is no longer required
  - `Switch- Case` is used to handle mappings from `type` names to `Zod schemas`

#### Additional Code Quality Work
- Used fallback mechanism for safety and to avoid runtime errors
- Explicit handling of types to ease overall maintainability and readability
- Added in-line comments as appropriate

#### Trickiest Portions to handle
- Nested Parameters like `[p5.Color|String|Number|Number[], Number][]`
- Rest Parametrs `"...Number[]"`
- Functions with parameters `function(p5.Geometry)`

#### Observations and Results
- Tested and validated the `parameterData.json` to verify the expected results 

#### Additional Checks 
- [x] `npm run docs` - to generate the `parameterData.json` doc
- [x] `npm run lint` - lint checker for code style and standards
- [x] `npm test` - to re-validate all the test suites passed 