### PR TITLE
Improve WebGL font error message to suggest textFont() usage

### DIFF
--- a/src/webgl/text.js
+++ b/src/webgl/text.js
@@ -685,7 +685,7 @@ function text(p5, fn) {
 
     if (!p5.Font.hasGlyphData(this.states.textFont)) {
       console.log(
-        'WEBGL: only Opentype (.otf) and Truetype (.ttf) fonts with glyph data are supported'
+        'WEBGL: only Opentype (.otf) and Truetype (.ttf) fonts with glyph data are supported. Make sure to set the font using textFont() before drawing text.'
       );
       return;
     }


### PR DESCRIPTION
Improves the error message when rendering text in WebGL mode without properly setting a font.

Problem:
The current error "only Opentype (.otf) and Truetype (.ttf) fonts are supported" is misleading when users have loaded a valid font but forgot to call textFont().

Solution:
Added clarification: "Make sure to set the font using textFont() before drawing text."
#### PR Checklist
<!--
  To check any option, replace the "[ ]" with a "[x]". Be sure to check out how it looks in the Preview tab! Feel free to remove any portion of the template that is not relevant for your issue.
-->

- [x] `npm run lint` passes
- [ ] [Inline reference] is included / updated
- [ ] [Unit tests] are included / updated

[Inline reference]: https://p5js.org/contribute/contributing_to_the_p5js_reference/
[Unit tests]: https://github.com/processing/p5.js/tree/main/contributor_docs#unit-tests
