### PR TITLE
Fix `loadImage` SVG file loading regression

### DIFF
--- a/src/image/loading_displaying.js
+++ b/src/image/loading_displaying.js
@@ -125,8 +125,18 @@ function loadingDisplaying(p5, fn){
 
       } else {
         // Non-GIF Section
-        const blob = new Blob([data]);
-        const img = await createImageBitmap(blob);
+        const img = await new Promise((resolve, reject) => {
+          const img = new Image();
+          img.onload = () => resolve(img);
+          img.onerror = e => reject(e);
+
+          // Set crossOrigin to prevent a tainted canvas if image is served with CORS headers
+          // See https://developer.mozilla.org/en-US/docs/HTML/CORS_Enabled_Image
+          // Skip this step if it's just a local data URL image
+          if (!path.startsWith('data:image/')) img.crossOrigin = 'Anonymous';
+
+          img.src = path;
+        });
 
         pImg.width = pImg.canvas.width = img.width;
         pImg.height = pImg.canvas.height = img.height;

--- a/src/image/loading_displaying.js
+++ b/src/image/loading_displaying.js
@@ -127,15 +127,16 @@ function loadingDisplaying(p5, fn){
         // Non-GIF Section
         const img = await new Promise((resolve, reject) => {
           const img = new Image();
-          img.onload = () => resolve(img);
+          const blob = new Blob([data], { type: contentType });
+          const url = URL.createObjectURL(blob);
+
           img.onerror = e => reject(e);
+          img.onload = () => {
+            URL.revokeObjectURL(url);
+            resolve(img);
+          };
 
-          // Set crossOrigin to prevent a tainted canvas if image is served with CORS headers
-          // See https://developer.mozilla.org/en-US/docs/HTML/CORS_Enabled_Image
-          // Skip this step if it's just a local data URL image
-          if (!path.startsWith('data:image/')) img.crossOrigin = 'Anonymous';
-
-          img.src = path;
+          img.src = url;
         });
 
         pImg.width = pImg.canvas.width = img.width;

--- a/test/unit/assets/green.svg
+++ b/test/unit/assets/green.svg
@@ -1,0 +1,8 @@
+<svg version="1.2" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 48 48" width="48" height="48">
+	<style>
+		.s0 { fill: #00ff00 } 
+	</style>
+	<g id="Layer 1">
+		<path id="Shape 1" fill-rule="evenodd" class="s0" d="m48 0v48h-48v-48z"/>
+	</g>
+</svg>

--- a/test/unit/image/loading.js
+++ b/test/unit/image/loading.js
@@ -245,6 +245,14 @@ suite('loading images', function() {
 
     const img = await mockP5Prototype.loadImage(svgImage);
     assert.isTrue(img instanceof mockP5.Image);
+
+    // ensure the sample svg is fully parsed and drawn correctly
+    assert.equal(img.width, 48);
+    assert.equal(img.height, 48);
+
+    const GREEN = [0, 255, 0, 255];
+    assert.deepEqual(img.get(0, 0), GREEN);
+    assert.deepEqual(img.get(47, 47), GREEN);
   });
 });
 

--- a/test/unit/image/loading.js
+++ b/test/unit/image/loading.js
@@ -40,6 +40,7 @@ suite('loading images', function() {
   const disposeNoneGif = '/test/unit/assets/dispose_none.gif';
   const disposeBackgroundGif = '/test/unit/assets/dispose_background.gif';
   const disposePreviousGif = '/test/unit/assets/dispose_previous.gif';
+  const svgImage = '/test/unit/assets/green.svg';
   const invalidFile = '404file';
 
   beforeAll(async function() {
@@ -237,6 +238,13 @@ suite('loading images', function() {
     gifImage.reset();
     assert.equal(gifImage.gifProperties.displayIndex, 0);
     assert.equal(gifImage.gifProperties.timeDisplayed, 0);
+  });
+
+  test('loads vector (SVG) images', async () => {
+    await expect(mockP5Prototype.loadImage(svgImage)).resolves.not.toThrow();
+
+    const img = await mockP5Prototype.loadImage(svgImage);
+    assert.isTrue(img instanceof mockP5.Image);
   });
 });
 


### PR DESCRIPTION
<!--
  Thank you for contributing! Please use this pull request (PR) template.


 In the description field of this PR, include "resolves #XXXX" tagging the issue you are fixing. If this PR addresses the issue but doesn't completely resolve it (ie the issue should remain open after your PR is merged), write "addresses #XXXX".-->
Resolves #8921

## Changes:
<!-- Add here what changes were made in this pull request and if possible provide links showcasing the changes. -->
- Load images with `HTMLImageElement` instead of `createImageBitmap`. 

   Reverts to the `loadImage` implementation in p5.js <v2.0 (pre- commit e43f709, which introduced the regression).

`createImageBitmap` [cannot load vector images](https://html.spec.whatwg.org/multipage/imagebitmap-and-animations.html#dom-createimagebitmap) and will reject with an `InvalidStateError`. 

Further reading:
- https://issues.chromium.org/issues/40461578
- https://html.spec.whatwg.org/multipage/imagebitmap-and-animations.html#dom-createimagebitmap
- https://forum.babylonjs.com/t/dynamic-svg-texture-loading-fails-using-webgpu-but-works-using-webgl/41091/3


## PR Checklist
<!--
  To check any option, replace the "[ ]" with a "[x]". Be sure to check out how it looks in the Preview tab! Feel free to remove any portion of the template that is not relevant for your issue.
-->

- [x] `npm run lint` passes
- [ ] [Inline reference] is included / updated
- [x] [Unit tests] are included / updated

[Inline reference]: https://p5js.org/contribute/contributing_to_the_p5js_reference/
[Unit tests]: https://github.com/processing/p5.js/tree/main/contributor_docs#unit-tests
