### PR TITLE
Fix chainable p5 instance methods returning void instead of p5

### DIFF
--- a/utils/typescript.mjs
+++ b/utils/typescript.mjs
@@ -504,9 +504,13 @@ function generateMethodDeclaration(method, options = {}) {
         .join(', ');
 
       let returnType = 'void';
-      if (method.chainable && !globalFunction && options.currentClass !== 'p5') {
-        returnType = options.currentClass || 'this';
-        // TODO: Decide what should be chainable. Many of these are accidental / not thought through
+      if (method.chainable && !globalFunction) {
+        // In global mode, use P5 (the imported class type) instead of p5 (the namespace)
+        if (options.inGlobalMode && options.currentClass === 'p5') {
+          returnType = 'P5';
+        } else {
+          returnType = options.currentClass || 'this';
+        }
       } else if (overload.return && overload.return.type) {
         returnType = convertTypeToTypeScript(overload.return.type, options);
       } else if (method.return && method.return.type) {


### PR DESCRIPTION
<!--
  Thank you for contributing! Please use this pull request (PR) template.


 In the description field of this PR, include "resolves #XXXX" tagging the issue you are fixing. If this PR addresses the issue but doesn't completely resolve it (ie the issue should remain open after your PR is merged), write "addresses #XXXX".-->
Resolves #8415 

 Changes:
<!-- Add here what changes were made in this pull request and if possible provide links showcasing the changes. -->

Previously, chainable methods on the main p5 class (like background(), stroke(), fill(), translate(), etc.) were typed to return void instead of p5 in the generated TypeScript definitions. This was due to an explicit exclusion condition `options.currentClass !== 'p5'` in the type generation logic. 
                                                                                                                                                                                                                              
- Removes the exclusion so chainable methods on p5 return p5                                                          
- Adds special handling for global mode to use P5 (the imported type) instead of p5 (which is a namespace in global.d.ts)

 Screenshots of the change:
<!-- If applicable, add screenshots depicting the changes. -->

#### PR Checklist
<!--
  To check any option, replace the "[ ]" with a "[x]". Be sure to check out how it looks in the Preview tab! Feel free to remove any portion of the template that is not relevant for your issue.
-->

- [x] `npm run lint` passes
- [x] [Inline reference] is included / updated
- [x] [Unit tests] are included / updated

[Inline reference]: https://p5js.org/contribute/contributing_to_the_p5js_reference/
[Unit tests]: https://github.com/processing/p5.js/tree/main/contributor_docs#unit-tests
