### PR TITLE
fromAngle returns a 2D Vector

### DIFF
--- a/src/math/p5.Vector.js
+++ b/src/math/p5.Vector.js
@@ -3241,7 +3241,7 @@ class Vector {
    *   // Create a p5.Vector object.
    *   let v = p5.Vector.random2D();
    *
-   *   // Prints "p5.Vector Object : [x, y, 0]" to the console
+   *   // Prints "p5.Vector Object : [x, y]" to the console
    *   // where x and y are small random numbers.
    *   print(v.toString());
    * }


### PR DESCRIPTION
Addresses https://github.com/processing/p5.js/issues/8118 - this thread has much more detail, but the short version is as follows.

In 2.x, there are n-dimensional vectors, rather than 3D vectors, or 2D vectors that are underneath actually 3D with a 0 z-value. While this change is stabilizing, there are a couple of consequences.

First, the bug linked above: the `random2D()` function which uses `fromAngle()` should both be using 2D vectors, as they both are defined in 2D space. See the above thread for the whole discussion, but rather than a breaking change, this has been recognized as an unintentional bug.

Second, operations on vectors of non-matching sizes have to be handled. To make the whole topic more actionable, this is considered to be the scope of this issue: https://github.com/processing/p5.js/issues/8117