### PR TITLE
Fix typos in documentation and comments

### DIFF
--- a/src/image/loading_displaying.js
+++ b/src/image/loading_displaying.js
@@ -924,7 +924,7 @@ function _sAssign(sVal, iVal) {
  * destination rectangle. This may have the effect of zooming into the
  * subsection.
  *
- * The tenth and eleventh paremeters, `xAlign` and `yAlign`, are also
+ * The tenth and eleventh parameters, `xAlign` and `yAlign`, are also
  * optional. They determine how to align the fitted subsection. `xAlign` can
  * be set to either `LEFT`, `RIGHT`, or `CENTER`. `yAlign` can be set to
  * either `TOP`, `BOTTOM`, or `CENTER`. By default, both `xAlign` and `yAlign`

--- a/src/math/trigonometry.js
+++ b/src/math/trigonometry.js
@@ -540,7 +540,7 @@ p5.prototype.degrees = angle => angle * constants.RAD_TO_DEG;
  *
  *   background(200);
  *
- *   // Caclulate the angle conversion.
+ *   // Calculate the angle conversion.
  *   let deg = 45;
  *   let rad = radians(deg);
  *


### PR DESCRIPTION


**Description:**
🔍 Minor fixes:
- Corrected spelling of "parameters" in `loading_displaying.js`
- Fixed spelling of "Calculate" in `trigonometry.js`

