### PR TITLE
Add ES6 default export for TypeScript/ES module support

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -104,3 +104,4 @@ import './webgl/text';
 import './core/init';
 
 module.exports = p5;
+export default p5;


### PR DESCRIPTION
Fixes #8370 - p5 does not work with TypeScript / module importing

Added 'export default p5' alongside the existing CommonJS export to support modern ES6 imports like 'import p5 from "p5"'

<!--
  Thank you for contributing! Please use this pull request (PR) template.


 In the description field of this PR, include "resolves #8370 " tagging the issue you are fixing. If this PR addresses the issue but doesn't completely resolve it (ie the issue should remain open after your PR is merged), write "addresses #8370 ".-->
Resolves #8370 

 Changes:
Added ES6 default export (export default p5) alongside the existing CommonJS export (module.exports = p5) in app.js to support modern ES6/TypeScript module imports.


 Screenshots of the change:
N/A - This is a module export change with no visual impact.

#### PR Checklist
<!--
  To check any option, replace the "[ ]" with a "[x]". Be sure to check out how it looks in the Preview tab! Feel free to remove any portion of the template that is not relevant for your issue.
-->

- [X] `npm run lint` passes
- [ ] [Inline reference] is included / updated
- [ ] [Unit tests] are included / updated

[Inline reference]: https://p5js.org/contribute/contributing_to_the_p5js_reference/
[Unit tests]: https://github.com/processing/p5.js/tree/main/contributor_docs#unit-tests
