### PR TITLE
Fix JSDoc typos: widhts → widths, coordniates → coordinates, coordian…

### DIFF
--- a/src/core/helpers.js
+++ b/src/core/helpers.js
@@ -15,7 +15,7 @@ function modeAdjust(a, b, c, d, mode) {
   if (mode === constants.CORNER) {
 
     // CORNER mode already corresponds to a bounding box (top-left corner, width, height).
-    // For negative widhts or heights, the absolute value is used.
+    // For negative widths or heights, the absolute value is used.
     bbox = {
       x: a,
       y: b,
@@ -26,7 +26,7 @@ function modeAdjust(a, b, c, d, mode) {
   } else if (mode === constants.CORNERS) {
 
     // CORNERS mode uses two opposite corners, in any configuration.
-    // Make sure to get the top left corner by using the minimum of the x and y coordniates.
+    // Make sure to get the top left corner by using the minimum of the x and y coordinates.
     bbox = {
       x: Math.min(a, c),
       y: Math.min(b, d),

--- a/src/webgl/utils.js
+++ b/src/webgl/utils.js
@@ -7,8 +7,8 @@ import { Texture } from "./p5.Texture";
  * @param {Uint8Array|Float32Array|undefined} pixels An existing pixels array to reuse if the size is the same
  * @param {WebGLRenderingContext} gl The WebGL context
  * @param {WebGLFramebuffer|null} framebuffer The Framebuffer to read
- * @param {Number} x The x coordiante to read, premultiplied by pixel density
- * @param {Number} y The y coordiante to read, premultiplied by pixel density
+ * @param {Number} x The x coordinate to read, premultiplied by pixel density
+ * @param {Number} y The y coordinate to read, premultiplied by pixel density
  * @param {Number} width The width in pixels to be read (factoring in pixel density)
  * @param {Number} height The height in pixels to be read (factoring in pixel density)
  * @param {GLEnum} format Either RGB or RGBA depending on how many channels to read


### PR DESCRIPTION
Follow-up to #8748 per @ksen0's request in #8744 — applies the typo fix to `dev-2.0`.

While checking `dev-2.0`, I found that the file structure has changed since `main`:

- `src/core/helpers.js` still has the original `widhts` typo, plus an additional typo (`coordniates`) that didn't exist on `main`.
- `src/webgl/p5.RendererGL.js` is already clean on `dev-2.0` — the `coordiante` typo from `main` no longer exists in this file.
- `src/webgl/utils.js` is a new file on `dev-2.0` that contains the `coordiante` typo (×2) in JSDoc comments.

### Changes

- `src/core/helpers.js`: `widhts` → `widths`
- `src/core/helpers.js`: `coordniates` → `coordinates`
- `src/webgl/utils.js`: `coordiante` → `coordinate` (×2)

#### PR Checklist

- [x] `npm run lint` passes
- [ ] [Inline reference] is included / updated
- [ ] [Unit tests] are included / updated