### PR TITLE
Add marioguzzzman as Spanish i18n steward

### DIFF
--- a/stewards.yml
+++ b/stewards.yml
@@ -89,3 +89,7 @@ coseeian:
 hana-cho:
   - i18n:
       - ko
+
+marioguzzzman:
+  - i18n:
+      - es


### PR DESCRIPTION
Based on discussion with @marioguzzzman who has recently provided reviews of Spanish translations for `p5.js-website`, adding as [steward](https://p5js.org/contribute/steward_guidelines/) for i18n