### PR TITLE
Fix saveGif duration validation to be a silent no-op

### DIFF
--- a/src/image/loading_displaying.js
+++ b/src/image/loading_displaying.js
@@ -304,7 +304,7 @@ p5.prototype.saveGif = async function(
     throw TypeError('Duration parameter must be a number');
   }
   if (duration <= 0) {
-    throw RangeError('Duration parameter must be a positive number');
+    return;
   }
 
   // extract variables for more comfortable use

--- a/src/image/loading_displaying.js
+++ b/src/image/loading_displaying.js
@@ -303,6 +303,9 @@ p5.prototype.saveGif = async function(
   if (typeof duration !== 'number') {
     throw TypeError('Duration parameter must be a number');
   }
+  if (duration <= 0) {
+    throw RangeError('Duration parameter must be a positive number');
+  }
 
   // extract variables for more comfortable use
   const delay = (options && options.delay) || 0;  // in seconds

--- a/test/unit/image/downloading.js
+++ b/test/unit/image/downloading.js
@@ -370,6 +370,15 @@ suite('p5.prototype.saveGif', function() {
     });
   });
 
+  test('should throw an error if duration is less than or equal to 0', function() {
+    assert.throws(function() {
+      myp5.saveGif('myGif', 0);
+    }, RangeError);
+    assert.throws(function() {
+      myp5.saveGif('myGif', -5);
+    }, RangeError);
+  });
+
   testWithDownload('should download a GIF', async function(blobContainer) {
     myp5.saveGif(myGif, 3, 2);
     await waitForBlob(blobContainer);


### PR DESCRIPTION
Bug: saveGif throws a RangeError if duration is <= 0.

Root cause: Explicit parameter validation in saveGif throws an error if duration <= 0, which is inconsistent with how p5.js usually handles unexpected input.

Fix: Changed the validation to be a silent no-op (early return) instead of throwing an error, to align with the rest of the codebase.