### PR TITLE
Fix typo in createCanvas() reference example

### DIFF
--- a/src/core/rendering.js
+++ b/src/core/rendering.js
@@ -100,7 +100,7 @@ const defaultClass = 'p5Canvas';
  * <div>
  * <code>
  * function setup() {
- *   // Create a p5.Render object.
+ *   // Create a p5.Renderer object.
  *   let cnv = createCanvas(50, 50);
  *
  *   // Position the canvas.


### PR DESCRIPTION
<!--
  Thank you for contributing! Please use this pull request (PR) template.


 In the description field of this PR, include "resolves #XXXX" tagging the issue you are fixing. If this PR addresses the issue but doesn't completely resolve it (ie the issue should remain open after your PR is merged), write "addresses #XXXX".-->
Resolves : https://github.com/processing/p5.js-website/issues/1167

 Changes:
<!-- Add here what changes were made in this pull request and if possible provide links showcasing the changes. -->
Fixed a typo in createCanvas documentation to correctly reference the p5.Renderer object.

 Screenshots of the change:
<!-- If applicable, add screenshots depicting the changes. -->

#### PR Checklist
<!--
  To check any option, replace the "[ ]" with a "[x]". Be sure to check out how it looks in the Preview tab! Feel free to remove any portion of the template that is not relevant for your issue.
-->

- [x] `npm run lint` passes
- [x] [Inline reference] is included / updated
- [ ] [Unit tests] are included / updated

[Inline reference]: https://p5js.org/contribute/contributing_to_the_p5js_reference/
[Unit tests]: https://github.com/processing/p5.js/tree/main/contributor_docs#unit-tests
