### PR TITLE
Fix TypeError: _validateParameters is not a function

### DIFF
--- a/src/core/friendly_errors/validate_params.js
+++ b/src/core/friendly_errors/validate_params.js
@@ -756,7 +756,7 @@ if (typeof IS_MINIFIED !== 'undefined') {
       }
     }
   };
-  p5.prototype._validateParameters = p5.validateParameters;
+  p5.prototype._validateParameters = p5._validateParameters;
 }
 
 export default p5;


### PR DESCRIPTION
Bug: Parameter validation was throwing a hard error when triggered, because `p5.prototype._validateParameters` was incorrectly aliased to the undefined `p5.validateParameters` instead of `p5._validateParameters`.

Root cause: The alias in `validate_params.js` referenced an undefined property instead of the static method defined earlier in the file. This prevented the FES (Friendly Error System) from correctly logging parameter errors and instead crashed the program when it attempted to execute the wrapper.

Why fix is correct: Pointing the alias to the correct static method `p5._validateParameters` restores the intended FES behavior without crashing the program, fixing Issue #8818.