### PR TITLE
Fixes 8323

### DIFF
--- a/src/core/environment.js
+++ b/src/core/environment.js
@@ -323,7 +323,7 @@ function environment(p5, fn, lifecycles){
         y = typeof y === 'number' ? y : 0;
         // Note that x and y values must be unit-less positive integers < 32
         // https://developer.mozilla.org/en-US/docs/Web/CSS/cursor
-        coords = `${Math.max(x,0)} ${Math.max(y,0)}`;
+        coords = `${Math.max(x, 0)} ${Math.max(y, 0)}`;
       }
       if (
         type.substring(0, 7) === 'http://' ||


### PR DESCRIPTION
Resolves #8323

 Changes:

Changed `(x && y && ...)` to use `typeof` checks

 Screenshots of the change:

old:
<img width="634" height="127" alt="image" src="https://github.com/user-attachments/assets/da98d05f-f125-4751-9fca-0de7ec7f4255" />

new:
<img width="625" height="146" alt="image" src="https://github.com/user-attachments/assets/c92b5866-5cd3-4bfd-9ba2-abaf226f7f11" />


