### PR TITLE
Updated point() examples for visible points.

### DIFF
--- a/src/shape/2d_primitives.js
+++ b/src/shape/2d_primitives.js
@@ -761,7 +761,7 @@ function primitives(p5, fn){
    *
    *   background(200);
    *   
-   *   // Making point to 5 pixels.
+   *   // Making point to 5 pixels
    *   strokeWeight(5);
    * 
    *   // Top-left.


### PR DESCRIPTION
<!--
  Thank you for contributing! Please use this pull request (PR) template.


 In the description field of this PR, include "resolves #8266 " tagging the issue you are fixing. If this PR addresses the issue but doesn't completely resolve it (ie the issue should remain open after your PR is merged), write "addresses #8266".-->
Resolves #8266

 Changes:
There were three examples of point() in the docs which I updated and made them visible as compared to before.


 Screenshots of the change:
before:
<img width="100" height="100" alt="image" src="https://github.com/user-attachments/assets/a7f0cc7b-45f6-4f8a-be62-ff700c09d180" />

after:
<img width="100" height="100" alt="image" src="https://github.com/user-attachments/assets/cbf9de5d-4415-4653-9b00-3843990e6667" />


#### PR Checklist
<!--
  To check any option, replace the "[ ]" with a "[x]". Be sure to check out how it looks in the Preview tab! Feel free to remove any portion of the template that is not relevant for your issue.
-->

- [x] `npm run lint` passes
- [x] [Inline reference] is included / updated
- [ ] [Unit tests] are included / updated

[Inline reference]: https://p5js.org/contribute/contributing_to_the_p5js_reference/
[Unit tests]: https://github.com/processing/p5.js/tree/main/contributor_docs#unit-tests
