### PR TITLE
Add minified ESM build output

### DIFF
--- a/package.json
+++ b/package.json
@@ -90,6 +90,7 @@
     "lib/p5.min.js",
     "lib/p5.js",
     "lib/p5.esm.js",
+    "lib/p5.esm.min.js",
     "translations/**",
     "types/**"
   ],

--- a/rollup.config.mjs
+++ b/rollup.config.mjs
@@ -89,7 +89,7 @@ rmSync("./dist", {
 });
 
 export default [
-  //// Unminified and ESM library build ////
+  //// Library builds (IIFE and ESM) ////
   {
     input: 'src/app.js',
     output: [
@@ -108,6 +108,25 @@ export default [
         banner,
         plugins: [
           bundleSize('p5.esm.js')
+        ]
+      },
+      {
+        file: './lib/p5.esm.min.js',
+        format: 'esm',
+        banner,
+        sourcemap: 'hidden',
+        plugins: [
+          terser({
+            compress: {
+              global_defs: {
+                IS_MINIFIED: true
+              }
+            },
+            format: {
+              comments: false
+            }
+          }),
+          bundleSize('p5.esm.min.js', true)
         ]
       }
     ],


### PR DESCRIPTION
Resolves #7974

 Changes:
- Add p5.esm.min.js output to rollup config with terser minification
- Include p5.esm.min.js in package.json files field for npm publishing

 Screenshots of the change:
N/A

#### PR Checklist
<!--
  To check any option, replace the "[ ]" with a "[x]". Be sure to check out how it looks in the Preview tab! Feel free to remove any portion of the template that is not relevant for your issue.
-->

_This PR has no source changes, and only affects developers_

- [ ] `npm run lint` passes
- [ ] [Inline reference] is included / updated
- [ ] [Unit tests] are included / updated

[Inline reference]: https://p5js.org/contribute/contributing_to_the_p5js_reference/
[Unit tests]: https://github.com/processing/p5.js/tree/main/contributor_docs#unit-tests
