### PR TITLE
Save + restore 2D text canvas context when font is applied in WebGL mode

### DIFF
--- a/src/core/p5.Renderer3D.js
+++ b/src/core/p5.Renderer3D.js
@@ -160,6 +160,7 @@ export class Renderer3D extends Renderer {
 
     // clipping
     this._clipDepths = [];
+    this._textContextSavedStack = [];
     this._isClipApplied = false;
     this._stencilTestOn = false;
 
@@ -1329,9 +1330,11 @@ export class Renderer3D extends Renderer {
 
   push() {
     super.push()
-    if (this.states.textFont?.font) {
-      this.textDrawingContext()?.save()
+    const saved = !!(this.states.textFont?.font);
+    if (saved) {
+      this.textDrawingContext().save()
     }
+    this._textContextSavedStack.push(saved);
   }
 
   pop(...args) {
@@ -1341,8 +1344,8 @@ export class Renderer3D extends Renderer {
     ) {
       this._clearClip();
     }
-    if (this.states.textFont?.font) {
-      this.textDrawingContext()?.restore()
+    if (this._textContextSavedStack.pop()) {
+      this.textDrawingContext().restore()
     }
     super.pop(...args);
     this._applyStencilTestIfClipping();

--- a/src/core/p5.Renderer3D.js
+++ b/src/core/p5.Renderer3D.js
@@ -1327,12 +1327,22 @@ export class Renderer3D extends Renderer {
     return this;
   }
 
+  push() {
+    super.push()
+    if (this.states.textFont?.font) {
+      this.textDrawingContext()?.save()
+    }
+  }
+
   pop(...args) {
     if (
       this._clipDepths.length > 0 &&
       this._pushPopDepth === this._clipDepths[this._clipDepths.length - 1]
     ) {
       this._clearClip();
+    }
+    if (this.states.textFont?.font) {
+      this.textDrawingContext()?.restore()
     }
     super.pop(...args);
     this._applyStencilTestIfClipping();

--- a/test/unit/webgl/p5.RendererGL.js
+++ b/test/unit/webgl/p5.RendererGL.js
@@ -3016,5 +3016,20 @@ suite('p5.RendererGL', function() {
 
       expect(widthAt20).toBeGreaterThan(widthAt12);
     });
+
+    test('fontWidth restores correctly when font is unset inside push/pop', async function() {
+      myp5.createCanvas(100, 100, myp5.WEBGL);
+      const font = await myp5.loadFont('test/unit/assets/acmesa.ttf');
+      myp5.textFont(font);
+      myp5.textSize(12);
+      myp5.push();
+      myp5.textFont('sans-serif'); // unset loaded font
+      myp5.pop();
+      // After pop, should be back to size 12 with loaded font
+      const widthAfterPop = myp5.fontWidth('X');
+      myp5.textSize(20);
+      const widthAt20 = myp5.fontWidth('X');
+      expect(widthAfterPop).toBeLessThan(widthAt20);
+    });
   });
 });

--- a/test/unit/webgl/p5.RendererGL.js
+++ b/test/unit/webgl/p5.RendererGL.js
@@ -2998,4 +2998,23 @@ suite('p5.RendererGL', function() {
       expect(myp5.get(5, 5)).toEqual([255, 0, 0, 255]);
     });
   });
+
+  suite('fontWidth', function() {
+    test('respects textSize changes across push/pop', async function() {
+      myp5.createCanvas(100, 100, myp5.WEBGL);
+      const font = await myp5.loadFont('test/unit/assets/acmesa.ttf');
+
+      myp5.push();
+      myp5.textFont(font);
+      myp5.textSize(12);
+      myp5.push();
+      myp5.textSize(20);
+      const widthAt20 = myp5.fontWidth('X');
+      myp5.pop();
+      const widthAt12 = myp5.fontWidth('X');
+      myp5.pop();
+
+      expect(widthAt20).toBeGreaterThan(widthAt12);
+    });
+  });
 });


### PR DESCRIPTION
<!--
  Thank you for contributing! Please use this pull request (PR) template.


 In the description field of this PR, include "resolves #XXXX" tagging the issue you are fixing. If this PR addresses the issue but doesn't completely resolve it (ie the issue should remain open after your PR is merged), write "addresses #XXXX".-->
Resolves https://github.com/processing/p5.js/issues/8746

Changes:
- In push/pop, we now also save/restore the 2D text drawing context when there's a font applied

Live: editor.p5js.org/davepagurek/sketches/LAiOOhGjM

<img width="602" height="460" alt="image" src="https://github.com/user-attachments/assets/fa7d4818-c773-4054-bf0f-ecab48143162" />


#### PR Checklist
<!--
  To check any option, replace the "[ ]" with a "[x]". Be sure to check out how it looks in the Preview tab! Feel free to remove any portion of the template that is not relevant for your issue.
-->

- [x] `npm run lint` passes
- [ ] [Inline reference] is included / updated
- [x] [Unit tests] are included / updated

[Inline reference]: https://p5js.org/contribute/contributing_to_the_p5js_reference/
[Unit tests]: https://github.com/processing/p5.js/tree/main/contributor_docs#unit-tests
