### PR TITLE
fix: allow negative divisors in p5.Vector.rem()

### DIFF
--- a/src/math/p5.Vector.js
+++ b/src/math/p5.Vector.js
@@ -652,11 +652,11 @@ class Vector {
 
     if (Array.isArray(args)) {
       for (let i = 0; i < this.values.length; i++) {
-        if (args[i] > 0) {
+        if (Math.abs(args[i]) > 0) {
           this.values[i] = this.values[i] % args[i];
         }
       }
-    } else if (args > 0) {
+    } else if (Math.abs(args) > 0) {
       for (let i = 0; i < this.values.length; i++) {
         this.values[i] = this.values[i] % args;
       }

--- a/test/unit/math/p5.Vector.js
+++ b/test/unit/math/p5.Vector.js
@@ -616,6 +616,41 @@ suite('p5.Vector', function () {
       });
     });
 
+    suite('with negative divisors', function () {
+      let v;
+      beforeEach(function () {
+        v = new Vector(3, 4, 5);
+      });
+
+      test('should calculate remainder with a negative number', function () {
+        v.rem(-2);
+        expect(v.x).to.eql(1);
+        expect(v.y).to.eql(0);
+        expect(v.z).to.eql(1);
+      });
+
+      test('should calculate remainder with negative numbers', function () {
+        v.rem(-2, 3, -4);
+        expect(v.x).to.eql(1);
+        expect(v.y).to.eql(1);
+        expect(v.z).to.eql(1);
+      });
+
+      test('should calculate remainder with an array containing negative numbers', function () {
+        v.rem([-2, 3, -4]);
+        expect(v.x).to.eql(1);
+        expect(v.y).to.eql(1);
+        expect(v.z).to.eql(1);
+      });
+
+      test('should calculate remainder with a p5.Vector containing negative numbers', function () {
+        v.rem(new Vector(-2, 3, -4));
+        expect(v.x).to.eql(1);
+        expect(v.y).to.eql(1);
+        expect(v.z).to.eql(1);
+      });
+    });
+
     suite('with Arrays', function () {
       test('should return remainder of vector components for 3D vector', function () {
         v.rem([2, 3, 0]);


### PR DESCRIPTION
Resolves #9132

Changes:
In p5.js 2.x, `p5.Vector.prototype.rem()` used `args[i] > 0` and `args > 0` to guard against division by zero. This caused negative divisors to be silently ignored (e.g., `v.rem(-2)` or `v.rem([-2, 3, -4])`), which was a regression from 1.x.

This PR updates the guards to `Math.abs(...) > 0` (as suggested by @ksen0 in #9132) so that:
- Remainder operations with negative divisors (single numbers, multiple numbers, arrays, and `p5.Vector` objects) are correctly evaluated.
- Division by zero continues to be skipped.
- Unit tests covering negative divisors for `rem()` have been added.

Screenshots of the change:
N/A (Math/Vector method)

#### PR Checklist
- [x] `npm run lint` passes
- [ ] [Inline reference] is included / updated
- [x] [Unit tests] are included / updated