### PR TITLE
fix(color): prevent NaN saturation in HSLA to HSBA at zero lightness

### DIFF
--- a/src/color/color_conversion.js
+++ b/src/color/color_conversion.js
@@ -113,7 +113,7 @@ p5.ColorConversion = {
     }
 
     // Convert saturation.
-    sat = 2 * (val - li) / val;
+    sat = val === 0 ? 0 : 2 * (val - li) / val;
 
     // Hue and alpha stay the same.
     return [hue, sat, val, hsla[3]];

--- a/test/unit/color/color_conversion.js
+++ b/test/unit/color/color_conversion.js
@@ -57,6 +57,12 @@ suite('color/p5.ColorConversion', function() {
       result = p5.ColorConversion._hslaToHSBA(hsla);
       assert.arrayApproximately(result, hsba, accuracy);
     });
+
+    test('zero lightness does not produce NaN saturation', function() {
+      result = p5.ColorConversion._hslaToHSBA([0, 1, 0, 1]);
+      assert.isFalse(isNaN(result[1]));
+      assert.strictEqual(result[1], 0);
+    });
   });
 
   suite('hsbaToHSLA', function() {


### PR DESCRIPTION
## Bug
`color.toString('hsb')` returns NaN saturation for HSL black (`color(0, 100, 0)` in HSL mode).

## Root cause
`_hslaToHSBA` divides by `val` when computing saturation. For zero lightness, `val` is 0, producing `0/0`.

## Why this fix is correct
Return saturation 0 when `val === 0`, matching how `_hsbaToHSLA` already guards the `li === 1` case.

Resolves N/A (discovered during color conversion review; no open issue).

#### PR Checklist
- [x] `npm run lint` passes
- [ ] [Inline reference] is included / updated
- [x] [Unit tests] are included / updated

Made with [Cursor](https://cursor.com)