### PR TITLE
fix: replace raw console.log calls with FES warnings (fixes #8577)

### DIFF
--- a/src/data/local_storage.js
+++ b/src/data/local_storage.js
@@ -120,20 +120,25 @@ import p5 from '../core/main';
  * </code>
  * </div>
  */
-p5.prototype.storeItem = function(key, value) {
+p5.prototype.storeItem = function (key, value) {
   if (typeof key !== 'string') {
-    console.log(
-      `The argument that you passed to storeItem() - ${key} is not a string.`
+    p5._friendlyError(
+      `The argument that you passed to storeItem() - ${key} is not a string.`,
+      'storeItem'
     );
   }
   if (key.endsWith('p5TypeID')) {
-    console.log(
-      `The argument that you passed to storeItem() - ${key} must not end with 'p5TypeID'.`
+    p5._friendlyError(
+      `The argument that you passed to storeItem() - ${key} must not end with 'p5TypeID'.`,
+      'storeItem'
     );
   }
 
   if (typeof value === 'undefined') {
-    console.log('You cannot store undefined variables using storeItem().');
+    p5._friendlyError(
+      'You cannot store undefined variables using storeItem().',
+      'storeItem'
+    );
   }
   let type = typeof value;
   switch (type) {
@@ -276,12 +281,13 @@ p5.prototype.storeItem = function(key, value) {
  * </code>
  * </div>
  */
-p5.prototype.getItem = function(key) {
+p5.prototype.getItem = function (key) {
   let value = localStorage.getItem(key);
   const type = localStorage.getItem(`${key}p5TypeID`);
   if (typeof type === 'undefined') {
-    console.log(
-      `Unable to determine type of item stored under ${key}in local storage. Did you save the item with something other than setItem()?`
+    p5._friendlyError(
+      `Unable to determine type of item stored under ${key} in local storage. Did you save the item with something other than setItem()?`,
+      'getItem'
     );
   } else if (value !== null) {
     switch (type) {
@@ -442,10 +448,11 @@ p5.prototype.clearStorage = function () {
  * </code>
  * </div>
  */
-p5.prototype.removeItem = function(key) {
+p5.prototype.removeItem = function (key) {
   if (typeof key !== 'string') {
-    console.log(
-      `The argument that you passed to removeItem() - ${key} is not a string.`
+    p5._friendlyError(
+      `The argument that you passed to removeItem() - ${key} is not a string.`,
+      'removeItem'
     );
   }
   localStorage.removeItem(key);

--- a/src/data/p5.TypedDict.js
+++ b/src/data/p5.TypedDict.js
@@ -164,7 +164,10 @@ p5.TypedDict = class TypedDict {
     if (this.data.hasOwnProperty(key)) {
       return this.data[key];
     } else {
-      console.log(`${key} does not exist in this Dictionary`);
+      p5._friendlyError(
+        `${key} does not exist in this Dictionary`,
+        'p5.TypedDict.get'
+      );
     }
   }
 
@@ -191,7 +194,10 @@ p5.TypedDict = class TypedDict {
     if (this._validate(value)) {
       this.data[key] = value;
     } else {
-      console.log('Those values dont work for this dictionary type.');
+      p5._friendlyError(
+        "Those values don't work for this dictionary type.",
+        'p5.TypedDict.set'
+      );
     }
   }
 
@@ -235,9 +241,10 @@ p5.TypedDict = class TypedDict {
     } else if (typeof key !== 'undefined') {
       this.set(key, value);
     } else {
-      console.log(
+      p5._friendlyError(
         'In order to create a new Dictionary entry you must pass ' +
-        'an object or a key, value pair'
+        'an object or a key, value pair',
+        'p5.TypedDict.create'
       );
     }
   }
@@ -459,7 +466,10 @@ p5.NumberDict = class NumberDict extends p5.TypedDict {
     if (this.data.hasOwnProperty(key)) {
       this.data[key] += amount;
     } else {
-      console.log(`The key - ${key} does not exist in this dictionary.`);
+      p5._friendlyError(
+        `The key - ${key} does not exist in this dictionary.`,
+        'p5.NumberDict.add'
+      );
     }
   }
 
@@ -509,7 +519,10 @@ p5.NumberDict = class NumberDict extends p5.TypedDict {
     if (this.data.hasOwnProperty(key)) {
       this.data[key] *= amount;
     } else {
-      console.log(`The key - ${key} does not exist in this dictionary.`);
+      p5._friendlyError(
+        `The key - ${key} does not exist in this dictionary.`,
+        'p5.NumberDict.mult'
+      );
     }
   }
 
@@ -536,7 +549,10 @@ p5.NumberDict = class NumberDict extends p5.TypedDict {
     if (this.data.hasOwnProperty(key)) {
       this.data[key] /= amount;
     } else {
-      console.log(`The key - ${key} does not exist in this dictionary.`);
+      p5._friendlyError(
+        `The key - ${key} does not exist in this dictionary.`,
+        'p5.NumberDict.div'
+      );
     }
   }
 

--- a/src/dom/dom.js
+++ b/src/dom/dom.js
@@ -225,7 +225,7 @@ p5.prototype._wrapElement = function (elt) {
   const children = Array.prototype.slice.call(elt.children);
   if (elt.tagName === 'INPUT' && elt.type === 'checkbox') {
     let converted = new p5.Element(elt, this);
-    converted.checked = function(...args) {
+    converted.checked = function (...args) {
       if (args.length === 0) {
         return this.elt.checked;
       } else if (args[0]) {
@@ -1101,7 +1101,7 @@ p5.prototype.createButton = function (label, value) {
  * </code>
  * </div>
  */
-p5.prototype.createCheckbox = function(...args) {
+p5.prototype.createCheckbox = function (...args) {
   p5._validateParameters('createCheckbox', args);
 
   // Create a container element
@@ -1121,7 +1121,7 @@ p5.prototype.createCheckbox = function(...args) {
   //checkbox must be wrapped in p5.Element before label so that label appears after
   const self = addElement(elt, this);
 
-  self.checked = function(...args) {
+  self.checked = function (...args) {
     const cb = self.elt.firstElementChild.getElementsByTagName('input')[0];
     if (cb) {
       if (args.length === 0) {
@@ -1328,7 +1328,7 @@ p5.prototype.createCheckbox = function(...args) {
  * @return {p5.Element}
  */
 
-p5.prototype.createSelect = function(...args) {
+p5.prototype.createSelect = function (...args) {
   p5._validateParameters('createSelect', args);
   let self;
   let arg = args[0];
@@ -1597,7 +1597,7 @@ p5.prototype.createSelect = function(...args) {
 
 //counter for unique names on radio button
 let counter = 0;
-p5.prototype.createRadio = function(...args) {
+p5.prototype.createRadio = function (...args) {
   // Creates a div, adds each option as an individual input inside it.
   // If already given with a containerEl, will search for all input[radio]
   // it, create a p5.Element out of it, add options to it and return the p5.Element.
@@ -2052,8 +2052,9 @@ p5.prototype.createFileInput = function (callback, multiple = false) {
 
   // If File API's are not supported, throw Error
   if (!(window.File && window.FileReader && window.FileList && window.Blob)) {
-    console.log(
-      'The File APIs are not fully supported in this browser. Cannot create element.'
+    p5._friendlyError(
+      'The File APIs are not fully supported in this browser. Cannot create element.',
+      'createFileInput'
     );
     return;
   }
@@ -2412,7 +2413,7 @@ if (navigator.mediaDevices.getUserMedia === undefined) {
  * </code>
  * </div>
  */
-p5.prototype.createCapture = function(...args) {
+p5.prototype.createCapture = function (...args) {
   p5._validateParameters('createCapture', args);
 
   // return if getUserMedia is not supported by the browser
@@ -2454,7 +2455,7 @@ p5.prototype.createCapture = function(...args) {
         domElement.src = window.URL.createObjectURL(stream);
       }
     }
-    catch(err) {
+    catch (err) {
       domElement.src = stream;
     }
   }).catch(e => {
@@ -2485,7 +2486,7 @@ p5.prototype.createCapture = function(...args) {
 
     if (callback) callback(domElement.srcObject);
   });
-  videoEl.flipped=flipped;
+  videoEl.flipped = flipped;
   return videoEl;
 };
 
@@ -2965,7 +2966,7 @@ p5.Element.prototype.center = function (align) {
  * @param  {boolean} [append] whether to append HTML to existing
  * @chainable
  */
-p5.Element.prototype.html = function(...args) {
+p5.Element.prototype.html = function (...args) {
   if (args.length === 0) {
     return this.elt.innerHTML;
   } else if (args[1]) {
@@ -3035,7 +3036,7 @@ p5.Element.prototype.html = function(...args) {
  * @param  {String} [positionType] it can be static, fixed, relative, sticky, initial or inherit (optional)
  * @chainable
  */
-p5.Element.prototype.position = function(...args) {
+p5.Element.prototype.position = function (...args) {
   if (args.length === 0) {
     return { x: this.elt.offsetLeft, y: this.elt.offsetTop };
   } else {
@@ -3060,7 +3061,7 @@ p5.Element.prototype.position = function(...args) {
 };
 
 /* Helper method called by p5.Element.style() */
-p5.Element.prototype._translate = function(...args) {
+p5.Element.prototype._translate = function (...args) {
   this.elt.style.position = 'absolute';
   // save out initial non-translate transform styling
   let transform = '';
@@ -3092,7 +3093,7 @@ p5.Element.prototype._translate = function(...args) {
 };
 
 /* Helper method called by p5.Element.style() */
-p5.Element.prototype._rotate = function(...args) {
+p5.Element.prototype._rotate = function (...args) {
   // save out initial non-rotate transform styling
   let transform = '';
   if (this.elt.style.transform) {
@@ -3479,7 +3480,7 @@ p5.Element.prototype.removeAttribute = function (attr) {
  * @param  {String|Number}     value
  * @chainable
  */
-p5.Element.prototype.value = function(...args) {
+p5.Element.prototype.value = function (...args) {
   if (args.length > 0) {
     this.elt.value = args[0];
     return this;
@@ -3936,7 +3937,10 @@ p5.Element.prototype.drop = function (callback, fxn) {
       this
     );
   } else {
-    console.log('The File APIs are not fully supported in this browser.');
+    p5._friendlyError(
+      'The File APIs are not fully supported in this browser.',
+      'drop'
+    );
   }
 
   return this;
@@ -4022,10 +4026,10 @@ p5.Element.prototype.draggable = function (elmMove) {
     closeDragElementEvt = isTouch ? 'touchend' : 'mouseup',
     elementDragEvt = isTouch ? 'touchmove' : 'mousemove';
 
-  if(elmMove === undefined){
+  if (elmMove === undefined) {
     elmMove = this.elt;
     elmDrag = elmMove;
-  }else if(elmMove !== this.elt && elmMove.elt !== this.elt){
+  } else if (elmMove !== this.elt && elmMove.elt !== this.elt) {
     elmMove = elmMove.elt;
     elmDrag = this.elt;
   }
@@ -4036,11 +4040,11 @@ p5.Element.prototype.draggable = function (elmMove) {
   function dragMouseDown(e) {
     e = e || window.event;
 
-    if(isTouch){
+    if (isTouch) {
       const touches = e.changedTouches;
       px = parseInt(touches[0].clientX);
       py = parseInt(touches[0].clientY);
-    }else{
+    } else {
       px = parseInt(e.clientX);
       py = parseInt(e.clientY);
     }
@@ -4053,13 +4057,13 @@ p5.Element.prototype.draggable = function (elmMove) {
   function elementDrag(e) {
     e = e || window.event;
 
-    if(isTouch){
+    if (isTouch) {
       const touches = e.changedTouches;
       x = px - parseInt(touches[0].clientX);
       y = py - parseInt(touches[0].clientY);
       px = parseInt(touches[0].clientX);
       py = parseInt(touches[0].clientY);
-    }else{
+    } else {
       x = px - parseInt(e.clientX);
       y = py - parseInt(e.clientY);
       px = parseInt(e.clientX);
@@ -5386,7 +5390,6 @@ class MediaElement extends p5.Element {
   removeCue(id) {
     for (let i = 0; i < this._cues.length; i++) {
       if (this._cues[i].id === id) {
-        console.log(id);
         this._cues.splice(i, 1);
       }
     }

--- a/src/events/mouse.js
+++ b/src/events/mouse.js
@@ -811,7 +811,7 @@ p5.prototype.mouseButton = 0;
  */
 p5.prototype.mouseIsPressed = false;
 
-p5.prototype._updateNextMouseCoords = function(e) {
+p5.prototype._updateNextMouseCoords = function (e) {
   if (this._curElement !== null && (!e.touches || e.touches.length > 0)) {
     const mousePos = getMousePos(
       this._curElement.elt,
@@ -853,7 +853,7 @@ p5.prototype._updateNextMouseCoords = function(e) {
   }
 };
 
-p5.prototype._updateMouseCoords = function() {
+p5.prototype._updateMouseCoords = function () {
   this._setProperty('pmouseX', this.mouseX);
   this._setProperty('pmouseY', this.mouseY);
   this._setProperty('pwinMouseX', this.winMouseX);
@@ -883,7 +883,7 @@ function getMousePos(canvas, w, h, evt) {
   };
 }
 
-p5.prototype._setMouseButton = function(e) {
+p5.prototype._setMouseButton = function (e) {
   if (e.button === 1) {
     this._setProperty('mouseButton', constants.CENTER);
   } else if (e.button === 2) {
@@ -1069,7 +1069,7 @@ p5.prototype._setMouseButton = function(e) {
  * </code>
  * </div>
  */
-p5.prototype._onmousemove = function(e) {
+p5.prototype._onmousemove = function (e) {
   const context = this._isGlobal ? window : this;
   let executeDefault;
   this._updateNextMouseCoords(e);
@@ -1240,7 +1240,7 @@ p5.prototype._onmousemove = function(e) {
  * </code>
  * </div>
  */
-p5.prototype._onmousedown = function(e) {
+p5.prototype._onmousedown = function (e) {
   const context = this._isGlobal ? window : this;
   let executeDefault;
   this._setProperty('mouseIsPressed', true);
@@ -1413,7 +1413,7 @@ p5.prototype._onmousedown = function(e) {
  * </code>
  * </div>
  */
-p5.prototype._onmouseup = function(e) {
+p5.prototype._onmouseup = function (e) {
   const context = this._isGlobal ? window : this;
   let executeDefault;
   this._setProperty('mouseIsPressed', false);
@@ -1586,7 +1586,7 @@ p5.prototype._ondragover = p5.prototype._onmousemove;
  * </code>
  * </div>
  */
-p5.prototype._onclick = function(e) {
+p5.prototype._onclick = function (e) {
   const context = this._isGlobal ? window : this;
   if (typeof context.mouseClicked === 'function') {
     const executeDefault = context.mouseClicked(e);
@@ -1717,7 +1717,7 @@ p5.prototype._onclick = function(e) {
  * </div>
  */
 
-p5.prototype._ondblclick = function(e) {
+p5.prototype._ondblclick = function (e) {
   const context = this._isGlobal ? window : this;
   if (typeof context.doubleClicked === 'function') {
     const executeDefault = context.doubleClicked(e);
@@ -1865,7 +1865,7 @@ p5.prototype._pmouseWheelDeltaY = 0;
  * </code>
  * </div>
  */
-p5.prototype._onwheel = function(e) {
+p5.prototype._onwheel = function (e) {
   const context = this._isGlobal ? window : this;
   this._setProperty('_mouseWheelDeltaY', e.deltaY);
   if (typeof context.mouseWheel === 'function') {
@@ -1930,13 +1930,16 @@ p5.prototype._onwheel = function(e) {
  * </code>
  * </div>
  */
-p5.prototype.requestPointerLock = function() {
+p5.prototype.requestPointerLock = function () {
   // pointer lock object forking for cross browser
   const canvas = this._curElement.elt;
   canvas.requestPointerLock =
     canvas.requestPointerLock || canvas.mozRequestPointerLock;
   if (!canvas.requestPointerLock) {
-    console.log('requestPointerLock is not implemented in this browser');
+    p5._friendlyError(
+      'requestPointerLock is not implemented in this browser',
+      'requestPointerLock'
+    );
     return false;
   }
   canvas.requestPointerLock();
@@ -1999,7 +2002,7 @@ p5.prototype.requestPointerLock = function() {
  * </code>
  * </div>
  */
-p5.prototype.exitPointerLock = function() {
+p5.prototype.exitPointerLock = function () {
   document.exitPointerLock();
 };
 

--- a/src/image/p5.Image.js
+++ b/src/image/p5.Image.js
@@ -312,7 +312,7 @@ p5.Image = class {
  */
   pixelDensity(density) {
     if (typeof density !== 'undefined') {
-    // Setter: set the density and handle resize
+      // Setter: set the density and handle resize
       if (density <= 0) {
         const errorObj = {
           type: 'INVALID_VALUE',
@@ -334,7 +334,7 @@ p5.Image = class {
 
       return this; // Return the image instance for chaining if needed
     } else {
-    // Getter: return the default density
+      // Getter: return the default density
       return this._pixelDensity;
     }
   }
@@ -1808,8 +1808,9 @@ p5.Image = class {
         props.displayIndex = index;
         this.drawingContext.putImageData(props.frames[index].image, 0, 0);
       } else {
-        console.log(
-          'Cannot set GIF to a frame number that is higher than total number of frames or below zero.'
+        p5._friendlyError(
+          'Cannot set GIF to a frame number that is higher than total number of frames or below zero.',
+          'p5.Image.setFrame'
         );
       }
     }


### PR DESCRIPTION
## Summary

Replaces 15 raw `console.log()` calls with `p5._friendlyError()` across 5 source files so that warning messages respect `p5.disableFriendlyErrors = true`.

Resolves #8577

## Changes

| File | Changes |
|------|---------|
| [src/data/p5.TypedDict.js](cci:7://file:///c:/Users/Vedant%20Gupta/OneDrive/Desktop/saksham_gsoc/src/data/p5.TypedDict.js:0:0-0:0) | 6 `console.log` → `p5._friendlyError()` + fixed typo `"dont"` → `"don't"` |
| [src/data/local_storage.js](cci:7://file:///c:/Users/Vedant%20Gupta/OneDrive/Desktop/saksham_gsoc/src/data/local_storage.js:0:0-0:0) | 5 `console.log` → `p5._friendlyError()` + fixed missing space in error message |
| [src/dom/dom.js](cci:7://file:///c:/Users/Vedant%20Gupta/OneDrive/Desktop/saksham_gsoc/src/dom/dom.js:0:0-0:0) | 2 `console.log` → `p5._friendlyError()` + removed leftover debug `console.log(id)` in [removeCue()](cci:1://file:///c:/Users/Vedant%20Gupta/OneDrive/Desktop/saksham_gsoc/src/dom/dom.js:5331:2-5399:3) |
| [src/events/mouse.js](cci:7://file:///c:/Users/Vedant%20Gupta/OneDrive/Desktop/saksham_gsoc/src/events/mouse.js:0:0-0:0) | 1 `console.log` → `p5._friendlyError()` |
| [src/image/p5.Image.js](cci:7://file:///c:/Users/Vedant%20Gupta/OneDrive/Desktop/saksham_gsoc/src/image/p5.Image.js:0:0-0:0) | 1 `console.log` → `p5._friendlyError()` |

## Notes

- The `console.log` in `p5.TypedDict.print()` is **intentional** (user-facing API) and was not changed.
- Similar approach to #8387 which did the same for [3d_primitives.js](cci:7://file:///c:/Users/Vedant%20Gupta/OneDrive/Desktop/saksham_gsoc/src/webgl/3d_primitives.js:0:0-0:0).
- All existing tests pass (1848 passing, 0 failing).
