### PR TITLE
Expose dimensions property on Vector

### DIFF
--- a/src/math/p5.Vector.js
+++ b/src/math/p5.Vector.js
@@ -3683,6 +3683,14 @@ function vector(p5, fn) {
    * @property z
    * @name z
    */
+
+  /**
+   * The dimensions of the vector
+   * @type {Number}
+   * @for p5.Vector
+   * @property dimensions
+   * @name dimensions
+   */
 }
 
 export default vector;


### PR DESCRIPTION
Fixes #8155

The behavior of dimensions has been corrected since 2.3.0 (`vectorName.dimensions` is equivalent to `vectorName.values.length`), but it does not show up in the reference.