### PR TITLE
fix: pass geometry to freeGeometry in CPU transform benchmark

### DIFF
--- a/test/bench/cpu_transforms.bench.js
+++ b/test/bench/cpu_transforms.bench.js
@@ -76,7 +76,7 @@ describe.sequential('Dave bench test', () => {
           // Flattens into a single buffer
           const shape = myp5.buildGeometry(drawCircles);
           myp5.model(shape);
-          myp5.freeGeometry(myp5.model);
+          myp5.freeGeometry(shape);
         } else {
           drawCircles();
         }


### PR DESCRIPTION
## Summary

Fixes #9041.

This PR corrects an incorrect cleanup call in the CPU-transform benchmark.

## Details

`test/bench/cpu_transforms.bench.js` passed the `myp5.model` function reference to `freeGeometry()` instead of the geometry instance created during the run. This emitted an FES “Expected Geometry” validation message even though the benchmark completed.

The cleanup call now passes `shape`, the generated geometry instance.

## Validation

- Ran `npx vitest bench test/bench/cpu_transforms.bench.js`.
  - Chromium WebGL and WebGPU benchmark contexts passed.
  - The prior `Expected Geometry` FES message no longer appeared.
- Ran `npm test`: 2,251 tests passed with 0 failures; 12 skipped and 216 todo.
- Ran `npm run lint` successfully with 0 errors.

## AI usage

I used Codex/ChatGPT for assistive debugging and workflow guidance. I reviewed the change, implemented it, and ran the local validation myself.
