### PR TITLE
Feature/8097 get camera function

### DIFF
--- a/src/webgl/p5.Camera.js
+++ b/src/webgl/p5.Camera.js
@@ -3980,14 +3980,36 @@ function camera(p5, fn){
     return _cam;
   };
 
-  RendererGL.prototype.setCamera = function(cam) {
+  /**
+   * Sets the active camera.
+   * @method activeCamera
+   * @for p5.RendererGL
+   * @param  {p5.Camera} [cam] camera that should be made active.
+   * @chainable
+   */
+  /**
+   * Returns the active camera.
+   * @method activeCamera
+   * @for p5.RendererGL
+   * @return {p5.Camera} the active camera.
+   */
+  RendererGL.prototype.activeCamera = function(cam) {
+    if (cam === undefined) {
+      return this.states.getValue('curCamera');
+    }
     this.states.setValue('curCamera', cam);
+    return this;
+  };
+
+  RendererGL.prototype.setCamera = function(cam) {
+    this.activeCamera(cam);
 
     // set the projection matrix (which is not normally updated each frame)
     this.states.setValue('uPMatrix', this.states.uPMatrix.clone());
     this.states.uPMatrix.set(cam.projMatrix);
     this.states.setValue('uViewMatrix', this.states.uViewMatrix.clone());
     this.states.uViewMatrix.set(cam.cameraMatrix);
+    return this;
   };
 }
 


### PR DESCRIPTION
**Resolves #8097** 

**Changes:**
This pull request introduces a new joint getter/setter function, activeCamera(), to the p5.RendererGL.prototype to standardize how the active camera is accessed and modified.

1. New activeCamera() function:

- When called with no arguments (activeCamera()), it acts as a getter and returns the current camera object.
- When called with a camera object (activeCamera(myCam)), it acts as a setter for the active camera.

2. Deprecated setCamera():

- The existing setCamera() function is now deprecated.
- For backward compatibility, it continues to function by calling the new activeCamera() internally.
- These changes align with the common p5.js pattern of using joint getter/setter functions and improve the consistency of the WebGL API.

**PR Checklist**

- [ ]  npm run lint passes
- [ ] Inline reference is included / updated
- [ ] Unit tests are included / updated