### PR TITLE
Update vector docs to indicate recommended usage

### DIFF
--- a/src/math/p5.Vector.js
+++ b/src/math/p5.Vector.js
@@ -2690,14 +2690,15 @@ class Vector {
    * Returns the vector's components as an array of numbers.
    *
    * @return {Number[]} array with the vector's components.
+   * @deprecated To retrieve vector components, use `v.values`
    * @example
    * // META:norender
    * function setup() {
    *   // Create a p5.Vector object.
    *   let v = createVector(20, 30);
    *
-   *   // Prints "[20, 30, 0]" to the console.
-   *   print(v.array());
+   *   // Prints "[20, 30]" to the console.
+   *   print(v.values);
    * }
    */
   array() {

--- a/src/math/p5.Vector.js
+++ b/src/math/p5.Vector.js
@@ -2700,8 +2700,8 @@ class Vector {
    *   // Create a p5.Vector object.
    *   let v = createVector(20, 30);
    *
-   *   // Prints "[20, 30]" to the console.
-   *   print(v.values);
+   *   // Prints "[20, 30, 0]" to the console.
+   *   print(v.array());
    * }
    */
   array() {

--- a/src/math/p5.Vector.js
+++ b/src/math/p5.Vector.js
@@ -1372,6 +1372,9 @@ class Vector {
    * The cross product is a vector that points straight out of the plane created
    * by two vectors. The cross product's magnitude is the area of the parallelogram
    * formed by the original two vectors.
+   * 
+   * The cross product is defined on 3-dimensional vectors, and will use the `x`, `y`,
+   * and `z` components. This method should only be used with 3D vectors.
    *
    * The static version of `cross()`, as in `p5.Vector.cross(v1, v2)`, is the same
    * as calling `v1.cross(v2)`.


### PR DESCRIPTION
Addresses https://github.com/processing/p5.js/issues/8151 and https://github.com/processing/p5.js/issues/8210 

* `array()` is marked for deprecation, and should not be used (`.values`) is recommended)
* `cross()` is defined only on three-dimensional vectors. To avoid breaking older code that relied on zero-padded vectors, no change in behavior is introduced to prevent use on vectors of unexpected dimensions. However, documentation has been updated.