### PR TITLE
Fix p5.strands uniform calls, add instance mode construct

### DIFF
--- a/src/webgl/ShaderGenerator.js
+++ b/src/webgl/ShaderGenerator.js
@@ -16,8 +16,10 @@ function shadergenerator(p5, fn) {
 
   const oldModify = p5.Shader.prototype.modify
 
-  p5.Shader.prototype.modify = function(shaderModifier, options = { parser: true, srcLocations: false }) {
+  p5.Shader.prototype.modify = function(shaderModifier, scope = {}) {
     if (shaderModifier instanceof Function) {
+      // TODO make this public. Currently for debugging only.
+      const options = { parser: true, srcLocations: false };
       let generatorFunction;
       if (options.parser) {
         const sourceString = shaderModifier.toString()
@@ -27,13 +29,17 @@ function shadergenerator(p5, fn) {
         });
         ancestor(ast, ASTCallbacks, undefined, { varyings: {} });
         const transpiledSource = escodegen.generate(ast);
-        generatorFunction = new Function(
+        const scopeKeys = Object.keys(scope);
+        const internalGeneratorFunction = new Function(
+          'p5',
+          ...scopeKeys,
           transpiledSource
           .slice(
             transpiledSource.indexOf('{') + 1,
             transpiledSource.lastIndexOf('}')
           ).replaceAll(';', '')
         );
+        generatorFunction = () => internalGeneratorFunction(p5, ...scopeKeys.map(key => scope[key]));
       } else {
         generatorFunction = shaderModifier;
       }
@@ -64,15 +70,24 @@ function shadergenerator(p5, fn) {
     }
   }
 
-  function ancestorIsUniform(ancestor) {
+  function nodeIsUniform(ancestor) {
     return ancestor.type === 'CallExpression'
-      && ancestor.callee?.type === 'Identifier'
-      && ancestor.callee?.name.startsWith('uniform');
+      && (
+        (
+          // Global mode
+          ancestor.callee?.type === 'Identifier' &&
+          ancestor.callee?.name.startsWith('uniform')
+        ) || (
+          // Instance mode
+          ancestor.callee?.type === 'MemberExpression' &&
+          ancestor.callee?.property.name.startsWith('uniform')
+        )
+      );
   }
 
   const ASTCallbacks = {
-    UnaryExpression(node, _state, _ancestors) {
-      if (_ancestors.some(ancestorIsUniform)) { return; }
+    UnaryExpression(node, _state, ancestors) {
+      if (ancestors.some(nodeIsUniform)) { return; }
 
       const signNode = {
         type: 'Literal',
@@ -83,7 +98,7 @@ function shadergenerator(p5, fn) {
           node.type = 'CallExpression'
           node.callee = {
             type: 'Identifier',
-            name: 'unaryNode',
+            name: 'p5.unaryNode',
           }
           node.arguments = [node.argument, signNode]
       }
@@ -106,7 +121,7 @@ function shadergenerator(p5, fn) {
             type: 'CallExpression',
             callee: {
               type: 'Identifier',
-              name: 'unaryNode'
+              name: 'p5.unaryNode'
             },
             arguments: [node.argument.object, signNode],
           };
@@ -123,8 +138,9 @@ function shadergenerator(p5, fn) {
       delete node.argument;
       delete node.operator;
     },
-    VariableDeclarator(node, _state, _ancestors) {
-      if (node.init.callee && node.init.callee.name?.startsWith('uniform')) {
+    VariableDeclarator(node, _state, ancestors) {
+      if (ancestors.some(nodeIsUniform)) { return; }
+      if (nodeIsUniform(node.init)) {
         const uniformNameLiteral = {
           type: 'Literal',
           value: node.id.name
@@ -140,7 +156,8 @@ function shadergenerator(p5, fn) {
         _state.varyings[node.id.name] = varyingNameLiteral;
       }
     },
-    Identifier(node, _state, _ancestors) {
+    Identifier(node, _state, ancestors) {
+      if (ancestors.some(nodeIsUniform)) { return; }
       if (_state.varyings[node.name]
           && !_ancestors.some(a => a.type === 'AssignmentExpression' && a.left === node)) {
         node.type = 'ExpressionStatement';
@@ -163,16 +180,18 @@ function shadergenerator(p5, fn) {
     },
     // The callbacks for AssignmentExpression and BinaryExpression handle
     // operator overloading including +=, *= assignment expressions
-    ArrayExpression(node, _state, _ancestors) {
+    ArrayExpression(node, _state, ancestors) {
+      if (ancestors.some(nodeIsUniform)) { return; }
       const original = JSON.parse(JSON.stringify(node));
       node.type = 'CallExpression';
       node.callee = {
         type: 'Identifier',
-        name: 'dynamicNode',
+        name: 'p5.dynamicNode',
       };
       node.arguments = [original];
     },
-    AssignmentExpression(node, _state, _ancestors) {
+    AssignmentExpression(node, _state, ancestors) {
+      if (ancestors.some(nodeIsUniform)) { return; }
       if (node.operator !== '=') {
         const methodName = replaceBinaryOperator(node.operator.replace('=',''));
         const rightReplacementNode = {
@@ -209,10 +228,10 @@ function shadergenerator(p5, fn) {
           }
         }
       },
-    BinaryExpression(node, _state, _ancestors) {
+    BinaryExpression(node, _state, ancestors) {
       // Don't convert uniform default values to node methods, as
       // they should be evaluated at runtime, not compiled.
-      if (_ancestors.some(ancestorIsUniform)) { return; }
+      if (ancestors.some(nodeIsUniform)) { return; }
       // If the left hand side of an expression is one of these types,
       // we should construct a node from it.
       const unsafeTypes = ['Literal', 'ArrayExpression', 'Identifier'];
@@ -221,7 +240,7 @@ function shadergenerator(p5, fn) {
           type: 'CallExpression',
           callee: {
             type: 'Identifier',
-            name: 'dynamicNode',
+            name: 'p5.dynamicNode',
           },
           arguments: [node.left]
         }
@@ -1010,7 +1029,7 @@ function shadergenerator(p5, fn) {
     return length
   }
 
-  fn.dynamicNode = function (input) {
+  p5.dynamicNode = function (input) {
     if (isShaderNode(input)) {
       return input;
     }
@@ -1023,8 +1042,8 @@ function shadergenerator(p5, fn) {
   }
 
   // For replacing unary expressions
-  fn.unaryNode = function(input, sign) {
-    input = dynamicNode(input);
+  p5.unaryNode = function(input, sign) {
+    input = p5.dynamicNode(input);
     return dynamicAddSwizzleTrap(new UnaryExpressionNode(input, sign));
   }
 
@@ -1131,6 +1150,7 @@ function shadergenerator(p5, fn) {
       }
 
       const windowOverrides = {};
+      const fnOverrides = {};
 
       Object.keys(availableHooks).forEach((hookName) => {
         const hookTypes = originalShader.hookTypes(hookName);
@@ -1166,7 +1186,7 @@ function shadergenerator(p5, fn) {
           // If the expected return type is a struct we need to evaluate each of its properties
           if (!isGLSLNativeType(expectedReturnType.typeName)) {
             Object.entries(returnedValue).forEach(([propertyName, propertyNode]) => {
-              propertyNode = dynamicNode(propertyNode);
+              propertyNode = p5.dynamicNode(propertyNode);
               toGLSLResults[propertyName] = propertyNode.toGLSLBase(this.context);
               this.context.updateComponents(propertyNode);
             });
@@ -1216,9 +1236,13 @@ function shadergenerator(p5, fn) {
           this.resetGLSLContext();
         }
         windowOverrides[hookTypes.name] = window[hookTypes.name];
+        fnOverrides[hookTypes.name] = fn[hookTypes.name];
 
         // Expose the Functions to global scope for users to use
         window[hookTypes.name] = function(userOverride) {
+          GLOBAL_SHADER[hookTypes.name](userOverride);
+        };
+        fn[hookTypes.name] = function(userOverride) {
           GLOBAL_SHADER[hookTypes.name](userOverride);
         };
       });
@@ -1227,6 +1251,9 @@ function shadergenerator(p5, fn) {
       this.cleanup = () => {
         for (const key in windowOverrides) {
           window[key] = windowOverrides[key];
+        }
+        for (const key in fnOverrides) {
+          fn[key] = fnOverrides[key];
         }
       };
     }
@@ -1636,14 +1663,14 @@ function shadergenerator(p5, fn) {
     if (!GLOBAL_SHADER?.isGenerating) {
       return originalNoise.apply(this, args); // fallback to regular p5.js noise
     }
-    
+
     GLOBAL_SHADER.output.vertexDeclarations.add(noiseGLSL);
     GLOBAL_SHADER.output.fragmentDeclarations.add(noiseGLSL);
     return fnNodeConstructor('noise', args, { args: ['vec2'], returnType: 'float' });
   };
 }
-  
-  
+
+
 export default shadergenerator;
 
 if (typeof p5 !== 'undefined') {

--- a/src/webgl/p5.Shader.js
+++ b/src/webgl/p5.Shader.js
@@ -297,7 +297,7 @@ class Shader {
    *   createCanvas(200, 200, WEBGL);
    *   myShader = baseMaterialShader().modify(() => {
    *     getPixelInputs((inputs) => {
-   *       inputs.color = [1, 0, 0, 1];
+   *       inputs.color = [inputs.texCoord, 0, 1];
    *       return inputs;
    *     });
    *   });
@@ -305,6 +305,7 @@ class Shader {
    *
    * function draw() {
    *   background(255);
+   *   noStroke();
    *   shader(myShader); // Apply the custom shader
    *   plane(width, height); // Draw a plane with the shader applied
    * }
@@ -327,7 +328,11 @@ class Shader {
    *     let t = uniformFloat(() => millis());
    *
    *     getPixelInputs((inputs) => {
-   *       inputs.color = [sin(t * 0.01) / 2 + 0.5, 0, 0, 1];
+   *       inputs.color = [
+   *         inputs.texCoord,
+   *         sin(t * 0.01) / 2 + 0.5,
+   *         1,
+   *       ];
    *       return inputs;
    *     });
    *   });
@@ -335,6 +340,7 @@ class Shader {
    *
    * function draw() {
    *   background(255);
+   *   noStroke(255);
    *   shader(myShader); // Apply the custom shader
    *   plane(width, height); // Draw a plane with the shader applied
    * }
@@ -354,7 +360,7 @@ class Shader {
    *     sketch.createCanvas(200, 200, sketch.WEBGL);
    *     myShader = sketch.baseMaterialShader().modify(() => {
    *       sketch.getPixelInputs((inputs) => {
-   *         inputs.color = [1, 0, 0, 1];
+   *         inputs.color = [inputs.texCoord, 0, 1];
    *         return inputs;
    *       });
    *     }, { sketch });
@@ -362,6 +368,7 @@ class Shader {
    *
    *   sketch.draw = function() {
    *     sketch.background(255);
+   *     sketch.noStroke();
    *     sketch.shader(myShader); // Apply the custom shader
    *     sketch.plane(sketch.width, sketch.height); // Draw a plane with the shader applied
    *   }

--- a/test/unit/webgl/p5.Shader.js
+++ b/test/unit/webgl/p5.Shader.js
@@ -413,4 +413,25 @@ suite('p5.Shader', function() {
       });
     });
   });
+
+  suite('p5.strands', () => {
+    it('does not break when arrays are in uniform callbacks', () => {
+      myp5.createCanvas(5, 5, myp5.WEBGL);
+      const myShader = myp5.baseMaterialShader().modify(() => {
+        const size = myp5.uniformVector2(() => [myp5.width, myp5.height]);
+        myp5.getPixelInputs((inputs) => {
+          inputs.color = [
+            size / 1000,
+            0,
+            1
+          ];
+          return inputs;
+        });
+      }, { myp5 });
+      expect(() => {
+        myp5.shader(myShader);
+        myp5.plane(myp5.width, myp5.height);
+      }).not.toThrowError();
+    });
+  });
 });


### PR DESCRIPTION
Resolves https://github.com/processing/p5.js/issues/7960

### Changes
- Allows `uniformVector2(() => [a, b])` syntax to work again
- Added support for instance mode in order to create tests
  - This involves adding the API `shader.modify(() => { .... }, { a, b })` to let variables `a` and `b` work in the callback. To do this though, I've removed the `options` object that turns off rewriting. @lukeplowden do you think that's ok?
- Updates `shader.modify()` docs:
  - they now mention p5.strands as the primary API
  - they mention how to pass in local variables, e.g. for instance mode
  - pure GLSL hooks are now shown only at the end
  - examples are interleaved with the reference now so that you see the p5.strands-only examples first, and the advance cases later
  - I'll maybe update the examples a bit more before merging; it's quite simple currently

Live: https://editor.p5js.org/davepagurek/sketches/3U6iPl83z

#### PR Checklist
<!--
  To check any option, replace the "[ ]" with a "[x]". Be sure to check out how it looks in the Preview tab! Feel free to remove any portion of the template that is not relevant for your issue.
-->

- [x] `npm run lint` passes
- [x] [Inline reference] is included / updated
- [x] [Unit tests] are included / updated

[Inline reference]: https://p5js.org/contribute/contributing_to_the_p5js_reference/
[Unit tests]: https://github.com/processing/p5.js/tree/main/contributor_docs#unit-tests
