### PR TITLE
Re-enable passing HSLA/HSBA getter tests in p5.Color

### DIFF
--- a/test/unit/color/p5.Color.js
+++ b/test/unit/color/p5.Color.js
@@ -464,7 +464,7 @@ suite('p5.Color', function () {
       c = mockP5Prototype.color('rgba(255, 0, 102, 0.8)');
     });
 
-    test.todo('should correctly get HSLA property', function () {
+    test('should correctly get HSLA property', function () {
       assert.approximately(c._getHue(), 336, 0.5);
       assert.approximately(c._getSaturation(), 100, 0.5);
       assert.approximately(c._getLightness(), 50, 0.5);
@@ -487,7 +487,7 @@ suite('p5.Color', function () {
       c = mockP5Prototype.color('hsla(336, 100%, 50%, 0.8)');
     });
 
-    test.todo('should correctly get HSLA property', function () {
+    test('should correctly get HSLA property', function () {
       assert.approximately(c._getHue(), 336, 0.5);
       assert.approximately(c._getSaturation(), 100, 0.5);
       assert.approximately(c._getLightness(), 50, 0.5);
@@ -514,7 +514,7 @@ suite('p5.Color', function () {
       c = mockP5Prototype.color('hsba(336, 100%, 100%, 0.8)');
     });
 
-    test.todo('should correctly get HSLA property', function () {
+    test('should correctly get HSLA property', function () {
       assert.approximately(c._getHue(), 336, 0.5);
       assert.approximately(c._getSaturation(), 100, 0.5);
       assert.approximately(c._getLightness(), 50, 0.5);
@@ -634,7 +634,7 @@ suite('p5.Color', function () {
       c = mockP5Prototype.color('rgba(255, 0, 102, 0.8)');
     });
 
-    test.todo('should correctly get HSBA property', function () {
+    test('should correctly get HSBA property', function () {
       assert.approximately(c._getHue(), 336, 0.5);
       assert.approximately(c._getSaturation(), 100, 0.5);
       assert.approximately(c._getBrightness(), 100, 0.5);
@@ -682,7 +682,7 @@ suite('p5.Color', function () {
       c = mockP5Prototype.color('hsla(336, 100%, 50%, 0.8)');
     });
 
-    test.todo('should correctly get HSBA property', function () {
+    test('should correctly get HSBA property', function () {
       assert.approximately(c._getHue(), 336, 0.5);
       assert.approximately(c._getSaturation(), 100, 0.5);
       assert.approximately(c._getBrightness(), 100, 0.5);


### PR DESCRIPTION
Resolves #9139

Five `test.todo` → `test` in test/unit/color/p5.Color.js (lines 467, 490, 517,
637, 685). No source changes.

These were disabled in 7af496704 ("Mark most failing tests as todos", Sep 2024)
during the 2.0 work and pass on current main. They cover the HSL/HSB getters
reached via three different string-parsing paths (rgba(), hsla(), hsba()).

Verified against current main after rebase:
- test/unit/color/p5.Color.js passes 97/97
- `npm run lint` unchanged at 6 warnings / 0 errors
- The five fail as expected when `_getHue()` is deliberately broken
  (`AssertionError: expected 999 to be close to 336 +/- 0.5`), so they exercise
  the code rather than passing vacuously

Left alone: line 252's `suite.todo('invalid string')` has no body and is a
genuinely unwritten test.