### PR TITLE
Solves Issue 7975

### DIFF
--- a/.github/workflows/auto-close-issues.yml
+++ b/.github/workflows/auto-close-issues.yml
@@ -1,0 +1,39 @@
+name: Close Linked Issues on PR Merge
+
+on:
+  pull_request:
+    types:
+      - closed
+    branches:
+      - 2.0
+      - dev-2.0
+
+jobs:
+  close_issues:
+    if: github.event.pull_request.merged == true
+    runs-on: ubuntu-latest
+    steps:
+      - name: Extract and Close Issues
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const prBody = context.payload.pull_request.body;
+            const issueRegex = /(Fixes|Resolves|Closes)\s+#(\d+)/gi;
+            let match;
+            while ((match = issueRegex.exec(prBody)) !== null) {
+              const issueNumber = parseInt(match[2], 10);
+              console.log(`Closing issue #${issueNumber}`);
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: issueNumber,
+                body: `Closed by merged PR #${context.payload.pull_request.number}`
+              });
+              await github.rest.issues.update({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: issueNumber,
+                state: "closed"
+              });
+            }
+


### PR DESCRIPTION
So basically whenever someone creates a pr, then when maintainer comments:
```
Resolves https://github.com/processing/p5.js/issues/7975
```
so it handles by itself, tried for like test-merge-action to my own feature-branch
Resolves #7962 

 Changes:
Introduced a yaml file for same

 Screenshots of the change:
<img width="1250" height="739" alt="workflow run" src="https://github.com/user-attachments/assets/c65956ce-6281-4e45-9730-a11b24e1bd3b" />
<img width="1241" height="694" alt="local pr test" src="https://github.com/user-attachments/assets/f51df78a-ad11-44a1-909a-431ee173d2b7" />


#### PR Checklist
<!--
  To check any option, replace the "[ ]" with a "[x]". Be sure to check out how it looks in the Preview tab! Feel free to remove any portion of the template that is not relevant for your issue.
-->

- [ ] `npm run lint` passes
- [ ] [Inline reference] is included / updated
- [ ] [Unit tests] are included / updated

[Inline reference]: https://p5js.org/contribute/contributing_to_the_p5js_reference/
[Unit tests]: https://github.com/processing/p5.js/tree/main/contributor_docs#unit-tests
