### PR TITLE
Fix mouseX/mouseY not updating on canvas resize

### DIFF
--- a/src/core/environment.js
+++ b/src/core/environment.js
@@ -772,6 +772,11 @@ p5.prototype.windowHeight = 0;
 p5.prototype._onresize = function(e) {
   this._setProperty('windowWidth', getWindowWidth());
   this._setProperty('windowHeight', getWindowHeight());
+  // Update mouse coordinates when window resizes
+  // This ensures mouseX/mouseY reflect the mouse position relative to the new canvas size
+  if (this._hasMouseInteracted && this._lastMouseEvent) {
+    this._updateNextMouseCoords(this._lastMouseEvent);
+  }
   const context = this._isGlobal ? window : this;
   let executeDefault;
   if (typeof context.windowResized === 'function') {

--- a/src/events/mouse.js
+++ b/src/events/mouse.js
@@ -820,6 +820,8 @@ p5.prototype._updateNextMouseCoords = function(e) {
       e
     );
 
+    // Store the last mouse event for recalculating coordinates on resize
+    this._setProperty('_lastMouseEvent', e);
 
     this._setProperty('mouseX', mousePos.x);
     this._setProperty('mouseY', mousePos.y);


### PR DESCRIPTION
<!--
  Thank you for contributing! Please use this pull request (PR) template.


 In the description field of this PR, include "resolves #XXXX" tagging the issue you are fixing. If this PR addresses the issue but doesn't completely resolve it (ie the issue should remain open after your PR is merged), write "addresses #XXXX".-->
Resolves #8139 

 Changes:
<!-- Add here what changes were made in this pull request and if possible provide links showcasing the changes. -->
- Store last mouse event in _updateNextMouseCoords()
- Recalculate mouse coordinates in _onresize() using stored event


<!-- If applicable, add screenshots depicting the changes. -->

#### PR Checklist
<!--
  To check any option, replace the "[ ]" with a "[x]". Be sure to check out how it looks in the Preview tab! Feel free to remove any portion of the template that is not relevant for your issue.
-->

- [x] `npm run lint` passes
- [ ] [Inline reference] is included / updated
- [ ] [Unit tests] are included / updated

[Inline reference]: https://p5js.org/contribute/contributing_to_the_p5js_reference/
[Unit tests]: https://github.com/processing/p5.js/tree/main/contributor_docs#unit-tests
