### PR TITLE
Fix Camera.slerp for ortho by cloning projMatrix into uPMatrix when active

### DIFF
--- a/src/webgl/p5.Camera.js
+++ b/src/webgl/p5.Camera.js
@@ -1602,8 +1602,7 @@ class Camera {
       );
       // If the camera is active, make uPMatrix reflect changes in projMatrix.
       if (this._isActive()) {
-        this._renderer.states.setValue('uPMatrix', this._renderer.states.uPMatrix.clone());
-        this._renderer.states.uPMatrix.mat4 = this.projMatrix.mat4.slice();
+        this._renderer.states.setValue('uPMatrix', this.projMatrix.clone());
       }
     }
 


### PR DESCRIPTION
**Resolves #8295**

This PR fixes the crash that occurs when calling `Camera.slerp()` between orthographic cameras.

The solution updates `uPMatrix` using `states.setValue()`—as recommended by @davepagurek—instead of assigning directly to `mat4`, which avoids the crash while keeping the renderer state consistent.

**Change:**

* Replace direct `mat4` assignment with a `states.setValue('uPMatrix', …)` update inside `Camera.slerp()`.