### PR TITLE
Fix(vector): restrict setHeading() to 2D vectors and add friendly error for others

### DIFF
--- a/src/math/p5.Vector.js
+++ b/src/math/p5.Vector.js
@@ -2229,7 +2229,21 @@ p5.Vector = class {
 
   setHeading(a) {
     if (this.isPInst) a = this._toRadians(a);
-    let m = this.mag();
+    if (this.z !== 0) {
+      p5._friendlyError(
+        'p5.Vector.setHeading() only supports 2D vectors (z === 0). ' +
+        'For 3D or higher-dimensional vectors, use rotate() or another ' +
+        'appropriate method instead.',
+        'p5.Vector.setHeading'
+      );
+      return this;
+    }
+    const m = this.mag();
+    if (m === 0) {
+      this.x = 0;
+      this.y = 0;
+      return this;
+    }
     this.x = m * Math.cos(a);
     this.y = m * Math.sin(a);
     return this;


### PR DESCRIPTION


<!--
  Thank you for contributing! Please use this pull request (PR) template.


 In the description field of this PR, include "resolves #XXXX" tagging the issue you are fixing. If this PR addresses the issue but doesn't completely resolve it (ie the issue should remain open after your PR is merged), write "addresses #XXXX".-->
Resolves #8215

 Changes:
<!-- Add here what changes were made in this pull request and if possible provide links showcasing the changes. -->
This PR updates the p5.Vector.setHeading() method to support only 2D vectors in alignment with the proposed 2.x design.

- Added a dimension check in `setHeading()`:
- If the vector’s z component is nonzero (i.e., not 2D), the method now emits a clear `p5._friendlyError()` explaining that `setHeading()` is 2D-only in p5.js 2.x.
- For 2D vectors (`z === 0`), heading behavior remains the same, preserving magnitude and rotating in the xy-plane.
- Keeps compatibility with existing sketches that use `setHeading()` on true 2D vectors.


<!-- If applicable, add screenshots depicting the changes. -->

#### PR Checklist
<!--
  To check any option, replace the "[ ]" with a "[x]". Be sure to check out how it looks in the Preview tab! Feel free to remove any portion of the template that is not relevant for your issue.
-->

- [x] `npm run lint` passes
- [ ] [Inline reference] is included / updated
- [ ] [Unit tests] are included / updated

[Inline reference]: https://p5js.org/contribute/contributing_to_the_p5js_reference/
[Unit tests]: https://github.com/processing/p5.js/tree/main/contributor_docs#unit-tests
