### PR TITLE
Update createCamera docs since it no longer sets the active camera

### DIFF
--- a/src/webgl/p5.Camera.js
+++ b/src/webgl/p5.Camera.js
@@ -3682,8 +3682,7 @@ function camera(p5, fn){
   };
 
   /**
-   * Creates a new <a href="#/p5.Camera">p5.Camera</a> object and sets it
-   * as the current (active) camera.
+   * Creates a new <a href="#/p5.Camera">p5.Camera</a> object.
    *
    * The new camera is initialized with a default position `(0, 0, 800)` and a
    * default perspective projection. Its properties can be controlled with


### PR DESCRIPTION
<!--
  Thank you for contributing! Please use this pull request (PR) template.


 In the description field of this PR, include "resolves #XXXX" tagging the issue you are fixing. If this PR addresses the issue but doesn't completely resolve it (ie the issue should remain open after your PR is merged), write "addresses #XXXX".-->

@quarks mentioned in this comment https://github.com/processing/p5.js/issues/8097#issuecomment-3312167746 that the 2.0 docs still state that `createCamera` sets the camera as active. This is no longer true in 2.x, so this PR removes that line.


#### PR Checklist
<!--
  To check any option, replace the "[ ]" with a "[x]". Be sure to check out how it looks in the Preview tab! Feel free to remove any portion of the template that is not relevant for your issue.
-->

- [x] `npm run lint` passes
- [x] [Inline reference] is included / updated
- [ ] [Unit tests] are included / updated

[Inline reference]: https://p5js.org/contribute/contributing_to_the_p5js_reference/
[Unit tests]: https://github.com/processing/p5.js/tree/main/contributor_docs#unit-tests
