### PR TITLE
Fix saveTable() not escaping double quotes in CSV output

### DIFF
--- a/src/io/files.js
+++ b/src/io/files.js
@@ -2272,6 +2272,16 @@ function escapeHelper(content) {
     .replace(/'/g, '&#039;');
 }
 
+// RFC 4180 escape: double inner quotes, wrap when value has comma/quote/newline
+function csvEscape(val, ext) {
+  if (ext !== 'csv') return String(val);
+  let s = String(val);
+  if (s.includes(',') || s.includes('"') || s.includes('\n')) {
+    return '"' + s.replace(/"/g, '""') + '"';
+  }
+  return s;
+}
+
 /**
  *  Writes the contents of a <a href="#/p5.Table">Table</a> object to a file. Defaults to a
  *  text file with comma-separated-values ('csv') but can also
@@ -2331,9 +2341,9 @@ p5.prototype.saveTable = function(table, filename, options) {
     if (header[0] !== '0') {
       for (let h = 0; h < header.length; h++) {
         if (h < header.length - 1) {
-          pWriter.write(header[h] + sep);
+          pWriter.write(csvEscape(header[h], ext) + sep);
         } else {
-          pWriter.write(header[h]);
+          pWriter.write(csvEscape(header[h], ext));
         }
       }
       pWriter.write('\n');
@@ -2341,22 +2351,11 @@ p5.prototype.saveTable = function(table, filename, options) {
 
     // make rows
     for (let i = 0; i < table.rows.length; i++) {
-      let j;
-      for (j = 0; j < table.rows[i].arr.length; j++) {
+      for (let j = 0; j < table.rows[i].arr.length; j++) {
         if (j < table.rows[i].arr.length - 1) {
-          //double quotes should be inserted in csv only if contains comma separated single value
-          if (ext === 'csv' && String(table.rows[i].arr[j]).includes(',')) {
-            pWriter.write('"' + table.rows[i].arr[j] + '"' + sep);
-          } else {
-            pWriter.write(table.rows[i].arr[j] + sep);
-          }
+          pWriter.write(csvEscape(table.rows[i].arr[j], ext) + sep);
         } else {
-          //double quotes should be inserted in csv only if contains comma separated single value
-          if (ext === 'csv' && String(table.rows[i].arr[j]).includes(',')) {
-            pWriter.write('"' + table.rows[i].arr[j] + '"');
-          } else {
-            pWriter.write(table.rows[i].arr[j]);
-          }
+          pWriter.write(csvEscape(table.rows[i].arr[j], ext));
         }
       }
       pWriter.write('\n');

--- a/test/unit/io/saveTable.js
+++ b/test/unit/io/saveTable.js
@@ -86,12 +86,12 @@ suite('saveTable', function() {
       myp5.saveTable(myTable, 'filename');
       let myBlob = blobContainer.blob;
       let text = await myBlob.text();
-      let myTableStr = myTable.columns.join(',') + '\n';
-      for (let i = 0; i < myTable.rows.length; i++) {
-        myTableStr += myTable.rows[i].arr.join(',') + '\n';
-      }
-
-      assert.strictEqual(text, myTableStr);
+      let expected =
+        'name,age,height\n' +
+        'David,31,80\n' +
+        '"David, Jr.",11,61.5\n' +
+        '"David,\nSr. ""the boss""",95,88\n';
+      assert.strictEqual(text, expected);
     },
     true
   );


### PR DESCRIPTION
Resolves #8551

Changes:
`saveTable()` only quoted CSV fields containing commas, but never escaped `"` inside them, producing malformed output. Added `csvEscape()` next to the existing `escapeHelper`, which doubles inner quotes and triggers quoting on `"` and `\n` too, not just `,`. Also fixes headers, which were never quoted at all. Updated the CSV download test to assert against the actual expected RFC 4180 output instead of rebuilding the same broken string.





[Inline reference]: https://p5js.org/contribute/contributing_to_the_p5js_reference/
[Unit tests]: https://github.com/processing/p5.js/tree/main/contributor_docs#unit-tests