### PR TITLE
Fix: p5 reference error in p5.MediaElement.loadPixels (ES module context)

### DIFF
--- a/src/dom/dom.js
+++ b/src/dom/dom.js
@@ -2303,7 +2303,7 @@ if (navigator.mediaDevices.getUserMedia === undefined) {
  *
  * The first parameter, `type`, is optional. It sets the type of capture to
  * use. By default, `createCapture()` captures both audio and video. If `VIDEO`
- * is passed, as in `createCapture(VIDEO)`, only video will be captured.
+ * is passed, as in `createCapture(VIDEO)`, only video will be cshould work with tintaptured.
  * If `AUDIO` is passed, as in `createCapture(AUDIO)`, only audio will be
  * captured. A constraints object can also be passed to customize the stream.
  * See the <a href="http://w3c.github.io/mediacapture-main/getusermedia.html#media-track-constraints" target="_blank">
@@ -4955,22 +4955,23 @@ class MediaElement extends p5.Element {
       this.setModified(true);
       this._frameOnCanvas = this._pInst.frameCount;
     }
+  } loadPixels(...args) {
+    this._ensureCanvas();
+    let renderer = null;
+    // Use the current p5 instance’s renderer if available
+    if (this._pInst && this._pInst._renderer) {
+      renderer = this._pInst._renderer;
+    } else if (typeof p5 !== 'undefined' && p5.instance && p5.instance._renderer) {
+      // Fallback for global mode
+      renderer = p5.instance._renderer;
+    } if (!renderer || typeof renderer.loadPixels !== 'function') {
+      throw new Error(
+        'p5 renderer not available in MediaElement.loadPixels()'
+      );
+    }
+    // Call renderer.loadPixels() but do NOT return anything
+    renderer.loadPixels(...args);
   }
- loadPixels(...args) {
-  this._ensureCanvas();
-
-  // ✅ use the current p5 instance’s renderer instead of global p5
-  if (this._pInst && this._pInst._renderer) {
-    return this._pInst._renderer.loadPixels(...args);
-  }
-
-  // fallback for old global mode (just in case)
-  if (typeof p5 !== 'undefined' && p5.Renderer2D && p5.Renderer2D.prototype) {
-    return p5.Renderer2D.prototype.loadPixels.apply(this, args);
-  }
-
-  throw new Error('p5 instance or renderer not available in MediaElement.loadPixels()');
-}
   updatePixels(x, y, w, h) {
     if (this.loadedmetadata) {
       // wait for metadata

--- a/src/dom/dom.js
+++ b/src/dom/dom.js
@@ -4956,10 +4956,21 @@ class MediaElement extends p5.Element {
       this._frameOnCanvas = this._pInst.frameCount;
     }
   }
-  loadPixels(...args) {
-    this._ensureCanvas();
+ loadPixels(...args) {
+  this._ensureCanvas();
+
+  // ✅ use the current p5 instance’s renderer instead of global p5
+  if (this._pInst && this._pInst._renderer) {
+    return this._pInst._renderer.loadPixels(...args);
+  }
+
+  // fallback for old global mode (just in case)
+  if (typeof p5 !== 'undefined' && p5.Renderer2D && p5.Renderer2D.prototype) {
     return p5.Renderer2D.prototype.loadPixels.apply(this, args);
   }
+
+  throw new Error('p5 instance or renderer not available in MediaElement.loadPixels()');
+}
   updatePixels(x, y, w, h) {
     if (this.loadedmetadata) {
       // wait for metadata

--- a/src/dom/dom.js
+++ b/src/dom/dom.js
@@ -2303,7 +2303,7 @@ if (navigator.mediaDevices.getUserMedia === undefined) {
  *
  * The first parameter, `type`, is optional. It sets the type of capture to
  * use. By default, `createCapture()` captures both audio and video. If `VIDEO`
- * is passed, as in `createCapture(VIDEO)`, only video will be cshould work with tintaptured.
+ * is passed, as in `createCapture(VIDEO)`, only video will be captured.
  * If `AUDIO` is passed, as in `createCapture(AUDIO)`, only audio will be
  * captured. A constraints object can also be passed to customize the stream.
  * See the <a href="http://w3c.github.io/mediacapture-main/getusermedia.html#media-track-constraints" target="_blank">
@@ -4955,7 +4955,8 @@ class MediaElement extends p5.Element {
       this.setModified(true);
       this._frameOnCanvas = this._pInst.frameCount;
     }
-  }updatePixels(x, y, w, h) {
+  }
+  updatePixels(x, y, w, h) {
     if (this.loadedmetadata) {
       // wait for metadata
       this._ensureCanvas();
@@ -5474,25 +5475,18 @@ class MediaElement extends p5.Element {
 
 p5.MediaElement = MediaElement;
 // Fix for MediaElement.loadPixels renderer reference per instance
-function attachMediaElementPixelMethods(p5Inst) {
-  p5Inst.MediaElement.prototype.loadPixels = function (...args) {
-    this._ensureCanvas();
-    // Use the 2D renderer prototype method directly on the MediaElement
-    // MediaElement acts as its own 2D renderer context
-    return p5Inst.Renderer2D.prototype.loadPixels.apply(this, args);
-  };
+p5.MediaElement.prototype.loadPixels = function (...args) {
+  this._ensureCanvas();
+  // Use the 2D renderer prototype method directly on the MediaElement
+  // MediaElement acts as its own 2D renderer context
+  return p5.Renderer2D.prototype.loadPixels.apply(this, args);
+};
 
-  p5Inst.MediaElement.prototype.updatePixels = function (x, y, w, h) {
-    this._ensureCanvas();
-    // Use the 2D renderer prototype method directly on the MediaElement
-    return p5Inst.Renderer2D.prototype.updatePixels.apply(this, x, y, w, h);
-  };
-}
-
-// Attach to current instance if available
-if (typeof p5 !== 'undefined') {
-  attachMediaElementPixelMethods(p5);
-}
+p5.MediaElement.prototype.updatePixels = function (x, y, w, h) {
+  this._ensureCanvas();
+  // Use the 2D renderer prototype method directly on the MediaElement
+  return p5.Renderer2D.prototype.updatePixels.apply(this, x, y, w, h);
+};
 
 
 


### PR DESCRIPTION
Resolves #7968

Changes:
- Fixed missing p5 reference when calling loadPixels from p5.MediaElement in ES module contexts.
- Ensured compatibility with both global and modular usage.

Testing:
- Verified MediaElement.loadPixels works in both global and ES module imports.