### PR TITLE
Madhav/issue7833

### DIFF
--- a/test/unit/core/param_errors.js
+++ b/test/unit/core/param_errors.js
@@ -110,10 +110,10 @@ suite('Validate Params', function () {
 
     const invalidInputs = [
       { name: 'missing required arc parameters #4, #5', input: [200, 100, 100, 80], msg: '🌸 p5.js says: Expected at least 6 arguments, but received fewer in p5.arc(). For more information, see https://p5js.org/reference/p5/arc.' },
-      { name: 'missing required param #0', input: [undefined, 100, 100, 80, 0, Math.PI, constants.PIE, 30], msg: '🌸 p5.js says: Expected number at the first parameter, but received undefined in p5.arc().' },
-      { name: 'missing required param #4', input: [200, 100, 100, 80, undefined, 0], msg: '🌸 p5.js says: Expected number at the fifth parameter, but received undefined in p5.arc().' },
-      { name: 'missing optional param #5', input: [200, 100, 100, 80, 0, undefined, Math.PI], msg: '🌸 p5.js says: Expected number at the sixth parameter, but received undefined in p5.arc().' },
-      { name: 'wrong param type at #0', input: ['a', 100, 100, 80, 0, Math.PI, constants.PIE, 30], msg: '🌸 p5.js says: Expected number at the first parameter, but received string in p5.arc().' }
+      { name: 'missing required param #0', input: [undefined, 100, 100, 80, 0, Math.PI, constants.PIE, 30], msg: '🌸 p5.js says: Expected number at the first parameter, but received Invalid input: expected number, received undefined in p5.arc().' },
+      { name: 'missing required param #4', input: [200, 100, 100, 80, undefined, 0], msg: '🌸 p5.js says: Expected number at the fifth parameter, but received Invalid input: expected number, received undefined in p5.arc().' },
+      { name: 'missing optional param #5', input: [200, 100, 100, 80, 0, undefined, Math.PI], msg: '🌸 p5.js says: Expected number at the sixth parameter, but received Invalid input: expected number, received undefined in p5.arc().' },
+      { name: 'wrong param type at #0', input: ['a', 100, 100, 80, 0, Math.PI, constants.PIE, 30], msg: '🌸 p5.js says: Expected number at the first parameter, but received Invalid input: expected number, received string in p5.arc().' }
     ];
 
     invalidInputs.forEach(({ name, input, msg }) => {
@@ -130,7 +130,7 @@ suite('Validate Params', function () {
       console.log(result);
       assert.equal(
         result.error,
-        '🌸 p5.js says: Did you mean to put `await` before a loading function? An unexpected Promise was found. Expected Image or Element or Texture or Framebuffer or FramebufferTexture or Renderer or Graphics at the first parameter in p5.image().'
+        '🌸 p5.js says: Did you mean to put `await` before a loading function? An unexpected Promise was found. Expected Image or Element or Texture or Framebuffer or FramebufferTexture or Renderer or Graphics at the first parameter, but received Input not instance of Image in p5.image().'
       );
     });
   });
@@ -144,13 +144,13 @@ suite('Validate Params', function () {
 
   suite('validateParams: a few edge cases', function () {
     const invalidInputs = [
-      { fn: 'color', name: 'wrong type for optional parameter', input: [0, 0, 0, 'A'], msg: '🌸 p5.js says: Expected number at the fourth parameter, but received string in p5.color().' },
-      { fn: 'color', name: 'superfluous parameter', input: [[0, 0, 0], 0], msg: '🌸 p5.js says: Expected number at the first parameter, but received array in p5.color().' },
-      { fn: 'color', name: 'wrong element types', input: [['A', 'B', 'C']], msg: '🌸 p5.js says: Expected number at the first parameter, but received array in p5.color().' },
-      { fn: 'rect', name: 'null, non-trailing, optional parameter', input: [0, 0, 0, 0, null, 0, 0, 0], msg: '🌸 p5.js says: Expected number at the fifth parameter, but received null in p5.rect().' },
+      { fn: 'color', name: 'wrong type for optional parameter', input: [0, 0, 0, 'A'], msg: '🌸 p5.js says: Expected number at the fourth parameter, but received Invalid input: expected number, received string in p5.color().' },
+      { fn: 'color', name: 'superfluous parameter', input: [[0, 0, 0], 0], msg: '🌸 p5.js says: Expected number at the first parameter, but received Invalid input: expected number, received array in p5.color().' },
+      { fn: 'color', name: 'wrong element types', input: [['A', 'B', 'C']], msg: '🌸 p5.js says: Expected number at the first parameter, but received Invalid input: expected number, received array in p5.color().' },
+      { fn: 'rect', name: 'null, non-trailing, optional parameter', input: [0, 0, 0, 0, null, 0, 0, 0], msg: '🌸 p5.js says: Expected number at the fifth parameter, but received Invalid input: expected number, received null in p5.rect().' },
       { fn: 'color', name: 'too many args + wrong types too', input: ['A', 'A', 0, 0, 0, 0, 0, 0, 0, 0], msg: '🌸 p5.js says: Expected at most 4 arguments, but received more in p5.color(). For more information, see https://p5js.org/reference/p5/color.' },
-      { fn: 'line', name: 'null string given', input: [1, 2, 4, 'null'], msg: '🌸 p5.js says: Expected number at the fourth parameter, but received string in p5.line().' },
-      { fn: 'line', name: 'NaN value given', input: [1, 2, 4, NaN], msg: '🌸 p5.js says: Expected number at the fourth parameter, but received nan in p5.line().' }
+      { fn: 'line', name: 'null string given', input: [1, 2, 4, 'null'], msg: '🌸 p5.js says: Expected number at the fourth parameter, but received Invalid input: expected number, received string in p5.line().' },
+      { fn: 'line', name: 'NaN value given', input: [1, 2, 4, NaN], msg: '🌸 p5.js says: Expected number at the fourth parameter, but received Invalid input: expected number, received NaN in p5.line().' }
     ];
 
     invalidInputs.forEach(({ name, input, fn, msg }) => {
@@ -163,12 +163,12 @@ suite('Validate Params', function () {
 
   suite('validateParams: trailing undefined arguments', function () {
     const invalidInputs = [
-      { fn: 'color', name: 'missing params #1, #2', input: [12, undefined, undefined], msg: '🌸 p5.js says: Expected number at the second parameter, but received undefined in p5.color().' },
+      { fn: 'color', name: 'missing params #1, #2', input: [12, undefined, undefined], msg: '🌸 p5.js says: Expected number at the second parameter, but received Invalid input: expected number, received undefined in p5.color().' },
       // Even though the undefined arguments are technically allowed for
       // optional parameters, it is more likely that the user wanted to call
       // the function with meaningful arguments.
       { fn: 'random', name: 'missing params #0, #1', input: [undefined, undefined], msg: '🌸 p5.js says: All arguments for p5.random() are undefined. There is likely an error in the code.' },
-      { fn: 'circle', name: 'missing compulsory parameter #2', input: [5, 5, undefined], msg: '🌸 p5.js says: Expected number at the third parameter, but received undefined in p5.circle().' }
+      { fn: 'circle', name: 'missing compulsory parameter #2', input: [5, 5, undefined], msg: '🌸 p5.js says: Expected number at the third parameter, but received Invalid input: expected number, received undefined in p5.circle().' }
     ];
 
     invalidInputs.forEach(({ fn, name, input, msg }) => {
@@ -193,9 +193,9 @@ suite('Validate Params', function () {
     });
 
     const invalidInputs = [
-      { name: 'optional parameter, incorrect type', input: [65, 100, 100, 'a'], msg: '🌸 p5.js says: Expected number at the fourth parameter, but received string in p5.color().' },
-      { name: 'extra parameter', input: [[65, 100, 100], 100], msg: '🌸 p5.js says: Expected number at the first parameter, but received array in p5.color().' },
-      { name: 'incorrect element type', input: ['A', 'B', 'C'], msg: '🌸 p5.js says: Expected number at the first parameter, but received string in p5.color().' },
+      { name: 'optional parameter, incorrect type', input: [65, 100, 100, 'a'], msg: '🌸 p5.js says: Expected number at the fourth parameter, but received Invalid input: expected number, received string in p5.color().' },
+      { name: 'extra parameter', input: [[65, 100, 100], 100], msg: '🌸 p5.js says: Expected number at the first parameter, but received Invalid input: expected number, received array in p5.color().' },
+      { name: 'incorrect element type', input: ['A', 'B', 'C'], msg: '🌸 p5.js says: Expected number at the first parameter, but received Invalid input: expected number, received string in p5.color().' },
       { name: 'incorrect parameter count', input: ['A', 'A', 0, 0, 0, 0, 0, 0], msg: '🌸 p5.js says: Expected at most 4 arguments, but received more in p5.color(). For more information, see https://p5js.org/reference/p5/color.' }
     ];
 
@@ -223,7 +223,7 @@ suite('Validate Params', function () {
 
     test(`set() with Boolean (invalid)`, function () {
       const result = mockP5Prototype.validate('p5.set', [0, 0, true]);
-      assert.equal(result.error, '🌸 p5.js says: Expected number or array or object at the third parameter, but received boolean in p5.set().');
+      assert.equal(result.error, '🌸 p5.js says: Expected number or array or object at the third parameter, but received Invalid input: expected number, received boolean in p5.set().');
     });
   });
 


### PR DESCRIPTION
<!--
  Thank you for contributing! Please use this pull request (PR) template.


 In the description field of this PR, include "resolves #XXXX" tagging the issue you are fixing. If this PR addresses the issue but doesn't completely resolve it (ie the issue should remain open after your PR is merged), write "addresses #XXXX".-->
Resolves #7833 

 Changes:
<!-- Add here what changes were made in this pull request and if possible provide links showcasing the changes. -->
- line 325 schema `items` can be accessed within `def`
- line 356 and 360 `_def` is deprecated, use `def` or directly use `options`
 - line 393 `zodErrorObj.errors[0]` changes to `zodErrorObj.issues[0]`
- line 410 `union error` changes to `errors`
- line 414 and 459, `received` changes to `message`
- Test cases are updated. According to zod 4, error messages are elaborated

### Important
[constant.js](https://github.com/processing/p5.js/blob/dev-2.0/src/core/constants.js) have some variable which are Symbols , according to zod 4, Symbols aren't considered literal values, nor can they be simply compared with ===. This was an oversight in Zod 3.

 Screenshots of the change:
<!-- If applicable, add screenshots depicting the changes. -->

#### PR Checklist
<!--
  To check any option, replace the "[ ]" with a "[x]". Be sure to check out how it looks in the Preview tab! Feel free to remove any portion of the template that is not relevant to your issue.
-->

- [x] `npm run lint` passes
- [ ] [Inline reference] is included / updated
- [x] [Unit tests] are included / updated

[Inline reference]: https://p5js.org/contribute/contributing_to_the_p5js_reference/
[Unit tests]: https://github.com/processing/p5.js/tree/main/contributor_docs#unit-tests
