### PR TITLE
Add FES Korean translation for preloadDisabled

### DIFF
--- a/translations/ko/translation.json
+++ b/translations/ko/translation.json
@@ -47,6 +47,7 @@
     "misspelling": "{{location}} 혹시 p5.js의 {{type}}를 사용하시려면 \"{{name}}\"를 {{actualName}}로 고쳐 보세요.",
     "misspelling_plural": "{{location}} 혹시 p5.js의 {{type}}를 사용하시려면 \"{{name}}\"를 다음 중 하나로 고쳐보세요: \n{{suggestions}}",
     "misusedTopLevel": "{{location}} 혹시 p5.js의 {{symbolType}} 타입 {{symbolName}}을 사용하셨나요? 그렇다면 {{symbolName}}을 작성 중인 setup() 함수의 대괄호 안으로 옮겨보세요.\n\n+ 추가 정보: {{url}}",
+    "preloadDisabled": "preload() 함수는 p5.js 2.0에서 제거되었습니다. setup() 함수에서 async/await 키워드나 콜백을 사용하여 에셋을 로드하세요. 2.0 및 호환성에 대한 자세한 내용은 https://github.com/processing/p5.js-compatibility 를 참고하거나, Promise와 async/await에 대한 자세한 내용은 https://dev.to/limzykenneth/asynchronous-p5js-20-458f 를 참고하세요.",
     "positions": {
       "p_1": "1번째",
       "p_10": "10번째",


### PR DESCRIPTION
Resolves #8395

 Changes:
Added Korean translation for FES `preloadDisabled`.

#### PR Checklist
<!--
  To check any option, replace the "[ ]" with a "[x]". Be sure to check out how it looks in the Preview tab! Feel free to remove any portion of the template that is not relevant for your issue.
-->

- [ ] `npm run lint` passes
- [ ] [Inline reference] is included / updated
- [ ] [Unit tests] are included / updated

[Inline reference]: https://p5js.org/contribute/contributing_to_the_p5js_reference/
[Unit tests]: https://github.com/processing/p5.js/tree/main/contributor_docs#unit-tests
