### PR TITLE
Update radio input manual test

### DIFF
--- a/test/manual-test-examples/dom/radio_test/sketch.js
+++ b/test/manual-test-examples/dom/radio_test/sketch.js
@@ -5,13 +5,13 @@ function setup() {
   radio.id('test');
   //radio = createSelect(); // for comparison
 
-  // just mucking around
+  // The first is the value; the second is the optional label
   radio.option('apple', '1');
   radio.option('orange', '2');
   radio.option('pear');
 
   // Set what it starts as
-  radio.selected('2');
+  radio.selected('orange');
 
   radio.changed(mySelectEvent);
 }
@@ -24,7 +24,7 @@ function draw() {
 }
 
 function mySelectEvent() {
-  var selected = this.selected();
+  var selected = this.selected().value;
   console.log(this.value());
   if (selected === 'pear') {
     console.log("it's a pear!");


### PR DESCRIPTION
Fixes #8166

After reviewing the manual test behavior with @davepagurek , found that it's the manual test which is using the setter and the getter incorrectly. The getter is returning an element since 2020 https://github.com/processing/p5.js/pull/4430/files and the appearance of it returning an empty object is particular to the p5.js Editor