### PR TITLE
Fix friendly error handling in color APIs to prevent runtime crashes

### DIFF
--- a/src/color/creating_reading.js
+++ b/src/color/creating_reading.js
@@ -111,8 +111,12 @@ import '../core/friendly_errors/fes_core';
  */
 p5.prototype.alpha = function(c) {
   p5._validateParameters('alpha', arguments);
-  return this.color(c)._getAlpha();
+  if (!(c instanceof p5.Color)) {
+    c = this.color(c);
+  }
+  return c._getAlpha();
 };
+
 
 /**
  * Gets the blue value of a color.
@@ -1008,11 +1012,8 @@ p5.prototype.hue = function(c) {
 p5.prototype.lerpColor = function(c1, c2, amt) {
   p5._validateParameters('lerpColor', arguments);
 
-  if (!(c1 instanceof p5.Color)) {
-    c1 = color(c1);
-  }
-  if (!(c2 instanceof p5.Color)) {
-    c2 = color(c2);
+  if (!(c1 instanceof p5.Color) || !(c2 instanceof p5.Color)) {
+    return;
   }
 
   const mode = this._colorMode;


### PR DESCRIPTION
Resolves #8458

While testing color-related APIs in p5.js 2.x, I noticed that several functions emit a Friendly Error but still throw runtime exceptions (e.g. TypeError, uncaught Error), causing sketches to crash.
<img width="711" height="150" alt="image" src="https://github.com/user-attachments/assets/cd8dbebf-175e-4035-83b4-56478c63abf0" />
<img width="492" height="187" alt="image" src="https://github.com/user-attachments/assets/aaf8672b-bcd8-4d12-acb4-9309c356cfcc" />


Friendly Errors are generally expected to report invalid input and fail gracefully without terminating execution, but this behavior was inconsistent across color APIs.

This PR improves error handling in
 color “creating & reading” functions to ensure that after a Friendly Error is logged, execution exits safely instead of throwing.