### PR TITLE
Fix p5.strands parsing of named function callbacks

### DIFF
--- a/src/strands/strands_transpiler.js
+++ b/src/strands/strands_transpiler.js
@@ -1197,7 +1197,7 @@ const ASTCallbacks = {
     recursive(ast, { varyings: {}, inControlFlow: 0 }, postOrderControlFlowTransform);
     const transpiledSource = escodegen.generate(ast);
     const scopeKeys = Object.keys(scope);
-    const match = /\(?\s*(?:function)?\s*\(([^)]*)\)\s*(?:=>)?\s*{((?:.|\n)*)}\s*;?\s*\)?/
+    const match = /\(?\s*(?:function)?\s*\w*\s*\(([^)]*)\)\s*(?:=>)?\s*{((?:.|\n)*)}\s*;?\s*\)?/
       .exec(transpiledSource);
     if (!match) {
       console.log(transpiledSource);

--- a/test/unit/webgl/p5.Shader.js
+++ b/test/unit/webgl/p5.Shader.js
@@ -408,6 +408,26 @@ suite('p5.Shader', function() {
     });
   });
   suite('p5.strands', () => {
+    test('handles named function callbacks', () => {
+      myp5.createCanvas(5, 5, myp5.WEBGL);
+      function myMaterial() {
+        myp5.getPixelInputs(inputs => {
+          inputs.color = [
+            1,
+            0,
+            0,
+            1
+          ];
+          return inputs;
+        });
+      }
+      const myShader = myp5.baseMaterialShader().modify(myMaterial, { myp5 });
+      expect(() => {
+        myp5.shader(myShader);
+        myp5.plane(myp5.width, myp5.height);
+      }).not.toThrowError();
+    });
+
     test('does not break when arrays are in uniform callbacks', () => {
       myp5.createCanvas(5, 5, myp5.WEBGL);
       const myShader = myp5.baseMaterialShader().modify(() => {


### PR DESCRIPTION



Resolves https://github.com/processing/p5.js/issues/8413

Changes:
- Updates regex parsing transpiler output to handle named functions
- Adds a unit test with named function usage so we don't have more regressions for this code style, which is becoming the one we use in the docs


#### PR Checklist
<!--
  To check any option, replace the "[ ]" with a "[x]". Be sure to check out how it looks in the Preview tab! Feel free to remove any portion of the template that is not relevant for your issue.
-->

- [x] `npm run lint` passes
- [ ] [Inline reference] is included / updated
- [x] [Unit tests] are included / updated

[Inline reference]: https://p5js.org/contribute/contributing_to_the_p5js_reference/
[Unit tests]: https://github.com/processing/p5.js/tree/main/contributor_docs#unit-tests
