### PR TITLE
Use FES internationalization within the minor version

### DIFF
--- a/src/core/internationalization.js
+++ b/src/core/internationalization.js
@@ -1,6 +1,7 @@
 import i18next from 'i18next';
 import LanguageDetector from 'i18next-browser-languagedetector';
 import { default as fallbackResources, languages } from '../../translations';
+import { VERSION } from './constants';
 
 if (typeof IS_MINIFIED === 'undefined') {
   // internationalization is only for the unminified build
@@ -147,8 +148,12 @@ export const initialize = () => {
       },
       backend: {
         fallback: 'en',
-        loadPath:
-          'https://cdn.jsdelivr.net/npm/p5/translations/{{lng}}/{{ns}}.json'
+        
+        // ensure that the FES internationalization strings are loaded
+        // from the latest patch of the current minor version of p5.js
+        loadPath: `https://cdn.jsdelivr.net/npm/p5@${
+          VERSION.replace(/^(\d+\.\d+)\.\d+.*$/, '$1')
+        }/translations/{{lng}}/{{ns}}.json`
       },
       partialBundledLanguages: true,
       resources: fallbackResources


### PR DESCRIPTION
Resolves #7813
The 2.0 branch patch matching https://github.com/processing/p5.js/pull/7878 (which has been reviewed and merged)

- [x] `npm run lint` passes
- [x] [Inline reference] is included / updated
- [ ] [Unit tests] are included / updated

[Inline reference]: https://p5js.org/contribute/contributing_to_the_p5js_reference/
[Unit tests]: https://github.com/processing/p5.js/tree/main/contributor_docs#unit-tests


```js
const version = '1.11.7';
const loadPath = 'https://cdn.jsdelivr.net/npm/p5@' + version.replace(/^(\d+\.\d+)\.\d+.*$/, '$1') + '/translations/{{lng}}/{{ns}}.json';
console.log(loadPath);
// https://cdn.jsdelivr.net/npm/p5@1.11/translations/{{lng}}/{{ns}}.json
// will become https://cdn.jsdelivr.net/npm/p5@1.11/translations/es/translation.json which exists
```
