### PR TITLE
Fix directionalLight example: add missing doubleClicked handler

### DIFF
--- a/src/webgl/light.js
+++ b/src/webgl/light.js
@@ -546,6 +546,11 @@ p5.prototype.specularColor = function (v1, v2, v3) {
  *   // Draw the sphere.
  *   sphere(30);
  * }
+ *
+ * function doubleClicked() {
+ *   isLit = !isLit;
+ *   return false;
+ * }
  * </code>
  * </div>
  *


### PR DESCRIPTION
The `directionalLight()` reference example mentions double-click behavior and defines `isLit`, but does not implement a `doubleClicked()` handler.

This PR adds a minimal `doubleClicked()` function to toggle the light state so the example matches the documented behavior.

Related to processing/p5.js#8798.
