### PR TITLE
feat(typography): add JUSTIFIED horizontal alignment for bounded text in 2D renderer

### DIFF
--- a/src/core/constants.js
+++ b/src/core/constants.js
@@ -1058,6 +1058,7 @@ export const WORD = 'WORD';
 export const _DEFAULT_TEXT_FILL = '#000000';
 export const _DEFAULT_LEADMULT = 1.25;
 export const _CTX_MIDDLE = 'middle';
+export const JUSTIFIED = 'justified';
 
 // VERTICES
 /**

--- a/src/core/constants.js
+++ b/src/core/constants.js
@@ -1057,12 +1057,12 @@ export const WORD = 'WORD';
  * @property {String} PRETTY
  * @final
  */
-export const PRETTY = 'pretty';
+export const PRETTY = 'PRETTY';
 /**
  * @property {String} BALANCE
  * @final
  */
-export const BALANCE = 'balance';
+export const BALANCE = 'BALANCE';
 
 // TYPOGRAPHY-INTERNAL
 export const _DEFAULT_TEXT_FILL = '#000000';

--- a/src/core/constants.js
+++ b/src/core/constants.js
@@ -1053,6 +1053,16 @@ export const CHAR = 'CHAR';
  * @final
  */
 export const WORD = 'WORD';
+/**
+ * @property {String} PRETTY
+ * @final
+ */
+export const PRETTY = 'pretty';
+/**
+ * @property {String} BALANCE
+ * @final
+ */
+export const BALANCE = 'balance';
 
 // TYPOGRAPHY-INTERNAL
 export const _DEFAULT_TEXT_FILL = '#000000';

