### PR TITLE
fix: support get() at pixel density > 1 in p5.Framebuffer (fixes #8583)

### DIFF
--- a/src/webgl/p5.Framebuffer.js
+++ b/src/webgl/p5.Framebuffer.js
@@ -198,8 +198,8 @@ class Framebuffer {
       if ((settings.width === undefined) !== (settings.height === undefined)) {
         console.warn(
           'Please supply both width and height for a framebuffer to give it a ' +
-            'size. Only one was given, so the framebuffer will match the size ' +
-            'of its canvas.'
+          'size. Only one was given, so the framebuffer will match the size ' +
+          'of its canvas.'
         );
       }
       this.width = target.width;
@@ -486,7 +486,7 @@ class Framebuffer {
     ) {
       console.warn(
         'Unable to create depth textures in this environment. Falling back ' +
-          'to a framebuffer without depth.'
+        'to a framebuffer without depth.'
       );
       this.useDepth = false;
     }
@@ -498,7 +498,7 @@ class Framebuffer {
     ) {
       console.warn(
         'FLOAT depth format is unavailable in WebGL 1. ' +
-          'Defaulting to UNSIGNED_INT.'
+        'Defaulting to UNSIGNED_INT.'
       );
       this.depthFormat = constants.UNSIGNED_INT;
     }
@@ -510,8 +510,8 @@ class Framebuffer {
     ].includes(this.format)) {
       console.warn(
         'Unknown Framebuffer format. ' +
-          'Please use UNSIGNED_BYTE, FLOAT, or HALF_FLOAT. ' +
-          'Defaulting to UNSIGNED_BYTE.'
+        'Please use UNSIGNED_BYTE, FLOAT, or HALF_FLOAT. ' +
+        'Defaulting to UNSIGNED_BYTE.'
       );
       this.format = constants.UNSIGNED_BYTE;
     }
@@ -521,7 +521,7 @@ class Framebuffer {
     ].includes(this.depthFormat)) {
       console.warn(
         'Unknown Framebuffer depth format. ' +
-          'Please use UNSIGNED_INT or FLOAT. Defaulting to FLOAT.'
+        'Please use UNSIGNED_INT or FLOAT. Defaulting to FLOAT.'
       );
       this.depthFormat = constants.FLOAT;
     }
