### PR TITLE
Fix false "Expected at most 2 arguments" error for variadic min()/max()

### DIFF
--- a/docs/parameterData.json
+++ b/docs/parameterData.json
@@ -2153,7 +2153,8 @@
       "overloads": [
         [
           "Number",
-          "Number"
+          "Number",
+          "...Number[]"
         ],
         [
           "Number[]"
@@ -2338,7 +2339,8 @@
       "overloads": [
         [
           "Number",
-          "Number"
+          "Number",
+          "...Number[]"
         ],
         [
           "Number[]"

--- a/src/math/calculation.js
+++ b/src/math/calculation.js
@@ -973,6 +973,7 @@ function calculation(p5, fn) {
    * @method max
    * @param  {Number} n0 first number to compare.
    * @param  {Number} n1 second number to compare.
+   * @param  {...Number} rest additional numbers to compare.
    * @return {Number}             maximum number.
    */
   /**
@@ -1092,6 +1093,7 @@ function calculation(p5, fn) {
    * @method min
    * @param  {Number} n0 first number to compare.
    * @param  {Number} n1 second number to compare.
+   * @param  {...Number} rest additional numbers to compare.
    * @return {Number}             minimum number.
    */
   /**

--- a/test/unit/core/param_errors.js
+++ b/test/unit/core/param_errors.js
@@ -380,6 +380,35 @@ suite('Validate Params', function () {
     });
   });
 
+  suite('validateParams: variadic min/max', function () {
+    ['min', 'max'].forEach(fn => {
+      test(`${fn}(): works with two numbers`, function () {
+        const result = mockP5Prototype._validate(`p5.${fn}`, [1, 2]);
+        assert.isTrue(result.success);
+      });
+      test(`${fn}(): works with more than two numbers`, function () {
+        const result = mockP5Prototype._validate(`p5.${fn}`, [1, 2, 3, 4]);
+        assert.isTrue(result.success);
+      });
+      test(`${fn}(): works with a single array of numbers`, function () {
+        const result = mockP5Prototype._validate(`p5.${fn}`, [[1, 2, 3, 4]]);
+        assert.isTrue(result.success);
+      });
+      test(`${fn}(): fails with no args`, function () {
+        const result = mockP5Prototype._validate(`p5.${fn}`, []);
+        assert.isFalse(result.success);
+      });
+      test(`${fn}(): fails with a single number`, function () {
+        const result = mockP5Prototype._validate(`p5.${fn}`, [5]);
+        assert.isFalse(result.success);
+      });
+      test(`${fn}(): fails with a non-number among the rest`, function () {
+        const result = mockP5Prototype._validate(`p5.${fn}`, [1, 2, '3', 4]);
+        assert.isFalse(result.success);
+      });
+    });
+  });
+
   suite('validateParams: rest arguments', function () {
     test('createVector(): works with no args', function () {
       const result = mockP5Prototype._validate('p5.createVector', []);


### PR DESCRIPTION
Resolves #9039

Changes:

The runtime implementation of `min()` and `max()` is variadic, but their documented overloads only declared `(n0, n1)`, so the FES parameter validator (which derives its Zod schemas from the inline reference via `docs/parameterData.json`) rejected calls like `min(1, 2, 3, 4)` with a false *"Expected at most 2 arguments, but received more in min()"*. This restores the 1.x behavior (the 1.x version of this same problem was fixed in #4890).

- Added a `@param {...Number} rest` parameter to the two-number overload of both `min()` and `max()` in `src/math/calculation.js`, following the existing pattern used by `createVector()`.
- Updated `docs/parameterData.json` so the first overload reads `["Number", "Number", "...Number[]"]` for both functions. I edited just these two entries by hand: running the full `npm run docs` locally reorders hundreds of unrelated entries (the checked-in file seems out of sync with a full regeneration), which would have buried the actual change. I did verify that a full regeneration produces exactly these values for `min`/`max` — happy to commit the fully regenerated file instead if you prefer.
- Added a "variadic min/max" suite to `test/unit/core/param_errors.js` covering both functions (valid: two numbers, more than two numbers, a single array; invalid: no arguments, a single number, a non-number among the arguments).

Following up on @limzykenneth's notes in the issue:

- With only number arguments, at least 2 are still required: `min()` and `min(5)` still fail validation, and the friendly error message is byte-identical to the current behavior (I compared the old and new schemas side by side).
- The single-array overload `min([1, 2, 3])` is unchanged and still valid.
- The rest parameter translated cleanly to FES validation — no changes to `param_validator.js` were needed, since it already supports rest parameters (`...Number[]`) via `z.tuple`'s rest argument.
- A wrong type among the extra arguments is reported with its position, e.g. `min(1, 2, '3', 4)` → *"Expected number at the third parameter, but received string in min()"*.

Test results: `test/unit/math/` + `test/unit/core/` — 646 passed, 0 failed.

#### PR Checklist

- [x] `npm run lint` passes
- [x] [Inline reference] is included / updated
- [x] [Unit tests] are included / updated

[Inline reference]: https://p5js.org/contribute/contributing_to_the_p5js_reference/
[Unit tests]: https://github.com/processing/p5.js/tree/main/contributor_docs#unit-tests
