### PR TITLE
Fix Typo in Comments: "trhough" to "through" in textOutput.js

### DIFF
--- a/src/accessibility/textOutput.js
+++ b/src/accessibility/textOutput.js
@@ -59,7 +59,7 @@ function _textSummary(numShapes, background, width, height) {
 function _shapeDetails(idT, ingredients) {
   let shapeDetails = '';
   let shapeNumber = 0;
-  //goes trhough every shape type in ingredients
+  //goes through every shape type in ingredients
   for (let x in ingredients) {
     //and for every shape
     for (let y in ingredients[x]) {
@@ -91,7 +91,7 @@ function _shapeDetails(idT, ingredients) {
 function _shapeList(idT, ingredients) {
   let shapeList = '';
   let shapeNumber = 0;
-  //goes trhough every shape type in ingredients
+  //goes through every shape type in ingredients
   for (let x in ingredients) {
     for (let y in ingredients[x]) {
       //it creates a line in a list


### PR DESCRIPTION


Description:  
This pull request corrects a typo in the comments within the `src/accessibility/textOutput.js` file. The word "trhough" has been replaced with the correct spelling "through" in two locations. No functional code changes were made; this update is for improved readability and documentation accuracy.