### PR TITLE
fix: run canvas teardown in Renderer3D.remove()

### DIFF
--- a/src/core/p5.Renderer3D.js
+++ b/src/core/p5.Renderer3D.js
@@ -437,13 +437,6 @@ export class Renderer3D extends Renderer {
     }
   }
 
-  remove() {
-    this.wrappedElt.remove();
-    this.wrappedElt = null;
-    this.canvas = null;
-    this.elt = null;
-  }
-
   //////////////////////////////////////////////
   // Geometry Building
   //////////////////////////////////////////////
@@ -2176,6 +2169,10 @@ export class Renderer3D extends Renderer {
     if (this._textCanvas) {
       this._textCanvas.parentElement.removeChild(this._textCanvas);
     }
+    this.wrappedElt.remove();
+    this.wrappedElt = null;
+    this.canvas = null;
+    this.elt = null;
     super.remove();
   }
 }


### PR DESCRIPTION
Split out of #9103 at review, where it was flagged as a refactor that did not belong in a lint cleanup.

Changes:

`Renderer3D` declares `remove()` twice, at L440 and L2175. A class body is evaluated top to bottom, so the second definition overwrites the first and `Renderer3D.prototype.remove` has only ever been the later one. The overwritten method is the canvas teardown, identical to `Renderer2D.remove()`. It stopped running when the second `remove()` was added for `_textCanvas` cleanup in ef28cbc7.

This shows up as a 2D/3D asymmetry at two call sites:

- `p5.Graphics.remove()` calls `_renderer.remove()` and nothing else, so `createGraphics(w, h, WEBGL).remove()` leaves its canvas in the DOM. The 2D equivalent does not.
- `createCanvas()` called a second time disposes the old renderer the same way, so the old WebGL canvas is orphaned. In 2D it is not.

`p5.remove()` is unaffected since it detaches `e.elt` for everything in `_elements` regardless.

The fix deletes the overwritten declaration and folds its body into the surviving one, after the `_textCanvas` block (which reads `parentElement`, so it has to run before `canvas` and `elt` are nulled). `super.remove()` is a no-op in the base class so its position is unchanged.

This makes `remove()` non-idempotent in the same way `Renderer2D.remove()` already is: a second call throws on `this.wrappedElt.remove()`. Happy to guard it if preferred.

Screenshots of the change:

N/A

#### PR Checklist

- [x] `npm run lint` passes
- [ ] [Inline reference] is included / updated (N/A, no public API changes)
- [ ] [Unit tests] are included / updated (existing suites pass: 2174 passed, 0 failed)

[Inline reference]: https://p5js.org/contribute/contributing_to_the_p5js_reference/
[Unit tests]: https://github.com/processing/p5.js/tree/main/contributor_docs#unit-tests
