### PR TITLE
Alias GLSL's mix function as lerp in p5.strands (#7875)

### DIFF
--- a/src/webgl/ShaderGenerator.js
+++ b/src/webgl/ShaderGenerator.js
@@ -1620,6 +1620,17 @@ function shadergenerator(p5, fn) {
   })
 }
 
+// Alias GLSL's mix function as lerp in p5.strands
+// Bridging p5.js lerp and GLSL mix for consistency in shader expressions
+const originalLerp = fn.lerp;
+fn.lerp = function (...args) {
+  if (GLOBAL_SHADER?.isGenerating) {
+    return fn.mix(...args); // Use mix inside p5.strands
+  } else {
+    return originalLerp.apply(this, args); // Fallback to normal p5.js lerp
+  }
+};
+
 export default shadergenerator;
 
 if (typeof p5 !== 'undefined') {


### PR DESCRIPTION
Resolves #7875

## Changes:
- Introduced an alias for the GLSL `mix` function under the name `lerp` in `p5.strands`.
- Ensures that `lerp()` within `p5.strands` maps to `mix()` when generating shader expressions.
- Falls back to the original p5.js `lerp()` function outside of `p5.strands`.

## Rationale:
This change bridges the gap between core `p5.js` and `p5.strands` by making `lerp()` work seamlessly within shader code. It increases accessibility by allowing familiar p5.js functions to be used in new contexts.

A short inline comment was also added for clarity:

#### PR Checklist

- [x] `npm run lint` passes
- [x] [Inline reference] is included / updated
- [x] [Unit tests] are included / updated

[Inline reference]: https://p5js.org/contribute/contributing_to_the_p5js_reference/
[Unit tests]: https://github.com/processing/p5.js/tree/main/contributor_docs#unit-tests
