### PR TITLE
GSOC 26: apply mtl material state to single-material models

### DIFF
--- a/src/webgl/loading.js
+++ b/src/webgl/loading.js
@@ -190,10 +190,21 @@ async function loadMaterialTextures(materials, modelPath, instance) {
 // as the aggregate; each part gets its own localised verts with faces re-indexed
 // against them, plus its material's state.
 function buildMaterialParts(model, faceMaterials, materials) {
-  // only split when there are genuinely multiple materials. a single material
-  // (or none) stays as the geometry's own part and renders as before. one group
-  // per material, plus a null group for faces before any usemtl so none drop.
+  // one group per material, plus a null group for faces before any usemtl so
+  // none drop.
   const names = [...new Set(faceMaterials)];
+
+  // one material covering every face. the geometry is already its own part, so
+  // hand it the state directly: splitting would duplicate every vertex to say
+  // the same thing, and would stop parts[0] being the geometry itself. without
+  // this a single material model never receives its maps at all.
+  if (names.length === 1 && names[0] != null) {
+    Object.assign(model.partState, mtlToPartState(materials[names[0]]));
+    return;
+  }
+
+  // nothing to split on: no materials, or one material alongside faces that
+  // were declared before any usemtl and so have none.
   if (names.filter(name => name != null).length < 2) return;
 
   const hasUvs = model.uvs.length > 0;

--- a/test/unit/assets/single_material_textured.mtl
+++ b/test/unit/assets/single_material_textured.mtl
@@ -1,0 +1,5 @@
+newmtl only
+Kd 1.000 1.000 1.000
+Ks 0.500 0.500 0.500
+Ns 60
+map_Kd cat.jpg

--- a/test/unit/assets/single_material_textured.obj
+++ b/test/unit/assets/single_material_textured.obj
@@ -1,0 +1,12 @@
+mtllib single_material_textured.mtl
+v 0 0 0
+v 1 0 0
+v 1 1 0
+v 0 1 0
+vt 0 0
+vt 1 0
+vt 1 1
+vt 0 1
+usemtl only
+f 1/1 2/2 3/3
+f 1/1 3/3 4/4

--- a/test/unit/io/loadModel.js
+++ b/test/unit/io/loadModel.js
@@ -159,6 +159,25 @@ suite('loadModel', function () {
     assert.equal(model.parts[0], model, 'the geometry is its own single part');
   });
 
+  test('a single-material OBJ still receives its maps', async function () {
+    const fakeImage = { width: 1, height: 1 };
+    mockP5Prototype.loadImage = async () => fakeImage;
+    try {
+      const model = await mockP5Prototype.loadModel(
+        '/test/unit/assets/single_material_textured.obj'
+      );
+      // one material, so no split: the geometry stays its own only part
+      assert.equal(model.parts.length, 1);
+      assert.equal(model.parts[0], model);
+      // and it carries the material's state rather than dropping it
+      assert.equal(model.partState.texture, fakeImage);
+      assert.equal(model.partState.shininess, 60);
+      assert.deepEqual(model.partState.specularColor, [0.5, 0.5, 0.5]);
+    } finally {
+      delete mockP5Prototype.loadImage;
+    }
+  });
+
   test('a 12-material OBJ splits into 12 parts', async function () {
     const model = await mockP5Prototype.loadModel(
       '/test/unit/assets/multi_material_12.obj'


### PR DESCRIPTION
found while testing the mtl work against real models downloaded off the internet rather than my own fixtures. a model with exactly one material loads its textures and then drops them, so it renders untextured.

**what was happening**

`buildMaterialParts` returned early when a file named fewer than two materials. that was deliberate on my part, to keep single-material rendering byte-for-byte unchanged, but it also meant such a model never received a `partState`, so nothing from its `.mtl` was ever applied. the maps were parsed and fetched, then thrown away at the last step.

single material with one `map_Kd` is the most common shape a real export takes, so this is the case most people would hit first.

**the fix**

a geometry already carries its own `partState` and sets `parts = [this]`, so when one material covers every face the state can go straight onto the geometry. no split, no part allocated, `parts[0]` is still the geometry, and nothing about the geometry layout changes.

splitting instead would have duplicated every vertex to describe the same thing, and would have broken `parts[0] === geometry`, which the existing tests rely on.

the mixed case is untouched. an obj with faces declared before any `usemtl` plus one named material still returns early and renders as it did, since applying that material to the whole geometry would wrongly colour the faces that have none.

**tests**

one new fixture, a single-material obj with `map_Kd`, and a test asserting the geometry stays its own only part while carrying the texture, shininess and specular colour.

full suite passes. one typography screenshot test is flaky on this machine, but it flakes the same way on a clean checkout with no changes, so it is unrelated.