### PR TITLE
Documentation fix for swapped parameters in splinePoint and bezierPoint

### DIFF
--- a/src/shape/curves.js
+++ b/src/shape/curves.js
@@ -237,10 +237,10 @@ function curves(p5, fn){
    * between them.
    *
    * @method bezierPoint
-   * @param {Number} a coordinate of first control point.
-   * @param {Number} b coordinate of first anchor point.
-   * @param {Number} c coordinate of second anchor point.
-   * @param {Number} d coordinate of second control point.
+   * @param {Number} a coordinate of first anchor point.
+   * @param {Number} b coordinate of first control point.
+   * @param {Number} c coordinate of second control point.
+   * @param {Number} d coordinate of second anchor point.
    * @param {Number} t amount to interpolate between 0 and 1.
    * @return {Number} coordinate of the point on the curve.
    *
@@ -684,10 +684,10 @@ function curves(p5, fn){
    * between them.
    *
    * @method splinePoint
-   * @param {Number} a coordinate of first anchor point.
-   * @param {Number} b coordinate of first control point.
-   * @param {Number} c coordinate of second control point.
-   * @param {Number} d coordinate of second anchor point.
+   * @param {Number} a coordinate of first control point.
+   * @param {Number} b coordinate of first anchor point.
+   * @param {Number} c coordinate of second anchor point.
+   * @param {Number} d coordinate of second control point.
    * @param {Number} t amount to interpolate between 0 and 1.
    * @return {Number} coordinate of a point on the curve.
    *


### PR DESCRIPTION
Parameter documentation for `splinePoint()` and `bezierPoint()` swapped. Fixes beta equivalent to issue: https://github.com/processing/p5.js/issues/7986#issuecomment-3124555017

Changes:
* Fix swapped parameters documentation for `splinePoint()` and `bezierPoint`. Equivalent fix applied to main: https://github.com/processing/p5.js/commit/ef2f4e6efdfbf5b861d20a6115f915548cad90b7

- [X] `npm run lint` passes
- [X] [Inline reference] is included / updated
- [ ] [Unit tests] are included / updated

[Inline reference]: https://p5js.org/contribute/contributing_to_the_p5js_reference/
[Unit tests]: https://github.com/processing/p5.js/tree/main/contributor_docs#unit-tests
