### PR TITLE
Fix: Add property w JSDoc block after property  #8154

### DIFF
--- a/src/math/p5.Vector.js
+++ b/src/math/p5.Vector.js
@@ -3685,6 +3685,14 @@ function vector(p5, fn) {
    */
 
   /**
+   * The w component of the vector
+   * @type {Number}
+   * @for p5.Vector
+   * @property w
+   * @name w
+   */
+
+  /**
    * The dimensions of the vector
    * @type {Number}
    * @for p5.Vector


### PR DESCRIPTION
Resolves #8154

## Changes

Add `@property w` JSDoc block for `p5.Vector` alongside the existing `x`, `y`, `z` property blocks. The `w` component was already implemented as a getter/setter but was missing from the documentation definition, so it never appeared in the generated reference docs.

## PR Checklist

- [x] npm run lint passes
- [x] npm test passes
- [x] `npm run docs` generates correct data with `w` as a p5.Vector member
 

## screenshot 



<img width="1327" height="783" alt="done 2" src="https://github.com/user-attachments/assets/568b85ab-e3ef-4643-86dd-ffa02a2e494a" />