@@ -530,7 +530,7 @@ class Framebuffer {
     if (!support.float && this.format === constants.FLOAT) {
       console.warn(
         'This environment does not support FLOAT textures. ' +
-          'Falling back to UNSIGNED_BYTE.'
+        'Falling back to UNSIGNED_BYTE.'
       );
       this.format = constants.UNSIGNED_BYTE;
     }
@@ -541,14 +541,14 @@ class Framebuffer {
     ) {
       console.warn(
         'This environment does not support FLOAT depth textures. ' +
-          'Falling back to UNSIGNED_INT.'
+        'Falling back to UNSIGNED_INT.'
       );
       this.depthFormat = constants.UNSIGNED_INT;
     }
     if (!support.halfFloat && this.format === constants.HALF_FLOAT) {
       console.warn(
         'This environment does not support HALF_FLOAT textures. ' +
-          'Falling back to UNSIGNED_BYTE.'
+        'Falling back to UNSIGNED_BYTE.'
       );
       this.format = constants.UNSIGNED_BYTE;
     }
@@ -559,7 +559,7 @@ class Framebuffer {
     ) {
       console.warn(
         'FLOAT and HALF_FLOAT formats do not work cross-platform with only ' +
-          'RGB channels. Falling back to RGBA.'
+        'RGB channels. Falling back to RGBA.'
       );
       this.channels = constants.RGBA;
     }
@@ -1500,8 +1500,9 @@ class Framebuffer {
       h = this.height;
     } else if (w === undefined && h === undefined) {
       if (x < 0 || y < 0 || x >= this.width || y >= this.height) {
-        console.warn(
-          'The x and y values passed to p5.Framebuffer.get are outside of its range and will be clamped.'
+        p5._friendlyError(
+          'The x and y values passed to p5.Framebuffer.get are outside of its range and will be clamped.',
+          'p5.Framebuffer.get'
         );
         x = this.target.constrain(x, 0, this.width - 1);
         y = this.target.constrain(y, 0, this.height - 1);
@@ -1562,7 +1563,7 @@ class Framebuffer {
       }
     }
 
-    // Create an image from the data
+    // Create an image from the data at the full framebuffer resolution
     const region = new p5.Image(w * this.density, h * this.density);
     region.imageData = region.canvas.getContext('2d').createImageData(
       region.width,
@@ -1572,8 +1573,11 @@ class Framebuffer {
     region.pixels = region.imageData.data;
     region.updatePixels();
     if (this.density !== 1) {
-      // TODO: support get() at a pixel density > 1
-      region.resize(w, h);
+      // Set the pixel density on the returned image so that it retains
+      // its full-resolution data while reporting the correct logical
+      // width and height. This avoids the lossy downscale that resize()
+      // would perform.
+      region.pixelDensity(this.density);
     }
     return region;
   }


### PR DESCRIPTION
## Summary

Fixes `p5.Framebuffer.get()` to properly support pixel density > 1 by using `p5.Image.pixelDensity()` instead of lossy [resize()](cci:1://file:///c:/Users/Vedant%20Gupta/OneDrive/Desktop/saksham_gsoc/src/webgl/p5.Framebuffer.js:237:2-294:3).

Resolves #8583

## Problem

When `density > 1`, [get()](cci:1://file:///c:/Users/Vedant%20Gupta/OneDrive/Desktop/saksham_gsoc/src/core/p5.Renderer.js:135:2-167:3) reads the full high-resolution pixel data (e.g. 200×200 at density 2 for a 100×100 framebuffer) but then calls [resize(100, 100)](cci:1://file:///c:/Users/Vedant%20Gupta/OneDrive/Desktop/saksham_gsoc/src/webgl/p5.Framebuffer.js:237:2-294:3) which performs a lossy downscale — discarding the extra resolution that high-DPI displays need.

## Fix

Replace [resize(w, h)](cci:1://file:///c:/Users/Vedant%20Gupta/OneDrive/Desktop/saksham_gsoc/src/webgl/p5.Framebuffer.js:237:2-294:3) with [pixelDensity(density)](cci:1://file:///c:/Users/Vedant%20Gupta/OneDrive/Desktop/saksham_gsoc/src/webgl/p5.Framebuffer.js:296:2-399:3) on the returned `p5.Image`. This way the image retains its full-resolution data (200×200 pixels) while reporting the correct logical dimensions (100×100), matching how high-DPI images work throughout p5.js.

## Changes

| Location | What Changed |
|----------|-------------|
| [get()](cci:1://file:///c:/Users/Vedant%20Gupta/OneDrive/Desktop/saksham_gsoc/src/core/p5.Renderer.js:135:2-167:3) line 1574 | [resize(w, h)](cci:1://file:///c:/Users/Vedant%20Gupta/OneDrive/Desktop/saksham_gsoc/src/webgl/p5.Framebuffer.js:237:2-294:3) → [pixelDensity(this.density)](cci:1://file:///c:/Users/Vedant%20Gupta/OneDrive/Desktop/saksham_gsoc/src/webgl/p5.Framebuffer.js:296:2-399:3) |
| [get()](cci:1://file:///c:/Users/Vedant%20Gupta/OneDrive/Desktop/saksham_gsoc/src/core/p5.Renderer.js:135:2-167:3) line 1503 | `console.warn` → `p5._friendlyError()` for out-of-bounds warning |
| | Removed `TODO` comment |

## Notes
- All existing tests pass
- 1 file changed: 20 insertions, 16 deletions
