### PR TITLE
States tests and rename

### DIFF
--- a/src/core/States.js
+++ b/src/core/States.js
@@ -14,7 +14,7 @@ export class States {
     this[key] = value;
   }
 
-  getDiff() {
+  takeDiff() {
     const diff = this.#modified;
     this.#modified = {};
     return diff;

--- a/src/core/p5.Renderer.js
+++ b/src/core/p5.Renderer.js
@@ -135,7 +135,7 @@ class Renderer {
   // and push it into the push pop stack
   push() {
     this._pushPopDepth++;
-    this._pushPopStack.push(this.states.getDiff());
+    this._pushPopStack.push(this.states.takeDiff());
   }
 
   // Pop the previous states out of the push pop stack and

--- a/test/unit/core/States.js
+++ b/test/unit/core/States.js
@@ -1,0 +1,70 @@
+import { States } from '../../../src/core/States.js';
+
+suite('States', function () {
+  test('initialises with provided state', function () {
+    const s = new States({ fill: 'red', stroke: 'blue' });
+    assert.equal(s.fill, 'red');
+    assert.equal(s.stroke, 'blue');
+  });
+
+  test('setValue() updates the value', function () {
+    const s = new States({ fill: 'red' });
+    s.setValue('fill', 'green');
+    assert.equal(s.fill, 'green');
+  });
+
+  test('setValue() records the original before first modification', function () {
+    const s = new States({ fill: 'red' });
+    s.setValue('fill', 'green');
+    assert.equal(s.getModified().fill, 'red');
+  });
+
+  test('setValue() does not overwrite original on repeated calls', function () {
+    const s = new States({ fill: 'red' });
+    s.setValue('fill', 'green');
+    s.setValue('fill', 'blue');
+    assert.equal(s.getModified().fill, 'red');
+  });
+
+  test('takeDiff() returns the modified map', function () {
+    const s = new States({ fill: 'red' });
+    s.setValue('fill', 'green');
+    const diff = s.takeDiff();
+    assert.equal(diff.fill, 'red');
+  });
+
+  test('takeDiff() clears #modified after returning', function () {
+    const s = new States({ fill: 'red' });
+    s.setValue('fill', 'green');
+    s.takeDiff();
+    assert.deepEqual(s.takeDiff(), {});
+  });
+
+  test('applyDiff() undoes current modifications and replaces #modified', function () {
+    const s = new States({ fill: 'red' });
+    s.setValue('fill', 'green');
+    const outerModified = {};
+    s.applyDiff(outerModified);
+    assert.equal(s.fill, 'red');
+    assert.deepEqual(s.getModified(), {});
+  });
+
+  test('applyDiff() with a non-empty prevModified replaces #modified', function () {
+    const s = new States({ fill: 'red', stroke: 'black' });
+    s.setValue('fill', 'green');
+    const outerModified = { stroke: 'black' };
+    s.applyDiff(outerModified);
+    assert.equal(s.fill, 'red');
+    assert.deepEqual(s.getModified(), { stroke: 'black' });
+  });
+
+  test('push/pop cycle: applyDiff restores prior state', function () {
+    const s = new States({ fill: 'red' });
+    const beforePush = s.takeDiff();
+    s.setValue('fill', 'green');
+    assert.equal(s.fill, 'green');
+    s.applyDiff(beforePush);
+    assert.equal(s.fill, 'red');
+    assert.deepEqual(s.getModified(), {});
+  });
+});


### PR DESCRIPTION
Resolves #8761

### Changes

- Renamed `States.getDiff()` → `States.takeDiff()` to reflect that it mutates state (clears `#modified` after returning), per discussion in #8761 with @davepagurek.
- Updated the one call site in `src/core/p5.Renderer.js` to use the new name.
- Added a new test file `test/unit/core/States.js` with 9 tests covering the public API: constructor, `setValue`, `getModified`, `takeDiff`, `applyDiff`, plus a push/pop integration test.

### Notes on test results

Local `npm test` shows all 9 new `States` tests passing. There are 4 pre-existing unrelated timeout failures in visual regression tests (`test/unit/visual/cases/noise.js`, `test/unit/visual/cases/shape_modes.js`) that don't reference any of the code I changed — they appear flaky on my machine. Running the new test file in isolation (`npx vitest run test/unit/core/States.js`) shows clean 9/9 pass.

### PR Checklist

- [x] `npm run lint` passes
- [ ] [Inline reference] is included / updated
- [x] [Unit tests] are included / updated

[Inline reference]: https://p5js.org/contribute/contributing_to_the_p5js_reference/
[Unit tests]: https://github.com/processing/p5.js/tree/main/contributor_docs#unit-tests