### PR TITLE
p5.Vector perf updates

### DIFF
--- a/src/core/friendly_errors/param_validator.js
+++ b/src/core/friendly_errors/param_validator.js
@@ -606,6 +606,9 @@ function validateParams(p5, fn, lifecycles) {
     function(target, { kind, name }){
       if(kind === 'method'){
         return function(...args){
+          if (p5.disableFriendlyErrors) {
+            return target.apply(this, args);
+          }
           const wasInternalCall = this._isUserCall;
           this._isUserCall = true;
           try {

--- a/src/math/math.js
+++ b/src/math/math.js
@@ -92,7 +92,7 @@ function math(p5, fn) {
    * }
    */
   fn.createVector = function (...args) {
-    if (this._boundFromRadians) {
+    if (!this._boundFromRadians) {
       this._boundFromRadians = this._fromRadians.bind(this);
       this._boundToRadians = this._toRadians.bind(this);
     }

--- a/src/math/math.js
+++ b/src/math/math.js
@@ -92,7 +92,15 @@ function math(p5, fn) {
    * }
    */
   fn.createVector = function (...args) {
-    return new p5.Vector(...args);
+    if (this._boundFromRadians) {
+      this._boundFromRadians = this._fromRadians.bind(this);
+      this._boundToRadians = this._toRadians.bind(this);
+    }
+    if (this instanceof p5) {
+      return new p5.Vector(this._boundFromRadians, this._boundToRadians, ...args);
+    } else {
+      return new p5.Vector(...args);
+    }
   };
 
   /**

--- a/src/math/math.js
+++ b/src/math/math.js
@@ -92,11 +92,11 @@ function math(p5, fn) {
    * }
    */
   fn.createVector = function (...args) {
-    if (!this._boundFromRadians) {
-      this._boundFromRadians = this._fromRadians.bind(this);
-      this._boundToRadians = this._toRadians.bind(this);
-    }
     if (this instanceof p5) {
+      if (!this._boundFromRadians) {
+        this._boundFromRadians = this._fromRadians.bind(this);
+        this._boundToRadians = this._toRadians.bind(this);
+      }
       return new p5.Vector(this._boundFromRadians, this._boundToRadians, ...args);
     } else {
       return new p5.Vector(...args);

--- a/src/math/p5.Vector.js
+++ b/src/math/p5.Vector.js
@@ -1280,10 +1280,12 @@ class Vector {
    * }
    */
   magSq() {
-    return this.values.reduce(
-      (sum, component) => sum + component * component,
-      0
-    );
+    let sum = 0;
+    for (let i = 0; i < this.values.length; i++) {
+      const component = this.values[i];
+      sum += component * component;
+    }
+    return sum;
   }
 
   /**

--- a/src/math/p5.Vector.js
+++ b/src/math/p5.Vector.js
@@ -1378,7 +1378,7 @@ class Vector {
     if (args[0] instanceof Vector) {
       vals = args[0].values;
     }
-    const minDimension = prioritizeSmallerDimension(this.dimensions, args);
+    const minDimension = prioritizeSmallerDimension(this.dimensions, vals);
     let sum = 0;
     for (let i = 0; i < minDimension; i++) {
       sum += this.values[i] * vals[i];

--- a/src/math/p5.Vector.js
+++ b/src/math/p5.Vector.js
@@ -1167,15 +1167,15 @@ class Vector {
     const minDimension = prioritizeSmallerDimension(this.dimensions, args);
     shrinkToDimension(this.values, minDimension);
 
-    if (!this.friendlyErrorsDisabled()) {
-      for (let i = 0; i < this.values.length; i++) {
-        if (typeof args[i] !== 'number' || args[i] === 0) {
+    for (let i = 0; i < this.values.length; i++) {
+      if (typeof args[i] !== 'number' || args[i] === 0) {
+        if (!this.friendlyErrorsDisabled()) {
           console.warn(
             'p5.Vector.prototype.div',
             'Arguments contain components that are 0'
           );
-          return this;
         }
+        return this;
       }
     }
 

--- a/src/math/p5.Vector.js
+++ b/src/math/p5.Vector.js
@@ -78,18 +78,22 @@ class Vector {
     }
 
     this.values = args;
-    if (!Vector.friendlyErrorsDisabled() && Array.isArray(args)) {
+    if (Array.isArray(args)) {
       for (let i = 0; i < args.length; i++) {
         const v = args[i];
         if (typeof v !== 'number' || !Number.isFinite(v)) {
-          this._friendlyError(
-            'Arguments contain non-finite numbers',
-            'p5.Vector'
-          );
+          if (!Vector.friendlyErrorsDisabled()) {
+            this._friendlyError(
+              'Arguments contain non-finite numbers',
+              'p5.Vector'
+            );
+          }
+          this.values = [];
+          break;
         }
-        this.values = [];
-        break;
       }
+    } else {
+      this.values = [];
     }
 
     // This property is here where duck typing (checking if obj.isVector) needs

--- a/src/math/p5.Vector.js
+++ b/src/math/p5.Vector.js
@@ -656,18 +656,6 @@ class Vector {
   rem(...args) {
     const minDimension = prioritizeSmallerDimension(this.dimensions, args);
 
-    for (let i = 0; i < minDimension; i++) {
-      if (typeof args[i] !== 'number' || args[i] === 0) {
-        if (!this.friendlyErrorsDisabled()) {
-          console.warn(
-            'p5.Vector.prototype.div',
-            'Arguments contain components that are 0'
-          );
-        }
-        return this;
-      }
-    }
-
     shrinkToDimension(this.values, minDimension);
     for (let i = 0; i < this.values.length; i++) {
       if (args[i] > 0) {

--- a/src/math/p5.Vector.js
+++ b/src/math/p5.Vector.js
@@ -527,11 +527,11 @@ class Vector {
    */
   add(...args) {
     const minDimension = prioritizeSmallerDimension(this.dimensions, args);
+    shrinkToDimension(this.values, minDimension);
 
-    this.values = this.values.reduce((acc, v, i) => {
-      if(i < minDimension) acc[i] = this.values[i] + Number(args[i]);
-      return acc;
-    }, new Array(minDimension));
+    for (let i = 0; i < this.values.length; i++) {
+      this.values[i] += args[i];
+    }
 
     return this;
   }
@@ -651,10 +651,11 @@ class Vector {
    */
   rem(...args) {
     const minDimension = prioritizeSmallerDimension(this.dimensions, args);
+    shrinkToDimension(this.values, minDimension);
 
-    this.values = Array.from({ length: minDimension }, (_, i) => {
-      return (args[i] > 0) ? this.values[i] % args[i] : this.values[i];
-    });
+    for (let i = 0; i < this.values.length; i++) {
+      this.values[i] = this.values[i] % args[i];
+    }
 
     return this;
   }
@@ -971,50 +972,12 @@ class Vector {
    */
   mult(...args) {
     const minDimension = prioritizeSmallerDimension(this.dimensions, args);
+    shrinkToDimension(this.values, minDimension);
 
-    this.values = this.values.reduce((acc, v, i) => {
-      if(i < minDimension) acc[i] = this.values[i] * args[i];
-      return acc;
-    }, new Array(minDimension));
+    for (let i = 0; i < this.values.length; i++) {
+      this.values[i] *= args[i];
+    }
 
-    // if (args.length === 1 && args[0] instanceof Vector) {
-    //   const v = args[0];
-    //   const maxLen = Math.min(this.values.length, v.values.length);
-    //   for (let i = 0; i < maxLen; i++) {
-    //     if (Number.isFinite(v.values[i]) && typeof v.values[i] === 'number') {
-    //       if(!this.values[i]) this.values[i] = 0;
-    //       this.values[i] *= v.values[i];
-    //     } else {
-    //       console.warn(
-    //         'p5.Vector.prototype.mult:',
-    //         'v contains components that are either undefined or not finite numbers'
-    //       );
-    //       return this;
-    //     }
-    //   }
-    // } else if (args.length === 1 && Array.isArray(args[0])) {
-    //   const arr = args[0];
-    //   const maxLen = Math.min(this.values.length, arr.length);
-    //   for (let i = 0; i < maxLen; i++) {
-    //     if (Number.isFinite(arr[i]) && typeof arr[i] === 'number') {
-    //       this.values[i] *= arr[i];
-    //     } else {
-    //       console.warn(
-    //         'p5.Vector.prototype.mult:',
-    //         'arr contains elements that are either undefined or not finite numbers'
-    //       );
-    //       return this;
-    //     }
-    //   }
-    // } else if (
-    //   args.length === 1 &&
-    //   typeof args[0] === 'number' &&
-    //   Number.isFinite(args[0])
-    // ) {
-    //   for (let i = 0; i < this.values.length; i++) {
-    //     this.values[i] *= args[0];
-    //   }
-    // }
     return this;
   }
 
@@ -1198,19 +1161,23 @@ class Vector {
    */
   div(...args) {
     const minDimension = prioritizeSmallerDimension(this.dimensions, args);
+    shrinkToDimension(this.values, minDimension);
 
-    if(!args.every(v => typeof v === 'number' && v !== 0)){
-      console.warn(
-        'p5.Vector.prototype.div',
-        'Arguments contain components that are 0'
-      );
-      return this;
-    };
+    if (!this.friendlyErrorsDisabled()) {
+      for (let i = 0; i < this.values.length; i++) {
+        if (typeof args[i] !== 'number' || args[i] === 0) {
+          console.warn(
+            'p5.Vector.prototype.div',
+            'Arguments contain components that are 0'
+          );
+          return this;
+        }
+      }
+    }
 
-    this.values = this.values.reduce((acc, v, i) => {
-      if(i < minDimension) acc[i] = this.values[i] / args[i];
-      return acc;
-    }, new Array(minDimension));
+    for (let i = 0; i < this.values.length; i++) {
+      this.values[i] *= args[i];
+    }
 
     return this;
   }
@@ -1247,7 +1214,12 @@ class Vector {
    * }
    */
   mag() {
-    return Math.sqrt(this.magSq());
+    let sum = 0;
+    for (let i = 0; i < this.values.length; i++) {
+      const component = this.values[i];
+      sum += component * component;
+    }
+    return Math.sqrt(sum);
   }
 
   /**
@@ -1384,12 +1356,16 @@ class Vector {
    * @return {Number}
    */
   dot(...args) {
+    let vals = args;
     if (args[0] instanceof Vector) {
-      return this.dot(...args[0].values);
+      vals = args[0].values;
     }
-    return this.values.reduce((sum, component, index) => {
-      return sum + component * (args[index] || 0);
-    }, 0);
+    const minDimension = prioritizeSmallerDimension(this.dimensions, args);
+    let sum = 0;
+    for (let i = 0; i < minDimension; i++) {
+      sum += this.values[i] * vals[i];
+    }
+    return sum;
   }
 
   /**

--- a/src/math/p5.Vector.js
+++ b/src/math/p5.Vector.js
@@ -1547,7 +1547,12 @@ class Vector {
    * }
    */
   dist(v) {
-    return v.copy().sub(this).mag();
+    const minDimension = prioritizeSmallerDimension(this.dimensions, v.values);
+    const components = this.values.slice(0, minDimension);
+    for (let i = 0; i < minDimension; i++) {
+      components[i] -= v.values[i];
+    }
+    return Math.hypot(...components);
   }
 
   /**

--- a/src/math/p5.Vector.js
+++ b/src/math/p5.Vector.js
@@ -1548,11 +1548,12 @@ class Vector {
    */
   dist(v) {
     const minDimension = prioritizeSmallerDimension(this.dimensions, v.values);
-    const components = this.values.slice(0, minDimension);
+    let sum = 0;
     for (let i = 0; i < minDimension; i++) {
-      components[i] -= v.values[i];
+      const component = this.values[i] - v.values[i];
+      sum += component * component;
     }
-    return Math.hypot(...components);
+    return Math.sqrt(sum);
   }
 
   /**

--- a/src/math/p5.Vector.js
+++ b/src/math/p5.Vector.js
@@ -643,7 +643,7 @@ class Vector {
    *   let v2 = createVector(2, 3, 4);
    *
    *   // Divide without modifying the original vectors.
-   *   let v3 = p5.Vector.rem(v1, v2);
+   *  let v3 = p5.Vector.rem(v1, v2);
    *
    *   // Prints 'p5.Vector Object : [1, 1, 1]'.
    *   print(v3.toString());
@@ -655,10 +655,24 @@ class Vector {
    */
   rem(...args) {
     const minDimension = prioritizeSmallerDimension(this.dimensions, args);
-    shrinkToDimension(this.values, minDimension);
 
+    for (let i = 0; i < minDimension; i++) {
+      if (typeof args[i] !== 'number' || args[i] === 0) {
+        if (!this.friendlyErrorsDisabled()) {
+          console.warn(
+            'p5.Vector.prototype.div',
+            'Arguments contain components that are 0'
+          );
+        }
+        return this;
+      }
+    }
+
+    shrinkToDimension(this.values, minDimension);
     for (let i = 0; i < this.values.length; i++) {
-      this.values[i] = this.values[i] % args[i];
+      if (args[i] > 0) {
+        this.values[i] = this.values[i] % args[i];
+      }
     }
 
     return this;
@@ -1165,9 +1179,8 @@ class Vector {
    */
   div(...args) {
     const minDimension = prioritizeSmallerDimension(this.dimensions, args);
-    shrinkToDimension(this.values, minDimension);
 
-    for (let i = 0; i < this.values.length; i++) {
+    for (let i = 0; i < minDimension; i++) {
       if (typeof args[i] !== 'number' || args[i] === 0) {
         if (!this.friendlyErrorsDisabled()) {
           console.warn(
@@ -1179,6 +1192,7 @@ class Vector {
       }
     }
 
+    shrinkToDimension(this.values, minDimension);
     for (let i = 0; i < this.values.length; i++) {
       this.values[i] *= args[i];
     }

--- a/src/math/p5.Vector.js
+++ b/src/math/p5.Vector.js
@@ -73,12 +73,11 @@ class Vector {
 
     if (typeof args[0] === 'function') {
       this.isPInst = true;
-      this._fromRadians = args[0];
-      this._toRadians = args[1];
-      args = args.slice(2);
+      this._fromRadians = args.shift();
+      this._toRadians = args.shift();
     }
 
-    this.values = [];
+    this.values = args;
     if (!Vector.friendlyErrorsDisabled() && Array.isArray(args)) {
       for (let i = 0; i < args.length; i++) {
         const v = args[i];
@@ -88,9 +87,9 @@ class Vector {
             'p5.Vector'
           );
         }
+        this.values = [];
+        break;
       }
-    } else {
-      this.values = args;
     }
 
     // This property is here where duck typing (checking if obj.isVector) needs

--- a/src/math/p5.Vector.js
+++ b/src/math/p5.Vector.js
@@ -1194,7 +1194,7 @@ class Vector {
 
     shrinkToDimension(this.values, minDimension);
     for (let i = 0; i < this.values.length; i++) {
-      this.values[i] *= args[i];
+      this.values[i] /= args[i];
     }
 
     return this;

--- a/src/math/p5.Vector.js
+++ b/src/math/p5.Vector.js
@@ -5,12 +5,23 @@
 import * as constants from '../core/constants';
 
 /**
+ * @private
  * This function is used by binary vector operations to prioritize shorter vectors,
  * and to emit a warning when lengths do not match.
  */
 const prioritizeSmallerDimension = function(currentVectorDimension, args) {
   return Math.min(currentVectorDimension, args.length);
 };
+
+/**
+ * @private
+ * In-place, shrinks an array to a dimension.
+ */
+const shrinkToDimension = function(arr, dim) {
+  while (arr.length > dim) {
+    arr.pop();
+  }
+}
 
 
 class Vector {
@@ -41,6 +52,15 @@ class Vector {
    */
   values = [];
 
+  /**
+   * @private
+   * Check for disabled friendly errors.
+   * This is overridden in the addon function to check the p5 instance.
+   */
+  static friendlyErrorsDisabled() {
+    return true;
+  }
+
   // This is how it comes in with createVector()
   // This check if the first argument is a function
   constructor(...args) {
@@ -59,11 +79,16 @@ class Vector {
     }
 
     this.values = [];
-    if(Array.isArray(args) && !args.every(v => typeof v === 'number' && Number.isFinite(v))){
-      this._friendlyError(
-        'Arguments contain non-finite numbers',
-        'p5.Vector'
-      );
+    if (!Vector.friendlyErrorsDisabled() && Array.isArray(args)) {
+      for (let i = 0; i < args.length; i++) {
+        const v = args[i];
+        if (typeof v !== 'number' || !Number.isFinite(v)) {
+          this._friendlyError(
+            'Arguments contain non-finite numbers',
+            'p5.Vector'
+          );
+        }
+      }
     } else {
       this.values = args;
     }
@@ -759,11 +784,11 @@ class Vector {
    */
   sub(...args) {
     const minDimension = prioritizeSmallerDimension(this.dimensions, args);
+    shrinkToDimension(this.values, minDimension);
 
-    this.values = this.values.reduce((acc, v, i) => {
-      if(i < minDimension) acc[i] = this.values[i] - args[i];
-      return acc;
-    }, new Array(minDimension));
+    for (let i = 0; i < this.values.length; i++) {
+      this.values[i] -= args[i];
+    }
 
     return this;
   }
@@ -1372,7 +1397,7 @@ class Vector {
    * The cross product is a vector that points straight out of the plane created
    * by two vectors. The cross product's magnitude is the area of the parallelogram
    * formed by the original two vectors.
-   * 
+   *
    * The cross product is defined on 3-dimensional vectors, and will use the `x`, `y`,
    * and `z` components. This method should only be used with 3D vectors.
    *
@@ -1986,7 +2011,7 @@ class Vector {
     if (this.dimensions < 2 || (
       this._values instanceof Array && this._values.slice(2).some(v => v !== 0))
     ) {
-      p5._friendlyError(  
+      p5._friendlyError(
         'p5.Vector.setHeading() only supports 2D vectors (z === 0). ' +
         'For 3D or higher-dimensional vectors, use rotate() or another ' +
         'appropriate method instead.',
@@ -3617,6 +3642,9 @@ function vector(p5, fn) {
   p5.Vector = Vector;
 
   Vector.prototype._friendlyError = p5._friendlyError;
+  Vector.prototype.friendlyErrorsDisabled = function() {
+    return p5.disableFriendlyErrors;
+  };
 
   /**
    * The x component of the vector

--- a/src/math/patch-vector.js
+++ b/src/math/patch-vector.js
@@ -43,16 +43,18 @@ export function _validatedVectorOperation(expectsSoloNumberArgument){
         args = new Array(3).fill(args[0]);
       }
 
-      if (!Vector.friendlyErrorsDisabled() && Array.isArray(args)) {
+      if (Array.isArray(args)) {
         for (let i = 0; i < args.length; i++) {
           const v = args[i];
           if (typeof v !== 'number' || !Number.isFinite(v)) {
-            this._friendlyError(
-              'Arguments contain non-finite numbers',
-              'p5.Vector'
-            );
+            if (!Vector.friendlyErrorsDisabled()) {
+              this._friendlyError(
+                'Arguments contain non-finite numbers',
+                'p5.Vector'
+              );
+              return this;
+            }
           }
-          return this;
         }
       }
 

--- a/src/math/patch-vector.js
+++ b/src/math/patch-vector.js
@@ -43,13 +43,20 @@ export function _validatedVectorOperation(expectsSoloNumberArgument){
         args = new Array(3).fill(args[0]);
       }
 
-      if(Array.isArray(args) && !args.every(v => typeof v === 'number' && Number.isFinite(v))){
-        this._friendlyError(
-          'Arguments contain non-finite numbers',
-          target.name
-        );
-        return this;
-      };
+      if (!Vector.friendlyErrorsDisabled() && Array.isArray(args)) {
+        for (let i = 0; i < args.length; i++) {
+          const v = args[i];
+          if (typeof v !== 'number' || !Number.isFinite(v)) {
+            this._friendlyError(
+              'Arguments contain non-finite numbers',
+              'p5.Vector'
+            );
+          }
+          return this;
+        }
+      } else {
+        this.values = args;
+      }
 
       return target.call(this, ...args);
     };

--- a/src/math/patch-vector.js
+++ b/src/math/patch-vector.js
@@ -54,8 +54,6 @@ export function _validatedVectorOperation(expectsSoloNumberArgument){
           }
           return this;
         }
-      } else {
-        this.values = args;
       }
 
       return target.call(this, ...args);

--- a/src/math/patch-vector.js
+++ b/src/math/patch-vector.js
@@ -52,8 +52,8 @@ export function _validatedVectorOperation(expectsSoloNumberArgument){
                 'Arguments contain non-finite numbers',
                 'p5.Vector'
               );
-              return this;
             }
+            return this;
           }
         }
       }


### PR DESCRIPTION
Live: https://editor.p5js.org/davepagurek/sketches/3Sqe9enCg

This updates some of our p5.Vector code to make that test Nature of Code sketch run faster. The thing that had by far the biggest effect was removing methods that make intermediate arrays. Most operations are done in-place now.

Other minor things:
- Made our `console.warn`s only run if FES is not disabled
- Fixed an issue where we were never using the p5 instance's angle mode state for vectors created with `createVector`

#### PR Checklist
<!--
  To check any option, replace the "[ ]" with a "[x]". Be sure to check out how it looks in the Preview tab! Feel free to remove any portion of the template that is not relevant for your issue.
-->

- [x] `npm run lint` passes
- [ ] [Inline reference] is included / updated
- [ ] [Unit tests] are included / updated

[Inline reference]: https://p5js.org/contribute/contributing_to_the_p5js_reference/
[Unit tests]: https://github.com/processing/p5.js/tree/main/contributor_docs#unit-tests
