### PR TITLE
Fix FES null number

### DIFF
--- a/src/core/friendly_errors/param_validator.js
+++ b/src/core/friendly_errors/param_validator.js
@@ -64,7 +64,7 @@ function validateParams(p5, fn, lifecycles) {
     'Boolean': z.boolean(),
     'Function': z.function(),
     'Integer': z.number().int(),
-    'Number': z.number(),
+    'Number': z.number({invalid_type_error: 'Expected Number'}).refine(val=>val!==null, {message: 'Expected Number'}), //Added Null validation
     'Object': z.object({}),
     'String': z.string()
   };


### PR DESCRIPTION
<!--
  Thank you for contributing! Please use this pull request (PR) template.


 In the description field of this PR, include "resolves #XXXX" tagging the issue you are fixing. If this PR addresses the issue but doesn't completely resolve it (ie the issue should remain open after your PR is merged), write "addresses #XXXX".-->
Resolves #8407

 Changes:
- Updated Friendly Error System (Zod-based parameter validation) to treat `null` as an invalid value for numeric parameters.
- This makes behaviour consistent across functions like noise(), lerp(), and dist(), ensuring `null` triggers a friendly validation warning instead of being coerced.

 Screenshots of the change:
-Not Applicable

#### PR Checklist
<!--
  To check any option, replace the "[ ]" with a "[x]". Be sure to check out how it looks in the Preview tab! Feel free to remove any portion of the template that is not relevant for your issue.
-->

- [ ] `npm run lint` passes
- [ ] [Inline reference] is included / updated
- [ ] [Unit tests] are included / updated

[Inline reference]: https://p5js.org/contribute/contributing_to_the_p5js_reference/
[Unit tests]: https://github.com/processing/p5.js/tree/main/contributor_docs#unit-tests
