### PR TITLE
Fix: prevent print() with no arguments from triggering browser print dialog

### DIFF
--- a/src/core/environment.js
+++ b/src/core/environment.js
@@ -48,7 +48,7 @@ p5.prototype._targetFrameRate = 60;
  */
 p5.prototype.print = function(...args) {
   if (!args.length) {
-    console.warn('p5.js: print() called with no arguments. Nothing to print.');
+    console.log('');
     return;
   } else {
     console.log(...args);


### PR DESCRIPTION
Resolves [processing/p5.js-web-editor#3678](https://github.com/processing/p5.js-web-editor/issues/3678)

 Changes:
<!-- Add here what changes were made in this pull request and if possible provide links showcasing the changes. -->
- Updated src/core/environment.js
- Modified p5.prototype.print to check for empty arguments before calling window.print().
- Added a console warning when print() is called without any arguments instead of triggering the browser print dialog.

 Behavior Before:
```js
print(); // opened browser print popup
print("Hello"); // logged correctly
```
Behavior After:
```js
print(); // logs a warning, no popup
print("Hello"); // logs correctly
```

#### PR Checklist
<!--
  To check any option, replace the "[ ]" with a "[x]". Be sure to check out how it looks in the Preview tab! Feel free to remove any portion of the template that is not relevant for your issue.
-->

- [x] `npm run lint` passes
- [x] [Inline reference] is included / updated
- [x] [Unit tests] are included / updated

[Inline reference]: https://p5js.org/contribute/contributing_to_the_p5js_reference/
[Unit tests]: https://github.com/processing/p5.js/tree/main/contributor_docs#unit-tests
