### PR TITLE
Return NaN from int() for unrecognised input types

### DIFF
--- a/src/utilities/conversion.js
+++ b/src/utilities/conversion.js
@@ -227,6 +227,7 @@ p5.prototype.int = function(n, radix = 10) {
   } else if (n instanceof Array) {
     return n.map(n => p5.prototype.int(n, radix));
   }
+  return NaN;
 };
 
 /**


### PR DESCRIPTION
## Bug

`p5.prototype.int()` silently returns `undefined` when it's given a
value that doesn't match any of its recognised input types, so callers
that pass `null`, `undefined`, or a plain object get a non-numeric
result that poisons downstream arithmetic (e.g. `int(null) + 1` is
`NaN`, but from an unexpected source — the debugger shows `int()`
returned `undefined`, not a number).

## Root cause

```javascript
p5.prototype.int = function(n, radix = 10) {
  if (n === Infinity || n === 'Infinity') {
    return Infinity;
  } else if (n === -Infinity || n === '-Infinity') {
    return -Infinity;
  } else if (typeof n === 'string') {
    return parseInt(n, radix);
  } else if (typeof n === 'number') {
    return n | 0;
  } else if (typeof n === 'boolean') {
    return n ? 1 : 0;
  } else if (n instanceof Array) {
    return n.map(n => p5.prototype.int(n, radix));
  }
};
```

Every branch returns a concrete value, but the `if/else if` chain has
no final `else`, so unmatched types fall off the end and JavaScript
returns `undefined` implicitly.

## Why the fix is correct

- Matches the documented behaviour of the sibling `float()` helper in
  the same file, whose docstring already promises:
  *"If a string can't be converted to a number, as in `float('giraffe')`,
  then the value `NaN` (not a number) will be returned."*
- `NaN` is the conventional JavaScript signal for "couldn't coerce
  to a number" (same as what `parseInt`/`Number` produce for bad
  input), so downstream math produces `NaN` in a predictable,
  self-describing way instead of a silent `undefined`.
- Every existing code path is untouched; the new `return NaN;` only
  runs on inputs that previously fell through to `undefined`.

## Change

`src/utilities/conversion.js`: add `return NaN;` at the end of
`p5.prototype.int`. One-line addition.