### PR TITLE
Fix framebuffer texture size clamping using wrong pixel density

### DIFF
--- a/src/webgl/p5.Framebuffer.js
+++ b/src/webgl/p5.Framebuffer.js
@@ -93,7 +93,7 @@ class Framebuffer {
     this.density = settings.density || this.renderer._pixelDensity;
     if (settings.width && settings.height) {
       const dimensions =
-        this.renderer._adjustDimensions(settings.width, settings.height);
+        this.renderer._adjustDimensions(settings.width, settings.height, this.density);
       this.width = dimensions.adjustedWidth;
       this.height = dimensions.adjustedHeight;
       this._autoSized = false;
@@ -175,7 +175,7 @@ class Framebuffer {
   resize(width, height) {
     this._autoSized = false;
     const dimensions =
-      this.renderer._adjustDimensions(width, height);
+      this.renderer._adjustDimensions(width, height, this.density);
     width = dimensions.adjustedWidth;
     height = dimensions.adjustedHeight;
     this.width = width;

--- a/src/webgl/p5.RendererGL.js
+++ b/src/webgl/p5.RendererGL.js
@@ -441,14 +441,14 @@ class RendererGL extends Renderer3D {
     return gl.getParameter(gl.MAX_TEXTURE_SIZE);
   }
 
-  _adjustDimensions(width, height) {
+  _adjustDimensions(width, height, density = this._pixelDensity) {
     if (!this._maxTextureSize) {
       this._maxTextureSize = this._getMaxTextureSize();
     }
     let maxTextureSize = this._maxTextureSize;
 
     let maxAllowedPixelDimensions = Math.floor(
-      maxTextureSize / this._pixelDensity
+      maxTextureSize / density
     );
     let adjustedWidth = Math.min(width, maxAllowedPixelDimensions);
     let adjustedHeight = Math.min(height, maxAllowedPixelDimensions);


### PR DESCRIPTION
`_adjustDimensions` always divided by the renderer's pixel density, but framebuffers can have their own independent density. Added a density parameter (defaulting to renderer density for backwards compatibility) so framebuffer call sites can pass their own density instead.
<!--
  Thank you for contributing! Please use this pull request (PR) template.


 In the description field of this PR, include "resolves #XXXX" tagging the issue you are fixing. If this PR addresses the issue but doesn't completely resolve it (ie the issue should remain open after your PR is merged), write "addresses #XXXX".-->
Resolves #8963 

 Changes:
<!-- Add here what changes were made in this pull request and if possible provide links showcasing the changes. -->
- Added `density` parameter to `_adjustDimensions(width, height, density = this._pixelDensity)` in `src/webgl/p5.RendererGL.js:444`
- Updated `src/webgl/p5.Framebuffer.js` constructor (line 96) and `resize()` (line 178) to pass `this.density` instead of relying on the renderer's pixel density


 Screenshots of the change:
<!-- If applicable, add screenshots depicting the changes. -->
N/A

#### PR Checklist

- [X] `npm run lint` passes
- [X] [Inline reference] is included / updated
- [X] [Unit tests] are included / updated

[Inline reference]: https://p5js.org/contribute/contributing_to_the_p5js_reference/
[Unit tests]: https://github.com/processing/p5.js/tree/main/contributor_docs#unit-tests