### PR TITLE
Fix WebGPU filters in CDN builds using duck typing for nodes (closes …

### DIFF
--- a/src/strands/ir_builders.js
+++ b/src/strands/ir_builders.js
@@ -164,7 +164,7 @@ export function memberAccessNode(strandsContext, parentNode, componentNode, memb
 }
 
 export function structInstanceNode(strandsContext, structTypeInfo, identifier, dependsOn) {
-  const { cfg, dag, } = strandsContext;
+  const { cfg, dag } = strandsContext;
   if (dependsOn.length === 0) {
     for (const prop of structTypeInfo.properties) {
       const typeInfo = prop.dataType;
@@ -202,7 +202,7 @@ function mapPrimitiveDepsToIDs(strandsContext, typeInfo, dependsOn) {
   let calculatedDimensions = 0;
   let originalNodeID = null;
   for (const dep of inputs.flat(Infinity)) {
-    if (dep instanceof StrandsNode) {
+    if (dep && dep.isStrandsNode) {
       const node = DAG.getNodeDataFromID(dag, dep.id);
       originalNodeID = dep.id;
       baseType = node.baseType;

--- a/src/strands/strands_node.js
+++ b/src/strands/strands_node.js
@@ -7,6 +7,7 @@ export class StrandsNode {
     this.id = id;
     this.strandsContext = strandsContext;
     this.dimension = dimension;
+    this.isStrandsNode = true;
 
     // Store original identifier for varying variables
     const dag = this.strandsContext.dag;


### PR DESCRIPTION
Resolves #8344 
This Resolves the issue of filter not working with WEBGPU with CDN.
Problem - the instanceof in StrandsNode is not working properly with p5.webgpu.js.
fix - introduced duck typing with isStrandsNode property.

Tested locally with built lib/p5.js + lib/p5.webgpu.js:
- Before: filter(BLUR) has no effect + type error
- After: Blur applies correctly to canvas.



 Changes:
<!-- Add here what changes were made in this pull request and if possible provide links showcasing the changes. -->

before: 
<img width="700" height="400" alt="image" src="https://github.com/user-attachments/assets/dba36689-7426-4a6b-ba0f-22a7d3387d6e" />

after:
<img width="312" height="372" alt="Screenshot 2025-12-19 161303" src="https://github.com/user-attachments/assets/685088bb-a62a-4ad3-9181-a1bde7d2540c" />
getting something like this.

#### PR Checklist
<!--
  To check any option, replace the "[ ]" with a "[x]". Be sure to check out how it looks in the Preview tab! Feel free to remove any portion of the template that is not relevant for your issue.
-->

- [x] `npm run lint` passes
- [ ] [Inline reference] is included / updated
- [ ] [Unit tests] are included / updated

[Inline reference]: https://p5js.org/contribute/contributing_to_the_p5js_reference/
[Unit tests]: https://github.com/processing/p5.js/tree/main/contributor_docs#unit-tests
