### PR TITLE
fix(data): ensure local storage validation uses FES and blocks invalid ops (#8608)

### DIFF
--- a/src/data/local_storage.js
+++ b/src/data/local_storage.js
@@ -120,20 +120,23 @@ import p5 from '../core/main';
  * </code>
  * </div>
  */
-p5.prototype.storeItem = function(key, value) {
+p5.prototype.storeItem = function (key, value) {
   if (typeof key !== 'string') {
-    console.log(
+    p5._friendlyError(
       `The argument that you passed to storeItem() - ${key} is not a string.`
     );
+    return;
   }
   if (key.endsWith('p5TypeID')) {
-    console.log(
+    p5._friendlyError(
       `The argument that you passed to storeItem() - ${key} must not end with 'p5TypeID'.`
     );
+    return;
   }
 
   if (typeof value === 'undefined') {
-    console.log('You cannot store undefined variables using storeItem().');
+    p5._friendlyError('You cannot store undefined variables using storeItem().');
+    return;
   }
   let type = typeof value;
   switch (type) {
@@ -276,13 +279,14 @@ p5.prototype.storeItem = function(key, value) {
  * </code>
  * </div>
  */
-p5.prototype.getItem = function(key) {
+p5.prototype.getItem = function (key) {
   let value = localStorage.getItem(key);
   const type = localStorage.getItem(`${key}p5TypeID`);
   if (typeof type === 'undefined') {
-    console.log(
+    p5._friendlyError(
       `Unable to determine type of item stored under ${key}in local storage. Did you save the item with something other than setItem()?`
     );
+    return;
   } else if (value !== null) {
     switch (type) {
       case 'number':
@@ -442,11 +446,12 @@ p5.prototype.clearStorage = function () {
  * </code>
  * </div>
  */
-p5.prototype.removeItem = function(key) {
+p5.prototype.removeItem = function (key) {
   if (typeof key !== 'string') {
-    console.log(
+    p5._friendlyError(
       `The argument that you passed to removeItem() - ${key} is not a string.`
     );
+    return;
   }
   localStorage.removeItem(key);
   localStorage.removeItem(`${key}p5TypeID`);


### PR DESCRIPTION
### 1. Changes made
Refactored [src/data/local_storage.js](cci:7://file:///Users/gourijain/p5.js/p5.js/src/data/local_storage.js:0:0-0:0) to correctly utilize the Friendly Error System (`p5._friendlyError()`) instead of raw `console.log()` outputs for invalid arguments passed into [storeItem](cci:1://file:///Users/gourijain/p5.js/p5.js/src/data/local_storage.js:9:0-164:2), [getItem](cci:1://file:///Users/gourijain/p5.js/p5.js/src/data/local_storage.js:166:0-314:2), and [removeItem](cci:1://file:///Users/gourijain/p5.js/p5.js/src/data/local_storage.js:383:0-457:2). 

Additionally, I added early `return;` statements directly below warning triggers within [storeItem](cci:1://file:///Users/gourijain/p5.js/p5.js/src/data/local_storage.js:9:0-164:2) and [removeItem](cci:1://file:///Users/gourijain/p5.js/p5.js/src/data/local_storage.js:383:0-457:2) to ensure invalid operations are properly halted and that invalid data does not accidentally get logged to localStorage. 

### 2. Which issue this PR fixes
Fixes #8608 

### 3. Steps to test changes
- Call [storeItem()](cci:1://file:///Users/gourijain/p5.js/p5.js/src/data/local_storage.js:9:0-164:2) with an invalid key, such as [storeItem(123, 'hello');](cci:1://file:///Users/gourijain/p5.js/p5.js/src/data/local_storage.js:9:0-164:2) or value [storeItem('key', undefined);](cci:1://file:///Users/gourijain/p5.js/p5.js/src/data/local_storage.js:9:0-164:2)
- Verify that a friendly error is triggered and that no data is saved to `localStorage` when checking browser DevTools.
- Verify that setting `p5.disableFriendlyErrors = true` properly suppresses the errors.
