### PR TITLE
Add doradocodes to Maintainers team

### DIFF
--- a/stewards.yml
+++ b/stewards.yml
@@ -87,6 +87,7 @@ Nwakaego-Ego:
   
 doradocodes:
   - p5.js-website
+  - Maintainers
 
 coseeian:
   - Accessibility:


### PR DESCRIPTION
After consulting with current maintainers over Discord, @doradocodes was added to the maintainers team on GitHub