### PR TITLE
fix: convert tint to RGBA array in _getTintedImageCanvas

### DIFF
--- a/src/core/p5.Renderer2D.js
+++ b/src/core/p5.Renderer2D.js
@@ -444,10 +444,12 @@ class Renderer2D extends Renderer {
     ctx.save();
     ctx.clearRect(0, 0, img.canvas.width, img.canvas.height);
 
+    const tint = this.states.tint._getRGBA([255, 255, 255, 255]);
+
     if (
-      this.states.tint[0] < 255 ||
-      this.states.tint[1] < 255 ||
-      this.states.tint[2] < 255
+      tint[0] < 255 ||
+      tint[1] < 255 ||
+      tint[2] < 255
     ) {
       // Color tint: we need to use the multiply blend mode to change the colors.
       // However, the canvas implementation of this destroys the alpha channel of
@@ -470,16 +472,16 @@ class Renderer2D extends Renderer {
 
       // Apply color tint
       ctx.globalCompositeOperation = 'multiply';
-      ctx.fillStyle = `rgb(${this.states.tint.slice(0, 3).join(', ')})`;
+      ctx.fillStyle = `rgb(${tint.slice(0, 3).join(', ')})`;
       ctx.fillRect(0, 0, img.canvas.width, img.canvas.height);
 
       // Replace the alpha channel with the original alpha * the alpha tint
       ctx.globalCompositeOperation = 'destination-in';
-      ctx.globalAlpha = this.states.tint[3] / 255;
+      ctx.globalAlpha = tint[3] / 255;
       ctx.drawImage(img.canvas, 0, 0);
     } else {
       // If we only need to change the alpha, we can skip all the extra work!
-      ctx.globalAlpha = this.states.tint[3] / 255;
+      ctx.globalAlpha = tint[3] / 255;
       ctx.drawImage(img.canvas, 0, 0);
     }
 


### PR DESCRIPTION
Resolves #8910

## Changes:
Fixed `tint()` not working in 2D mode by converting the `p5.Color` object to an RGBA array before use in `_getTintedImageCanvas()`.

The issue was that `tint()` stored a `p5.Color` object in `this.states.tint`, but `_getTintedImageCanvas()` tried to access it as a numeric array (e.g., `this.states.tint[3]`), resulting in `undefined` values and `ctx.globalAlpha = NaN`.

The fix adds `const tint = this.states.tint._getRGBA([255, 255, 255, 255]);` after `ctx.clearRect()` to convert the color object to an array, then uses the local `tint` variable throughout the function for accessing color channels.

## Screenshots of the change:

**After fix:**
<img width="959" height="497" alt="Screenshot 2026-06-18 000711" src="https://github.com/user-attachments/assets/6172d539-1ded-4321-811a-39fdbce9d611" />


**Before fix:**
<img width="959" height="493" alt="Screenshot 2026-06-18 000222" src="https://github.com/user-attachments/assets/9c3cd5ee-1476-42c4-a1cd-a90852234952" />


#### PR Checklist
- [x] `npm run lint` passes
- [ ] [Inline reference] is included / updated
- [ ] [Unit tests] are included / updated

**Note:** This is a bug fix. Inline reference and unit tests were not modified as the fix does not change the API behavior.

[Inline reference]: https://p5js.org/contribute/contributing_to_the_p5js_reference/
[Unit tests]: https://github.com/processing/p5.js/tree/main/contributor_docs#unit-tests
