### PR TITLE
fix(image): use FES for setFrame validation errors (#8610)

### DIFF
--- a/src/image/p5.Image.js
+++ b/src/image/p5.Image.js
@@ -312,7 +312,7 @@ p5.Image = class {
  */
   pixelDensity(density) {
     if (typeof density !== 'undefined') {
-    // Setter: set the density and handle resize
+      // Setter: set the density and handle resize
       if (density <= 0) {
         const errorObj = {
           type: 'INVALID_VALUE',
@@ -334,7 +334,7 @@ p5.Image = class {
 
       return this; // Return the image instance for chaining if needed
     } else {
-    // Getter: return the default density
+      // Getter: return the default density
       return this._pixelDensity;
     }
   }
@@ -1808,7 +1808,7 @@ p5.Image = class {
         props.displayIndex = index;
         this.drawingContext.putImageData(props.frames[index].image, 0, 0);
       } else {
-        console.log(
+        p5._friendlyError(
           'Cannot set GIF to a frame number that is higher than total number of frames or below zero.'
         );
       }


### PR DESCRIPTION
### 1. Changes made
Replaced a raw `console.log()` call inside [setFrame()](cci:1://file:///Users/gourijain/p5.js/p5.js/src/image/p5.Image.js:1757:2-1815:3) (in [src/image/p5.Image.js](cci:7://file:///Users/gourijain/p5.js/p5.js/src/image/p5.Image.js:0:0-0:0)) with `p5._friendlyError()`. This guarantees that if a user tries to set a GIF to an invalid frame index, the warning goes through the Friendly Error System and is suppressed properly if `p5.disableFriendlyErrors` is set to true.

### 2. Which issue this PR fixes
Fixes #8610 

### 3. Steps to test changes
- Load a GIF using `loadImage()`.
- Disable the Friendly Error System (`p5.disableFriendlyErrors = true;`).
- Attempt to set an invalid frame, such as `gif.setFrame(9999);` or `gif.setFrame(-1);`.
- Verify nothing is logged due to FES being disabled.
- Re-enable the FES and run the sketch again to verify the correct friendly error gets logged in the standard red FES format.
