### PR TITLE
Fix error of noteToFreq() in p5.sound.js

### DIFF
--- a/lib/addons/p5.sound.js
+++ b/lib/addons/p5.sound.js
@@ -895,8 +895,8 @@ function noteToFreq(note) {
   }
 
   var wholeNotes = {
-    A: 21,
-    B: 23,
+    A: 33,
+    B: 35,
     C: 24,
     D: 26,
     E: 28,


### PR DESCRIPTION
Changes:
- Fixed the `wholeNotes` object's value in `p5.sound.js` (please help me update `p5.sound.min.js` as well...)

When building a project using the p5.sound.js library, there's an error in the [p5.MonoSynth.triggerAttack()](https://p5js.org/reference/p5.MonoSynth/triggerAttack) function when passing a MIDI value in Note/Octave format (`"C4"`, `"Eb3"`, etc.) as the parameter. The frequency of notes `"A"` and `"B"` (and related notes like `"A#"`, `"Ab"`) should belong to the next octave. (i.e., when passing `"B5"` as the parameter, the result is actually the frequency of `"B4"`).

This sketch showcases the error: https://editor.p5js.org/CharlieEL/sketches/cit_Ecpdm

By adding 12 to the `A` and `B` values of the `wholeNotes` object, the bug should be fixed.