### PR TITLE
ci: bump contributors-png workflow to Node 22

### DIFF
--- a/.github/workflows/contributors-png.yml
+++ b/.github/workflows/contributors-png.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
-          node-version: 20
+          node-version: 22
 
       - name: Install dependencies
         run: npm install canvas


### PR DESCRIPTION
`contributors-png.yml` was the only workflow still on `node-version: 20` —
missed when #8852 moved the rest to 22. Node 20 reached EOL in April, so this
brings it in line.

Kept at 22 to match every other workflow on `main` rather than jumping to 24,
since the step below runs `npm install canvas` (a native module) and whether
`main` moves to 24 is a separate call.

Verified on my fork: `npm install canvas` and `node utils/contributors-png.js`
run cleanly on Node 22.