### PR TITLE
fix: fix `exports` field in package.json

### DIFF
--- a/docs/parameterData.json
+++ b/docs/parameterData.json
@@ -4656,6 +4656,10 @@
     "modify": {
       "overloads": [
         [
+          "Function",
+          "Object?"
+        ],
+        [
           "Object?"
         ]
       ]

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -80,7 +80,7 @@ const commonRules = {
   '@stylistic/max-len': [
     warn,
     {
-      code: 80,
+      code: 120,
       ignoreComments: true,
       ignoreStrings: true,
       ignoreTemplateLiterals: true,

--- a/package.json
+++ b/package.json
@@ -69,20 +69,62 @@
   "license": "LGPL-2.1",
   "browser": "./lib/p5.min.js",
   "exports": {
-    ".": "./dist/app.js",
-    "./core": "./dist/core/main.js",
-    "./shape": "./dist/shape/index.js",
-    "./accessibility": "./dist/accessibility/index.js",
-    "./friendlyErrors": "./dist/core/friendlyErrors/index.js",
-    "./data": "./dist/data/index.js",
-    "./dom": "./dist/dom/index.js",
-    "./events": "./dist/events/index.js",
-    "./image": "./dist/image/index.js",
-    "./io": "./dist/io/index.js",
-    "./math": "./dist/math/index.js",
-    "./utilities": "./dist/utilities/index.js",
-    "./webgl": "./dist/webgl/index.js",
-    "./type": "./dist/type/index.js"
+    ".": {
+      "default": "./dist/app.js",
+      "types": "./types/p5.d.ts"
+    },
+    "./core": {
+      "default": "./dist/core/main.js",
+      "types": "./types/core/main.d.ts"
+    },
+    "./shape": {
+      "default": "./dist/shape/index.js",
+      "types": "./types/shape/index.d.ts"
+    },
+    "./accessibility": {
+      "default": "./dist/accessibility/index.js",
+      "types": "./types/accessibility/index.d.ts"
+    },
+    "./friendly_errors": {
+      "default": "./dist/core/friendly_errors/index.js",
+      "types": "./types/core/friendly_errors/index.d.ts"
+    },
+    "./data": {
+      "default": "./dist/data/index.js",
+      "types": "./types/data/index.d.ts"
+    },
+    "./dom": {
+      "default": "./dist/dom/index.js",
+      "types": "./types/dom/index.d.ts"
+    },
+    "./events": {
+      "default": "./dist/events/index.js",
+      "types": "./types/events/index.d.ts"
+    },
+    "./image": {
+      "default": "./dist/image/index.js",
+      "types": "./types/image/index.d.ts"
+    },
+    "./io": {
+      "default": "./dist/io/index.js",
+      "types": "./types/io/index.d.ts"
+    },
+    "./math": {
+      "default": "./dist/math/index.js",
+      "types": "./types/math/index.d.ts"
+    },
+    "./utilities": {
+      "default": "./dist/utilities/index.js",
+      "types": "./types/utilities/index.d.ts"
+    },
+    "./webgl": {
+      "default": "./dist/webgl/index.js",
+      "types": "./types/webgl/index.d.ts"
+    },
+    "./type": {
+      "default": "./dist/type/index.js",
+      "types": "./types/type/index.d.ts"
+    }
   },
   "files": [
     "dist/**",
@@ -111,6 +153,5 @@
     "workerDirectory": [
       "test"
     ]
-  },
-  "types": "./types/p5.d.ts"
+  }
 }

--- a/utils/convert.mjs
+++ b/utils/convert.mjs
@@ -232,11 +232,11 @@ function getParams(entry) {
   // string, so we match these params to the Documentation.js-provided `params`
   // array and grab the description from those.
   return (entry.tags || [])
-  
+
     // Filter out the nested parameters (eg. options.extrude),
     // to be treated as part of parent parameters (eg. options)
     // and not separate entries
-    .filter(t => t.title === 'param' && !t.name.includes('.')) 
+    .filter(t => t.title === 'param' && !t.name.includes('.'))
     .map(node => {
       const param = (entry.params || []).find(param => param.name === node.name);
       return {
@@ -522,7 +522,7 @@ function cleanUpClassItems(data) {
         return Object.values(overload.params).map(param => processParam(param));
       }
       return overload;
-    }
+    };
 
     // To simplify `parameterData.json`, instead of having a separate field for
     // optional parameters, we'll add a ? to the end of parameter type to
@@ -536,7 +536,7 @@ function cleanUpClassItems(data) {
         type = `...${type}[]`;
       }
       return type;
-    }
+    };
 
     // In some cases, even when the arguments are intended to mean different
     // things, their types and order are identical. Since the exact meaning
@@ -549,7 +549,7 @@ function cleanUpClassItems(data) {
       }
       uniqueOverloads.add(overloadString);
       return true;
-    }
+    };
 
     for (const [key, value] of Object.entries(funcObj)) {
       if (value && typeof value === 'object' && value.overloads) {

--- a/utils/convert.mjs
+++ b/utils/convert.mjs
@@ -517,13 +517,6 @@ function cleanUpClassItems(data) {
   const flattenOverloads = funcObj => {
     const result = {};
 
-    const processOverload = overload => {
-      if (overload.params) {
-        return Object.values(overload.params).map(param => processParam(param));
-      }
-      return overload;
-    };
-
     // To simplify `parameterData.json`, instead of having a separate field for
     // optional parameters, we'll add a ? to the end of parameter type to
     // indicate that it's optional.
@@ -536,6 +529,13 @@ function cleanUpClassItems(data) {
         type = `...${type}[]`;
       }
       return type;
+    };
+
+    const processOverload = overload => {
+      if (overload.params) {
+        return Object.values(overload.params).map(param => processParam(param));
+      }
+      return overload;
     };
 
     // In some cases, even when the arguments are intended to mean different

--- a/utils/generate-types.mjs
+++ b/utils/generate-types.mjs
@@ -3,7 +3,7 @@ import path from 'path';
 import { fileURLToPath } from 'url';
 import {
   generateTypeDefinitions
-} from "./helper.mjs";
+} from './helper.mjs';
 
 // Fix for __dirname equivalent in ES modules
 const __filename = fileURLToPath(import.meta.url);
@@ -19,7 +19,7 @@ function findDtsFiles(dir, files = []) {
   }
 
   const entries = fs.readdirSync(dir, { withFileTypes: true });
-  
+
   for (const entry of entries) {
     const fullPath = path.join(dir, entry.name);
     if (entry.isDirectory()) {
@@ -44,7 +44,7 @@ export function generateAllDeclarationFiles() {
   fileTypes.forEach((content, filePath) => {
     const parsedPath = path.parse(filePath);
     const relativePath = path.relative(
-      path.join(__dirname, "../src"),
+      path.join(__dirname, '../src'),
       filePath
     );
     const dtsPath = path.join(

--- a/utils/generate-types.mjs
+++ b/utils/generate-types.mjs
@@ -10,6 +10,7 @@ const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 
 const data = JSON.parse(fs.readFileSync(path.join(__dirname, '../docs/data.json')));
+const packageJson = JSON.parse(fs.readFileSync(path.join(__dirname, '../package.json')));
 
 function findDtsFiles(dir, files = []) {
   // Only search in src directory
@@ -75,6 +76,34 @@ export function generateAllDeclarationFiles() {
 
   fs.writeFileSync(path.join(typesDir, 'p5.d.ts'), p5Types, 'utf8');
   fs.writeFileSync(path.join(typesDir, 'global.d.ts'), globalTypes, 'utf8');
+
+  // Create `index.d.ts` for every sub-module directory
+  /** @type { Record<string, string> } */
+  const subModuleDefinitions = {};
+  for (const entrypoint of Object.values(packageJson.exports)) {
+    if (entrypoint === '.') continue;
+    const subModuleName = entrypoint.default.replace('./dist', '').replace(/\/index\.js$/, '');
+    subModuleDefinitions[subModuleName] = '// This file is auto-generated from JSDoc documentation\n\n';
+  }
+
+  for (const file of dtsFiles) {
+    for (const subModuleName of Object.keys(subModuleDefinitions)) {
+      if (file.startsWith(subModuleName + '/') && file !== subModuleName + '/index.d.ts') {
+        subModuleDefinitions[subModuleName] += `/// <reference path="./${file.replace(subModuleName + '/', '')}" />\n`;
+      }
+    }
+  }
+
+  for (const [subModuleName, content] of Object.entries(subModuleDefinitions)) {
+    const subModuleDir = path.join(typesDir, subModuleName);
+    const destPath = path.join(
+      path.relative(process.cwd(), subModuleDir),
+      'index.d.ts'
+    );
+    fs.mkdirSync(subModuleDir, { recursive: true });
+    fs.writeFileSync(destPath, content, 'utf8');
+    console.log(`Generated ${destPath}`);
+  }
 }
 
 generateAllDeclarationFiles();

--- a/utils/helper.mjs
+++ b/utils/helper.mjs
@@ -256,6 +256,7 @@ function generateDeclarationFile(items, organizedData) {
             }
           }
           break;
+        }
       }
     }
   });

--- a/utils/helper.mjs
+++ b/utils/helper.mjs
@@ -18,7 +18,6 @@ export function normalizeClassName(className) {
 }
 
 export function generateTypeDefinitions(data) {
-
   const organized = organizeData(data);
 
   return {
@@ -28,477 +27,76 @@ export function generateTypeDefinitions(data) {
   };
 }
 function generateP5TypeDefinitions(organizedData) {
-    let output = '// This file is auto-generated from JSDoc documentation\n\n';
+  let output = '// This file is auto-generated from JSDoc documentation\n\n';
 
-    output += `declare class p5 {\n`;
-    output += `  constructor(sketch?: (p: p5) => void, node?: HTMLElement, sync?: boolean);\n\n`;
-    const instanceItems = organizedData.classitems.filter(item =>
-      item.class === 'p5' && !item.isStatic
-    );
-    instanceItems.forEach(item => {
-      output += generateMethodDeclarations(item, false);
-    });
+  output += 'declare class p5 {\n';
+  output += '  constructor(sketch?: (p: p5) => void, node?: HTMLElement, sync?: boolean);\n\n';
+  const instanceItems = organizedData.classitems.filter(item =>
+    item.class === 'p5' && !item.isStatic
+  );
+  instanceItems.forEach(item => {
+    output += generateMethodDeclarations(item, false);
+  });
 
-    const staticItems = organizedData.classitems.filter(item =>
-      item.class === 'p5' && item.isStatic
-    );
-    staticItems.forEach(item => {
-      output += generateMethodDeclarations(item, true);
-    });
+  const staticItems = organizedData.classitems.filter(item =>
+    item.class === 'p5' && item.isStatic
+  );
+  staticItems.forEach(item => {
+    output += generateMethodDeclarations(item, true);
+  });
 
-    Object.values(organizedData.consts).forEach(constData => {
-      if (constData.class === 'p5') {
-        if (constData.description) {
-          output += `  /**\n   * ${constData.description}\n   */\n`;
-        }
-        if (constData.kind === 'constant') {
-          output += `  readonly ${constData.name.toUpperCase()}: ${constData.type};\n\n`;
-        } else {
-          output += `  static ${constData.name}: ${constData.type};\n\n`;
-        }
+  Object.values(organizedData.consts).forEach(constData => {
+    if (constData.class === 'p5') {
+      if (constData.description) {
+        output += `  /**\n   * ${constData.description}\n   */\n`;
       }
-    });
-
-    output += `}\n\n`;
-
-    output += `declare namespace p5 {\n`;
-
-    Object.values(organizedData.consts).forEach(constData => {
-      if (constData.kind === 'typedef') {
-        if (constData.description) {
-          output += `  /**\n   * ${constData.description}\n   */\n`;
-        }
-        output += `  type ${constData.name} = ${constData.type};\n\n`;
+      if (constData.kind === 'constant') {
+        output += `  readonly ${constData.name.toUpperCase()}: ${constData.type};\n\n`;
+      } else {
+        output += `  static ${constData.name}: ${constData.type};\n\n`;
       }
-    });
+    }
+  });
 
-    Object.values(organizedData.classes).forEach(classDoc => {
-      if (classDoc.name !== 'p5') {
-        output += generateClassDeclaration(classDoc, organizedData);
+  output += '}\n\n';
+
+  output += 'declare namespace p5 {\n';
+
+  Object.values(organizedData.consts).forEach(constData => {
+    if (constData.kind === 'typedef') {
+      if (constData.description) {
+        output += `  /**\n   * ${constData.description}\n   */\n`;
       }
-    });
-    output += `}\n\n`;
+      output += `  type ${constData.name} = ${constData.type};\n\n`;
+    }
+  });
 
-    output += `export default p5;\n`;
-    output += `export as namespace p5;\n`;
+  Object.values(organizedData.classes).forEach(classDoc => {
+    if (classDoc.name !== 'p5') {
+      output += generateClassDeclaration(classDoc, organizedData);
+    }
+  });
+  output += '}\n\n';
 
-    return output;
-  }
+  output += 'export default p5;\n';
+  output += 'export as namespace p5;\n';
+
+  return output;
+}
 
 function generateGlobalTypeDefinitions(organizedData) {
-    let output = '// This file is auto-generated from JSDoc documentation\n\n';
-    output += `import p5 from 'p5';\n\n`;
-    output += `declare global {\n`;
+  let output = '// This file is auto-generated from JSDoc documentation\n\n';
+  output += 'import p5 from \'p5\';\n\n';
+  output += 'declare global {\n';
 
-    const instanceItems = organizedData.classitems.filter(item =>
-      item.class === 'p5' && !item.isStatic
-    );
-    instanceItems.forEach(item => {
-      if (item.kind === 'function') {
-        if (item.description) {
-          output += `  /**\n${formatJSDocComment(item.description, 2)}\n   */\n`;
-        }
-
-        if (item.overloads?.length > 0) {
-          item.overloads.forEach(overload => {
-            const params = (overload.params || [])
-              .map(param => generateParamDeclaration(param))
-              .join(', ');
-            const returnType = overload.returns?.[0]?.type
-              ? generateTypeFromTag(overload.returns[0])
-              : 'void';
-            output += `  function ${item.name}(${params}): ${returnType};\n`;
-          });
-        }
-
-        const params = (item.params || [])
-          .map(param => generateParamDeclaration(param))
-          .join(', ');
-        output += `  function ${item.name}(${params}): ${item.returnType};\n\n`;
-      }
-    });
-
-    Object.values(organizedData.consts).forEach(constData => {
-      if (constData.kind === 'constant') {
-        if (constData.description) {
-          output += `  /**\n${formatJSDocComment(constData.description, 2)}\n   */\n`;
-       }
-        output += `  const ${constData.name.toUpperCase()}: p5.${constData.name.toUpperCase()};\n\n`;
-      }
-    });
-
-    output += `  interface Window {\n`;
-
-    instanceItems.forEach(item => {
-      if (item.kind === 'function') {
-        output += `    ${item.name}: typeof ${item.name};\n`;
-      }
-    });
-
-    Object.values(organizedData.consts).forEach(constData => {
-      if (constData.kind === 'constant') {
-        if (constData.description) {
-          output += `    /**\n     * ${constData.description}\n     */\n`;
-        }
-        output += `    readonly ${constData.name.toUpperCase()}: typeof ${constData.name.toUpperCase()};\n`;
-      }
-    });
-
-    output += `  }\n`;
-    output += `}\n\n`;
-    output += `export {};\n`;
-
-    return output;
-  }
-
-function generateFileTypeDefinitions(organizedData, data) {
-    const fileDefinitions = new Map();
-    const fileGroups = groupByFile(getAllEntries(data));
-
-    fileGroups.forEach((items, filePath) => {
-      const declarationContent = generateDeclarationFile(items, organizedData);
-      fileDefinitions.set(filePath, declarationContent);
-    });
-
-    return fileDefinitions;
-  }
-  const organized = {
-    modules: {},
-    classes: {},
-    classitems: [],
-    consts: {}
-  };
-
-function generateDeclarationFile(items, organizedData) {
-    let output = '// This file is auto-generated from JSDoc documentation\n\n';
-    const imports = new Set([`import p5 from 'p5';`]);
-    const hasColorDependency = items.some(item => {
-      const typeName = item.type?.name;
-      const desc = extractDescription(item.description);
-      return typeName === 'Color' || (typeof desc === 'string' && desc.includes('Color'));
-    });
-
-    const hasVectorDependency = items.some(item => {
-      const typeName = item.type?.name;
-      const desc = extractDescription(item.description);
-      return typeName === 'Vector' || (typeof desc === 'string' && desc.includes('Vector'));
-    });
-
-    const hasConstantsDependency = items.some(item =>
-      item.tags?.some(tag => tag.title === 'requires' && tag.description === 'constants')
-    );
-
-    if (hasColorDependency) {
-      imports.add(`import { Color } from '../color/p5.Color';`);
-    }
-    if (hasVectorDependency) {
-      imports.add(`import { Vector } from '../math/p5.Vector';`);
-    }
-    if (hasConstantsDependency) {
-      imports.add(`import * as constants from '../core/constants';`);
-    }
-
-    output += Array.from(imports).join('\n') + '\n\n';
-    output += `declare module 'p5' {\n`;
-
-    const classDoc = items.find(item => item.kind === 'class');
-    if (classDoc) {
-      const fullClassName = normalizeClassName(classDoc.name);
-      const classDocName = fullClassName.replace('p5.', '');
-      let parentClass = classDoc.tags?.find(tag => tag.title === 'extends')?.name;
-      if (parentClass) {
-        parentClass = parentClass.replace('p5.', '');
-      }
-      const extendsClause = parentClass ? ` extends ${parentClass}` : '';
-
-      output += `  class ${classDocName}${extendsClause} {\n`;
-
-      if (classDoc.params?.length > 0) {
-        output += '    constructor(';
-        output += classDoc.params
-          .map(param => generateParamDeclaration(param))
-          .join(', ');
-        output += ');\n\n';
-      }
-
-      const classItems = organizedData.classitems.filter(item =>
-        item.class === fullClassName ||
-        item.class === fullClassName.replace('p5.', '')
-      );
-
-      const staticItems = classItems.filter(item => item.isStatic);
-      const instanceItems = classItems.filter(item => !item.isStatic);
-      staticItems.forEach(item => {
-        output += generateMethodDeclarations(item, true);
-      });
-      instanceItems.forEach(item => {
-        output += generateMethodDeclarations(item, false);
-      });
-      output += '  }\n\n';
-    }
-
-    items.forEach(item => {
-      if (item.kind !== 'class' && (!item.memberof || item.memberof !== classDoc?.name)) {
-        switch (item.kind) {
-          case 'function':
-            output += generateFunctionDeclaration(item);
-            break;
-          case 'constant':
-          case 'typedef':
-            const constData = organizedData.consts[item.name];
-            if (constData) {
-              if (constData.description) {
-                output += `  /**\n   * ${constData.description}\n   */\n`;
-              }
-              if (constData.kind === 'constant') {
-                output += `  const ${constData.name}: ${constData.type};\n\n`;
-              } else {
-                output += `  type ${constData.name} = ${constData.type};\n\n`;
-              }
-            }
-            break;
-        }
-      }
-    });
-
-    output += '}\n\n';
-
-    return output;
-  }
-
-  export function organizeData(data) {
-    const allData = getAllEntries(data);
-
-    organized.modules = {};
-    organized.classes = {};
-    organized.classitems = [];
-    organized.consts = {};
-
-    allData.forEach(entry => {
-      const { module, submodule, forEntry } = getModuleInfo(entry);
-      const className = normalizeClassName(forEntry || entry.memberof || 'p5');
-
-      switch(entry.kind) {
-        case 'class':
-          organized.classes[className] = {
-            name: entry.name,
-            description: extractDescription(entry.description),
-            params: (entry.params || []).map(param => ({
-              name: param.name,
-              type: generateTypeFromTag(param),
-              optional: param.type?.type === 'OptionalType'
-            })),
-            module,
-            submodule,
-            extends: entry.tags?.find(tag => tag.title === 'extends')?.name || null
-          }; break;
-          case 'function':
-          case 'property':
-            const overloads = entry.overloads?.map(overload => ({
-              params: overload.params,
-              returns: overload.returns,
-              description: extractDescription(overload.description)
-            }));
-
-            organized.classitems.push({
-              name: entry.name,
-              kind: entry.kind,
-              description: extractDescription(entry.description),
-              params: (entry.params || []).map(param => ({
-                name: param.name,
-                type: generateTypeFromTag(param),
-                optional: param.type?.type === 'OptionalType'
-              })),
-              returnType: entry.returns?.[0] ? generateTypeFromTag(entry.returns[0]) : 'void',
-              module,
-              submodule,
-              class: className,
-              isStatic: entry.path?.[0]?.scope === 'static',
-              overloads
-            }); break;
-          case 'constant':
-          case 'typedef':
-            organized.consts[entry.name] = {
-              name: entry.name,
-              kind: entry.kind,
-              description: extractDescription(entry.description),
-              type: entry.kind === 'constant' ? `P5.${entry.name.toUpperCase()}` : (entry.type ? generateTypeFromTag(entry) : 'any'),
-              module,
-              submodule,
-              class: forEntry || 'p5'
-            }; break;
-        }
-      });
-    return organized;
-  }
-
-  export function getModuleInfo(entry) {
-    return {
-        module: entry.tags?.find(tag => tag.title === 'module')?.name || 'p5',
-        submodule: entry.tags?.find(tag => tag.title === 'submodule')?.description || null,
-        forEntry: entry.tags?.find(tag => tag.title === 'for')?.description || entry.memberof
-    };
-}
-export function extractDescription(desc) {
-    if (!desc) return '';
-    if (typeof desc === 'string') return desc;
-    if (desc.children) {
-      return desc.children.map(child => {
-          if (child.type === 'text') return child.value;
-          if (child.type === 'paragraph') return extractDescription(child);
-          if (child.type === 'inlineCode' || child.type === 'code') return `\`${child.value}\``;
-          return '';
-        })
-        .join('').trim().replace(/\n{3,}/g, '\n\n');
-    }
-    return '';
-  }
-export function generateTypeFromTag(param) {
-    if (!param || !param.type) return 'any';
-
-    switch (param.type.type) {
-      case 'NameExpression':
-        return normalizeTypeName(param.type.name);
-      case 'TypeApplication': {
-        const baseType = normalizeTypeName(param.type.expression.name);
-
-        if (baseType === 'Array') {
-          const innerType = param.type.applications[0];
-          const innerTypeStr = generateTypeFromTag({ type: innerType });
-          return `${innerTypeStr}[]`;
-        }
-
-        const typeParams = param.type.applications
-          .map(app => generateTypeFromTag({ type: app }))
-          .join(', ');
-        return `${baseType}<${typeParams}>`;
-      }
-      case 'UnionType':
-        const unionTypes = param.type.elements
-          .map(el => generateTypeFromTag({ type: el }))
-          .join(' | ');
-        return unionTypes;
-      case 'OptionalType':
-        return generateTypeFromTag({ type: param.type.expression });
-      case 'AllLiteral':
-        return 'any';
-      case 'RecordType':
-        return 'object';
-      case 'StringLiteralType':
-        return `'${param.type.value}'`;
-      case 'UndefinedLiteralType':
-        return 'undefined';
-      case 'ArrayType': {
-        const innerTypeStrs = param.type.elements.map(e => generateTypeFromTag({ type: e }));
-        return `[${innerTypeStrs.join(', ')}]`;
-      }
-      case 'RestType':
-        return `${generateTypeFromTag({ type: param.type.expression })}[]`;
-      default:
-        return 'any';
-    }
-  }
-
-  export function normalizeTypeName(type) {
-    if (!type) return 'any';
-
-    if (type === '[object Object]') return 'any';
-
-    const primitiveTypes = {
-      'String': 'string',
-      'Number': 'number',
-      'Integer': 'number',
-      'Boolean': 'boolean',
-      'Void': 'void',
-      'Object': 'object',
-      'Array': 'Array',
-      'Function': 'Function'
-    };
-
-    return primitiveTypes[type] || type;
-  }
-
-  export function generateParamDeclaration(param) {
-    if (!param) return 'any';
-
-    let type = param.type;
-    let prefix = '';
-    const isOptional = param.type?.type === 'OptionalType';
-    if (typeof type === 'string') {
-      type = normalizeTypeName(type);
-    } else if (param.type?.type) {
-      type = generateTypeFromTag(param);
-    } else {
-      type = 'any';
-    }
-
-    if (param.type?.type === 'RestType') {
-      prefix = '...';
-    }
-
-    return `${prefix}${param.name}${isOptional ? '?' : ''}: ${type}`;
-  }
-
-  export function generateFunctionDeclaration(funcDoc) {
-
-    let output = '';
-
-    if (funcDoc.description || funcDoc.tags?.length > 0) {
-      output += '/**\n';
-      const description = extractDescription(funcDoc.description);
-      if (description) {
-        output += formatJSDocComment(description) + '\n';
-      }
-      if (funcDoc.tags) {
-        if (description) {
-          output += ' *\n';
-        }
-        funcDoc.tags.forEach(tag => {
-          if (tag.description) {
-            const tagDesc = extractDescription(tag.description);
-            output += formatJSDocComment(`@${tag.title} ${tagDesc}`, 0) + '\n';
-          }
-        });
-      }
-      output += ' */\n';
-    }
-
-    const params = (funcDoc.params || [])
-      .map(param => generateParamDeclaration(param))
-      .join(', ');
-
-    const returnType = funcDoc.returns?.[0]?.type
-      ? generateTypeFromTag(funcDoc.returns[0])
-      : 'void';
-
-    output += `function ${funcDoc.name}(${params}): ${returnType};\n\n`;
-    return output;
-  }
-
-  export function generateMethodDeclarations(item, isStatic = false, isGlobal = false) {
-    let output = '';
-
-    if (item.description) {
-      output += '  /**\n';
-      const itemDesc = extractDescription(item.description);
-      output += formatJSDocComment(itemDesc, 2) + '\n';
-      if (item.params?.length > 0) {
-        output += ' *\n';
-        item.params.forEach(param => {
-          const paramDesc = extractDescription(param.description);
-          output += formatJSDocComment(`@param ${paramDesc}`, 2) + '\n';
-        });
-      }
-      if (item.returns) {
-        output += ' *\n';
-        const returnDesc = extractDescription(item.returns[0]?.description);
-        output += formatJSDocComment(`@return ${returnDesc}`, 2) + '\n';
-      }
-      output += '   */\n';
-    }
-
+  const instanceItems = organizedData.classitems.filter(item =>
+    item.class === 'p5' && !item.isStatic
+  );
+  instanceItems.forEach(item => {
     if (item.kind === 'function') {
-      const staticPrefix = isStatic ? 'static ' : '';
+      if (item.description) {
+        output += `  /**\n${formatJSDocComment(item.description, 2)}\n   */\n`;
+      }
 
       if (item.overloads?.length > 0) {
         item.overloads.forEach(overload => {
@@ -508,56 +106,114 @@ export function generateTypeFromTag(param) {
           const returnType = overload.returns?.[0]?.type
             ? generateTypeFromTag(overload.returns[0])
             : 'void';
-          output += `  ${staticPrefix}${item.name}(${params}): ${returnType};\n`;
+          output += `  function ${item.name}(${params}): ${returnType};\n`;
         });
       }
 
       const params = (item.params || [])
         .map(param => generateParamDeclaration(param))
         .join(', ');
-      output += `  ${staticPrefix}${item.name}(${params}): ${item.returnType};\n\n`;
-    } else {
-      const staticPrefix = isStatic ? 'static ' : '';
-      output += `  ${staticPrefix}${item.name}: ${item.returnType};\n\n`;
+      output += `  function ${item.name}(${params}): ${item.returnType};\n\n`;
     }
+  });
 
-    return output;
+  Object.values(organizedData.consts).forEach(constData => {
+    if (constData.kind === 'constant') {
+      if (constData.description) {
+        output += `  /**\n${formatJSDocComment(constData.description, 2)}\n   */\n`;
+      }
+      output += `  const ${constData.name.toUpperCase()}: p5.${constData.name.toUpperCase()};\n\n`;
+    }
+  });
+
+  output += '  interface Window {\n';
+
+  instanceItems.forEach(item => {
+    if (item.kind === 'function') {
+      output += `    ${item.name}: typeof ${item.name};\n`;
+    }
+  });
+
+  Object.values(organizedData.consts).forEach(constData => {
+    if (constData.kind === 'constant') {
+      if (constData.description) {
+        output += `    /**\n     * ${constData.description}\n     */\n`;
+      }
+      output += `    readonly ${constData.name.toUpperCase()}: typeof ${constData.name.toUpperCase()};\n`;
+    }
+  });
+
+  output += '  }\n';
+  output += '}\n\n';
+  output += 'export {};\n';
+
+  return output;
+}
+
+function generateFileTypeDefinitions(organizedData, data) {
+  const fileDefinitions = new Map();
+  const fileGroups = groupByFile(getAllEntries(data));
+
+  fileGroups.forEach((items, filePath) => {
+    const declarationContent = generateDeclarationFile(items, organizedData);
+    fileDefinitions.set(filePath, declarationContent);
+  });
+
+  return fileDefinitions;
+}
+const organized = {
+  modules: {},
+  classes: {},
+  classitems: [],
+  consts: {}
+};
+
+function generateDeclarationFile(items, organizedData) {
+  let output = '// This file is auto-generated from JSDoc documentation\n\n';
+  const imports = new Set(['import p5 from \'p5\';']);
+  const hasColorDependency = items.some(item => {
+    const typeName = item.type?.name;
+    const desc = extractDescription(item.description);
+    return typeName === 'Color' || (typeof desc === 'string' && desc.includes('Color'));
+  });
+
+  const hasVectorDependency = items.some(item => {
+    const typeName = item.type?.name;
+    const desc = extractDescription(item.description);
+    return typeName === 'Vector' || (typeof desc === 'string' && desc.includes('Vector'));
+  });
+
+  const hasConstantsDependency = items.some(item =>
+    item.tags?.some(tag => tag.title === 'requires' && tag.description === 'constants')
+  );
+
+  if (hasColorDependency) {
+    imports.add('import { Color } from \'../color/p5.Color\';');
+  }
+  if (hasVectorDependency) {
+    imports.add('import { Vector } from \'../math/p5.Vector\';');
+  }
+  if (hasConstantsDependency) {
+    imports.add('import * as constants from \'../core/constants\';');
   }
 
-export function generateClassDeclaration(classDoc, organizedData) {
+  output += Array.from(imports).join('\n') + '\n\n';
+  output += 'declare module \'p5\' {\n';
 
-
-    let output = '';
-
-    if (classDoc.description || classDoc.tags?.length > 0) {
-      output += '/**\n';
-      const description = extractDescription(classDoc.description);
-      if (description) {
-        output += formatJSDocComment(description) + '\n';
-      }
-      if (classDoc.tags) {
-        if (description) {
-          output += ' *\n';
-        }
-        classDoc.tags.forEach(tag => {
-          if (tag.description) {
-            const tagDesc = extractDescription(tag.description);
-            output += formatJSDocComment(`@${tag.title} ${tagDesc}`, 0) + '\n';
-          }
-        });
-      }
-      output += ' */\n';
-    }
-
-    const parentClass = classDoc.extends;
-    const extendsClause = parentClass ? ` extends ${parentClass}` : '';
-
+  const classDoc = items.find(item => item.kind === 'class');
+  if (classDoc) {
     const fullClassName = normalizeClassName(classDoc.name);
     const classDocName = fullClassName.replace('p5.', '');
-    output += `class ${classDocName}${extendsClause} {\n`;
+    let parentClass = classDoc.tags?.find(tag => tag.title === 'extends')?.name;
+    if (parentClass) {
+      parentClass = parentClass.replace('p5.', '');
+    }
+    const extendsClause = parentClass ? ` extends ${parentClass}` : '';
+
+    output += `  class ${classDocName}${extendsClause} {\n`;
 
     if (classDoc.params?.length > 0) {
-      output += '  constructor(';
+      output += '    constructor(';
       output += classDoc.params
         .map(param => generateParamDeclaration(param))
         .join(', ');
@@ -568,54 +224,396 @@ export function generateClassDeclaration(classDoc, organizedData) {
       item.class === fullClassName ||
       item.class === fullClassName.replace('p5.', '')
     );
+
     const staticItems = classItems.filter(item => item.isStatic);
     const instanceItems = classItems.filter(item => !item.isStatic);
-
     staticItems.forEach(item => {
       output += generateMethodDeclarations(item, true);
     });
-
     instanceItems.forEach(item => {
       output += generateMethodDeclarations(item, false);
     });
-
-    output += '}\n\n';
-    return output;
+    output += '  }\n\n';
   }
+
+  items.forEach(item => {
+    if (item.kind !== 'class' && (!item.memberof || item.memberof !== classDoc?.name)) {
+      switch (item.kind) {
+        case 'function':
+          output += generateFunctionDeclaration(item);
+          break;
+        case 'constant':
+        case 'typedef': {
+          const constData = organizedData.consts[item.name];
+          if (constData) {
+            if (constData.description) {
+              output += `  /**\n   * ${constData.description}\n   */\n`;
+            }
+            if (constData.kind === 'constant') {
+              output += `  const ${constData.name}: ${constData.type};\n\n`;
+            } else {
+              output += `  type ${constData.name} = ${constData.type};\n\n`;
+            }
+          }
+          break;
+      }
+    }
+  });
+
+  output += '}\n\n';
+
+  return output;
+}
+
+export function organizeData(data) {
+  const allData = getAllEntries(data);
+
+  organized.modules = {};
+  organized.classes = {};
+  organized.classitems = [];
+  organized.consts = {};
+
+  allData.forEach(entry => {
+    const { module, submodule, forEntry } = getModuleInfo(entry);
+    const cassName = normalizeClassNam(forEntry || entry.memberof || 'p5');
+
+    switch (entry.kind) {
+      case 'class':
+        organized.classes[className] = {
+          name: entry.name,
+          description: extractDescription(entry.description),
+          params: (entry.params || []).map(param => ({
+            name: param.name,
+            type: generateTypeFromTag(param),
+            optional: param.type?.type === 'OptionalType'
+          })),
+          module,
+          submodule,
+          extends: entry.tags?.find(tag => tag.title === 'extends')?.name || null
+        }; break;
+      case 'function':
+      case 'property':
+        const overloads = entry.overloads?.map(overload => ({
+          params: overload.params,
+          returns: overload.returns,
+          description: extractDescription(overload.description)
+        }));
+
+        organized.classitems.push({
+          name: entry.name,
+          kind: entry.kind,
+          description: extractDescription(entry.description),
+          params: (entry.params || []).map(param => ({
+            name: param.name,
+            type: generateTypeFromTag(param),
+            optional: param.type?.type === 'OptionalType'
+          })),
+          returnType: entry.returns?.[0] ? generateTypeFromTag(entry.returns[0]) : 'void',
+          module,
+          submodule,
+          class: className,
+          isStatic: entry.path?.[0]?.scope === 'static',
+          overloads
+        }); break;
+      case 'constant':
+      case 'typedef':
+        organized.consts[entry.name] = {
+          name: entry.name,
+          kind: entry.kind,
+          description: extractDescription(entry.description),
+          type: entry.kind === 'constant' ? `P5.${entry.name.toUpperCase()}` : (entry.type ? generateTypeFromTag(entry) : 'any'),
+          module,
+          submodule,
+          class: forEntry || 'p5'
+        }; break;
+    }
+  });
+  return organized;
+}
+
+export function getModuleInfo(entry) {
+  return {
+    module: entry.tags?.find(tag => tag.title === 'module')?.name || 'p5',
+    submodule: entry.tags?.find(tag => tag.title === 'submodule')?.description || null,
+    forEntry: entry.tags?.find(tag => tag.title === 'for')?.description || entry.memberof
+  };
+}
+export function extractDescription(desc) {
+  if (!desc) return '';
+  if (typeof desc === 'string') return desc;
+  if (desc.children) {
+    return desc.children.map(child => {
+      if (child.type === 'text') return child.value;
+      if (child.type === 'paragraph') return extractDescription(child);
+      if (child.type === 'inlineCode' || child.type === 'code') return `\`${child.value}\``;
+      return '';
+    })
+      .join('').trim().replace(/\n{3,}/g, '\n\n');
+  }
+  return '';
+}
+export function generateTypeFromTag(param) {
+  if (!param || !param.type) return 'any';
+
+  switch (param.type.type) {
+    case 'NameExpression':
+      return normalizeTypeName(param.type.name);
+    case 'TypeApplication': {
+      const baseType = normalizeTypeName(param.type.expression.name);
+
+      if (baseType === 'Array') {
+        const innerType = param.type.applications[0];
+        const innerTypeStr = generateTypeFromTag({ type: innerType });
+        return `${innerTypeStr}[]`;
+      }
+
+      const typeParams = param.type.applications
+        .map(app => generateTypeFromTag({ type: app }))
+        .join(', ');
+      return `${baseType}<${typeParams}>`;
+    }
+    case 'UnionType':
+      const unionTypes = param.type.elements
+        .map(el => generateTypeFromTag({ type: el }))
+        .join(' | ');
+      return unionTypes;
+    case 'OptionalType':
+      return generateTypeFromTag({ type: param.type.expression });
+    case 'AllLiteral':
+      return 'any';
+    case 'RecordType':
+      return 'object';
+    case 'StringLiteralType':
+      return `'${param.type.value}'`;
+    case 'UndefinedLiteralType':
+      return 'undefined';
+    case 'ArrayType': {
+      const innerTypeStrs = param.type.elements.map(e => generateTypeFromTag({ type: e }));
+      return `[${innerTypeStrs.join(', ')}]`;
+    }
+    case 'RestType':
+      return `${generateTypeFromTag({ type: param.type.expression })}[]`;
+    default:
+      return 'any';
+  }
+}
+
+export function normalizeTypeName(type) {
+  if (!type) return 'any';
+
+  if (type === '[object Object]') return 'any';
+
+  const primitiveTypes = {
+    'String': 'string',
+    'Number': 'number',
+    'Integer': 'number',
+    'Boolean': 'boolean',
+    'Void': 'void',
+    'Object': 'object',
+    'Array': 'Array',
+    'Function': 'Function'
+  };
+
+  return primitiveTypes[type] || type;
+}
+
+export function generateParamDeclaration(param) {
+  if (!param) return 'any';
+
+  let type = param.type;
+  let prefix = '';
+  const isOptional = param.type?.type === 'OptionalType';
+  if (typeof type === 'string') {
+    type = normalizeTypeName(type);
+  } else if (param.type?.type) {
+    type = generateTypeFromTag(param);
+  } else {
+    type = 'any';
+  }
+
+  if (param.type?.type === 'RestType') {
+    prefix = '...';
+  }
+
+  return `${prefix}${param.name}${isOptional ? '?' : ''}: ${type}`;
+}
+
+export function generateFunctionDeclaration(funcDoc) {
+  let output = '';
+
+  if (funcDoc.description || funcDoc.tags?.length > 0) {
+    output += '/**\n';
+    const description = extractDescription(funcDoc.description);
+    if (description) {
+      output += formatJSDocComment(description) + '\n';
+    }
+    if (funcDoc.tags) {
+      if (description) {
+        output += ' *\n';
+      }
+      funcDoc.tags.forEach(tag => {
+        if (tag.description) {
+          const tagDesc = extractDescription(tag.description);
+          output += formatJSDocComment(`@${tag.title} ${tagDesc}`, 0) + '\n';
+        }
+      });
+    }
+    output += ' */\n';
+  }
+
+  const params = (funcDoc.params || [])
+    .map(param => generateParamDeclaration(param))
+    .join(', ');
+
+  const returnType = funcDoc.returns?.[0]?.type
+    ? generateTypeFromTag(funcDoc.returns[0])
+    : 'void';
+
+  output += `function ${funcDoc.name}(${params}): ${returnType};\n\n`;
+  return output;
+}
+
+export function generateMethodDeclarations(item, isStatic = false, isGlobal = false) {
+  let output = '';
+
+  if (item.description) {
+    output += '  /**\n';
+    const itemDesc = extractDescription(item.description);
+    output += formatJSDocComment(itemDesc, 2) + '\n';
+    if (item.params?.length > 0) {
+      output += ' *\n';
+      item.params.forEach(param => {
+        const paramDesc = extractDescription(param.description);
+        output += formatJSDocComment(`@param ${paramDesc}`, 2) + '\n';
+      });
+    }
+    if (item.returns) {
+      output += ' *\n';
+      const returnDesc = extractDescription(item.returns[0]?.description);
+      output += formatJSDocComment(`@return ${returnDesc}`, 2) + '\n';
+    }
+    output += '   */\n';
+  }
+
+  if (item.kind === 'function') {
+    const staticPrefix = isStatic ? 'static ' : '';
+
+    if (item.overloads?.length > 0) {
+      item.overloads.forEach(overload => {
+        const params = (overload.params || [])
+          .map(param => generateParamDeclaration(param))
+          .join(', ');
+        const returnType = overload.returns?.[0]?.type
+          ? generateTypeFromTag(overload.returns[0])
+          : 'void';
+        output += `  ${staticPrefix}${item.name}(${params}): ${returnType};\n`;
+      });
+    }
+
+    const params = (item.params || [])
+      .map(param => generateParamDeclaration(param))
+      .join(', ');
+    output += `  ${staticPrefix}${item.name}(${params}): ${item.returnType};\n\n`;
+  } else {
+    const staticPrefix = isStatic ? 'static ' : '';
+    output += `  ${staticPrefix}${item.name}: ${item.returnType};\n\n`;
+  }
+
+  return output;
+}
+
+export function generateClassDeclaration(classDoc, organizedData) {
+
+
+  let output = '';
+
+  if (classDoc.description || classDoc.tags?.length > 0) {
+    output += '/**\n';
+    const description = extractDescription(classDoc.description);
+    if (description) {
+      output += formatJSDocComment(description) + '\n';
+    }
+    if (classDoc.tags) {
+      if (description) {
+        output += ' *\n';
+      }
+      classDoc.tags.forEach(tag => {
+        if (tag.description) {
+          const tagDesc = extractDescription(tag.description);
+          output += formatJSDocComment(`@${tag.title} ${tagDesc}`, 0) + '\n';
+        }
+      });
+    }
+    output += ' */\n';
+  }
+
+  const parentClass = classDoc.extends;
+  const extendsClause = parentClass ? ` extends ${parentClass}` : '';
+
+  const fullClassName = normalizeClassName(classDoc.name);
+  const classDocName = fullClassName.replace('p5.', '');
+  output += `class ${classDocName}${extendsClause} {\n`;
+
+  if (classDoc.params?.length > 0) {
+    output += '  constructor(';
+    output += classDoc.params
+      .map(param => generateParamDeclaration(param))
+      .join(', ');
+    output += ');\n\n';
+  }
+
+  const classItems = organizedData.classitems.filter(item =>
+    item.class === fullClassName ||
+    item.class === fullClassName.replace('p5.', '')
+  );
+  const staticItems = classItems.filter(item => item.isStatic);
+  const instanceItems = classItems.filter(item => !item.isStatic);
+
+  staticItems.forEach(item => {
+    output += generateMethodDeclarations(item, true);
+  });
+
+  instanceItems.forEach(item => {
+    output += generateMethodDeclarations(item, false);
+  });
+
+  output += '}\n\n';
+  return output;
+}
 
 function formatJSDocComment(text, indentLevel = 0) {
-    if (!text) return '';
-    const indent = ' '.repeat(indentLevel);
+  if (!text) return '';
+  const indent = ' '.repeat(indentLevel);
 
-    const lines = text
-      .split('\n')
-      .map(line => line.trim())
-      .reduce((acc, line) => {
-        // If we're starting and line is empty, skip it
-        if (acc.length === 0 && line === '') return acc;
-        // If we have content and hit an empty line, keep one empty line
-        if (acc.length > 0 && line === '' && acc[acc.length - 1] === '') return acc;
-        acc.push(line);
-        return acc;
-      }, [])
-      .filter((line, i, arr) => i < arr.length - 1 || line !== ''); // Remove trailing empty line
+  const lines = text
+    .split('\n')
+    .map(line => line.trim())
+    .reduce((acc, line) => {
+      // If we're starting and line is empty, skip it
+      if (acc.length === 0 && line === '') return acc;
+      // If we have content and hit an empty line, keep one empty line
+      if (acc.length > 0 && line === '' && acc[acc.length - 1] === '') return acc;
+      acc.push(line);
+      return acc;
+    }, [])
+    .filter((line, i, arr) => i < arr.length - 1 || line !== ''); // Remove trailing empty line
 
-    return lines
-      .map(line => `${indent} * ${line}`)
-      .join('\n');
-  }
-  function groupByFile(items) {
-    const fileGroups = new Map();
+  return lines
+    .map(line => `${indent} * ${line}`)
+    .join('\n');
+}
+function groupByFile(items) {
+  const fileGroups = new Map();
 
-    items.forEach(item => {
-      if (!item.context || !item.context.file) return;
+  items.forEach(item => {
+    if (!item.context || !item.context.file) return;
 
-      const filePath = item.context.file;
-      if (!fileGroups.has(filePath)) {
-        fileGroups.set(filePath, []);
-      }
-      fileGroups.get(filePath).push(item);
-    });
+    const filePath = item.context.file;
+    if (!fileGroups.has(filePath)) {
+      fileGroups.set(filePath, []);
+    }
+    fileGroups.get(filePath).push(item);
+  });
 
-    return fileGroups;
-  }
+  return fileGroups;
+}

--- a/utils/helper.mjs
+++ b/utils/helper.mjs
@@ -276,7 +276,7 @@ export function organizeData(data) {
 
   allData.forEach(entry => {
     const { module, submodule, forEntry } = getModuleInfo(entry);
-    const cassName = normalizeClassNam(forEntry || entry.memberof || 'p5');
+    const className = normalizeClassName(forEntry || entry.memberof || 'p5');
 
     switch (entry.kind) {
       case 'class':
@@ -293,7 +293,7 @@ export function organizeData(data) {
           extends: entry.tags?.find(tag => tag.title === 'extends')?.name || null
         }; break;
       case 'function':
-      case 'property':
+      case 'property': {
         const overloads = entry.overloads?.map(overload => ({
           params: overload.params,
           returns: overload.returns,
@@ -315,7 +315,9 @@ export function organizeData(data) {
           class: className,
           isStatic: entry.path?.[0]?.scope === 'static',
           overloads
-        }); break;
+        });
+        break;
+      }
       case 'constant':
       case 'typedef':
         organized.consts[entry.name] = {
@@ -326,7 +328,8 @@ export function organizeData(data) {
           module,
           submodule,
           class: forEntry || 'p5'
-        }; break;
+        };
+        break;
     }
   });
   return organized;
@@ -373,11 +376,12 @@ export function generateTypeFromTag(param) {
         .join(', ');
       return `${baseType}<${typeParams}>`;
     }
-    case 'UnionType':
+    case 'UnionType': {
       const unionTypes = param.type.elements
         .map(el => generateTypeFromTag({ type: el }))
         .join(' | ');
       return unionTypes;
+    }
     case 'OptionalType':
       return generateTypeFromTag({ type: param.type.expression });
     case 'AllLiteral':

--- a/utils/patch.mjs
+++ b/utils/patch.mjs
@@ -1,41 +1,41 @@
 import fs from 'fs';
 
 const replace = (path, src, dest) => {
-    try {
-        const data = fs
-            .readFileSync(path, { encoding: 'utf-8' })
-            .replace(src, dest);
-        fs.writeFileSync(path, data);
-    } catch (err) {
-        console.error(err);
-    }
+  try {
+    const data = fs
+      .readFileSync(path, { encoding: 'utf-8' })
+      .replace(src, dest);
+    fs.writeFileSync(path, data);
+  } catch (err) {
+    console.error(err);
+  }
 };
 
 replace(
-    "./types/core/structure.d.ts",
-    "function p5(sketch: object, node: string | HTMLElement): void;",
-    "function p5: typeof p5"
+  './types/core/structure.d.ts',
+  'function p5(sketch: object, node: string | HTMLElement): void;',
+  'function p5: typeof p5'
 );
 
 replace(
-    "./types/webgl/p5.Geometry.d.ts",
-    "constructor(detailX?: number, detailY?: number, callback?: function);",
-    `constructor(
-        detailX?: number,
-        detailY?: number,
-        callback?: (this: {
-            detailY: number,
-            detailX: number,
-            vertices: p5.Vector[],
-            uvs: number[]
-        }) => void);`
+  './types/webgl/p5.Geometry.d.ts',
+  'constructor(detailX?: number, detailY?: number, callback?: function);',
+  `constructor(
+    detailX?: number,
+    detailY?: number,
+    callback?: (this: {
+      detailY: number,
+      detailX: number,
+      vertices: p5.Vector[],
+      uvs: number[]
+    }) => void);`
 );
 
 // https://github.com/p5-types/p5.ts/issues/31
 replace(
-    "./types/math/random.d.ts",
-    "function random(choices: Array): any;",
-    "function random<T>(choices: T[]): T;"
+  './types/math/random.d.ts',
+  'function random(choices: Array): any;',
+  'function random<T>(choices: T[]): T;'
 );
 
 

--- a/utils/sample-linter.mjs
+++ b/utils/sample-linter.mjs
@@ -101,7 +101,7 @@ const plugin = {
         return globalSamples.map(s => s.code + userFunctionTrailer);
       },
 
-      postprocess: function(sampleMessages, filename) {
+      postprocess: function(sampleMessages, _filename) {
         const problems = [];
 
         for (let i = 0; i < sampleMessages.length; i++) {


### PR DESCRIPTION
<!--
  Thank you for contributing! Please use this pull request (PR) template.


 In the description field of this PR, include "resolves #XXXX" tagging the issue you are fixing. If this PR addresses the issue but doesn't completely resolve it (ie the issue should remain open after your PR is merged), write "addresses #XXXX".-->


 Changes:
This PR fixes `exports` field in package.json.
Currently, `tsc` ignores `types` field in package.json if there is `exports` field. This PR fixes this issue by adding definition of each entrypoints.

This PR is forked from #8055 to edit files under `utils/`.

 Screenshots of the change:
N/A
<!-- If applicable, add screenshots depicting the changes. -->

#### PR Checklist
<!--
  To check any option, replace the "[ ]" with a "[x]". Be sure to check out how it looks in the Preview tab! Feel free to remove any portion of the template that is not relevant for your issue.
-->

- [x] `npm run lint` passes
- [ ] [Inline reference] is included / updated
- [ ] [Unit tests] are included / updated

[Inline reference]: https://p5js.org/contribute/contributing_to_the_p5js_reference/
[Unit tests]: https://github.com/processing/p5.js/tree/main/contributor_docs#unit-tests
