### PR TITLE
Handle strands set() calls in branches and loops

### DIFF
--- a/src/strands/ir_builders.js
+++ b/src/strands/ir_builders.js
@@ -86,8 +86,17 @@ export function binaryOpNode(strandsContext, leftStrandsNode, rightArg, opCode) 
   let finalRightNodeID = rightStrandsNode.id;
 
   // Check if we have to cast either node
-  const leftType = DAG.extractNodeTypeInfo(dag, leftStrandsNode.id);
-  const rightType = DAG.extractNodeTypeInfo(dag, rightStrandsNode.id);
+  let leftType = DAG.extractNodeTypeInfo(dag, leftStrandsNode.id);
+  let rightType = DAG.extractNodeTypeInfo(dag, rightStrandsNode.id);
+
+  // Update ASSIGN_ON_USE nodes to match the type of the other operand
+  if (leftType.baseType === BaseType.ASSIGN_ON_USE && rightType.baseType !== BaseType.ASSIGN_ON_USE) {
+    DAG.propagateTypeToAssignOnUse(dag, leftStrandsNode.id, rightType.baseType, rightType.dimension);
+    leftType = DAG.extractNodeTypeInfo(dag, leftStrandsNode.id);
+  } else if (rightType.baseType === BaseType.ASSIGN_ON_USE && leftType.baseType !== BaseType.ASSIGN_ON_USE) {
+    DAG.propagateTypeToAssignOnUse(dag, rightStrandsNode.id, leftType.baseType, leftType.dimension);
+    rightType = DAG.extractNodeTypeInfo(dag, rightStrandsNode.id);
+  }
   const cast = { node: null, toType: leftType };
   const bothDeferred = leftType.baseType === rightType.baseType && leftType.baseType === BaseType.DEFER;
   if (bothDeferred) {

--- a/test/unit/webgl/p5.Shader.js
+++ b/test/unit/webgl/p5.Shader.js
@@ -2057,6 +2057,76 @@ test('returns numbers for builtin globals outside hooks and a strandNode when ca
       assert.approximately(pixelColor[1], 127, 5);
       assert.approximately(pixelColor[2], 0, 5);
     });
+
+    test('handle .set() in if-else branches with flat API', () => {
+      myp5.createCanvas(50, 50, myp5.WEBGL);
+
+      const testShader = myp5.baseFilterShader().modify(() => {
+        myp5.filterColor.begin();
+        let value = 1;
+        if (value > 0.5) {
+          myp5.filterColor.set([1, 0, 0, 1]);
+        } else {
+          myp5.filterColor.set([0, 1, 0, 1]);
+        }
+        myp5.filterColor.end();
+      }, { myp5 });
+
+      myp5.background(255, 255, 255);
+      myp5.filter(testShader);
+
+      const pixelColor = myp5.get(25, 25);
+      assert.approximately(pixelColor[0], 255, 5);
+      assert.approximately(pixelColor[1], 0, 5);
+      assert.approximately(pixelColor[2], 0, 5);
+    });
+
+    test('handle .set() in for loop with flat API', () => {
+      myp5.createCanvas(50, 50, myp5.WEBGL);
+
+      const testShader = myp5.baseFilterShader().modify(() => {
+        myp5.filterColor.begin();
+        for (let i = 0; i < 3; i++) {
+          if (i === 2) {
+            myp5.filterColor.set([i/2, 0, 0, 1]);
+          }
+        }
+        myp5.filterColor.end();
+      }, { myp5 });
+
+      myp5.background(255, 255, 255);
+      myp5.filter(testShader);
+
+      const pixelColor = myp5.get(25, 25);
+      assert.approximately(pixelColor[0], 255, 5);
+      assert.approximately(pixelColor[1], 0, 5);
+      assert.approximately(pixelColor[2], 0, 5);
+    });
+
+    test('handle false .set() in if with content afterwards with flat API', () => {
+      myp5.createCanvas(50, 50, myp5.WEBGL);
+
+      const testShader = myp5.baseFilterShader().modify(() => {
+        myp5.filterColor.begin();
+        let value = 1;
+        if (value < 0.5) {
+          myp5.filterColor.set([1, 0, 0, 1]);
+        }
+
+        let otherValue = 0.2;
+        otherValue *= 2;
+        myp5.filterColor.set([otherValue, 0, 0, 1]);
+        myp5.filterColor.end();
+      }, { myp5 });
+
+      myp5.background(255, 255, 255);
+      myp5.filter(testShader);
+
+      const pixelColor = myp5.get(25, 25);
+      assert.approximately(pixelColor[0], 0.4 * 255, 5);
+      assert.approximately(pixelColor[1], 0, 5);
+      assert.approximately(pixelColor[2], 0, 5);
+    });
   });
 
   suite('p5.strands error messages', () => {


### PR DESCRIPTION
<!--
  Thank you for contributing! Please use this pull request (PR) template.


 In the description field of this PR, include "resolves #XXXX" tagging the issue you are fixing. If this PR addresses the issue but doesn't completely resolve it (ie the issue should remain open after your PR is merged), write "addresses #XXXX".-->
Resolves https://github.com/processing/p5.js/issues/8573

Changes:
- So the problem here is that ifs and fors determine what updates each loop/branch based on parsing of `=` statements. But calling `.set(...)`, a new construct, doesn't get noticed as part of that.
- Rather than doing a refactor to handle `=` OR `.set()` calls in loops and branching, instead this transpiles away `.set()` calls in loops/branches to use an intermediate variable outside the loop, assign to it normally inside the loop, and then call `.set()` on the result at the end.
- Also fixes an issue with `let something;` intermediate variables that don't have a type. Previously they worked only if you use them as a "flat" dependency, i.e. you assign them directly with a value. If you have a conditional update where you assign it to either itself or a real value, then we get a nested dependency, and it breaks. So now we *recursively* update types when you do that, so that all nested dependencies get type info.


Screenshots of the change:

Live: https://editor.p5js.org/davepagurek/sketches/iY_hzGaAj

#### PR Checklist
<!--
  To check any option, replace the "[ ]" with a "[x]". Be sure to check out how it looks in the Preview tab! Feel free to remove any portion of the template that is not relevant for your issue.
-->

- [x] `npm run lint` passes
- [ ] [Inline reference] is included / updated
- [x] [Unit tests] are included / updated

[Inline reference]: https://p5js.org/contribute/contributing_to_the_p5js_reference/
[Unit tests]: https://github.com/processing/p5.js/tree/main/contributor_docs#unit-tests
