### PR TITLE
Make sure all p5.strands math operators are converted to strands nodes

### DIFF
--- a/src/strands/strands_transpiler.js
+++ b/src/strands/strands_transpiler.js
@@ -323,17 +323,14 @@ function transformBinaryOrLogical(node, state, ancestors) {
   if (ancestors.some(a => nodeIsUniform(a) || nodeIsUniformCallbackFn(a, state.uniformCallbackNames))) {
     return;
   }
-  const unsafeTypes = ['Literal', 'ArrayExpression', 'Identifier'];
-  if (unsafeTypes.includes(node.left.type)) {
-    node.left = {
-      type: 'CallExpression',
-      callee: {
-        type: 'Identifier',
-        name: '__p5.strandsNode',
-      },
-      arguments: [node.left]
-    };
-  }
+  node.left = {
+    type: 'CallExpression',
+    callee: {
+      type: 'Identifier',
+      name: '__p5.strandsNode',
+    },
+    arguments: [node.left]
+  };
   node.type = 'CallExpression';
   node.callee = {
     type: 'MemberExpression',
@@ -1240,8 +1237,8 @@ const ASTCallbacks = {
     delete node.update;
   },
 
-  
-  
+
+
 }
 
 // Helper function to check if a function body contains return statements in control flow

--- a/test/unit/webgl/p5.Shader.js
+++ b/test/unit/webgl/p5.Shader.js
@@ -459,6 +459,21 @@ suite('p5.Shader', function() {
       }).not.toThrowError();
     });
 
+    test('buildFilterShader can use numeric constants from scope', () => {
+      myp5.createCanvas(5, 5, myp5.WEBGL);
+      const constants = { val: 100 };
+      const myShader = myp5.buildFilterShader(({ constants }) => {
+        filterColor.begin();
+        let c = 0;
+        c += constants.val / 255;
+        filterColor.set([c, c, c, 1]);
+        filterColor.end();
+      }, { constants });
+      expect(() => {
+        myp5.filter(myShader);
+      }).not.toThrowError();
+    });
+
     test('buildMaterialShader forwards scope to modify', () => {
       myp5.createCanvas(5, 5, myp5.WEBGL);
       expect(() => {


### PR DESCRIPTION
<!--
  Thank you for contributing! Please use this pull request (PR) template.


 In the description field of this PR, include "resolves #XXXX" tagging the issue you are fixing. If this PR addresses the issue but doesn't completely resolve it (ie the issue should remain open after your PR is merged), write "addresses #XXXX".-->
Resolves https://github.com/processing/p5.js/issues/8784

### Changes
Previously, we were only ensuring something is a strands node before chaining strands methods on it like `.mult` if it's a variable name, an array, or a value literal. There are other cases where you could end up chaining methods though, one of which being if you reference a property of a js object.

To be safe, now, instead of picking out specific types of code that need to be turned into a strands node, I've made it apply to everything. This has no effect if an operator is already a strands node other than the transpiled code looking a tad more complex, but means we'll always ensure we have a strands node before calling a method on it.


#### PR Checklist
<!--
  To check any option, replace the "[ ]" with a "[x]". Be sure to check out how it looks in the Preview tab! Feel free to remove any portion of the template that is not relevant for your issue.
-->

- [x] `npm run lint` passes
- [ ] [Inline reference] is included / updated
- [x] [Unit tests] are included / updated

[Inline reference]: https://p5js.org/contribute/contributing_to_the_p5js_reference/
[Unit tests]: https://github.com/processing/p5.js/tree/main/contributor_docs#unit-tests
