### PR TITLE
fix: background(image) support in WEBGL

### DIFF
--- a/src/color/setting.js
+++ b/src/color/setting.js
@@ -666,34 +666,6 @@ p5.prototype.clip = function(callback, options) {
  * @chainable
  */
 p5.prototype.background = function(...args) {
-
-  // WEBGL: support background(image)
-  if (this._renderer && this._renderer.isP3D && args.length > 0) {
-    const img = args[0];
-
-    const isImageLike =
-      img instanceof p5.Image ||
-      img instanceof p5.Graphics ||
-      (typeof HTMLImageElement !== 'undefined' && img instanceof HTMLImageElement) ||
-      (typeof HTMLVideoElement !== 'undefined' && img instanceof HTMLVideoElement) ||
-      (typeof p5.MediaElement !== 'undefined' && img instanceof p5.MediaElement);
-
-    if (isImageLike) {
-      // Clear WebGL buffers
-      this.clear();
-
-      // Draw image in screen space
-      this.push();
-      this.resetMatrix();
-      this.imageMode(this.CENTER);
-      this.image(img, 0, 0, this.width, this.height);
-      this.pop();
-
-      return this;
-    }
-  }
-
-  // Default behavior (2D + color backgrounds)
   this._renderer.background(...args);
   return this;
 };

--- a/src/webgl/p5.RendererGL.js
+++ b/src/webgl/p5.RendererGL.js
@@ -934,6 +934,30 @@ p5.RendererGL = class RendererGL extends p5.Renderer {
  * [background description]
  */
   background(...args) {
+    const a0 = args[0];
+
+    const isImageLike =
+      a0 instanceof p5.Image ||
+      a0 instanceof p5.Graphics ||
+      (typeof HTMLImageElement !== 'undefined' && a0 instanceof HTMLImageElement) ||
+      (typeof HTMLVideoElement !== 'undefined' && a0 instanceof HTMLVideoElement) ||
+      (typeof p5.MediaElement !== 'undefined' && a0 instanceof p5.MediaElement);
+
+    // WEBGL: support background(image)
+    if (args.length > 0 && isImageLike) {
+      // Clear WebGL buffers (color + depth)
+      this._pInst.clear();
+
+      // Draw background image in screen space (ignore camera)
+      this._pInst.push();
+      this._pInst.resetMatrix();
+      this._pInst.imageMode(this._pInst.CENTER);
+      this._pInst.image(a0, 0, 0, this._pInst.width, this._pInst.height);
+      this._pInst.pop();
+      return;
+    }
+
+    // Default WEBGL background(color)
     const _col = this._pInst.color(...args);
     const _r = _col.levels[0] / 255;
     const _g = _col.levels[1] / 255;


### PR DESCRIPTION
Description:

In WEBGL mode, calling background(image) was forwarded directly to the renderer and treated as a color value, which caused an error. This change intercepts image-like arguments in `p5.prototype.background`, clears the WebGL buffers, and draws the image screen-aligned using image().

A regression unit test has been added to ensure background(image) does not
throw in WEBGL mode.
<!--
  Thank you for contributing! Please use this pull request (PR) template.


 In the description field of this PR, include "resolves #XXXX" tagging the issue you are fixing. If this PR addresses the issue but doesn't completely resolve it (ie the issue should remain open after your PR is merged), write "addresses #XXXX".-->
Resolves #7917


<!-- Add here what changes were made in this pull request and if possible provide links showcasing the changes. -->



<!-- If applicable, add screenshots depicting the changes. -->

#### PR Checklist
<!--
  To check any option, replace the "[ ]" with a "[x]". Be sure to check out how it looks in the Preview tab! Feel free to remove any portion of the template that is not relevant for your issue.
-->

- [x] `npm run lint` passes
- [ ] [Inline reference] is included / updated
- [x] [Unit tests] are included / updated

[Inline reference]: https://p5js.org/contribute/contributing_to_the_p5js_reference/
[Unit tests]: https://github.com/processing/p5.js/tree/main/contributor_docs#unit-tests
