### PR TITLE
Optimize bottlenecks in 2.0 code

### DIFF
--- a/src/core/friendly_errors/param_validator.js
+++ b/src/core/friendly_errors/param_validator.js
@@ -573,7 +573,10 @@ function validateParams(p5, fn, lifecycles) {
   lifecycles.presetup = function(){
     loadP5Constructors();
 
-    if(p5.disableParameterValidator !== true){
+    if(
+      p5.disableParameterValidator !== true &&
+      p5.disableFriendlyErrors !== true
+    ){
       const excludes = ['validate'];
       for(const f in this){
         if(!excludes.includes(f) && !f.startsWith('_') && typeof this[f] === 'function'){

--- a/src/core/main.js
+++ b/src/core/main.js
@@ -120,24 +120,40 @@ class p5 {
       if (isPrototypeFunction) {
         // For regular functions, cache the bound function
         const boundFunction = p5.prototype[property].bind(this);
-        Object.defineProperty(window, property, {
-          configurable: true,
-          enumerable: true,
-          get() {
-            return boundFunction;
-          },
-          set: createSetter()
-        });
+        if (p5.disableFriendlyErrors) {
+          Object.defineProperty(window, property, {
+            configurable: true,
+            enumerable: true,
+            value: boundFunction,
+          });
+        } else {
+          Object.defineProperty(window, property, {
+            configurable: true,
+            enumerable: true,
+            get() {
+              return boundFunction;
+            },
+            set: createSetter()
+          });
+        }
       } else if (isConstant) {
         // For constants, cache the value directly
-        Object.defineProperty(window, property, {
-          configurable: true,
-          enumerable: true,
-          get() {
-            return constantValue;
-          },
-          set: createSetter()
-        });
+        if (p5.disableFriendlyErrors) {
+          Object.defineProperty(window, property, {
+            configurable: true,
+            enumerable: true,
+            value: constantValue,
+          });
+        } else {
+          Object.defineProperty(window, property, {
+            configurable: true,
+            enumerable: true,
+            get() {
+              return constantValue;
+            },
+            set: createSetter()
+          });
+        }
       } else if (hasGetter || !isPrototypeFunction) {
         // For properties with getters or non-function properties, use lazy optimization
         // On first access, determine the type and optimize subsequent accesses

--- a/src/core/main.js
+++ b/src/core/main.js
@@ -78,28 +78,69 @@ class p5 {
     this._updateWindowSize();
 
     const bindGlobal = property => {
-      Object.defineProperty(window, property, {
-        configurable: true,
-        enumerable: true,
-        get: () => {
-          if(typeof this[property] === 'function'){
-            return this[property].bind(this);
-          }else{
-            return this[property];
+      if (property === 'constructor') return;
+
+      // Check if this property has a getter on the instance or prototype
+      const instanceDescriptor = Object.getOwnPropertyDescriptor(this, property);
+      const prototypeDescriptor = Object.getOwnPropertyDescriptor(p5.prototype, property);
+      const hasGetter = (instanceDescriptor && instanceDescriptor.get) ||
+                       (prototypeDescriptor && prototypeDescriptor.get);
+
+      // Only check if it's a function if it doesn't have a getter
+      // to avoid actually evaluating getters before things like the
+      // renderer are fully constructed
+      let isPrototypeFunction = false;
+      if (!hasGetter) {
+        const prototypeValue = p5.prototype[property];
+        isPrototypeFunction = typeof prototypeValue === 'function';
+      }
+
+      if (isPrototypeFunction) {
+        // For regular functions, cache the bound function
+        const boundFunction = p5.prototype[property].bind(this);
+        Object.defineProperty(window, property, {
+          configurable: true,
+          enumerable: true,
+          get() {
+            return boundFunction;
+          },
+          set(newValue) {
+            Object.defineProperty(window, property, {
+              configurable: true,
+              enumerable: true,
+              value: newValue,
+              writable: true
+            });
+            if (!p5.disableFriendlyErrors) {
+              console.log(`You just changed the value of "${property}", which was a p5 function. This could cause problems later if you're not careful.`);
+            }
           }
-        },
-        set: newValue => {
-          Object.defineProperty(window, property, {
-            configurable: true,
-            enumerable: true,
-            value: newValue,
-            writable: true
-          });
-          if (!p5.disableFriendlyErrors) {
-            console.log(`You just changed the value of "${property}", which was a p5 global value. This could cause problems later if you're not careful.`);
+        });
+      } else {
+        // For properties with getters or non-function properties, use dynamic access
+        Object.defineProperty(window, property, {
+          configurable: true,
+          enumerable: true,
+          get: () => {
+            if(typeof this[property] === 'function'){
+              return this[property].bind(this);
+            }else{
+              return this[property];
+            }
+          },
+          set: newValue => {
+            Object.defineProperty(window, property, {
+              configurable: true,
+              enumerable: true,
+              value: newValue,
+              writable: true
+            });
+            if (!p5.disableFriendlyErrors) {
+              console.log(`You just changed the value of "${property}", which was a p5 global value. This could cause problems later if you're not careful.`);
+            }
           }
-        }
-      });
+        });
+      }
     };
     // If the user has created a global setup or draw function,
     // assume "global" mode and make everything global (i.e. on the window)

--- a/src/core/main.js
+++ b/src/core/main.js
@@ -80,6 +80,19 @@ class p5 {
     const bindGlobal = property => {
       if (property === 'constructor') return;
 
+      // Common setter for all property types
+      const createSetter = () => newValue => {
+        Object.defineProperty(window, property, {
+          configurable: true,
+          enumerable: true,
+          value: newValue,
+          writable: true
+        });
+        if (!p5.disableFriendlyErrors) {
+          console.log(`You just changed the value of "${property}", which was a p5 global value. This could cause problems later if you're not careful.`);
+        }
+      };
+
       // Check if this property has a getter on the instance or prototype
       const instanceDescriptor = Object.getOwnPropertyDescriptor(this, property);
       const prototypeDescriptor = Object.getOwnPropertyDescriptor(p5.prototype, property);
@@ -113,17 +126,7 @@ class p5 {
           get() {
             return boundFunction;
           },
-          set(newValue) {
-            Object.defineProperty(window, property, {
-              configurable: true,
-              enumerable: true,
-              value: newValue,
-              writable: true
-            });
-            if (!p5.disableFriendlyErrors) {
-              console.log(`You just changed the value of "${property}", which was a p5 function. This could cause problems later if you're not careful.`);
-            }
-          }
+          set: createSetter()
         });
       } else if (isConstant) {
         // For constants, cache the value directly
@@ -133,17 +136,7 @@ class p5 {
           get() {
             return constantValue;
           },
-          set(newValue) {
-            Object.defineProperty(window, property, {
-              configurable: true,
-              enumerable: true,
-              value: newValue,
-              writable: true
-            });
-            if (!p5.disableFriendlyErrors) {
-              console.log(`You just changed the value of "${property}", which was a p5 constant. This could cause problems later if you're not careful.`);
-            }
-          }
+          set: createSetter()
         });
       } else if (hasGetter || !isPrototypeFunction) {
         // For properties with getters or non-function properties, use lazy optimization
@@ -180,17 +173,7 @@ class p5 {
               return currentValue;
             }
           },
-          set: newValue => {
-            Object.defineProperty(window, property, {
-              configurable: true,
-              enumerable: true,
-              value: newValue,
-              writable: true
-            });
-            if (!p5.disableFriendlyErrors) {
-              console.log(`You just changed the value of "${property}", which was a p5 global value. This could cause problems later if you're not careful.`);
-            }
-          }
+          set: createSetter()
         });
       }
     };

--- a/src/math/Matrices/Matrix.js
+++ b/src/math/Matrices/Matrix.js
@@ -6,7 +6,7 @@ import { Vector } from '../p5.Vector';
 import { MatrixInterface } from './MatrixInterface';
 
 const isPerfectSquare = arr => {
-  const sqDimention = Math.sqrt(Array.from(arr).length);
+  const sqDimention = Math.sqrt(arr.length);
   if (sqDimention % 1 !== 0) {
     throw new Error('Array length must be a perfect square.');
   }
@@ -29,7 +29,7 @@ export class Matrix extends MatrixInterface {
     // This is default behavior when object
     // instantiated using createMatrix()
     if (isMatrixArray(args[0]) && isPerfectSquare(args[0])) {
-      const sqDimention = Math.sqrt(Array.from(args[0]).length);
+      const sqDimention = Math.sqrt(args[0].length);
       this.#sqDimention = sqDimention;
       this.matrix = GLMAT_ARRAY_TYPE.from(args[0]);
     } else if (typeof args[0] === 'number') {
@@ -568,7 +568,7 @@ export class Matrix extends MatrixInterface {
       _src = multMatrix.matrix;
     } else if (isMatrixArray(multMatrix) && isPerfectSquare(multMatrix)) {
       _src = multMatrix;
-    } else if (isPerfectSquare(arguments)) {
+    } else if (isPerfectSquare(Array.from(arguments))) {
       _src = Array.from(arguments);
     } else {
       return; // nothing to do.

--- a/src/math/Matrices/MatrixInterface.js
+++ b/src/math/Matrices/MatrixInterface.js
@@ -11,7 +11,8 @@ export class MatrixInterface {
     if (this.constructor === MatrixInterface) {
       throw new Error("Class is of abstract type and can't be instantiated");
     }
-    const methods = [
+    // TODO: don't check this at runtime but still at compile time
+    /*const methods = [
       'add',
       'setElement',
       'reset',
@@ -48,6 +49,6 @@ export class MatrixInterface {
       if (this[method] === undefined) {
         throw new Error(`${method}() method must be implemented`);
       }
-    });
+    });*/
   }
 }

--- a/src/math/p5.Vector.js
+++ b/src/math/p5.Vector.js
@@ -33,12 +33,12 @@ class Vector {
   // This is how it comes in with createVector()
   // This check if the first argument is a function
   constructor(...args) {
-    let values = args.map(arg => arg || 0);
+    let values = args; // .map(arg => arg || 0);
     if (typeof args[0] === 'function') {
       this.isPInst = true;
       this._fromRadians = args[0];
       this._toRadians = args[1];
-      values = args.slice(2).map(arg => arg || 0);
+      values = args.slice(2); // .map(arg => arg || 0);
     }
     let dimensions = values.length; // TODO: make default 3 if no arguments
     if (dimensions === 0) {
@@ -272,7 +272,7 @@ class Vector {
    * </div>
    */
   toString() {
-    return `[${this.values.join(', ')}]`;
+    return `[${this._values.join(', ')}]`;
   }
 
   /**
@@ -334,13 +334,13 @@ class Vector {
    */
   set(...args) {
     if (args[0] instanceof Vector) {
-      this.values = args[0].values.slice();
+      this._values = args[0].values.slice();
     } else if (Array.isArray(args[0])) {
-      this.values = args[0].map(arg => arg || 0);
+      this._values = args[0].map(arg => arg || 0);
     } else {
-      this.values = args.map(arg => arg || 0);
+      this._values = args.map(arg => arg || 0);
     }
-    this.dimensions = this.values.length;
+    this.dimensions = this._values.length;
     return this;
   }
 
@@ -374,9 +374,9 @@ class Vector {
    */
   copy() {
     if (this.isPInst) {
-      return new Vector(this._fromRadians, this._toRadians, ...this.values);
+      return new Vector(this._fromRadians, this._toRadians, ...this._values);
     } else {
-      return new Vector(...this.values);
+      return new Vector(...this._values);
     }
   }
 
@@ -521,7 +521,7 @@ class Vector {
       args = args[0];
     }
     args.forEach((value, index) => {
-      this.values[index] = (this.values[index] || 0) + (value || 0);
+      this._values[index] = (this._values[index] || 0) + (value || 0);
     });
     return this;
   }
@@ -833,15 +833,15 @@ class Vector {
   sub(...args) {
     if (args[0] instanceof Vector) {
       args[0].values.forEach((value, index) => {
-        this.values[index] -= value || 0;
+        this._values[index] -= value || 0;
       });
     } else if (Array.isArray(args[0])) {
       args[0].forEach((value, index) => {
-        this.values[index] -= value || 0;
+        this._values[index] -= value || 0;
       });
     } else {
       args.forEach((value, index) => {
-        this.values[index] -= value || 0;
+        this._values[index] -= value || 0;
       });
     }
     return this;
@@ -1044,7 +1044,7 @@ class Vector {
   mult(...args) {
     if (args.length === 1 && args[0] instanceof Vector) {
       const v = args[0];
-      const maxLen = Math.min(this.values.length, v.values.length);
+      const maxLen = Math.min(this._values.length, v.values.length);
       for (let i = 0; i < maxLen; i++) {
         if (Number.isFinite(v.values[i]) && typeof v.values[i] === 'number') {
           this._values[i] *= v.values[i];
@@ -1058,7 +1058,7 @@ class Vector {
       }
     } else if (args.length === 1 && Array.isArray(args[0])) {
       const arr = args[0];
-      const maxLen = Math.min(this.values.length, arr.length);
+      const maxLen = Math.min(this._values.length, arr.length);
       for (let i = 0; i < maxLen; i++) {
         if (Number.isFinite(arr[i]) && typeof arr[i] === 'number') {
           this._values[i] *= arr[i];


### PR DESCRIPTION
<!--
  Thank you for contributing! Please use this pull request (PR) template.


 In the description field of this PR, include "resolves #XXXX" tagging the issue you are fixing. If this PR addresses the issue but doesn't completely resolve it (ie the issue should remain open after your PR is merged), write "addresses #XXXX".-->
Resolves https://github.com/processing/p5.js/issues/8017
Resolves https://github.com/processing/p5.js/issues/8013

This implements some of the changes discussed in the above two issues.

Previously, this was the performance profile of time spent in functions:
<img width="430" height="251" alt="image" src="https://github.com/user-attachments/assets/01d8177c-7051-47c1-9719-c4e96ca90d2f" />

After these changes, it looks like this:
<img width="434" height="240" alt="image" src="https://github.com/user-attachments/assets/1f9c7e3a-9448-49a8-bf9a-1775c2f6dc0c" />

According to those, the largest problems were:
- Matrix constructors
- Vector constructors
- getters (I saw two: primarily the global binding getter, and to a lesser extent, one in p5.Vector.copy)

[On this test sketch](https://editor.p5js.org/davepagurek/sketches/uvm_o0k7-), starting with a base runtime of 420ms, here are the optimizations I made and the new runtimes afterwards:
- Remove the extra array copy from p5.Matrix constructor: 400ms
- Removes the Matrix interface method checks from the constructor: 390ms
- Caching bound functions on `p5.prototype`and constants that we make global: 315ms
- Removal of extra `get()`s in `p5.Vector` (using `.values` when `._values` is the same): 299ms
- Removal of extra `.map()`s in `p5.Vector` constructor: 292ms
- Removal of dynamic `typeof`s + caching bound functions in global non-`p5.prototype` functions: 250ms

For comparison, when using 1.11.0, the performance is 215ms. So this is still not *quite* at 1.x perf, but it's a lot closer.

## Takeaways

Dynamic getters are generally slower than property accesses! We should consider whether they're really necessary when we use them if it's something that will be accessed a lot, e.g. a constant.

Not from these particular tests, but at work we experimented in the past with using a `Proxy` to wrap p5 in order to get multiple global mode sketches to be able to run in a shared environment without them knowing, but found base performance proxying all p5 methods to be significantly worse. Rewriting the sketch code to use direct accesses gave comparable performance to regular global mode, despite the proxy methods all being pretty simple. So Proxies aren't an across-the-board replacement for dynamic getters either without measuring. In general we should just try to make as much as possible non-dynamic when it isn't necessary.