### PR TITLE
Make line shader hooks use unmultiplied alpha

### DIFF
--- a/src/webgl/shaders/line.frag
+++ b/src/webgl/shaders/line.frag
@@ -69,6 +69,7 @@ void main() {
       discard;
     }
   }
-  OUT_COLOR = HOOK_getFinalColor(vec4(inputs.color.rgb, 1.) * inputs.color.a, vec2(0.0, 0.0));
+  OUT_COLOR = HOOK_getFinalColor(inputs.color, vec2(0.0, 0.0));
+  OUT_COLOR.rgb *= OUT_COLOR.a;
   HOOK_afterFragment();
 }


### PR DESCRIPTION
<!--
  Thank you for contributing! Please use this pull request (PR) template.


 In the description field of this PR, include "resolves #XXXX" tagging the issue you are fixing. If this PR addresses the issue but doesn't completely resolve it (ie the issue should remain open after your PR is merged), write "addresses #XXXX".-->
Resolves https://github.com/processing/p5.js/issues/8786

Changes:
- Updates the WebGL line shader to accept unmultiplied color input and expect unmultiplied color output to be consistent with all the other hooks

#### PR Checklist
<!--
  To check any option, replace the "[ ]" with a "[x]". Be sure to check out how it looks in the Preview tab! Feel free to remove any portion of the template that is not relevant for your issue.
-->

- [x] `npm run lint` passes
- [ ] [Inline reference] is included / updated
- [ ] [Unit tests] are included / updated

[Inline reference]: https://p5js.org/contribute/contributing_to_the_p5js_reference/
[Unit tests]: https://github.com/processing/p5.js/tree/main/contributor_docs#unit-tests
