### PR TITLE
Replace fn with direct downloadFile import to fix issue where fn was not found

### DIFF
--- a/src/webgl/p5.Geometry.js
+++ b/src/webgl/p5.Geometry.js
@@ -11,6 +11,7 @@
 import * as constants from '../core/constants';
 import { DataArray } from './p5.DataArray';
 import { Vector } from '../math/p5.Vector';
+import { downloadFile } from '../io/utilities';
 
 class Geometry {
   constructor(detailX, detailY, callback, renderer) {
@@ -413,7 +414,7 @@ class Geometry {
     });
 
     const blob = new Blob([objStr], { type: 'text/plain' });
-    fn.downloadFile(blob, fileName , 'obj');
+    downloadFile(blob, fileName , 'obj');
 
   }
 
@@ -536,7 +537,7 @@ class Geometry {
       modelOutput += 'endsolid ' + name + '\n';
     }
     const blob = new Blob([modelOutput], { type: 'text/plain' });
-    fn.downloadFile(blob, fileName, 'stl');
+    downloadFile(blob, fileName, 'stl');
   }
 
   /**


### PR DESCRIPTION
Resolves #7905 

 Changes:
Change the ```p5.Geometry``` file to import ```downloadFile``` directly and call it rather than relying on ```fn```, which was returning undefined. Also updated the ```stlSave``` function and tested that it worked. 

Wasn't sure if the ```fn``` in the geometry function was needed so left it. Also wasn't sure if unit tests should be added, so I left as is for the moment. 

<!-- If applicable, add screenshots depicting the changes. -->

#### PR Checklist
<!--
  To check any option, replace the "[ ]" with a "[x]". Be sure to check out how it looks in the Preview tab! Feel free to remove any portion of the template that is not relevant for your issue.
-->

- [x] `npm run lint` passes
- [ ] [Inline reference] is included / updated
- [ ] [Unit tests] are included / updated

[Inline reference]: https://p5js.org/contribute/contributing_to_the_p5js_reference/
[Unit tests]: https://github.com/processing/p5.js/tree/main/contributor_docs#unit-tests
