### PR TITLE
Replaced redundant else if statement with else statement

### DIFF
--- a/src/accessibility/outputs.js
+++ b/src/accessibility/outputs.js
@@ -492,7 +492,8 @@ p5.prototype._accsOutput = function(f, args) {
   if (!this.ingredients.shapes[f]) {
     this.ingredients.shapes[f] = [include];
     //if other shapes of this type have been created
-  } else{
+  } else {
+``
     //for every shape of this type
     for (let y in this.ingredients.shapes[f]) {
       //compare it with current shape and if it already exists make add false

--- a/src/accessibility/outputs.js
+++ b/src/accessibility/outputs.js
@@ -493,7 +493,6 @@ p5.prototype._accsOutput = function(f, args) {
     this.ingredients.shapes[f] = [include];
     //if other shapes of this type have been created
   } else {
-``
     //for every shape of this type
     for (let y in this.ingredients.shapes[f]) {
       //compare it with current shape and if it already exists make add false

--- a/src/accessibility/outputs.js
+++ b/src/accessibility/outputs.js
@@ -492,7 +492,7 @@ p5.prototype._accsOutput = function(f, args) {
   if (!this.ingredients.shapes[f]) {
     this.ingredients.shapes[f] = [include];
     //if other shapes of this type have been created
-  } else if (this.ingredients.shapes[f] !== [include]) {
+  } else{
     //for every shape of this type
     for (let y in this.ingredients.shapes[f]) {
       //compare it with current shape and if it already exists make add false


### PR DESCRIPTION
###  Resolves #6660 

 Changes:
In this pull request, my team, which includes @npNSU, @kaybcodes, @SilasVM, and I made a change to line 495, which addressed the error of JavaScript being only able to check for references and not values. I changed the else if statement to an else statement and deleted the conditions. Hopefully, this is not too similar to  [PR#6662](https://github.com/processing/p5.js/pull/6662), and it also makes the program run more efficiently by removing a redundant check.

  Hey @limzykenneth and @davepagurek, we noticed you two have been working diligently to find a pull request that can resolve the issue. We saw a comment about breaking early. If you have any advice on that, we may be able to implement it. Please let us know what you think. Thank you both for all that you have done.

 Screenshots of the change:
<img width="657" height="150" alt="image" src="https://github.com/user-attachments/assets/4f3ccc47-eb14-4cb2-b910-31eb5502e36f" />

#### PR Checklist
- [X] `npm run lint` passes
- [X] [Inline reference] is included / updated
- [ ] [Unit tests] are included / updated

[Inline reference]: https://p5js.org/contribute/contributing_to_the_p5js_reference/
[Unit tests]: https://github.com/processing/p5.js/tree/main/contributor_docs#unit-tests
