### PR TITLE
Add WebGPU label to labeler config

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -35,3 +35,5 @@
   - '\[[xX]\]\s*Friendly Errors'
 "p5.strands":
   - '\[[xX]\]\s*p5.strands'
+"Area:WebGPU":
+  - '\[[xX]\]\s*WebGPU'


### PR DESCRIPTION
Currently if you tick the WebGPU box when filing an issue, we don't auto-add the WebGPU label. This adds a line to the labeller config to handle that.