### PR TITLE
Fix inline anonymous functions causing a parsing error in p5.strands callbacks

### DIFF
--- a/src/webgl/ShaderGenerator.js
+++ b/src/webgl/ShaderGenerator.js
@@ -19,7 +19,7 @@ function shadergenerator(p5, fn) {
     if (shaderModifier instanceof Function) {
       let generatorFunction;
       if (options.parser) {
-        const sourceString = shaderModifier.toString()
+        const sourceString = `(${shaderModifier.toString()})`;
         const ast = parse(sourceString, {
           ecmaVersion: 2021,
           locations: options.srcLocations

--- a/src/webgl/ShaderGenerator.js
+++ b/src/webgl/ShaderGenerator.js
@@ -19,6 +19,8 @@ function shadergenerator(p5, fn) {
     if (shaderModifier instanceof Function) {
       let generatorFunction;
       if (options.parser) {
+        // #7955 Wrap function declaration code in brackets so anonymous functions are not top level statements, which causes an error in acorn when parsing
+        // https://github.com/acornjs/acorn/issues/1385
         const sourceString = `(${shaderModifier.toString()})`;
         const ast = parse(sourceString, {
           ecmaVersion: 2021,

--- a/test/unit/webgl/p5.Shader.js
+++ b/test/unit/webgl/p5.Shader.js
@@ -324,6 +324,11 @@ suite('p5.Shader', function() {
         expect(modified.fragSrc()).not.to.match(/#define AUGMENTED_HOOK_getVertexColor/);
       });
 
+      test('anonymous function shaderModifier does not throw when parsed', function() {
+        const callModify = () => myShader.modify(function() {});
+        expect(callModify).not.toThrowError();
+      });
+
       test('filled hooks do have an AUGMENTED_HOOK define', function() {
         const modified = myShader.modify({
           'vec4 getVertexColor': `(vec4 c) {


### PR DESCRIPTION
<!--
  Thank you for contributing! Please use this pull request (PR) template.


 In the description field of this PR, include "resolves #XXXX" tagging the issue you are fixing. If this PR addresses the issue but doesn't completely resolve it (ie the issue should remain open after your PR is merged), write "addresses #XXXX".-->
Resolves #7955

 Changes:
<!-- Add here what changes were made in this pull request and if possible provide links showcasing the changes. -->

WebGL `ShaderGenerator.js`
- Wraps function source string in round brackets to prevent issues with [acorn](https://github.com/acornjs/acorn) parsing top level function statements

Unit Tests
- Adds a unit test to `p5.Shader` for an anonymous function being passed into the shader

#### Screenshots of the change

Example from the issue running locally with no errors
![image](https://github.com/user-attachments/assets/42cdd65c-6def-460b-937f-28e61a6fa9d8)

#### PR Checklist
<!--
  To check any option, replace the "[ ]" with a "[x]". Be sure to check out how it looks in the Preview tab! Feel free to remove any portion of the template that is not relevant for your issue.
-->


- [x] `npm run lint` passes
- [x] [Unit tests] are included / updated

[Inline reference]: https://p5js.org/contribute/contributing_to_the_p5js_reference/
[Unit tests]: https://github.com/processing/p5.js/tree/main/contributor_docs#unit-tests
