### PR TITLE
fix(data): replace raw console logs with FES in TypedDict (#8607)

### DIFF
--- a/src/data/p5.TypedDict.js
+++ b/src/data/p5.TypedDict.js
@@ -164,7 +164,7 @@ p5.TypedDict = class TypedDict {
     if (this.data.hasOwnProperty(key)) {
       return this.data[key];
     } else {
-      console.log(`${key} does not exist in this Dictionary`);
+      p5._friendlyError(`${key} does not exist in this Dictionary`);
     }
   }
 
@@ -191,7 +191,7 @@ p5.TypedDict = class TypedDict {
     if (this._validate(value)) {
       this.data[key] = value;
     } else {
-      console.log('Those values dont work for this dictionary type.');
+      p5._friendlyError('Those values dont work for this dictionary type.');
     }
   }
 
@@ -235,7 +235,7 @@ p5.TypedDict = class TypedDict {
     } else if (typeof key !== 'undefined') {
       this.set(key, value);
     } else {
-      console.log(
+      p5._friendlyError(
         'In order to create a new Dictionary entry you must pass ' +
         'an object or a key, value pair'
       );
@@ -459,7 +459,7 @@ p5.NumberDict = class NumberDict extends p5.TypedDict {
     if (this.data.hasOwnProperty(key)) {
       this.data[key] += amount;
     } else {
-      console.log(`The key - ${key} does not exist in this dictionary.`);
+      p5._friendlyError(`The key - ${key} does not exist in this dictionary.`);
     }
   }
 
@@ -509,7 +509,7 @@ p5.NumberDict = class NumberDict extends p5.TypedDict {
     if (this.data.hasOwnProperty(key)) {
       this.data[key] *= amount;
     } else {
-      console.log(`The key - ${key} does not exist in this dictionary.`);
+      p5._friendlyError(`The key - ${key} does not exist in this dictionary.`);
     }
   }
 
@@ -536,7 +536,7 @@ p5.NumberDict = class NumberDict extends p5.TypedDict {
     if (this.data.hasOwnProperty(key)) {
       this.data[key] /= amount;
     } else {
-      console.log(`The key - ${key} does not exist in this dictionary.`);
+      p5._friendlyError(`The key - ${key} does not exist in this dictionary.`);
     }
   }
 


### PR DESCRIPTION
### 1. Changes you have made
Replaced 6 instances of raw `console.log()` outputs with `p5._friendlyError()` across the Dictionary classes in [src/data/p5.TypedDict.js](cci:7://file:///Users/gourijain/p5.js/p5.js/src/data/p5.TypedDict.js:0:0-0:0). This ensures that validation error messages regarding nonexistent keys, invalid dictionary creation parameters, and unsupported key/value types are properly suppressible and formatted by the Friendly Error System. 

(*Note: As requested in the issue, the intentional `console.log` output inside the `.print()` method was left alone.*)

### 2. Which issue this PR fixes
Fixes #8607 

### 3. Steps to test changes
- Set `p5.disableFriendlyErrors = true;`.
- Construct a [createStringDict()](cci:1://file:///Users/gourijain/p5.js/p5.js/src/data/p5.TypedDict.js:42:0-45:2) or [createNumberDict()](cci:1://file:///Users/gourijain/p5.js/p5.js/src/data/p5.TypedDict.js:76:0-79:2) object.
- Attempt to use `.get()`, `.div()`, or `.add()` on a key that you haven't added to the dictionary yet.
- Verify nothing gets logged to your console.
- Set `p5.disableFriendlyErrors = false;` (the default).
- Verify the standard formatting of `p5._friendlyError` properly logs the warning.
