### PR TITLE
Use FES internationalization within the minor version

### DIFF
--- a/src/core/internationalization.js
+++ b/src/core/internationalization.js
@@ -1,6 +1,6 @@
 import i18next from 'i18next';
 import LanguageDetector from 'i18next-browser-languagedetector';
-import * as constants from './constants';
+import { VERSION } from './constants';
 
 
 let fallbackResources, languages;
@@ -129,7 +129,6 @@ export let translator = (key, values) => {
  * Set up our translation function, with loaded languages
  */
 export const initialize = () => {
-  let latestMinorVersionPath = 'https://cdn.jsdelivr.net/npm/p5@' + constants.VERSION.replace(/^(\d+\.\d+)\.\d+.*$/, '$1');
   let i18init = i18next
     .use(LanguageDetector)
     .use(FetchResources)
@@ -152,7 +151,12 @@ export const initialize = () => {
       },
       backend: {
         fallback: 'en',
-        loadPath: latestMinorVersionPath + '/translations/{{lng}}/{{ns}}.json'
+
+        // ensure that the FES internationalization strings are loaded
+        // from the latest patch of the current minor version of p5.js
+        loadPath: `https://cdn.jsdelivr.net/npm/p5@${
+          VERSION.replace(/^(\d+\.\d+)\.\d+.*$/, '$1')
+        }/translations/{{lng}}/{{ns}}.json`
       },
       partialBundledLanguages: true,
       resources: fallbackResources


### PR DESCRIPTION
Addresses #7813

- [x] `npm run lint` passes
- [x] [Inline reference] is included / updated
- [ ] [Unit tests] are included / updated

[Inline reference]: https://p5js.org/contribute/contributing_to_the_p5js_reference/
[Unit tests]: https://github.com/processing/p5.js/tree/main/contributor_docs#unit-tests


```js
const version = '1.11.7';
const loadPath = 'https://cdn.jsdelivr.net/npm/p5@' + version.replace(/^(\d+\.\d+)\.\d+.*$/, '$1') + '/translations/{{lng}}/{{ns}}.json';
console.log(loadPath);
// https://cdn.jsdelivr.net/npm/p5@1.11/translations/{{lng}}/{{ns}}.json
// will become https://cdn.jsdelivr.net/npm/p5@1.11/translations/es/translation.json which exists
```
