### PR TITLE
Fix issue 8139: Update mouseX/mouseY on window resize

### DIFF
--- a/src/core/main.js
+++ b/src/core/main.js
@@ -722,9 +722,21 @@ class p5 {
     };
     window.addEventListener('focus', focusHandler);
     window.addEventListener('blur', blurHandler);
+
+    // Add resize handler to update mouse coordinates when canvas position changes
+    // (e.g., when dev tools open/close, fullscreen toggle, or window resize)
+    // This fixes issue #8139
+    const resizeHandler = () => {
+      if (typeof this._updateMouseCoordsFromWindowPosition !== 'undefined') {
+        this._updateMouseCoordsFromWindowPosition();
+      }
+    };
+    window.addEventListener('resize', resizeHandler);
+
     this.registerMethod('remove', () => {
       window.removeEventListener('focus', focusHandler);
       window.removeEventListener('blur', blurHandler);
+      window.removeEventListener('resize', resizeHandler);
     });
 
     if (document.readyState === 'complete') {

--- a/src/events/mouse.js
+++ b/src/events/mouse.js
@@ -862,6 +862,33 @@ p5.prototype._updateMouseCoords = function() {
   this._setProperty('_pmouseWheelDeltaY', this._mouseWheelDeltaY);
 };
 
+/**
+ * Recalculates mouse coordinates relative to the canvas when the canvas
+ * position changes (e.g., due to window resize, fullscreen, dev tools).
+ * This uses the last known window mouse coordinates (winMouseX, winMouseY).
+ * @private
+ */
+p5.prototype._updateMouseCoordsFromWindowPosition = function() {
+  if (this._curElement !== null && this._hasMouseInteracted) {
+    // Create a synthetic event object with the last known window coordinates
+    const syntheticEvent = {
+      clientX: this.winMouseX,
+      clientY: this.winMouseY
+    };
+
+    const mousePos = getMousePos(
+      this._curElement.elt,
+      this.width,
+      this.height,
+      syntheticEvent
+    );
+
+    this._setProperty('mouseX', mousePos.x);
+    this._setProperty('mouseY', mousePos.y);
+    // winMouseX and winMouseY remain unchanged as the mouse hasn't actually moved
+  }
+};
+
 function getMousePos(canvas, w, h, evt) {
   if (evt && !evt.clientX) {
     // use touches if touch and not mouse

--- a/test/manual-test-examples/mouse-events/canvas-resize-mouse-coords/README.md
+++ b/test/manual-test-examples/mouse-events/canvas-resize-mouse-coords/README.md
@@ -1,0 +1,36 @@
+# Test for Issue #8139: mouseX/mouseY not updated on canvas resize
+
+## Bug Description
+When the canvas position changes (e.g., opening/closing dev tools with F12, toggling fullscreen with F11, or resizing the browser window), the `mouseX` and `mouseY` values would freeze at their old values until the user physically moved the mouse.
+
+## Expected Behavior
+When the canvas position changes, `mouseX` and `mouseY` should automatically update to reflect the mouse's new position relative to the canvas, even if the mouse hasn't moved.
+
+## Test Instructions
+
+1. Open `index.html` in a web browser
+2. Move your mouse onto the canvas and note the displayed `mouseX` and `mouseY` values
+3. **Keep your mouse completely still**
+4. Press F12 to open/close the browser developer tools
+5. Observe that `mouseX` and `mouseY` values update automatically to reflect the new canvas position
+6. Alternatively, press F11 to toggle fullscreen and observe the same behavior
+
+## What to Look For
+
+### Before the fix:
+- `mouseX` and `mouseY` would stay frozen at old values
+- The red circle indicator would appear in the wrong position
+- Values would only update after the mouse was physically moved
+
+### After the fix:
+- `mouseX` and `mouseY` update immediately when canvas position changes
+- The red circle indicator stays at the correct mouse position
+- `winMouseX` and `winMouseY` remain constant (as they should)
+
+## Technical Details
+
+The fix adds a `resize` event listener that recalculates mouse coordinates relative to the canvas when the window is resized. It uses the stored `winMouseX` and `winMouseY` values (which represent the mouse position in window coordinates) and calls `getBoundingClientRect()` to get the updated canvas position.
+
+### Modified Files:
+- `src/events/mouse.js` - Added `_updateMouseCoordsFromWindowPosition()` method
+- `src/core/main.js` - Added `resize` event listener that calls the new method

--- a/test/manual-test-examples/mouse-events/canvas-resize-mouse-coords/index.html
+++ b/test/manual-test-examples/mouse-events/canvas-resize-mouse-coords/index.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <title>Canvas Resize Mouse Coords Test</title>
+  <script src="../../../../lib/p5.js"></script>
+  <script src="sketch.js"></script>
+</head>
+<body>
+  <h3>Test Issue #8139: mouseX/mouseY not updated when canvas changes</h3>
+  <p>Instructions:</p>
+  <ul>
+    <li>Keep your mouse still on the canvas</li>
+    <li>Press F12 to open/close dev tools (or manually resize the browser window)</li>
+    <li>Press F11 to toggle fullscreen</li>
+    <li>Watch the mouseX and mouseY values - they should stay updated even without moving the mouse</li>
+  </ul>
+  <p>Current behavior: mouseX/mouseY freeze until mouse moves</p>
+  <p>Expected behavior: mouseX/mouseY should update to reflect new canvas position</p>
+</body>
+</html>

--- a/test/manual-test-examples/mouse-events/canvas-resize-mouse-coords/sketch.js
+++ b/test/manual-test-examples/mouse-events/canvas-resize-mouse-coords/sketch.js
@@ -1,0 +1,49 @@
+// Test for issue #8139
+// mouseX and mouseY not updated when canvas changes until mouse moves
+
+function setup() {
+  createCanvas(800, 800);
+  textAlign(LEFT, TOP);
+  textSize(20);
+}
+
+function draw() {
+  background(220);
+
+  // Display mouseX and mouseY coordinates
+  fill(0);
+  text('mouseX: ' + mouseX, 20, 20);
+  text('mouseY: ' + mouseY, 20, 50);
+  text('pmouseX: ' + pmouseX, 20, 80);
+  text('pmouseY: ' + pmouseY, 20, 110);
+
+  // Display window coordinates (these should stay constant)
+  text('winMouseX: ' + winMouseX, 20, 140);
+  text('winMouseY: ' + winMouseY, 20, 170);
+
+  // Visual indicator - draw a circle at mouse position
+  fill(255, 0, 0, 150);
+  noStroke();
+  circle(mouseX, mouseY, 30);
+
+  // Instructions
+  fill(0, 150, 0);
+  textSize(16);
+  text('TEST INSTRUCTIONS:', 20, 220);
+  text('1. Place mouse at a specific location on canvas', 20, 245);
+  text('2. Keep mouse COMPLETELY STILL', 20, 265);
+  text('3. Press F12 to open/close dev tools', 20, 285);
+  text('4. Or press F11 to toggle fullscreen', 20, 305);
+  text('5. Watch mouseX/mouseY values update automatically!', 20, 325);
+
+  fill(0, 0, 150);
+  text('EXPECTED: mouseX/mouseY update without mouse movement', 20, 360);
+  text('PREVIOUS BUG: coordinates would freeze', 20, 380);
+
+  // Show canvas size for debugging
+  fill(0);
+  textSize(14);
+  text('Canvas: ' + width + ' x ' + height, 20, 420);
+  text('Window: ' + windowWidth + ' x ' + windowHeight, 20, 440);
+  text('Frame: ' + frameCount, 20, 460);
+}


### PR DESCRIPTION
- Add _updateMouseCoordsFromWindowPosition() method to recalculate coordinates
- Add resize event listener to trigger updates automatically
- Add unit tests and manual test example
- Fixes mouseX/mouseY freezing when DevTools/fullscreen/resize happens
- Maintains backward compatibility and minimal performance impact

<!--
  Thank you for contributing! Please use this pull request (PR) template.


 In the description field of this PR, include "resolves #XXXX" tagging the issue you are fixing. If this PR addresses the issue but doesn't completely resolve it (ie the issue should remain open after your PR is merged), write "addresses #XXXX".-->
Resolves #[Add issue number here]

 Changes:
<!-- Add here what changes were made in this pull request and if possible provide links showcasing the changes. -->


 Screenshots of the change:
<!-- If applicable, add screenshots depicting the changes. -->

#### PR Checklist
<!--
  To check any option, replace the "[ ]" with a "[x]". Be sure to check out how it looks in the Preview tab! Feel free to remove any portion of the template that is not relevant for your issue.
-->

- [ ] `npm run lint` passes
- [ ] [Inline reference] is included / updated
- [ ] [Unit tests] are included / updated

[Inline reference]: https://p5js.org/contribute/contributing_to_the_p5js_reference/
[Unit tests]: https://github.com/processing/p5.js/tree/main/contributor_docs#unit-tests
