### PR TITLE
Mark p5.Image modified after copy to refresh WEBGL textures

### DIFF
--- a/src/image/p5.Image.js
+++ b/src/image/p5.Image.js
@@ -1104,6 +1104,7 @@ p5.Image = class {
    */
   copy(...args) {
     p5.prototype.copy.apply(this, args);
+    this.setModified(true);
   }
 
   /**


### PR DESCRIPTION
## Bug
Fixes #8811. `p5.Image.copy()` in WEBGL mode updates the destination framebuffer but the displayed texture stays stale until a pixel is manually changed (e.g. via `set()`).

## Root cause
`p5.Texture` only re-uploads p5.Image pixel data when `isModified()` is true. `copy()` never calls `setModified(true)`, unlike `set()`, `updatePixels()`, and `mask()`.

## Why this fix is correct
Calling `setModified(true)` after copy matches the existing pattern used by other mutating image methods and ensures the next draw uploads the copied pixels to the GPU texture.


Made with [Cursor](https://cursor.com)