### PR TITLE
docs(p5.Vector): document w component property

### DIFF
--- a/src/math/p5.Vector.js
+++ b/src/math/p5.Vector.js
@@ -3685,6 +3685,14 @@ function vector(p5, fn) {
    */
 
   /**
+   * The w component of the vector
+   * @type {Number}
+   * @for p5.Vector
+   * @property w
+   * @name w
+   */
+
+  /**
    * The dimensions of the vector
    * @type {Number}
    * @for p5.Vector


### PR DESCRIPTION
Resolves #8154

The `w` getter on `p5.Vector` exists but was missing from the class property doc list, so it never rendered in the reference. Adds the `w` entry mirroring `x`/`y`/`z`. This is the fix suggested by @ksen0. Reference build (`npm run docs`) now includes the `w` property node.