### PR TITLE
Fix setHeading behavior for non-2D p5.Vector instances

### DIFF
--- a/src/math/p5.Vector.js
+++ b/src/math/p5.Vector.js
@@ -2228,12 +2228,18 @@ p5.Vector = class {
  */
 
   setHeading(a) {
+    if (this.z !== undefined && this.z !== 0) {
+      throw new Error('setHeading() is only supported for 2D vectors.');
+    }
+
     if (this.isPInst) a = this._toRadians(a);
     let m = this.mag();
     this.x = m * Math.cos(a);
     this.y = m * Math.sin(a);
     return this;
   }
+
+
 
   /**
  * Rotates a 2D vector by an angle without changing its magnitude.

--- a/test/unit/math/p5.Vector.js
+++ b/test/unit/math/p5.Vector.js
@@ -1,3 +1,14 @@
+suite('p5.Vector.prototype.setHeading (invalid dimensions)', function () {
+  test('throws an error for vectors with non-zero z component', function () {
+    let v3 = new p5.Vector(1, 2, 3);
+
+    assert.throws(() => {
+      v3.setHeading(Math.PI / 2);
+    }, Error);
+  });
+});
+
+
 suite('p5.Vector', function() {
   var RADIANS = 'radians';
   var DEGREES = 'degrees';


### PR DESCRIPTION
Resolves #8215

Changes:
- Restrict `p5.Vector.prototype.setHeading()` to vectors with a zero or undefined z component.
- Throw an error when `setHeading()` is called on vectors with a non-zero z value.
- Added unit tests to cover invalid-dimension behavior.

Screenshots of the change:
N/A (non-visual change)

#### PR Checklist

- [x] `npm run lint` passes
- [ ] [Inline reference] is included / updated
- [x] [Unit tests] are included / updated
