### PR TITLE
Update release action to omit WebGPU tests, add TS tests

### DIFF
--- a/.github/workflows/release-workflow-v2.yml
+++ b/.github/workflows/release-workflow-v2.yml
@@ -42,13 +42,17 @@ jobs:
         env:
           CI: true
       - name: Run test
-        run: npm test
+        run: npm test -- --project=unit-tests
         env:
           CI: true
       - name: Run build
         run: npm run build
       - name: Generate types
         run: npm run generate-types
+      - name: test TypeScript types
+        run: npm run test:types
+        env:
+          CI: true
 
       # 2. Prepare release files
       - run: mkdir release && mkdir p5 && cp -r ./lib/* p5/


### PR DESCRIPTION
Releases are currently stalling because while CI is split into multiple test runners now (the regular one, and then a currently unused new one that can run on custom runners with GPUs in the future for WebGPU) but the release action is not. This updates the release action to only run the regular unit tests, and also adds the TS type tests.