### PR TITLE
Reset mouseIsPressed on window blur

### DIFF
--- a/src/events/keyboard.js
+++ b/src/events/keyboard.js
@@ -806,6 +806,7 @@ p5.prototype._onkeypress = function(e) {
  */
 p5.prototype._onblur = function(e) {
   this._downKeys = {};
+  this._setProperty('mouseIsPressed', false);
 };
 
 /**

--- a/test/unit/events/mouse.js
+++ b/test/unit/events/mouse.js
@@ -249,6 +249,13 @@ suite('Mouse Events', function() {
       window.dispatchEvent(new MouseEvent('mousedown'));
       assert.strictEqual(myp5.mouseIsPressed, true);
     });
+
+    test('mouseIsPressed should reset to false on blur', function() {
+      window.dispatchEvent(new MouseEvent('mousedown'));
+      assert.strictEqual(myp5.mouseIsPressed, true);
+      myp5._onblur();
+      assert.strictEqual(myp5.mouseIsPressed, false);
+    });
   });
 
   suite('mouseMoved', function() {


### PR DESCRIPTION
## Summary
- When the window loses focus while the mouse button is held down, the `mouseup` event never fires, leaving `mouseIsPressed` stuck as `true`
- Extended the existing `_onblur` handler in `keyboard.js` to also reset `mouseIsPressed` to `false` (following the same pattern already used for `_downKeys`)

## Test plan
- [x] Added test verifying `mouseIsPressed` resets to `false` when `_onblur` fires after a `mousedown`
- [x] All 1850 existing tests continue to pass

Fixes #8552