### PR TITLE
Return renderer state from pop()

### DIFF
--- a/src/core/p5.Renderer.js
+++ b/src/core/p5.Renderer.js
@@ -100,6 +100,7 @@ class Renderer extends p5.Element {
     // copy the style properties back into the renderer
       Object.assign(this, style.properties);
     }
+    return style;
   }
 
   beginClip(options = {}) {


### PR DESCRIPTION
<!--
  Thank you for contributing! Please use this pull request (PR) template.


 In the description field of this PR, include "resolves #XXXX" tagging the issue you are fixing. If this PR addresses the issue but doesn't completely resolve it (ie the issue should remain open after your PR is merged), write "addresses #XXXX".-->
Addresses a renderer contract mismatch noted in code comments.

Changes:
- Updated `p5.Renderer.pop()` to return the restored renderer style after state restoration.
- Aligns implementation with comments in `p5.Renderer2D.js` that describe the expected renderer contract.
- Note: While running the test suite locally, one existing documentation test for `loadFont` (example #4) failed. This appears unrelated to the renderer change and was present prior to this modification.



 Screenshots of the change:
N/A (code-only change)


#### PR Checklist
<!--
  To check any option, replace the "[ ]" with a "[x]". Be sure to check out how it looks in the Preview tab! Feel free to remove any portion of the template that is not relevant for your issue.
-->

- [ ] `npm run lint` passes
- [ ] [Inline reference] is included / updated (not applicable)
- [ ] [Unit tests] are included / updated (not applicable)

[Inline reference]: https://p5js.org/contribute/contributing_to_the_p5js_reference/
[Unit tests]: https://github.com/processing/p5.js/tree/main/contributor_docs#unit-tests
