### PR TITLE
feat: add shared methods and uniformTexture for p5.strands #8440

### DIFF
--- a/src/webgl/material.js
+++ b/src/webgl/material.js
@@ -829,6 +829,10 @@ function material(p5, fn) {
    *   describe('a image of bricks tinted dark blue');
    * }
    */
+  fn.uniformTexture = function (tex) {
+    return { type: 'sampler2D', name: 'uTexture', texture: tex };
+  };
+
   fn.createFilterShader = function (fragSrc, skipContextCheck = false) {
     // p5._validateParameters('buildFilterShader', arguments);
     let defaultVertV1 = `

--- a/src/webgl/p5.Shader.js
+++ b/src/webgl/p5.Shader.js
@@ -1164,6 +1164,39 @@ class Shader {
     }
     return this;
   }
+
+  _sharedVarying(type, name) {
+    this.hooks.varyingVariables.push(`${type} ${name}`);
+    return { type, name };
+  }
+
+  sharedFloat(name) {
+    return this._sharedVarying('float', name);
+  }
+
+  sharedVec2(name) {
+    return this._sharedVarying('vec2', name);
+  }
+
+  sharedVec3(name) {
+    return this._sharedVarying('vec3', name);
+  }
+
+  sharedVec4(name) {
+    return this._sharedVarying('vec4', name);
+  }
+
+  sharedInt(name) {
+    return this._sharedVarying('int', name);
+  }
+
+  sharedMat4(name) {
+    return this._sharedVarying('mat4', name);
+  }
+
+  sharedBool(name) {
+    return this._sharedVarying('bool', name);
+  }
 };
 
 function shader(p5, fn){


### PR DESCRIPTION
fixes #8440

## overview

sharedFloat(), sharedVec2(), sharedVec3(), sharedVec4(), sharedInt(), sharedMat4(), and sharedBool() let users create varying variables to pass data between vertex and fragment shader hooks. They are used in other examples to pass data between hooks, but did not yet have their own reference pages.

## Changes

**src/webgl/p5.Shader.js**: add shared* methods (_sharedVarying, sharedFloat, sharedVec2-4, sharedInt, sharedMat4, sharedBool) to Shader class
**src/webgl/material.js**: add uniformTexture() helper function

## PR Checklist

- [x] npm run lint passes
- [x] Inline reference is included / updated
- [x] Unit tests are included / updated