### PR TITLE
Add font readiness wait to create() function in p5.Font.js

### DIFF
--- a/src/type/p5.Font.js
+++ b/src/type/p5.Font.js
@@ -950,6 +950,9 @@ async function create(pInst, name, path, descriptors, rawFont) {
   // add it to the document
   document.fonts.add(face);
 
+  // ensure the font is ready to be rendered
+  await document.fonts.ready;
+
   // return a new p5.Font
   return new Font(pInst, face, name, path, rawFont);
 }


### PR DESCRIPTION
Resolves #7823 

 Changes:
Adds an `await document.fonts.ready` inside the create() function in p5.Font.js to ensure the font is fully loaded before the function resolves. This should guarantee that rendering depending on the font won't proceed prematurely.

#### PR Checklist
- [x] `npm run lint` passes
