### PR TITLE
Add shader examples to noise random and millis functions

### DIFF
--- a/src/math/noise.js
+++ b/src/math/noise.js
@@ -227,6 +227,32 @@ function noise(p5, fn){
    *     }
    *   }
    * }
+   *
+   * `noise()` can also be used in shaders with p5.strands. The following example
+   * uses `noise()` to create a cloud-like texture effect in a filter shader.
+   *
+   * ```js example
+   * let myFilter;
+   *
+   * function setup() {
+   *   createCanvas(100, 100, WEBGL);
+   *   myFilter = buildFilterShader(shaderCallback);
+   *   describe('A cloud-like noise pattern.');
+   * }
+   *
+   * function shaderCallback() {
+   *   filterColor.begin();
+   *   let coord = filterColor.texCoord;
+   *   let t = millis() / 2000;
+   *   let value = noise(coord.x * 5, coord.y * 5, t);
+   *   filterColor.set(mix([0.1, 0.1, 0.3, 1], [0.9, 0.9, 1, 1], value));
+   *   filterColor.end();
+   * }
+   *
+   * function draw() {
+   *   filter(myFilter);
+   * }
+   * ```
    */
   fn.noise = function(x, y = 0, z = 0) {
     if (perlin == null) {

--- a/src/math/noise.js
+++ b/src/math/noise.js
@@ -244,8 +244,10 @@ function noise(p5, fn){
    *   filterColor.begin();
    *   let coord = filterColor.texCoord;
    *   let t = millis() / 2000;
-   *   let value = noise(coord.x * 5, coord.y * 5, t);
-   *   filterColor.set(mix([0.1, 0.1, 0.3, 1], [0.9, 0.9, 1, 1], value));
+   *   let mixFraction = noise(coord.x * 5, coord.y * 5, t);
+   *   let darkBlue = [0.1, 0.1, 0.3, 1];
+   *   let lightBlue = [0.9, 0.9, 1, 1];
+   *   filterColor.set(mix(darkBlue, lightBlue, mixFraction));
    *   filterColor.end();
    * }
    *

--- a/src/math/noise.js
+++ b/src/math/noise.js
@@ -228,8 +228,9 @@ function noise(p5, fn){
    *   }
    * }
    *
-   * `noise()` can also be used in shaders with p5.strands. The following example
-   * uses `noise()` to create a cloud-like texture effect in a filter shader.
+   * `noise()` can also be used in shaders with p5.strands, where it returns
+   * values in the range 0 to 1. The following example uses `noise()` to create
+   * a cloud-like texture effect in a filter shader.
    *
    * ```js example
    * let myFilter;
@@ -244,6 +245,7 @@ function noise(p5, fn){
    *   filterColor.begin();
    *   let coord = filterColor.texCoord;
    *   let t = millis() / 2000;
+   *   // noise() returns values in the range 0 to 1.
    *   let mixFraction = noise(coord.x * 5, coord.y * 5, t);
    *   let darkBlue = [0.1, 0.1, 0.3, 1];
    *   let lightBlue = [0.9, 0.9, 1, 1];

--- a/src/math/random.js
+++ b/src/math/random.js
@@ -230,6 +230,35 @@ function random(p5, fn){
    *   // Draw the point.
    *   point(x, y);
    * }
+   *
+   * `random()` can also be used in shaders with p5.strands. The following example
+   * uses `random()` to create varying colors on a shape.
+   *
+   * ```js example
+   * let myShader;
+   *
+   * function setup() {
+   *   createCanvas(100, 100, WEBGL);
+   *   myShader = buildColorShader(shaderCallback);
+   *   describe('A sphere with randomly varying colors.');
+   * }
+   *
+   * function shaderCallback() {
+   *   let r = random();
+   *   let g = random();
+   *   let b = random();
+   *   finalColor.begin();
+   *   finalColor.set([r, g, b, 1]);
+   *   finalColor.end();
+   * }
+   *
+   * function draw() {
+   *   background(220);
+   *   shader(myShader);
+   *   noStroke();
+   *   sphere(30);
+   * }
+   * ```
    */
   /**
    * @method random

--- a/src/utilities/time_date.js
+++ b/src/utilities/time_date.js
@@ -214,8 +214,10 @@ function timeDate(p5, fn){
    * function shaderCallback() {
    *   let t = millis() * 0.001;
    *   let value = 0.5 + 0.5 * sin(t);
+   *   let skyBlue = [0.2, 0.6, 0.8, 1];
+   *   let magenta = [0.8, 0.2, 0.6, 1];
    *   finalColor.begin();
-   *   finalColor.set(mix([0.2, 0.6, 0.8, 1], [0.8, 0.2, 0.6, 1], value));
+   *   finalColor.set(mix(skyBlue, magenta, value));
    *   finalColor.end();
    * }
    *

--- a/src/utilities/time_date.js
+++ b/src/utilities/time_date.js
@@ -198,6 +198,34 @@ function timeDate(p5, fn){
    *     `The text "It took ${round(ms, 2)} ms to load the data" written in black on a gray background.`
    *   );
    * }
+   *
+   * `millis()` can also be used in shaders with p5.strands. The following example
+   * uses `millis()` to create time-based color transitions on a shape.
+   *
+   * ```js example
+   * let myShader;
+   *
+   * function setup() {
+   *   createCanvas(100, 100, WEBGL);
+   *   myShader = buildColorShader(shaderCallback);
+   *   describe('A sphere whose color shifts over time.');
+   * }
+   *
+   * function shaderCallback() {
+   *   let t = millis() * 0.001;
+   *   let value = 0.5 + 0.5 * sin(t);
+   *   finalColor.begin();
+   *   finalColor.set(mix([0.2, 0.6, 0.8, 1], [0.8, 0.2, 0.6, 1], value));
+   *   finalColor.end();
+   * }
+   *
+   * function draw() {
+   *   background(220);
+   *   shader(myShader);
+   *   noStroke();
+   *   sphere(30);
+   * }
+   * ```
    */
   fn.millis = function() {
     if (this._millisStart === -1) {


### PR DESCRIPTION
Resolves  #8777 (Noise, Random, Time batch)

 Changes:
Adds inline `p5.strands` examples to the reference documentation for 3 functions across 3 files:

`src/math/noise.js`
- `noise()` — cloud-like texture effect using `buildFilterShader()` with `filterColor`

`src/math/random.js`
- `random()` — random RGB colors on a shape

`src/utilities/time_date.js`
- `millis()` — time-based color transitions

Each example includes a brief explanation that the function can be used in shaders with p5.strands. The `noise()` example demonstrates `buildFilterShader()` for 2D filter effects, while `random()` and `millis()` use `buildColorShader()`.


 Screenshots of the change:
<!-- If applicable, add screenshots depicting the changes. -->

#### PR Checklist
<!--
  To check any option, replace the "[ ]" with a "[x]". Be sure to check out how it looks in the Preview tab! Feel free to remove any portion of the template that is not relevant for your issue.
-->

- [x] `npm run lint` passes
- [x] [Inline reference] is included / updated
- [ ] [Unit tests] are included / updated

[Inline reference]: https://p5js.org/contribute/contributing_to_the_p5js_reference/
[Unit tests]: https://github.com/processing/p5.js/tree/main/contributor_docs#unit-tests
