### PR TITLE
Fix graphics size error

### DIFF
--- a/src/dom/dom.js
+++ b/src/dom/dom.js
@@ -3683,6 +3683,13 @@ p5.Element.prototype.size = function (w, h) {
   if (arguments.length === 0) {
     return { width: this.elt.offsetWidth, height: this.elt.offsetHeight };
   } else {
+    if (this instanceof p5.Graphics) {
+      p5._friendlyError(
+        'size() is not supported for p5.Graphics. Use resizeCanvas() instead.',
+        'p5.Graphics.size'
+      );
+      return this;
+    }
     let aW = w;
     let aH = h;
     const AUTO = p5.prototype.AUTO;

--- a/test/unit/core/p5.Graphics.js
+++ b/test/unit/core/p5.Graphics.js
@@ -186,7 +186,7 @@ suite('Graphics', function() {
   });
 
   suite('p5.Graphics.size()', function () {
-    test('it shows friendly error when size() is called', function () {
+    test('it shows error when size() is called', function () {
       var graph = myp5.createGraphics(100, 100);
       var consoleStub = sinon.stub(console, 'error');
       graph.size(50, 50);

--- a/test/unit/core/p5.Graphics.js
+++ b/test/unit/core/p5.Graphics.js
@@ -185,6 +185,17 @@ suite('Graphics', function() {
     });
   });
 
+  suite('p5.Graphics.size()', function () {
+    test('it shows friendly error when size() is called', function () {
+      var graph = myp5.createGraphics(100, 100);
+      var consoleStub = sinon.stub(console, 'error');
+      graph.size(50, 50);
+      assert(consoleStub.called);
+      assert.include(consoleStub.getCall(0).args[0], 'resizeCanvas()');
+      consoleStub.restore();
+    });
+  });
+
   suite('p5.Graphics.remove()', function() {
     test('it sets properties to undefined after removal', function() {
       var graph = myp5.createGraphics(10, 17);


### PR DESCRIPTION
Resolved #4956 

 Changes:
- Added instanceof check in `p5.Element.prototype.size()` to detect p5.Graphics
- Shows error directing users to `resizeCanvas()`
- Added unit test to verify the error message is shown

#### PR Checklist
- [x] `npm run lint` passes
- [ ] [Inline reference] is included / updated
- [x] [Unit tests] are included / updated

[Inline reference]: https://p5js.org/contribute/contributing_to_the_p5js_reference/
[Unit tests]: https://github.com/processing/p5.js/tree/main/contributor_docs#unit-tests
