### PR TITLE
Remove incorrect mouseX/mouseY docs regarding WEBGL mode in dev-2.0 branch.

### DIFF
--- a/src/events/pointer.js
+++ b/src/events/pointer.js
@@ -109,13 +109,9 @@ function pointer(p5, fn){
   /**
    * A `Number` system variable that tracks the mouse's horizontal position.
    *
-   * In 2D mode, `mouseX` keeps track of the mouse's position relative to the
+   * `mouseX` keeps track of the mouse's position relative to the
    * top-left corner of the canvas. For example, if the mouse is 50 pixels from
    * the left edge of the canvas, then `mouseX` will be 50.
-   *
-   * In WebGL mode, `mouseX` keeps track of the mouse's position relative to the
-   * center of the canvas. For example, if the mouse is 50 pixels to the right
-   * of the canvas' center, then `mouseX` will be 50.
    *
    * If touch is used instead of the mouse, then `mouseX` will hold the
    * x-coordinate of the most recent touch point.
@@ -157,7 +153,7 @@ function pointer(p5, fn){
    *   textSize(16);
    *
    *   // Display the mouse's coordinates.
-   *   text(`x: ${mouseX} y: ${mouseY}`, 50, 50);
+   *   text(`x: ${int(mouseX)} y: ${int(mouseY)}`, 50, 50);
    * }
    * </code>
    * </div>
@@ -208,7 +204,7 @@ function pointer(p5, fn){
    *   fill(0);
    *
    *   // Display the mouse's coordinates.
-   *   text(`x: ${mouseX} y: ${mouseY}`, 0, 0);
+   *   text(`x: ${int(mouseX)} y: ${int(mouseY)}`, 0, 0);
    * }
    * </code>
    * </div>
@@ -218,13 +214,9 @@ function pointer(p5, fn){
   /**
    * A `Number` system variable that tracks the mouse's vertical position.
    *
-   * In 2D mode, `mouseY` keeps track of the mouse's position relative to the
+   * `mouseY` keeps track of the mouse's position relative to the
    * top-left corner of the canvas. For example, if the mouse is 50 pixels from
    * the top edge of the canvas, then `mouseY` will be 50.
-   *
-   * In WebGL mode, `mouseY` keeps track of the mouse's position relative to the
-   * center of the canvas. For example, if the mouse is 50 pixels below the
-   * canvas' center, then `mouseY` will be 50.
    *
    * If touch is used instead of the mouse, then `mouseY` will hold the
    * y-coordinate of the most recent touch point.
@@ -266,7 +258,7 @@ function pointer(p5, fn){
    *   textSize(16);
    *
    *   // Display the mouse's coordinates.
-   *   text(`x: ${mouseX} y: ${mouseY}`, 50, 50);
+   *   text(`x: ${int(mouseX)} y: ${int(mouseY)}`, 50, 50);
    * }
    * </code>
    * </div>
@@ -317,7 +309,7 @@ function pointer(p5, fn){
    *   fill(0);
    *
    *   // Display the mouse's coordinates.
-   *   text(`x: ${mouseX} y: ${mouseY}`, 0, 0);
+   *   text(`x: ${int(mouseX)} y: ${int(mouseY)}`, 0, 0);
    * }
    * </code>
    * </div>
@@ -328,15 +320,11 @@ function pointer(p5, fn){
    * A `Number` system variable that tracks the mouse's previous horizontal
    * position.
    *
-   * In 2D mode, `pmouseX` keeps track of the mouse's position relative to the
+   * `pmouseX` keeps track of the mouse's position relative to the
    * top-left corner of the canvas. Its value is
    * <a href="#/p5/mouseX">mouseX</a> from the previous frame. For example, if
    * the mouse was 50 pixels from the left edge of the canvas during the last
    * frame, then `pmouseX` will be 50.
-   *
-   * In WebGL mode, `pmouseX` keeps track of the mouse's position relative to the
-   * center of the canvas. For example, if the mouse was 50 pixels to the right
-   * of the canvas' center during the last frame, then `pmouseX` will be 50.
    *
    * If touch is used instead of the mouse, then `pmouseX` will hold the
    * x-coordinate of the last touch point.
@@ -397,15 +385,11 @@ function pointer(p5, fn){
    * A `Number` system variable that tracks the mouse's previous vertical
    * position.
    *
-   * In 2D mode, `pmouseY` keeps track of the mouse's position relative to the
+   * `pmouseY` keeps track of the mouse's position relative to the
    * top-left corner of the canvas. Its value is
    * <a href="#/p5/mouseY">mouseY</a> from the previous frame. For example, if
    * the mouse was 50 pixels from the top edge of the canvas during the last
    * frame, then `pmouseY` will be 50.
-   *
-   * In WebGL mode, `pmouseY` keeps track of the mouse's position relative to the
-   * center of the canvas. For example, if the mouse was 50 pixels below the
-   * canvas' center during the last frame, then `pmouseY` will be 50.
    *
    * If touch is used instead of the mouse, then `pmouseY` will hold the
    * y-coordinate of the last touch point.
@@ -496,7 +480,7 @@ function pointer(p5, fn){
    *   textSize(16);
    *
    *   // Display the mouse's coordinates within the browser window.
-   *   text(`x: ${winMouseX} y: ${winMouseY}`, 50, 50);
+   *   text(`x: ${int(winMouseX)} y: ${int(winMouseY)}`, 50, 50);
    * }
    * </code>
    * </div>
@@ -537,7 +521,7 @@ function pointer(p5, fn){
    *   textSize(16);
    *
    *   // Display the mouse's coordinates within the browser window.
-   *   text(`x: ${winMouseX} y: ${winMouseY}`, 50, 50);
+   *   text(`x: ${int(winMouseX)} y: ${int(winMouseY)}`, 50, 50);
    * }
    * </code>
    * </div>


### PR DESCRIPTION
resolves https://github.com/processing/p5.js/issues/8002

 Changes:
The docs for mouseX, mouseY, pmouseX, pmouseY incorrectly state that in WEBGL mode the number is relative to the center of the screen. In fact, is relative to the top-left corner. Removes the distinction between 2d and webgl. 



#### PR Checklist
<!--
  To check any option, replace the "[ ]" with a "[x]". Be sure to check out how it looks in the Preview tab! Feel free to remove any portion of the template that is not relevant for your issue.
-->

- [ ] `npm run lint` passes
- [ ] [Inline reference] is included / updated
- [ ] [Unit tests] are included / updated

[Inline reference]: https://p5js.org/contribute/contributing_to_the_p5js_reference/
[Unit tests]: https://github.com/processing/p5.js/tree/main/contributor_docs#unit-tests
