### PR TITLE
Update RendererGL comments to reflect current state of pixel functions

### DIFF
--- a/src/webgl/p5.RendererGL.js
+++ b/src/webgl/p5.RendererGL.js
@@ -529,7 +529,7 @@ class RendererGL extends Renderer3D {
 
   /**
    * Loads the pixels data for this canvas into the pixels[] attribute.
-   * Note that updatePixels() and set() do not work.
+   * Note that set() does not work.
    * Any pixel manipulation must be done directly to the pixels[] array.
    *
    * @private


### PR DESCRIPTION
This just updates a comment in RendererGL that incorrectly states that `updatePixels` isn't implemented. `set()` isn't, but `updatePixels` did get implemented in https://github.com/processing/p5.js/issues/5155, but I never updated this comment :')

Updating now to not confuse people reading the code.
