### PR TITLE
Fix preload functions hanging when assets fail without error callback

### DIFF
--- a/src/image/loading_displaying.js
+++ b/src/image/loading_displaying.js
@@ -143,10 +143,10 @@ p5.prototype.loadImage = function(path, successCallback, failureCallback) {
           e => {
             if (typeof failureCallback === 'function') {
               failureCallback(e);
-              self._decrementPreload();
             } else {
               console.error(e);
             }
+            self._decrementPreload();
           }
         );
       } else {
@@ -170,10 +170,10 @@ p5.prototype.loadImage = function(path, successCallback, failureCallback) {
           p5._friendlyFileLoadError(0, img.src);
           if (typeof failureCallback === 'function') {
             failureCallback(e);
-            self._decrementPreload();
           } else {
             console.error(e);
           }
+          self._decrementPreload();
         };
 
         // Set crossOrigin in case image is served with CORS headers.
@@ -193,10 +193,10 @@ p5.prototype.loadImage = function(path, successCallback, failureCallback) {
       p5._friendlyFileLoadError(0, path);
       if (typeof failureCallback === 'function') {
         failureCallback(e);
-        self._decrementPreload();
       } else {
         console.error(e);
       }
+      self._decrementPreload();
     });
   return pImg;
 };

--- a/src/io/files.js
+++ b/src/io/files.js
@@ -298,8 +298,9 @@ p5.prototype.loadJSON = function(...args) {
       if (errorCallback) {
         errorCallback(err);
       } else {
-        throw err;
+        console.error(err);
       }
+      self._decrementPreload();
     }
   );
 
@@ -494,8 +495,9 @@ p5.prototype.loadStrings = function(...args) {
       if (errorCallback) {
         errorCallback(err);
       } else {
-        throw err;
+        console.error(err);
       }
+      self._decrementPreload();
     }
   );
 
@@ -757,6 +759,7 @@ p5.prototype.loadTable = function(path) {
       } else {
         console.error(err);
       }
+      self._decrementPreload();
     }
   );
 
@@ -975,8 +978,9 @@ p5.prototype.loadXML = function(...args) {
       if (errorCallback) {
         errorCallback(err);
       } else {
-        throw err;
+        console.error(err);
       }
+      self._decrementPreload();
     }
   );
 
@@ -1033,8 +1037,9 @@ p5.prototype.loadBytes = function(file, callback, errorCallback) {
       if (errorCallback) {
         errorCallback(err);
       } else {
-        throw err;
+        console.error(err);
       }
+      self._decrementPreload();
     }
   );
   return ret;

--- a/src/typography/loading_displaying.js
+++ b/src/typography/loading_displaying.js
@@ -135,9 +135,11 @@ p5.prototype.loadFont = function(path, onSuccess, onError) {
     if (err) {
       p5._friendlyFileLoadError(4, path);
       if (typeof onError !== 'undefined') {
-        return onError(err);
+        onError(err);
+      } else {
+        console.error(err, path);
       }
-      console.error(err, path);
+      self._decrementPreload();
       return;
     }
 

--- a/src/webgl/loading.js
+++ b/src/webgl/loading.js
@@ -498,6 +498,7 @@ p5.prototype.loadModel = function(path,options) {
         'Sorry, the file type is invalid. Only OBJ and STL files are supported.'
       );
     }
+    self._decrementPreload();
   }
   return model;
 };


### PR DESCRIPTION
Resolves #8420

 Changes:
- Ensured _decrementPreload() is always called in preload error paths, regardless of whether a user-provided error callback exists.
- Applied this fix consistently across all preload utilities so failed assets no longer block sketch execution.

Files updated:

> 1. src/image/loading_displaying.js
> 2. Fixed preload counter decrement in:
> 3. GIF arrayBuffer error handler
> 4. Non-GIF img.onerror handler
> 5. fetch().catch() handler
> 6. src/typography/loading_displaying.js
> 7. Fixed opentype.load error handler in loadFont
> 8. src/io/files.js
> 9. Fixed error handlers for:
> 10. loadJSON
> 11. loadStrings
> 12. loadTable
> 13. loadXML
> 14. loadBytes
> 15. src/webgl/loading.js
> 16. Fixed unsupported file type error path in loadModel
> 17. Behavior before:
> 18. Asset fails + no error callback → preload never completes
> 19. Sketch stuck indefinitely on “Loading…”
> 20. setup() / draw() never execute
> 21. Behavior after:
> 22. Asset fails → error is logged (or callback called)
> 23. Preload counter decrements correctly
> 24. setup() executes, allowing sketches to continue gracefully

#### PR Checklist

- [✔️] `npm run lint` passes
- [ ] [Inline reference] is included / updated
- [ ] [Unit tests] are included / updated
