### PR TITLE
docs: use random in strands dithering example

### DIFF
--- a/src/webgl/material.js
+++ b/src/webgl/material.js
@@ -2115,7 +2115,7 @@ function material(p5, fn) {
    *   // Replace alpha in the color with dithering by
    *   // randomly setting pixel colors to 0 based on opacity
    *   let a = 1;
-   *   if (noise(pixelInputs.position.xy) > pixelInputs.color.a) {
+   *   if (random() > pixelInputs.color.a) {
    *     a = 0;
    *   }
    *   pixelInputs.color.a = a;


### PR DESCRIPTION
## Summary
- updates the `buildStrokeShader` dithering example to use `random()` instead of `noise()` for per-pixel random masking
- keeps continuous `noise()` examples unchanged where coherence over position/time is intended

Fixes #8776.

## Testing
- `npm ci`
- `npm run docs`
- `git diff --check`
- `npx eslint src/webgl/material.js` (exits 0; existing warnings remain in the file)
