### PR TITLE
Add webgpu build back to rolldown config

### DIFF
--- a/rolldown.config.js
+++ b/rolldown.config.js
@@ -70,6 +70,27 @@ export default defineConfig([
       // })
     ]
   },
+  //// Addon module builds (e.g. WebGPU) ////
+  ...['webgpu'].map(module => ({
+    input: `src/${module}/index.js`,
+    output: [
+      {
+        file: `./lib/p5.${module}.js`,
+        format: 'iife'
+      },
+      {
+        file: `./lib/p5.${module}.min.js`,
+        format: 'iife',
+        minify: true
+      },
+      {
+        file: `./lib/p5.${module}.esm.js`,
+        format: 'esm'
+      }
+    ],
+    external: ['../core/main'],
+    plugins
+  })),
   //// ESM source build ////
   {
     input: Object.fromEntries(


### PR DESCRIPTION
I noticed while working on https://github.com/processing/p5.js/pull/9086 that the build no longer creates a WebGPU file. This revives that from the previous config.