### PR TITLE
fix(dom/events): ensure mouseReleased fires after DOM interactions

### DIFF
--- a/src/dom/dom.js
+++ b/src/dom/dom.js
@@ -481,9 +481,15 @@ p5.Element.prototype.input = function (fxn) {
 function addElement(elt, pInst, media) {
   const node = pInst._userNode ? pInst._userNode : document.body;
   node.appendChild(elt);
+  elt.addEventListener('mouseup', e => {
+    if (pInst && pInst.mouseIsPressed && typeof pInst._onmouseup === 'function') {
+      pInst._onmouseup(e);
+    }
+  });
   const c = media
     ? new p5.MediaElement(elt, pInst)
     : new p5.Element(elt, pInst);
+
   pInst._elements.push(c);
   return c;
 }

--- a/src/dom/dom.js
+++ b/src/dom/dom.js
@@ -481,11 +481,6 @@ p5.Element.prototype.input = function (fxn) {
 function addElement(elt, pInst, media) {
   const node = pInst._userNode ? pInst._userNode : document.body;
   node.appendChild(elt);
-  elt.addEventListener('mouseup', e => {
-    if (pInst && pInst.mouseIsPressed && typeof pInst._onmouseup === 'function') {
-      pInst._onmouseup(e);
-    }
-  });
   const c = media
     ? new p5.MediaElement(elt, pInst)
     : new p5.Element(elt, pInst);

--- a/src/events/mouse.js
+++ b/src/events/mouse.js
@@ -1073,6 +1073,11 @@ p5.prototype._onmousemove = function(e) {
   const context = this._isGlobal ? window : this;
   let executeDefault;
   this._updateNextMouseCoords(e);
+
+  if (this.mouseIsPressed && e.buttons === 0) {
+    this._onmouseup(e);
+  }
+
   if (!this.mouseIsPressed) {
     if (typeof context.mouseMoved === 'function') {
       executeDefault = context.mouseMoved(e);

--- a/test/unit/events/mouse.js
+++ b/test/unit/events/mouse.js
@@ -294,7 +294,7 @@ suite('Mouse Events', function() {
       };
 
       window.dispatchEvent(new MouseEvent('mousedown')); //dispatch a mousedown event
-      window.dispatchEvent(new MouseEvent('mousemove')); //dispatch mousemove event while mouse is down to trigger mouseDragged
+      window.dispatchEvent(new MouseEvent('mousemove', { buttons: 1 })); //dispatch mousemove event while mouse is down to trigger mouseDragged
       assert.deepEqual(count, 1);
     });
 
@@ -313,7 +313,7 @@ suite('Mouse Events', function() {
       let sketches = parallelSketches([sketchFn, sketchFn]); //create two sketches
       await sketches.setup; //wait for all sketches to setup
       window.dispatchEvent(new MouseEvent('mousedown')); //dispatch a mousedown event
-      window.dispatchEvent(new MouseEvent('mousemove')); //dispatch mousemove event while mouse is down to trigger mouseDragged
+      window.dispatchEvent(new MouseEvent('mousemove', { buttons: 1 })); //dispatch mousemove event while mouse is down to trigger mouseDragged
       sketches.end(); //resolve all sketches by calling their finish functions
       let counts = await sketches.result; //get array holding number of times mouseDragged was called. Rejected sketches also thrown here
       assert.deepEqual(counts, [1, 1]);


### PR DESCRIPTION
### Summary
Fixes an issue where interacting with p5 DOM elements (e.g. `createSelect`)
in Safari triggers `mousePressed` but not `mouseReleased`, leaving
`mouseIsPressed` stuck in a true state.

### Details
- Safari does not always propagate `mouseup` back to the canvas after DOM interactions
- This patch forwards DOM `mouseup` events to p5’s internal mouse handler
- Guarded to only trigger when `mouseIsPressed` is true
- Implemented centrally in `addElement` to cover all p5 DOM elements

Resolves #8293
