### PR TITLE
added error while changing setHeading() for 1D vector

### DIFF
--- a/src/math/p5.Vector.js
+++ b/src/math/p5.Vector.js
@@ -2233,6 +2233,7 @@ p5.Vector = class {
         'The vector must have x and y components to set heading, vector should be in 2D',
         'p5.Vector.setHeading'
       );
+      return this;
     }
     if (this.isPInst) a = this._toRadians(a);
     let m = this.mag();


### PR DESCRIPTION
resolves #8215

- [x] `npm run lint` passes
- [ ] [Inline reference] is included / updated
- [ ] [Unit tests] are included / updated
