### PR TITLE
docs: update blend() constants to match blendMode()

### DIFF
--- a/src/image/p5.Image.js
+++ b/src/image/p5.Image.js
@@ -1457,14 +1457,9 @@ p5.Image = class {
    * @param  {Integer} dw destination image width.
    * @param  {Integer} dh destination image height.
    * @param  {Constant} blendMode the blend mode. either
-   *     BLEND, DARKEST, LIGHTEST, DIFFERENCE,
-   *     MULTIPLY, EXCLUSION, SCREEN, REPLACE, OVERLAY, HARD_LIGHT,
-   *     SOFT_LIGHT, DODGE, BURN, ADD or NORMAL.
-   *
-   * Available blend modes are: normal | multiply | screen | overlay |
-   *            darken | lighten | color-dodge | color-burn | hard-light |
-   *            soft-light | difference | exclusion | hue | saturation |
-   *            color | luminosity
+   *             BLEND, DARKEST, LIGHTEST, DIFFERENCE, MULTIPLY,
+   *             EXCLUSION, SCREEN, REPLACE, OVERLAY, HARD_LIGHT,
+   *             SOFT_LIGHT, DODGE, BURN, ADD, REMOVE or SUBTRACT
    *
    * http://blogs.adobe.com/webplatform/2013/01/28/blending-features-in-canvas/
    *


### PR DESCRIPTION
<!--
  Thank you for contributing! Please use this pull request (PR) template.


 In the description field of this PR, include "resolves #XXXX" tagging the issue you are fixing. If this PR addresses the issue but doesn't completely resolve it (ie the issue should remain open after your PR is merged), write "addresses #XXXX".-->
Resolves #7236 

 Changes:
I updated the documentation for blend() in p5.Image.js to ensure the listed constants match blendMode() for the 2.0 release.


 Screenshots of the change:
<!-- If applicable, add screenshots depicting the changes. -->

#### PR Checklist
<!--
  To check any option, replace the "[ ]" with a "[x]". Be sure to check out how it looks in the Preview tab! Feel free to remove any portion of the template that is not relevant for your issue.
-->

- [x ] `npm run lint` passes
- [ ] [Inline reference] is included / updated
- [ ] [Unit tests] are included / updated

[Inline reference]: https://p5js.org/contribute/contributing_to_the_p5js_reference/
[Unit tests]: https://github.com/processing/p5.js/tree/main/contributor_docs#unit-tests
