### PR TITLE
Skip adding degenerate faces in textToModel

### DIFF
--- a/src/type/p5.Font.js
+++ b/src/type/p5.Font.js
@@ -537,8 +537,11 @@ export class Font {
     ({ width, height, options } = this._parseArgs(width, height, options));
     const extrude = options?.extrude || 0;
     const contours = this.textToContours(str, x, y, width, height, options);
+
     const geom = this._pInst.buildGeometry(() => {
       if (extrude === 0) {
+        const prevValidateFaces = this._pInst._renderer._validateFaces;
+        this._pInst._renderer._validateFaces = true;
         this._pInst.beginShape();
         this._pInst.normal(0, 0, 1);
         for (const contour of contours) {
@@ -549,7 +552,11 @@ export class Font {
           this._pInst.endContour(this._pInst.CLOSE);
         }
         this._pInst.endShape();
+        this._pInst._renderer._validateFaces = prevValidateFaces;
       } else {
+        const prevValidateFaces = this._pInst._renderer._validateFaces;
+        this._pInst._renderer._validateFaces = true;
+
         // Draw front faces
         for (const side of [1, -1]) {
           this._pInst.beginShape();
@@ -561,8 +568,9 @@ export class Font {
             this._pInst.endContour(this._pInst.CLOSE);
           }
           this._pInst.endShape();
-          this._pInst.beginShape();
         }
+        this._pInst._renderer._validateFaces = prevValidateFaces;
+
         // Draw sides
         for (const contour of contours) {
           this._pInst.beginShape(this._pInst.QUAD_STRIP);

--- a/src/webgl/GeometryBuilder.js
+++ b/src/webgl/GeometryBuilder.js
@@ -108,7 +108,7 @@ class GeometryBuilder {
    * Adds geometry from the renderer's immediate mode into the builder's
    * combined geometry.
    */
-  addImmediate(geometry, shapeMode) {
+  addImmediate(geometry, shapeMode, { validateFaces = false } = {}) {
     const faces = [];
 
     if (this.renderer.states.fillColor) {
@@ -129,7 +129,14 @@ class GeometryBuilder {
         }
       } else {
         for (let i = 0; i < geometry.vertices.length; i += 3) {
-          faces.push([i, i + 1, i + 2]);
+          if (
+            !validateFaces ||
+            geometry.vertices[i].copy().sub(geometry.vertices[i+1])
+              .cross(geometry.vertices[i].copy().sub(geometry.vertices[i+2]))
+              .magSq() > 0
+          ) {
+            faces.push([i, i + 1, i + 2]);
+          }
         }
       }
     }

--- a/src/webgl/p5.RendererGL.js
+++ b/src/webgl/p5.RendererGL.js
@@ -455,6 +455,10 @@ class RendererGL extends Renderer {
       }
       return this._internalDisable.call(this.drawingContext, key);
     };
+
+    // Whether or not to remove degenerate faces from geometry. This is usually
+    // set to false for performance.
+    this._validateFaces = false;
   }
 
   remove() {
@@ -562,7 +566,8 @@ class RendererGL extends Renderer {
     if (this.geometryBuilder) {
       this.geometryBuilder.addImmediate(
         this.shapeBuilder.geometry,
-        this.shapeBuilder.shapeMode
+        this.shapeBuilder.shapeMode,
+        { validateFaces: this._validateFaces }
       );
     } else if (this.states.fillColor || this.states.strokeColor) {
       if (this.shapeBuilder.shapeMode === constants.POINTS) {
@@ -2614,7 +2619,7 @@ function rendererGL(p5, fn) {
    * }
    * </code>
    * </div>
-   * 
+   *
    * <div>
    * <code>
    *  // Now with the antialias attribute set to true.


### PR DESCRIPTION
Addresses one case of #4791

While this warning generally indicates a problem with the user's vertex input, we also get this warning sometimes when calling `font.textToModel()`. In this case, there's nothing the user can do about it, so the warning is distracting and misleading. While this doesn't fully deal with that warning happening more often than it should, this resolves the `textToModel` case.

(EDIT: maybe this actually does fully resolve the original issue? Looking back at it, the original sketch in question was also triangulating a font. Now that we have a way to do this internally that doesn't create warnings, the rest is likely user input issues.)

Changes:
- Adds a `_validateFaces` flag which, when set to true, checks if faces are valid before adding them to a p5.Geometry
  - Currently this is only used for internal triangulated shapes, so the checking is not yet done in TRIANGLE_STRIP mode.
- Turns on this flag while generating models of text, as this uses triangulation and may get a warning after calling `computeNormals` otherwise.

Before:
![image](https://github.com/user-attachments/assets/fa530fe1-7347-49ea-aa98-5f23cb32ae92)


After:
![image](https://github.com/user-attachments/assets/dfed9206-e47b-4427-83b9-040f3ed15135)


Live: https://editor.p5js.org/davepagurek/sketches/zOmI5K3__ (try toggling the script tag to 2.0.3 in index.html)

#### PR Checklist
<!--
  To check any option, replace the "[ ]" with a "[x]". Be sure to check out how it looks in the Preview tab! Feel free to remove any portion of the template that is not relevant for your issue.
-->

- [x] `npm run lint` passes
- [ ] [Inline reference] is included / updated
- [ ] [Unit tests] are included / updated

[Inline reference]: https://p5js.org/contribute/contributing_to_the_p5js_reference/
[Unit tests]: https://github.com/processing/p5.js/tree/main/contributor_docs#unit-tests
