### PR TITLE
Suppress stroke warnings during buildGeometry

### DIFF
--- a/src/webgl/3d_primitives.js
+++ b/src/webgl/3d_primitives.js
@@ -993,7 +993,7 @@ p5.prototype.plane = function(
     planeGeom.computeFaces().computeNormals();
     if (detailX <= 1 && detailY <= 1) {
       planeGeom._makeTriangleEdges()._edgesToVertices();
-    } else if (this._renderer._doStroke) {
+    } else if (this._renderer._doStroke && !this._renderer.geometryBuilder) {
       console.log(
         'Cannot draw stroke on plane objects with more' +
         ' than 1 detailX or 1 detailY'
@@ -1208,7 +1208,7 @@ p5.prototype.box = function(width, height, depth, detailX, detailY) {
     boxGeom.computeNormals();
     if (detailX <= 4 && detailY <= 4) {
       boxGeom._edgesToVertices();
-    } else if (this._renderer._doStroke) {
+    } else if (this._renderer._doStroke && !this._renderer.geometryBuilder) {
       console.log(
         'Cannot draw stroke on box objects with more' +
         ' than 4 detailX or 4 detailY'
@@ -1713,7 +1713,7 @@ p5.prototype.cylinder = function(
     // normals are computed in call to _truncatedCone
     if (detailX <= 24 && detailY <= 16) {
       cylinderGeom._makeTriangleEdges()._edgesToVertices();
-    } else if (this._renderer._doStroke) {
+    } else if (this._renderer._doStroke && !this._renderer.geometryBuilder) {
       console.log(
         'Cannot draw stroke on cylinder objects with more' +
         ' than 24 detailX or 16 detailY'
@@ -1948,7 +1948,7 @@ p5.prototype.cone = function(
     _truncatedCone.call(coneGeom, 1, 0, 1, detailX, detailY, cap, false);
     if (detailX <= 24 && detailY <= 16) {
       coneGeom._makeTriangleEdges()._edgesToVertices();
-    } else if (this._renderer._doStroke) {
+    } else if (this._renderer._doStroke && !this._renderer.geometryBuilder) {
       console.log(
         'Cannot draw stroke on cone objects with more' +
         ' than 24 detailX or 16 detailY'
@@ -2166,7 +2166,7 @@ p5.prototype.ellipsoid = function(
     ellipsoidGeom.computeFaces();
     if (detailX <= 24 && detailY <= 24) {
       ellipsoidGeom._makeTriangleEdges()._edgesToVertices();
-    } else if (this._renderer._doStroke) {
+    } else if (this._renderer._doStroke && !this._renderer.geometryBuilder) {
       console.log(
         'Cannot draw stroke on ellipsoids with more' +
         ' than 24 detailX or 24 detailY'
@@ -2388,7 +2388,7 @@ p5.prototype.torus = function(radius, tubeRadius, detailX, detailY) {
     torusGeom.computeFaces();
     if (detailX <= 24 && detailY <= 16) {
       torusGeom._makeTriangleEdges()._edgesToVertices();
-    } else if (this._renderer._doStroke) {
+    } else if (this._renderer._doStroke && !this._renderer.geometryBuilder) {
       console.log(
         'Cannot draw strokes on torus object with more' +
         ' than 24 detailX or 16 detailY'


### PR DESCRIPTION
Addresses #8387 

Changes:
Suppresses high-detail stroke warnings while geometry is being constructed via `buildGeometry()` / `beginGeometry()`.
During geometry construction, p5.js cannot yet know whether the resulting geometry will be rendered with strokes, so emitting warnings at that stage can be misleading. The warning behavior during normal drawing remains unchanged.

#### PR Checklist

- [x] `npm run lint` passes
- [ ] [Inline reference] is included / updated
- [ ] [Unit tests] are included / updated