### PR TITLE
Include use of relevant maxes in `hue()`, `saturation()`, `brightness()` and `lightness()`

### DIFF
--- a/src/color/creating_reading.js
+++ b/src/color/creating_reading.js
@@ -1237,13 +1237,7 @@ function creatingReading(p5, fn){
    * </div>
    */
   fn.saturation = function(c) {
-    const colorMode = (
-      this._renderer.states.colorMode === HSB ||
-      this._renderer.states.colorMode === HSL
-    ) ?
-      this._renderer.states.colorMode :
-      HSL;
-
+    const colorMode = (this._renderer.states.colorMode === HSB) ? HSB : HSL;
     return this.color(c)._getSaturation(
       this._renderer.states.colorMaxes[colorMode][1]
     );

--- a/src/color/creating_reading.js
+++ b/src/color/creating_reading.js
@@ -1043,8 +1043,25 @@ function creatingReading(p5, fn){
    * </div>
    */
   fn.hue = function(c) {
-    // p5._validateParameters('hue', arguments);
-    return this.color(c)._getHue();
+    let colorMode = HSL;
+    let i = 0;
+
+    if(
+      this._renderer.states.colorMode === HSB ||
+      this._renderer.states.colorMode === HSL
+    ){
+      colorMode = this._renderer.states.colorMode;
+    }else if(
+      this._renderer.states.colorMode === LCH ||
+      this._renderer.states.colorMode === OKLCH
+    ){
+      colorMode = this._renderer.states.colorMode;
+      i = 2;
+    }
+
+    return this.color(c)._getHue(
+      this._renderer.states.colorMaxes[colorMode][i]
+    );
   };
 
   /**
@@ -1220,8 +1237,16 @@ function creatingReading(p5, fn){
    * </div>
    */
   fn.saturation = function(c) {
-    // p5._validateParameters('saturation', arguments);
-    return this.color(c)._getSaturation();
+    const colorMode = (
+      this._renderer.states.colorMode === HSB ||
+      this._renderer.states.colorMode === HSL
+    ) ?
+      this._renderer.states.colorMode :
+      HSL;
+
+    return this.color(c)._getSaturation(
+      this._renderer.states.colorMaxes[colorMode][1]
+    );
   };
 
   /**
@@ -1365,8 +1390,9 @@ function creatingReading(p5, fn){
    * </div>
    */
   fn.brightness = function(c) {
-    // p5._validateParameters('brightness', arguments);
-    return this.color(c)._getBrightness();
+    return this.color(c)._getBrightness(
+      this._renderer.states.colorMaxes.hsb[2]
+    );
   };
 
   /**
@@ -1510,8 +1536,9 @@ function creatingReading(p5, fn){
    * </div>
    */
   fn.lightness = function(c) {
-    // p5._validateParameters('lightness', arguments);
-    return this.color(c)._getLightness();
+    return this.color(c)._getLightness(
+      this._renderer.states.colorMaxes.hsl[2]
+    );
   };
 
   /**

--- a/src/color/p5.Color.js
+++ b/src/color/p5.Color.js
@@ -630,6 +630,7 @@ class Color {
       return map(to(this._color, 'hsl').coords[1], colorjsMax[0], colorjsMax[1], max[0], max[1]);
     }
   }
+
   /**
    * Brightness obtains the HSB brightness value from either a p5.Color object,
    * an array of color components, or a CSS color string.Depending on value,
@@ -637,7 +638,6 @@ class Color {
    * brightness value in the range. By default, this function will return
    * the HSB brightness within the range 0 - 100.
    */
-
   _getBrightness(max=[0, 100]) {
     if(!Array.isArray(max)){
       max = [0, max];


### PR DESCRIPTION
<!--
  Thank you for contributing! Please use this pull request (PR) template.


 In the description field of this PR, include "resolves #XXXX" tagging the issue you are fixing. If this PR addresses the issue but doesn't completely resolve it (ie the issue should remain open after your PR is merged), write "addresses #XXXX".-->
Resolves #7998

 Changes:
<!-- Add here what changes were made in this pull request and if possible provide links showcasing the changes. -->
The utility functions didn't take into account the current maxes of the relevant color modes, this implements it. One particular caveat is that `hue()` applies to `HSB`, `HSL` but also `LCH` and `OKLCH` which also have hue values. This may or may not be desired but for consistency sake they are included.

#### PR Checklist
<!--
  To check any option, replace the "[ ]" with a "[x]". Be sure to check out how it looks in the Preview tab! Feel free to remove any portion of the template that is not relevant for your issue.
-->

- [x] `npm run lint` passes
- [ ] [Inline reference] is included / updated
- [ ] [Unit tests] are included / updated

[Inline reference]: https://p5js.org/contribute/contributing_to_the_p5js_reference/
[Unit tests]: https://github.com/processing/p5.js/tree/main/contributor_docs#unit-tests
