### PR TITLE
2.0 strands docs: add simple noise() example for buildFilterShader

### DIFF
--- a/src/webgl/material.js
+++ b/src/webgl/material.js
@@ -684,7 +684,7 @@ function material(p5, fn) {
    * }
    * ```
    *
-   * We can use the `noise()` function built into strands to generate a color for each pixel.  Again we'll animate by setting an announced uniform variable - time - with `setUniform()` each frame.
+   * We can use the `noise()` function built into strands to generate a color for each pixel.  (Again no need here for underlying content for the filter to operate on.)  Again we'll animate by passing in an announced uniform variable  `time` with `setUniform()`, each frame.
    *
    * ```js example
    * let myFilter;
@@ -692,6 +692,7 @@ function material(p5, fn) {
    * function setup() {
    *   createCanvas(100, 100, WEBGL);
    *   myFilter = buildFilterShader(noiseShaderCallback);
+   *   describe('Evolving animated cloud-like noise in cyan and magenta');
    * }
    *
    * function noiseShaderCallback() {


### PR DESCRIPTION
Changes:

Adds [this example](https://editor.p5js.org/neill0/sketches/MR0jUy7Mm) to the docs for buildFilterShader showing the simplest use of the built-in noise() function to generate an animated  texture.

<img width="100" height="100" alt="image" src="https://github.com/user-attachments/assets/e262d8b5-b499-4efb-b3bb-f7fc3077b7af" />

This is correctly positioned into the progression, after the intro of:
* generating colour by coordinate, and 
* animation by time uniform

(The PR also corrects a link in the docs from baseFilterShader to buildFilterShader)

- [x] `npm run lint` passes
- [x] [Inline reference] is included / updated
- [x] `npx documentation lint src/webgl/material.js` (it doesn't complain about the _new_ code...)
