### PR TITLE
fix(dom, mouse): use FES for browser capability warnings (#8611)

### DIFF
--- a/src/dom/dom.js
+++ b/src/dom/dom.js
@@ -225,7 +225,7 @@ p5.prototype._wrapElement = function (elt) {
   const children = Array.prototype.slice.call(elt.children);
   if (elt.tagName === 'INPUT' && elt.type === 'checkbox') {
     let converted = new p5.Element(elt, this);
-    converted.checked = function(...args) {
+    converted.checked = function (...args) {
       if (args.length === 0) {
         return this.elt.checked;
       } else if (args[0]) {
@@ -1101,7 +1101,7 @@ p5.prototype.createButton = function (label, value) {
  * </code>
  * </div>
  */
-p5.prototype.createCheckbox = function(...args) {
+p5.prototype.createCheckbox = function (...args) {
   p5._validateParameters('createCheckbox', args);
 
   // Create a container element
@@ -1121,7 +1121,7 @@ p5.prototype.createCheckbox = function(...args) {
   //checkbox must be wrapped in p5.Element before label so that label appears after
   const self = addElement(elt, this);
 
-  self.checked = function(...args) {
+  self.checked = function (...args) {
     const cb = self.elt.firstElementChild.getElementsByTagName('input')[0];
     if (cb) {
       if (args.length === 0) {
@@ -1328,7 +1328,7 @@ p5.prototype.createCheckbox = function(...args) {
  * @return {p5.Element}
  */
 
-p5.prototype.createSelect = function(...args) {
+p5.prototype.createSelect = function (...args) {
   p5._validateParameters('createSelect', args);
   let self;
   let arg = args[0];
@@ -1597,7 +1597,7 @@ p5.prototype.createSelect = function(...args) {
 
 //counter for unique names on radio button
 let counter = 0;
-p5.prototype.createRadio = function(...args) {
+p5.prototype.createRadio = function (...args) {
   // Creates a div, adds each option as an individual input inside it.
   // If already given with a containerEl, will search for all input[radio]
   // it, create a p5.Element out of it, add options to it and return the p5.Element.
@@ -2052,7 +2052,7 @@ p5.prototype.createFileInput = function (callback, multiple = false) {
 
   // If File API's are not supported, throw Error
   if (!(window.File && window.FileReader && window.FileList && window.Blob)) {
-    console.log(
+    p5._friendlyError(
       'The File APIs are not fully supported in this browser. Cannot create element.'
     );
     return;
@@ -2412,7 +2412,7 @@ if (navigator.mediaDevices.getUserMedia === undefined) {
  * </code>
  * </div>
  */
-p5.prototype.createCapture = function(...args) {
+p5.prototype.createCapture = function (...args) {
   p5._validateParameters('createCapture', args);
 
   // return if getUserMedia is not supported by the browser
@@ -2454,7 +2454,7 @@ p5.prototype.createCapture = function(...args) {
         domElement.src = window.URL.createObjectURL(stream);
       }
     }
-    catch(err) {
+    catch (err) {
       domElement.src = stream;
     }
   }).catch(e => {
@@ -2485,7 +2485,7 @@ p5.prototype.createCapture = function(...args) {
 
     if (callback) callback(domElement.srcObject);
   });
-  videoEl.flipped=flipped;
+  videoEl.flipped = flipped;
   return videoEl;
 };
 
@@ -2965,7 +2965,7 @@ p5.Element.prototype.center = function (align) {
  * @param  {boolean} [append] whether to append HTML to existing
  * @chainable
  */
-p5.Element.prototype.html = function(...args) {
+p5.Element.prototype.html = function (...args) {
   if (args.length === 0) {
     return this.elt.innerHTML;
   } else if (args[1]) {
@@ -3035,7 +3035,7 @@ p5.Element.prototype.html = function(...args) {
  * @param  {String} [positionType] it can be static, fixed, relative, sticky, initial or inherit (optional)
  * @chainable
  */
-p5.Element.prototype.position = function(...args) {
+p5.Element.prototype.position = function (...args) {
   if (args.length === 0) {
     return { x: this.elt.offsetLeft, y: this.elt.offsetTop };
   } else {
@@ -3060,7 +3060,7 @@ p5.Element.prototype.position = function(...args) {
 };
 
 /* Helper method called by p5.Element.style() */
-p5.Element.prototype._translate = function(...args) {
+p5.Element.prototype._translate = function (...args) {
   this.elt.style.position = 'absolute';
   // save out initial non-translate transform styling
   let transform = '';
@@ -3092,7 +3092,7 @@ p5.Element.prototype._translate = function(...args) {
 };
 
 /* Helper method called by p5.Element.style() */
-p5.Element.prototype._rotate = function(...args) {
+p5.Element.prototype._rotate = function (...args) {
   // save out initial non-rotate transform styling
   let transform = '';
   if (this.elt.style.transform) {
@@ -3479,7 +3479,7 @@ p5.Element.prototype.removeAttribute = function (attr) {
  * @param  {String|Number}     value
  * @chainable
  */
-p5.Element.prototype.value = function(...args) {
+p5.Element.prototype.value = function (...args) {
   if (args.length > 0) {
     this.elt.value = args[0];
     return this;
@@ -3936,7 +3936,7 @@ p5.Element.prototype.drop = function (callback, fxn) {
       this
     );
   } else {
-    console.log('The File APIs are not fully supported in this browser.');
+    p5._friendlyError('The File APIs are not fully supported in this browser.');
   }
 
   return this;
@@ -4022,10 +4022,10 @@ p5.Element.prototype.draggable = function (elmMove) {
     closeDragElementEvt = isTouch ? 'touchend' : 'mouseup',
     elementDragEvt = isTouch ? 'touchmove' : 'mousemove';
 
-  if(elmMove === undefined){
+  if (elmMove === undefined) {
     elmMove = this.elt;
     elmDrag = elmMove;
-  }else if(elmMove !== this.elt && elmMove.elt !== this.elt){
+  } else if (elmMove !== this.elt && elmMove.elt !== this.elt) {
     elmMove = elmMove.elt;
     elmDrag = this.elt;
   }
@@ -4036,11 +4036,11 @@ p5.Element.prototype.draggable = function (elmMove) {
   function dragMouseDown(e) {
     e = e || window.event;
 
-    if(isTouch){
+    if (isTouch) {
       const touches = e.changedTouches;
       px = parseInt(touches[0].clientX);
       py = parseInt(touches[0].clientY);
-    }else{
+    } else {
       px = parseInt(e.clientX);
       py = parseInt(e.clientY);
     }
@@ -4053,13 +4053,13 @@ p5.Element.prototype.draggable = function (elmMove) {
   function elementDrag(e) {
     e = e || window.event;
 
-    if(isTouch){
+    if (isTouch) {
       const touches = e.changedTouches;
       x = px - parseInt(touches[0].clientX);
       y = py - parseInt(touches[0].clientY);
       px = parseInt(touches[0].clientX);
       py = parseInt(touches[0].clientY);
-    }else{
+    } else {
       x = px - parseInt(e.clientX);
       y = py - parseInt(e.clientY);
       px = parseInt(e.clientX);

--- a/src/events/mouse.js
+++ b/src/events/mouse.js
@@ -1936,7 +1936,7 @@ p5.prototype.requestPointerLock = function() {
   canvas.requestPointerLock =
     canvas.requestPointerLock || canvas.mozRequestPointerLock;
   if (!canvas.requestPointerLock) {
-    console.log('requestPointerLock is not implemented in this browser');
+    p5._friendlyError('requestPointerLock is not implemented in this browser');
     return false;
   }
   canvas.requestPointerLock();


### PR DESCRIPTION
### 1. Changes made
Replaced hardcoded `console.log()` outputs in [src/dom/dom.js](cci:7://file:///Users/gourijain/p5.js/p5.js/src/dom/dom.js:0:0-0:0) and [src/events/mouse.js](cci:7://file:///Users/gourijain/p5.js/p5.js/src/events/mouse.js:0:0-0:0) with calls to `p5._friendlyError()`. This guarantees that browser capability warnings (like [requestPointerLock](cci:1://file:///Users/gourijain/p5.js/p5.js/src/events/mouse.js:1879:0-1943:2) or File APIs not being fully supported) accurately respect the Friendly Error System and the `p5.disableFriendlyErrors` configuration setting.

### 2. Which issue this PR fixes
Fixes #8611 

### 3. Steps to test your changes
- Set up a sketch calling either [requestPointerLock()](cci:1://file:///Users/gourijain/p5.js/p5.js/src/events/mouse.js:1879:0-1943:2), [createFileInput()](cci:1://file:///Users/gourijain/p5.js/p5.js/src/dom/dom.js:1941:0-2065:2), or [drop()](cci:1://file:///Users/gourijain/p5.js/p5.js/src/dom/dom.js:3789:0-3942:2) using a browser/environment that doesn't fully support those functionalities.
- Turn off FES (`p5.disableFriendlyErrors = true;`).
- Notice that the raw console warnings no longer unexpectedly bypass the FES setting.
- Re-enable FES and confirm the messages display nicely through the Friendly Error System output format. 

