### PR TITLE
Reset millis() after setup

### DIFF
--- a/src/core/main.js
+++ b/src/core/main.js
@@ -238,7 +238,8 @@ class p5 {
       constants.P2D
     );
 
-    // Record the time when sketch starts
+    // Record the time when setup starts. millis() will start at 0 within
+    // setup, but this isn't documented, locked-in behavior yet.
     this._millisStart = window.performance.now();
 
     const context = this._isGlobal ? window : this;
@@ -274,6 +275,10 @@ class p5 {
 
     // Run `postsetup` hooks
     await this._runLifecycleHook('postsetup');
+
+    // Record the time when the draw loop starts so that millis() starts at 0
+    // when the draw loop begins.
+    this._millisStart = window.performance.now();
   }
 
   // While '#_draw' here is async, it is not awaited as 'requestAnimationFrame'
@@ -468,11 +473,11 @@ for (const k in constants) {
  * If `setup()` is declared `async` (e.g. `async function setup()`),
  * execution pauses at each `await` until its promise resolves.
  * For example, `font = await loadFont(...)` waits for the font asset
- * to load because `loadFont()` function returns a promise, and the await 
+ * to load because `loadFont()` function returns a promise, and the await
  * keyword means the program will wait for the promise to resolve.
  * This ensures that all assets are fully loaded before the sketch continues.
 
- * 
+ *
  * loading assets.
  *
  * Note: `setup()` doesn’t have to be declared, but it’s common practice to do so.

--- a/test/unit/core/main.js
+++ b/test/unit/core/main.js
@@ -179,4 +179,36 @@ suite('Core', function () {
       assert.isUndefined(logMsg);
     });
   });
+
+  suite('millis()', () => {
+    let myp5
+
+    beforeEach(() => {
+      vi.useFakeTimers();
+    });
+    afterEach(() => {
+      vi.useRealTimers();
+      if (myp5) {
+        myp5.remove();
+        myp5 = undefined;
+      }
+    });
+
+    test('millis() starts at 0 when the draw loop begins', async () => {
+      const t = await new Promise((resolve) => {
+        myp5 = new p5((p) => {
+          p.setup = () => {
+            // Pretend setup takes 1s
+            vi.advanceTimersByTime(1000);
+          };
+          p.draw = () => {
+            // Pretend draw() happens 50ms after setup
+            vi.advanceTimersByTime(50);
+            resolve(p.millis());
+          };
+        });
+      });
+      expect(t).toEqual(50);
+    });
+  });
 });

--- a/vitest.workspace.mjs
+++ b/vitest.workspace.mjs
@@ -1,4 +1,4 @@
-import { defineWorkspace } from 'vitest/config';
+import { defineWorkspace, configDefaults } from 'vitest/config';
 import vitePluginString from 'vite-plugin-string';
 
 const plugins = [
@@ -38,7 +38,10 @@ export default defineWorkspace([
         name: 'chrome',
         provider: 'webdriverio',
         screenshotFailures: false
-      }
+      },
+      fakeTimers: {
+        toFake: [...(configDefaults.fakeTimers.toFake ?? []), 'performance'],
+      },
     }
   }
 ]);


### PR DESCRIPTION
<!--
  Thank you for contributing! Please use this pull request (PR) template.


 In the description field of this PR, include "resolves #XXXX" tagging the issue you are fixing. If this PR addresses the issue but doesn't completely resolve it (ie the issue should remain open after your PR is merged), write "addresses #XXXX".-->
Resolves https://github.com/processing/p5.js/issues/8001

Changes:
- Updates the `millis()` start time again after `setup` (and postsetup hooks)


#### PR Checklist
<!--
  To check any option, replace the "[ ]" with a "[x]". Be sure to check out how it looks in the Preview tab! Feel free to remove any portion of the template that is not relevant for your issue.
-->

- [x] `npm run lint` passes
- [ ] [Inline reference] is included / updated
- [x] [Unit tests] are included / updated

[Inline reference]: https://p5js.org/contribute/contributing_to_the_p5js_reference/
[Unit tests]: https://github.com/processing/p5.js/tree/main/contributor_docs#unit-tests
