### PR TITLE
Add validation for Infinity/NaN and negative value for arc

### DIFF
--- a/src/core/shape/2d_primitives.js
+++ b/src/core/shape/2d_primitives.js
@@ -316,6 +316,42 @@ p5.prototype._normalizeArcAngles = (
 p5.prototype.arc = function(x, y, w, h, start, stop, mode, detail) {
   p5._validateParameters('arc', arguments);
 
+  // Validate that numeric parameters are finite numbers
+  if (!Number.isFinite(x)) {
+    console.warn('arc(): x parameter should be a finite number. Received: ' + x);
+    return this;
+  }
+  if (!Number.isFinite(y)) {
+    console.warn('arc(): y parameter should be a finite number. Received: ' + y);
+    return this;
+  }
+  if (!Number.isFinite(w)) {
+    console.warn('arc(): w parameter should be a finite number. Received: ' + w);
+    return this;
+  }
+  if (!Number.isFinite(h)) {
+    console.warn('arc(): h parameter should be a finite number. Received: ' + h);
+    return this;
+  }
+  if (!Number.isFinite(start)) {
+    console.warn('arc(): start angle should be a finite number. Received: ' + start);
+    return this;
+  }
+  if (!Number.isFinite(stop)) {
+    console.warn('arc(): stop angle should be a finite number. Received: ' + stop);
+    return this;
+  }
+
+  // Validate that width and height are positive
+  if (w <= 0) {
+    console.warn('arc(): width (w) should be a positive number. Received: ' + w);
+    return this;
+  }
+  if (h <= 0) {
+    console.warn('arc(): height (h) should be a positive number. Received: ' + h);
+    return this;
+  }
+
   // if the current stroke and fill settings wouldn't result in something
   // visible, exit immediately
   if (!this._renderer._doStroke && !this._renderer._doFill) {
@@ -335,7 +371,7 @@ p5.prototype.arc = function(x, y, w, h, start, stop, mode, detail) {
   if (angles.correspondToSamePoint) {
     // If the arc starts and ends at (near enough) the same place, we choose to
     // draw an ellipse instead.  This is preferable to faking an ellipse (by
-    // making stop ever-so-slightly less than start + TWO_PI) because the ends
+    // making stop ever so-slightly less than start + TWO_PI) because the ends
     // join up to each other rather than at a vertex at the centre (leaving
     // an unwanted spike in the stroke/fill).
     this._renderer.ellipse([vals.x, vals.y, vals.w, vals.h, detail]);
@@ -367,7 +403,6 @@ p5.prototype.arc = function(x, y, w, h, start, stop, mode, detail) {
 
   return this;
 };
-
 /**
  * Draws an ellipse (oval).
  *

--- a/src/core/shape/2d_primitives.js
+++ b/src/core/shape/2d_primitives.js
@@ -315,41 +315,43 @@ p5.prototype._normalizeArcAngles = (
  */
 p5.prototype.arc = function(x, y, w, h, start, stop, mode, detail) {
   p5._validateParameters('arc', arguments);
+  // Skip validation when Friendly Errors are disabled
+  if (p5.disableFriendlyErrors || typeof IS_MINIFIED !== 'undefined') {
+    // Validate that numeric parameters are finite numbers
+    if (!Number.isFinite(x)) {
+      console.warn('arc(): x parameter should be a finite number. Received: ' + x);
+      return this;
+    }
+    if (!Number.isFinite(y)) {
+      console.warn('arc(): y parameter should be a finite number. Received: ' + y);
+      return this;
+    }
+    if (!Number.isFinite(w)) {
+      console.warn('arc(): w parameter should be a finite number. Received: ' + w);
+      return this;
+    }
+    if (!Number.isFinite(h)) {
+      console.warn('arc(): h parameter should be a finite number. Received: ' + h);
+      return this;
+    }
+    if (!Number.isFinite(start)) {
+      console.warn('arc(): start angle should be a finite number. Received: ' + start);
+      return this;
+    }
+    if (!Number.isFinite(stop)) {
+      console.warn('arc(): stop angle should be a finite number. Received: ' + stop);
+      return this;
+    }
 
-  // Validate that numeric parameters are finite numbers
-  if (!Number.isFinite(x)) {
-    console.warn('arc(): x parameter should be a finite number. Received: ' + x);
-    return this;
-  }
-  if (!Number.isFinite(y)) {
-    console.warn('arc(): y parameter should be a finite number. Received: ' + y);
-    return this;
-  }
-  if (!Number.isFinite(w)) {
-    console.warn('arc(): w parameter should be a finite number. Received: ' + w);
-    return this;
-  }
-  if (!Number.isFinite(h)) {
-    console.warn('arc(): h parameter should be a finite number. Received: ' + h);
-    return this;
-  }
-  if (!Number.isFinite(start)) {
-    console.warn('arc(): start angle should be a finite number. Received: ' + start);
-    return this;
-  }
-  if (!Number.isFinite(stop)) {
-    console.warn('arc(): stop angle should be a finite number. Received: ' + stop);
-    return this;
-  }
-
-  // Validate that width and height are positive
-  if (w <= 0) {
-    console.warn('arc(): width (w) should be a positive number. Received: ' + w);
-    return this;
-  }
-  if (h <= 0) {
-    console.warn('arc(): height (h) should be a positive number. Received: ' + h);
-    return this;
+    // Validate that width and height are positive
+    if (w <= 0) {
+      console.warn('arc(): width (w) should be a positive number. Received: ' + w);
+      return this;
+    }
+    if (h <= 0) {
+      console.warn('arc(): height (h) should be a positive number. Received: ' + h);
+      return this;
+    }
   }
 
   // if the current stroke and fill settings wouldn't result in something


### PR DESCRIPTION
Resolves #8198 

 Changes:
This PR adds validation for invalid numeric values in the `arc()` function to prevent silent failures and improve debugging.

### What was added:
- Added finite number validation for all numeric parameters (x, y, w, h, start, stop)
- Added positive value validation for width and height parameters
- Added helpful console warnings when invalid values are detected (Infinity, NaN, negative/zero dimensions)
- Function now returns early when invalid values are passed, preventing rendering errors

Console shows clear warnings for:
- Infinity values
- NaN values  
- Negative width/height
- Zero width/height





#### PR Checklist
<!--
  To check any option, replace the "[ ]" with a "[x]". Be sure to check out how it looks in the Preview tab! Feel free to remove any portion of the template that is not relevant for your issue.
-->

- [x] `npm run lint` passes
- [ ] [Inline reference] is included / updated
- [ ] [Unit tests] are included / updated

[Inline reference]: https://p5js.org/contribute/contributing_to_the_p5js_reference/
[Unit tests]: https://github.com/processing/p5.js/tree/main/contributor_docs#unit-tests
