### PR TITLE
feat: add accTitle/accDescr to class diagram in WebGL architecture doc

### DIFF
--- a/contributor_docs/webgl_mode_architecture.md
+++ b/contributor_docs/webgl_mode_architecture.md
@@ -249,6 +249,11 @@ It also has the following per-vertex attributes:
 title: p5.js WebGL Classes
 ---
 classDiagram
+    accTitle: p5.js WebGL Class Diagram
+    accDescr {
+      p5.Renderer is the base class for p5.Renderer2D and p5.RendererGL.
+      p5.RendererGL has a one-to-many composition relationship with multiple p5.Shaders, p5.Textures, and p5.Framebuffers. Additionally, p5.RendererGL has a many-to-many aggregation relationship with p5.Geometry.
+    }
     class Base["p5.Renderer"] {
     }
     class P2D["p5.Renderer2D"] {


### PR DESCRIPTION
<!--
  Thank you for contributing! Please use this pull request (PR) template.


 In the description field of this PR, include "resolves #XXXX" tagging the issue you are fixing. If this PR addresses the issue but doesn't completely resolve it (ie the issue should remain open after your PR is merged), write "addresses #XXXX".-->

 Changes:
<!-- Add here what changes were made in this pull request and if possible provide links showcasing the changes. -->

Adds accessibility tags (`accTitle` and `accDescr`) to the mermaid class diagram in the WebGL architecture documentation.

In response to discussion in https://github.com/processing/p5.js-website/issues/168#issuecomment-3616076425: Mermaid.js supports embedding accessibility metadata directly into generated SVG diagrams. This improves the experience for users with screen readers and other assistive technologies by providing a concise title and detailed description of the diagram's structure.

Reference: [Mermaid.js Accessibility Documentation](https://mermaid.ai/open-source/config/accessibility.html#accessible-title-and-description)

Screenshots of the change:

<img width="1863" height="933" alt="Screenshot 2026-01-01 at 10 09 49" src="https://github.com/user-attachments/assets/b0308685-7ae6-4a2b-bae0-282259428388" />


#### PR Checklist
<!--
  To check any option, replace the "[ ]" with a "[x]". Be sure to check out how it looks in the Preview tab! Feel free to remove any portion of the template that is not relevant for your issue.
-->

- [x] `npm run lint` passes
- [ ] [Inline reference] is included / updated
- [ ] [Unit tests] are included / updated

[Inline reference]: https://p5js.org/contribute/contributing_to_the_p5js_reference/
[Unit tests]: https://github.com/processing/p5.js/tree/main/contributor_docs#unit-tests
