### PR TITLE
Docs: fix typos and anchors

### DIFF
--- a/contributor_docs/zh-Hans/fes_reference_dev_notes.md
+++ b/contributor_docs/zh-Hans/fes_reference_dev_notes.md
@@ -6,7 +6,7 @@
 * `_friendlyFileLoadError()`
 * `_friendlyError()`
 * `helpForMisusedAtTopLevelCode()`
-* `_fesErrorMontitor()`
+* `_fesErrorMonitor()`
 
 这些函数位于 `core/friendly_errors/` 文件夹中。
 * `fes_core.js` 包含 FES 的核心功能和其他杂项功能。

--- a/contributor_docs/zh-Hans/friendly_error_system.md
+++ b/contributor_docs/zh-Hans/friendly_error_system.md
@@ -129,13 +129,13 @@ p5.js从多个位置调用FES，以处理不同的情况，包括：
 这些函数主要负责捕获错误并生成FES消息：
 * [`_friendlyFileLoadError()`] 捕获文件加载错误。
 * [`_validateParameters()`] 根据内联文档检查p5.js函数的输入参数。
-* [`_fesErrorMontitor()`] 处理全局错误。
+* [`_fesErrorMonitor()`] 处理全局错误。
 
 如需完整参考，请查阅我们的[开发笔记]。
 
 [`_friendlyFileLoadError()`]: https://github.com/processing/p5.js/blob/main/contributor_docs/fes_reference_dev_notes.md#_friendlyfileloaderror
 [`_validateParameters()`]: https://github.com/processing/p5.js/blob/main/contributor_docs/fes_reference_dev_notes.md#validateparameters
-[`_fesErrorMontitor()`]: https://github.com/processing/p5.js/blob/main/contributor_docs/fes_reference_dev_notes.md#feserrormonitor
+[`_fesErrorMonitor()`]: https://github.com/processing/p5.js/blob/main/contributor_docs/fes_reference_dev_notes.md#feserrormonitor
 [开发笔记]: https://github.com/processing/p5.js/blob/main/contributor_docs/fes_reference_dev_notes.md
 
 

--- a/contributor_docs/zh-Hans/web_accessibility.md
+++ b/contributor_docs/zh-Hans/web_accessibility.md
@@ -36,12 +36,12 @@
   * `_canvasLocator()`: 返回映射到画布的 10*10 网格上的形状的位置。
   * `_getArea()`: 返回形状的面积占画布总面积的百分比。
 
-当 `this._accessibleOutputs.text` 或 `this._accessibleOutputs.text` 为 `true` 时，p5.js 库中的多个函数会调用 output.js 中的函数：
+当 `this._accessibleOutputs.text` 或 `this._accessibleOutputs.grid` 为 `true` 时，p5.js 库中的多个函数会调用 output.js 中的函数：
 * `_accsOutput()` 在以下函数中被调用：
   * `p5.prototype.triangle()`
   * `p5.prototype._renderRect()`
   * `p5.prototype.quad()`
-  * `pp5.prototype.point()`
+  * `p5.prototype.point()`
   * `p5.prototype.line()`
   * `p5.prototype._renderEllipse()`
   * `p5.prototype.arc()`


### PR DESCRIPTION
Changes:
- contributor_docs/zh-Hans/fes_reference_dev_notes.md: fix `_fesErrorMontitor` → `_fesErrorMonitor` in the function list.
- contributor_docs/zh-Hans/friendly_error_system.md: fix `_fesErrorMontitor` → `_fesErrorMonitor` and update the reference anchor to `#feserrormonitor`.
- contributor_docs/zh-Hans/web_accessibility.md: correct condition to “this._accessibleOutputs.text or this._accessibleOutputs.grid” (was duplicated `text`), and fix `pp5.prototype.point()` → `p5.prototype.point()`.
