### PR TITLE
Docs/fix broken links

### DIFF
--- a/contributor_docs/contributor_guidelines.md
+++ b/contributor_docs/contributor_guidelines.md
@@ -62,7 +62,7 @@ The majority of the activity on p5.js' GitHub repositories (repo for short) happ
 
 While an issue can be opened for a wide variety of reasons, we usually only use issues to discuss the development of p5.js source code. Topics such as debugging your own code, inviting collaborators to your project, or other unrelated topics should be discussed
 
-either on the [forum](https://discourse.processing.org/c/p5js) or on other platforms such as [Discord](https://discord.com/invite/SHQ8dH25r9).
+either on the [forum](https://discourse.processing.org) or on other platforms such as [Discord](https://discord.com/invite/SHQ8dH25r9).
 
 We have created easy-to-use issue templates to aid you in deciding whether a topic should be a GitHub issue or posted elsewhere!
 


### PR DESCRIPTION
Resolves #8398

 Changes:
 fix broken p5js forum and discord link in p5.js/contributor_docs/contributor_guidelines.md
Page: https://p5js.org/contribute/contributor_guidelines/

- Forum: https://discourse.processing.com/ replaced with https://discourse.processing.org/c/p5js
- Discord: https://discord.gg/SHQ8dH25r9 replaced with https://discord.com/invite/SHQ8dH25r9

#### PR Checklist

- [ ] `npm run lint` passes
- [ ] [Inline reference] is included / updated
- [ ] [Unit tests] are included / updated

This PR only updates contributor documentation links, so linting, inline reference updates, and unit tests are not applicable.

[Inline reference]: https://p5js.org/contribute/contributing_to_the_p5js_reference/
[Unit tests]: https://github.com/processing/p5.js/tree/main/contributor_docs#unit-tests
