### PR TITLE
fix: replace raw console.log() with p5._friendlyError() in WebGL modules

### DIFF
--- a/src/webgl/3d_primitives.js
+++ b/src/webgl/3d_primitives.js
@@ -1698,7 +1698,7 @@ function primitives3D(p5, fn){
       if (detail <= 50) {
         arcGeom._edgesToVertices(arcGeom);
       } else if (this.states.strokeColor) {
-        console.log(
+        p5._friendlyError(
           `Cannot apply a stroke to an ${shape} with more than 50 detail`
         );
       }
@@ -2243,7 +2243,7 @@ function primitives3D(p5, fn){
       if (detailX <= 1 && detailY <= 1) {
         planeGeom._makeTriangleEdges()._edgesToVertices();
       } else if (this.states.strokeColor) {
-        console.log(
+        p5._friendlyError(
           'Cannot draw stroke on plane objects with more' +
           ' than 1 detailX or 1 detailY'
         );
@@ -2327,7 +2327,7 @@ function primitives3D(p5, fn){
       if (detailX <= 4 && detailY <= 4) {
         boxGeom._edgesToVertices();
       } else if (this.states.strokeColor) {
-        console.log(
+        p5._friendlyError(
           'Cannot draw stroke on box objects with more' +
           ' than 4 detailX or 4 detailY'
         );
@@ -2391,7 +2391,7 @@ function primitives3D(p5, fn){
       if (detailX <= 24 && detailY <= 24) {
         ellipsoidGeom._makeTriangleEdges()._edgesToVertices();
       } else if (this.states.strokeColor) {
-        console.log(
+        p5._friendlyError(
           'Cannot draw stroke on ellipsoids with more' +
           ' than 24 detailX or 24 detailY'
         );
@@ -2432,7 +2432,7 @@ function primitives3D(p5, fn){
       if (detailX <= 24 && detailY <= 16) {
         cylinderGeom._makeTriangleEdges()._edgesToVertices();
       } else if (this.states.strokeColor) {
-        console.log(
+        p5._friendlyError(
           'Cannot draw stroke on cylinder objects with more' +
           ' than 24 detailX or 16 detailY'
         );
@@ -2473,7 +2473,7 @@ function primitives3D(p5, fn){
       if (detailX <= 24 && detailY <= 16) {
         coneGeom._makeTriangleEdges()._edgesToVertices();
       } else if (this.states.strokeColor) {
-        console.log(
+        p5._friendlyError(
           'Cannot draw stroke on cone objects with more' +
           ' than 24 detailX or 16 detailY'
         );
@@ -2541,7 +2541,7 @@ function primitives3D(p5, fn){
       if (detailX <= 24 && detailY <= 16) {
         torusGeom._makeTriangleEdges()._edgesToVertices();
       } else if (this.states.strokeColor) {
-        console.log(
+        p5._friendlyError(
           'Cannot draw strokes on torus object with more' +
           ' than 24 detailX or 16 detailY'
         );

--- a/src/webgl/ShapeBuilder.js
+++ b/src/webgl/ShapeBuilder.js
@@ -438,13 +438,13 @@ export class ShapeBuilder {
 
     function begincallback(type) {
       if (type !== libtess.primitiveType.GL_TRIANGLES) {
-        console.log(`expected TRIANGLES but got type: ${type}`);
+        p5._friendlyError(`Unexpected tessellation type: expected TRIANGLES but got type: ${type}. If you see this, please report it as a bug at https://github.com/processing/p5.js/issues`);
       }
     }
 
     function errorcallback(errno) {
-      console.log('error callback');
-      console.log(`error number: ${errno}`);
+      p5._friendlyError(`Tessellation error (error number: ${errno}). If you see this, please report it as a bug at https://github.com/processing/p5.js/issues`);
+
     }
 
     // callback for when segments intersect and must be split

--- a/src/webgl/p5.Camera.js
+++ b/src/webgl/p5.Camera.js
@@ -206,14 +206,14 @@ class Camera {
 
     if (near <= 0.0001) {
       near = 0.01;
-      console.log(
+      p5._friendlyError(
         'Avoid perspective near plane values close to or below 0. ' +
         'Setting value to 0.01.'
       );
     }
 
     if (far < near) {
-      console.log(
+      p5._friendlyError(
         'Perspective far plane value is less than near plane value. ' +
         'Nothing will be shown.'
       );

--- a/src/webgl/p5.RendererGL.js
+++ b/src/webgl/p5.RendererGL.js
@@ -250,9 +250,7 @@ class RendererGL extends Renderer3D {
             count
           );
         } catch (e) {
-          console.log(
-            "🌸 p5.js says: Instancing is only supported in WebGL2 mode"
-          );
+          p5._friendlyError("Instancing is only supported in WebGL2 mode.");
         }
        }
     } else if (this._curShader.shaderType === 'text') {
@@ -292,9 +290,7 @@ class RendererGL extends Renderer3D {
             count
           );
         } catch (e) {
-          console.log(
-            "🌸 p5.js says: Instancing is only supported in WebGL2 mode"
-          );
+          p5._friendlyError("Instancing is only supported in WebGL2 mode.");
         }
       }
     } else {
@@ -305,9 +301,7 @@ class RendererGL extends Renderer3D {
         try {
           gl.drawArraysInstanced(glMode, 0, geometry.vertices.length, count);
         } catch (e) {
-          console.log(
-            "🌸 p5.js says: Instancing is only supported in WebGL2 mode"
-          );
+          p5._friendlyError("Instancing is only supported in WebGL2 mode.");
         }
       }
     }
@@ -351,7 +345,7 @@ class RendererGL extends Renderer3D {
 
   _setAttributes(key, value) {
     if (typeof this._pInst._glAttributes === "undefined") {
-      console.log(
+      p5._friendlyError(
         "You are trying to use setAttributes on a p5.Graphics object " +
           "that does not use a WEBGL renderer."
       );
@@ -538,7 +532,7 @@ class RendererGL extends Renderer3D {
   loadPixels() {
     //@todo_FES
     if (this._pInst._glAttributes.preserveDrawingBuffer !== true) {
-      console.log(
+      p5._friendlyError(
         "loadPixels only works in WebGL when preserveDrawingBuffer " +
           "is true."
       );

--- a/src/webgl/text.js
+++ b/src/webgl/text.js
@@ -674,7 +674,7 @@ function text(p5, fn) {
 
   Renderer3D.prototype._renderText = function (line, x, y, maxY, minY) {
     if (!this.states.textFont || typeof this.states.textFont === 'string') {
-      console.log(
+      p5._friendlyError(
         'WEBGL: you must load and set a font before drawing text. See `loadFont` and `textFont` for more details.'
       );
       return;
@@ -684,7 +684,7 @@ function text(p5, fn) {
     }
 
     if (!p5.Font.hasGlyphData(this.states.textFont)) {
-      console.log(
+      p5._friendlyError(
         'WEBGL: only Opentype (.otf) and Truetype (.ttf) fonts with glyph data are supported. Make sure to set the font using textFont() before drawing text.'
       );
       return;

--- a/src/webgl/utils.js
+++ b/src/webgl/utils.js
@@ -276,9 +276,8 @@ export function setWebGLUniformValue(shader, uniform, data, getTexture, gl) {
           data > gl.TEXTURE31 ||
           data !== Math.ceil(data)
         ) {
-          console.log(
-            "🌸 p5.js says: " +
-              "You're trying to use a number as the data for a texture." +
+          p5._friendlyError(
+            "You're trying to use a number as the data for a texture." +
               "Please use a texture.",
           );
           return;
@@ -313,9 +312,8 @@ export function setWebGLUniformValue(shader, uniform, data, getTexture, gl) {
         data > gl.TEXTURE31 ||
         data !== Math.ceil(data)
       ) {
-        console.log(
-          "🌸 p5.js says: " +
-            "You're trying to use a number as the data for a texture." +
+        p5._friendlyError(
+          "You're trying to use a number as the data for a texture." +
             "Please use a texture.",
         );
         break;


### PR DESCRIPTION
Resolves #8651

## Changes:
Replace 20 raw `console.log()` calls with `p5._friendlyError()` across 6 WebGL module files, as discussed in the issue:

- **ShapeBuilder.js** (2): Tessellation callbacks — now include bug report encouragement
- **p5.RendererGL.js** (5): Instancing, [setAttributes](cci:1://file:///c:/Users/Vedant%20Gupta/OneDrive/Desktop/saksham_gsoc/src/webgl/p5.RendererGL.js:1909:2-2054:4), and [loadPixels](cci:1://file:///c:/Users/Vedant%20Gupta/OneDrive/Desktop/saksham_gsoc/src/webgl/p5.RendererGL.js:524:2-556:3) errors
- **p5.Camera.js** (2): Perspective near/far plane warnings
- **text.js** (2): Font loading errors
- **utils.js** (2): Texture data validation
- **3d_primitives.js** (7): Stroke limitation warnings on shapes

`p5.Shader.inspectHooks()` is intentionally left unchanged as it is a user-facing debug tool (per maintainer feedback).

## Screenshots of the change:
Not applicable — no visual changes. Only error/warning output channel changed from `console.log` to FES.

#### PR Checklist

- [x] `npm run lint` passes
- [ ] [Inline reference] is included / updated
- [ ] [Unit tests] are included / updated

[Inline reference]: https://p5js.org/contribute/contributing_to_the_p5js_reference/
[Unit tests]: https://github.com/processing/p5.js/tree/main/contributor_docs#unit-tests
