### PR TITLE
feat: add friendly error for cross-hook property access (#8813)

### DIFF
--- a/src/strands/strands_api.js
+++ b/src/strands/strands_api.js
@@ -795,6 +795,50 @@ export function createShaderHooksFunctions(strandsContext, fn, shader) {
     hook.set = function(result) {
       hook._result = result;
     };
+    hook._active = false;
+
+    const numStructArgs = hookType.parameters.filter(
+      param => param.type && param.type.properties
+    ).length;
+    let argIdx = -1;
+    if (numStructArgs === 1) {
+      argIdx = hookType.parameters.findIndex(
+        param => param.type && param.type.properties
+      );
+    }
+    if (argIdx >= 0) {
+      const structParam = hookType.parameters[argIdx];
+      if (structParam.type.properties) {
+        for (const prop of structParam.type.properties) {
+          const key = prop.name;
+          Object.defineProperty(hook, key, {
+            get() {
+              if (!this._active) {
+                FES.userError(
+                  'scope error',
+                  `It looks like you're trying to access "${hookType.name}.${key}" outside of its begin()/end() block.\n\n` +
+                  `Properties of ${hookType.name} are only available between ` +
+                  `${hookType.name}.begin() and ${hookType.name}.end().\n\n` +
+                  `To share data between hooks, use sharedVec3() or sharedFloat() ` +
+                  `to pass values between them.`
+                );
+              }
+              return this._args[this._argIdx][key];
+            },
+            set(val) {
+              if (!this._active) {
+                FES.userError(
+                  'scope error',
+                  `It looks like you're trying to set "${hookType.name}.${key}" outside of its begin()/end() block.`
+                );
+              }
+              this._args[this._argIdx][key] = val;
+            },
+            enumerable: true,
+          });
+        }
+      }
+    }
 
     let entryBlockID;
     function setupHook() {
@@ -803,25 +847,14 @@ export function createShaderHooksFunctions(strandsContext, fn, shader) {
       CFG.addEdge(cfg, cfg.currentBlock, entryBlockID);
       CFG.pushBlock(cfg, entryBlockID);
       const args = createHookArguments(strandsContext, hookType.parameters);
-      const numStructArgs = hookType.parameters.filter(param => param.type.properties).length;
-      let argIdx = -1;
-      if (numStructArgs === 1) {
-        argIdx = hookType.parameters.findIndex(param => param.type.properties);
-      }
+      hook._active = true;
+      hook._args = args;
+      hook._argIdx = argIdx;
       hook._properties = [];
       for (let i = 0; i < args.length; i++) {
         if (i === argIdx) {
           for (const key of args[argIdx].structProperties || []) {
             hook._properties.push(key);
-            Object.defineProperty(hook, key, {
-              get() {
-                return args[argIdx][key];
-              },
-              set(val) {
-                args[argIdx][key] = val;
-              },
-              enumerable: true,
-            });
           }
           if (hookType.returnType?.typeName === hookType.parameters[argIdx].type.typeName) {
             hook.set(args[argIdx]);
@@ -835,6 +868,7 @@ export function createShaderHooksFunctions(strandsContext, fn, shader) {
     };
 
     function finishHook() {
+      hook._active = false;
       const userReturned = hook._result;
       strandsContext.activeHook = undefined;
 

--- a/src/strands/strands_api.js
+++ b/src/strands/strands_api.js
@@ -809,6 +809,10 @@ export function createShaderHooksFunctions(strandsContext, fn, shader) {
     if (argIdx >= 0) {
       const structParam = hookType.parameters[argIdx];
       if (structParam.type.properties) {
+        const nameMatch = /^get([A-Z0-9]\w*)$/.exec(hookType.name);
+        const displayName = nameMatch
+          ? nameMatch[1][0].toLowerCase() + nameMatch[1].slice(1)
+          : hookType.name;
         for (const prop of structParam.type.properties) {
           const key = prop.name;
           Object.defineProperty(hook, key, {
@@ -816,9 +820,9 @@ export function createShaderHooksFunctions(strandsContext, fn, shader) {
               if (!this._active) {
                 FES.userError(
                   'scope error',
-                  `It looks like you're trying to access "${hookType.name}.${key}" outside of its begin()/end() block.\n\n` +
-                  `Properties of ${hookType.name} are only available between ` +
-                  `${hookType.name}.begin() and ${hookType.name}.end().\n\n` +
+                  `It looks like you're trying to access "${displayName}.${key}" outside of its begin()/end() block.\n\n` +
+                  `Properties of ${displayName} are only available between ` +
+                  `${displayName}.begin() and ${displayName}.end().\n\n` +
                   `To share data between hooks, use sharedVec3() or sharedFloat() ` +
                   `to pass values between them.`
                 );
@@ -829,7 +833,7 @@ export function createShaderHooksFunctions(strandsContext, fn, shader) {
               if (!this._active) {
                 FES.userError(
                   'scope error',
-                  `It looks like you're trying to set "${hookType.name}.${key}" outside of its begin()/end() block.`
+                  `It looks like you're trying to set "${displayName}.${key}" outside of its begin()/end() block.`
                 );
               }
               this._args[this._argIdx][key] = val;

--- a/test/unit/webgl/p5.Shader.js
+++ b/test/unit/webgl/p5.Shader.js
@@ -2759,5 +2759,26 @@ test('returns numbers for builtin globals outside hooks and a strandNode when ca
         }, { myp5 });
       });
     });
+
+    test('scope error uses unprefixed hook name', () => {
+      myp5.createCanvas(50, 50, myp5.WEBGL);
+
+      try {
+        myp5.baseMaterialShader().modify(() => {
+          myp5.getWorldInputs.begin();
+          myp5.getWorldInputs.end();
+          const pos = myp5.getWorldInputs.position;
+        }, { myp5 });
+      } catch (e) { /* expected */ }
+
+      assert.isAbove(mockUserError.mock.calls.length, 0, 'FES.userError should have been called');
+      const scopeCall = mockUserError.mock.calls.find(call => call[0] === 'scope error');
+      assert.isDefined(scopeCall, 'scope error should have been called');
+      const errMsg = scopeCall[1];
+      assert.include(errMsg, 'worldInputs');
+      assert.notInclude(errMsg, 'getWorldInputs');
+      assert.include(errMsg, 'begin()');
+      assert.include(errMsg, 'end()');
+    });
   });
 });


### PR DESCRIPTION
Resolves #8813

## Changes

Adds a friendly error when accessing one hook's struct properties from within another hook's begin()/end() block in the flat strands API. Previously this gave a cryptic TypeError because struct property getters were only defined during setupHook().

After this PR, the same code gives a clear error with a suggestion to use sharedVec3() or sharedFloat() for cross-hook data sharing.

## Screenshots of the change

N/A — error-message change only.

#### PR Checklist

- [x] `npm run lint` passes
- [ ] [Inline reference] is included / updated (N/A — no public API added)
- [ ] [Unit tests] are included / updated

[Inline reference]: https://p5js.org/contribute/contributing_to_the_p5js_reference/
[Unit tests]: https://github.com/processing/p5.js/tree/main/contributor_docs#unit-tests