### PR TITLE
Add WebGPU built files to npm releases

### DIFF
--- a/package.json
+++ b/package.json
@@ -104,6 +104,9 @@
     "lib/p5.js",
     "lib/p5.esm.js",
     "lib/p5.esm.min.js",
+    "lib/p5.webgpu.js",
+    "lib/p5.webgpu.min.js",
+    "lib/p5.webgpu.esm.js",
     "translations/**",
     "types/**"
   ],


### PR DESCRIPTION
This adds the built WebGPU module to the exported files on NPM so that they can be accessed via CDNs.