### PR TITLE
Add matrix transformation builtins to strands

### DIFF
--- a/src/strands/ir_builders.js
+++ b/src/strands/ir_builders.js
@@ -101,7 +101,6 @@ export function binaryOpNode(strandsContext, leftStrandsNode, rightArg, opCode) 
   if (opCode === OpCode.Binary.MULTIPLY) {
     if (leftType.baseType === BaseType.MAT) {
       if (rightType.baseType === BaseType.MAT && rightType.dimension === leftType.dimension) {
-        // mat × mat → mat
         const nodeData = DAG.createNodeData({
           nodeType: NodeType.OPERATION,
           opCode,
@@ -114,7 +113,6 @@ export function binaryOpNode(strandsContext, leftStrandsNode, rightArg, opCode) 
         return { id, dimension: leftType.dimension };
       }
       if (rightType.baseType === BaseType.FLOAT && rightType.dimension === leftType.dimension) {
-        // mat × vec → vec (float)
         const nodeData = DAG.createNodeData({
           nodeType: NodeType.OPERATION,
           opCode,
@@ -129,7 +127,6 @@ export function binaryOpNode(strandsContext, leftStrandsNode, rightArg, opCode) 
     }
     if (rightType.baseType === BaseType.MAT && leftType.baseType === BaseType.FLOAT &&
         leftType.dimension === rightType.dimension) {
-      // vec × mat → vec (float)
       const nodeData = DAG.createNodeData({
         nodeType: NodeType.OPERATION,
         opCode,

--- a/src/strands/ir_builders.js
+++ b/src/strands/ir_builders.js
@@ -97,6 +97,52 @@ export function binaryOpNode(strandsContext, leftStrandsNode, rightArg, opCode) 
     DAG.propagateTypeToAssignOnUse(dag, rightStrandsNode.id, leftType.baseType, leftType.dimension);
     rightType = DAG.extractNodeTypeInfo(dag, rightStrandsNode.id);
   }
+
+  if (opCode === OpCode.Binary.MULTIPLY) {
+    if (leftType.baseType === BaseType.MAT) {
+      if (rightType.baseType === BaseType.MAT && rightType.dimension === leftType.dimension) {
+        // mat × mat → mat
+        const nodeData = DAG.createNodeData({
+          nodeType: NodeType.OPERATION,
+          opCode,
+          dependsOn: [leftStrandsNode.id, rightStrandsNode.id],
+          baseType: BaseType.MAT,
+          dimension: leftType.dimension,
+        });
+        const id = DAG.getOrCreateNode(dag, nodeData);
+        CFG.recordInBasicBlock(cfg, cfg.currentBlock, id);
+        return { id, dimension: leftType.dimension };
+      }
+      if (rightType.baseType === BaseType.FLOAT && rightType.dimension === leftType.dimension) {
+        // mat × vec → vec (float)
+        const nodeData = DAG.createNodeData({
+          nodeType: NodeType.OPERATION,
+          opCode,
+          dependsOn: [leftStrandsNode.id, rightStrandsNode.id],
+          baseType: BaseType.FLOAT,
+          dimension: leftType.dimension,
+        });
+        const id = DAG.getOrCreateNode(dag, nodeData);
+        CFG.recordInBasicBlock(cfg, cfg.currentBlock, id);
+        return { id, dimension: leftType.dimension };
+      }
+    }
+    if (rightType.baseType === BaseType.MAT && leftType.baseType === BaseType.FLOAT &&
+        leftType.dimension === rightType.dimension) {
+      // vec × mat → vec (float)
+      const nodeData = DAG.createNodeData({
+        nodeType: NodeType.OPERATION,
+        opCode,
+        dependsOn: [leftStrandsNode.id, rightStrandsNode.id],
+        baseType: BaseType.FLOAT,
+        dimension: rightType.dimension,
+      });
+      const id = DAG.getOrCreateNode(dag, nodeData);
+      CFG.recordInBasicBlock(cfg, cfg.currentBlock, id);
+      return { id, dimension: rightType.dimension };
+    }
+  }
+
   const cast = { node: null, toType: leftType };
   const bothDeferred = leftType.baseType === rightType.baseType && leftType.baseType === BaseType.DEFER;
   if (bothDeferred) {
@@ -221,6 +267,7 @@ function mapPrimitiveDepsToIDs(strandsContext, typeInfo, dependsOn) {
   const inputs = Array.isArray(dependsOn) ? dependsOn : [dependsOn];
   const mappedDependencies = [];
   let { dimension, baseType } = typeInfo;
+  const originalBaseType = baseType;
 
   const dag = strandsContext.dag;
   let calculatedDimensions = 0;
@@ -243,7 +290,8 @@ function mapPrimitiveDepsToIDs(strandsContext, typeInfo, dependsOn) {
       continue;
     }
     else if (typeof dep === 'number') {
-      const { id, dimension } = scalarLiteralNode(strandsContext, { dimension: 1, baseType }, dep);
+      const scalarBaseType = baseType === BaseType.MAT ? BaseType.FLOAT : baseType;
+      const { id, dimension } = scalarLiteralNode(strandsContext, { dimension: 1, baseType: scalarBaseType }, dep);
       mappedDependencies.push(id);
       calculatedDimensions += dimension;
       continue;
@@ -267,13 +315,16 @@ function mapPrimitiveDepsToIDs(strandsContext, typeInfo, dependsOn) {
     dimension = calculatedDimensions;
   } else if (dimension > calculatedDimensions && calculatedDimensions === 1) {
     calculatedDimensions = dimension;
-  } else if(calculatedDimensions !== 1 && calculatedDimensions !== dimension) {
-    FES.userError('type error', `You've tried to construct a ${baseType + dimension} with ${calculatedDimensions} components`);
+  } else if (calculatedDimensions !== 1 && calculatedDimensions !== dimension) {
+    if (originalBaseType !== BaseType.MAT || calculatedDimensions !== dimension * dimension) {
+      FES.userError('type error', `You've tried to construct a ${baseType + dimension} with ${calculatedDimensions} components`);
+    }
+    // Keep the MAT dimension, not the total scalar count
   }
   const inferredTypeInfo = {
     dimension,
-    baseType,
-    priority: BasePriority[baseType],
+    baseType: originalBaseType === BaseType.MAT ? BaseType.MAT : baseType,
+    priority: BasePriority[originalBaseType === BaseType.MAT ? BaseType.MAT : baseType],
   }
   return { originalNodeID, mappedDependencies, inferredTypeInfo };
 }

--- a/src/strands/ir_builders.js
+++ b/src/strands/ir_builders.js
@@ -316,7 +316,6 @@ function mapPrimitiveDepsToIDs(strandsContext, typeInfo, dependsOn) {
     if (originalBaseType !== BaseType.MAT || calculatedDimensions !== dimension * dimension) {
       FES.userError('type error', `You've tried to construct a ${baseType + dimension} with ${calculatedDimensions} components`);
     }
-    // Keep the MAT dimension, not the total scalar count
   }
   const inferredTypeInfo = {
     dimension,

--- a/src/strands/p5.strands.js
+++ b/src/strands/p5.strands.js
@@ -7,6 +7,9 @@
 import { transpileStrandsToJS } from "./strands_transpiler";
 import { BlockType } from "./ir_types";
 
+import matrixTransformGLSL from "../webgl/shaders/functions/matrixTransformGLSL.glsl";
+import matrixTransformWGSL from "../webgpu/shaders/functions/matrixTransformWGSL.js";
+
 import { createDirectedAcyclicGraph } from "./ir_dag";
 import {
   createControlFlowGraph,
@@ -132,6 +135,12 @@ function strands(p5, fn) {
           renderer: this._renderer,
           baseShader: this,
         });
+
+        const isGLSLBackend = this._renderer.strandsBackend.instanceIdReference() === 'gl_InstanceID';
+        strandsContext.vertexDeclarations.add(isGLSLBackend ? matrixTransformGLSL : matrixTransformWGSL);
+        strandsContext.fragmentDeclarations.add(isGLSLBackend ? matrixTransformGLSL : matrixTransformWGSL);
+        strandsContext.computeDeclarations.add(isGLSLBackend ? matrixTransformGLSL : matrixTransformWGSL);
+
         createShaderHooksFunctions(strandsContext, fn, this);
         // TODO: expose this, is internal for debugging for now.
         options.parser = true;

--- a/src/strands/strands_api.js
+++ b/src/strands/strands_api.js
@@ -765,6 +765,9 @@ const _rgb2hsl = (instance, colorNode) => {
         typeAliases.push('Texture')
       } else if (/^vec/.test(typeInfo.fnName)) {
         typeAliases.push(pascalTypeName.replace('Vec', 'Vector'));
+      } else if (/^Mat\d+x\d+$/.test(pascalTypeName)) {
+        const shortName = pascalTypeName.replace(/x\d+$/, '');
+        typeAliases.push(shortName);
       }
     }
     augmentFn(fn, p5, `uniform${pascalTypeName}`, function(name, defaultValue) {
@@ -835,6 +838,11 @@ const _rgb2hsl = (instance, colorNode) => {
         );
       }
     });
+
+    if (typeInfo.baseType === BaseType.MAT) {
+      const shortName = typeInfo.fnName.replace(/x\d+$/, '');
+      augmentFn(fn, p5, shortName, fn[typeInfo.fnName]);
+    }
   }
 
   // Storage buffer uniform function for compute shaders

--- a/src/strands/strands_builtins.js
+++ b/src/strands/strands_builtins.js
@@ -107,6 +107,52 @@ const builtInGLSLFunctions = {
   refract: [{ params: [GenType.FLOAT, GenType.FLOAT,DataType.float1], returnType: GenType.FLOAT, isp5Function: false}],
 }
 
+const matrixFunctions = {
+  transform2D: [
+    { params: [DataType.float1, DataType.float1, DataType.float1, DataType.float1, DataType.float1, DataType.float1], returnType: DataType.mat3, isp5Function: false },
+  ],
+  transform3D: [
+    { params: [DataType.float1, DataType.float1, DataType.float1, DataType.float1, DataType.float1, DataType.float1, DataType.float1, DataType.float1, DataType.float1], returnType: DataType.mat4, isp5Function: false },
+  ],
+  translate: [
+    { params: [DataType.float1, DataType.float1], returnType: DataType.mat4, isp5Function: false },
+    { params: [DataType.float2], returnType: DataType.mat4, isp5Function: false },
+    { params: [DataType.float1, DataType.float1, DataType.float1], returnType: DataType.mat4, isp5Function: false },
+    { params: [DataType.float3], returnType: DataType.mat4, isp5Function: false },
+  ],
+  rotate: [
+    { params: [DataType.float1], returnType: DataType.mat4, isp5Function: false },
+    { params: [DataType.float1, DataType.float3], returnType: DataType.mat4, isp5Function: false },
+  ],
+  scale: [
+    { params: [DataType.float1], returnType: DataType.mat4, isp5Function: false },
+    { params: [DataType.float1, DataType.float1], returnType: DataType.mat4, isp5Function: false },
+    { params: [DataType.float2], returnType: DataType.mat4, isp5Function: false },
+    { params: [DataType.float1, DataType.float1, DataType.float1], returnType: DataType.mat4, isp5Function: false },
+    { params: [DataType.float3], returnType: DataType.mat4, isp5Function: false },
+  ],
+  multiply: [
+    { params: [DataType.mat4, DataType.mat4], returnType: DataType.mat4, isp5Function: false },
+    { params: [DataType.mat3, DataType.mat3], returnType: DataType.mat3, isp5Function: false },
+    { params: [DataType.mat2, DataType.mat2], returnType: DataType.mat2, isp5Function: false },
+    { params: [DataType.mat4, DataType.float4], returnType: DataType.float4, isp5Function: false },
+    { params: [DataType.mat3, DataType.float3], returnType: DataType.float3, isp5Function: false },
+    { params: [DataType.mat2, DataType.float2], returnType: DataType.float2, isp5Function: false },
+    { params: [DataType.float4, DataType.mat4], returnType: DataType.float4, isp5Function: false },
+    { params: [DataType.float3, DataType.mat3], returnType: DataType.float3, isp5Function: false },
+    { params: [DataType.float2, DataType.mat2], returnType: DataType.float2, isp5Function: false },
+  ],
+  transformPoint: [
+    { params: [DataType.mat4, DataType.float3], returnType: DataType.float3, isp5Function: false },
+    { params: [DataType.mat3, DataType.float2], returnType: DataType.float2, isp5Function: false },
+  ],
+  transformNormal: [
+    { params: [DataType.mat4, DataType.float3], returnType: DataType.float3, isp5Function: false },
+    { params: [DataType.mat3, DataType.float2], returnType: DataType.float2, isp5Function: false },
+  ],
+};
+
 export const strandsBuiltinFunctions = {
   ...builtInGLSLFunctions,
+  ...matrixFunctions,
 }

--- a/src/webgl/shaders/functions/matrixTransformGLSL.glsl
+++ b/src/webgl/shaders/functions/matrixTransformGLSL.glsl
@@ -1,0 +1,115 @@
+mat3 transform2D(float a, float b, float c, float d, float e, float f) {
+  return mat3(a, b, 0.0, c, d, 0.0, e, f, 1.0);
+}
+
+mat4 transform3D(float a, float b, float c, float d, float e, float f, float g, float h, float i) {
+  return mat4(a, b, c, 0.0, d, e, f, 0.0, g, h, i, 0.0, 0.0, 0.0, 0.0, 1.0);
+}
+
+mat4 translate(float x, float y) {
+  return mat4(1.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, x, y, 0.0, 1.0);
+}
+
+mat4 translate(vec2 v) {
+  return translate(v.x, v.y);
+}
+
+mat4 translate(float x, float y, float z) {
+  return mat4(1.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, x, y, z, 1.0);
+}
+
+mat4 translate(vec3 v) {
+  return translate(v.x, v.y, v.z);
+}
+
+mat4 rotate(float angle) {
+  float c = cos(angle);
+  float s = sin(angle);
+  return mat4(c, s, 0.0, 0.0, -s, c, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 1.0);
+}
+
+mat4 rotate(float angle, vec3 axis) {
+  vec3 a = normalize(axis);
+  float c = cos(angle);
+  float s = sin(angle);
+  float t = 1.0 - c;
+  float x = a.x, y = a.y, z = a.z;
+  return mat4(
+    t*x*x + c,    t*x*y + s*z,  t*x*z - s*y,  0.0,
+    t*x*y - s*z,  t*y*y + c,    t*y*z + s*x,  0.0,
+    t*x*z + s*y,  t*y*z - s*x,  t*z*z + c,    0.0,
+    0.0,          0.0,          0.0,          1.0
+  );
+}
+
+mat4 scale(float s) {
+  return mat4(s, 0.0, 0.0, 0.0, 0.0, s, 0.0, 0.0, 0.0, 0.0, s, 0.0, 0.0, 0.0, 0.0, 1.0);
+}
+
+mat4 scale(float x, float y) {
+  return mat4(x, 0.0, 0.0, 0.0, 0.0, y, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 1.0);
+}
+
+mat4 scale(vec2 v) {
+  return scale(v.x, v.y);
+}
+
+mat4 scale(float x, float y, float z) {
+  return mat4(x, 0.0, 0.0, 0.0, 0.0, y, 0.0, 0.0, 0.0, 0.0, z, 0.0, 0.0, 0.0, 0.0, 1.0);
+}
+
+mat4 scale(vec3 v) {
+  return scale(v.x, v.y, v.z);
+}
+
+vec3 transformPoint(mat4 m, vec3 p) {
+  return (m * vec4(p, 1.0)).xyz;
+}
+
+vec2 transformPoint(mat3 m, vec2 p) {
+  return (m * vec3(p, 1.0)).xy;
+}
+
+vec3 transformNormal(mat4 m, vec3 n) {
+  return mat3(m) * n;
+}
+
+vec2 transformNormal(mat3 m, vec2 n) {
+  return (m * vec3(n, 0.0)).xy;
+}
+
+mat4 multiply(mat4 a, mat4 b) {
+  return a * b;
+}
+
+mat3 multiply(mat3 a, mat3 b) {
+  return a * b;
+}
+
+mat2 multiply(mat2 a, mat2 b) {
+  return a * b;
+}
+
+vec4 multiply(mat4 a, vec4 b) {
+  return a * b;
+}
+
+vec3 multiply(mat3 a, vec3 b) {
+  return a * b;
+}
+
+vec2 multiply(mat2 a, vec2 b) {
+  return a * b;
+}
+
+vec4 multiply(vec4 a, mat4 b) {
+  return a * b;
+}
+
+vec3 multiply(vec3 a, mat3 b) {
+  return a * b;
+}
+
+vec2 multiply(vec2 a, mat2 b) {
+  return a * b;
+}

--- a/src/webgpu/shaders/functions/matrixTransformWGSL.js
+++ b/src/webgpu/shaders/functions/matrixTransformWGSL.js
@@ -1,0 +1,85 @@
+export default `
+fn translate2(x: f32, y: f32) -> mat4x4<f32> {
+  return mat4x4<f32>(1.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, x, y, 0.0, 1.0);
+}
+
+fn translate2v(v: vec2<f32>) -> mat4x4<f32> {
+  return translate2(v.x, v.y);
+}
+
+fn translate3(x: f32, y: f32, z: f32) -> mat4x4<f32> {
+  return mat4x4<f32>(1.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, x, y, z, 1.0);
+}
+
+fn translate3v(v: vec3<f32>) -> mat4x4<f32> {
+  return translate3(v.x, v.y, v.z);
+}
+
+fn rotateZ(angle: f32) -> mat4x4<f32> {
+  let c = cos(angle);
+  let s = sin(angle);
+  return mat4x4<f32>(c, s, 0.0, 0.0, -s, c, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 1.0);
+}
+
+fn rotateAxis(angle: f32, axis: vec3<f32>) -> mat4x4<f32> {
+  let a = normalize(axis);
+  let c = cos(angle);
+  let s = sin(angle);
+  let t = 1.0 - c;
+  let x = a.x;
+  let y = a.y;
+  let z = a.z;
+  return mat4x4<f32>(
+    t*x*x + c,    t*x*y + s*z,  t*x*z - s*y,  0.0,
+    t*x*y - s*z,  t*y*y + c,    t*y*z + s*x,  0.0,
+    t*x*z + s*y,  t*y*z - s*x,  t*z*z + c,    0.0,
+    0.0,          0.0,          0.0,          1.0
+  );
+}
+
+fn scale1(s: f32) -> mat4x4<f32> {
+  return mat4x4<f32>(s, 0.0, 0.0, 0.0, 0.0, s, 0.0, 0.0, 0.0, 0.0, s, 0.0, 0.0, 0.0, 0.0, 1.0);
+}
+
+fn scale2(x: f32, y: f32) -> mat4x4<f32> {
+  return mat4x4<f32>(x, 0.0, 0.0, 0.0, 0.0, y, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 1.0);
+}
+
+fn scale2v(v: vec2<f32>) -> mat4x4<f32> {
+  return scale2(v.x, v.y);
+}
+
+fn scale3(x: f32, y: f32, z: f32) -> mat4x4<f32> {
+  return mat4x4<f32>(x, 0.0, 0.0, 0.0, 0.0, y, 0.0, 0.0, 0.0, 0.0, z, 0.0, 0.0, 0.0, 0.0, 1.0);
+}
+
+fn scale3v(v: vec3<f32>) -> mat4x4<f32> {
+  return scale3(v.x, v.y, v.z);
+}
+
+fn transformPoint4(m: mat4x4<f32>, p: vec3<f32>) -> vec3<f32> {
+  return (m * vec4<f32>(p, 1.0)).xyz;
+}
+
+fn transformPoint3(m: mat3x3<f32>, p: vec2<f32>) -> vec2<f32> {
+  return (m * vec3<f32>(p, 1.0)).xy;
+}
+
+fn transformNormal4(m: mat4x4<f32>, n: vec3<f32>) -> vec3<f32> {
+  return mat3x3<f32>(m[0].xyz, m[1].xyz, m[2].xyz) * n;
+}
+
+fn transformNormal3(m: mat3x3<f32>, n: vec2<f32>) -> vec2<f32> {
+  return (m * vec3<f32>(n, 0.0)).xy;
+}
+
+fn mult4x4(a: mat4x4<f32>, b: mat4x4<f32>) -> mat4x4<f32> { return a * b; }
+fn mult3x3(a: mat3x3<f32>, b: mat3x3<f32>) -> mat3x3<f32> { return a * b; }
+fn mult2x2(a: mat2x2<f32>, b: mat2x2<f32>) -> mat2x2<f32> { return a * b; }
+fn mult4x4v(a: mat4x4<f32>, b: vec4<f32>) -> vec4<f32> { return a * b; }
+fn mult3x3v(a: mat3x3<f32>, b: vec3<f32>) -> vec3<f32> { return a * b; }
+fn mult2x2v(a: mat2x2<f32>, b: vec2<f32>) -> vec2<f32> { return a * b; }
+fn multv4x4(a: vec4<f32>, b: mat4x4<f32>) -> vec4<f32> { return a * b; }
+fn multv3x3(a: vec3<f32>, b: mat3x3<f32>) -> vec3<f32> { return a * b; }
+fn multv2x2(a: vec2<f32>, b: mat2x2<f32>) -> vec2<f32> { return a * b; }
+`;


### PR DESCRIPTION
Resolves #8953

## Changes:
Adds 8 matrix transformation builtins (transform2D, transform3D, translate, rotate, scale, multiply, transformPoint, transformNormal) as GLSL/WGSL function snippets injected into strands shader declarations. Includes matrix type aliases (Mat4x4 → Mat4, etc.) and constructor aliases (mat4x4 → mat4, etc.), plus * operator overload support for mat×mat, mat×vec, and vec×mat multiplication.

- `src/strands/ir_builders.js` – MAT type constructor handling, matrix multiplication in binaryOpNode
- `src/strands/strands_builtins.js` – All matrix function overloads registered
- `src/strands/strands_api.js` – Matrix type and constructor aliases
- `src/strands/p5.strands.js` – Matrix snippet injection into shader declarations
- `src/webgl/shaders/functions/matrixTransformGLSL.glsl` – GLSL implementations
- `src/webgpu/shaders/functions/matrixTransformWGSL.js` – WGSL implementations

## PR Checklist
- [x] `npm run lint` passes
- [ ] Inline reference is included / updated
- [ ] Unit tests are included / updated