### PR TITLE
Add saveGif parameter validation

### DIFF
--- a/src/image/loading_displaying.js
+++ b/src/image/loading_displaying.js
@@ -296,6 +296,7 @@ p5.prototype.saveGif = async function(
     notificationID: 'progressBar'
   }
 ) {
+  p5._validateParameters('saveGif', arguments);
   // validate parameters
   if (typeof fileName !== 'string') {
     throw TypeError('fileName parameter must be a string');


### PR DESCRIPTION
## Bug
`saveGif()` does not run the standard p5 argument validator, so invalid arguments bypass the library's normal `ValidationError` path.

## Root cause
The API implementation never called `p5._validateParameters('saveGif', arguments)` even though the rest of the image API follows that pattern and the existing tests expect it.

## Why this fix is correct
Calling the shared validator at the start restores the expected argument-validation behavior without changing the rest of `saveGif()`. I verified the three targeted `saveGif` wrong-type tests in headless Chrome after this change.