### PR TITLE
Update stewards-update.yml to only make PR with README

### DIFF
--- a/.github/workflows/stewards-update.yml
+++ b/.github/workflows/stewards-update.yml
@@ -24,6 +24,12 @@ jobs:
       - name: Run table generator
         run: node utils/stewards-table.js
         
+      - name: Reset all changes except README.md
+        run: |
+          git restore --staged .
+          git add README.md
+          git checkout -- .
+          
       - name: Create Pull Request
         uses: peter-evans/create-pull-request@v5
         with:


### PR DESCRIPTION
 Fixes the creation of a PR with unnecessary files included: https://github.com/processing/p5.js/pull/7894

- [ ] `npm run lint` passes
- [ ] [Inline reference] is included / updated
- [ ] [Unit tests] are included / updated

[Inline reference]: https://p5js.org/contribute/contributing_to_the_p5js_reference/
[Unit tests]: https://github.com/processing/p5.js/tree/main/contributor_docs#unit-tests
