### PR TITLE
Fix saveGif crash when duration <= 0

### DIFF
--- a/src/image/loading_displaying.js
+++ b/src/image/loading_displaying.js
@@ -303,6 +303,9 @@ p5.prototype.saveGif = async function(
   if (typeof duration !== 'number') {
     throw TypeError('Duration parameter must be a number');
   }
+  if (duration <= 0) {
+    throw RangeError('Duration parameter must be a positive number');
+  }
 
   // extract variables for more comfortable use
   const delay = (options && options.delay) || 0;  // in seconds

--- a/test/unit/image/downloading.js
+++ b/test/unit/image/downloading.js
@@ -370,6 +370,15 @@ suite('p5.prototype.saveGif', function() {
     });
   });
 
+  test('should throw an error if duration is less than or equal to 0', function() {
+    assert.throws(function() {
+      myp5.saveGif('myGif', 0);
+    }, RangeError);
+    assert.throws(function() {
+      myp5.saveGif('myGif', -5);
+    }, RangeError);
+  });
+
   testWithDownload('should download a GIF', async function(blobContainer) {
     myp5.saveGif(myGif, 3, 2);
     await waitForBlob(blobContainer);


### PR DESCRIPTION
### Bug
Calling `saveGif('test', 0)` or a negative duration leads to `TypeError: Cannot read properties of undefined (reading 'length')`.

### Root Cause
When the duration parameter is less than or equal to 0, no frames are recorded during the execution. However, downstream code assumes at least one frame was captured (accessing `frames[0].length` for palette generation and saving), resulting in an unhandled `TypeError`.

### Why Fix is Correct
This change introduces an early parameter validation check in `p5.prototype.saveGif` to throw a `RangeError` if the duration parameter is less than or equal to 0. This matches the existing type validations on parameters and ensures p5.js rejects invalid durations gracefully instead of crashing with a confusing internal error.