### PR TITLE
fix: replace console.warn with p5._friendlyError in light.js and material.js (fixes #8595)

### DIFF
--- a/src/webgl/light.js
+++ b/src/webgl/light.js
@@ -1233,22 +1233,25 @@ p5.prototype.lightFalloff = function (
 
   if (constantAttenuation < 0) {
     constantAttenuation = 0;
-    console.warn(
-      'Value of constant argument in lightFalloff() should be never be negative. Set to 0.'
+    p5._friendlyError(
+      'Value of constant argument in lightFalloff() should be never be negative. Set to 0.',
+      'lightFalloff'
     );
   }
 
   if (linearAttenuation < 0) {
     linearAttenuation = 0;
-    console.warn(
-      'Value of linear argument in lightFalloff() should be never be negative. Set to 0.'
+    p5._friendlyError(
+      'Value of linear argument in lightFalloff() should be never be negative. Set to 0.',
+      'lightFalloff'
     );
   }
 
   if (quadraticAttenuation < 0) {
     quadraticAttenuation = 0;
-    console.warn(
-      'Value of quadratic argument in lightFalloff() should be never be negative. Set to 0.'
+    p5._friendlyError(
+      'Value of quadratic argument in lightFalloff() should be never be negative. Set to 0.',
+      'lightFalloff'
     );
   }
 
@@ -1257,8 +1260,9 @@ p5.prototype.lightFalloff = function (
     (linearAttenuation === 0 && quadraticAttenuation === 0)
   ) {
     constantAttenuation = 1;
-    console.warn(
-      'Either one of the three arguments in lightFalloff() should be greater than zero. Set constant argument to 1.'
+    p5._friendlyError(
+      'Either one of the three arguments in lightFalloff() should be greater than zero. Set constant argument to 1.',
+      'lightFalloff'
     );
   }
 
@@ -1636,10 +1640,10 @@ p5.prototype.spotLight = function (
       break;
 
     default:
-      console.warn(
-        `Sorry, input for spotlight() is not in prescribed format. Too ${
-          length < 3 ? 'few' : 'many'
-        } arguments were provided`
+      p5._friendlyError(
+        `Sorry, input for spotlight() is not in prescribed format. Too ${length < 3 ? 'few' : 'many'
+        } arguments were provided.`,
+        'spotLight'
       );
       return this;
   }
@@ -1668,8 +1672,9 @@ p5.prototype.spotLight = function (
 
   if (concentration !== undefined && concentration < 1) {
     concentration = 1;
-    console.warn(
-      'Value of concentration needs to be greater than 1. Setting it to 1'
+    p5._friendlyError(
+      'Value of concentration needs to be greater than 1. Setting it to 1.',
+      'spotLight'
     );
   } else if (concentration === undefined) {
     concentration = 100;

--- a/src/webgl/material.js
+++ b/src/webgl/material.js
@@ -1189,7 +1189,7 @@ p5.prototype.shader = function (s) {
  * </code>
  * </div>
  */
-p5.prototype.baseMaterialShader = function() {
+p5.prototype.baseMaterialShader = function () {
   this._assert3d('baseMaterialShader');
   return this._renderer.baseMaterialShader();
 };
@@ -1284,7 +1284,7 @@ p5.prototype.baseMaterialShader = function() {
  * </code>
  * </div>
  */
-p5.prototype.baseNormalShader = function() {
+p5.prototype.baseNormalShader = function () {
   this._assert3d('baseNormalShader');
   return this._renderer.baseNormalShader();
 };
@@ -1347,7 +1347,7 @@ p5.prototype.baseNormalShader = function() {
  * </code>
  * </div>
  */
-p5.prototype.baseColorShader = function() {
+p5.prototype.baseColorShader = function () {
   this._assert3d('baseColorShader');
   return this._renderer.baseColorShader();
 };
@@ -1620,7 +1620,7 @@ p5.prototype.baseColorShader = function() {
  * </code>
  * </div>
  */
-p5.prototype.baseStrokeShader = function() {
+p5.prototype.baseStrokeShader = function () {
   this._assert3d('baseStrokeShader');
   return this._renderer.baseStrokeShader();
 };
@@ -2071,8 +2071,9 @@ p5.prototype.texture = function (tex) {
  */
 p5.prototype.textureMode = function (mode) {
   if (mode !== constants.IMAGE && mode !== constants.NORMAL) {
-    console.warn(
-      `You tried to set ${mode} textureMode only supports IMAGE & NORMAL `
+    p5._friendlyError(
+      `You tried to set ${mode} textureMode only supports IMAGE & NORMAL.`,
+      'textureMode'
     );
   } else {
     this._renderer.textureMode = mode;
@@ -3191,7 +3192,7 @@ p5.prototype.metalness = function (metallic) {
  * transparency internally, e.g. via vertex colors
  * @return {Number[]}  Normalized numbers array
  */
-p5.RendererGL.prototype._applyColorBlend = function(colors, hasTransparency) {
+p5.RendererGL.prototype._applyColorBlend = function (colors, hasTransparency) {
   const gl = this.GL;
 
   const isTexture = this.drawMode === constants.TEXTURE;
@@ -3278,8 +3279,9 @@ p5.RendererGL.prototype._applyBlendMode = function () {
         );
         gl.blendFuncSeparate(gl.ONE, gl.ONE, gl.ONE, gl.ONE);
       } else {
-        console.warn(
-          'blendMode(DARKEST) does not work in your browser in WEBGL mode.'
+        p5._friendlyError(
+          'blendMode(DARKEST) does not work in your browser in WEBGL mode.',
+          'blendMode'
         );
       }
       break;
@@ -3291,8 +3293,9 @@ p5.RendererGL.prototype._applyBlendMode = function () {
         );
         gl.blendFuncSeparate(gl.ONE, gl.ONE, gl.ONE, gl.ONE);
       } else {
-        console.warn(
-          'blendMode(LIGHTEST) does not work in your browser in WEBGL mode.'
+        p5._friendlyError(
+          'blendMode(LIGHTEST) does not work in your browser in WEBGL mode.',
+          'blendMode'
         );
       }
       break;


### PR DESCRIPTION
## Summary
Replaces 9 `console.warn` calls across [light.js](cci:7://file:///c:/Users/Vedant%20Gupta/OneDrive/Desktop/saksham_gsoc/src/webgl/light.js:0:0-0:0) (6) and [material.js](cci:7://file:///c:/Users/Vedant%20Gupta/OneDrive/Desktop/saksham_gsoc/src/webgl/material.js:0:0-0:0) (3) with `p5._friendlyError()`.

Resolves #8595

## Changes
| File | Count | Warnings |
|------|-------|----------|
| [light.js](cci:7://file:///c:/Users/Vedant%20Gupta/OneDrive/Desktop/saksham_gsoc/src/webgl/light.js:0:0-0:0) | 6 | lightFalloff (4), spotLight (2) |
| [material.js](cci:7://file:///c:/Users/Vedant%20Gupta/OneDrive/Desktop/saksham_gsoc/src/webgl/material.js:0:0-0:0) | 3 | textureMode (1), blendMode (2) |

All messages now respect `p5.disableFriendlyErrors`.

## Notes
- All existing tests pass (1913 passing)
- 2 files changed: 33 insertions, 25 deletions
