### PR TITLE
Fix: call failureCallback if omggif fails to parse GIF in loadImage

### DIFF
--- a/src/image/loading_displaying.js
+++ b/src/image/loading_displaying.js
@@ -646,7 +646,20 @@ function _createGif(
   failureCallback,
   finishCallback
 ) {
-  const gifReader = new omggif.GifReader(arrayBuffer);
+  let gifReader;
+  try {
+    gifReader = new omggif.GifReader(arrayBuffer);
+  } catch (e) {
+    p5._friendlyFileLoadError(8, pImg.src);
+    if (typeof failureCallback === 'function') {
+      failureCallback(e);
+    } else {
+      console.error(e);
+    }
+    finishCallback();
+    return;
+  }
+
   pImg.width = pImg.canvas.width = gifReader.width;
   pImg.height = pImg.canvas.height = gifReader.height;
   const frames = [];


### PR DESCRIPTION
Resolves #8021

Changes:

Wrapped the omggif.GifReader constructor in a try/catch block in loading_displaying.js.
If a GIF cannot be parsed, the failureCallback of loadImage is now called with the error, instead of throwing an uncatchable exception.
This allows sketches to handle image loading errors gracefully and prevents the sketch from crashing.
Tested locally with a broken GIF using a simple HTML test file (test-gif-error.html).
Screenshots of the change:
<img width="1609" height="679" alt="Screenshot 2025-08-24 111218" src="https://github.com/user-attachments/assets/0bac8160-6bcd-426c-8b34-4c8614f27025" />


When loading a broken GIF, the failure callback is called and the sketch continues running (see console and page output in the test file).

PR Checklist
 npm run lint passes
 Inline reference is included / updated (not applicable)
 Unit tests are included / updated (manual test provided)


test-gif-error.html  ( p5.js  --> create [ test-gif-error.html  ] )

code in [[ test-gif-error.html ]]

<!DOCTYPE html>
<html>
  <head>
    <script src="lib/p5.js"></script>
    <!-- or dist/p5.js, depending on your build -->
    <script>
      function preload() {
        loadImage(
          "broken.gif", // Use a GIF that omggif cannot parse
          (img) => console.log("Loaded!", img),
          (err) => {
            console.error("Properly handled error:", err);
            document.body.innerHTML += "<p>Failure callback called!</p>";
          }
        );
      }
      function setup() {
        createCanvas(100, 100);
        background(200);
      }
    </script>
  </head>
  <body></body>
</html>
