### PR TITLE
Remove deprecated, unmaintained vscode extension "npm" from recommendations (main)

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -4,7 +4,6 @@
 
   // List of extensions which should be recommended for users of this workspace.
   "recommendations": [
-    "eg2.vscode-npm-script",
     "yzhang.markdown-all-in-one",
     "dbaeumer.vscode-eslint"
   ],


### PR DESCRIPTION
Fixes #8496

Changes:

Remove from `.vscode/extensions.json` the entry recommending the deprecated, unmaintained extension eg2.vscode-npm-script.