### PR TITLE
Handle backtick strings as p5.strands uniform names

### DIFF
--- a/src/strands/strands_transpiler.js
+++ b/src/strands/strands_transpiler.js
@@ -565,6 +565,7 @@ const ASTCallbacks = {
       if (
         node.init.arguments.length === 0 ||
         node.init.arguments[0].type !== 'Literal' ||
+        node.init.arguments[0].type !== 'TemplateLiteral' ||
         typeof node.init.arguments[0].value !== 'string'
       ) {
         const uniformName = getOrCreateInternalShaderName(

--- a/src/strands/strands_transpiler.js
+++ b/src/strands/strands_transpiler.js
@@ -564,9 +564,13 @@ const ASTCallbacks = {
       // Only inject the variable name if the first argument isn't already a string
       if (
         node.init.arguments.length === 0 ||
-        node.init.arguments[0].type !== 'Literal' ||
-        node.init.arguments[0].type !== 'TemplateLiteral' ||
-        typeof node.init.arguments[0].value !== 'string'
+        !(
+          (
+            node.init.arguments[0].type === 'Literal' &&
+            typeof node.init.arguments[0].value === 'string'
+          ) ||
+          node.init.arguments[0].type === 'TemplateLiteral'
+        )
       ) {
         const uniformName = getOrCreateInternalShaderName(
           state.shaderNameMap,

--- a/test/unit/webgl/p5.Shader.js
+++ b/test/unit/webgl/p5.Shader.js
@@ -894,6 +894,31 @@ suite('p5.Shader', function () {
       assert.approximately(pixelColor[2], 204, 5);
     });
 
+    test('handle custom uniform names with template strings', () => {
+      myp5.createCanvas(50, 50, myp5.WEBGL);
+      const testShader = myp5.baseMaterialShader().modify(
+        () => {
+          // Variable name is 'brightness' but uniform name is 'customBrightness'
+          const brightness = myp5.uniformFloat(`customBrightness`, () => 0.8);
+          myp5.getPixelInputs(inputs => {
+            inputs.color = [brightness, brightness, brightness, 1.0];
+            return inputs;
+          });
+        },
+        { myp5 }
+      );
+
+      myp5.noStroke();
+      myp5.shader(testShader);
+      myp5.plane(myp5.width, myp5.height);
+
+      // Check that the shader uses the automatic value (0.8)
+      const pixelColor = myp5.get(25, 25);
+      assert.approximately(pixelColor[0], 204, 5); // 0.8 * 255 = 204
+      assert.approximately(pixelColor[1], 204, 5);
+      assert.approximately(pixelColor[2], 204, 5);
+    });
+
     test('handle custom uniform names with manual setUniform', () => {
       myp5.createCanvas(50, 50, myp5.WEBGL);
       const testShader = myp5.baseMaterialShader().modify(


### PR DESCRIPTION
<!--
  Thank you for contributing! Please use this pull request (PR) template.


 In the description field of this PR, include "resolves #XXXX" tagging the issue you are fixing. If this PR addresses the issue but doesn't completely resolve it (ie the issue should remain open after your PR is merged), write "addresses #XXXX".-->

Resolves #9111

Changes:
- Updates strands transpiler to not inject the variable name as the uniform name if there is already a template literal in the first argument


#### PR Checklist

<!--
  To check any option, replace the "[ ]" with a "[x]". Be sure to check out how it looks in the Preview tab! Feel free to remove any portion of the template that is not relevant for your issue.
-->

- [x] `npm run lint` passes
- [ ] [Inline reference] is included / updated
- [x] [Unit tests] are included / updated

[Inline reference]: https://p5js.org/contribute/contributing_to_the_p5js_reference/
[Unit tests]: https://github.com/processing/p5.js/tree/main/contributor_docs#unit-tests
