### PR TITLE
Update labeler.yml to correctly group DevOps lables

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -26,7 +26,6 @@
   - '\[[xX]\]\s*Internationalization'
 "DevOps":
   - '\[[xX]\]\s*Build Process'
-"DevOps":
   - '\[[xX]\]\s*Unit Testing'
 "Build Process":
   - '\[[xX]\]\s*Build Process'


### PR DESCRIPTION
- [x] `npm run lint` passes
- [ ] [Inline reference] is included / updated
- [ ] [Unit tests] are included / updated

[Inline reference]: https://p5js.org/contribute/contributing_to_the_p5js_reference/
[Unit tests]: https://github.com/processing/p5.js/tree/main/contributor_docs#unit-tests
