### PR TITLE
fix: throw on non-positive saveGif duration

### DIFF
--- a/src/image/loading_displaying.js
+++ b/src/image/loading_displaying.js
@@ -267,6 +267,9 @@ function loadingDisplaying(p5, fn){
     if (typeof duration !== 'number') {
       throw TypeError('Duration parameter must be a number');
     }
+    if (duration <= 0) {
+      throw TypeError('Duration parameter must be greater than 0');
+    }
 
     // extract variables for more comfortable use
     const delay = (options && options.delay) || 0;  // in seconds


### PR DESCRIPTION
Fixes #8710

When \duration\ is <= 0, the frame-count calculation is invalid. Throw a TypeError like the existing non-number check.