### PR TITLE
Docs describe function limits and best practice

### DIFF
--- a/contributor_docs/web_accessibility.md
+++ b/contributor_docs/web_accessibility.md
@@ -334,5 +334,5 @@ The page will output:
 
 When writing text for `describe()` and `describeElement()`, keep the following screen reader limitations in mind:
 
-- **Avoid transliterations:** Text-to-Speech (TTS) engines cannot reliably pronounce transliterations of languages. This makes it hard for screen reader users to understand the text. We encourage sketch creators to use their native script language when writing the text for describe functions.
-- **macOS VoiceOver limitations:** macOS VoiceOver ignores the HTML `lang` attribute completely. As a result, Latin-script languages (Spanish, German, French, etc.) will be read with the default English voice, making it likely that words won't be pronounced correctly.
+- **Avoid transliterations:** Text to Speech (TTS) engines cannot reliably pronounce transliterations of languages. This makes it hard for screen reader users to understand the text. We encourage sketch creators to use their native script language when writing the text for describe functions.
+- **macOS VoiceOver limitations:** macOS VoiceOver ignores the HTML `lang` attribute completely. As a result, Latin script languages (Spanish, German, French, etc.) will be read with the default English voice, making it likely that words won't be pronounced correctly.

--- a/contributor_docs/web_accessibility.md
+++ b/contributor_docs/web_accessibility.md
@@ -329,3 +329,10 @@ function setup() {
 The page will output:
 
 ![A p5.js canvas, followed by two lines of description: "A red heart and yellow circle over a pink background," and "Heart: A red heart in the bottom-right corner."](images/sketch-text-output3.png)
+
+### Best Practices
+
+When writing text for `describe()` and `describeElement()`, keep the following screen reader limitations in mind:
+
+- **Avoid transliterations:** Text-to-Speech (TTS) engines cannot reliably pronounce transliterations of languages. This makes it hard for screen reader users to understand the text. We encourage sketch creators to use their native script language when writing the text for describe functions.
+- **macOS VoiceOver limitations:** macOS VoiceOver ignores the HTML `lang` attribute completely. As a result, Latin-script languages (Spanish, German, French, etc.) will be read with the default English voice, making it likely that words won't be pronounced correctly.


### PR DESCRIPTION
Resolves #9105 

Changes:

- Added a Best Practices section for `describe()` & `describeElement()` in `contributor_docs/web_accessibility.md`
- Documented TTS engine limitations regarding transliterations
- Documented macOS VoiceOver's failure to respect the `lang` attribute for Latin Script langs


Screenshots of the change:
NA

#### PR Checklist

- [x] `npm run lint` passes
- [ ] [Inline reference] is included / updated
- [ ] [Unit tests] are included / updated

[Inline reference]: https://p5js.org/contribute/contributing_to_the_p5js_reference/
[Unit tests]: https://github.com/processing/p5.js/tree/main/contributor_docs#unit-tests
