### PR TITLE
fix(color): correct toString() format string for 'hsla%' case

### DIFF
--- a/src/color/p5.Color.js
+++ b/src/color/p5.Color.js
@@ -552,7 +552,7 @@ p5.Color = class Color {
 
       case 'hsla%':
         if (!this.hsla) this.hsla = color_conversion._rgbaToHSLA(this._array);
-        return 'hsl('.concat(
+        return 'hsla('.concat(
           (100 * this.hsla[0]).toPrecision(3),
           '%, ',
           (100 * this.hsla[1]).toPrecision(3),


### PR DESCRIPTION
## Bug

In `p5.Color.toString()`, the `'hsla%'` case returns a string starting with `'hsl('` instead of `'hsla('`, so the output is a three-component HSL string even though the caller explicitly requested the four-component HSLA format with an alpha channel.

## Root cause

```js
case 'hsla%':
  if (!this.hsla) this.hsla = color_conversion._rgbaToHSLA(this._array);
  return 'hsl('.concat(   // ← 'a' missing
    ...alpha...
  );
```

The value is appended as the fourth component but the function name prefix is wrong, so the returned string is `hsl(H%, S%, L%, A%)` — not a valid CSS colour — instead of the correct `hsla(H%, S%, L%, A%)`.

## Why the fix is correct

The parallel `'hsba%'` case (line 507) correctly uses `'hsba('.concat(...)`. The `'hsla'` case (line 542) also correctly uses `'hsla('.concat(...)`. The `'hsla%'` case should follow the same pattern; the only change is adding the missing `'a'` to the format prefix.