### PR TITLE
Fix JSDoc return type for p5.Vector.cross (2.0)

### DIFF
--- a/src/math/p5.Vector.js
+++ b/src/math/p5.Vector.js
@@ -3536,7 +3536,7 @@ class Vector {
    * @static
    * @param  {p5.Vector} v1 first <a href="#/p5.Vector">p5.Vector</a>.
    * @param  {p5.Vector} v2 second <a href="#/p5.Vector">p5.Vector</a>.
-   * @return {Number}     cross product.
+   * @return {p5.Vector}     cross product.
    */
   static cross(v1, v2) {
     return v1.cross(v2);


### PR DESCRIPTION
<!--
  Thank you for contributing! Please use this pull request (PR) template.


 In the description field of this PR, include "resolves #XXXX" tagging the issue you are fixing. If this PR addresses the issue but doesn't completely resolve it (ie the issue should remain open after your PR is merged), write "addresses #XXXX".-->
Addresses #8335

 Changes:
<!-- Add here what changes were made in this pull request and if possible provide links showcasing the changes. -->
Updated the JSDoc return type for p5.Vector.cross(v1, v2) to reflect its actual runtime behavior (returns p5.Vector). This applies the same correction to the `dev-2.0` branch.



#### PR Checklist
<!--
  To check any option, replace the "[ ]" with a "[x]". Be sure to check out how it looks in the Preview tab! Feel free to remove any portion of the template that is not relevant for your issue.
-->

- [ ] `npm run lint` passes
- [x] [Inline reference] is included / updated
- [ ] [Unit tests] are included / updated

[Inline reference]: https://p5js.org/contribute/contributing_to_the_p5js_reference/
[Unit tests]: https://github.com/processing/p5.js/tree/main/contributor_docs#unit-tests
