### PR TITLE
Add missing color module exports

### DIFF
--- a/package.json
+++ b/package.json
@@ -82,6 +82,7 @@
     "./core": {
       "default": "./dist/core/main.js"
     },
+    "./color": "./dist/color/index.js",
     "./shape": "./dist/shape/index.js",
     "./accessibility": "./dist/accessibility/index.js",
     "./friendlyErrors": "./dist/core/friendlyErrors/index.js",


### PR DESCRIPTION
Color module was not exported in current release of 2.x p5.js by mistake. This PR adds it so that it is accessible to package consumers.