### PR TITLE
Refactor global node handling and add millis function

### DIFF
--- a/src/strands/strands_api.js
+++ b/src/strands/strands_api.js
@@ -79,14 +79,14 @@ function getBuiltinGlobalNode(strandsContext, name) {
   if (!spec) return null;
 
   const uniformName = `_p5_global_${name}`;
+  const instance = strandsContext.renderer?._pInst || strandsContext.p5?.instance;
 
   const node = getOrCreateUniformNode(
     strandsContext,
     uniformName,
     spec.typeInfo,
     () => {
-      const p5Instance = strandsContext.renderer?._pInst || strandsContext.p5?.instance;
-      return p5Instance ? spec.get(p5Instance) : undefined;
+      return instance ? spec.get(instance) : undefined;
     }
   );
 
@@ -321,13 +321,13 @@ export function initGlobalStrandsAPI(p5, fn, strandsContext) {
     if (!strandsContext.active) {
       return originalMillis.apply(this, args);
     }
+    const instance = strandsContext.renderer?._pInst || strandsContext.p5?.instance;
     return getOrCreateUniformNode(
       strandsContext,
       '_p5_global_millis',
       DataType.float1,
       () => {
-        const p5Instance = strandsContext.renderer?._pInst || strandsContext.p5?.instance;
-        return p5Instance ? p5Instance.millis() : undefined;
+        return instance ? instance.millis() : undefined;
       }
     );
   };


### PR DESCRIPTION
<!--
  Thank you for contributing! Please use this pull request (PR) template.


 In the description field of this PR, include "resolves #8474 " tagging the issue you are fixing. If this PR addresses the issue but doesn't completely resolve it (ie the issue should remain open after your PR is merged), write "addresses #8474 ".-->
Resolves #8474 

 Changes:

Added support for millis(),

Here's the result. 
 https://editor.p5js.org/aman12345/sketches/YPHvvipq7

In the code side we are doing nothing but 

`getOrCreateUniformNode`: This function checks if a StrandsNode for a given uniform already exists. If it exists, it returns the cached node. If it doesn’t, it registers the uniform in `strandsContext.uniforms` (only once), builds the IR variable node, wraps it using `createStrandsNode` to make a StrandsNode, stores it in the cache, and returns it.

Using the same function as an helper for `getBuiltinGlobalNode` as we do same stuffs there for global property like mouseX etc. 


#### PR Checklist
<!--
  To check any option, replace the "[ ]" with a "[x]". Be sure to check out how it looks in the Preview tab! Feel free to remove any portion of the template that is not relevant for your issue.
-->

- [ ] `npm run lint` passes
- [ ] [Inline reference] is included / updated
- [ ] [Unit tests] are included / updated

[Inline reference]: https://p5js.org/contribute/contributing_to_the_p5js_reference/
[Unit tests]: https://github.com/processing/p5.js/tree/main/contributor_docs#unit-tests
