### PR TITLE
fix: clean up instance remove lifecycle hooks

### DIFF
--- a/src/core/main.js
+++ b/src/core/main.js
@@ -126,11 +126,11 @@ class p5 {
     };
 
     if (typeof window !== 'undefined') {
-      window.addEventListener('focus', focusHandler);
-      window.addEventListener('blur', blurHandler);
-      p5.lifecycleHooks.remove.push(function () {
-        window.removeEventListener('focus', focusHandler);
-        window.removeEventListener('blur', blurHandler);
+      window.addEventListener('focus', focusHandler, {
+        signal: this._removeSignal
+      });
+      window.addEventListener('blur', blurHandler, {
+        signal: this._removeSignal
       });
 
       // Initialization complete, start runtime

--- a/test/unit/core/environment.js
+++ b/test/unit/core/environment.js
@@ -81,6 +81,78 @@ suite('Environment', function () {
     });
   });
 
+  suite('p5.prototype.focused with multiple instances', function () {
+  test('removing one instance should not remove another instance focus listeners', async function () {
+    let instance1;
+    let instance2;
+
+    await Promise.all([
+      new Promise(function (resolve) {
+        new p5(function (p) {
+          p.setup = function () {
+            instance1 = p;
+            resolve();
+          };
+        });
+      }),
+      new Promise(function (resolve) {
+        new p5(function (p) {
+          p.setup = function () {
+            instance2 = p;
+            resolve();
+          };
+        });
+      })
+    ]);
+
+    window.dispatchEvent(new Event('blur'));
+    assert.strictEqual(instance2.focused, false);
+
+    await instance1.remove();
+
+    window.dispatchEvent(new Event('focus'));
+    assert.strictEqual(instance2.focused, true);
+
+    await instance2.remove();
+  });
+  });
+
+  suite('p5.lifecycleHooks.remove cleanup', function () {
+    test('remove hooks should not accumulate after instances are removed', async function () {
+      const before = p5.lifecycleHooks.remove.length;
+
+      let instance1;
+      let instance2;
+
+      await Promise.all([
+        new Promise(function (resolve) {
+          new p5(function (p) {
+            p.setup = function () {
+              instance1 = p;
+              resolve();
+            };
+          });
+        }),
+        new Promise(function (resolve) {
+          new p5(function (p) {
+            p.setup = function () {
+              instance2 = p;
+              resolve();
+            };
+          });
+        })
+      ]);
+
+      await instance1.remove();
+      await instance2.remove();
+
+      assert.strictEqual(
+        p5.lifecycleHooks.remove.length,
+        before
+      );
+    });
+  });
+
   suite('p5.prototype.cursor', function () {
     test('should change cursor to cross', function () {
       myp5.cursor(myp5.CROSS);


### PR DESCRIPTION
Resolves #9072 

Changes:

Replaced the instance-specific lifecycle hook named `remove` that was used for clearing the `focus` and `blur` event listeners with the signal from the existing `AbortController`.
This stops the function `p5.lifecycleHooks.remove` from accumulating hooks when p5 instances are removed. I've also added a regression test to ensure that the hooks are cleaned up after the instances have been removed.

Screenshots of the change:

Not applicable.

#### PR Checklist

* [x] `npm run lint` passes
* [ ] [[Inline reference](https://p5js.org/contribute/contributing_to_the_p5js_reference/)] is included / updated
* [x] [[Unit tests](https://github.com/processing/p5.js/tree/main/contributor_docs#unit-tests)] are included / updated

[Inline reference]: https://p5js.org/contribute/contributing_to_the_p5js_reference/
[Unit tests]: https://github.com/processing/p5.js/tree/main/contributor_docs#unit-tests