### PR TITLE
Fix WebGL shader version method regex on 1.x branch

### DIFF
--- a/src/webgl/p5.Shader.js
+++ b/src/webgl/p5.Shader.js
@@ -240,7 +240,7 @@ p5.Shader = class {
    * @returns {String} The GLSL version used by the shader.
    */
   version() {
-    const match = /#version (.+)$/.exec(this.vertSrc());
+    const match = /#version (.+)$/m.exec(this.vertSrc());
     if (match) {
       return match[1];
     } else {

--- a/test/unit/webgl/p5.Shader.js
+++ b/test/unit/webgl/p5.Shader.js
@@ -309,6 +309,30 @@ suite('p5.Shader', function() {
       assert.isFalse(s.isStrokeShader());
     });
 
+    test('version() detects a #version directive', function() {
+      const shader = myp5.createShader(
+        `
+          #version 300 es
+          precision highp float;
+          attribute vec3 aPosition;
+          uniform mat4 uModelViewMatrix;
+          uniform mat4 uProjectionMatrix;
+
+          void main() {
+            gl_Position = uProjectionMatrix * uModelViewMatrix * vec4(aPosition, 1.0);
+          }
+        `,
+        `
+          precision highp float;
+
+          void main() {
+            gl_FragColor = vec4(1.0);
+          }
+        `
+      );
+      assert.strictEqual(shader.version(), '300 es');
+    });
+
     suite('Hooks', function() {
       let myShader;
 


### PR DESCRIPTION

Addresses #8856

 Changes:
- Apply fix from #8857 to the `main` branch

#### PR Checklist

- [ ] `npm run lint` passes
- [ ] [Inline reference] is included / updated
- [x] [Unit tests] are included / updated

[Inline reference]: https://p5js.org/contribute/contributing_to_the_p5js_reference/
[Unit tests]: https://github.com/processing/p5.js/tree/main/contributor_docs#unit-tests
