### PR TITLE
Changing URL which comes when user is not in WEBGL mode

### DIFF
--- a/src/webgl/p5.RendererGL.js
+++ b/src/webgl/p5.RendererGL.js
@@ -2537,7 +2537,7 @@ p5.RendererGL = class RendererGL extends p5.Renderer {
 p5.prototype._assert3d = function (name) {
   if (!this._renderer.isP3D)
     throw new Error(
-      `${name}() is only supported in WEBGL mode. If you'd like to use 3D graphics and WebGL, see  https://p5js.org/examples/form-3d-primitives.html for more information.`
+      `${name}() is only supported in WEBGL mode. If you'd like to use 3D graphics and WebGL, see https://p5js.org/examples/3d-geometries/ for more information.`
     );
 };
 


### PR DESCRIPTION
Changing URLwhich was leading to somewhere else 

Resolves #7952

 Changes:

Changed link in error which comes when user is not in WEBGL mode and provided link to use 3D graphics and WEBGL



#### PR Checklist


- [x] `npm run lint` passes
- [x] [Inline reference] is included / updated
- [x] [Unit tests] are included / updated


