### PR TITLE
Correct set() documentation

### DIFF
--- a/src/math/p5.Vector.js
+++ b/src/math/p5.Vector.js
@@ -310,16 +310,11 @@ class Vector {
   }
 
   /**
-   * Sets the vector's `x`, `y`, and `z` components.
+   * Sets the the vector to a new value.
    *
    * `set()` can use separate numbers, as in `v.set(1, 2, 3)`, a
    * <a href="#/p5.Vector">p5.Vector</a> object, as in `v.set(v2)`, or an
    * array of numbers, as in `v.set([1, 2, 3])`.
-   *
-   * If a value isn't provided for a component, it will be set to 0. For
-   * example, `v.set(4, 5)` sets `v.x` to 4, `v.y` to 5, and `v.z` to 0.
-   * Calling `set()` with no arguments, as in `v.set()`, sets all the vector's
-   * components to 0.
    *
    * @param {Number} [x] x component of the vector.
    * @param {Number} [y] y component of the vector.


### PR DESCRIPTION
Testing 2.3.0-rc.6 with [this nature of code example](https://editor.p5js.org/natureofcode/sketches/MQZWruTlD),  Discord/sidwellr found using `set()` according to docs resulted in "mismatched dimension" FES warnings from the binary vector operations.

Discord/sidwellr suggested:

> Change the first paragraph "Sets the vector's x, y, and z components." to "Sets a vector to a new value."

> Change the third paragraph "If a value isn't provided for a component..." to something like:

> The vector will be replaced with the new one, which might have a different number of dimensions. For example, v.set(4, 5) will set v to a two dimensional vector vector[4, 5]. v.set(v2) is similar to v = v2.copy() (but works even if v is a const). Calling v.set() with no arguments sets v to an empty vector.


@limzykenneth said:

> Agreed for the first paragraph change, it shouldn't mention x, y, z components any more (I changed those for mult etc already).

> For the third paragraph suggestion, I'm not sure conceptually "vector will be replaced with the new one" is the right wording. While the vector's dimension may change and so it technically would be a different vector, the vector object itself is not replaced ie. v === v is still true. Implying the vector is replaced for me implies v !== v. Same with implying v = v2.copy() which creates another vector and violates v === v.

```js
function setup() {
  createCanvas(400, 400);
  v = createVector(1, 2);
  v2 = v;
  v.set(2, 3);
  console.log(v === v2); // This is true
}
```

The PR changes the first paragraph, and removes the third, because the current version is actively misleading.