### PR TITLE
Fix shuffle() TypeScript typing

### DIFF
--- a/src/utilities/array_functions.js
+++ b/src/utilities/array_functions.js
@@ -195,9 +195,10 @@ p5.prototype.shorten = function(list) {
  * making a copy.
  *
  * @method shuffle
- * @param  {Array} array array to shuffle.
- * @param  {Boolean} [bool] if `true`, shuffle the original array in place. Defaults to `false`.
- * @return {Array} shuffled array.
+ * @template T
+ * @param {T[]} arr array to shuffle.
+ * @param {Boolean} [bool] if `true`, shuffle the original array in place. Defaults to `false`.
+ * @return {T[]} shuffled array.
  *
  * @example
  * <div>


### PR DESCRIPTION
Fixes #8409
Adds a generic @template T to shuffle() so that generated TypeScript definitions preserve array element types instead of defaulting to any[ ].No runtime behavior changes.