### PR TITLE
Fix: Add filterColor alias support for 2D filter shaders

### DIFF
--- a/src/image/filterRenderer2D.js
+++ b/src/image/filterRenderer2D.js
@@ -299,7 +299,10 @@ class FilterRenderer2D {
             'vec4 getColor': `(FilterInputs inputs, in sampler2D canvasContent) {
               return getTexture(canvasContent, inputs.texCoord);
             }`
-          }
+          },
+          hookAliases: {
+            'getColor': ['filterColor'],
+          },
         }
       );
     }


### PR DESCRIPTION
Resolves #8670

## Changes

This PR fixes the `filterColor is not defined` issue when using filter shaders in 2D sketches.

### Added `filterColor` alias in 2D filter renderer
- Updated `src/image/filterRenderer2D.js`
- Added:

```js
hookAliases: {
  'getColor': ['filterColor'],
}
```
## Reason

In the WebGL renderer, `filterColor` is available as an alias for `getColor` via `hookAliases`.  
However, the 2D filter renderer was missing this alias, causing shaders using `filterColor` to fail.

This change brings consistency between the 2D and WebGL renderers.

## Testing

- Verified that filter shaders using `filterColor` now work correctly in 2D mode  
- Confirmed that the previous error (`filterColor is not defined`) is resolved  

## Notes

- This PR addresses only the `filterColor` issue  
- Support for `noise()` in 2D filter shaders will be handled separately  

## Screenshots of the change

N/A (behavioral fix, no visual UI change)

#### PR Checklist

- [x] `npm run lint` passes  
- [ ] Inline reference is included / updated  
- [ ] Unit tests are included / updated  