### PR TITLE
feat: add parameter validation to WebGL light functions

### DIFF
--- a/src/webgl/light.js
+++ b/src/webgl/light.js
@@ -173,7 +173,20 @@ function light(p5, fn){
    */
   fn.ambientLight = function (v1, v2, v3, a) {
     this._assert3d('ambientLight');
-    // p5._validateParameters('ambientLight', arguments);
+
+    // ambientLight() accepts:
+    //   (v1, v2, v3[, a])  - RGB/HSB/HSL with optional alpha
+    //   (gray[, alpha])    - grayscale with optional alpha
+    //   (value)            - CSS color string
+    //   (values)           - array of color values
+    //   (color)            - p5.Color object
+    if (arguments.length === 0) {
+      p5._friendlyError(
+        'ambientLight() requires at least 1 argument, but none were provided.',
+        'ambientLight'
+      );
+      return this;
+    }
 
     this._renderer.ambientLight(...arguments);
 
@@ -404,7 +417,20 @@ function light(p5, fn){
    */
   fn.specularColor = function (v1, v2, v3) {
     this._assert3d('specularColor');
-    // p5._validateParameters('specularColor', arguments);
+
+    // specularColor() accepts:
+    //   (v1, v2, v3)   - RGB/HSB/HSL color values
+    //   (gray)          - grayscale value
+    //   (value)         - CSS color string
+    //   (values)        - array of color values
+    //   (color)         - p5.Color object
+    if (arguments.length === 0) {
+      p5._friendlyError(
+        'specularColor() requires at least 1 argument, but none were provided.',
+        'specularColor'
+      );
+      return this;
+    }
 
     this._renderer.specularColor(...arguments);
 
@@ -584,9 +610,22 @@ function light(p5, fn){
    */
   fn.directionalLight = function (v1, v2, v3, x, y, z) {
     this._assert3d('directionalLight');
-    // p5._validateParameters('directionalLight', arguments);
 
-    //@TODO: check parameters number
+    // directionalLight() accepts:
+    //   (v1, v2, v3, x, y, z)     - color components + direction components
+    //   (v1, v2, v3, direction)   - color components + p5.Vector direction
+    //   (color, x, y, z)          - p5.Color/String/Array + direction components
+    //   (color, direction)         - p5.Color/String/Array + p5.Vector direction
+    const len = arguments.length;
+    if (len < 2) {
+      p5._friendlyError(
+        'directionalLight() requires at least 2 arguments (color and direction), ' +
+        'but ' + len + ' ' + (len === 1 ? 'was' : 'were') + ' provided.',
+        'directionalLight'
+      );
+      return this;
+    }
+
     this._renderer.directionalLight(...arguments);
 
     return this;
@@ -810,9 +849,22 @@ function light(p5, fn){
    */
   fn.pointLight = function (v1, v2, v3, x, y, z) {
     this._assert3d('pointLight');
-    // p5._validateParameters('pointLight', arguments);
 
-    //@TODO: check parameters number
+    // pointLight() accepts:
+    //   (v1, v2, v3, x, y, z)     - color components + position components
+    //   (v1, v2, v3, position)    - color components + p5.Vector position
+    //   (color, x, y, z)          - p5.Color/String/Array + position components
+    //   (color, position)          - p5.Color/String/Array + p5.Vector position
+    const len = arguments.length;
+    if (len < 2) {
+      p5._friendlyError(
+        'pointLight() requires at least 2 arguments (color and position), ' +
+        'but ' + len + ' ' + (len === 1 ? 'was' : 'were') + ' provided.',
+        'pointLight'
+      );
+      return this;
+    }
+
     this._renderer.pointLight(...arguments);
 
     return this;
@@ -1066,7 +1118,28 @@ function light(p5, fn){
     quadraticAttenuation
   ) {
     this._assert3d('lightFalloff');
-    // p5._validateParameters('lightFalloff', arguments);
+
+    // lightFalloff() requires exactly 3 numeric arguments:
+    //   (constant, linear, quadratic)
+    if (arguments.length < 3) {
+      p5._friendlyError(
+        'lightFalloff() requires 3 arguments (constant, linear, quadratic), ' +
+        'but only ' + arguments.length + ' ' + (arguments.length === 1 ? 'was' : 'were') + ' provided.',
+        'lightFalloff'
+      );
+      return this;
+    }
+    if (
+      typeof constantAttenuation !== 'number' ||
+      typeof linearAttenuation !== 'number' ||
+      typeof quadraticAttenuation !== 'number'
+    ) {
+      p5._friendlyError(
+        'lightFalloff() requires all arguments to be Numbers.',
+        'lightFalloff'
+      );
+      return this;
+    }
 
     this._renderer.lightFalloff(
       constantAttenuation,
@@ -1286,7 +1359,20 @@ function light(p5, fn){
     concentration
   ) {
     this._assert3d('spotLight');
-    // p5._validateParameters('spotLight', arguments);
+
+    // spotLight() accepts many overloads, minimum 3 arguments:
+    //   (color, position, direction[, angle[, concentration]])
+    //   (v1, v2, v3, x, y, z, nx, ny, nz[, angle[, concentration]])
+    //   etc.
+    const len = arguments.length;
+    if (len < 3) {
+      p5._friendlyError(
+        'spotLight() requires at least 3 arguments (color, position, and direction), ' +
+        'but only ' + len + ' ' + (len === 1 ? 'was' : 'were') + ' provided.',
+        'spotLight'
+      );
+      return this;
+    }
 
     this._renderer.spotLight(...arguments);
 
@@ -1349,7 +1435,15 @@ function light(p5, fn){
    */
   fn.noLights = function (...args) {
     this._assert3d('noLights');
-    // p5._validateParameters('noLights', args);
+
+    // noLights() takes no arguments
+    if (args.length > 0) {
+      p5._friendlyError(
+        'noLights() does not accept any arguments, but ' + args.length +
+        ' ' + (args.length === 1 ? 'was' : 'were') + ' provided.',
+        'noLights'
+      );
+    }
 
     this._renderer.noLights();
 
@@ -1483,22 +1577,25 @@ function light(p5, fn){
   ) {
     if (constantAttenuation < 0) {
       constantAttenuation = 0;
-      console.warn(
-        'Value of constant argument in lightFalloff() should be never be negative. Set to 0.'
+      p5._friendlyError(
+        'Value of constant argument in lightFalloff() should never be negative. Set to 0.',
+        'lightFalloff'
       );
     }
 
     if (linearAttenuation < 0) {
       linearAttenuation = 0;
-      console.warn(
-        'Value of linear argument in lightFalloff() should be never be negative. Set to 0.'
+      p5._friendlyError(
+        'Value of linear argument in lightFalloff() should never be negative. Set to 0.',
+        'lightFalloff'
       );
     }
 
     if (quadraticAttenuation < 0) {
       quadraticAttenuation = 0;
-      console.warn(
-        'Value of quadratic argument in lightFalloff() should be never be negative. Set to 0.'
+      p5._friendlyError(
+        'Value of quadratic argument in lightFalloff() should never be negative. Set to 0.',
+        'lightFalloff'
       );
     }
 
@@ -1507,8 +1604,9 @@ function light(p5, fn){
       (linearAttenuation === 0 && quadraticAttenuation === 0)
     ) {
       constantAttenuation = 1;
-      console.warn(
-        'Either one of the three arguments in lightFalloff() should be greater than zero. Set constant argument to 1.'
+      p5._friendlyError(
+        'Either one of the three arguments in lightFalloff() should be greater than zero. Set constant argument to 1.',
+        'lightFalloff'
       );
     }
 
@@ -1681,10 +1779,11 @@ function light(p5, fn){
         break;
 
       default:
-        console.warn(
-          `Sorry, input for spotlight() is not in prescribed format. Too ${
+        p5._friendlyError(
+          `Sorry, input for spotLight() is not in prescribed format. Too ${
             length < 3 ? 'few' : 'many'
-          } arguments were provided`
+          } arguments were provided.`,
+          'spotLight'
         );
         return;
     }
@@ -1720,8 +1819,9 @@ function light(p5, fn){
 
     if (concentration !== undefined && concentration < 1) {
       concentration = 1;
-      console.warn(
-        'Value of concentration needs to be greater than 1. Setting it to 1'
+      p5._friendlyError(
+        'Value of concentration needs to be greater than 1. Setting it to 1.',
+        'spotLight'
       );
     } else if (concentration === undefined) {
       concentration = 100;

--- a/test/unit/webgl/light.js
+++ b/test/unit/webgl/light.js
@@ -415,4 +415,225 @@ suite('light', function() {
       assert.deepEqual(myp5._renderer.states.spotLightConc, [7]);
     });
   });
+
+  suite('parameter validation', function() {
+    let spy;
+
+    beforeEach(function() {
+      myp5.noLights();
+      spy = vi.spyOn(p5, '_friendlyError').mockImplementation(() => {});
+    });
+
+    afterEach(function() {
+      vi.restoreAllMocks();
+    });
+
+    // ambientLight validation
+    test('ambientLight() with no args emits friendly error', function() {
+      myp5.ambientLight();
+      expect(spy).toHaveBeenCalledTimes(1);
+      expect(spy.mock.calls[0][1]).toBe('ambientLight');
+    });
+
+    test('ambientLight() with valid args does not emit error', function() {
+      myp5.ambientLight(200, 100, 100);
+      expect(spy).not.toHaveBeenCalled();
+    });
+
+    test('ambientLight() with single grayscale arg does not emit error', function() {
+      myp5.ambientLight(128);
+      expect(spy).not.toHaveBeenCalled();
+    });
+
+    test('ambientLight() with CSS string arg does not emit error', function() {
+      myp5.ambientLight('red');
+      expect(spy).not.toHaveBeenCalled();
+    });
+
+    test('ambientLight() with p5.Color arg does not emit error', function() {
+      const c = myp5.color(100, 200, 100);
+      myp5.ambientLight(c);
+      expect(spy).not.toHaveBeenCalled();
+    });
+
+    // specularColor validation
+    test('specularColor() with no args emits friendly error', function() {
+      myp5.specularColor();
+      expect(spy).toHaveBeenCalledTimes(1);
+      expect(spy.mock.calls[0][1]).toBe('specularColor');
+    });
+
+    test('specularColor() with valid args does not emit error', function() {
+      myp5.specularColor(255, 0, 0);
+      expect(spy).not.toHaveBeenCalled();
+    });
+
+    // directionalLight validation
+    test('directionalLight() with 0 args emits friendly error', function() {
+      myp5.directionalLight();
+      expect(spy).toHaveBeenCalledTimes(1);
+      expect(spy.mock.calls[0][1]).toBe('directionalLight');
+    });
+
+    test('directionalLight() with 1 arg emits friendly error', function() {
+      myp5.directionalLight(255);
+      expect(spy).toHaveBeenCalledTimes(1);
+      expect(spy.mock.calls[0][1]).toBe('directionalLight');
+    });
+
+    test('directionalLight() with valid color+vector does not emit error', function() {
+      const c = myp5.color(255, 0, 0);
+      const d = new p5.Vector(0, 0, -1);
+      myp5.directionalLight(c, d);
+      expect(spy).not.toHaveBeenCalled();
+    });
+
+    test('directionalLight() with 6 numeric args does not emit error', function() {
+      myp5.directionalLight(255, 0, 0, 0, 0, -1);
+      expect(spy).not.toHaveBeenCalled();
+    });
+
+    // pointLight validation
+    test('pointLight() with 0 args emits friendly error', function() {
+      myp5.pointLight();
+      expect(spy).toHaveBeenCalledTimes(1);
+      expect(spy.mock.calls[0][1]).toBe('pointLight');
+    });
+
+    test('pointLight() with 1 arg emits friendly error', function() {
+      myp5.pointLight(255);
+      expect(spy).toHaveBeenCalledTimes(1);
+      expect(spy.mock.calls[0][1]).toBe('pointLight');
+    });
+
+    test('pointLight() with valid color+vector does not emit error', function() {
+      const c = myp5.color(255, 0, 0);
+      const pos = new p5.Vector(0, 0, 0);
+      myp5.pointLight(c, pos);
+      expect(spy).not.toHaveBeenCalled();
+    });
+
+    test('pointLight() with 6 numeric args does not emit error', function() {
+      myp5.pointLight(255, 0, 0, 1, 2, 3);
+      expect(spy).not.toHaveBeenCalled();
+    });
+
+    // lightFalloff validation
+    test('lightFalloff() with 0 args emits friendly error', function() {
+      myp5.lightFalloff();
+      expect(spy).toHaveBeenCalledTimes(1);
+      expect(spy.mock.calls[0][1]).toBe('lightFalloff');
+    });
+
+    test('lightFalloff() with 1 arg emits friendly error', function() {
+      myp5.lightFalloff(1);
+      expect(spy).toHaveBeenCalledTimes(1);
+      expect(spy.mock.calls[0][1]).toBe('lightFalloff');
+    });
+
+    test('lightFalloff() with 2 args emits friendly error', function() {
+      myp5.lightFalloff(1, 0);
+      expect(spy).toHaveBeenCalledTimes(1);
+      expect(spy.mock.calls[0][1]).toBe('lightFalloff');
+    });
+
+    test('lightFalloff() with non-numeric args emits friendly error', function() {
+      myp5.lightFalloff('a', 'b', 'c');
+      expect(spy).toHaveBeenCalledTimes(1);
+      expect(spy.mock.calls[0][1]).toBe('lightFalloff');
+    });
+
+    test('lightFalloff() with 3 valid numeric args does not emit error', function() {
+      myp5.lightFalloff(1, 0, 0);
+      expect(spy).not.toHaveBeenCalled();
+    });
+
+    test('lightFalloff() with negative constant emits friendly error', function() {
+      myp5.lightFalloff(-1, 0, 1);
+      expect(spy).toHaveBeenCalledTimes(1);
+      expect(spy.mock.calls[0][1]).toBe('lightFalloff');
+      // Should clamp to 0
+      assert.deepEqual(myp5._renderer.states.constantAttenuation, 0);
+    });
+
+    test('lightFalloff() with all zeros emits friendly error and sets constant to 1', function() {
+      myp5.lightFalloff(0, 0, 0);
+      expect(spy).toHaveBeenCalledTimes(1);
+      expect(spy.mock.calls[0][1]).toBe('lightFalloff');
+      assert.deepEqual(myp5._renderer.states.constantAttenuation, 1);
+    });
+
+    // spotLight validation
+    test('spotLight() with 0 args emits friendly error', function() {
+      myp5.spotLight();
+      expect(spy).toHaveBeenCalledTimes(1);
+      expect(spy.mock.calls[0][1]).toBe('spotLight');
+    });
+
+    test('spotLight() with 1 arg emits friendly error', function() {
+      myp5.spotLight(255);
+      expect(spy).toHaveBeenCalledTimes(1);
+      expect(spy.mock.calls[0][1]).toBe('spotLight');
+    });
+
+    test('spotLight() with 2 args emits friendly error', function() {
+      myp5.spotLight(255, 0);
+      expect(spy).toHaveBeenCalledTimes(1);
+      expect(spy.mock.calls[0][1]).toBe('spotLight');
+    });
+
+    test('spotLight() with valid color+pos+dir objects does not emit error', function() {
+      const c = myp5.color(255, 0, 255);
+      const pos = new p5.Vector(1, 2, 3);
+      const dir = new p5.Vector(0, 1, 0);
+      myp5.spotLight(c, pos, dir);
+      expect(spy).not.toHaveBeenCalled();
+    });
+
+    test('spotLight() with 9 numeric args does not emit error', function() {
+      myp5.spotLight(255, 0, 255, 1, 2, 3, 0, 1, 0);
+      expect(spy).not.toHaveBeenCalled();
+    });
+
+    // noLights validation
+    test('noLights() with args emits friendly error but still works', function() {
+      myp5.ambientLight(200, 0, 0);
+      myp5.noLights(1, 2, 3);
+      expect(spy).toHaveBeenCalledTimes(1);
+      expect(spy.mock.calls[0][1]).toBe('noLights');
+      // Should still clear lights
+      assert.deepEqual(myp5._renderer.states.ambientLightColors, []);
+    });
+
+    test('noLights() without args does not emit error', function() {
+      myp5.noLights();
+      expect(spy).not.toHaveBeenCalled();
+    });
+
+    // Verify chainability on error
+    test('ambientLight() returns this on validation error for chaining', function() {
+      const result = myp5.ambientLight();
+      assert.equal(result, myp5);
+    });
+
+    test('directionalLight() returns this on validation error for chaining', function() {
+      const result = myp5.directionalLight();
+      assert.equal(result, myp5);
+    });
+
+    test('pointLight() returns this on validation error for chaining', function() {
+      const result = myp5.pointLight();
+      assert.equal(result, myp5);
+    });
+
+    test('lightFalloff() returns this on validation error for chaining', function() {
+      const result = myp5.lightFalloff();
+      assert.equal(result, myp5);
+    });
+
+    test('spotLight() returns this on validation error for chaining', function() {
+      const result = myp5.spotLight();
+      assert.equal(result, myp5);
+    });
+  });
 });


### PR DESCRIPTION
Resolves #9007 

Changes:

- Added parameter validation to 7 WebGL light functions in `src/webgl/light.js`:
  - `ambientLight()` - validates at least 1 argument
  - `specularColor()` - validates at least 1 argument
  - `directionalLight()` - validates at least 2 arguments (color + direction)
  - `pointLight()` - validates at least 2 arguments (color + position)
  - `lightFalloff()` - validates exactly 3 numeric arguments
  - `spotLight()` - validates at least 3 arguments (color + position + direction)
  - `noLights()` - warns if unexpected arguments are passed

- Replaced commented-out `p5._validateParameters()` calls with proper checks using `p5._friendlyError()`

- Resolved `@TODO: check parameters number` comments in `directionalLight` and `pointLight`

- Converted 6 `console.warn()` calls to `p5._friendlyError()` in renderer-level `lightFalloff` and `spotLight` methods for consistent FES integration

- All functions preserve chainability by returning `this` on validation error

- Added 31 new unit tests in `test/unit/webgl/light.js` covering:
  - Invalid argument counts (too few args)
  - Valid argument combinations (no false positives)
  - Type validation (non-numeric lightFalloff args)
  - Edge cases (negative values, all-zero falloff, CSS strings, p5.Color objects)
  - Chainability on error (all functions return `this`)

Screenshots of the change:
N/A - this is internal validation logic, no visual changes.

#### PR Checklist

- [x] `npm run lint` passes
- [x] [Inline reference] is included / updated
- [x] [Unit tests] are included / updated

[Inline reference]: https://p5js.org/contribute/contributing_to_the_p5js_reference/
[Unit tests]: https://github.com/processing/p5.js/tree/main/contributor_docs#unit-tests
