### PR TITLE
Fix memory leak on `loadImage` failure

### DIFF
--- a/src/image/loading_displaying.js
+++ b/src/image/loading_displaying.js
@@ -130,7 +130,11 @@ function loadingDisplaying(p5, fn){
           const blob = new Blob([data], { type: contentType });
           const url = URL.createObjectURL(blob);
 
-          img.onerror = e => reject(e);
+          img.onerror = e => {
+            URL.revokeObjectURL(url);
+            reject(e);
+          };
+
           img.onload = () => {
             URL.revokeObjectURL(url);
             resolve(img);

--- a/test/unit/image/loading.js
+++ b/test/unit/image/loading.js
@@ -254,6 +254,23 @@ suite('loading images', function() {
     assert.deepEqual(img.get(0, 0), GREEN);
     assert.deepEqual(img.get(47, 47), GREEN);
   });
+
+  test('revokes any object URLs created during loading', async () => {
+    const createSpy = vi.spyOn(URL, 'createObjectURL');
+    const revokeSpy = vi.spyOn(URL, 'revokeObjectURL');
+
+    // successful load
+    await mockP5Prototype.loadImage(svgImage);
+    expect(revokeSpy).toHaveBeenCalledTimes(createSpy.mock.calls.length);
+
+    // errored load
+    const INVALID_PATH = '';
+    try { await mockP5Prototype.loadImage(INVALID_PATH); } catch {}
+    expect(revokeSpy).toHaveBeenCalledTimes(createSpy.mock.calls.length);
+
+    createSpy.mockRestore();
+    revokeSpy.mockRestore();
+  });
 });
 
 suite.todo('displaying images', function() {


### PR DESCRIPTION
<!--
  Thank you for contributing! Please use this pull request (PR) template.


 In the description field of this PR, include "resolves #XXXX" tagging the issue you are fixing. If this PR addresses the issue but doesn't completely resolve it (ie the issue should remain open after your PR is merged), write "addresses #XXXX".-->

A follow-up to PR #8937, which resolved #8921. (I got an OK from @ksen0 for this follow-up after a discussion on Discord!)

 Changes:
<!-- Add here what changes were made in this pull request and if possible provide links showcasing the changes. -->
- Revoke the blob object URL used by `loadImage` on an image loading error, which is previously only cleaned up on a successful load.
- Added tests for ensuring all URL objects are properly cleaned up during `loadImage` regardless of implementation.

#### PR Checklist
<!--
  To check any option, replace the "[ ]" with a "[x]". Be sure to check out how it looks in the Preview tab! Feel free to remove any portion of the template that is not relevant for your issue.
-->

- [x] `npm run lint` passes
- [ ] [Inline reference] is included / updated
- [x] [Unit tests] are included / updated

[Inline reference]: https://p5js.org/contribute/contributing_to_the_p5js_reference/
[Unit tests]: https://github.com/processing/p5.js/tree/main/contributor_docs#unit-tests
