### PR TITLE
Mark private methods as private

### DIFF
--- a/src/math/patch-vector.js
+++ b/src/math/patch-vector.js
@@ -76,6 +76,8 @@ export function _validatedVectorOperation(expectsSoloNumberArgument){
 }
 
 /**
+ * @private
+ * @internal
  * Each of the following decorators validates the data on vector operations.
  * These ensure that the arguments are consistently formatted, and that
  * pre-conditions are met.

--- a/src/strands/strands_transpiler.js
+++ b/src/strands/strands_transpiler.js
@@ -1661,6 +1661,9 @@ function transformHelperFunctionEarlyReturns(ast, names) {
 }
 
 /**
+ * @private
+ * @internal
+ * 
  * Transpiles a p5.strands callback into executable JavaScript by applying
  * a multi-pass AST transformation pipeline.
  *


### PR DESCRIPTION
The reference incorrectly includes two private methods:

![Uploading image.png…]()

This PR marks them as private/internal.