--- a/src/core/p5.Renderer.js
+++ b/src/core/p5.Renderer.js
@@ -49,6 +49,9 @@ class Renderer extends p5.Element {
     this._textAlign = constants.LEFT;
     this._textBaseline = constants.BASELINE;
     this._textWrap = constants.WORD;
+    this._justifyActive = false;
+    this._justifyWidth = 0;
+    this._justifyIsLastLine = false;
 
     this._rectMode = constants.CORNER;
     this._ellipseMode = constants.CENTER;
@@ -351,6 +354,9 @@ class Renderer extends p5.Element {
             testLine = `${line + words[wordIndex]}` + ' ';
             testWidth = this.textWidth(testLine);
             if (testWidth > maxWidth && line.length > 0) {
+              this._justifyActive = this._textAlign === constants.JUSTIFIED;
+              this._justifyWidth = maxWidth;
+              this._justifyIsLastLine = false;
               this._renderText(
                 p,
                 line.trim(),
@@ -359,12 +365,16 @@ class Renderer extends p5.Element {
                 finalMaxHeight,
                 finalMinHeight
               );
+              this._justifyActive = false;
               line = `${words[wordIndex]}` + ' ';
               y += p.textLeading();
             } else {
               line = testLine;
             }
           }
+          this._justifyActive = this._textAlign === constants.JUSTIFIED;
+          this._justifyWidth = maxWidth;
+          this._justifyIsLastLine = true;
           this._renderText(
             p,
             line.trim(),
@@ -373,6 +383,7 @@ class Renderer extends p5.Element {
             finalMaxHeight,
             finalMinHeight
           );
+          this._justifyActive = false;
           y += p.textLeading();
         }
       } else {
@@ -446,6 +457,7 @@ class Renderer extends p5.Element {
 
       // Renders lines of text at any line breaks present in the original string
       for (let i = 0; i < lines.length; i++) {
+        this._justifyActive = false;
         this._renderText(
           p,
           lines[i],

--- a/test/manual-test-examples/type/index.html
+++ b/test/manual-test-examples/type/index.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<html>
+
+<head>
+  <meta charset="UTF-8">
+  <script language="javascript" type="text/javascript" src="../../../lib/p5.js?v=123456"></script>
+  <script language="javascript" type="text/javascript" src="sketch.js?v=123456"></script>
+  <style>
+    body {
+      padding: 0;
+      margin: 0;
+    }
+  </style>
+</head>
+
+<body>
+  <script>console.log("HTML loaded");</script>
+</body>
+
+</html>

--- a/test/manual-test-examples/type/sketch.js
+++ b/test/manual-test-examples/type/sketch.js
@@ -1,0 +1,88 @@
+function setup() {
+  console.log('Setup called');
+  createCanvas(1000, 1200);
+  background(255);
+  textSize(14);
+  textFont('sans-serif');
+
+  let alignments = [LEFT, CENTER, RIGHT];
+  let vertAlignments = [BASELINE, BOTTOM, CENTER, TOP];
+  // Using string literals as constants might not be exposed in this build environment yet
+  let wrapModes = ['pretty', 'balance'];
+  console.log('window.PRETTY:', window.PRETTY);
+  let sampleText = 'text gonna wrap when it gets too long and is then breaking.';
+
+  let xStart = 50;
+  let yStart = 50;
+  let boxWidth = 200;
+  let boxHeight = 80;
+  let xGap = 220;
+  let yGap = 100;
+
+  // Test PRETTY and BALANCE with different alignments
+  for (let w = 0; w < wrapModes.length; w++) {
+    let mode = wrapModes[w];
+    let modeName = (mode === PRETTY) ? 'PRETTY' : 'BALANCE';
+
+    fill(0);
+    noStroke();
+    text(`textWrap(${modeName})`, xStart, yStart - 20);
+
+    for (let i = 0; i < vertAlignments.length; i++) {
+      for (let j = 0; j < alignments.length; j++) {
+        let x = xStart + j * xGap;
+        let y = yStart + i * yGap;
+
+        let horiz = alignments[j];
+        let vert = vertAlignments[i];
+
+        let horizName = (horiz === LEFT) ? 'LEFT' : (horiz === CENTER) ? 'CENTER' : 'RIGHT';
+        let vertName = (vert === BASELINE) ? 'BASELINE' : (vert === BOTTOM) ? 'BOTTOM' : (vert === CENTER) ? 'CENTER' : 'TOP';
+
+        stroke(255, 0, 0);
+        noFill();
+        rect(x, y, boxWidth, boxHeight);
+
+        noStroke();
+        fill(0);
+        textAlign(horiz, vert);
+        textWrap(mode);
+        text(`${horizName} ${vertName} ${sampleText}`, x, y, boxWidth, boxHeight);
+      }
+    }
+    yStart += 500;
+  }
+
+  // Test JUSTIFIED
+  fill(0);
+  noStroke();
+  text('textAlign(JUSTIFIED)', xStart, yStart - 20);
+
+  let justifiedText = 'This is a longer text that should be justified when it wraps to multiple lines. It should look clean and aligned on both sides.';
+
+  stroke(255, 0, 0);
+  noFill();
+  rect(xStart, yStart, boxWidth, boxHeight * 2);
+
+  noStroke();
+  fill(0);
+  textAlign(JUSTIFIED, TOP);
+  textWrap(WORD);
+  text(justifiedText, xStart, yStart, boxWidth, boxHeight * 2);
+
+  stroke(255, 0, 0);
+  noFill();
+  rect(xStart + xGap, yStart, boxWidth, boxHeight * 2);
+
+  noStroke();
+  fill(0);
+  textAlign(JUSTIFIED, TOP);
+  textWrap(PRETTY);
+  text(justifiedText, xStart + xGap, yStart, boxWidth, boxHeight * 2);
+
+  fill(0);
+  noStroke();
+  textAlign(LEFT, TOP);
+  text('WORD', xStart, yStart + boxHeight * 2 + 10);
+  text('PRETTY', xStart + xGap, yStart + boxHeight * 2 + 10);
+}

--- a/test/manual-test-examples/type/sketch.js
+++ b/test/manual-test-examples/type/sketch.js
@@ -8,7 +8,7 @@ function setup() {
   let alignments = [LEFT, CENTER, RIGHT];
   let vertAlignments = [BASELINE, BOTTOM, CENTER, TOP];
   // Using string literals as constants might not be exposed in this build environment yet
-  let wrapModes = ['pretty', 'balance'];
+  let wrapModes = ['PRETTY', 'BALANCE'];
   console.log('window.PRETTY:', window.PRETTY);
   let sampleText = 'text gonna wrap when it gets too long and is then breaking.';
 

--- a/test/unit/visual/cases/typography.js
+++ b/test/unit/visual/cases/typography.js
@@ -17,4 +17,46 @@ visualSuite('Typography', function() {
       screenshot();
     });
   });
+
+  visualSuite('JUSTIFIED alignment', function() {
+    visualTest('WORD wrap justified non-final lines', function (p5, screenshot) {
+      p5.createCanvas(300, 160);
+      p5.textSize(16);
+      p5.textAlign(p5.JUSTIFIED, p5.TOP);
+      p5.textWrap(p5.WORD);
+      const s = 'This is a line of text that should justify on non-final lines.';
+      p5.text(s, 10, 10, 280, 140);
+      screenshot();
+    });
+  });
+
+  visualSuite('PRETTY/BALANCE wrap', function() {
+    visualTest('PRETTY wrap LEFT', function (p5, screenshot) {
+      p5.createCanvas(300, 160);
+      p5.textSize(16);
+      p5.textAlign(p5.LEFT, p5.TOP);
+      p5.textWrap(p5.PRETTY);
+      const s = 'Balanced wrapping aims to reduce raggedness of lines.';
+      p5.text(s, 10, 10, 280, 140);
+      screenshot();
+    });
+    visualTest('BALANCE wrap RIGHT', function (p5, screenshot) {
+      p5.createCanvas(300, 160);
+      p5.textSize(16);
+      p5.textAlign(p5.RIGHT, p5.TOP);
+      p5.textWrap(p5.BALANCE);
+      const s = 'Balanced wrapping aims to reduce raggedness of lines.';
+      p5.text(s, 290, 10, 280, 140);
+      screenshot();
+    });
+    visualTest('PRETTY wrap with JUSTIFIED', function (p5, screenshot) {
+      p5.createCanvas(300, 160);
+      p5.textSize(16);
+      p5.textAlign(p5.JUSTIFIED, p5.TOP);
+      p5.textWrap(p5.PRETTY);
+      const s = 'Pretty wrapping combined with justification for non-final lines.';
+      p5.text(s, 10, 10, 280, 140);
+      screenshot();
+    });
+  });
 });


### PR DESCRIPTION
PR 1
- Adds textAlign(JUSTIFIED) support in the 2D renderer for bounded text(...) .
- Distributes inter-word spacing to fill maxWidth on non-final lines; final line remains ragged.
- Canvas2D maps JUSTIFIED to LEFT internally; WEBGL remains left-aligned for now.
- Lint/build pass locally. Follow-up PR will add textWrap(PRETTY) and BALANCE .

Addresses #7712