### PR TITLE
fixing-mouseClick

### DIFF
--- a/src/events/pointer.js
+++ b/src/events/pointer.js
@@ -1069,6 +1069,10 @@ function pointer(p5, fn, lifecycles){
     this._activePointers.set(e.pointerId, e);
     this._setMouseButton(e);
 
+    if (this.mouseIsPressed && e.buttons === 0) {
+      this._onpointerup(e);
+    }
+
     if (
       !this.mouseIsPressed &&
       typeof this._customActions.mouseMoved === 'function'

--- a/test/unit/events/mouse.js
+++ b/test/unit/events/mouse.js
@@ -303,7 +303,7 @@ suite.todo('Mouse Events', function() {
       };
 
       window.dispatchEvent(new PointerEvent('pointerdown')); //dispatch a mousedown event
-      window.dispatchEvent(new PointerEvent('pointermove')); //dispatch mousemove event while mouse is down to trigger mouseDragged
+      window.dispatchEvent(new PointerEvent('pointermove', { buttons: 1 })); //dispatch mousemove event while mouse is down to trigger mouseDragged
       assert.deepEqual(count, 1);
     });
 
@@ -322,7 +322,7 @@ suite.todo('Mouse Events', function() {
       let sketches = parallelSketches([sketchFn, sketchFn]); //create two sketches
       await sketches.setup; //wait for all sketches to setup
       window.dispatchEvent(new PointerEvent('pointerdown')); //dispatch a mousedown event
-      window.dispatchEvent(new PointerEvent('pointermove')); //dispatch mousemove event while mouse is down to trigger mouseDragged
+      window.dispatchEvent(new PointerEvent('pointermove', { buttons: 1 })); //dispatch mousemove event while mouse is down to trigger mouseDragged
       sketches.end(); //resolve all sketches by calling their finish functions
       let counts = await sketches.result; //get array holding number of times mouseDragged was called. Rejected sketches also thrown here
       assert.deepEqual(counts, [1, 1]);


### PR DESCRIPTION
<!--
  Thank you for contributing! Please use this pull request (PR) template.


 In the description field of this PR, include "resolves #8293 " tagging the issue you are fixing. If this PR addresses the issue but doesn't completely resolve it (ie the issue should remain open after your PR is merged), write "addresses #8293 ".-->
Resolves #8293 

 Changes:
Fixes an issue where interacting with p5 DOM elements (e.g. createSelect)
in Safari triggers mousePressed but not mouseReleased, leaving
mouseIsPressed stuck in a true state.


 Screenshots of the change:
<!-- If applicable, add screenshots depicting the changes. -->

#### PR Checklist
<!--
  To check any option, replace the "[ ]" with a "[x]". Be sure to check out how it looks in the Preview tab! Feel free to remove any portion of the template that is not relevant for your issue.
-->

- [ ] `npm run lint` passes
- [ ] [Inline reference] is included / updated
- [ ] [Unit tests] are included / updated

[Inline reference]: https://p5js.org/contribute/contributing_to_the_p5js_reference/
[Unit tests]: https://github.com/processing/p5.js/tree/main/contributor_docs#unit-tests
