### PR TITLE
fixed the bug of black-frames

### DIFF
--- a/src/image/loading_displaying.js
+++ b/src/image/loading_displaying.js
@@ -256,7 +256,8 @@ function loadingDisplaying(p5, fn){
       units: 'seconds',
       silent: false,
       notificationDuration: 0,
-      notificationID: 'progressBar'
+      notificationID: 'progressBar',
+      reset:true
     }
   ) {
     // validate parameters
@@ -273,7 +274,7 @@ function loadingDisplaying(p5, fn){
     const silent = (options && options.silent) || false;
     const notificationDuration = (options && options.notificationDuration) || 0;
     const notificationID = (options && options.notificationID) || 'progressBar';
-
+     const resetAnimation = (options && options.reset !== undefined) ? options.reset : true;
     // if arguments in the options object are not correct, cancel operation
     if (typeof delay !== 'number') {
       throw TypeError('Delay parameter must be a number');
@@ -324,11 +325,19 @@ function loadingDisplaying(p5, fn){
     // that duration translates to
     const nFrames = units === 'seconds' ? duration * _frameRate : duration;
     const nFramesDelay = units === 'seconds' ? delay * _frameRate : delay;
-    const totalNumberOfFrames = nFrames + nFramesDelay;
 
     // initialize variables for the frames processing
-    let frameIterator = nFramesDelay;
-    this.frameCount = frameIterator;
+ let frameIterator;
+    let totalNumberOfFrames;
+    if (resetAnimation) {
+      frameIterator = nFramesDelay;
+      this.frameCount = frameIterator;
+      totalNumberOfFrames = nFrames + nFramesDelay;
+    } else {
+      frameIterator = this.frameCount + nFramesDelay;
+      totalNumberOfFrames = frameIterator + nFrames;
+    }
+
 
     const lastPixelDensity = this._renderer._pixelDensity;
     this.pixelDensity(1);
@@ -381,7 +390,7 @@ function loadingDisplaying(p5, fn){
         to be drawn and immediately save it to a buffer and continue
       */
       this.redraw();
-
+ await new Promise(resolve => requestAnimationFrame(resolve));
       // depending on the context we'll extract the pixels one way
       // or another
       let data = undefined;


### PR DESCRIPTION
fix(saveGif): Resolve black frames and add 'reset' option

This PR addresses a long-standing bug in `saveGif()` that caused the initial frames of a generated GIF to be black. It also introduces a new feature, as suggested by the maintainer, to provide users with more control over the recording process.

---
### 🐛 The Bug

When calling `saveGif()`, the first few frames of the output GIF were often black. This was caused by a race condition:
1.  The `saveGif` function manually calls `this.redraw()` to render a single frame.
2.  Immediately after, it captures the pixels from the canvas.
3.  However, `redraw()` is asynchronous and only *schedules* a paint. The pixel capture was happening *before* the browser had a chance to complete the rendering, resulting in a capture of a blank (black) canvas.

---
### ✨ The Solution

This PR implements a two-part solution to fix the bug while preserving the function's intended design.

#### 1. Synchronized Frame Capture
The core timing bug is resolved by `await`-ing a `requestAnimationFrame` promise immediately after `this.redraw()` is called. This ensures that the `while` loop pauses until the frame is fully rendered on the canvas before capturing the pixels. This completely eliminates the black frames.

#### 2. New `reset` Option
As per the maintainer's feedback, the intentional resetting of `frameCount` is crucial for recording animations from their start. This behavior has been preserved as the default.

A new `reset` option has been added to the `options` object to give users the choice to either reset the animation or record from the current state of the sketch.

---
### 🚀 Usage

The `saveGif` function now accepts a `reset` boolean in its `options` object, which defaults to `true`.

**Default Behavior (Resetting the animation)**
This will reset `frameCount` to `0` and record the animation from the beginning.
```javascript
function keyPressed() {
  if (key === 's') {
    // Records the animation from the start for 5 seconds.
    saveGif('my-animation.gif', 5);
  }
}