### PR TITLE
Vector mismatch dimension prints warning message

### DIFF
--- a/src/math/p5.Vector.js
+++ b/src/math/p5.Vector.js
@@ -9,8 +9,14 @@ import * as constants from '../core/constants';
  * This function is used by binary vector operations to prioritize shorter vectors,
  * and to emit a warning when lengths do not match.
  */
-const prioritizeSmallerDimension = function(currentVectorDimension, args) {
-  return Math.min(currentVectorDimension, args.length);
+const prioritizeSmallerDimension = function (currentVectorDimension, args) {
+  const resultDimension = Math.min(currentVectorDimension, args.length);
+  if (Array.isArray(args) && currentVectorDimension !== args.length) {
+    console.warn(
+      'When working with two vectors of different sizes, the smaller dimension is used. In this operation, both vector will be treated as ' + resultDimension + 'D vectors, and any additional values of the linger vector will be ignored.'
+    );
+  }
+  return resultDimension;
 };
 
 /**
@@ -529,7 +535,7 @@ class Vector {
    * @param  {p5.Vector|Number[]} value The vector to add
    * @chainable
    */
-  add(...args) {
+  add(args) {
     const minDimension = prioritizeSmallerDimension(this.dimensions, args);
     shrinkToDimension(this.values, minDimension);
 
@@ -653,13 +659,18 @@ class Vector {
    * @param {p5.Vector | Number[]}  value  divisor vector.
    * @chainable
    */
-  rem(...args) {
+  rem(args) {
     const minDimension = prioritizeSmallerDimension(this.dimensions, args);
 
     shrinkToDimension(this.values, minDimension);
-    for (let i = 0; i < this.values.length; i++) {
-      if (args[i] > 0) {
+
+    if(Array.isArray(args)){
+      for (let i = 0; i < this.values.length; i++) {
         this.values[i] = this.values[i] % args[i];
+      }
+    } else {
+      for (let i = 0; i < this.values.length; i++) {
+        this.values[i] = this.values[i] % args;
       }
     }
 
@@ -788,7 +799,7 @@ class Vector {
    * @param  {p5.Vector|Number[]} value the vector to subtract
    * @chainable
    */
-  sub(...args) {
+  sub(args) {
     const minDimension = prioritizeSmallerDimension(this.dimensions, args);
     shrinkToDimension(this.values, minDimension);
 
@@ -976,12 +987,18 @@ class Vector {
    * @param  {p5.Vector} v vector to multiply with the components of the original vector.
    * @chainable
    */
-  mult(...args) {
+  mult(args) {
     const minDimension = prioritizeSmallerDimension(this.dimensions, args);
     shrinkToDimension(this.values, minDimension);
 
-    for (let i = 0; i < this.values.length; i++) {
-      this.values[i] *= args[i];
+    if(Array.isArray(args)){
+      for (let i = 0; i < this.values.length; i++) {
+        this.values[i] *= args[i];
+      }
+    } else {
+      for (let i = 0; i < this.values.length; i++) {
+        this.values[i] *= args;
+      }
     }
 
     return this;
@@ -1165,24 +1182,41 @@ class Vector {
    * @param  {p5.Vector} v vector to divide the components of the original vector by.
    * @chainable
    */
-  div(...args) {
+  div(args) {
     const minDimension = prioritizeSmallerDimension(this.dimensions, args);
 
-    for (let i = 0; i < minDimension; i++) {
-      if (typeof args[i] !== 'number' || args[i] === 0) {
-        if (!this.friendlyErrorsDisabled()) {
-          console.warn(
-            'p5.Vector.prototype.div',
-            'Arguments contain components that are 0'
-          );
+    if (Array.isArray(args)) {
+      for (let i = 0; i < minDimension; i++) {
+        if ((typeof args[i] !== 'number' || args[i] === 0)) {
+          if (!this.friendlyErrorsDisabled()) {
+            console.warn(
+              'p5.Vector.prototype.div',
+              'Arguments contain components that are 0'
+            );
+          }
+          return this;
         }
-        return this;
       }
+    } else if(typeof args !== 'number' || args === 0) {
+      if (!this.friendlyErrorsDisabled()) {
+        console.warn(
+          'p5.Vector.prototype.div',
+          'Arguments contain components that are 0'
+        );
+      }
+      return this;
     }
 
     shrinkToDimension(this.values, minDimension);
-    for (let i = 0; i < this.values.length; i++) {
-      this.values[i] /= args[i];
+
+    if(Array.isArray(args)){
+      for (let i = 0; i < this.values.length; i++) {
+        this.values[i] /= args[i];
+      }
+    } else {
+      for (let i = 0; i < this.values.length; i++) {
+        this.values[i] /= args;
+      }
     }
 
     return this;
@@ -1361,7 +1395,7 @@ class Vector {
    * @param  {p5.Vector} v <a href="#/p5.Vector">p5.Vector</a> to be dotted.
    * @return {Number}
    */
-  dot(...args) {
+  dot(args) {
     let vals = args;
     if (args[0] instanceof Vector) {
       vals = args[0].values;

--- a/src/math/p5.Vector.js
+++ b/src/math/p5.Vector.js
@@ -1397,7 +1397,7 @@ class Vector {
    * @param  {p5.Vector} v <a href="#/p5.Vector">p5.Vector</a> to be dotted.
    * @return {Number}
    */
-  dot(args) {
+  dot(...args) {
     let vals = args;
     if (args[0] instanceof Vector) {
       vals = args[0].values;

--- a/src/math/p5.Vector.js
+++ b/src/math/p5.Vector.js
@@ -405,8 +405,6 @@ class Vector {
     }
   }
 
-
-
   /**
    * Adds to a vector's components.
    *
@@ -414,11 +412,10 @@ class Vector {
    * another <a href="#/p5.Vector">p5.Vector</a> object, as in `v.add(v2)`, or
    * an array of numbers, as in `v.add([1, 2, 3])`.
    *
-   * Add vectors only when they are the same size: both 2-dimensional, or
-   * both 3-dimensional. When two vectors of different sizes are added, the
-   * smaller dimension will be used, any additional values of the longer
-   * vector will be ignored.
-   * For example, adding `[1, 2, 3]` and `[4, 5]` will result in `[5, 7]`.
+   * You should add vectors only when they are the same size. When two vectors
+   * of different sizes are added, the smaller dimension will be used, any
+   * additional values of the longer vector will be ignored. For example,
+   * adding `[1, 2, 3]` and `[4, 5]` will result in `[5, 7]`.
    *
    * Calling `add()` with no arguments, as in `v.add()`, has no effect.
    *
@@ -546,11 +543,8 @@ class Vector {
     return this;
   }
 
-
-
   /**
-   * Performs modulo (remainder) division with a vector's `x`, `y`, and `z`
-   * components.
+   * Performs modulo (remainder) division with a vector's components.
    *
    * `rem()` can use separate numbers, as in `v.rem(1, 2, 3)`,
    * another <a href="#/p5.Vector">p5.Vector</a> object, as in `v.rem(v2)`, or
@@ -560,8 +554,8 @@ class Vector {
    * will be set to their values modulo 2. Calling `rem()` with no
    * arguments, as in `v.rem()`, has no effect.
    *
-   * Modulo vectors only when they are the same size: both 2D, or both 3D.
-   * When two vectors of different sizes are used, the smaller dimension will be
+   * You should modulo vectors only when they are the same size. When two
+   * vectors of different sizes are used, the smaller dimension will be
    * used, any additional values of the longer vector will be ignored.
    * For example, taking `[3, 6, 9]` modulo `[2, 4]` will result in `[1, 2]`.
    *
@@ -680,7 +674,7 @@ class Vector {
   }
 
   /**
-   * Subtracts from a vector's `x`, `y`, and `z` components.
+   * Subtracts from a vector's components.
    *
    * `sub()` can use separate numbers, as in `v.sub(1, 2, 3)`, another
    * <a href="#/p5.Vector">p5.Vector</a> object, as in `v.sub(v2)`, or an array
@@ -688,8 +682,8 @@ class Vector {
    *
    * Calling `sub()` with no arguments, as in `v.sub()`, has no effect.
    *
-   * Subtract vectors only when they are the same size: both 2D, or both 3D.
-   * When two vectors of different sizes are used, the smaller dimension will be
+   * You should subtract vectors only when they are the same size. When two
+   * vectors of different sizes are used, the smaller dimension will be
    * used, any additional values of the longer vector will be ignored.
    * For example, subtracting `[1, 2]` from `[3, 5, 7]` will result in `[2, 3]`.
    *
@@ -813,7 +807,7 @@ class Vector {
   }
 
   /**
-   * Multiplies a vector's `x`, `y`, and `z` components.
+   * Multiplies a vector's components.
    *
    * `mult()` can use separate numbers, as in `v.mult(1, 2, 3)`, another
    * <a href="#/p5.Vector">p5.Vector</a> object, as in `v.mult(v2)`, or an array
@@ -823,8 +817,8 @@ class Vector {
    * will be multiplied by 2. Calling `mult()` with no arguments, as in `v.mult()`, has
    * no effect.
    *
-   * Multiply vectors only when they are the same size: both 2D, or both 3D.
-   * When two vectors of different sizes are multiplied, the smaller dimension will be
+   * You should multiply vectors only when they are the same size. When two
+   * vectors of different sizes are multiplied, the smaller dimension will be
    * used, any additional values of the longer vector will be ignored.
    * For example, multiplying `[1, 2, 3]` by `[4, 5]` will result in `[4, 10]`.
    *
@@ -1007,7 +1001,7 @@ class Vector {
   }
 
   /**
-   * Divides a vector's `x`, `y`, and `z` components.
+   * Divides a vector's components.
    *
    * `div()` can use separate numbers, as in `v.div(1, 2, 3)`, another
    * <a href="#/p5.Vector">p5.Vector</a> object, as in `v.div(v2)`, or an array
@@ -1017,8 +1011,8 @@ class Vector {
    * will be divided by 2. Calling `div()` with no arguments, as in `v.div()`, has
    * no effect.
    *
-   * Divide vectors only when they are the same size: both 2D, or both 3D.
-   * When two vectors of different sizes are divided, the smaller dimension will be
+   * You should divide vectors only when they are the same size. When two
+   * vectors of different sizes are divided, the smaller dimension will be
    * used, any additional values of the longer vector will be ignored.
    * For example, dividing `[8, 12, 21]` by `[2, 3]` will result in `[4, 4]`.
    *

--- a/src/math/p5.Vector.js
+++ b/src/math/p5.Vector.js
@@ -666,9 +666,11 @@ class Vector {
 
     if(Array.isArray(args)){
       for (let i = 0; i < this.values.length; i++) {
-        this.values[i] = this.values[i] % args[i];
+        if (args[i] > 0) {
+          this.values[i] = this.values[i] % args[i];
+        }
       }
-    } else {
+    } else if(args > 0) {
       for (let i = 0; i < this.values.length; i++) {
         this.values[i] = this.values[i] % args;
       }

--- a/src/math/patch-vector.js
+++ b/src/math/patch-vector.js
@@ -28,7 +28,7 @@ export function _defaultEmptyVector(target){
  */
 export function _validatedVectorOperation(expectsSoloNumberArgument){
   return function(target){
-    return function(...args){
+    return function (...args) {
       if (args.length === 0) {
         // No arguments? No action
         return this;
@@ -38,12 +38,14 @@ export function _validatedVectorOperation(expectsSoloNumberArgument){
       } else if (Array.isArray(args[0])) {
         // First argument is an array? Great, keep it!
         args = args[0];
-      } else if (expectsSoloNumberArgument && args.length === 1){
+      } else if (args.length === 1){
         // Special case for a solo numeric arguments only applies sometimes
-        args = new Array(3).fill(args[0]);
+        if (expectsSoloNumberArgument) {
+          args = args[0];
+        }
       }
 
-      if (Array.isArray(args)) {
+      if(Array.isArray(args)){
         for (let i = 0; i < args.length; i++) {
           const v = args[i];
           if (typeof v !== 'number' || !Number.isFinite(v)) {
@@ -56,9 +58,19 @@ export function _validatedVectorOperation(expectsSoloNumberArgument){
             return this;
           }
         }
+      } else {
+        if (typeof args !== 'number' || !Number.isFinite(args)) {
+          if (!Vector.friendlyErrorsDisabled()) {
+            this._friendlyError(
+              'Arguments contain non-finite numbers',
+              'p5.Vector'
+            );
+          }
+          return this;
+        }
       }
 
-      return target.call(this, ...args);
+      return target.call(this, args);
     };
   };
 }


### PR DESCRIPTION
<!--
  Thank you for contributing! Please use this pull request (PR) template.


 In the description field of this PR, include "resolves #XXXX" tagging the issue you are fixing. If this PR addresses the issue but doesn't completely resolve it (ie the issue should remain open after your PR is merged), write "addresses #XXXX".-->
Resolves #8819 as well.

Changes:
When encountering vector dimension mismatch, a warning message will be printed to indicate that the smaller dimension vector is being presumed. Also resolves issue where not all elements were multiplied when multiplying a vector by a scalar.

The documentation still need updating.