### PR TITLE
fix:erase() function creates transparency instead of opaque white

### DIFF
--- a/src/core/main.js
+++ b/src/core/main.js
@@ -283,7 +283,15 @@ class p5 {
     this._userNode = node;
     this._curElement = null;
     this._elements = [];
-    this._glAttributes = null;
+    this._glAttributes = {
+      alpha: true,
+      depth: true,
+      stencil: true,
+      antialias: false,
+      premultipliedAlpha: false,
+      preserveDrawingBuffer: true,
+      perPixelLighting: true
+    };
     this._requestAnimId = 0;
     this._preloadCount = 0;
     this._loop = true;
@@ -406,7 +414,7 @@ class p5 {
       }
     };
 
-    this._runIfPreloadsAreDone = function() {
+    this._runIfPreloadsAreDone = function () {
       const context = this._isGlobal ? window : this;
       if (context._preloadCount === 0) {
         const loadingScreen = document.getElementById(context._loadingScreenId);
@@ -425,7 +433,7 @@ class p5 {
       }
     };
 
-    this._decrementPreload = function() {
+    this._decrementPreload = function () {
       const context = this._isGlobal ? window : this;
       if (!context._preloadDone && typeof context.preload === 'function') {
         context._setProperty('_preloadCount', context._preloadCount - 1);
@@ -433,7 +441,7 @@ class p5 {
       }
     };
 
-    this._wrapPreload = function(obj, fnName) {
+    this._wrapPreload = function (obj, fnName) {
       return (...args) => {
         //increment counter
         this._incrementPreload();
@@ -442,7 +450,7 @@ class p5 {
       };
     };
 
-    this._incrementPreload = function() {
+    this._incrementPreload = function () {
       const context = this._isGlobal ? window : this;
       // Do nothing if we tried to increment preloads outside of `preload`
       if (context._preloadDone) return;
@@ -596,7 +604,7 @@ class p5 {
      */
     this.remove = () => {
       // Remove start listener to prevent orphan canvas being created
-      if(this._startListener){
+      if (this._startListener) {
         window.removeEventListener('load', this._startListener, false);
       }
       const loadingScreen = document.getElementById(this._loadingScreenId);

--- a/src/webgl/material.js
+++ b/src/webgl/material.js
@@ -1189,7 +1189,7 @@ p5.prototype.shader = function (s) {
  * </code>
  * </div>
  */
-p5.prototype.baseMaterialShader = function() {
+p5.prototype.baseMaterialShader = function () {
   this._assert3d('baseMaterialShader');
   return this._renderer.baseMaterialShader();
 };
@@ -1284,7 +1284,7 @@ p5.prototype.baseMaterialShader = function() {
  * </code>
  * </div>
  */
-p5.prototype.baseNormalShader = function() {
+p5.prototype.baseNormalShader = function () {
   this._assert3d('baseNormalShader');
   return this._renderer.baseNormalShader();
 };
@@ -1347,7 +1347,7 @@ p5.prototype.baseNormalShader = function() {
  * </code>
  * </div>
  */
-p5.prototype.baseColorShader = function() {
+p5.prototype.baseColorShader = function () {
   this._assert3d('baseColorShader');
   return this._renderer.baseColorShader();
 };
@@ -1620,7 +1620,7 @@ p5.prototype.baseColorShader = function() {
  * </code>
  * </div>
  */
-p5.prototype.baseStrokeShader = function() {
+p5.prototype.baseStrokeShader = function () {
   this._assert3d('baseStrokeShader');
   return this._renderer.baseStrokeShader();
 };
@@ -3191,7 +3191,7 @@ p5.prototype.metalness = function (metallic) {
  * transparency internally, e.g. via vertex colors
  * @return {Number[]}  Normalized numbers array
  */
-p5.RendererGL.prototype._applyColorBlend = function(colors, hasTransparency) {
+p5.RendererGL.prototype._applyColorBlend = function (colors, hasTransparency) {
   const gl = this.GL;
 
   const isTexture = this.drawMode === constants.TEXTURE;
@@ -3242,8 +3242,13 @@ p5.RendererGL.prototype._applyBlendMode = function () {
       gl.blendFunc(gl.ONE, gl.ONE);
       break;
     case constants.REMOVE:
-      gl.blendEquation(gl.FUNC_ADD);
-      gl.blendFunc(gl.ZERO, gl.ONE_MINUS_SRC_ALPHA);
+      gl.blendEquationSeparate(gl.FUNC_ADD, gl.FUNC_ADD);
+      gl.blendFuncSeparate(
+        gl.ZERO,
+        gl.ONE_MINUS_SRC_ALPHA,
+        gl.ZERO,
+        gl.ONE_MINUS_SRC_ALPHA
+      );
       break;
     case constants.MULTIPLY:
       gl.blendEquation(gl.FUNC_ADD);

--- a/src/webgl/p5.RendererGL.js
+++ b/src/webgl/p5.RendererGL.js
@@ -829,7 +829,7 @@ p5.RendererGL = class RendererGL extends p5.Renderer {
     if (adjustedWidth !== width || adjustedHeight !== height) {
       console.warn(
         'Warning: The requested width/height exceeds hardware limits. ' +
-          `Adjusting dimensions to width: ${adjustedWidth}, height: ${adjustedHeight}.`
+        `Adjusting dimensions to width: ${adjustedWidth}, height: ${adjustedHeight}.`
       );
     }
 
@@ -966,7 +966,26 @@ p5.RendererGL = class RendererGL extends p5.Renderer {
     const _g = _col.levels[1] / 255;
     const _b = _col.levels[2] / 255;
     const _a = _col.levels[3] / 255;
-    this.clear(_r, _g, _b, _a);
+    this.clear(0, 0, 0, 0);
+    // This allows transparent pixels to show through
+    this._pInst.push();
+    this._pInst.resetMatrix();
+    // Disable depth testing for this specific draw operation
+    const gl = this.GL;
+    const depthTestEnabled = gl.isEnabled(gl.DEPTH_TEST);
+    gl.disable(gl.DEPTH_TEST);
+
+    // Draw background quad
+    this._pInst.translate(0, 0, -1000);
+    this._pInst.noStroke();
+    this._pInst.fill(_r * 255, _g * 255, _b * 255, _a * 255);
+    this._pInst.rectMode(this._pInst.CENTER);
+    this._pInst.rect(0, 0, this.width * 2, this.height * 2);
+
+    // Restore depth testing to its previous state
+    if (depthTestEnabled) {
+      gl.enable(gl.DEPTH_TEST);
+    }
   }
 
   //////////////////////////////////////////////
@@ -2368,8 +2387,8 @@ p5.RendererGL = class RendererGL extends p5.Renderer {
     // Enable per-vertex color for POINTS when available
     const useVertexColor =
       (this.immediateMode && this.immediateMode.geometry &&
-       this.immediateMode.geometry.vertexStrokeColors &&
-       this.immediateMode.geometry.vertexStrokeColors.length > 0);
+        this.immediateMode.geometry.vertexStrokeColors &&
+        this.immediateMode.geometry.vertexStrokeColors.length > 0);
     pointShader.setUniform('uUseVertexColor', !!useVertexColor);
   }
 


### PR DESCRIPTION
<!--
  Thank you for contributing! Please use this pull request (PR) template.


 In the description field of this PR, include "resolves #XXXX" tagging the issue you are fixing. If this PR addresses the issue but doesn't completely resolve it (ie the issue should remain open after your PR is merged), write "addresses #XXXX".-->
Resolves #5448

### Changes:
This PR fixes the `erase()` function in WEBGL mode to create true transparency instead of rendering white opaque pixels.

### Testing:
The following code now correctly shows the red background through the erased area:
```html
<script>
    function setup() {
      createCanvas(400, 400, WEBGL);
    }

    function draw() {
      background(220, 0, 0);
      fill(0, 0, 255);
      plane(200);
      erase();
      plane(100);
      noErase();
      push();
      translate(0, 0, 50);
      fill(255, 255, 0);
      plane(50);
      pop();
    }
  </script>
  
  <style>
    body {
      background-color: lime;  // To see the change
    }
  </style>
```
**Before:** White opaque square in center
**After:** Red background visible through erased area (transparent)

### Screenshots of the change
<img width="350" height="200" alt="image" src="https://github.com/user-attachments/assets/1828f32a-ee54-4392-a0fd-28bb6e2048a9" />

#### PR Checklist
<!--
  To check any option, replace the "[ ]" with a "[x]". Be sure to check out how it looks in the Preview tab! Feel free to remove any portion of the template that is not relevant for your issue.
-->

- [x] `npm run lint` passes
- [x] [Inline reference] is included / updated
- [x] [Unit tests] are included / updated

[Inline reference]: https://p5js.org/contribute/contributing_to_the_p5js_reference/
[Unit tests]: https://github.com/processing/p5.js/tree/main/contributor_docs#unit-tests
