### PR TITLE
Fixed typo in quaternion multiplication

### DIFF
--- a/src/webgl/p5.Quat.js
+++ b/src/webgl/p5.Quat.js
@@ -41,7 +41,7 @@ class Quat {
   multiply(quat) {
 
     return new Quat(
-      this.w * quat.w - this.vec.x * quat.vec.x - this.vec.y * quat.vec.y - this.vec.z - quat.vec.z,
+      this.w * quat.w - this.vec.x * quat.vec.x - this.vec.y * quat.vec.y - this.vec.z * quat.vec.z,
       this.w * quat.vec.x + this.vec.x * quat.w + this.vec.y * quat.vec.z - this.vec.z * quat.vec.y,
       this.w * quat.vec.y - this.vec.x * quat.vec.z + this.vec.y * quat.w + this.vec.z * quat.vec.x,
       this.w * quat.vec.z + this.vec.x * quat.vec.y - this.vec.y * quat.vec.x + this.vec.z * quat.w

--- a/src/webgl/p5.Quat.js
+++ b/src/webgl/p5.Quat.js
@@ -34,7 +34,7 @@ class Quat {
 
   /**
    * Multiplies a quaternion with other quaternion.
-   * @method mult
+   * @method multiply
    * @param  {p5.Quat} [quat] quaternion to multiply with the quaternion calling the method.
    * @chainable
    */


### PR DESCRIPTION
This is the fix for  #9006

There is a typo in the p5.Quat multiplication;
In line https://github.com/processing/p5.js/blob/main/src/webgl/p5.Quat.js#L44 where it reads  this.vec.z - quat.vec.z it should be  this.vec.z * quat.vec.z. It is just replacing the - for *.
It quite easy to verify agains the textbook quaternion multiplication.
I am not sure about the implications this has in p5, as of how extensively this has afected p5 in general.
Not sure either if there have been other fixes to compesate this error in other places of the math.