### PR TITLE
Fix Generate Contributors PNG workflow: convert script to ESM

### DIFF
--- a/.github/workflows/contributors-png.yml
+++ b/.github/workflows/contributors-png.yml
@@ -26,7 +26,7 @@ jobs:
         run: npm install canvas
 
       - name: Run contributors-png generator
-        run: node utils/contributors-png.js
+        run: node utils/contributors-png.mjs
 
       - name: Reset all changes except contributors.png
         run: |

--- a/utils/contributors-png.mjs
+++ b/utils/contributors-png.mjs
@@ -1,0 +1,54 @@
+import { createCanvas, loadImage } from 'canvas';
+import fs from 'fs';
+
+const data = fs.readFileSync('.all-contributorsrc', 'utf-8');
+const parsed = JSON.parse(data);
+const contributors = parsed.contributors;
+
+const AVATAR_SIZE = 50;
+const GAP = 4;
+const COLS = 40;
+const ROWS = Math.ceil(contributors.length / COLS);
+
+const width = COLS * AVATAR_SIZE + (COLS - 1) * GAP;
+const height = ROWS * AVATAR_SIZE + (ROWS - 1) * GAP;
+
+const canvas = createCanvas(width, height);
+const ctx = canvas.getContext('2d');
+
+async function loadAvatar(url) {
+  try {
+    const res = await fetch(url);
+    if (!res.ok) throw new Error(`HTTP ${res.status}`);
+    const buffer = Buffer.from(await res.arrayBuffer());
+    return await loadImage(buffer);
+  } catch (err) {
+    return null;
+  }
+}
+
+for (let i = 0; i < contributors.length; i++) {
+  const c = contributors[i];
+  const col = i % COLS;
+  const row = Math.floor(i / COLS);
+  const x = col * (AVATAR_SIZE + GAP);
+  const y = row * (AVATAR_SIZE + GAP);
+  const img = await loadAvatar(c.avatar_url);
+
+  ctx.save();
+  ctx.beginPath();
+  ctx.arc(
+    x + AVATAR_SIZE / 2,
+    y + AVATAR_SIZE / 2,
+    AVATAR_SIZE / 2,
+    0,
+    Math.PI * 2
+  );
+  ctx.clip();
+  if (img) {
+    ctx.drawImage(img, x, y, AVATAR_SIZE, AVATAR_SIZE);
+  }
+  ctx.restore();
+}
+
+fs.writeFileSync('contributors.png', canvas.toBuffer('image/png'));


### PR DESCRIPTION
## Changes

The `Generate Contributors PNG` workflow fails on every run with `ReferenceError: require is not defined in ES module scope`. `utils/contributors-png.js` is CommonJS, but `package.json` has `"type": "module"`, so Node resolves it as ESM. It fails on every Node version — the script was added a month after the repo switched to ESM and has never worked, which is why `contributors.png` has only ever been updated by hand.

- Renamed `utils/contributors-png.js` → `utils/contributors-png.mjs` and converted it to ESM (`import` instead of `require`, top-level `await` instead of the async IIFE). Matches `utils/`, where every other script is already `.mjs`.
- Updated the `run:` step in `.github/workflows/contributors-png.yml`.

No behaviour change beyond the module format.

The workflow can't run on a PR (`on: push` filtered to `.all-contributorsrc`, gated on `refs/heads/main`), so tested on a fork: <link to successful run>. This is a stopgap — the script is meant to be replaced by processing/all-contributors-image#4.

## Screenshots of the change

<!-- attach the generated contributors.png -->

#### PR Checklist

- [x] `npm run lint` passes
- [ ] [Inline reference] is included / updated
- [ ] [Unit tests] are included / updated

[Inline reference]: https://p5js.org/contribute/contributing_to_the_p5js_reference/
[Unit tests]: https://github.com/processing/p5.js/tree/main/contributor_docs#unit-tests