### PR TITLE
Restore FES warnings in createVector via this.constructor._friendlyError

### DIFF
--- a/src/math/patch-vector.js
+++ b/src/math/patch-vector.js
@@ -7,7 +7,7 @@ import { Vector } from './p5.Vector.js';
 export function _defaultEmptyVector(target){
   return function(...args){
     if(args.length === 0){
-      this._friendlyError(
+      this.constructor._friendlyError(
         'In 1.x, createVector() was a shortcut for createVector(0, 0, 0). In 2.x, p5.js has vectors of any dimension, so you must provide your desired number of zeros. Use createVector(0, 0) for a 2D vector and createVector(0, 0, 0) for a 3D vector.',
         'p5.createVector'
       );
@@ -49,7 +49,7 @@ export function _validatedVectorOperation(expectsSoloNumberArgument){
         for (let i = 0; i < args.length; i++) {
           const v = args[i];
           if (typeof v !== 'number' || !Number.isFinite(v)) {
-            if (!Vector.friendlyErrorsDisabled()) {
+            if (!this.friendlyErrorsDisabled()) {
               this._friendlyError(
                 'Arguments contain non-finite numbers',
                 'p5.Vector'
@@ -60,7 +60,7 @@ export function _validatedVectorOperation(expectsSoloNumberArgument){
         }
       } else {
         if (typeof args !== 'number' || !Number.isFinite(args)) {
-          if (!Vector.friendlyErrorsDisabled()) {
+          if (!this.friendlyErrorsDisabled()) {
             this._friendlyError(
               'Arguments contain non-finite numbers',
               'p5.Vector'


### PR DESCRIPTION
<!--
  Thank you for contributing! Please use this pull request (PR) template.


 In the description field of this PR, include "resolves #8818" tagging the issue you are fixing. If this PR addresses the issue but doesn't completely resolve it (ie the issue should remain open after your PR is merged), write "addresses #8818".-->
Resolves #8818

 Changes:

Inside the `createVector` decorator, `this` is the p5 sketch instance. We want to call `_friendlyError` to show a warning, but `_friendlyError` lives on the p5 class itself, not on each instance, so `this._friendlyError` doesn't exist and the warning never fires. Every instance has a built-in .constructor property that points back to its class, so `this.constructor._friendlyError` jumps from the instance up to the p5 class where the function actually lives. Same trick is used in [p5.Renderer3D.js:665.](https://github.com/processing/p5.js/blob/030b18a169a3b106b48687d1b4881f0f04c51c3c/src/core/p5.Renderer3D.js#L665)


 Screenshots of the change:
<!-- If applicable, add screenshots depicting the changes. -->

#### PR Checklist
<!--
  To check any option, replace the "[ ]" with a "[x]". Be sure to check out how it looks in the Preview tab! Feel free to remove any portion of the template that is not relevant for your issue.
-->

- [ ] `npm run lint` passes
- [ ] [Inline reference] is included / updated
- [ ] [Unit tests] are included / updated

[Inline reference]: https://p5js.org/contribute/contributing_to_the_p5js_reference/
[Unit tests]: https://github.com/processing/p5.js/tree/main/contributor_docs#unit-tests
