### PR TITLE
Fix JSDoc typos:widhts->widths,coordiante->coordinate

### DIFF
--- a/src/core/helpers.js
+++ b/src/core/helpers.js
@@ -16,7 +16,7 @@ function modeAdjust(a, b, c, d, mode) {
   if (mode === constants.CORNER) {
 
     // CORNER mode already corresponds to a bounding box (top-left corner, width, height).
-    // For negative widhts or heights, the absolute value is used.
+    // For negative widths or heights, the absolute value is used.
     bbox = {
       x: a,
       y: b,

--- a/src/webgl/p5.RendererGL.js
+++ b/src/webgl/p5.RendererGL.js
@@ -320,8 +320,8 @@ p5.prototype.setAttributes = function (key, value) {
  * @param {Uint8Array|Float32Array|undefined} pixels An existing pixels array to reuse if the size is the same
  * @param {WebGLRenderingContext} gl The WebGL context
  * @param {WebGLFramebuffer|null} framebuffer The Framebuffer to read
- * @param {Number} x The x coordiante to read, premultiplied by pixel density
- * @param {Number} y The y coordiante to read, premultiplied by pixel density
+ * @param {Number} x The x coordinate to read, premultiplied by pixel density
+ * @param {Number} y The y coordinate to read, premultiplied by pixel density
  * @param {Number} width The width in pixels to be read (factoring in pixel density)
  * @param {Number} height The height in pixels to be read (factoring in pixel density)
  * @param {GLEnum} format Either RGB or RGBA depending on how many channels to read


### PR DESCRIPTION
Resolves #8744 

### Changes

Fixed three JSDoc/comment typos. No behavior changes — comment-only edits.

- `src/core/helpers.js` (line 19): `widhts` → `widths`
- `src/webgl/p5.RendererGL.js` (lines 323–324): `coordiante` → `coordinate` (two occurrences in the JSDoc for `@param x` and `@param y`)

### Screenshots of the change

N/A — comment-only change, no visual impact.

#### PR Checklist

- [x] `npm run lint` passes
- [ ] [Inline reference] is included / updated
- [ ] [Unit tests] are included / updated

[Inline reference]: https://p5js.org/contribute/contributing_to_the_p5js_reference/
[Unit tests]: https://github.com/processing/p5.js/tree/main/contributor_docs#unit-tests
