### PR TITLE
Revise security policy and reporting guidelines

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,19 @@
+# Security Policy
+
+## Reporting a Vulnerability
+
+Please report security vulnerabilities by emailing: responsible.disclosure@processingfoundation.org
+
+## What to Expect
+- We will acknowledge your email within 72 hours
+- We will provide regular updates about our progress
+- Once the issue is confirmed and fixed, we may ask you to verify the solution
+
+## Disclosure Policy
+- Please do not disclose the vulnerability publicly until we have had a chance to address it
+- We do not offer bounties as we are a non-profit organization
+- We appreciate your efforts to responsibly disclose your findings
+
+## Scope
+
+You can use the above email to report vulnerabilities in p5.js and related repositories managed by the processing org, including the reference website.


### PR DESCRIPTION
This PR adds the security policy to the repository. (Private vulnerability reporting is also enabled)

- [ ] `npm run lint` passes
- [ ] [Inline reference] is included / updated
- [ ] [Unit tests] are included / updated

[Inline reference]: https://p5js.org/contribute/contributing_to_the_p5js_reference/
[Unit tests]: https://github.com/processing/p5.js/tree/main/contributor_docs#unit-tests
