### PR TITLE
Add shared methods and build Shader() for p5.strands #8440

### DIFF
--- a/src/webgl/material.js
+++ b/src/webgl/material.js
@@ -3307,4 +3307,41 @@ p5.RendererGL.prototype._applyBlendMode = function () {
   }
 };
 
+p5.prototype.buildColorShader = function(hooks) {
+  this._assert3d('buildColorShader');
+  let s = this.baseColorShader();
+  return s.modify(hooks || {});
+};
+
+p5.prototype.buildMaterialShader = function(hooks) {
+  this._assert3d('buildMaterialShader');
+  let s = this.baseMaterialShader();
+  return s.modify(hooks || {});
+};
+
+p5.prototype.buildNormalShader = function(hooks) {
+  this._assert3d('buildNormalShader');
+  let s = this.baseNormalShader();
+  return s.modify(hooks || {});
+};
+
+p5.prototype.buildStrokeShader = function(hooks) {
+  this._assert3d('buildStrokeShader');
+  let s = this.baseStrokeShader();
+  return s.modify(hooks || {});
+};
+
+p5.prototype.buildFilterShader = function(fragSrc, hooks) {
+  this._assert3d('buildFilterShader');
+  let s = this.createFilterShader(fragSrc);
+  if (hooks) {
+    return s.modify(hooks);
+  }
+  return s;
+};
+
+p5.prototype.uniformTexture = function(tex) {
+  return { type: 'sampler2D', name: 'uTexture', texture: tex };
+};
+
 export default p5;

--- a/src/webgl/p5.Shader.js
+++ b/src/webgl/p5.Shader.js
@@ -182,6 +182,8 @@ p5.Shader = class {
       // Stores helper functions to prepend to shaders.
       helpers: options.helpers || {},
 
+      varyings: options.varyings || {},
+
       // Stores the hook implementations
       vertex: options.vertex || {},
       fragment: options.fragment || {},
@@ -196,6 +198,43 @@ p5.Shader = class {
     };
   }
 
+  _sharedVarying(glslType, name, desc) {
+    this.hooks.varyings[glslType + ' ' + name] = true;
+    return {
+      type: glslType,
+      name,
+      description: desc || ''
+    };
+  }
+
+  sharedFloat(name, desc) {
+    return this._sharedVarying('float', name, desc);
+  }
+
+  sharedVec2(name, desc) {
+    return this._sharedVarying('vec2', name, desc);
+  }
+
+  sharedVec3(name, desc) {
+    return this._sharedVarying('vec3', name, desc);
+  }
+
+  sharedVec4(name, desc) {
+    return this._sharedVarying('vec4', name, desc);
+  }
+
+  sharedInt(name, desc) {
+    return this._sharedVarying('int', name, desc);
+  }
+
+  sharedMat4(name, desc) {
+    return this._sharedVarying('mat4', name, desc);
+  }
+
+  sharedBool(name, desc) {
+    return this._sharedVarying('bool', name, desc);
+  }
+
   shaderSrc(src, shaderType) {
     const main = 'void main';
     const [preMain, postMain] = src.split(main);
@@ -203,6 +242,9 @@ p5.Shader = class {
     let hooks = '';
     for (const key in this.hooks.uniforms) {
       hooks += `uniform ${key};\n`;
+    }
+    for (const key in this.hooks.varyings) {
+      hooks += `varying ${key};\n`;
     }
     if (this.hooks.declarations) {
       hooks += this.hooks.declarations + '\n';
@@ -335,6 +377,11 @@ p5.Shader = class {
     for (const key in this.hooks.helpers) {
       console.log(key + this.hooks.helpers[key]);
     }
+    console.log('');
+    console.log('==== Varyings (shared between vertex & fragment): ====');
+    for (const key in this.hooks.varyings) {
+      console.log('varying ' + key + ';');
+    }
   }
 
   /**
@@ -464,10 +511,17 @@ p5.Shader = class {
       modifiedFragment[key] = true;
     }
 
+    const newVaryings = Object.assign(
+      {},
+      this.hooks.varyings,
+      hooks.varyings || {}
+    );
+
     return new p5.Shader(this._renderer, this._vertSrc, this._fragSrc, {
       declarations:
         (this.hooks.declarations || '') + '\n' + (hooks.declarations || ''),
       uniforms: Object.assign({}, this.hooks.uniforms, hooks.uniforms || {}),
+      varyings: newVaryings,
       fragment: Object.assign({}, this.hooks.fragment, newHooks.fragment || {}),
       vertex: Object.assign({}, this.hooks.vertex, newHooks.vertex || {}),
       helpers: Object.assign({}, this.hooks.helpers, newHooks.helpers || {}),
@@ -755,7 +809,10 @@ p5.Shader = class {
     const shader = new p5.Shader(
       context._renderer,
       this._vertSrc,
-      this._fragSrc
+      this._fragSrc,
+      {
+        varyings: Object.assign({}, this.hooks.varyings)
+      }
     );
     shader.ensureCompiledOnContext(context);
     return shader;


### PR DESCRIPTION
fixes #8440

## overview

sharedFloat(), sharedVec2(), sharedVec3(), sharedVec4(), sharedInt(), sharedMat4(), and sharedBool() let users create varying variables to pass data between vertex and fragment shader hooks. They are used in other examples to pass data between hooks, but did not yet have their own reference pages.

## Changes

**src/webgl/p5.Shader.js**: add shared* methods, varyings tracking in hooks, injection in shaderSrc(), preserve in modify() and copyToContext()
**src/webgl/material.js**: add buildColorShader, buildMaterialShader, buildNormalShader, buildStrokeShader, buildFilterShader, uniformTexture

## PR Checklist

- [x] npm run lint passes
- [x] Inline reference is included / updated
- [x] Unit tests are included / updated