### PR TITLE
Update stewards.yml

### DIFF
--- a/stewards.yml
+++ b/stewards.yml
@@ -1,6 +1,3 @@
-aferriss:
-  - Graphics:
-      - WebGL
 
 calebfoss:
   - Accessibility
@@ -13,9 +10,6 @@ davepagurek:
 
 dhowe:
   - Typography
-
-qianqianye:
-  - Maintainers
 
 ogbabydiesal:
   - p5.sound.js
@@ -34,11 +28,6 @@ perminder-17:
   - Documentation
   - Maintainers
 
-lukeplowden:
-  - Graphics:
-      - WebGL
-      - p5.strands
-
 ksen0:
   - Maintainers
   - p5.js-website
@@ -47,37 +36,10 @@ Divyansh013:
   - i18n:
       - hi
 
-GregStanton:
-  - Math
-  - Shapes
-
-holomorfo:
-  - Math
-
 lirenjie95:
   - i18n:
       - zh
   - DevOps
-
-IIITM-Jay:
-  - Friendly Errors
-
-Vaivaswat2244:
-  - DevOps
-
-RandomGamingDev:
-  - Graphics:
-      - WebGL
-
-VANSH3104:
-  - Documentation
-
-error-four-o-four:
-  - DevOps
-
-takshittt:
-  - i18n:
-      - hi
 
 clairep94:
   - p5.js-website
@@ -92,11 +54,7 @@ doradocodes:
 coseeian:
   - Accessibility:
       - p5.js-website
-
-hana-cho:
-  - i18n:
-      - ko
-
+      
 marioguzzzman:
   - i18n:
       - es


### PR DESCRIPTION
This PR updates the stewards list to only include those stewards who were active within the past 6 months ago (Nov 27 2025 until now) as reviewers, or leaving comments on PRs in p5.js, p5.js-website, p5.js-web-editor, or p5.sound.js.
