### PR TITLE
fix: replace console.log/warn with p5._friendlyError in RendererGL (fixes #8591)

### DIFF
--- a/src/webgl/p5.RendererGL.Immediate.js
+++ b/src/webgl/p5.RendererGL.Immediate.js
@@ -30,7 +30,7 @@ import './p5.RenderBuffer';
  *                       and TESS(WEBGL only)
  * @chainable
  */
-p5.RendererGL.prototype.beginShape = function(mode) {
+p5.RendererGL.prototype.beginShape = function (mode) {
   this.immediateMode.shapeMode =
     mode !== undefined ? mode : constants.TESS;
   this.immediateMode.geometry.reset();
@@ -46,7 +46,7 @@ const immediateBufferStrides = {
   uvs: 2
 };
 
-p5.RendererGL.prototype.beginContour = function() {
+p5.RendererGL.prototype.beginContour = function () {
   if (this.immediateMode.shapeMode !== constants.TESS) {
     throw new Error('WebGL mode can only use contours with beginShape(TESS).');
   }
@@ -65,7 +65,7 @@ p5.RendererGL.prototype.beginContour = function() {
  * @chainable
  * @TODO implement handling of <a href="#/p5.Vector">p5.Vector</a> args
  */
-p5.RendererGL.prototype.vertex = function(x, y) {
+p5.RendererGL.prototype.vertex = function (x, y) {
   // WebGL 1 doesn't support QUADS or QUAD_STRIP, so we duplicate data to turn
   // QUADS into TRIANGLES and QUAD_STRIP into TRIANGLE_STRIP. (There is no extra
   // work to convert QUAD_STRIP here, since the only difference is in how edges
@@ -139,15 +139,16 @@ p5.RendererGL.prototype.vertex = function(x, y) {
       this.userStrokeShader !== undefined ||
       this.userPointShader !== undefined
     ) {
-    // Do nothing if user-defined shaders are present
+      // Do nothing if user-defined shaders are present
     } else if (
       this._tex === null &&
       arguments.length >= 4
     ) {
       // Only throw this warning if custom uv's have  been provided
-      console.warn(
+      p5._friendlyError(
         'You must first call texture() before using' +
-          ' vertex() with image based u and v coordinates'
+        ' vertex() with image based u and v coordinates.',
+        'vertex'
       );
     }
   }
@@ -178,7 +179,7 @@ p5.RendererGL.prototype.vertex = function(x, y) {
  * @param  {Vector} v
  * @chainable
  */
-p5.RendererGL.prototype.normal = function(xorv, y, z) {
+p5.RendererGL.prototype.normal = function (xorv, y, z) {
   if (xorv instanceof p5.Vector) {
     this._currentNormal = xorv;
   } else {
@@ -192,7 +193,7 @@ p5.RendererGL.prototype.normal = function(xorv, y, z) {
  * End shape drawing and render vertices to screen.
  * @chainable
  */
-p5.RendererGL.prototype.endShape = function(
+p5.RendererGL.prototype.endShape = function (
   mode,
   isCurve,
   isBezier,
@@ -212,7 +213,7 @@ p5.RendererGL.prototype.endShape = function(
   // but in case of triangle we can skip the breaking into small triangle
   // this can optimize performance by skipping the step of breaking it into triangles
   if (this.immediateMode.geometry.vertices.length === 3 &&
-      this.immediateMode.shapeMode === constants.TESS
+    this.immediateMode.shapeMode === constants.TESS
   ) {
     this.immediateMode.shapeMode = constants.TRIANGLES;
   }
@@ -280,7 +281,7 @@ p5.RendererGL.prototype.endShape = function(
  *                       POINTS,LINES,LINE_STRIP,LINE_LOOP,TRIANGLES,
  *                       TRIANGLE_STRIP, TRIANGLE_FAN and TESS(WEBGL only)
  */
-p5.RendererGL.prototype._processVertices = function(mode) {
+p5.RendererGL.prototype._processVertices = function (mode) {
   if (this.immediateMode.geometry.vertices.length === 0) return;
 
   const calculateStroke = this._doStroke;
@@ -323,7 +324,7 @@ p5.RendererGL.prototype._processVertices = function(mode) {
  * @private
  * @returns  {Number[]} indices for custom shape vertices indicating edges.
  */
-p5.RendererGL.prototype._calculateEdges = function(
+p5.RendererGL.prototype._calculateEdges = function (
   shapeMode,
   verts,
   shouldClose
@@ -409,7 +410,7 @@ p5.RendererGL.prototype._calculateEdges = function(
  * Called from _processVertices() when applicable. This function tesselates immediateMode.geometry.
  * @private
  */
-p5.RendererGL.prototype._tesselateShape = function() {
+p5.RendererGL.prototype._tesselateShape = function () {
   // TODO: handle non-TESS shape modes that have contours
   this.immediateMode.shapeMode = constants.TRIANGLES;
   const contours = [[]];
@@ -421,7 +422,7 @@ p5.RendererGL.prototype._tesselateShape = function() {
       this.immediateMode.contourIndices.shift();
       contours.push([]);
     }
-    contours[contours.length-1].push(
+    contours[contours.length - 1].push(
       this.immediateMode.geometry.vertices[i].x,
       this.immediateMode.geometry.vertices[i].y,
       this.immediateMode.geometry.vertices[i].z,
@@ -486,7 +487,7 @@ p5.RendererGL.prototype._tesselateShape = function() {
               const dX = orig.x - vert.x;
               const dY = orig.y - vert.y;
               const dZ = orig.z - vert.z;
-              const dist = dX*dX + dY*dY + dZ*dZ;
+              const dist = dX * dX + dY * dY + dZ * dZ;
               if (dist < closestDist) {
                 closestDist = dist;
                 closestIndex = i;
@@ -507,7 +508,7 @@ p5.RendererGL.prototype._tesselateShape = function() {
  * enabling all appropriate buffers, applying color blend, and drawing the fill geometry.
  * @private
  */
-p5.RendererGL.prototype._drawImmediateFill = function(count = 1) {
+p5.RendererGL.prototype._drawImmediateFill = function (count = 1) {
   const gl = this.GL;
   this._useVertexColor = (this.immediateMode.geometry.vertexColors.length > 0);
 
@@ -543,7 +544,7 @@ p5.RendererGL.prototype._drawImmediateFill = function(count = 1) {
       );
     }
     catch (e) {
-      console.log('🌸 p5.js says: Instancing is only supported in WebGL2 mode');
+      p5._friendlyError('Instancing is only supported in WebGL2 mode.', 'endShape');
     }
   }
   shader.unbindShader();
@@ -554,7 +555,7 @@ p5.RendererGL.prototype._drawImmediateFill = function(count = 1) {
  * enabling all appropriate buffers, applying color blend, and drawing the stroke geometry.
  * @private
  */
-p5.RendererGL.prototype._drawImmediateStroke = function() {
+p5.RendererGL.prototype._drawImmediateStroke = function () {
   const gl = this.GL;
 
   this._useLineColor =

--- a/src/webgl/p5.RendererGL.js
+++ b/src/webgl/p5.RendererGL.js
@@ -266,9 +266,10 @@ const filterShaderVert = readFileSync(join(__dirname, '/shaders/filters/default.
  */
 p5.prototype.setAttributes = function (key, value) {
   if (typeof this._glAttributes === 'undefined') {
-    console.log(
+    p5._friendlyError(
       'You are trying to use setAttributes on a p5.Graphics object ' +
-      'that does not use a WEBGL renderer.'
+      'that does not use a WEBGL renderer.',
+      'setAttributes'
     );
     return;
   }
@@ -954,9 +955,10 @@ p5.RendererGL = class RendererGL extends p5.Renderer {
     );
 
     if (adjustedWidth !== width || adjustedHeight !== height) {
-      console.warn(
-        'Warning: The requested width/height exceeds hardware limits. ' +
-          `Adjusting dimensions to width: ${adjustedWidth}, height: ${adjustedHeight}.`
+      p5._friendlyError(
+        'The requested width/height exceeds hardware limits. ' +
+        `Adjusting dimensions to width: ${adjustedWidth}, height: ${adjustedHeight}.`,
+        'p5.RendererGL'
       );
     }
 
@@ -1359,8 +1361,9 @@ p5.RendererGL = class RendererGL extends p5.Renderer {
       mode === constants.SOFT_LIGHT ||
       mode === constants.DODGE
     ) {
-      console.warn(
-        'BURN, OVERLAY, HARD_LIGHT, SOFT_LIGHT, and DODGE only work for blendMode in 2D mode.'
+      p5._friendlyError(
+        'BURN, OVERLAY, HARD_LIGHT, SOFT_LIGHT, and DODGE only work for blendMode in 2D mode.',
+        'blendMode'
       );
     }
   }
@@ -1529,8 +1532,9 @@ p5.RendererGL = class RendererGL extends p5.Renderer {
 
     //@todo_FES
     if (this._pInst._glAttributes.preserveDrawingBuffer !== true) {
-      console.log(
-        'loadPixels only works in WebGL when preserveDrawingBuffer ' + 'is true.'
+      p5._friendlyError(
+        'loadPixels only works in WebGL when preserveDrawingBuffer is true.',
+        'loadPixels'
       );
       return;
     }
@@ -2495,8 +2499,8 @@ p5.RendererGL = class RendererGL extends p5.Renderer {
     // Enable per-vertex color for POINTS when available
     const useVertexColor =
       (this.immediateMode && this.immediateMode.geometry &&
-       this.immediateMode.geometry.vertexStrokeColors &&
-       this.immediateMode.geometry.vertexStrokeColors.length > 0);
+        this.immediateMode.geometry.vertexStrokeColors &&
+        this.immediateMode.geometry.vertexStrokeColors.length > 0);
     pointShader.setUniform('uUseVertexColor', !!useVertexColor);
   }
 
@@ -2602,13 +2606,12 @@ p5.RendererGL = class RendererGL extends p5.Renderer {
 
     function begincallback(type) {
       if (type !== libtess.primitiveType.GL_TRIANGLES) {
-        console.log(`expected TRIANGLES but got type: ${type}`);
+        p5._friendlyError(`expected TRIANGLES but got type: ${type}`, 'p5.RendererGL._initTessy');
       }
     }
 
     function errorcallback(errno) {
-      console.log('error callback');
-      console.log(`error number: ${errno}`);
+      p5._friendlyError(`Tesselation error callback: error number ${errno}`, 'p5.RendererGL._initTessy');
     }
     // callback for when segments intersect and must be split
     function combinecallback(coords, data, weight) {


### PR DESCRIPTION
## Summary

Replaces 8 `console.log`/`console.warn` calls across [p5.RendererGL.js](cci:7://file:///c:/Users/Vedant%20Gupta/OneDrive/Desktop/saksham_gsoc/src/webgl/p5.RendererGL.js:0:0-0:0) and [p5.RendererGL.Immediate.js](cci:7://file:///c:/Users/Vedant%20Gupta/OneDrive/Desktop/saksham_gsoc/src/webgl/p5.RendererGL.Immediate.js:0:0-0:0) with `p5._friendlyError()`.

Resolves #8591

## Changes

| File | Count | Warnings |
|------|-------|----------|
| [p5.RendererGL.js](cci:7://file:///c:/Users/Vedant%20Gupta/OneDrive/Desktop/saksham_gsoc/src/webgl/p5.RendererGL.js:0:0-0:0) | 6 | setAttributes, dimension limits, blendMode, loadPixels, tesselation (2) |
| [p5.RendererGL.Immediate.js](cci:7://file:///c:/Users/Vedant%20Gupta/OneDrive/Desktop/saksham_gsoc/src/webgl/p5.RendererGL.Immediate.js:0:0-0:0) | 2 | vertex texture, instancing |

All messages now respect `p5.disableFriendlyErrors`.

## Notes
- All existing tests pass (1913 passing)
- 2 files changed: 35 insertions, 31 deletions
