### PR TITLE
fix(image): reject non-positive duration in saveGif()

### DIFF
--- a/src/image/loading_displaying.js
+++ b/src/image/loading_displaying.js
@@ -265,6 +265,11 @@ function loadingDisplaying(p5, fn){
     if (typeof duration !== 'number') {
       throw TypeError('Duration parameter must be a number');
     }
+    // a non-positive duration captures zero frames, which later crashes
+    // in palette generation (frames[0] is undefined). reject early.
+    if (duration <= 0) {
+      throw RangeError('Duration parameter must be greater than 0');
+    }
 
     // extract variables for more comfortable use
     const delay = (options && options.delay) || 0;  // in seconds

--- a/test/unit/image/downloading.js
+++ b/test/unit/image/downloading.js
@@ -177,6 +177,11 @@ suite('Downloading', () => {
       assert.typeOf(mockP5Prototype.saveGif, 'function');
     });
 
+    test('should reject a non-positive duration', async () => {
+      await expect(mockP5Prototype.saveGif('myGif', 0)).rejects.toThrow();
+      await expect(mockP5Prototype.saveGif('myGif', -3)).rejects.toThrow();
+    });
+
     // TODO: this implementation need refactoring
     test.todo('should not throw an error', async () => {
       await mockP5Prototype.saveGif('myGif', 3);


### PR DESCRIPTION
dug into #8710. root cause is in `saveGif()` (src/image/loading_displaying.js):

with `duration <= 0`, `nFrames` comes out `0`, so the capture loop records no frames and `frames` stays empty. later `_generateGlobalPalette` does `new Uint8Array(frames.length * frames[0].length)` — `frames[0]` is `undefined`, hence the reported `TypeError: Cannot read properties of undefined (reading 'length')`. same thing happens for any negative duration.

every other bad argument in `saveGif()` (fileName, delay, units, silent, ...) already throws up front. duration was the one gap, so this guards it the same way and throws a `RangeError` before recording starts instead of blowing up deep in palette generation.

added a small regression test in test/unit/image/downloading.js asserting `saveGif('myGif', 0)` and a negative value reject.

Fixes #8710