### PR TITLE
Warn via FES when bezierOrder() receives a value other than 2 or 3

### DIFF
--- a/src/shape/custom_shapes.js
+++ b/src/shape/custom_shapes.js
@@ -2174,6 +2174,17 @@ function customShapes(p5, fn) {
    * @returns {Number} The current Bézier order.
    */
   fn.bezierOrder = function (order) {
+    if (
+      !p5.disableFriendlyErrors &&
+      order !== undefined &&
+      order !== 2 &&
+      order !== 3
+    ) {
+      p5._friendlyError(
+        `bezierOrder() expects an order of 2 or 3, but received ${order}.`,
+        'bezierOrder'
+      );
+    }
     return this._renderer.bezierOrder(order);
   };
 

--- a/test/unit/core/vertex.js
+++ b/test/unit/core/vertex.js
@@ -31,6 +31,38 @@ suite('Vertex', function () {
     });
   });
 
+  suite('p5.prototype.bezierOrder', function () {
+    test('should be a function', function () {
+      assert.ok(myp5.bezierOrder);
+      assert.typeOf(myp5.bezierOrder,'function');
+    });
+
+    test('should warn when the order is not 2 or 3', function () {
+      const _friendlyErrorStub = vi.spyOn(p5, '_friendlyError');
+      myp5.bezierOrder(4);
+      expect(_friendlyErrorStub).toHaveBeenCalledTimes(1);
+    });
+
+    test('should not warn for an order of 2', function () {
+      const _friendlyErrorStub = vi.spyOn(p5, '_friendlyError');
+      myp5.bezierOrder(2);
+      expect(_friendlyErrorStub).not.toHaveBeenCalled();
+    });
+
+    test('should not warn for an order of 3', function () {
+      const _friendlyErrorStub = vi.spyOn(p5, '_friendlyError');
+      myp5.bezierOrder(3);
+      expect(_friendlyErrorStub).not.toHaveBeenCalled();
+    });
+
+    test('should not warn when reading the current order', function () {
+      const _friendlyErrorStub = vi.spyOn(p5, '_friendlyError');
+      myp5.bezierOrder();
+      expect(_friendlyErrorStub).not.toHaveBeenCalled();
+    });
+
+  });
+
   suite('p5.prototype.splineVertex', function () {
     test('should be a function', function () {
       assert.ok(myp5.splineVertex);


### PR DESCRIPTION
Resolves #9079

### Changes

`bezierOrder()` is documented as accepting 2 or 3 but validated nothing, so
out-of-range values reached the renderers and failed differently in each:
2D drew nothing, WebGL silently reinterpreted the shape as a quadratic, and
`bezierOrder(1)` threw a TypeError from inside p5.

`fn.bezierOrder` now emits a non-blocking FES warning when the order isn't
2 or 3. Renderer behaviour is unchanged — this only adds a message.

Per @davepagurek's preference on the issue, the check reads
`p5.disableFriendlyErrors` first, so a sketch with FES turned off does no
further work. `order !== undefined` is checked next so the getter form
(`bezierOrder()` with no argument) doesn't warn.

Non-numeric and non-integer values (`'3'`, `2.5`, `null`) also warn, since
they fail the same comparison.

The order-1 TypeError still occurs after the warning; the warning names
`bezierOrder` first, so the user sees the cause before the crash.

### PR Checklist
- [x] `npm run lint` passes
- [ ] [Inline reference] is included / updated
- [x] [Unit tests] are included / updated