### PR TITLE
Fix: Corrected code block in textureMode() in dev2.0

### DIFF
--- a/src/webgl/material.js
+++ b/src/webgl/material.js
@@ -2410,18 +2410,18 @@ function material(p5, fn){
    * to the pixel at coordinates `(u, v)` within an image. For example, the
    * corners of a rectangular image are mapped to the corners of a rectangle by default:
    *
-   * <code>
+   * ```js
    * // Apply the image as a texture.
    * texture(img);
    *
    * // Draw the rectangle.
    * rect(0, 0, 30, 50);
-   * </code>
+   * ```
    *
    * If the image in the code snippet above has dimensions of 300 x 500 pixels,
    * the same result could be achieved as follows:
    *
-   * <code>
+   * ```js
    * // Apply the image as a texture.
    * texture(img);
    *
@@ -2445,7 +2445,7 @@ function material(p5, fn){
    * vertex(0, 50, 0, 0, 500);
    *
    * endShape();
-   * </code>
+   * ```
    *
    * `textureMode()` changes the coordinate system for uv coordinates.
    *
@@ -2455,7 +2455,7 @@ function material(p5, fn){
    * be helpful for using the same code for multiple images of different sizes.
    * For example, the code snippet above could be rewritten as follows:
    *
-   * <code>
+   * ```js
    * // Set the texture mode to use normalized coordinates.
    * textureMode(NORMAL);
    *
@@ -2482,7 +2482,7 @@ function material(p5, fn){
    * vertex(0, 50, 0, 0, 1);
    *
    * endShape();
-   * </code>
+   * ```
    *
    * By default, `mode` is `IMAGE`, which scales uv coordinates to the
    * dimensions of the image. Calling `textureMode(IMAGE)` applies the default.


### PR DESCRIPTION
<!--
  Thank you for contributing! Please use this pull request (PR) template.

  In the description field of this PR, include "resolves #XXXX" tagging the issue you are fixing. If this PR addresses the issue but doesn't completely resolve it (ie the issue should remain open after your PR is merged), write "addresses #XXXX".
-->
Resolves #8010

### Changes:
- Fixed incorrect code block formatting for `textureMode()` in `src/webgl/material.js`


### Screenshots of the change:
_Not applicable (text/documentation fix only)_

---

#### PR Checklist

- [x] `npm run lint` passes
- [x] [Inline reference] is included / updated
- [ ] [Unit tests] are included / updated

[Inline reference]: https://p5js.org/contribute/contributing_to_the_p5js_reference/
[Unit tests]: https://github.com/processing/p5.js/tree/main/contributor_docs#unit-tests
