### PR TITLE
Use --shallow in doc build to prevent documentation.js from processing GLSL imports

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
     "build": "rollup -c",
     "dev": "vite preview/",
     "dev:global": "concurrently -n build,server \"rollup -c -w\" \"npx vite preview/global/\"",
-    "docs": "documentation build ./src/**/*.js ./src/**/**/*.js -o ./docs/data.json && node ./utils/convert.mjs",
+    "docs": "documentation build ./src/**/*.js ./src/**/**/*.js --shallow -o ./docs/data.json && node ./utils/convert.mjs",
     "bench": "vitest bench",
     "bench:report": "vitest bench --reporter=verbose",
     "test": "vitest",


### PR DESCRIPTION
Resolves #8499

### Changes:

Add `--shallow` to `documentation build` in `docs` script in [package.json](./package.json)

> shallow mode turns off dependency resolution, only processing the specified files (or the main script specified in package.json)
from `documentation build --help`

This seems like a good general policy, going forward.

### Testing

1. The change reduces error reports from documentation.js from 19 to 0 during `npm run docs`.  (It's no longer trying to parse .frag and .vert files imported by some of our .js files.)

2. The produced `/docs/data.json` file is the same before and after the addition of --shallow, except that elements are in different order.  Identical once sorted.

(Why the order changed: I guess documentation.js was previously processing files in dependency-resolved order, after the first file.  With shallow, it just processes files in order that the input files are given from the command-line glob.)

3. The reference website pages also build fine, as you'd expect, though i didn't diff website content before and after.

Here's a command-line to diff two JSON files after sorting them in-memory.  Needs `jq` json tool installed.

```bash
diff <(jq -S 'walk(if type == "array" then sort else . end)' docs/data.json) \
     <(jq -S 'walk(if type == "array" then sort else . end)' other.json)
```
