### PR TITLE
Fix misspellings in comment

### DIFF
--- a/src/core/friendly_errors/sketch_reader.js
+++ b/src/core/friendly_errors/sketch_reader.js
@@ -380,7 +380,7 @@ if (typeof IS_MINIFIED !== 'undefined') {
   const fesCodeReader = () => {
     //moveAhead will determine if a match is found outside
     //the setup and draw function. If a match is found then
-    //to prevent further potential reporting we will exit immidiately
+    //to prevent further potential reporting we will exit immediately
     let moveAhead = globalConstFuncCheck();
     if (moveAhead) return;
     let code = '';

--- a/src/core/friendly_errors/stacktrace.js
+++ b/src/core/friendly_errors/stacktrace.js
@@ -78,7 +78,7 @@ function ErrorStackParser() {
           .replace(/^\s+/, '')
           .replace(/\(eval code/g, '(');
 
-        // capture and preseve the parenthesized location "(/foo/my bar.js:12:87)" in
+        // capture and preserve the parenthesized location "(/foo/my bar.js:12:87)" in
         // case it has spaces in it, as the string is split on \s+ later on
         let location = sanitizedLine.match(/ (\((.+):(\d+):(\d+)\)$)/);
 


### PR DESCRIPTION
## Description

Fix misspellings in comment:
 - From `immidiately` to `immediately`
 - From `preseve` to `preserve`

No logic or functionality has been modified.