### PR TITLE
Limit `.get()`, `.set()` rewrites to storage-backed strands bindings

### DIFF
--- a/src/strands/ir_builders.js
+++ b/src/strands/ir_builders.js
@@ -522,11 +522,30 @@ export function swizzleTrap(id, dimension, strandsContext, onRebind) {
       ['r', 'g', 'b', 'a'],
       ['s', 't', 'p', 'q']
     ].map(s => s.slice(0, dimension));
+    const canonicalComponents = swizzleSets[0];
+    const numericIndexToSwizzle = (property) => {
+      const propString = typeof property === 'string' || typeof property === 'number'
+        ? property.toString()
+        : null;
+      if (propString === null || !/^\d+$/.test(propString)) {
+        return null;
+      }
+      const index = Number(propString);
+      if (index < 0 || index >= canonicalComponents.length) {
+        return null;
+      }
+      return canonicalComponents[index];
+    };
     const trap = {
       get(target, property, receiver) {
         if (property in target) {
           return Reflect.get(...arguments);
         } else {
+          const numericSwizzle = numericIndexToSwizzle(property);
+          if (numericSwizzle) {
+            const node = swizzleNode(strandsContext, target, numericSwizzle);
+            return createStrandsNode(node.id, node.dimension, strandsContext);
+          }
           for (const set of swizzleSets) {
             if ([...property.toString()].every(char => set.includes(char))) {
               const swizzle = [...property].map(char => {
@@ -540,6 +559,10 @@ export function swizzleTrap(id, dimension, strandsContext, onRebind) {
         }
     },
   set(target, property, value, receiver) {
+    const numericSwizzle = numericIndexToSwizzle(property);
+    if (numericSwizzle) {
+      property = numericSwizzle;
+    }
     for (const swizzleSet of swizzleSets) {
       const chars = [...property];
       const valid =

--- a/src/strands/ir_builders.js
+++ b/src/strands/ir_builders.js
@@ -517,130 +517,130 @@ export function swizzleNode(strandsContext, parentNode, swizzle) {
 }
 
 export function swizzleTrap(id, dimension, strandsContext, onRebind) {
-    const swizzleSets = [
-      ['x', 'y', 'z', 'w'],
-      ['r', 'g', 'b', 'a'],
-      ['s', 't', 'p', 'q']
-    ].map(s => s.slice(0, dimension));
-    const canonicalComponents = swizzleSets[0];
-    const numericIndexToSwizzle = (property) => {
-      const propString = typeof property === 'string' || typeof property === 'number'
-        ? property.toString()
-        : null;
-      if (propString === null || !/^\d+$/.test(propString)) {
-        return null;
-      }
-      const index = Number(propString);
-      if (index < 0 || index >= canonicalComponents.length) {
-        return null;
-      }
-      return canonicalComponents[index];
-    };
-    const trap = {
-      get(target, property, receiver) {
-        if (property in target) {
-          return Reflect.get(...arguments);
-        } else {
-          const numericSwizzle = numericIndexToSwizzle(property);
-          if (numericSwizzle) {
-            const node = swizzleNode(strandsContext, target, numericSwizzle);
+  const swizzleSets = [
+    ['x', 'y', 'z', 'w'],
+    ['r', 'g', 'b', 'a'],
+    ['s', 't', 'p', 'q']
+  ].map(s => s.slice(0, dimension));
+  const canonicalComponents = swizzleSets[0];
+  const numericIndexToSwizzle = (property) => {
+    const propString = typeof property === 'string' || typeof property === 'number'
+      ? property.toString()
+      : null;
+    if (propString === null || !/^\d+$/.test(propString)) {
+      return null;
+    }
+    const index = Number(propString);
+    if (index < 0 || index >= canonicalComponents.length) {
+      return null;
+    }
+    return canonicalComponents[index];
+  };
+  const trap = {
+    get(target, property, receiver) {
+      if (property in target) {
+        return Reflect.get(...arguments);
+      } else {
+        const numericSwizzle = numericIndexToSwizzle(property);
+        if (numericSwizzle) {
+          const node = swizzleNode(strandsContext, target, numericSwizzle);
+          return createStrandsNode(node.id, node.dimension, strandsContext);
+        }
+        for (const set of swizzleSets) {
+          if ([...property.toString()].every(char => set.includes(char))) {
+            const swizzle = [...property].map(char => {
+              const index = set.indexOf(char);
+              return swizzleSets[0][index];
+            }).join('');
+            const node = swizzleNode(strandsContext, target, swizzle);
             return createStrandsNode(node.id, node.dimension, strandsContext);
           }
-          for (const set of swizzleSets) {
-            if ([...property.toString()].every(char => set.includes(char))) {
-              const swizzle = [...property].map(char => {
-                const index = set.indexOf(char);
-                return swizzleSets[0][index];
-              }).join('');
-              const node = swizzleNode(strandsContext, target, swizzle);
-              return createStrandsNode(node.id, node.dimension, strandsContext);
-            }
-          }
         }
+      }
     },
-  set(target, property, value, receiver) {
-    const numericSwizzle = numericIndexToSwizzle(property);
-    if (numericSwizzle) {
-      property = numericSwizzle;
-    }
-    for (const swizzleSet of swizzleSets) {
-      const chars = [...property];
-      const valid =
-        chars.every(c => swizzleSet.includes(c)) &&
-        new Set(chars).size === chars.length &&
-        target.dimension >= chars.length;
-      if (!valid) continue;
-
-      const dim = target.dimension;
-
-      // lanes are the underlying values of the target vector
-      //  e.g. lane 0 holds the value aliased by 'x', 'r', and 's'
-      // the lanes array is in the 'correct' order
-      const lanes = new Array(dim);
-      for (let i = 0; i < dim; i++) {
-        const { id, dimension } = swizzleNode(strandsContext, target, 'xyzw'[i]);
-        lanes[i] = createStrandsNode(id, dimension, strandsContext);
+    set(target, property, value, receiver) {
+      const numericSwizzle = numericIndexToSwizzle(property);
+      if (numericSwizzle) {
+        property = numericSwizzle;
       }
+      for (const swizzleSet of swizzleSets) {
+        const chars = [...property];
+        const valid =
+          chars.every(c => swizzleSet.includes(c)) &&
+          new Set(chars).size === chars.length &&
+          target.dimension >= chars.length;
+        if (!valid) continue;
 
-      // The scalars array contains the individual components of the users values.
-      // This may not be the most efficient way, as we swizzle each component individually,
-      // so that .xyz becomes .x, .y, .z
-      let scalars = [];
-      if (value?.isStrandsNode) {
-        if (value.dimension === 1) {
-          scalars = Array(chars.length).fill(value);
-        } else if (value.dimension === chars.length) {
-          for (let k = 0; k < chars.length; k++) {
-            const { id, dimension } = swizzleNode(strandsContext, value, 'xyzw'[k]);
-            scalars.push(createStrandsNode(id, dimension, strandsContext));
+        const dim = target.dimension;
+
+        // lanes are the underlying values of the target vector
+        //  e.g. lane 0 holds the value aliased by 'x', 'r', and 's'
+        // the lanes array is in the 'correct' order
+        const lanes = new Array(dim);
+        for (let i = 0; i < dim; i++) {
+          const { id, dimension } = swizzleNode(strandsContext, target, 'xyzw'[i]);
+          lanes[i] = createStrandsNode(id, dimension, strandsContext);
+        }
+
+        // The scalars array contains the individual components of the users values.
+        // This may not be the most efficient way, as we swizzle each component individually,
+        // so that .xyz becomes .x, .y, .z
+        let scalars = [];
+        if (value?.isStrandsNode) {
+          if (value.dimension === 1) {
+            scalars = Array(chars.length).fill(value);
+          } else if (value.dimension === chars.length) {
+            for (let k = 0; k < chars.length; k++) {
+              const { id, dimension } = swizzleNode(strandsContext, value, 'xyzw'[k]);
+              scalars.push(createStrandsNode(id, dimension, strandsContext));
+            }
+          } else {
+            FES.userError('type error', `Swizzle assignment: RHS vector does not match LHS vector (need ${chars.length}, got ${value.dimension}).`);
           }
+        } else if (Array.isArray(value)) {
+          const flat = value.flat(Infinity);
+          if (flat.length === 1) {
+            scalars = Array(chars.length).fill(flat[0]);
+          } else if (flat.length === chars.length) {
+            scalars = flat;
+          } else {
+            FES.userError('type error', `Swizzle assignment: RHS length ${flat.length} does not match ${chars.length}.`);
+          }
+        } else if (typeof value === 'number') {
+          scalars = Array(chars.length).fill(value);
         } else {
-          FES.userError('type error', `Swizzle assignment: RHS vector does not match LHS vector (need ${chars.length}, got ${value.dimension}).`);
+          FES.userError('type error', `Unsupported RHS for swizzle assignment: ${value}`);
         }
-      } else if (Array.isArray(value)) {
-        const flat = value.flat(Infinity);
-        if (flat.length === 1) {
-          scalars = Array(chars.length).fill(flat[0]);
-        } else if (flat.length === chars.length) {
-          scalars = flat;
-        } else {
-          FES.userError('type error', `Swizzle assignment: RHS length ${flat.length} does not match ${chars.length}.`);
+
+        // The canonical index refers to the actual value's position in the vector lanes
+        // i.e. we are finding (3,2,1) from .zyx
+        // We set the correct value in the lanes array
+        for (let j = 0; j < chars.length; j++) {
+          const canonicalIndex = swizzleSet.indexOf(chars[j]);
+          lanes[canonicalIndex] = scalars[j];
         }
-      } else if (typeof value === 'number') {
-        scalars = Array(chars.length).fill(value);
-      } else {
-        FES.userError('type error', `Unsupported RHS for swizzle assignment: ${value}`);
+
+        const orig = DAG.getNodeDataFromID(strandsContext.dag, target.id);
+        const baseType = orig?.baseType ?? BaseType.FLOAT;
+        const { id: newID } = primitiveConstructorNode(
+          strandsContext,
+          { baseType, dimension: dim },
+          lanes
+        );
+
+        target.id = newID;
+
+        // If we swizzle assign on a struct component i.e.
+        //   inputs.position.rg = [1, 2]
+        // The onRebind callback will update the structs components so that it refers to the new values,
+        // and make a new ID for the struct with these new values
+        if (typeof onRebind === 'function') {
+          onRebind(newID);
+        }
+        return true;
       }
-
-      // The canonical index refers to the actual value's position in the vector lanes
-      // i.e. we are finding (3,2,1) from .zyx
-      // We set the correct value in the lanes array
-      for (let j = 0; j < chars.length; j++) {
-        const canonicalIndex = swizzleSet.indexOf(chars[j]);
-        lanes[canonicalIndex] = scalars[j];
-      }
-
-      const orig = DAG.getNodeDataFromID(strandsContext.dag, target.id);
-      const baseType = orig?.baseType ?? BaseType.FLOAT;
-      const { id: newID } = primitiveConstructorNode(
-        strandsContext,
-        { baseType, dimension: dim },
-        lanes
-      );
-
-      target.id = newID;
-
-      // If we swizzle assign on a struct component i.e.
-      //   inputs.position.rg = [1, 2]
-      // The onRebind callback will update the structs components so that it refers to the new values,
-      // and make a new ID for the struct with these new values
-      if (typeof onRebind === 'function') {
-        onRebind(newID);
-      }
-      return true;
+      return Reflect.set(...arguments);
     }
-    return Reflect.set(...arguments);
-  }
   };
   return trap;
 }

--- a/src/strands/strands_transpiler.js
+++ b/src/strands/strands_transpiler.js
@@ -40,6 +40,21 @@ function nodeIsUniform(ancestor) {
     );
 }
 
+function nodeIsUniformStorage(node) {
+  return node && node.type === 'CallExpression'
+    && (
+      (
+        // Global mode
+        node.callee?.type === 'Identifier' &&
+        node.callee?.name === 'uniformStorage'
+      ) || (
+        // Instance mode
+        node.callee?.type === 'MemberExpression' &&
+        node.callee?.property?.name === 'uniformStorage'
+      )
+    );
+}
+
 function nodeIsUniformCallbackFn(node, names) {
   if (!names?.size) return false;
   if (node.type === 'FunctionDeclaration' && names.has(node.id?.name)) return true;
@@ -82,6 +97,143 @@ function collectUniformCallbackNames(ast) {
     }
   });
   return names;
+}
+
+function markStorageBindings(ast) {
+  const lookupStorageBinding = (scopeStack, name) => {
+    for (let i = scopeStack.length - 1; i >= 0; i--) {
+      if (scopeStack[i].has(name)) {
+        return scopeStack[i].get(name);
+      }
+    }
+    return false;
+  };
+
+  const declareStorageBinding = (scopeStack, name, isStorage) => {
+    scopeStack[scopeStack.length - 1].set(name, isStorage);
+  };
+
+  const assignStorageBinding = (scopeStack, name, isStorage) => {
+    for (let i = scopeStack.length - 1; i >= 0; i--) {
+      if (scopeStack[i].has(name)) {
+        scopeStack[i].set(name, isStorage);
+        return;
+      }
+    }
+    scopeStack[scopeStack.length - 1].set(name, isStorage);
+  };
+
+  const expressionIsStorageBound = (node, scopeStack) => {
+    if (!node) return false;
+    if (nodeIsUniformStorage(node)) return true;
+    if (node.type === 'Identifier') {
+      return lookupStorageBinding(scopeStack, node.name);
+    }
+    return false;
+  };
+
+  recursive(ast, { scopeStack: [new Map()] }, {
+    Program(node, state, c) {
+      for (const statement of node.body) {
+        c(statement, state);
+      }
+    },
+    BlockStatement(node, state, c) {
+      state.scopeStack.push(new Map());
+      for (const statement of node.body) {
+        c(statement, state);
+      }
+      state.scopeStack.pop();
+    },
+    FunctionDeclaration(node, state, c) {
+      if (node.id?.name) {
+        declareStorageBinding(state.scopeStack, node.id.name, false);
+      }
+      state.scopeStack.push(new Map());
+      for (const param of node.params) {
+        if (param.type === 'Identifier') {
+          declareStorageBinding(state.scopeStack, param.name, false);
+        }
+      }
+      if (node.body) c(node.body, state);
+      state.scopeStack.pop();
+    },
+    FunctionExpression(node, state, c) {
+      state.scopeStack.push(new Map());
+      if (node.id?.name) {
+        declareStorageBinding(state.scopeStack, node.id.name, false);
+      }
+      for (const param of node.params) {
+        if (param.type === 'Identifier') {
+          declareStorageBinding(state.scopeStack, param.name, false);
+        }
+      }
+      if (node.body) c(node.body, state);
+      state.scopeStack.pop();
+    },
+    ArrowFunctionExpression(node, state, c) {
+      state.scopeStack.push(new Map());
+      for (const param of node.params) {
+        if (param.type === 'Identifier') {
+          declareStorageBinding(state.scopeStack, param.name, false);
+        }
+      }
+      if (node.body) c(node.body, state);
+      state.scopeStack.pop();
+    },
+    VariableDeclaration(node, state, c) {
+      for (const declaration of node.declarations) {
+        c(declaration, state);
+      }
+    },
+    VariableDeclarator(node, state, c) {
+      if (node.init) c(node.init, state);
+      if (node.id.type === 'Identifier') {
+        declareStorageBinding(
+          state.scopeStack,
+          node.id.name,
+          expressionIsStorageBound(node.init, state.scopeStack)
+        );
+      }
+    },
+    AssignmentExpression(node, state, c) {
+      if (node.left.type === 'MemberExpression') {
+        c(node.left.object, state);
+        if (node.left.property) c(node.left.property, state);
+      } else {
+        c(node.left, state);
+      }
+      if (node.right) c(node.right, state);
+
+      if (node.operator === '=') {
+        if (node.left.type === 'Identifier') {
+          assignStorageBinding(
+            state.scopeStack,
+            node.left.name,
+            expressionIsStorageBound(node.right, state.scopeStack)
+          );
+        } else if (
+          node.left.type === 'MemberExpression' &&
+          node.left.computed &&
+          node.left.object.type === 'Identifier' &&
+          lookupStorageBinding(state.scopeStack, node.left.object.name)
+        ) {
+          node._p5StorageSet = true;
+        }
+      }
+    },
+    MemberExpression(node, state, c) {
+      if (
+        node.computed &&
+        node.object.type === 'Identifier' &&
+        lookupStorageBinding(state.scopeStack, node.object.name)
+      ) {
+        node._p5StorageGet = true;
+      }
+      c(node.object, state);
+      if (node.property) c(node.property, state);
+    }
+  });
 }
 
 function nodeIsVarying(node) {
@@ -358,7 +510,7 @@ const ASTCallbacks = {
     ) {
       return;
     }
-    if (node.computed) {
+    if (node.computed && node._p5StorageGet) {
       const callee = node.object;
       const member = node.property;
       node.computed = undefined;
@@ -499,7 +651,7 @@ const ASTCallbacks = {
     // Handle swizzle assignment to varying variable: myVarying.xyz = value
     // Note: node.left.object might be worldPos.getValue() due to prior Identifier transformation
     else if (node.left.type === 'MemberExpression') {
-      if (node.left.computed) {
+      if (node.left.computed && node._p5StorageSet) {
         const source = node.left;
         const value = node.right;
         const callee = source.object;
@@ -1238,8 +1390,8 @@ const ASTCallbacks = {
     delete node.update;
   },
 
-  
-  
+
+
 }
 
 // Helper function to check if a function body contains return statements in control flow
@@ -1665,6 +1817,9 @@ export function transpileStrandsToJS(p5, sourceString, srcLocations, scope) {
 
   // Pre-pass: collect names of functions passed by reference as uniform callbacks
   const uniformCallbackNames = collectUniformCallbackNames(ast);
+
+  // Pre-pass: mark identifiers and computed accesses tied to storage bindings
+  markStorageBindings(ast);
 
   // First pass: transform .set() calls in control flow to use intermediate variables
   transformSetCallsInControlFlow(ast, uniformCallbackNames);

--- a/test/unit/webgpu/p5.RendererWebGPU.js
+++ b/test/unit/webgpu/p5.RendererWebGPU.js
@@ -253,5 +253,27 @@ suite('WebGPU p5.RendererWebGPU', function() {
         expect(result[i]).to.be.closeTo(input[i] * 2, 0.001);
       }
     });
+
+    test('reads back data modified through a storage alias in a compute shader', async function() {
+      const input = new Float32Array([1, 2, 3, 4]);
+      const buf = myp5.createStorage(input);
+
+      const computeShader = myp5.buildComputeShader(() => {
+        const data = myp5.uniformStorage();
+        const alias = data;
+        const idx = myp5.index.x;
+        alias[idx] = alias[idx] * 2;
+      }, { myp5 });
+
+      computeShader.setUniform('data', buf);
+      myp5.compute(computeShader, 4);
+
+      const result = await buf.read();
+
+      expect(result).to.be.instanceOf(Float32Array);
+      for (let i = 0; i < input.length; i++) {
+        expect(result[i]).to.be.closeTo(input[i] * 2, 0.001);
+      }
+    });
   });
 });

--- a/test/unit/webgpu/p5.Shader.js
+++ b/test/unit/webgpu/p5.Shader.js
@@ -41,6 +41,30 @@ suite('WebGPU p5.Shader', function() {
       }).not.toThrowError();
     });
 
+    test('does not rewrite ordinary array indexing to storage access', async () => {
+      await myp5.createCanvas(10, 10, myp5.WEBGPU);
+      const myShader = myp5.baseMaterialShader().modify(() => {
+        function palette() {
+          return [0.25, 0.75];
+        }
+
+        myp5.getPixelInputs(inputs => {
+          const values = palette();
+          inputs.color = [values[0], values[1], 0, 1];
+          return inputs;
+        });
+      }, { myp5 });
+
+      myp5.noStroke();
+      myp5.shader(myShader);
+      myp5.plane(myp5.width, myp5.height);
+
+      const pixelColor = await myp5.get(5, 5);
+      assert.approximately(pixelColor[0], 64, 5);
+      assert.approximately(pixelColor[1], 191, 5);
+      assert.approximately(pixelColor[2], 0, 5);
+    });
+
     suite('if statement conditionals', () => {
       test('handle simple if statement with true condition', async () => {
         await myp5.createCanvas(50, 50, myp5.WEBGPU);


### PR DESCRIPTION
Resolves #8756

## Changes:

### Summary
This fixes the `get() can only be used on storage buffers` error when `p5.strands` transpiles computed indexing on non storage values.  

Previously, the transpiler rewrote every computed access like `arr[i]` into `arr.get(i)` and every computed assignment like `arr[i] = value` into `arr.set(i, value)`. That was correct for `uniformStorage()` buffers, but incorrect for ordinary strands values created from array literals or helper returned vector like values. In those cases, indexing was being routed through the storage buffer only path.  

### What I found

426929575d65c23b7a825a1bb2118d8ae0892521 Added `.get()`, `set()` to `src/strands/strands_node.js`

db483fb8b1f39d7dc316d90fc6e9edd670831f9e Added `MemberExpression`, Modified `AssignmentExpression` to add `.get()`, `.set()` to the AST

`StrandsNode.get()`, `StrandsNode.set()` are meant to be used on storage buffers, but the transpiler put `.get()` on every computed member expression.

```js
// original code
function errorCallback() {
  let data = p.uniformStorage(storage);
  function getArray() {
    return [1, 2];
  }
  let arr = getArray();
  data[p.index.x] = arr[0] + arr[1] + float(p.index.x);
}
  
// transpiled code
let data = p.uniformStorage('data', storage);
function getArray() {
  return __p5.strandsNode([
    1,
    2
  ]);
}
let arr = getArray();
data.set(p.index.x, arr.get(0).add(arr.get(1)).add(float(p.index.x)));
```

The transpiler should only put `.get()`, `.set()` on storage buffers.

### What changed
#### 1. Added storage-binding analysis in `src/strands/strands_transpiler.js`
I added a pre-pass that tracks identifiers originating from `uniformStorage(...)` and propagates simple same scope aliases, for example:  

```js
const data = uniformStorage(...);
const alias = data;
```

This pass annotates computed member accesses that are definitely storage backed.

#### 2. Gated `.get()`, `.set()` rewrites to storage backed bindings only
`obj[idx]` → `obj.get(idx)`
`obj[idx] = value` → `obj.set(idx, value)`
The `MemberExpression` and computed `ArrayExpression` transpiler rewrites now only convert when `obj` is known to be storage backed.  

#### 3. Added numeric indexing support for ordinary vector-like `StrandsNode`s
In `src/strands/ir_builders.js`, I extended `swizzleTrap` so numeric indexing on non storage strands values maps to canonical swizzles:  
`value[0]` → `value.x`
`value[1]` → `value.y`
`value[2]` → `value.z`
`value[3]` → `value.w`


### Why this fixes the bug
With this change:  
- storage buffers still use `.get()`, `.set()`
- helper returned array like values no longer get misrouted into the storage only access path
- numeric indexing on ordinary strands values is handled through the existing swizzle machinery instead

### Tests added
I added targeted regressions for both sides of the behavior:  
1. a WebGPU compute-shader test that verifies storage aliases still work
2. a shader test that verifies ordinary array/vector indexing does not go through storage access

### Validation

#### Unit tests
`npm test -- test/unit/webgpu/p5.Shader.js test/unit/webgpu/p5.RendererWebGPU.js`
Both passed after the change.  

#### Sketch
Used an HTML file for `npm run dev` debugging. Put it at `preview/issue-8756.html`, and open browser to `http://localhost:5173/issue-8756.html`

<details>
<summary>HTML sketch file</summary>

```html
<!DOCTYPE html>
<html>

<head>
  <title>p5.js issue #8756 debug preview</title>
  <meta http-equiv="pragma" content="no-cache" />
  <meta http-equiv="cache-control" content="no-cache" />
  <meta charset="utf-8">
  <style>
    body {
      margin: 0;
      background: #111;
      min-height: 100vh;
    }

    #canvas {
      display: flex;
      align-items: center;
      justify-content: center;
      min-height: 100vh;
    }
  </style>
</head>

<body>
  <div id="canvas"></div>

  <script type="module">
    import p5 from '../src/app.js';
    import rendererWebGPU from '../src/webgpu/p5.RendererWebGPU.js';

    p5.registerAddon(rendererWebGPU);

    function captureTranspiledBodies(run) {
      const OriginalFunction = globalThis.Function;
      const captured = [];

      function WrappedFunction(...args) {
        captured.push({
          args: [...args],
          body: typeof args.at(-1) === 'string' ? args.at(-1) : null,
        });
        return OriginalFunction(...args);
      }

      WrappedFunction.prototype = OriginalFunction.prototype;
      Object.setPrototypeOf(WrappedFunction, OriginalFunction);
      globalThis.Function = WrappedFunction;

      try {
        return { value: run(), captured };
      } finally {
        globalThis.Function = OriginalFunction;
      }
    }

    const COUNT = 10;

    const sketch = function (p) {
      let storage;
      let okShader;

      function callback() {
        let data = p.uniformStorage(storage);
        function getNumber() {
          return 1;
        }
        let num = getNumber();
        data[p.index.x] = num + p.index.x;
      }

      function errorCallback() {
        let data = p.uniformStorage(storage);
        function getArray() {
          return [1, 2];
        }
        let arr = getArray();
        data[p.index.x] = arr[0] + arr[1] + p.index.x;
      }

      p.setup = async function () {
        const canvas = await p.createCanvas(420, 420, p.WEBGPU);
        canvas.parent('canvas');
        p.noLoop();
        p.background(24);

        storage = p.createStorage(new Float32Array(COUNT));

        console.log('=== baseComputeShader hooks ===');
        p.baseComputeShader().inspectHooks();

        console.log('=== building working scalar-return compute shader ===');
        const okCapture = captureTranspiledBodies(() =>
          p.buildComputeShader(callback, { p, storage })
        );
        okShader = okCapture.value;
        console.log('working shader created:', !!okShader);
        console.log('working transpiled callback body:');
        console.log(okCapture.captured.at(-1)?.body ?? '<no body captured>');
        console.log('working compute source:');
        console.log(okShader.computeSrc());
        okShader.inspectHooks();

        console.log('=== building failing array-return compute shader ===');
        try {
          const errorCapture = captureTranspiledBodies(() =>
            p.buildComputeShader(errorCallback, { p, storage })
          );
          console.log('unexpectedly built failing shader:', !!errorCapture.value);
          console.log('failing transpiled callback body:');
          console.log(errorCapture.captured.at(-1)?.body ?? '<no body captured>');
          if (errorCapture.value) {
            console.log('failing compute source:');
            console.log(errorCapture.value.computeSrc());
            errorCapture.value.inspectHooks();
          }
        } catch (error) {
          console.log('caught expected error while building failing shader:');
          console.log(error?.stack || String(error));

          const errorCapture = captureTranspiledBodies(() => {
            try {
              p.buildComputeShader(errorCallback, { p, storage });
            } catch {
              return null;
            }
          });
          console.log('captured transpiled callback body for failing shader:');
          console.log(errorCapture.captured.at(-1)?.body ?? '<no body captured>');
        }

        console.log('=== dispatching working shader ===');
        p.compute(okShader, COUNT);
        const data = await storage.read();
        console.log('storage.read() after working shader:', Array.from(data));

        p.fill('#4ECDC4');
        p.noStroke();
        p.circle(p.width / 2, p.height / 2, 120);
      };
    };

    new p5(sketch);
  </script>
</body>

</html>
```

</details>


<details>
<summary> Console output (before the fix) </summary>

```
client:733 [vite] connecting...
client:827 [vite] connected.
issue-8756.html:89 === baseComputeShader hooks ===
p5.Shader.js:182 ==== Compute shader hooks: ====
p5.Shader.js:184 void iteration(index: vec3<i32>) {}
p5.Shader.js:209 
p5.Shader.js:210 ==== Helper functions: ====
issue-8756.html:92 === building working scalar-return compute shader ===
param_validator.js:518 🌸 p5.js says: Expected at most 1 argument, but received more in buildComputeShader(). For more information, see https://p5js.org/reference/p5/buildComputeShader.
issue-8756.html:97 working shader created: true
issue-8756.html:98 working transpiled callback body:
issue-8756.html:99 
    let data = p.uniformStorage('data', storage);
    function getNumber() {
        return 1;
    }
    let num = getNumber();
    data.set(p.index.x, __p5.strandsNode(num).add(p.index.x));

issue-8756.html:100 working compute source:
issue-8756.html:101 
struct ComputeUniforms {
  uTotalCount: vec3<i32>,
  uPhysicalCount: vec3<i32>,
}
@group(0) @binding(0) var<uniform> uniforms: ComputeUniforms;


const AUGMENTED_HOOK_iteration = true;



@group(0) @binding(1) var<storage, read_write> data: array<f32>;
fn HOOK_iteration(index: vec3<i32>) {
  data[i32(index.x)] = (f32(1.0000) + f32(f32(index.x)));
}
@compute @workgroup_size(8, 8, 1)
fn main(
  @builtin(global_invocation_id) globalId: vec3<u32>,
  @builtin(local_invocation_id) localId: vec3<u32>,
  @builtin(workgroup_id) workgroupId: vec3<u32>,
  @builtin(local_invocation_index) localIndex: u32
) {
  let totalIterations = u32(uniforms.uTotalCount.x) * u32(uniforms.uTotalCount.y) * u32(uniforms.uTotalCount.z);
  let physicalId = globalId.x + globalId.y * (u32(uniforms.uPhysicalCount.x)) + globalId.z * (u32(uniforms.uPhysicalCount.x) * u32(uniforms.uPhysicalCount.y));

  if (physicalId >= totalIterations) {
    return;
  }

  var index = vec3<i32>(0);
  index.x = i32(physicalId % u32(uniforms.uTotalCount.x));
  let remainingY = physicalId / u32(uniforms.uTotalCount.x);
  index.y = i32(remainingY % u32(uniforms.uTotalCount.y));
  index.z = i32(remainingY / u32(uniforms.uTotalCount.y));

  HOOK_iteration(index);
}

p5.Shader.js:182 ==== Compute shader hooks: ====
p5.Shader.js:184 [MODIFIED] void iteration(index: vec3<i32>) {
  data[i32(index.x)] = (f32(1.0000) + f32(f32(index.x)));
}
p5.Shader.js:184 declarations
@group(0) @binding(1) var<storage, read_write> data: array<f32>;
p5.Shader.js:209 
p5.Shader.js:210 ==== Helper functions: ====
issue-8756.html:104 === building failing array-return compute shader ===
param_validator.js:518 🌸 p5.js says: Expected at most 1 argument, but received more in buildComputeShader(). For more information, see https://p5js.org/reference/p5/buildComputeShader.
issue-8756.html:118 caught expected error while building failing shader:
issue-8756.html:119 Error: get() can only be used on storage buffers
    at Proxy.get (strands_node.js:172:13)
    at eval (eval at WrappedFunction (issue-8756.html:43:16), <anonymous>:12:29)
    at strands_transpiler.js:1766:18
    at p5.Shader.modify (p5.strands.js:178:11)
    at fn.buildComputeShader (p5.Renderer3D.js:2391:37)
    at p5.buildComputeShader (param_validator.js:615:27)
    at issue-8756.html:107:15
    at captureTranspiledBodies (issue-8756.html:51:25)
    at p.setup (issue-8756.html:106:32)
    at async #_setup (main.js:238:7)
param_validator.js:518 🌸 p5.js says: Expected at most 1 argument, but received more in buildComputeShader(). For more information, see https://p5js.org/reference/p5/buildComputeShader.
issue-8756.html:128 captured transpiled callback body for failing shader:
issue-8756.html:129 
    let data = p.uniformStorage('data', storage);
    function getArray() {
        return __p5.strandsNode([
            1,
            2
        ]);
    }
    let arr = getArray();
    data.set(p.index.x, arr.get(0).add(arr.get(1)).add(p.index.x));

issue-8756.html:132 === dispatching working shader ===
issue-8756.html:135 storage.read() after working shader: (12) [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 0, 0]
```

</details>


<details>
<summary>Console output (after the fix) </summary>

```

issue-8756.html:89 === baseComputeShader hooks ===
p5.Shader.js:182 ==== Compute shader hooks: ====
p5.Shader.js:184 void iteration(index: vec3<i32>) {}
p5.Shader.js:209 
p5.Shader.js:210 ==== Helper functions: ====
issue-8756.html:92 === building working scalar-return compute shader ===
param_validator.js:518 🌸 p5.js says: Expected at most 1 argument, but received more in buildComputeShader(). For more information, see https://p5js.org/reference/p5/buildComputeShader.
issue-8756.html:97 working shader created: true
issue-8756.html:98 working transpiled callback body:
issue-8756.html:99 
    let data = p.uniformStorage('data', storage);
    function getNumber() {
        return 1;
    }
    let num = getNumber();
    data.set(p.index.x, __p5.strandsNode(num).add(p.index.x));

issue-8756.html:100 working compute source:
issue-8756.html:101 
struct ComputeUniforms {
  uTotalCount: vec3<i32>,
  uPhysicalCount: vec3<i32>,
}
@group(0) @binding(0) var<uniform> uniforms: ComputeUniforms;


const AUGMENTED_HOOK_iteration = true;



@group(0) @binding(1) var<storage, read_write> data: array<f32>;
fn HOOK_iteration(index: vec3<i32>) {
  data[i32(index.x)] = (f32(1.0000) + f32(f32(index.x)));
}
@compute @workgroup_size(8, 8, 1)
fn main(
  @builtin(global_invocation_id) globalId: vec3<u32>,
  @builtin(local_invocation_id) localId: vec3<u32>,
  @builtin(workgroup_id) workgroupId: vec3<u32>,
  @builtin(local_invocation_index) localIndex: u32
) {
  let totalIterations = u32(uniforms.uTotalCount.x) * u32(uniforms.uTotalCount.y) * u32(uniforms.uTotalCount.z);
  let physicalId = globalId.x + globalId.y * (u32(uniforms.uPhysicalCount.x)) + globalId.z * (u32(uniforms.uPhysicalCount.x) * u32(uniforms.uPhysicalCount.y));

  if (physicalId >= totalIterations) {
    return;
  }

  var index = vec3<i32>(0);
  index.x = i32(physicalId % u32(uniforms.uTotalCount.x));
  let remainingY = physicalId / u32(uniforms.uTotalCount.x);
  index.y = i32(remainingY % u32(uniforms.uTotalCount.y));
  index.z = i32(remainingY / u32(uniforms.uTotalCount.y));

  HOOK_iteration(index);
}

p5.Shader.js:182 ==== Compute shader hooks: ====
p5.Shader.js:184 [MODIFIED] void iteration(index: vec3<i32>) {
  data[i32(index.x)] = (f32(1.0000) + f32(f32(index.x)));
}
p5.Shader.js:184 declarations
@group(0) @binding(1) var<storage, read_write> data: array<f32>;
p5.Shader.js:209 
p5.Shader.js:210 ==== Helper functions: ====
issue-8756.html:104 === building failing array-return compute shader ===
param_validator.js:518 🌸 p5.js says: Expected at most 1 argument, but received more in buildComputeShader(). For more information, see https://p5js.org/reference/p5/buildComputeShader.
issue-8756.html:109 unexpectedly built failing shader: true
issue-8756.html:110 failing transpiled callback body:
issue-8756.html:111 
    let data = p.uniformStorage('data', storage);
    function getArray() {
        return __p5.strandsNode([
            1,
            2
        ]);
    }
    let arr = getArray();
    data.set(p.index.x, arr[0].add(arr[1]).add(p.index.x));

issue-8756.html:113 failing compute source:
issue-8756.html:114 
struct ComputeUniforms {
  uTotalCount: vec3<i32>,
  uPhysicalCount: vec3<i32>,
}
@group(0) @binding(0) var<uniform> uniforms: ComputeUniforms;


const AUGMENTED_HOOK_iteration = true;



@group(0) @binding(1) var<storage, read_write> data: array<f32>;
fn HOOK_iteration(index: vec3<i32>) {
  var T0: vec2<f32> = vec2<f32>(1.0000, 2.0000);
  data[i32(index.x)] = ((T0.x + T0.y) + f32(f32(index.x)));
}
@compute @workgroup_size(8, 8, 1)
fn main(
  @builtin(global_invocation_id) globalId: vec3<u32>,
  @builtin(local_invocation_id) localId: vec3<u32>,
  @builtin(workgroup_id) workgroupId: vec3<u32>,
  @builtin(local_invocation_index) localIndex: u32
) {
  let totalIterations = u32(uniforms.uTotalCount.x) * u32(uniforms.uTotalCount.y) * u32(uniforms.uTotalCount.z);
  let physicalId = globalId.x + globalId.y * (u32(uniforms.uPhysicalCount.x)) + globalId.z * (u32(uniforms.uPhysicalCount.x) * u32(uniforms.uPhysicalCount.y));

  if (physicalId >= totalIterations) {
    return;
  }

  var index = vec3<i32>(0);
  index.x = i32(physicalId % u32(uniforms.uTotalCount.x));
  let remainingY = physicalId / u32(uniforms.uTotalCount.x);
  index.y = i32(remainingY % u32(uniforms.uTotalCount.y));
  index.z = i32(remainingY / u32(uniforms.uTotalCount.y));

  HOOK_iteration(index);
}

p5.Shader.js:182 ==== Compute shader hooks: ====
p5.Shader.js:184 [MODIFIED] void iteration(index: vec3<i32>) {
  var T0: vec2<f32> = vec2<f32>(1.0000, 2.0000);
  data[i32(index.x)] = ((T0.x + T0.y) + f32(f32(index.x)));
}
p5.Shader.js:184 declarations
@group(0) @binding(1) var<storage, read_write> data: array<f32>;
p5.Shader.js:209 
p5.Shader.js:210 ==== Helper functions: ====
issue-8756.html:132 === dispatching working shader ===
issue-8756.html:135 storage.read() after working shader: (12) [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 0, 0]
```

</details>

AI (OpenAI Codex) was used to help investigate repo history, reason about the transpiler behavior(understanding acorn-walk source code, AST node types), and draft this fix. I reviewed and understood the final changes before submitting.

#### PR Checklist
- [ ] `npm run lint` passes
- [ ] [Inline reference] is included / updated
- [x] [Unit tests] are included / updated

[Inline reference]: https://p5js.org/contribute/contributing_to_the_p5js_reference/
[Unit tests]: https://github.com/processing/p5.js/tree/main/contributor_docs#unit-tests
