### PR TITLE
Use correct type for event param of windowResized

### DIFF
--- a/src/core/environment.js
+++ b/src/core/environment.js
@@ -717,7 +717,7 @@ p5.prototype.windowHeight = 0;
  * can be used for debugging or other purposes.
  *
  * @method windowResized
- * @param {UIEvent} [event] optional resize Event.
+ * @param {Event} [event] optional resize Event.
  * @example
  * <div class="norender">
  * <code>


### PR DESCRIPTION
See: https://developer.mozilla.org/en-US/docs/Web/API/Window/resize_event#event_type

Using the correct type should get rid of Zod printing errors in the console when window resize events are triggered:

    Zod error object {code: "custom", message: "Expected a UIEvent", …}
    p5.js says:  in windowResized().

<!--
  Thank you for contributing! Please use this pull request (PR) template.


 In the description field of this PR, include "resolves #XXXX" tagging the issue you are fixing. If this PR addresses the issue but doesn't completely resolve it (ie the issue should remain open after your PR is merged), write "addresses #XXXX".-->
Resolves #8128

 Changes:
Put correct event type in docstring of `windowResized`


#### PR Checklist
<!--
  To check any option, replace the "[ ]" with a "[x]". Be sure to check out how it looks in the Preview tab! Feel free to remove any portion of the template that is not relevant for your issue.
-->

- [x] `npm run lint` passes
- [ ] [Inline reference] is included / updated
- [ ] [Unit tests] are included / updated

[Inline reference]: https://p5js.org/contribute/contributing_to_the_p5js_reference/
[Unit tests]: https://github.com/processing/p5.js/tree/main/contributor_docs#unit-tests
