### PR TITLE
Fix mediaElement.copy

### DIFF
--- a/src/dom/p5.MediaElement.js
+++ b/src/dom/p5.MediaElement.js
@@ -816,7 +816,7 @@ class MediaElement extends Element {
   }
   copy(...args) {
     this._ensureCanvas();
-    fn.copy.apply(this, args);
+    p5.prototype.copy.apply(this, args);
   }
   mask(...args) {
     this.loadPixels();

--- a/test/unit/dom/p5.MediaElement.js
+++ b/test/unit/dom/p5.MediaElement.js
@@ -2,10 +2,12 @@ import { vi } from 'vitest';
 import { mockP5, mockP5Prototype } from '../../js/mocks';
 import { default as media, MediaElement } from '../../../src/dom/p5.MediaElement';
 import { Element } from '../../../src/dom/p5.Element';
+import { default as pixels } from '../../../src/image/pixels';
 
 suite('p5.MediaElement', () => {
   beforeAll(() => {
     media(mockP5, mockP5Prototype);
+    pixels(mockP5, mockP5Prototype);
     navigator.mediaDevices.getUserMedia = vi.fn()
       .mockResolvedValue("stream-value");
   });
@@ -235,4 +237,22 @@ suite('p5.MediaElement', () => {
       assert.isTrue(testElement.elt.playsInline);
     });
   });
+
+  suite("p5.MediaElement.copy", function () {
+    beforeAll(() => {
+      globalThis.p5 = { prototype: mockP5Prototype };
+    });
+
+    afterAll(() => {
+      delete globalThis.p5;
+      document.body.innerHTML = "";
+    });
+
+    test('should not throw an error', function() {
+      const testElement = mockP5Prototype.createVideo('/test/unit/assets/nyan_cat.gif');
+      assert.doesNotThrow(() => {
+        testElement.copy(0, 0, 10, 10, 0, 0, 10, 10);
+      });
+    });
+  })
 });


### PR DESCRIPTION
<!--
  Thank you for contributing! Please use this pull request (PR) template.


 In the description field of this PR, include "resolves #XXXX" tagging the issue you are fixing. If this PR addresses the issue but doesn't completely resolve it (ie the issue should remain open after your PR is merged), write "addresses #XXXX".-->
Resolves https://github.com/ml5js/ml5-next-gen/pull/258

 Changes:
<!-- Add here what changes were made in this pull request and if possible provide links showcasing the changes. -->

I'm currently working on updating ml5 to support p5.js version 2.0. However, the following example breaks during inspection:

```js
let bodySegmentation;
let video;
let segmentation;

let options = {
  maskType: "background",
};

function preload() {
  bodySegmentation = ml5.bodySegmentation("SelfieSegmentation", options);
}

function setup() {
  createCanvas(640, 480);
  // Create the video
  video = createCapture(VIDEO);
  video.size(640, 480);
  video.hide();

  bodySegmentation.detectStart(video, gotResults);
}

function draw() {
  background(0, 0, 255);
  if (segmentation) {
    video.mask(segmentation.mask);
    image(video, 0, 0);
  }
}

// callback function for body segmentation
function gotResults(result) {
  segmentation = result;
}

```

After debugging, I found that ·video.mask(segmentation.mask)` throws the following error:

```
ReferenceError: fn is not defined
```

<img width="1509" height="732" alt="image" src="https://github.com/user-attachments/assets/ad4a8307-33dc-45a8-91a5-2da15ce31939" />

So I updated `fn` to `p5.prototype` to fix it, based on the reference from the source code in the main branch.

 Screenshots of the change:

<!-- If applicable, add screenshots depicting the changes. -->

<img width="654" height="494" alt="image" src="https://github.com/user-attachments/assets/d3f58b07-901f-4662-88bf-12c4b3794df2" />

#### PR Checklist
<!--
  To check any option, replace the "[ ]" with a "[x]". Be sure to check out how it looks in the Preview tab! Feel free to remove any portion of the template that is not relevant for your issue.
-->

- [x] `npm run lint` passes
- [x] [Inline reference] is included / updated
- [x] [Unit tests] are included / updated

[Inline reference]: https://p5js.org/contribute/contributing_to_the_p5js_reference/
[Unit tests]: https://github.com/processing/p5.js/tree/main/contributor_docs#unit-tests
