### PR TITLE
fix: createGraphics inherits pixelDensity from parent sketch.

### DIFF
--- a/src/core/p5.Renderer.js
+++ b/src/core/p5.Renderer.js
@@ -72,7 +72,14 @@ class Renderer {
     this._pInst = pInst;
     this._isMainCanvas = isMainCanvas;
     this.pixels = [];
-    this._pixelDensity = Math.ceil(window.devicePixelRatio) || 1;
+
+    if (isMainCanvas) {
+      this._pixelDensity = Math.ceil(window.devicePixelRatio) || 1;
+    } else {
+      
+      const parentDensity = pInst._pInst?._renderer?._pixelDensity;
+      this._pixelDensity = parentDensity || Math.ceil(window.devicePixelRatio) || 1;
+    }
 
     this.width = w;
     this.height = h;

--- a/test/unit/core/rendering.js
+++ b/test/unit/core/rendering.js
@@ -285,4 +285,40 @@ suite('Rendering', function() {
       assert.deepEqual(pixelFromGfx, pixelFromImg);
     });
   });
+
+  suite('p5.prototype.createGraphics pixelDensity', function() {
+    let myp5;
+
+    beforeEach(function() {
+      myp5 = new p5(function(p) {
+        p.setup = function() {
+          p.createCanvas(100, 100);
+        };
+      });
+    });
+
+    afterEach(function() {
+      myp5.remove();
+    });
+
+    test('createGraphics should inherit pixelDensity from parent sketch', function() {
+      myp5.pixelDensity(1);
+      const g = myp5.createGraphics(100, 100);
+      assert.equal(g.pixelDensity(), 1);
+    });
+
+    test('createGraphics should inherit non-default pixelDensity', function() {
+      myp5.pixelDensity(3);
+      const g = myp5.createGraphics(100, 100);
+      assert.equal(g.pixelDensity(), 3);
+    });
+
+    test('createGraphics should use default pixelDensity when not explicitly set', function() {
+      // When no pixelDensity is set, both should match
+      const expectedDensity = myp5.pixelDensity();
+      const g = myp5.createGraphics(100, 100);
+      assert.equal(g.pixelDensity(), expectedDensity);
+    });
+  });
+
 });


### PR DESCRIPTION
 In p5.js ver.2x, createGraphics() used window.devicePixelRatio for the graphics buffer's pixel density, ignoring the parent sketch setting. This caused graphics buffer to render pixelDensity(2) on retina displays even when pixelDensity(1) was explicitly set. 

The fix makes graphics buffer renderers (isMainCanvas === false) inherit pixelDensity from the parent sketch via pInst._pInst._renderer instead of always using window.devicePixelRatio.


Resolves #8289 

Changes:

`createGraphics()` now inherits the parent sketch's `pixelDensity` instead of always using `window.devicePixelRatio`.

**Bug:** When calling `pixelDensity(1)` on the main sketch, `createGraphics()` still created a buffer with the screen's native pixel density (e.g., 2 on Retina/HiDPI displays).

```js
pixelDensity(1);
let g = createGraphics(400, 400);
console.log(g.pixelDensity()); // Expected: 1, Actual: 2
```

**Cause:** In the v2.0 refactoring, `_pixelDensity` was moved from the sketch to the `Renderer` constructor. For graphics buffers (`isMainCanvas === false`), the renderer always set:
```js
this._pixelDensity = Math.ceil(window.devicePixelRatio) || 1;
```
This ignores the parent sketch's `pixelDensity` setting entirely.

**Fix:** For graphics buffer renderers, inherit the pixel density from the parent sketch via `pInst._pInst._renderer._pixelDensity`, falling back to `window.devicePixelRatio` if unavailable.

**Files changed:**
- `src/core/p5.Renderer.js` — Fixed the constructor to inherit pixelDensity for non-main-canvas renderers
- `test/unit/core/rendering.js` — Added 3 unit tests for pixelDensity inheritance

**Screenshots of the change:**

Bug happened with code:
```js
const sketch = function(p) {
      p.setup = function() {
        p.createCanvas(400, 400);
        p.pixelDensity(1);
        let g = p.createGraphics(400, 400);
        console.log("Canvas pixelDensity:", p.pixelDensity());
        console.log("Graphics pixelDensity:", g.pixelDensity());
      };
    };
```
<img width="2503" height="1062" alt="image" src="https://github.com/user-attachments/assets/b0b6f519-f577-494a-858c-e52f4a8d5029" />

After fix:
<img width="2489" height="1050" alt="image" src="https://github.com/user-attachments/assets/5dd9b518-3456-4dfb-a849-dad098a86893" />

**Additional notes:**

There were 4 pre-existing failures in `p5.Shader.js` and `typography.js`, which looked unrelated from my fix.

<img width="2475" height="1552" alt="image" src="https://github.com/user-attachments/assets/7d152f2c-bc68-4dd8-9015-84339f11131e" />



#### PR Checklist

- [ ] `npm run lint` passes
- [x] [Inline reference] is included / updated
- [x] [Unit tests] are included / updated

[Inline reference]: https://p5js.org/contribute/contributing_to_the_p5js_reference/
[Unit tests]: https://github.com/processing/p5.js/tree/main/contributor_docs#unit-tests
