### PR TITLE
Docs: Add pipeline overview for transpileStrandsToJS

### DIFF
--- a/src/strands/strands_transpiler.js
+++ b/src/strands/strands_transpiler.js
@@ -1653,6 +1653,33 @@ function transformHelperFunctionEarlyReturns(ast, names) {
   }
 }
 
+/**
+ * Transpiles a p5.strands callback into executable JavaScript by applying
+ * a multi-pass AST transformation pipeline.
+ *
+ * Pipeline stages:
+ *
+ * 1. Collect uniform callback names
+ *    - Identifies functions passed into uniform() so they are excluded from transformation
+ *
+ * 2. transformSetCallsInControlFlow
+ *    - Rewrites `.set()` calls inside control flow into intermediate variable assignments
+ *
+ * 3. Non-control-flow transformations
+ *    - Applies ASTCallbacks to transform expressions, assignments, etc.
+ *    - Skips IfStatement and ForStatement (handled later)
+ *
+ * 4. transformHelperFunctionEarlyReturns
+ *    - Converts early returns in helper functions into a single return value pattern
+ *
+ * 5. Control flow transformation (post-order)
+ *    - Transforms IfStatement → __p5.strandsIf
+ *    - Transforms ForStatement → __p5.strandsFor
+ *    - Handles variable propagation across branches/loops
+ *
+ * This staged approach ensures correct ordering and avoids transformation conflicts.
+ */
+
 export function transpileStrandsToJS(p5, sourceString, srcLocations, scope) {
   // Reset counters at the start of each transpilation
   blockVarCounter = 0;


### PR DESCRIPTION
Addresses #8694

### Changes:

- Added a documentation block describing the multi-pass transformation pipeline in `transpileStrandsToJS`
- Clarified the purpose and ordering of each transformation stage
- Improved readability for contributors navigating the transpiler logic

This change does not modify behavior and is purely documentation.

---

### Screenshots of the change:

N/A (documentation only)

---

#### PR Checklist

- [x] `npm run lint` passes
- [ ] Inline reference is included / updated
- [ ] Unit tests are included / updated

[Inline reference]: https://p5js.org/contribute/contributing_to_the_p5js_reference/
[Unit tests]: https://github.com/processing/p5.js/tree/main/contributor_docs#unit-tests
