### PR TITLE
fix made max min with infinity

### DIFF
--- a/src/core/friendly_errors/validate_params.js
+++ b/src/core/friendly_errors/validate_params.js
@@ -342,15 +342,15 @@ if (typeof IS_MINIFIED !== 'undefined') {
    * @returns {Boolean} a boolean indicating whether input type is Number
    */
   const isNumber = param => {
-    if (isNaN(parseFloat(param))) return false;
-    switch (typeof param) {
-      case 'number':
-        return true;
-      case 'string':
-        return !isNaN(param);
-      default:
-        return false;
+    // Treat numeric Infinity values as numbers
+    if (param === Infinity || param === -Infinity) return true;
+    // Real numbers (exclude NaN)
+    if (typeof param === 'number') return !isNaN(param);
+    // Accept numeric strings (including "Infinity"/"-Infinity")
+    if (typeof param === 'string') {
+      return param.trim() !== '' && !isNaN(Number(param));
     }
+    return false;
   };
 
   /**

--- a/test/unit/math/calculation.js
+++ b/test/unit/math/calculation.js
@@ -293,6 +293,18 @@ suite('Calculation', function() {
       result = myp5.max([10, 10]);
       assert.equal(result, 10);
     });
+    test('should handle Infinity', function() {
+      result = myp5.max(3, Infinity);
+      assert.equal(result, Infinity);
+    });
+    test('should handle -Infinity', function() {
+      result = myp5.max(3, -Infinity);
+      assert.equal(result, 3);
+    });
+    test('should handle Infinity in array', function() {
+      result = myp5.max([3, Infinity, 5]);
+      assert.equal(result, Infinity);
+    });
   });
 
   suite('p5.prototype.min', function() {
@@ -324,6 +336,18 @@ suite('Calculation', function() {
     test('should return single value from array', function() {
       result = myp5.min([10, 10]);
       assert.equal(result, 10);
+    });
+    test('should handle Infinity', function() {
+      result = myp5.min(Infinity, 3);
+      assert.equal(result, 3);
+    });
+    test('should handle -Infinity', function() {
+      result = myp5.min(3, -Infinity);
+      assert.equal(result, -Infinity);
+    });
+    test('should handle -Infinity in array', function() {
+      result = myp5.min([3, -Infinity, 5]);
+      assert.equal(result, -Infinity);
     });
   });
 


### PR DESCRIPTION
I've fixed the bug where [min()]and [max()](with [Infinity] or [-Infinity]throw friendly errors in [p5.js} 2.0.4+

Changes Made

- Updated the [isNumber()] helper to properly recognize [Infinity] and [-Infinity]as valid numbers
- Now accepts both numeric [Infinity][-Infinity]and string forms like ["Infinity"]
- This prevents the FES (Friendly Error System) from incorrectly flagging them as wrong types

 Added test cases (
Added 3 tests for [max()]  and [min()]with Infinity values
These tests ensure the fix works and prevents regression