### PR TITLE
[p5.js 2.x] chore: enable `pre-commit` hooks

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,10 +53,12 @@
     "test": "vitest"
   },
   "husky": {
-    "hooks": {}
+    "hooks": {
+      "pre-commit": "lint-staged"
+    }
   },
   "lint-staged": {
-    "src/**/*.js": "eslint",
+    "src/**/*.js": "eslint --max-warnings=0",
     "test/**/*.js": "eslint",
     "utils/**/*.{js,mjs}": "eslint"
   },

--- a/package.json
+++ b/package.json
@@ -1,24 +1,70 @@
 {
   "name": "p5",
+  "version": "2.0.3",
+  "description": "[![npm version](https://badge.fury.io/js/p5.svg)](https://www.npmjs.com/package/p5)",
+  "homepage": "https://p5js.org",
+  "bugs": {
+    "url": "https://github.com/processing/p5.js/issues"
+  },
   "repository": "processing/p5.js",
+  "license": "LGPL-2.1",
+  "author": "",
+  "exports": {
+    ".": "./dist/app.js",
+    "./core": "./dist/core/main.js",
+    "./shape": "./dist/shape/index.js",
+    "./accessibility": "./dist/accessibility/index.js",
+    "./friendlyErrors": "./dist/core/friendlyErrors/index.js",
+    "./data": "./dist/data/index.js",
+    "./dom": "./dist/dom/index.js",
+    "./events": "./dist/events/index.js",
+    "./image": "./dist/image/index.js",
+    "./io": "./dist/io/index.js",
+    "./math": "./dist/math/index.js",
+    "./utilities": "./dist/utilities/index.js",
+    "./webgl": "./dist/webgl/index.js",
+    "./type": "./dist/type/index.js"
+  },
+  "browser": "./lib/p5.min.js",
+  "types": "./types/p5.d.ts",
+  "directories": {
+    "doc": "docs",
+    "test": "test"
+  },
+  "files": [
+    "dist/**",
+    "license.txt",
+    "lib/p5.min.js",
+    "lib/p5.js",
+    "lib/p5.esm.js",
+    "translations/**",
+    "types/**"
+  ],
   "scripts": {
+    "bench": "vitest bench",
+    "bench:report": "vitest bench --reporter=verbose",
     "build": "rollup -c",
     "dev": "vite preview/",
     "dev:global": "concurrently -n build,server \"rollup -c -w\" \"npx vite preview/global/\"",
     "docs": "documentation build ./src/**/*.js ./src/**/**/*.js -o ./docs/data.json && node ./utils/convert.mjs",
-    "bench": "vitest bench",
-    "bench:report": "vitest bench --reporter=verbose",
-    "test": "vitest",
+    "generate-types": "npm run docs && node utils/generate-types.mjs && node utils/patch.mjs",
     "lint": "eslint .",
     "lint:fix": "eslint --fix .",
-    "generate-types": "npm run docs && node utils/generate-types.mjs && node utils/patch.mjs"
+    "test": "vitest"
+  },
+  "husky": {
+    "hooks": {}
   },
   "lint-staged": {
     "src/**/*.js": "eslint",
     "test/**/*.js": "eslint",
     "utils/**/*.{js,mjs}": "eslint"
   },
-  "version": "2.0.3",
+  "msw": {
+    "workerDirectory": [
+      "test"
+    ]
+  },
   "dependencies": {
     "@davepagurek/bezier-path": "^0.0.2",
     "@japont/unicode-range": "^1.0.0",
@@ -65,51 +111,5 @@
     "vite-plugin-string": "^1.2.2",
     "vitest": "^2.1.5",
     "webdriverio": "^9.0.7"
-  },
-  "license": "LGPL-2.1",
-  "browser": "./lib/p5.min.js",
-  "exports": {
-    ".": "./dist/app.js",
-    "./core": "./dist/core/main.js",
-    "./shape": "./dist/shape/index.js",
-    "./accessibility": "./dist/accessibility/index.js",
-    "./friendlyErrors": "./dist/core/friendlyErrors/index.js",
-    "./data": "./dist/data/index.js",
-    "./dom": "./dist/dom/index.js",
-    "./events": "./dist/events/index.js",
-    "./image": "./dist/image/index.js",
-    "./io": "./dist/io/index.js",
-    "./math": "./dist/math/index.js",
-    "./utilities": "./dist/utilities/index.js",
-    "./webgl": "./dist/webgl/index.js",
-    "./type": "./dist/type/index.js"
-  },
-  "files": [
-    "dist/**",
-    "license.txt",
-    "lib/p5.min.js",
-    "lib/p5.js",
-    "lib/p5.esm.js",
-    "translations/**",
-    "types/**"
-  ],
-  "description": "[![npm version](https://badge.fury.io/js/p5.svg)](https://www.npmjs.com/package/p5)",
-  "bugs": {
-    "url": "https://github.com/processing/p5.js/issues"
-  },
-  "homepage": "https://p5js.org",
-  "directories": {
-    "doc": "docs",
-    "test": "test"
-  },
-  "author": "",
-  "husky": {
-    "hooks": {}
-  },
-  "msw": {
-    "workerDirectory": [
-      "test"
-    ]
-  },
-  "types": "./types/p5.d.ts"
+  }
 }


### PR DESCRIPTION
adresses #7930 

This PR enables the pre-commit hooks to make use of `lint-staged`.

As a one time fix this PR uses `npx sort-package-json` to sort the fields in the  package.json.