### PR TITLE
Don't use push(...arr) in GeometryBuilder for long vertex arrays

### DIFF
--- a/src/webgl/GeometryBuilder.js
+++ b/src/webgl/GeometryBuilder.js
@@ -64,11 +64,15 @@ class GeometryBuilder {
     }
 
     let startIdx = this.geometry.vertices.length;
-    this.geometry.vertices.push(...this.transformVertices(input.vertices));
-    this.geometry.vertexNormals.push(
-      ...this.transformNormals(input.vertexNormals)
-    );
-    this.geometry.uvs.push(...input.uvs);
+    for (const v of this.transformVertices(input.vertices)) {
+      this.geometry.vertices.push(v);
+    }
+    for (const vn of this.transformNormals(input.vertexNormals)) {
+      this.geometry.vertexNormals.push(vn);
+    }
+    for (const val of input.uvs) {
+      this.geometry.uvs.push(val);
+    }
 
     const inputUserVertexProps = input.userVertexProperties;
     const builtUserVertexProps = this.geometry.userVertexProperties;
@@ -103,15 +107,17 @@ class GeometryBuilder {
       );
     }
     if (this.renderer.states.strokeColor) {
-      this.geometry.edges.push(
-        ...input.edges.map(edge => edge.map(idx => idx + startIdx))
-      );
+      for (const edge of input.edges.map(edge => edge.map(idx => idx + startIdx))) {
+        this.geometry.edges.push(edge);
+      }
     }
     const vertexColors = [...input.vertexColors];
     while (vertexColors.length < input.vertices.length * 4) {
       vertexColors.push(...this.renderer.states.curFillColor);
     }
-    this.geometry.vertexColors.push(...vertexColors);
+    for (const c of vertexColors) {
+      this.geometry.vertexColors.push(c);
+    }
   }
 
   /**

--- a/test/unit/webgl/p5.RendererGL.js
+++ b/test/unit/webgl/p5.RendererGL.js
@@ -3089,6 +3089,23 @@ suite('p5.RendererGL', function() {
       myp5.model(geom);
       expect(myp5.get(5, 5)).toEqual([255, 0, 0, 255]);
     });
+    test('does not throw with a large number of vertices', function() {
+      myp5.createCanvas(10, 10, myp5.WEBGL);
+      // Enough triangles to exceed the ~65k argument limit of Function.prototype.apply,
+      // which would cause a stack overflow if vertices were spread into push() calls.
+      const numTriangles = 30000;
+      expect(() => {
+        myp5.buildGeometry(() => {
+          myp5.beginShape(myp5.TRIANGLES);
+          for (let i = 0; i < numTriangles; i++) {
+            myp5.vertex(0, 0, 0);
+            myp5.vertex(1, 0, 0);
+            myp5.vertex(0, 1, 0);
+          }
+          myp5.endShape();
+        });
+      }).not.toThrow();
+    });
   });
 
   suite('fontWidth', function() {


### PR DESCRIPTION
<!--
  Thank you for contributing! Please use this pull request (PR) template.


 In the description field of this PR, include "resolves #XXXX" tagging the issue you are fixing. If this PR addresses the issue but doesn't completely resolve it (ie the issue should remain open after your PR is merged), write "addresses #XXXX".-->
Resolves https://github.com/processing/p5.js/issues/8788

Changes:
- Instead of spreading an array into arguments of `push()`, which breaks if the array is bigger than the max number of function arguments in javascript, `GeometryBuilder` now uses a loop.

Non-crashing version of the sketch in the issue: https://editor.p5js.org/davepagurek/sketches/n6BJZ0GWI

#### PR Checklist
<!--
  To check any option, replace the "[ ]" with a "[x]". Be sure to check out how it looks in the Preview tab! Feel free to remove any portion of the template that is not relevant for your issue.
-->

- [x] `npm run lint` passes
- [ ] [Inline reference] is included / updated
- [x] [Unit tests] are included / updated

[Inline reference]: https://p5js.org/contribute/contributing_to_the_p5js_reference/
[Unit tests]: https://github.com/processing/p5.js/tree/main/contributor_docs#unit-tests
