### PR TITLE
Register the XYZ-D65 color space

### DIFF
--- a/src/color/p5.Color.js
+++ b/src/color/p5.Color.js
@@ -26,7 +26,9 @@ import {
   OKLCH as OKLCHSpace,
   contrastWCAG21,
   contrastAPCA,
-  P3
+  P3,
+
+  XYZ_D65 as XYZ_D65Space
 } from 'colorjs.io/fn';
 import HSBSpace from './color_spaces/hsb.js';
 
@@ -1030,6 +1032,11 @@ function color(p5, fn, lifecycles){
   p5.Color.addColorMode(LCH, LCHSpace);
   p5.Color.addColorMode(OKLAB, OKLab);
   p5.Color.addColorMode(OKLCH, OKLCHSpace);
+
+  // The fundamental color space to which all colors can be converted (https://colorjs.io/docs/spaces#xyz-d65)
+  // This needs to be registered with color.js for interpolation to work
+  // reliably.
+  ColorSpace.register(XYZ_D65Space);
 
   lifecycles.presetup = function(){
     const pInst = this;


### PR DESCRIPTION
Resolves #8806

I'm not sure whether this is the right approach. I didn't want to expose an additional color mode, so the color space is registered with `color.js` directly. The color space XYZ-D65 needs to be registered somehow, I think, in order for `lerp` to work between sRGB, Lab and Oklab colors.

Unfortunately, any time I tried to test this change, `p5.js` crashed with a message complaining about a totally different color space, HSB, being registered twice. Curiously, this happened even when I tried testing the base branch (i.e., without the change).

As a result, I'm submitting this as a draft in case it is of any use.

 Changes:
 - Fixed: Attempting to interpolate between colors defined in different color spaces could throw an exception in some cases.

#### PR Checklist

- [X] `npm run lint` passes
- [ ] [Inline reference] is included / updated
- [ ] [Unit tests] are included / updated

[Inline reference]: https://p5js.org/contribute/contributing_to_the_p5js_reference/
[Unit tests]: https://github.com/processing/p5.js/tree/main/contributor_docs#unit-tests
