### PR TITLE
Avoid NaN saturation when converting black from HSL to HSB

### DIFF
--- a/src/color/color_conversion.js
+++ b/src/color/color_conversion.js
@@ -112,8 +112,9 @@ p5.ColorConversion = {
       val = li + sat - li * sat;
     }
 
-    // Convert saturation.
-    sat = 2 * (val - li) / val;
+    // Convert saturation. When val is 0 (black) there is no hue or
+    // saturation; keep sat at 0 instead of dividing by zero (NaN).
+    sat = val === 0 ? 0 : 2 * (val - li) / val;
 
     // Hue and alpha stay the same.
     return [hue, sat, val, hsla[3]];


### PR DESCRIPTION
## Bug

`ColorConversion._hslaToHSBA` returns a NaN saturation when the input
is pure black. Any p5.Color constructed from an HSL black
(e.g. `color('hsl(0, 50%, 0%)')`) ends up with `sat = NaN` once it's
converted to the internal HSBA representation, and downstream
getters/serializers propagate that NaN.

## Root cause

```javascript
let val;
if (li < 0.5) {
  val = (1 + sat) * li;
} else {
  val = li + sat - li * sat;
}

// Convert saturation.
sat = 2 * (val - li) / val;
```

For black, `li === 0`, and the first branch sets `val = (1 + sat) * 0 = 0`.
The subsequent `2 * (val - li) / val` becomes `2 * 0 / 0`, which is
`NaN`.

## Why the fix is correct

- Pure black carries no hue and no meaningful saturation, so the
  conventional value is `0` - the same choice `_rgbaToHSBA` already
  makes for grayscale (`chroma === 0`) inputs elsewhere in the file.
- Gating the division on `val === 0` with a ternary keeps the
  existing formula unchanged for every non-black input (floating
  point `val` is only ever exactly `0` when `li === 0`, so the
  existing `val > 0` code path behaviour is identical).
- The return shape is the same; only the `NaN` output becomes `0`.

## Change

`src/color/color_conversion.js`: replace

```javascript
sat = 2 * (val - li) / val;
```

with a ternary guard returning `0` when `val === 0`. One-line fix
(plus a brief comment).