### PR TITLE
Fix noiseDetail docs to mark falloff as optional

### DIFF
--- a/src/math/noise.js
+++ b/src/math/noise.js
@@ -348,7 +348,7 @@ p5.prototype.noise = function(x, y = 0, z = 0) {
  *
  * @method noiseDetail
  * @param {Number} lod number of octaves to be used by the noise.
- * @param {Number} falloff falloff factor for each octave.
+ * @param {Number} [falloff=0.5] falloff factor for each octave.
  *
  * @example
  * <div>


### PR DESCRIPTION
<!--
  Thank you for contributing! Please use this pull request (PR) template.


 In the description field of this PR, include "resolves #XXXX" tagging the issue you are fixing. If this PR addresses the issue but doesn't completely resolve it (ie the issue should remain open after your PR is merged), write "addresses #XXXX".-->
Resolves #8402

 Changes:
- Updated the `@param` documentation for `noiseDetail()` to mark the `falloff` argument as optional.
- This aligns the reference docs with the actual behavior and Friendly Error System (calling `noiseDetail(1)` is valid and should not warn).



 Screenshots of the change:
Not applicable (documentation-only change).


#### PR Checklist
<!--
  To check any option, replace the "[ ]" with a "[x]". Be sure to check out how it looks in the Preview tab! Feel free to remove any portion of the template that is not relevant for your issue.
-->

- [ ] `npm run lint` passes
- [x] [Inline reference] is included / updated
- [ ] [Unit tests] are included / updated

[Inline reference]: https://p5js.org/contribute/contributing_to_the_p5js_reference/
[Unit tests]: https://github.com/processing/p5.js/tree/main/contributor_docs#unit-tests
