### PR TITLE
Remove incorrect mouseX/mouseY docs regarding WEBGL mode

### DIFF
--- a/src/events/mouse.js
+++ b/src/events/mouse.js
@@ -109,13 +109,9 @@ p5.prototype._hasMouseInteracted = false;
 /**
  * A `Number` system variable that tracks the mouse's horizontal position.
  *
- * In 2D mode, `mouseX` keeps track of the mouse's position relative to the
+ * `mouseX` keeps track of the mouse's position relative to the
  * top-left corner of the canvas. For example, if the mouse is 50 pixels from
  * the left edge of the canvas, then `mouseX` will be 50.
- *
- * In WebGL mode, `mouseX` keeps track of the mouse's position relative to the
- * center of the canvas. For example, if the mouse is 50 pixels to the right
- * of the canvas' center, then `mouseX` will be 50.
  *
  * If touch is used instead of the mouse, then `mouseX` will hold the
  * x-coordinate of the most recent touch point.
@@ -220,13 +216,9 @@ p5.prototype.mouseX = 0;
 /**
  * A `Number` system variable that tracks the mouse's vertical position.
  *
- * In 2D mode, `mouseY` keeps track of the mouse's position relative to the
+ * `mouseY` keeps track of the mouse's position relative to the
  * top-left corner of the canvas. For example, if the mouse is 50 pixels from
  * the top edge of the canvas, then `mouseY` will be 50.
- *
- * In WebGL mode, `mouseY` keeps track of the mouse's position relative to the
- * center of the canvas. For example, if the mouse is 50 pixels below the
- * canvas' center, then `mouseY` will be 50.
  *
  * If touch is used instead of the mouse, then `mouseY` will hold the
  * y-coordinate of the most recent touch point.
@@ -332,15 +324,11 @@ p5.prototype.mouseY = 0;
  * A `Number` system variable that tracks the mouse's previous horizontal
  * position.
  *
- * In 2D mode, `pmouseX` keeps track of the mouse's position relative to the
+ * `pmouseX` keeps track of the mouse's position relative to the
  * top-left corner of the canvas. Its value is
  * <a href="#/p5/mouseX">mouseX</a> from the previous frame. For example, if
  * the mouse was 50 pixels from the left edge of the canvas during the last
  * frame, then `pmouseX` will be 50.
- *
- * In WebGL mode, `pmouseX` keeps track of the mouse's position relative to the
- * center of the canvas. For example, if the mouse was 50 pixels to the right
- * of the canvas' center during the last frame, then `pmouseX` will be 50.
  *
  * If touch is used instead of the mouse, then `pmouseX` will hold the
  * x-coordinate of the last touch point.
@@ -401,15 +389,11 @@ p5.prototype.pmouseX = 0;
  * A `Number` system variable that tracks the mouse's previous vertical
  * position.
  *
- * In 2D mode, `pmouseY` keeps track of the mouse's position relative to the
+ * `pmouseY` keeps track of the mouse's position relative to the
  * top-left corner of the canvas. Its value is
  * <a href="#/p5/mouseY">mouseY</a> from the previous frame. For example, if
  * the mouse was 50 pixels from the top edge of the canvas during the last
  * frame, then `pmouseY` will be 50.
- *
- * In WebGL mode, `pmouseY` keeps track of the mouse's position relative to the
- * center of the canvas. For example, if the mouse was 50 pixels below the
- * canvas' center during the last frame, then `pmouseY` will be 50.
  *
  * If touch is used instead of the mouse, then `pmouseY` will hold the
  * y-coordinate of the last touch point.


### PR DESCRIPTION
resolves #8002

#### Changes:
The docs for `mouseX`, `mouseY`, `pmouseX`, `pmouseY` incorrectly state that in WEBGL mode the number is relative to the center of the screen. In fact, is relative to the top-left corner. Removes the distinction between 2d and webgl.

#### PR Checklist
<!--
  To check any option, replace the "[ ]" with a "[x]". Be sure to check out how it looks in the Preview tab! Feel free to remove any portion of the template that is not relevant for your issue.
-->

- [ ] `npm run lint` passes
- [ ] [Inline reference] is included / updated
- [ ] [Unit tests] are included / updated

[Inline reference]: https://p5js.org/contribute/contributing_to_the_p5js_reference/
[Unit tests]: https://github.com/processing/p5.js/tree/main/contributor_docs#unit-tests
