### PR TITLE
Docs: Clarify whitespace behavior in textWidth() (Fixes #7745)

### DIFF
--- a/src/typography/attributes.js
+++ b/src/typography/attributes.js
@@ -253,6 +253,19 @@ p5.prototype.textStyle = function(theStyle) {
 /**
  * Calculates the maximum width of a string of text drawn when
  * <a href="#/p5/text">text()</a> is called.
+ *  * 
+ * <p><strong>Note:</strong></p>
+ * <p>
+ * In p5.js 2.0, <code>textWidth()</code> may return <code>0</code> when
+ * measuring a string that contains only whitespace characters,
+ * such as a single space (<code>' '</code>). In earlier versions,
+ * whitespace contributed to the measured width.
+ * </p>
+ * <p>
+ * This behavior differs from <code>fontWidth()</code>, which measures
+ * individual glyph widths, including whitespace.
+ * </p>
+ *
  *
  * @method textWidth
  * @param {String} str string of text to measure.


### PR DESCRIPTION
Resolves #7745

## Changes:
- Clarified the documentation of `textWidth()` to explain how whitespace characters are handled.
- No functional code changes were made.
- This is a documentation-only update.

## Screenshots of the change:
Not applicable (documentation update only).

#### PR Checklist

- [x] `npm run lint` passes
- [x] [Inline reference] is included / updated
- [ ] [Unit tests] are included / updated
