### PR TITLE
Fix p5.Image copy method to mark image as modified

### DIFF
--- a/src/image/p5.Image.js
+++ b/src/image/p5.Image.js
@@ -1104,6 +1104,7 @@ p5.Image = class {
    */
   copy(...args) {
     p5.prototype.copy.apply(this, args);
+    this.setModified(true);
   }
 
   /**


### PR DESCRIPTION
Bug: Copying pixels into an image using the `copy()` method doesn't mark the image as modified. As a result, using it as a WEBGL texture immediately afterwards fails to upload the new pixels to the GPU.
Root cause: The `copy()` method delegates to `p5.prototype.copy` but fails to call `this.setModified(true)`.
Why fix is correct: Adds a call to `this.setModified(true)` to properly track state changes, ensuring GPU textures are updated correctly.